### PR TITLE
Decrease oracle quorum lower bound

### DIFF
--- a/x/oracle/types/params.go
+++ b/x/oracle/types/params.go
@@ -138,8 +138,8 @@ func validateVoteThreshold(i interface{}) error {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
 
-	if v.LT(sdk.NewDecWithPrec(33, 2)) {
-		return fmt.Errorf("vote threshold must be bigger than 33%%: %s", v)
+	if v.LT(sdk.ZeroDec()) {
+		return fmt.Errorf("vote threshold must be bigger than 0%%: %s", v)
 	}
 
 	if v.GT(sdk.OneDec()) {


### PR DESCRIPTION
We need lower the oracle quorum to enable the oracle in the incentivized testnet