### PR TITLE
Increase consensus params so validators stop missing blocks

### DIFF
--- a/app/params/config.go
+++ b/app/params/config.go
@@ -86,8 +86,8 @@ func SetTendermintConfigs(config *tmcfg.Config) {
 	config.Mempool.MaxTxsBytes = 10737418240
 	config.Mempool.MaxTxBytes = 2048576
 	// Consensus Configs
-	config.Consensus.TimeoutPrevote = 100 * time.Millisecond
-	config.Consensus.TimeoutPrecommit = 100 * time.Millisecond
-	config.Consensus.TimeoutCommit = 100 * time.Millisecond
+	config.Consensus.TimeoutPrevote = 500 * time.Millisecond
+	config.Consensus.TimeoutPrecommit = 500 * time.Millisecond
+	config.Consensus.TimeoutCommit = 500 * time.Millisecond
 	config.Consensus.SkipTimeoutCommit = true
 }


### PR DESCRIPTION
100ms is too aggressive resulting in a lot of slashing and missed blocks.