### PR TITLE
Fixes for loadtest

### DIFF
--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -109,10 +109,7 @@ func run(config Config) {
 	defer grpcConn.Close()
 	TxClient = typestx.NewServiceClient(grpcConn)
 	userHomeDir, _ := os.UserHomeDir()
-	err := os.Mkdir(filepath.Join(userHomeDir, "outputs"), os.ModePerm)
-	if err != nil {
-		panic(err)
-	}
+	_ = os.Mkdir(filepath.Join(userHomeDir, "outputs"), os.ModePerm)
 	filename := filepath.Join(userHomeDir, "outputs", "test_tx_hash")
 	_ = os.Remove(filename)
 	file, _ := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)

--- a/loadtest/sign.go
+++ b/loadtest/sign.go
@@ -42,7 +42,7 @@ func GetKey(accountIdx uint64) cryptotypes.PrivKey {
 	if err := json.Unmarshal(byteVal, &accountInfo); err != nil {
 		panic(err)
 	}
-	kr, _ := keyring.New(sdk.KeyringServiceName(), "os", filepath.Join(userHomeDir, ".sei-chain"), os.Stdin)
+	kr, _ := keyring.New(sdk.KeyringServiceName(), "test", filepath.Join(userHomeDir, ".sei"), os.Stdin)
 	keyringAlgos, _ := kr.SupportedAlgorithms()
 	algoStr := string(hd.Secp256k1Type)
 	algo, _ := keyring.NewSigningAlgoFromString(algoStr, keyringAlgos)
@@ -98,6 +98,9 @@ func GetAccountNumberSequenceNumber(privKey cryptotypes.PrivKey) (uint64, uint64
 	context = context.WithNodeURI(NodeURI)
 	context = context.WithClient(cl)
 	context = context.WithInterfaceRegistry(TestConfig.InterfaceRegistry)
+	userHomeDir, _ := os.UserHomeDir()
+	kr, _ := keyring.New(sdk.KeyringServiceName(), "test", filepath.Join(userHomeDir, ".sei"), os.Stdin)
+	context = context.WithKeyring(kr)
 	account, seq, err := accountRetriever.GetAccountNumberSequence(context, address)
 	if err != nil {
 		time.Sleep(5 * time.Second)


### PR DESCRIPTION
Fixes error on `/root/outputs` dir already existing when creating a file. Also uses "test" keyring backend so no password is required, and fixes homedir to be .sei