### PR TITLE
Loadtest fixes

### DIFF
--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -116,10 +116,6 @@ func run(config Config) {
 	filename := filepath.Join(userHomeDir, "outputs", "test_tx_hash")
 	_ = os.Remove(filename)
 	file, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		fmt.Printf("Error opening file %s", err)
-		return
-	}
 	TxHashFile = file
 	var mu sync.Mutex
 

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -115,7 +115,7 @@ func run(config Config) {
 	}
 	filename := filepath.Join(userHomeDir, "outputs", "test_tx_hash")
 	_ = os.Remove(filename)
-	file, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	file, _ := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	TxHashFile = file
 	var mu sync.Mutex
 

--- a/loadtest/scripts/populate_genesis_accounts.py
+++ b/loadtest/scripts/populate_genesis_accounts.py
@@ -5,7 +5,7 @@ import sys
 
 def add_genesis_account(account_name, local=False):
     if local:
-        add_key_cmd = f"yes | ~/go/bin/seid keys add {account_name}"
+        add_key_cmd = f"yes | ~/go/bin/seid keys add {account_name} --keyring-backend test"
     else:
         add_key_cmd = f"printf '12345678\n' | ~/go/bin/seid keys add {account_name}"
     add_key_output = subprocess.check_output(
@@ -17,7 +17,7 @@ def add_genesis_account(account_name, local=False):
     address = splitted_outputs[3].split(': ')[1]
     mnemonic = splitted_outputs[11]
     if local:
-        add_account_cmd = f"~/go/bin/seid add-genesis-account {address} 1000000000usei"
+        add_account_cmd = f"~/go/bin/seid add-genesis-account {address} 1000000000usei --keyring-backend test"
     else:
         add_account_cmd = f"printf '12345678\n' | ~/go/bin/seid add-genesis-account {address} 1000000000usei"
 

--- a/x/dex/exchange/market_order_test.go
+++ b/x/dex/exchange/market_order_test.go
@@ -12,8 +12,10 @@ import (
 	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
 )
 
-const TestTimestamp uint64 = 10000
-const TestHeight uint64 = 1
+const (
+	TestTimestamp uint64 = 10000
+	TestHeight    uint64 = 1
+)
 
 func TestMatchSingleMarketOrderFromShortBook(t *testing.T) {
 	_, ctx := keepertest.DexKeeper(t)


### PR DESCRIPTION
- Overwriting the existing file should not throw error
- Create accounts with keyring backend. For some reason, this works in integration but on loadtest, without this param it ends up creating it with a password which doesn't seem to work with the loadtest script: https://github.com/sei-protocol/sei-chain/blob/master/loadtest/sign.go#L29