### PR TITLE
Set status to be fulfilled if market order is fully executed

### DIFF
--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -481,6 +481,8 @@ func (am AppModule) endBlockForContract(ctx sdk.Context, contract types.Contract
 					Initiator: types.CancellationInitiator_USER,
 				})
 				am.keeper.UpdateOrderStatus(ctx, contractAddr, marketOrder.Id, types.OrderStatus_CANCELLED)
+			} else {
+				am.keeper.UpdateOrderStatus(ctx, contractAddr, marketOrder.Id, types.OrderStatus_FULFILLED)
 			}
 		}
 		for _, marketOrder := range marketSells {
@@ -490,6 +492,8 @@ func (am AppModule) endBlockForContract(ctx sdk.Context, contract types.Contract
 					Initiator: types.CancellationInitiator_USER,
 				})
 				am.keeper.UpdateOrderStatus(ctx, contractAddr, marketOrder.Id, types.OrderStatus_CANCELLED)
+			} else {
+				am.keeper.UpdateOrderStatus(ctx, contractAddr, marketOrder.Id, types.OrderStatus_FULFILLED)
 			}
 		}
 	}

--- a/x/dex/module_test.go
+++ b/x/dex/module_test.go
@@ -123,6 +123,9 @@ func TestEndBlockMarketOrder(t *testing.T) {
 	_, found = dexkeeper.GetLongBookByPrice(ctx, contractAddr.String(), sdk.MustNewDecFromStr("1"), pair.PriceDenom, pair.AssetDenom)
 	// Long book should be populated
 	require.False(t, found)
+
+	marketOrder := dexkeeper.GetOrdersByIds(ctx, contractAddr.String(), []uint64{2})[uint64(2)]
+	require.Equal(t, types.OrderStatus_FULFILLED, marketOrder.Status)
 }
 
 func TestEndBlockRollback(t *testing.T) {


### PR DESCRIPTION
Right now market order status would stay as `PLACED` even after it's fully executed. It makes more sense for its status to be updated to `FULFILLED` in such cases.