### PR TITLE
enable `sei` feature for wasm contracts

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -452,7 +452,7 @@ func New(
 	)
 	// The last arguments can contain custom message handlers, and custom query handlers,
 	// if we want to allow any custom callbacks
-	supportedFeatures := "iterator,staking,stargate"
+	supportedFeatures := "iterator,staking,stargate,sei"
 	wasmOpts = append(wasmbinding.RegisterCustomPlugins(&app.OracleKeeper, &app.DexKeeper, &app.EpochKeeper), wasmOpts...)
 	app.WasmKeeper = wasm.NewKeeper(
 		appCodec,


### PR DESCRIPTION
in the `sei-cosmwasm` package, there is [the following TODO item](https://github.com/sei-protocol/sei-cosmwasm/blob/1bf3aeebbce891265f715dd7e5b6d4c117992b1a/packages/sei-cosmwasm/src/lib.rs#L18-L22):

```rust
// TODO: properly support this requirement behavior in sei-chain
// // This export is added to all contracts that import this package, signifying that they require
// // "sei" support on the chain they run on.
// #[no_mangle]
// extern "C" fn requires_sei() {}
```

to enable this feature is easy, just add `sei` to the [`supportedFeatures`](https://github.com/sei-protocol/sei-chain/blob/9fb298f9850d02007dbad3e1d752153392ee91bd/app/app.go#L455) variable in `app.go`:

```diff
- supportedFeatures := "iterator,staking,stargate"
+ supportedFeatures := "iterator,staking,stargate,sei"
```

here's an example of deploying a contract that requires the `sei` feature on a chain that doesn't support this feature. it fails as expected:

```
$ marsd tx wasm store ./artifacts/sei_tester.wasm --from dev --chain-id mars-test-1 --gas auto --gas-adjustment 1.4 --gas-prices 0umars
Error: rpc error: code = InvalidArgument desc = failed to execute message; message index: 0: Error calling the VM: Error during static Wasm validation: Wasm contract requires unsupported features: {"sei"}: create wasm contract failed: invalid request
```

while the same tx succeeds on the sei chain:

```
$ seid tx wasm store ./artifacts/sei_tester.wasm --from dev --chain-id sei-test-1 --gas auto --gas-adjustme
nt 1.4 --gas-prices 0stake
confirm transaction before signing and broadcasting [y/N]: y
code: 0
codespace: ""
data: ""
events: []
gas_used: "0"
gas_wanted: "0"
height: "0"
info: ""
logs: []
raw_log: '[]'
timestamp: ""
tx: null
txhash: 788151C82ECF63F571696D19F23D0F3CB01A525E5821BD0A8DD50C0BE8F4E83C
```

see also: https://github.com/sei-protocol/sei-cosmwasm/pull/6