### PR TITLE
Catch all panics in DEX EndBlock

### DIFF
--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -259,7 +259,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) (ret []abc
 		if err := recover(); err != nil {
 			ctx.Logger().Error(fmt.Sprintf("panic occurred in dex EndBlock: %s", err))
 			telemetry.IncrCounterWithLabels(
-				[]string{types.ModuleName, "endblockpanic"},
+				[]string{fmt.Sprintf("%s%s", types.ModuleName, "endblockpanic")},
 				1,
 				[]metrics.Label{
 					telemetry.NewLabel("error", fmt.Sprintf("%s", err)),


### PR DESCRIPTION
For now we will catch all panics in EndBlock so that bugs won't cause the chain to be halted. Each panic will result in a metric being incremented with the error description as the label.

We will need to remove this catch before mainnet launch to prevent silent failing