### PR TITLE
Fix address prefix to sei

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -118,11 +118,6 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
-const (
-	AccountAddressPrefix = "cosmos"
-	Name                 = "sei"
-)
-
 // this line is used by starport scaffolding # stargate/wasm/app/enabledProposals
 
 func getGovProposalHandlers() []govclient.ProposalHandler {
@@ -203,7 +198,7 @@ func init() {
 		panic(err)
 	}
 
-	DefaultNodeHome = filepath.Join(userHomeDir, "."+Name)
+	DefaultNodeHome = filepath.Join(userHomeDir, "."+AppName)
 }
 
 // App extends an ABCI application, but with most of its parameters exported.
@@ -281,7 +276,7 @@ func New(
 	cdc := encodingConfig.Amino
 	interfaceRegistry := encodingConfig.InterfaceRegistry
 
-	bApp := baseapp.NewBaseApp(Name, logger, db, encodingConfig.TxConfig.TxDecoder(), baseAppOptions...)
+	bApp := baseapp.NewBaseApp(AppName, logger, db, encodingConfig.TxConfig.TxDecoder(), baseAppOptions...)
 	bApp.SetCommitMultiStoreTracer(traceStore)
 	bApp.SetVersion(version.Version)
 	bApp.SetInterfaceRegistry(interfaceRegistry)
@@ -684,7 +679,7 @@ func New(
 	return app
 }
 
-// Name returns the name of the App
+// AppName returns the name of the App
 func (app *App) Name() string { return app.BaseApp.Name() }
 
 // GetBaseApp returns the base app of the application
@@ -797,7 +792,7 @@ func (app *App) RegisterAPIRoutes(apiSvr *api.Server, apiConfig config.APIConfig
 
 	// register app's OpenAPI routes.
 	apiSvr.Router.Handle("/static/openapi.yml", http.FileServer(http.FS(docs.Docs)))
-	apiSvr.Router.HandleFunc("/", openapiconsole.Handler(Name, "/static/openapi.yml"))
+	apiSvr.Router.HandleFunc("/", openapiconsole.Handler(AppName, "/static/openapi.yml"))
 }
 
 // RegisterTxService implements the Application.RegisterTxService method.

--- a/app/const.go
+++ b/app/const.go
@@ -1,0 +1,8 @@
+package app
+
+const (
+	// Prefix of bech32 encoded address
+	AccountAddressPrefix = "sei"
+	// Application name
+	AppName = "sei"
+)

--- a/cmd/seid/main.go
+++ b/cmd/seid/main.go
@@ -9,10 +9,10 @@ import (
 
 func main() {
 	rootCmd, _ := NewRootCmd(
-		app.Name,
+		app.AppName,
 		app.AccountAddressPrefix,
 		app.DefaultNodeHome,
-		app.Name,
+		app.AppName,
 		app.ModuleBasics,
 		app.New,
 		// this line is used by starport scaffolding # root/arguments

--- a/cmd/seid/root.go
+++ b/cmd/seid/root.go
@@ -131,7 +131,7 @@ func NewRootCmd(
 		WithViper(rootOptions.envPrefix)
 
 	rootCmd := &cobra.Command{
-		Use:   "seid",
+		Use:   appName + "d",
 		Short: "Stargate Sei App",
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			// set the default command outputs

--- a/cmd/seid/root.go
+++ b/cmd/seid/root.go
@@ -131,8 +131,8 @@ func NewRootCmd(
 		WithViper(rootOptions.envPrefix)
 
 	rootCmd := &cobra.Command{
-		Use:   appName + "d",
-		Short: "Stargate CosmosHub App",
+		Use:   "seid",
+		Short: "Stargate Sei App",
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			// set the default command outputs
 			cmd.SetOut(cmd.OutOrStdout())


### PR DESCRIPTION
### Description
Set the prefix for accounts to start with `sei` rather than `cosmos`. Also do some small refactoring.

### Test
Started the chain and created account. Checked validator addr:
Account
```
> ./build/seid keys add seiprefixacc

- name: seiprefixacc
  type: local
  address: sei1pryw5ymj6dgq90ulsgvxan374nd0qy50lwnrd5
```
Validator
```
> ./build/seid q tendermint-validator-set
block_height: "4"
total: "1"
validators:
- address: seivalcons1p9pvsyjgyqjd5gppqh7dfs89kqgmacgm420hsq
  proposer_priority: "0"
```