### PR TITLE
Bump wasm size limit to 1MB

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -113,6 +113,7 @@ import (
 
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasmclient "github.com/CosmWasm/wasmd/x/wasm/client"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 
 	"go.opentelemetry.io/otel"
 )
@@ -881,4 +882,9 @@ func (app *App) BlacklistedAccAddrs() map[string]bool {
 	}
 
 	return blacklistedAddrs
+}
+
+func init() {
+	// override max wasm size to 1MB
+	wasmtypes.MaxWasmSize = 1024 * 1024
 }


### PR DESCRIPTION
Bumping limit to 1MB for now