### PR TITLE
Add more checks `ValidateBasic` message method

### DIFF
--- a/x/dex/types/message_cancel_orders.go
+++ b/x/dex/types/message_cancel_orders.go
@@ -47,5 +47,9 @@ func (msg *MsgCancelOrders) ValidateBasic() error {
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
+	_, err = sdk.AccAddressFromBech32(msg.ContractAddr)
+	if err != nil {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid contract address (%s)", err)
+	}
 	return nil
 }

--- a/x/dex/types/message_liquidation.go
+++ b/x/dex/types/message_liquidation.go
@@ -47,5 +47,9 @@ func (msg *MsgLiquidation) ValidateBasic() error {
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
+	_, err = sdk.AccAddressFromBech32(msg.ContractAddr)
+	if err != nil {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid contract address (%s)", err)
+	}
 	return nil
 }

--- a/x/dex/types/message_place_orders.go
+++ b/x/dex/types/message_place_orders.go
@@ -50,5 +50,13 @@ func (msg *MsgPlaceOrders) ValidateBasic() error {
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
+	_, err = sdk.AccAddressFromBech32(msg.ContractAddr)
+	if err != nil {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid contract address (%s)", err)
+	}
+	err = msg.Funds.Validate()
+	if err != nil {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidCoins, "invalid funds (%s)", err)
+	}
 	return nil
 }


### PR DESCRIPTION
`ValidateBasic` of `sdk.Msg` allows performing static checks for an sdk message.
These checks are performed before the message is broadcast to the network, therefore it is more optimized to have these checks in `ValidateBasic` rather that in the message handler to save gas for txs bound to fail.

This PR adds some more checks in message validate basic like contract address check or coins validity checks