### PR TITLE
Handle error when fetching price data

### DIFF
--- a/scripts/oracle/price_feeder.py
+++ b/scripts/oracle/price_feeder.py
@@ -115,6 +115,12 @@ class PriceFeeder:
             current_vote_period = self.get_current_vote_period()
             if last_combined_voted_period < current_vote_period:
                 prevote_prices = pf.create_price_feed(coins)
+
+                if prevote_prices is None or vote_prices is None:
+                    print ("No price data available, sleep 60")
+                    time.sleep(60)
+                    continue
+
                 print("submitting price feeds ", vote_prices, prevote_prices)
                 self.combined_vote_for_period(vote_prices, prevote_prices, salt)
                 vote_prices = prevote_prices

--- a/scripts/oracle/price_fetcher.py
+++ b/scripts/oracle/price_fetcher.py
@@ -18,7 +18,10 @@ class PriceFetcher:
 
     def create_price_feed(self, coin_list):
         price_feed = "1usei," # default 1 SEI to 1 USDC, will need to change once SEI price is available
-        usdc_conversion_rate = self.cg.get_price(ids='usd-coin', vs_currencies='usd')
+        try:
+            usdc_conversion_rate = self.cg.get_price(ids='usd-coin', vs_currencies='usd')
+        except:
+            return
 
         for coin in coin_list:
             coin_price = self.cg.get_price(ids=coin, vs_currencies='usd')


### PR DESCRIPTION
Fixes a crash when API limit is hit when fetching price data. And sleep 60 seconds in this case to make sure we have quota for the next price query.