### PR TITLE
1.0.5beta upgrade directory fix

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -23,7 +23,7 @@ const Upgrade103 = "1.0.3beta"
 const Upgrade104 = "1.0.4beta"
 
 // 1.0.5beta
-const Upgrade105 = "1.0.5beta upgrade"
+const Upgrade105 = "1.0.5beta"
 
 // 1.0.6beta
 const Upgrade106 = "1.0.6beta"


### PR DESCRIPTION
error 1.0.5beta for cosmovisor directory mistake fix.

must be...:$HOME/.sei/cosmovisor/upgrade/1.0.5beta/bin/seid

the current situation...:$HOME/.sei/cosmovisor/upgrade/1.0.5beta%20upgrade/bin/seid

discord:karboran#2719
sei testnet address:sei1vcd8d4k9fmyuwkc8cnfyhgxdva4j8ex07a6n7a 
validator moniker:karboran