### PR TITLE
Fix liquidation order placement

### DIFF
--- a/x/dex/exchange/market_order.go
+++ b/x/dex/exchange/market_order.go
@@ -28,9 +28,15 @@ func MatchMarketOrders(
 			if existingOrder.GetEntry().Quantity.IsZero() {
 				continue
 			}
-			if (direction == types.PositionDirection_LONG && marketOrder.Price.LT(existingOrder.GetPrice())) ||
-				(direction == types.PositionDirection_SHORT && marketOrder.Price.GT(existingOrder.GetPrice())) {
-				break
+			// If price is zero, it means the order sender
+			// doesn't want to specify a worst price, so
+			// we don't need to perform price check for such orders
+			if !marketOrder.Price.IsZero() {
+				// Check if worst price can be matched against order book
+				if (direction == types.PositionDirection_LONG && marketOrder.Price.LT(existingOrder.GetPrice())) ||
+					(direction == types.PositionDirection_SHORT && marketOrder.Price.GT(existingOrder.GetPrice())) {
+					break
+				}
 			}
 			var executed sdk.Dec
 			if marketOrder.Quantity.LTE(existingOrder.GetEntry().Quantity) {

--- a/x/dex/keeper/end_block_liquidation.go
+++ b/x/dex/keeper/end_block_liquidation.go
@@ -49,13 +49,13 @@ func (k *Keeper) HandleEBLiquidation(ctx context.Context, sdkCtx sdk.Context, tr
 	}
 
 	// Place liquidation orders
-	k.placeLiquidationOrders(sdkCtx, contractAddr, response.LiquidationOrders)
+	k.PlaceLiquidationOrders(sdkCtx, contractAddr, response.LiquidationOrders)
 
 	liquidationSpan.End()
 	return nil
 }
 
-func (k *Keeper) placeLiquidationOrders(ctx sdk.Context, contractAddr string, liquidationOrders []types.Order) {
+func (k *Keeper) PlaceLiquidationOrders(ctx sdk.Context, contractAddr string, liquidationOrders []types.Order) {
 	ctx.Logger().Info("Placing liquidation orders...")
 	nextID := k.GetNextOrderID(ctx)
 	for _, order := range liquidationOrders {

--- a/x/dex/keeper/end_block_liquidation.go
+++ b/x/dex/keeper/end_block_liquidation.go
@@ -56,7 +56,7 @@ func (k *Keeper) HandleEBLiquidation(ctx context.Context, sdkCtx sdk.Context, tr
 }
 
 func (k *Keeper) placeLiquidationOrders(ctx sdk.Context, contractAddr string, liquidationOrders []types.Order) {
-	ctx.Logger().Info(fmt.Sprintf("Placing liquidation orders..."))
+	ctx.Logger().Info("Placing liquidation orders...")
 	nextID := k.GetNextOrderID(ctx)
 	for _, order := range liquidationOrders {
 		ctx.Logger().Info(fmt.Sprintf("Liquidation order %s", order.String()))

--- a/x/dex/keeper/end_block_liquidation.go
+++ b/x/dex/keeper/end_block_liquidation.go
@@ -56,10 +56,12 @@ func (k *Keeper) HandleEBLiquidation(ctx context.Context, sdkCtx sdk.Context, tr
 }
 
 func (k *Keeper) placeLiquidationOrders(ctx sdk.Context, contractAddr string, liquidationOrders []types.Order) {
+	ctx.Logger().Info(fmt.Sprintf("Placing liquidation orders..."))
 	nextID := k.GetNextOrderID(ctx)
 	for _, order := range liquidationOrders {
+		ctx.Logger().Info(fmt.Sprintf("Liquidation order %s", order.String()))
 		pair := types.Pair{PriceDenom: order.PriceDenom, AssetDenom: order.AssetDenom}
-		orders := k.MemState.GetBlockOrders(types.ContractAddress(contractAddr), types.PairString(pair.String()))
+		orders := k.MemState.GetBlockOrders(types.ContractAddress(contractAddr), types.GetPairString(&pair))
 		order.Id = nextID
 		orders.AddOrder(order)
 		nextID++

--- a/x/dex/keeper/end_block_liquidation_test.go
+++ b/x/dex/keeper/end_block_liquidation_test.go
@@ -1,0 +1,19 @@
+package keeper_test
+
+import (
+	"testing"
+
+	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlaceLiquidationOrders(t *testing.T) {
+	keeper, ctx := keepertest.DexKeeper(t)
+	liquidationOrder := types.Order{
+		PriceDenom: TEST_PAIR.PriceDenom,
+		AssetDenom: TEST_PAIR.AssetDenom,
+	}
+	keeper.PlaceLiquidationOrders(ctx, TEST_CONTRACT, []types.Order{liquidationOrder})
+	require.Equal(t, 1, len(*keeper.MemState.GetBlockOrders(types.ContractAddress(TEST_CONTRACT), types.GetPairString(&TEST_PAIR))))
+}

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -348,6 +348,7 @@ func (am AppModule) endBlockForContract(ctx sdk.Context, contract types.Contract
 		orders := am.keeper.MemState.GetBlockOrders(typedContractAddr, typedPairStr)
 		cancels := am.keeper.MemState.GetBlockCancels(typedContractAddr, typedPairStr)
 		ctx.Logger().Info(string(typedPairStr))
+		ctx.Logger().Info(fmt.Sprintf("Order count: %d", len(*orders)))
 		marketBuys := orders.GetSortedMarketOrders(types.PositionDirection_LONG, true)
 		marketSells := orders.GetSortedMarketOrders(types.PositionDirection_SHORT, true)
 		limitBuys := orders.GetLimitOrders(types.PositionDirection_LONG)


### PR DESCRIPTION
Use `types.GetPairString(&pair)` as map key. This is the only non-testing place where `GetPairString` is not used.

Tested in integration tests