### PR TITLE
Add whitelist store utility

### DIFF
--- a/store/testutils.go
+++ b/store/testutils.go
@@ -1,0 +1,19 @@
+package store
+
+import (
+	"github.com/cosmos/cosmos-sdk/store/cachekv"
+	"github.com/cosmos/cosmos-sdk/store/cachemulti"
+	"github.com/cosmos/cosmos-sdk/store/dbadapter"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/cosmos/cosmos-sdk/types"
+	dbm "github.com/tendermint/tm-db"
+)
+
+func NewTestKVStore() types.KVStore {
+	mem := dbadapter.Store{DB: dbm.NewMemDB()}
+	return cachekv.NewStore(mem)
+}
+
+func NewTestCacheMultiStore(stores map[types.StoreKey]types.CacheWrapper) types.CacheMultiStore {
+	return cachemulti.NewStore(dbm.NewMemDB(), stores, map[string]types.StoreKey{}, nil, nil, make(map[types.StoreKey][]storetypes.WriteListener))
+}

--- a/store/whitelist/cachemulti/store.go
+++ b/store/whitelist/cachemulti/store.go
@@ -1,0 +1,36 @@
+package cachemulti
+
+import (
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/sei-protocol/sei-chain/store/whitelist/kv"
+)
+
+// Since `CacheMultiStore` has a method with the same name, we have to
+// type alias here or otherwise we won't be able to inherit or implement
+// `CacheMultiStore` the method.
+type sdkCacheMultiStore = storetypes.CacheMultiStore
+
+type Store struct {
+	sdkCacheMultiStore
+
+	storeKeyToWriteWhitelist map[storetypes.StoreKey][]string
+}
+
+func NewStore(parent storetypes.CacheMultiStore, storeKeyToWriteWhitelist map[storetypes.StoreKey][]string) storetypes.CacheMultiStore {
+	return &Store{
+		sdkCacheMultiStore:       parent,
+		storeKeyToWriteWhitelist: storeKeyToWriteWhitelist,
+	}
+}
+
+func (cms Store) CacheMultiStore() storetypes.CacheMultiStore {
+	return NewStore(cms.sdkCacheMultiStore.CacheMultiStore(), cms.storeKeyToWriteWhitelist)
+}
+
+func (cms Store) GetKVStore(key storetypes.StoreKey) storetypes.KVStore {
+	rawKVStore := cms.sdkCacheMultiStore.GetKVStore(key)
+	if writeWhitelist, ok := cms.storeKeyToWriteWhitelist[key]; ok {
+		return kv.NewStore(rawKVStore, writeWhitelist)
+	}
+	return rawKVStore
+}

--- a/store/whitelist/cachemulti/store_test.go
+++ b/store/whitelist/cachemulti/store_test.go
@@ -1,0 +1,53 @@
+package cachemulti_test
+
+import (
+	"testing"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/store"
+	"github.com/sei-protocol/sei-chain/store/whitelist/cachemulti"
+	"github.com/stretchr/testify/require"
+)
+
+var WhitelistedStoreKey = storetypes.NewKVStoreKey("whitelisted")
+var NotWhitelistedStoreKey = storetypes.NewKVStoreKey("not-whitelisted")
+var TestStoreKeyToWriteWhitelist = map[storetypes.StoreKey][]string{
+	WhitelistedStoreKey: {"foo"},
+}
+
+func TestWhitelistEnabledStore(t *testing.T) {
+	stores := map[types.StoreKey]types.CacheWrapper{
+		WhitelistedStoreKey: store.NewTestKVStore(),
+	}
+	multistore := store.NewTestCacheMultiStore(stores)
+	whitelistMultistore := cachemulti.NewStore(multistore, TestStoreKeyToWriteWhitelist)
+	kvStore := whitelistMultistore.GetKVStore(WhitelistedStoreKey)
+	require.Panics(t, func() { kvStore.Delete([]byte("bar")) })
+	require.NotPanics(t, func() { kvStore.Delete([]byte("foo")) })
+}
+
+func TestWhitelistDisabledStore(t *testing.T) {
+	stores := map[types.StoreKey]types.CacheWrapper{
+		WhitelistedStoreKey:    store.NewTestKVStore(),
+		NotWhitelistedStoreKey: store.NewTestKVStore(),
+	}
+	multistore := store.NewTestCacheMultiStore(stores)
+	whitelistMultistore := cachemulti.NewStore(multistore, TestStoreKeyToWriteWhitelist)
+	kvStore := whitelistMultistore.GetKVStore(NotWhitelistedStoreKey)
+	require.NotPanics(t, func() { kvStore.Delete([]byte("bar")) })
+	require.NotPanics(t, func() { kvStore.Delete([]byte("foo")) })
+}
+
+func TestCacheStillWhitelist(t *testing.T) {
+	stores := map[types.StoreKey]types.CacheWrapper{
+		WhitelistedStoreKey:    store.NewTestKVStore(),
+		NotWhitelistedStoreKey: store.NewTestKVStore(),
+	}
+	multistore := store.NewTestCacheMultiStore(stores)
+	whitelistMultistore := cachemulti.NewStore(multistore, TestStoreKeyToWriteWhitelist)
+	cacheWhitelistMultistore := whitelistMultistore.CacheMultiStore()
+	kvStore := cacheWhitelistMultistore.GetKVStore(WhitelistedStoreKey)
+	require.Panics(t, func() { kvStore.Delete([]byte("bar")) })
+	require.NotPanics(t, func() { kvStore.Delete([]byte("foo")) })
+}

--- a/store/whitelist/kv/store.go
+++ b/store/whitelist/kv/store.go
@@ -2,6 +2,7 @@ package kv
 
 import (
 	"fmt"
+	"strings"
 
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 )
@@ -35,9 +36,12 @@ func (store *Store) Delete(key []byte) {
 
 func (store *Store) validateKeyForWrite(key []byte) {
 	keyStr := string(key)
-	if _, ok := store.writeWhitelist[string(key)]; !ok {
-		// Panic since the Store interface does not return error on Set. Can be
-		// intercepted by calling routine through `err := recover()`
-		panic(fmt.Sprintf("Setting disallowed key %s in whitelisted KV store", keyStr))
+	for whitelist := range store.writeWhitelist {
+		if strings.HasPrefix(keyStr, whitelist) {
+			return
+		}
 	}
+	// Panic since the Store interface does not return error on Set. Can be
+	// intercepted by calling routine through `err := recover()`
+	panic(fmt.Sprintf("Setting disallowed key %s in whitelisted KV store", keyStr))
 }

--- a/store/whitelist/kv/store.go
+++ b/store/whitelist/kv/store.go
@@ -1,0 +1,43 @@
+package kv
+
+import (
+	"fmt"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+)
+
+type Store struct {
+	storetypes.KVStore
+
+	writeWhitelist map[string]struct{}
+}
+
+func NewStore(parent storetypes.KVStore, writeWhitelistKeys []string) storetypes.KVStore {
+	writeWhitelist := map[string]struct{}{}
+	for _, writeWhitelistKey := range writeWhitelistKeys {
+		writeWhitelist[writeWhitelistKey] = struct{}{}
+	}
+	return &Store{
+		KVStore:        parent,
+		writeWhitelist: writeWhitelist,
+	}
+}
+
+func (store *Store) Set(key []byte, value []byte) {
+	store.validateKeyForWrite(key)
+	store.KVStore.Set(key, value)
+}
+
+func (store *Store) Delete(key []byte) {
+	store.validateKeyForWrite(key)
+	store.KVStore.Delete(key)
+}
+
+func (store *Store) validateKeyForWrite(key []byte) {
+	keyStr := string(key)
+	if _, ok := store.writeWhitelist[string(key)]; !ok {
+		// Panic since the Store interface does not return error on Set. Can be
+		// intercepted by calling routine through `err := recover()`
+		panic(fmt.Sprintf("Setting disallowed key %s in whitelisted KV store", keyStr))
+	}
+}

--- a/store/whitelist/kv/store_test.go
+++ b/store/whitelist/kv/store_test.go
@@ -14,40 +14,48 @@ var TestWhiteList = []string{"foo"}
 func TestWhitelistedSet(t *testing.T) {
 	whitelistedStore := kv.NewStore(store.NewTestKVStore(), TestWhiteList)
 	require.NotPanics(t, func() { whitelistedStore.Set([]byte("foo"), []byte("val")) })
+	require.NotPanics(t, func() { whitelistedStore.Set([]byte("foofoo"), []byte("val")) })
 }
 
 func TestNotWhitelistedSet(t *testing.T) {
 	whitelistedStore := kv.NewStore(store.NewTestKVStore(), TestWhiteList)
 	require.Panics(t, func() { whitelistedStore.Set([]byte("bar"), []byte("val")) })
+	require.Panics(t, func() { whitelistedStore.Set([]byte("barfoo"), []byte("val")) })
 }
 
 func TestWhitelistedDelete(t *testing.T) {
 	whitelistedStore := kv.NewStore(store.NewTestKVStore(), TestWhiteList)
 	require.NotPanics(t, func() { whitelistedStore.Delete([]byte("foo")) })
+	require.NotPanics(t, func() { whitelistedStore.Set([]byte("foofoo"), []byte("val")) })
 }
 
 func TestNotWhitelistedDelete(t *testing.T) {
 	whitelistedStore := kv.NewStore(store.NewTestKVStore(), TestWhiteList)
 	require.Panics(t, func() { whitelistedStore.Delete([]byte("bar")) })
+	require.Panics(t, func() { whitelistedStore.Set([]byte("barfoo"), []byte("val")) })
 }
 
 // Read should never panic
 func TestWhitelistedHas(t *testing.T) {
 	whitelistedStore := kv.NewStore(store.NewTestKVStore(), TestWhiteList)
 	require.NotPanics(t, func() { whitelistedStore.Has([]byte("foo")) })
+	require.NotPanics(t, func() { whitelistedStore.Set([]byte("foofoo"), []byte("val")) })
 }
 
 func TestNotWhitelistedHas(t *testing.T) {
 	whitelistedStore := kv.NewStore(store.NewTestKVStore(), TestWhiteList)
 	require.NotPanics(t, func() { whitelistedStore.Has([]byte("bar")) })
+	require.Panics(t, func() { whitelistedStore.Set([]byte("barfoo"), []byte("val")) })
 }
 
 func TestWhitelistedGet(t *testing.T) {
 	whitelistedStore := kv.NewStore(store.NewTestKVStore(), TestWhiteList)
 	require.NotPanics(t, func() { whitelistedStore.Get([]byte("foo")) })
+	require.NotPanics(t, func() { whitelistedStore.Set([]byte("foofoo"), []byte("val")) })
 }
 
 func TestNotWhitelistedGet(t *testing.T) {
 	whitelistedStore := kv.NewStore(store.NewTestKVStore(), TestWhiteList)
 	require.NotPanics(t, func() { whitelistedStore.Get([]byte("bar")) })
+	require.Panics(t, func() { whitelistedStore.Set([]byte("barfoo"), []byte("val")) })
 }

--- a/store/whitelist/kv/store_test.go
+++ b/store/whitelist/kv/store_test.go
@@ -1,0 +1,53 @@
+package kv_test
+
+import (
+	"testing"
+
+	"github.com/sei-protocol/sei-chain/store"
+	"github.com/sei-protocol/sei-chain/store/whitelist/kv"
+	"github.com/stretchr/testify/require"
+)
+
+var TestWhiteList = []string{"foo"}
+
+// Write should only panic if key is not whitelisted
+func TestWhitelistedSet(t *testing.T) {
+	whitelistedStore := kv.NewStore(store.NewTestKVStore(), TestWhiteList)
+	require.NotPanics(t, func() { whitelistedStore.Set([]byte("foo"), []byte("val")) })
+}
+
+func TestNotWhitelistedSet(t *testing.T) {
+	whitelistedStore := kv.NewStore(store.NewTestKVStore(), TestWhiteList)
+	require.Panics(t, func() { whitelistedStore.Set([]byte("bar"), []byte("val")) })
+}
+
+func TestWhitelistedDelete(t *testing.T) {
+	whitelistedStore := kv.NewStore(store.NewTestKVStore(), TestWhiteList)
+	require.NotPanics(t, func() { whitelistedStore.Delete([]byte("foo")) })
+}
+
+func TestNotWhitelistedDelete(t *testing.T) {
+	whitelistedStore := kv.NewStore(store.NewTestKVStore(), TestWhiteList)
+	require.Panics(t, func() { whitelistedStore.Delete([]byte("bar")) })
+}
+
+// Read should never panic
+func TestWhitelistedHas(t *testing.T) {
+	whitelistedStore := kv.NewStore(store.NewTestKVStore(), TestWhiteList)
+	require.NotPanics(t, func() { whitelistedStore.Has([]byte("foo")) })
+}
+
+func TestNotWhitelistedHas(t *testing.T) {
+	whitelistedStore := kv.NewStore(store.NewTestKVStore(), TestWhiteList)
+	require.NotPanics(t, func() { whitelistedStore.Has([]byte("bar")) })
+}
+
+func TestWhitelistedGet(t *testing.T) {
+	whitelistedStore := kv.NewStore(store.NewTestKVStore(), TestWhiteList)
+	require.NotPanics(t, func() { whitelistedStore.Get([]byte("foo")) })
+}
+
+func TestNotWhitelistedGet(t *testing.T) {
+	whitelistedStore := kv.NewStore(store.NewTestKVStore(), TestWhiteList)
+	require.NotPanics(t, func() { whitelistedStore.Get([]byte("bar")) })
+}

--- a/store/whitelist/multi/store.go
+++ b/store/whitelist/multi/store.go
@@ -1,0 +1,32 @@
+package multi
+
+import (
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/sei-protocol/sei-chain/store/whitelist/cachemulti"
+	"github.com/sei-protocol/sei-chain/store/whitelist/kv"
+)
+
+type Store struct {
+	storetypes.MultiStore
+
+	storeKeyToWriteWhitelist map[storetypes.StoreKey][]string
+}
+
+func NewStore(parent storetypes.MultiStore, storeKeyToWriteWhitelist map[storetypes.StoreKey][]string) storetypes.MultiStore {
+	return &Store{
+		MultiStore:               parent,
+		storeKeyToWriteWhitelist: storeKeyToWriteWhitelist,
+	}
+}
+
+func (cms Store) CacheMultiStore() storetypes.CacheMultiStore {
+	return cachemulti.NewStore(cms.MultiStore.CacheMultiStore(), cms.storeKeyToWriteWhitelist)
+}
+
+func (cms Store) GetKVStore(key storetypes.StoreKey) storetypes.KVStore {
+	rawKVStore := cms.MultiStore.GetKVStore(key)
+	if writeWhitelist, ok := cms.storeKeyToWriteWhitelist[key]; ok {
+		return kv.NewStore(rawKVStore, writeWhitelist)
+	}
+	return rawKVStore
+}

--- a/store/whitelist/multi/store_test.go
+++ b/store/whitelist/multi/store_test.go
@@ -1,0 +1,53 @@
+package multi_test
+
+import (
+	"testing"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/store"
+	"github.com/sei-protocol/sei-chain/store/whitelist/multi"
+	"github.com/stretchr/testify/require"
+)
+
+var WhitelistedStoreKey = storetypes.NewKVStoreKey("whitelisted")
+var NotWhitelistedStoreKey = storetypes.NewKVStoreKey("not-whitelisted")
+var TestStoreKeyToWriteWhitelist = map[storetypes.StoreKey][]string{
+	WhitelistedStoreKey: {"foo"},
+}
+
+func TestWhitelistEnabledStore(t *testing.T) {
+	stores := map[types.StoreKey]types.CacheWrapper{
+		WhitelistedStoreKey: store.NewTestKVStore(),
+	}
+	multistore := store.NewTestCacheMultiStore(stores)
+	whitelistMultistore := multi.NewStore(multistore, TestStoreKeyToWriteWhitelist)
+	kvStore := whitelistMultistore.GetKVStore(WhitelistedStoreKey)
+	require.Panics(t, func() { kvStore.Delete([]byte("bar")) })
+	require.NotPanics(t, func() { kvStore.Delete([]byte("foo")) })
+}
+
+func TestWhitelistDisabledStore(t *testing.T) {
+	stores := map[types.StoreKey]types.CacheWrapper{
+		WhitelistedStoreKey:    store.NewTestKVStore(),
+		NotWhitelistedStoreKey: store.NewTestKVStore(),
+	}
+	multistore := store.NewTestCacheMultiStore(stores)
+	whitelistMultistore := multi.NewStore(multistore, TestStoreKeyToWriteWhitelist)
+	kvStore := whitelistMultistore.GetKVStore(NotWhitelistedStoreKey)
+	require.NotPanics(t, func() { kvStore.Delete([]byte("bar")) })
+	require.NotPanics(t, func() { kvStore.Delete([]byte("foo")) })
+}
+
+func TestCacheStillWhitelist(t *testing.T) {
+	stores := map[types.StoreKey]types.CacheWrapper{
+		WhitelistedStoreKey:    store.NewTestKVStore(),
+		NotWhitelistedStoreKey: store.NewTestKVStore(),
+	}
+	multistore := store.NewTestCacheMultiStore(stores)
+	whitelistMultistore := multi.NewStore(multistore, TestStoreKeyToWriteWhitelist)
+	cacheWhitelistMultistore := whitelistMultistore.CacheMultiStore()
+	kvStore := cacheWhitelistMultistore.GetKVStore(WhitelistedStoreKey)
+	require.Panics(t, func() { kvStore.Delete([]byte("bar")) })
+	require.NotPanics(t, func() { kvStore.Delete([]byte("foo")) })
+}


### PR DESCRIPTION
Add store wrapper such that only writes to whitelisted keys are permitted. Reads are not affected by the whitelist and can be made against any key.

These stores will be used to ensure no race condition during parallel execution. Specifically, each goroutine can instantiate a whitelisted MultiStore and set it to its context. The goroutine would then only be able to write to the whitelisted keys and thus prevent any race condition unless the same key is whitelisted in multiple concurrent goroutines.