### PR TITLE
Fix query empty exchange rates

### DIFF
--- a/wasmbinding/test/query_test.go
+++ b/wasmbinding/test/query_test.go
@@ -42,7 +42,7 @@ func TestWasmGetOracleExchangeRates(t *testing.T) {
 	var parsedRes oracletypes.QueryExchangeRatesResponse
 	err = json.Unmarshal(res, &parsedRes)
 	require.NoError(t, err)
-	require.Equal(t, oracletypes.QueryExchangeRatesResponse{DenomOracleExchangeRatePairs: oracletypes.DenomOracleExchangeRatePairs(nil)}, parsedRes)
+	require.Equal(t, oracletypes.QueryExchangeRatesResponse{DenomOracleExchangeRatePairs: oracletypes.DenomOracleExchangeRatePairs{}}, parsedRes)
 
 	testWrapper.Ctx = testWrapper.Ctx.WithBlockHeight(11)
 	testWrapper.App.OracleKeeper.SetBaseExchangeRate(testWrapper.Ctx, oracleutils.MicroAtomDenom, sdk.NewDec(12))

--- a/x/oracle/keeper/querier.go
+++ b/x/oracle/keeper/querier.go
@@ -57,7 +57,7 @@ func (q querier) ExchangeRate(c context.Context, req *types.QueryExchangeRateReq
 func (q querier) ExchangeRates(c context.Context, req *types.QueryExchangeRatesRequest) (*types.QueryExchangeRatesResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
 
-	var exchangeRates types.DenomOracleExchangeRatePairs
+	exchangeRates := []types.DenomOracleExchangeRatePair{}
 	q.IterateBaseExchangeRates(ctx, func(denom string, rate types.OracleExchangeRate) (stop bool) {
 		if denom == utils.MicroBaseDenom {
 			votePeriod := q.Keeper.GetParams(ctx).VotePeriod

--- a/x/oracle/keeper/querier_test.go
+++ b/x/oracle/keeper/querier_test.go
@@ -41,6 +41,17 @@ func TestQueryExchangeRate(t *testing.T) {
 	require.Equal(t, rate, res.OracleExchangeRate.ExchangeRate)
 }
 
+func TestQueryEmptyExchangeRates(t *testing.T) {
+	input := CreateTestInput(t)
+	ctx := sdk.WrapSDKContext(input.Ctx)
+	querier := NewQuerier(input.OracleKeeper)
+
+	res, err := querier.ExchangeRates(ctx, &types.QueryExchangeRatesRequest{})
+	require.NoError(t, err)
+
+	require.Equal(t, types.DenomOracleExchangeRatePairs{}, res.DenomOracleExchangeRatePairs)
+}
+
 func TestQueryExchangeRates(t *testing.T) {
 	input := CreateTestInput(t)
 	ctx := sdk.WrapSDKContext(input.Ctx)


### PR DESCRIPTION
Without explicitly initializing as empty array, the response would be nil, which will cause contract-side parsing to fail