### PR TITLE
Add usdc to min gas prices

### DIFF
--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -329,7 +329,7 @@ func initAppConfig() (string, interface{}) {
 	//   own app.toml to override, or use this default value.
 	//
 	// In simapp, we set the min gas prices to 0.
-	srvCfg.MinGasPrices = "0.01usei"
+	srvCfg.MinGasPrices = "0.01usei,0.001ibc/6D45A5CD1AADE4B527E459025AC1A5AEF41AE99091EF3069F3FEAACAFCECCD21"
 	srvCfg.API.Enable = true
 
 	// TODO: remove before mainnet launch


### PR DESCRIPTION
- On chain init (`seid init` ) enables usdc as gas price
- Validators can always change this in their `app.toml`