### PR TITLE
Add upgrade handlers

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -1,0 +1,15 @@
+package app
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+)
+
+const UpgradeNameOracleModule = "create-oracle-mod"
+
+func (app App) RegisterUpgradeHandlers() {
+	app.UpgradeKeeper.SetUpgradeHandler(UpgradeNameOracleModule, func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
+	})
+}

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -153,6 +153,8 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper, am.tracingInfo))
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
+
+	cfg.RegisterMigration(types.ModuleName, 1, func(ctx sdk.Context) error { return nil })
 }
 
 // RegisterInvariants registers the capability module's invariants.

--- a/x/epoch/module.go
+++ b/x/epoch/module.go
@@ -140,6 +140,8 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 // module-specific GRPC queries.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
+
+	cfg.RegisterMigration(types.ModuleName, 1, func(ctx sdk.Context) error { return nil })
 }
 
 // RegisterInvariants registers the capability module's invariants.

--- a/x/oracle/module.go
+++ b/x/oracle/module.go
@@ -137,6 +137,8 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	querier := keeper.NewQuerier(am.keeper)
 	types.RegisterQueryServer(cfg.QueryServer(), querier)
+
+	cfg.RegisterMigration(types.ModuleName, 1, func(ctx sdk.Context) error { return nil })
 }
 
 // InitGenesis performs genesis initialization for the oracle module. It returns
@@ -157,7 +159,7 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 }
 
 // ConsensusVersion implements AppModule/ConsensusVersion.
-func (AppModule) ConsensusVersion() uint64 { return 1 }
+func (AppModule) ConsensusVersion() uint64 { return 2 }
 
 // BeginBlock returns the begin blocker for the oracle module.
 func (AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}


### PR DESCRIPTION
- Add new store for `oracle` if the chain is upgraded from an older version when `oracle` doesn't exist
- Add no-op migration handlers for all modules