### PR TITLE
Add catch-all for all custom modules

### DIFF
--- a/x/epoch/module.go
+++ b/x/epoch/module.go
@@ -6,6 +6,7 @@ import (
 
 	// this line is used by starport scaffolding # 1
 
+	"github.com/armon/go-metrics"
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
@@ -15,6 +16,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/sei-protocol/sei-chain/x/epoch/client/cli"
@@ -170,6 +172,20 @@ func (AppModule) ConsensusVersion() uint64 { return 2 }
 
 // BeginBlock executes all ABCI BeginBlock logic respective to the capability module.
 func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
+	// TODO (codchen): Revert before mainnet so we don't silently fail on errors
+	defer func() {
+		if err := recover(); err != nil {
+			ctx.Logger().Error(fmt.Sprintf("panic occurred in %s BeginBlock: %s", types.ModuleName, err))
+			telemetry.IncrCounterWithLabels(
+				[]string{fmt.Sprintf("%s%s", types.ModuleName, "beginblockpanic")},
+				1,
+				[]metrics.Label{
+					telemetry.NewLabel("error", fmt.Sprintf("%s", err)),
+				},
+			)
+		}
+	}()
+
 	lastEpoch := am.keeper.GetEpoch(ctx)
 	ctx.Logger().Info(fmt.Sprintf("Current block time %s, last %s; duration %d", ctx.BlockTime().String(), lastEpoch.CurrentEpochStartTime.String(), lastEpoch.EpochDuration))
 	if ctx.BlockTime().Sub(lastEpoch.CurrentEpochStartTime) > lastEpoch.EpochDuration {

--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 
+	"github.com/armon/go-metrics"
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
@@ -14,6 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
@@ -148,6 +150,20 @@ func (AppModule) ConsensusVersion() uint64 { return 1 }
 
 // BeginBlock returns the begin blocker for the mint module.
 func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
+	// TODO (codchen): Revert before mainnet so we don't silently fail on errors
+	defer func() {
+		if err := recover(); err != nil {
+			ctx.Logger().Error(fmt.Sprintf("panic occurred in %s BeginBlock: %s", types.ModuleName, err))
+			telemetry.IncrCounterWithLabels(
+				[]string{fmt.Sprintf("%s%s", types.ModuleName, "beginblockpanic")},
+				1,
+				[]metrics.Label{
+					telemetry.NewLabel("error", fmt.Sprintf("%s", err)),
+				},
+			)
+		}
+	}()
+
 	BeginBlocker(ctx, am.keeper)
 }
 


### PR DESCRIPTION
Since we have custom logics for:
- `epoch` BeginBlock
- `dex` BeginBlock and EndBlock
- `mint` BeginBlock
- `oracle` EndBlock

We will also be adding catch-all logics just for the testing phase so that the chain isn't halted frequently. These need to be removed before mainnet launch.