### PR TITLE
Fix v4 to v5 migration handler

### DIFF
--- a/x/dex/exchange/limit_order.go
+++ b/x/dex/exchange/limit_order.go
@@ -18,10 +18,10 @@ func MatchLimitOrders(
 	zeroOrders *[]AccountOrderID,
 ) (sdk.Dec, sdk.Dec) {
 	for _, order := range longOrders {
-		addOrderToOrderBook(order, longBook, pair, longDirtyPrices)
+		addOrderToOrderBook(order, longBook, longDirtyPrices)
 	}
 	for _, order := range shortOrders {
-		addOrderToOrderBook(order, shortBook, pair, shortDirtyPrices)
+		addOrderToOrderBook(order, shortBook, shortDirtyPrices)
 	}
 	totalExecuted, totalPrice := sdk.ZeroDec(), sdk.ZeroDec()
 	longPtr, shortPtr := len(*longBook)-1, 0
@@ -63,7 +63,6 @@ func MatchLimitOrders(
 func addOrderToOrderBook(
 	order types.Order,
 	orderBook *[]types.OrderBook,
-	pair types.Pair,
 	dirtyPrices *DirtyPrices,
 ) {
 	insertAt := -1

--- a/x/dex/migrations/v2_to_v3.go
+++ b/x/dex/migrations/v2_to_v3.go
@@ -22,8 +22,14 @@ func DataTypeUpdate(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCode
  *          be used outside of a production setting.
  */
 func ClearStore(ctx sdk.Context, storeKey sdk.StoreKey) {
+	for i := 0; i < 256; i++ {
+		clearStoreForByte(ctx, storeKey, byte(i))
+	}
+}
+
+func clearStoreForByte(ctx sdk.Context, storeKey sdk.StoreKey, b byte) {
 	store := ctx.KVStore(storeKey)
-	iterator := sdk.KVStorePrefixIterator(store, []byte{})
+	iterator := sdk.KVStorePrefixIterator(store, []byte{b})
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
 		store.Delete(iterator.Key())

--- a/x/dex/migrations/v4_to_v5.go
+++ b/x/dex/migrations/v4_to_v5.go
@@ -15,7 +15,9 @@ import (
  */
 func V4ToV5(ctx sdk.Context, storeKey sdk.StoreKey, paramStore paramtypes.Subspace) error {
 	ClearStore(ctx, storeKey)
-	migratePriceSnapshotParam(ctx, paramStore)
+	if err := migratePriceSnapshotParam(ctx, paramStore); err != nil {
+		return err
+	}
 
 	// initialize epoch to 0
 	store := ctx.KVStore(storeKey)

--- a/x/dex/migrations/v4_to_v5_test.go
+++ b/x/dex/migrations/v4_to_v5_test.go
@@ -44,6 +44,7 @@ func TestMigrate4to5(t *testing.T) {
 	}
 	store := ctx.KVStore(storeKey)
 	store.Set([]byte("garbage key"), []byte("garbage value"))
+	require.True(t, store.Has([]byte("garbage key")))
 	err := migrations.V4ToV5(ctx, storeKey, paramsSubspace)
 	require.Nil(t, err)
 	require.False(t, store.Has([]byte("garbage key")))

--- a/x/oracle/client/rest/query.go
+++ b/x/oracle/client/rest/query.go
@@ -98,7 +98,7 @@ func queryTwapsHandlerFunction(cliCtx client.Context) http.HandlerFunc {
 			return
 		}
 
-		lookbackSeconds, ok := checkLookbackSecondsVar(w, r)
+		lookbackSeconds, ok := checkLookbackSecondsVar(r)
 		if !ok {
 			return
 		}
@@ -322,7 +322,7 @@ func checkDenomVar(w http.ResponseWriter, r *http.Request) (string, bool) {
 	return denom, true
 }
 
-func checkLookbackSecondsVar(w http.ResponseWriter, r *http.Request) (int64, bool) {
+func checkLookbackSecondsVar(r *http.Request) (int64, bool) {
 	lookbackSecondsStr := mux.Vars(r)[RestLookbackSeconds]
 	lookbackSeconds, err := strconv.ParseInt(lookbackSecondsStr, 10, 64)
 	if err != nil {


### PR DESCRIPTION
The production store doesn't accept empty byte array as a prefix, so we will just iterate through all possible byte values and clear those prefixes one-by-one.