### PR TITLE
Add missing upgrade handlers

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -3,11 +3,12 @@ package app
 import (
 	"context"
 	"fmt"
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 
 	appparams "github.com/sei-protocol/sei-chain/app/params"
 	"github.com/sei-protocol/sei-chain/wasmbinding"

--- a/app/app.go
+++ b/app/app.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	"io"
 	"os"
 	"path/filepath"
@@ -651,6 +652,19 @@ func New(
 	app.sm.RegisterStoreDecoders()
 
 	app.RegisterUpgradeHandlers()
+	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
+	if err != nil {
+		panic(err)
+	}
+
+	if upgradeInfo.Name == "1.0.4beta" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		storeUpgrades := storetypes.StoreUpgrades{
+			Added: []string{oracletypes.StoreKey},
+		}
+
+		// configure store loader that checks if version == upgradeHeight and applies store upgrades
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+	}
 
 	// initialize stores
 	app.MountKVStores(keys)

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -13,6 +13,8 @@ import (
 // for both the current (n) and the previous (n-1) upgrade name. There is a bug
 // in a missing value in a log statement for which the fix is not released
 var upgradesList = []string{
+	// 1.0.2beta
+	"1.0.2beta",
 	// 1.0.3beta
 	"1.0.3beta",
 	// 1.0.4beta

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -13,6 +13,10 @@ import (
 // for both the current (n) and the previous (n-1) upgrade name. There is a bug
 // in a missing value in a log statement for which the fix is not released
 var upgradesList = []string{
+	// 1.0.3beta
+	"1.0.3beta",
+	// 1.0.4beta
+	"1.0.4beta",
 	// 1.0.5beta
 	"1.0.5beta upgrade",
 	// 1.0.6beta


### PR DESCRIPTION
Ran into this when doing internal upgrade. Fixed by adding prev upgrade handlers
```
4:32AM INF Replay last block using real app module=consensus
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x165dbcd]

goroutine 1 [running]:
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.func1()
	/root/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.6.3/trace/span.go:359 +0x2a
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc0000c6600, {0x0, 0x0, 0x35ca3c0?})
	/root/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.6.3/trace/span.go:398 +0x8dd
panic({0x1b53140, 0x3510750})
	/usr/local/go/src/runtime/panic.go:838 +0x207
github.com/cosmos/cosmos-sdk/x/upgrade.BeginBlocker({{0xc0006211a0, 0xa}, 0xc0010a7320, {0x26f77b8, 0xc0013ae6a0}, {0x2718af0, 0xc0010e03f0}, 0xc000e59440, {0x26f1940, 0xc0000c1d40}, ...}, ...)
	/root/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.45.4/x/upgrade/abci.go:38 +0x100d
github.com/cosmos/cosmos-sdk/x/upgrade.AppModule.BeginBlock(...)
	/root/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.45.4/x/upgrade/module.go:130
github.com/cosmos/cosmos-sdk/types/module.(*Manager).BeginBlock(_, {{0x270caa0, 0xc0000520a0}, {0x271a2a0, 0xc00590ba80}, {{0xb, 0x0}, {0xc0052f1c50, 0x14}, 0x14fb19, ...}, ...}, ...)
	/root/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.45.4/types/module/module.go:479 +0x3a2
github.com/sei-protocol/sei-chain/app.(*App).BeginBlocker(_, {{0x270caa0, 0xc0000520a0}, {0x271a2a0, 0xc00590ba80}, {{0xb, 0x0}, {0xc0052f1c50, 0x14}, 0x14fb19, ...}, ...}, ...)
	/home/ubuntu/sei-chain/app/app.go:718 +0x85
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).BeginBlock(_, {{0xc0058ea500, 0x20, 0x20}, {{0xb, 0x0}, {0xc0052f1c50, 0x14}, 0x14fb19, {0x1187b491, ...}, ...}, ...})
	/root/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.45.4/baseapp/abci.go:194 +0x97c
github.com/sei-protocol/sei-chain/app.(*App).BeginBlock(_, {{0xc0058ea500, 0x20, 0x20}, {{0xb, 0x0}, {0xc0052f1c50, 0x14}, 0x14fb19, {0x1187b491, ...}, ...}, ...})
	/home/ubuntu/sei-chain/app/abci.go:17 +0x3a5
github.com/tendermint/tendermint/abci/client.(*localClient).BeginBlockSync(_, {{0xc0058ea500, 0x20, 0x20}, {{0xb, 0x0}, {0xc0052f1c50, 0x14}, 0x14fb19, {0x1187b491, ...}, ...}, ...})
	/root/go/pkg/mod/github.com/tendermint/tendermint@v0.34.19/abci/client/local_client.go:280 +0x118
github.com/tendermint/tendermint/proxy.(*appConnConsensus).BeginBlockSync(_, {{0xc0058ea500, 0x20, 0x20}, {{0xb, 0x0}, {0xc0052f1c50, 0x14}, 0x14fb19, {0x1187b491, ...}, ...}, ...})
	/root/go/pkg/mod/github.com/tendermint/tendermint@v0.34.19/proxy/app_conn.go:81 +0x55
github.com/tendermint/tendermint/state.execBlockOnProxyApp({0x270dbb0?, 0xc0054a3ce0}, {0x2713458, 0xc0013782e0}, 0xc0000012c0, {0x2719420, 0xc001279510}, 0x14fb18?)
	/root/go/pkg/mod/github.com/tendermint/tendermint@v0.34.19/state/execution.go:307 +0x3dd
github.com/tendermint/tendermint/state.(*BlockExecutor).ApplyBlock(_, {{{0xb, 0x0}, {0xc0055d5a20, 0x7}}, {0xc0052f16e0, 0x14}, 0x1, 0x14fb18, {{0xc0055bc1a0, ...}, ...}, ...}, ...)
	/root/go/pkg/mod/github.com/tendermint/tendermint@v0.34.19/state/execution.go:140 +0x171
github.com/tendermint/tendermint/consensus.(*Handshaker).replayBlock(_, {{{0xb, 0x0}, {0xc0055d5a20, 0x7}}, {0xc0052f16e0, 0x14}, 0x1, 0x14fb18, {{0xc0055bc1a0, ...}, ...}, ...}, ...)
	/root/go/pkg/mod/github.com/tendermint/tendermint@v0.34.19/consensus/replay.go:503 +0x23c
github.com/tendermint/tendermint/consensus.(*Handshaker).ReplayBlocks(_, {{{0xb, 0x0}, {0xc0055d5a20, 0x7}}, {0xc0052f16e0, 0x14}, 0x1, 0x14fb18, {{0xc0055bc1a0, ...}, ...}, ...}, ...)
	/root/go/pkg/mod/github.com/tendermint/tendermint@v0.34.19/consensus/replay.go:416 +0x7ae
github.com/tendermint/tendermint/consensus.(*Handshaker).Handshake(0xc001225fd0, {0x271ab00, 0xc0011c2d00})
	/root/go/pkg/mod/github.com/tendermint/tendermint@v0.34.19/consensus/replay.go:268 +0x3c8
github.com/tendermint/tendermint/node.doHandshake({_, _}, {{{0xb, 0x0}, {0xc0055d5a20, 0x7}}, {0xc0052f16e0, 0x14}, 0x1, 0x14fb18, ...}, ...)
	/root/go/pkg/mod/github.com/tendermint/tendermint@v0.34.19/node/node.go:325 +0x1b8
github.com/tendermint/tendermint/node.NewNode(0xc00110c780, {0x2709870, 0xc000d874a0}, 0xc0010e0350, {0x26f2960, 0xc004649ad0}, 0x0?, 0x0?, 0xc0010e05a0, {0x270dbb0, ...}, ...)
	/root/go/pkg/mod/github.com/tendermint/tendermint@v0.34.19/node/node.go:733 +0x577
github.com/cosmos/cosmos-sdk/server.startInProcess(_, {{0x0, 0x0, 0x0}, {0x2721898, 0xc0011dbbc0}, {0x0, 0x0}, {0x2711290, 0xc001011890}, ...}, ...)
	/root/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.45.4/server/start.go:272 +0x7db
github.com/cosmos/cosmos-sdk/server.StartCmd.func2(0xc00112d180?, {0x36013a8?, 0x0?, 0x0?})
	/root/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.45.4/server/start.go:126 +0x169
github.com/spf13/cobra.(*Command).execute(0xc00112d180, {0x36013a8, 0x0, 0x0})
	/root/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:856 +0x67c
github.com/spf13/cobra.(*Command).ExecuteC(0xc000165400)
	/root/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:974 +0x3b4
github.com/spf13/cobra.(*Command).Execute(...)
	/root/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:902
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	/root/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:895
github.com/cosmos/cosmos-sdk/server/cmd.Execute(0x0?, {0xc0006211a0, 0xa})
	/root/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.45.4/server/cmd/execute.go:36 +0x1eb
main.main()
	/home/ubuntu/sei-chain/cmd/seid/main.go:16 +0x31
```