### PR TITLE
Assert that upgrade names are sorted

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/server/config"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/cosmos/cosmos-sdk/simapp"
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/version"
@@ -652,19 +651,7 @@ func New(
 	app.sm.RegisterStoreDecoders()
 
 	app.RegisterUpgradeHandlers()
-	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
-	if err != nil {
-		panic(err)
-	}
 
-	if upgradeInfo.Name == UpgradeNameOracleModule && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
-		storeUpgrades := storetypes.StoreUpgrades{
-			Added: []string{oracletypes.StoreKey},
-		}
-
-		// configure store loader that checks if version == upgradeHeight and applies store upgrades
-		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
-	}
 	// initialize stores
 	app.MountKVStores(keys)
 	app.MountTransientStores(tkeys)

--- a/app/app.go
+++ b/app/app.go
@@ -657,7 +657,7 @@ func New(
 		panic(err)
 	}
 
-	if upgradeInfo.Name == Upgrade104 && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+	if upgradeInfo.Name == UpgradeNameOracleModule && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{
 			Added: []string{oracletypes.StoreKey},
 		}

--- a/app/upgrade_test.go
+++ b/app/upgrade_test.go
@@ -1,0 +1,16 @@
+package app_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/sei-protocol/sei-chain/app"
+)
+
+func TestUpgradesListIsSorted(t *testing.T) {
+	tm := time.Now().UTC()
+	valPub := secp256k1.GenPrivKey().PubKey()
+	testWrapper := app.NewTestWrapper(t, tm, valPub)
+	testWrapper.App.RegisterUpgradeHandlers()
+}

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -35,12 +35,13 @@ var upgradesList = []string{
 
 func (app App) RegisterUpgradeHandlers() {
 	// Upgrades names must be in alphabetical order
+	// https://github.com/cosmos/cosmos-sdk/blob/v0.45.4/docs/core/upgrade.md#order-of-migrations
 	// https://github.com/cosmos/cosmos-sdk/issues/11707
 	if !sort.StringsAreSorted(upgradesList) {
 		log.Fatal("New upgrades must be appended to 'upgradesList' in alphabetical order")
 	}
-	for _, upgrade := range upgradesList {
-		app.UpgradeKeeper.SetUpgradeHandler(upgrade, func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+	for _, upgradeName := range upgradesList {
+		app.UpgradeKeeper.SetUpgradeHandler(upgradeName, func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 			return app.mm.RunMigrations(ctx, app.configurator, fromVM)
 		})
 	}

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -9,7 +9,7 @@ import (
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 )
 
-// this will introduce the oracle module as well
+// UpgradeNameOracleModule - this will introduce the oracle module as well
 var UpgradeNameOracleModule = "1.0.4beta"
 
 // NOTE: When performing upgrades, make sure to keep / register the handlers

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -9,20 +9,10 @@ import (
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 )
 
-// UpgradeNameOracleModule - this will introduce the oracle module as well
-var UpgradeNameOracleModule = "1.0.4beta"
-
 // NOTE: When performing upgrades, make sure to keep / register the handlers
 // for both the current (n) and the previous (n-1) upgrade name. There is a bug
 // in a missing value in a log statement for which the fix is not released
 var upgradesList = []string{
-	// 1.0.2beta upgrades
-	"1.0.2beta",
-	"1.0.2beta-commit-timeout",
-	// 1.0.3beta
-	"1.0.3beta",
-	// 1.0.4beta
-	UpgradeNameOracleModule,
 	// 1.0.5beta
 	"1.0.5beta upgrade",
 	// 1.0.6beta
@@ -35,7 +25,6 @@ var upgradesList = []string{
 
 func (app App) RegisterUpgradeHandlers() {
 	// Upgrades names must be in alphabetical order
-	// https://github.com/cosmos/cosmos-sdk/blob/v0.45.4/docs/core/upgrade.md#order-of-migrations
 	// https://github.com/cosmos/cosmos-sdk/issues/11707
 	if !sort.StringsAreSorted(upgradesList) {
 		log.Fatal("New upgrades must be appended to 'upgradesList' in alphabetical order")

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -1,65 +1,47 @@
 package app
 
 import (
+	"log"
+	"sort"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 )
 
+// this will introduce the oracle module as well
+var UpgradeNameOracleModule = "1.0.4beta"
+
 // NOTE: When performing upgrades, make sure to keep / register the handlers
 // for both the current (n) and the previous (n-1) upgrade name. There is a bug
 // in a missing value in a log statement for which the fix is not released
-const IgniteCLIRemovalUpgradeHandler = "ignite-cli-removal-upgrade"
-
-// 1.0.2beta upgrades
-const Upgrade102 = "1.0.2beta"
-const Upgrade102CommitTimeout = "1.0.2beta-commit-timeout"
-
-// 1.0.3beta
-const Upgrade103 = "1.0.3beta"
-
-// 1.0.4beta
-// this will introduce the oracle module as well
-const Upgrade104 = "1.0.4beta"
-
-// 1.0.5beta
-const Upgrade105 = "1.0.5beta upgrade"
-
-// 1.0.6beta
-const Upgrade106 = "1.0.6beta"
-
-// 1.0.7beta
-const Upgrade107 = "1.0.7beta"
-
-// 1.0.7beta-postfix
-const Upgrade107PostFix = "1.0.7beta-postfix"
+var upgradesList = []string{
+	// 1.0.2beta upgrades
+	"1.0.2beta",
+	"1.0.2beta-commit-timeout",
+	// 1.0.3beta
+	"1.0.3beta",
+	// 1.0.4beta
+	UpgradeNameOracleModule,
+	// 1.0.5beta
+	"1.0.5beta upgrade",
+	// 1.0.6beta
+	"1.0.6beta",
+	// 1.0.7beta
+	"1.0.7beta",
+	// 1.0.7beta-postfix
+	"1.0.7beta-postfix",
+}
 
 func (app App) RegisterUpgradeHandlers() {
-	app.UpgradeKeeper.SetUpgradeHandler(IgniteCLIRemovalUpgradeHandler, func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
-	})
-	app.UpgradeKeeper.SetUpgradeHandler(Upgrade102, func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
-	})
-	app.UpgradeKeeper.SetUpgradeHandler(Upgrade102CommitTimeout, func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
-	})
-	app.UpgradeKeeper.SetUpgradeHandler(Upgrade103, func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
-	})
-	app.UpgradeKeeper.SetUpgradeHandler(Upgrade104, func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
-	})
-	app.UpgradeKeeper.SetUpgradeHandler(Upgrade105, func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
-	})
-	app.UpgradeKeeper.SetUpgradeHandler(Upgrade106, func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
-	})
-	app.UpgradeKeeper.SetUpgradeHandler(Upgrade107, func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
-	})
-	app.UpgradeKeeper.SetUpgradeHandler(Upgrade107PostFix, func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
-	})
+	// Upgrades names must be in alphabetical order
+	// https://github.com/cosmos/cosmos-sdk/issues/11707
+	if !sort.StringsAreSorted(upgradesList) {
+		log.Fatal("New upgrades must be appended to 'upgradesList' in alphabetical order")
+	}
+	for _, upgrade := range upgradesList {
+		app.UpgradeKeeper.SetUpgradeHandler(upgrade, func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+			return app.mm.RunMigrations(ctx, app.configurator, fromVM)
+		})
+	}
 }


### PR DESCRIPTION
Adds a check that the upgrade names are in alphabetical order before the handlers are registered. 

This will only prevent users from appending non-alphabetical ordering names. I think if we wanted to catch the case where users are inserting a "valid" upgrade name in between two past upgrades, we would need to know additional metadata (when it was added) or if an upgrade was already applied in the past. 

Note, I had to remove `"ignite-cli-removal-upgrade"` as it was conflicting with the alphabetical ordering assertion. It was causing the test to fail. 

### Testing
1. make install 
2. fresh instance of the chain 
3. propose 1.0.8beta at 25
4. restart chain with 1.0.8beta handler added  and proceeds fine 
5. propose 1.0.0beta and add handler to code after it stops
6. try to start and see that it errors out 
```
 ~/sei/brando  seid start                                                                                                             ✓  11266  01:25:46
2022/07/26 01:25:54 New upgrades must be appended to 'upgradesList' in alphabetical order
```

PRs are blocked if its not sorting: https://github.com/sei-protocol/sei-chain/pull/155

### Verify 
1. verify missing n-1 upgrade handler causes issues --> True
     - Reproduced the issue from this git issue: https://github.com/cosmos/cosmos-sdk/issues/11707 <-- Same class of issues
     - Saw the same error message reported 
5. verify unsorted causes issues  
     - Continue from above -- proposed `test-v1.0` at block 90
     - Stopped chain, removed `test-v0.9`  and added `test-v1.0`. See that it's still fine 
![image](https://user-images.githubusercontent.com/18161326/180954115-10acc952-4d0b-4a5d-8e61-f05205fb11b0.png)
      - proposed test-v1.1 at height 145
      - stopped chain, removed all past handlers, and add v1.1 
      - make install and run seid start and see that it ran fine and proceeded 
      
![image](https://user-images.githubusercontent.com/18161326/180955448-f28910d2-5072-45e0-b58c-137eb2bef79c.png)




