### PR TITLE
Update example proposals display type to micro denom

### DIFF
--- a/x/dex/example/add-asset-metadata-proposal.json
+++ b/x/dex/example/add-asset-metadata-proposal.json
@@ -25,8 +25,29 @@
                 ],
                 "base": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
                 "name": "USD Coin",
-                "display": "axlusdc",
+                "display": "uusdc",
                 "symbol": "USDC"
+            }
+        },
+        {
+            "type_asset": "native",
+            "metadata": {
+                "description": "Native token of Sei Network",
+                "denom_units": [
+                    {
+                      "denom": "usei",
+                      "exponent": 0,
+                      "aliases": ["usei"]
+                    },
+                    {
+                      "denom": "sei",
+                      "exponent": 6
+                    }
+                ],
+                "base": "SEI",
+                "name": "sei",
+                "display": "usei",
+                "symbol": "SEI"
             }
         }
     ],

--- a/x/dex/example/register-pair-proposal.json
+++ b/x/dex/example/register-pair-proposal.json
@@ -6,18 +6,18 @@
         "contract_addr": "sei14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sh9m79m",
         "pairs": [
           {
-            "price_denom": "usdc",
-            "asset_denom": "sei",
+            "price_denom": "uusdc",
+            "asset_denom": "usei",
             "tick_size": "0.2"
           },
           {
-            "price_denom": "usdc",
-            "asset_denom": "atom",
+            "price_denom": "uusdc",
+            "asset_denom": "uatom",
             "tick_size": "1.1"
           },
           {
-            "price_denom": "atom",
-            "asset_denom": "sei",
+            "price_denom": "uatom",
+            "asset_denom": "usei",
             "tick_size": "1.5"
           }
         ]

--- a/x/dex/example/update-tick-size-proposal.json
+++ b/x/dex/example/update-tick-size-proposal.json
@@ -4,8 +4,8 @@
     "tick_size_list": [
           {
             "pair": {
-              "price_denom": "atom",
-              "asset_denom": "sei"
+              "price_denom": "uatom",
+              "asset_denom": "usei"
             },
             "tick_size": "1.5",
             "contract_addr": "sei14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sh9m79m"


### PR DESCRIPTION
- Dex Asset List and Register Pair proposals should be the same denom as the price denom (accepted as deposits)
- Updates all display types (key for asset list) to micro denom e.g. "usei"