### PR TITLE
Add v4 to v5 migration handler

### DIFF
--- a/x/dex/migrations/v4_to_v5.go
+++ b/x/dex/migrations/v4_to_v5.go
@@ -1,8 +1,11 @@
 package migrations
 
 import (
+	"encoding/binary"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	"github.com/sei-protocol/sei-chain/x/dex/keeper"
 )
 
 /**
@@ -13,5 +16,11 @@ import (
 func V4ToV5(ctx sdk.Context, storeKey sdk.StoreKey, paramStore paramtypes.Subspace) error {
 	ClearStore(ctx, storeKey)
 	migratePriceSnapshotParam(ctx, paramStore)
+
+	// initialize epoch to 0
+	store := ctx.KVStore(storeKey)
+	bz := make([]byte, 8)
+	binary.BigEndian.PutUint64(bz, 0)
+	store.Set([]byte(keeper.EpochKey), bz)
 	return nil
 }

--- a/x/dex/migrations/v4_to_v5.go
+++ b/x/dex/migrations/v4_to_v5.go
@@ -1,0 +1,15 @@
+package migrations
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+/**
+ * No `dex` state exists in any public chain at the time this data type update happened.
+ * Any new chain (including local ones) should be based on a Sei version newer than this update
+ * and therefore doesn't need this migration
+ */
+func V4ToV5(ctx sdk.Context, storeKey sdk.StoreKey) error {
+	ClearStore(ctx, storeKey)
+	return nil
+}

--- a/x/dex/migrations/v4_to_v5.go
+++ b/x/dex/migrations/v4_to_v5.go
@@ -2,6 +2,7 @@ package migrations
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
 
 /**
@@ -9,7 +10,8 @@ import (
  * Any new chain (including local ones) should be based on a Sei version newer than this update
  * and therefore doesn't need this migration
  */
-func V4ToV5(ctx sdk.Context, storeKey sdk.StoreKey) error {
+func V4ToV5(ctx sdk.Context, storeKey sdk.StoreKey, paramStore paramtypes.Subspace) error {
 	ClearStore(ctx, storeKey)
+	migratePriceSnapshotParam(ctx, paramStore)
 	return nil
 }

--- a/x/dex/migrations/v4_to_v5_test.go
+++ b/x/dex/migrations/v4_to_v5_test.go
@@ -1,0 +1,33 @@
+package migrations_test
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/store"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/x/dex/migrations"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	tmdb "github.com/tendermint/tm-db"
+)
+
+func TestMigrate4to5(t *testing.T) {
+	storeKey := sdk.NewKVStoreKey(types.StoreKey)
+	memStoreKey := storetypes.NewMemoryStoreKey(types.MemStoreKey)
+
+	db := tmdb.NewMemDB()
+	stateStore := store.NewCommitMultiStore(db)
+	stateStore.MountStoreWithDB(storeKey, sdk.StoreTypeIAVL, db)
+	stateStore.MountStoreWithDB(memStoreKey, sdk.StoreTypeMemory, nil)
+	require.NoError(t, stateStore.LoadLatestVersion())
+
+	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())
+	store := ctx.KVStore(storeKey)
+	store.Set([]byte("garbage key"), []byte("garbage value"))
+	err := migrations.V4ToV5(ctx, storeKey)
+	require.Nil(t, err)
+	require.False(t, store.Has([]byte("garbage key")))
+}

--- a/x/dex/migrations/v4_to_v5_test.go
+++ b/x/dex/migrations/v4_to_v5_test.go
@@ -1,6 +1,7 @@
 package migrations_test
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -9,6 +10,7 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	typesparams "github.com/cosmos/cosmos-sdk/x/params/types"
+	"github.com/sei-protocol/sei-chain/x/dex/keeper"
 	"github.com/sei-protocol/sei-chain/x/dex/migrations"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 	"github.com/stretchr/testify/require"
@@ -49,4 +51,8 @@ func TestMigrate4to5(t *testing.T) {
 	params := types.Params{}
 	paramsSubspace.GetParamSet(ctx, &params)
 	require.Equal(t, uint64(types.DefaultPriceSnapshotRetention), params.PriceSnapshotRetention)
+
+	epochBytes := store.Get([]byte(keeper.EpochKey))
+	epoch := binary.BigEndian.Uint64(epochBytes)
+	require.Equal(t, uint64(0), epoch)
 }

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -163,6 +163,9 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	_ = cfg.RegisterMigration(types.ModuleName, 3, func(ctx sdk.Context) error {
 		return migrations.PriceSnapshotUpdate(ctx, am.keeper.Paramstore)
 	})
+	_ = cfg.RegisterMigration(types.ModuleName, 4, func(ctx sdk.Context) error {
+		return migrations.V4ToV5(ctx, am.keeper.GetStoreKey())
+	})
 }
 
 // RegisterInvariants registers the capability module's invariants.
@@ -187,7 +190,7 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 }
 
 // ConsensusVersion implements ConsensusVersion.
-func (AppModule) ConsensusVersion() uint64 { return 4 }
+func (AppModule) ConsensusVersion() uint64 { return 5 }
 
 func (am AppModule) getAllContractInfo(ctx sdk.Context) []types.ContractInfo {
 	return am.keeper.GetAllContractInfo(ctx)

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -164,7 +164,7 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 		return migrations.PriceSnapshotUpdate(ctx, am.keeper.Paramstore)
 	})
 	_ = cfg.RegisterMigration(types.ModuleName, 4, func(ctx sdk.Context) error {
-		return migrations.V4ToV5(ctx, am.keeper.GetStoreKey())
+		return migrations.V4ToV5(ctx, am.keeper.GetStoreKey(), am.keeper.Paramstore)
 	})
 }
 


### PR DESCRIPTION
Add a migration handler for `dex` v5 that nukes everything in `dex` store