### PR TITLE
Update ContractInfo data structure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,9 +22,9 @@ require (
 	go.opentelemetry.io/otel/exporters/jaeger v1.6.3
 	go.opentelemetry.io/otel/sdk v1.6.3
 	go.opentelemetry.io/otel/trace v1.6.3
-	google.golang.org/genproto v0.0.0-20220719170305-83ca9fad585f
+	google.golang.org/genproto v0.0.0-20220728213248-dd149ef739b9
 	google.golang.org/grpc v1.48.0
-	google.golang.org/protobuf v1.28.0
+	google.golang.org/protobuf v1.28.1
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -74,7 +74,7 @@ require (
 	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.1 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/gtank/merlin v0.1.1 // indirect
 	github.com/gtank/ristretto255 v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -508,6 +508,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.3 h1:BGNSrTRW4rwfhJiFwvwF4XQ0Y72
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.3/go.mod h1:VHn7KgNsRriXa4mcgtkpR00OXyQY6g67JWMvn+R27A4=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.0 h1:Ghn7copILfeIg0y8sTGRppI1bd8I4l2VN3cob0Xeqwg=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.0/go.mod h1:dnjr4snxnhRSn5GWqJUva2AoMbeaxyAcepvc0Tg8lXk=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.1 h1:/sDbPb60SusIXjiJGYLUoS/rAQurQmvGWmwn2bBPM9c=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.1/go.mod h1:G+WkljZi4mflcqVxYSgvt8MNctRQHjEH8ubKtt1Ka3w=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/gtank/merlin v0.1.1-0.20191105220539-8318aed1a79f/go.mod h1:T86dnYJhcGOh5BjZFCJWTDeTK7XW8uE+E21Cy/bIQ+s=
@@ -1525,6 +1527,8 @@ google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd h1:e0TwkXOdbnH/1x5
 google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/genproto v0.0.0-20220719170305-83ca9fad585f h1:P8EiVSxZwC6xH2niv2N66aqwMtYFg+D54gbjpcqKJtM=
 google.golang.org/genproto v0.0.0-20220719170305-83ca9fad585f/go.mod h1:GkXuJDJ6aQ7lnJcRF+SJVgFdQhypqgl3LB1C9vabdRE=
+google.golang.org/genproto v0.0.0-20220728213248-dd149ef739b9 h1:d3fKQZK+1rWQMg3xLKQbPMirUCo29I/NRdI2WarSzTg=
+google.golang.org/genproto v0.0.0-20220728213248-dd149ef739b9/go.mod h1:iHe1svFLAZg9VWz891+QbRMwUv9O/1Ww+/mngYeThbc=
 google.golang.org/grpc v1.33.2 h1:EQyQC3sa8M+p6Ulc8yy9SWSS2GVwyRc83gAbG8lrl4o=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
@@ -1543,6 +1547,8 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/proto/dex/contract.proto
+++ b/proto/dex/contract.proto
@@ -6,7 +6,22 @@ option go_package = "github.com/sei-protocol/sei-chain/x/dex/types";
 message ContractInfo {
   uint64 codeId = 1;
   string contractAddr = 2;
-  bool NeedHook = 3;
-  bool NeedOrderMatching = 4;
+  bool needHook = 3;
+  bool needOrderMatching = 4;
+  repeated ContractDependencyInfo dependencies = 5;
+  int64 numIncomingDependencies = 6;
+}
+
+message ContractDependencyInfo {
+  string dependency = 1;
+  string immediateElderSibling = 2;
+  string immediateYoungerSibling = 3;
+}
+
+message LegacyContractInfo {
+  uint64 codeId = 1;
+  string contractAddr = 2;
+  bool needHook = 3;
+  bool needOrderMatching = 4;
   repeated string dependentContractAddrs = 5;
 }

--- a/utils/slice.go
+++ b/utils/slice.go
@@ -9,3 +9,11 @@ func FilterUInt64Slice(slice []uint64, item uint64) []uint64 {
 	}
 	return res
 }
+
+func Map[I any, O any](input []I, lambda func(i I) O) []O {
+	res := []O{}
+	for _, i := range input {
+		res = append(res, lambda(i))
+	}
+	return res
+}

--- a/utils/slice_test.go
+++ b/utils/slice_test.go
@@ -13,3 +13,12 @@ func TestFilterUInt64Slice(t *testing.T) {
 	filteredS := utils.FilterUInt64Slice(s, uint64(toBeFiltered))
 	require.Equal(t, []uint64{1, 3}, filteredS)
 }
+
+func TestMap(t *testing.T) {
+	s := []int{1, 2, 3}
+	mapped := utils.Map(s, func(i int) int { return i + 1 })
+	require.Equal(t, 3, len(s))
+	require.Equal(t, 2, mapped[0])
+	require.Equal(t, 3, mapped[1])
+	require.Equal(t, 4, mapped[2])
+}

--- a/x/dex/contract/dag.go
+++ b/x/dex/contract/dag.go
@@ -47,18 +47,19 @@ func initNodes(contracts []types.ContractInfo) map[string]node {
 				incomingNodes: &emptyIncomingNodes,
 			}
 		}
-		if contract.DependentContractAddrs == nil {
+		if contract.Dependencies == nil {
 			continue
 		}
-		for _, dependentContract := range contract.DependentContractAddrs {
-			if _, ok := res[dependentContract]; !ok {
+		for _, dependentContract := range contract.Dependencies {
+			dependentAddr := dependentContract.Dependency
+			if _, ok := res[dependentAddr]; !ok {
 				emptyIncomingNodes := utils.NewStringSet([]string{})
-				res[dependentContract] = node{
-					contractAddr:  dependentContract,
+				res[dependentAddr] = node{
+					contractAddr:  dependentAddr,
 					incomingNodes: &emptyIncomingNodes,
 				}
 			}
-			res[dependentContract].incomingNodes.Add(contract.ContractAddr)
+			res[dependentAddr].incomingNodes.Add(contract.ContractAddr)
 		}
 	}
 	return res

--- a/x/dex/contract/dag_test.go
+++ b/x/dex/contract/dag_test.go
@@ -11,12 +11,20 @@ import (
 // A -> B -> C
 func TestTopologicalSortContractInfoSimple(t *testing.T) {
 	a := types.ContractInfo{
-		ContractAddr:           "A",
-		DependentContractAddrs: []string{"B"},
+		ContractAddr: "A",
+		Dependencies: []*types.ContractDependencyInfo{
+			{
+				Dependency: "B",
+			},
+		},
 	}
 	b := types.ContractInfo{
-		ContractAddr:           "B",
-		DependentContractAddrs: []string{"C"},
+		ContractAddr: "B",
+		Dependencies: []*types.ContractDependencyInfo{
+			{
+				Dependency: "C",
+			},
+		},
 	}
 	c := types.ContractInfo{
 		ContractAddr: "C",
@@ -31,15 +39,23 @@ func TestTopologicalSortContractInfoSimple(t *testing.T) {
 // A -> B, C -> D
 func TestTopologicalSortContractInfoIsolated(t *testing.T) {
 	a := types.ContractInfo{
-		ContractAddr:           "A",
-		DependentContractAddrs: []string{"B"},
+		ContractAddr: "A",
+		Dependencies: []*types.ContractDependencyInfo{
+			{
+				Dependency: "B",
+			},
+		},
 	}
 	b := types.ContractInfo{
 		ContractAddr: "B",
 	}
 	c := types.ContractInfo{
-		ContractAddr:           "C",
-		DependentContractAddrs: []string{"D"},
+		ContractAddr: "C",
+		Dependencies: []*types.ContractDependencyInfo{
+			{
+				Dependency: "D",
+			},
+		},
 	}
 	d := types.ContractInfo{
 		ContractAddr: "D",
@@ -65,16 +81,28 @@ func TestTopologicalSortContractInfoIsolated(t *testing.T) {
 // A -> B -> C -> A
 func TestTopologicalSortContractInfoCircular(t *testing.T) {
 	a := types.ContractInfo{
-		ContractAddr:           "A",
-		DependentContractAddrs: []string{"B"},
+		ContractAddr: "A",
+		Dependencies: []*types.ContractDependencyInfo{
+			{
+				Dependency: "B",
+			},
+		},
 	}
 	b := types.ContractInfo{
-		ContractAddr:           "B",
-		DependentContractAddrs: []string{"C"},
+		ContractAddr: "B",
+		Dependencies: []*types.ContractDependencyInfo{
+			{
+				Dependency: "C",
+			},
+		},
 	}
 	c := types.ContractInfo{
-		ContractAddr:           "C",
-		DependentContractAddrs: []string{"A"},
+		ContractAddr: "C",
+		Dependencies: []*types.ContractDependencyInfo{
+			{
+				Dependency: "A",
+			},
+		},
 	}
 	res, err := contract.TopologicalSortContractInfo([]types.ContractInfo{b, c, a})
 	require.NotNil(t, err)

--- a/x/dex/handler.go
+++ b/x/dex/handler.go
@@ -7,15 +7,14 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	"github.com/sei-protocol/sei-chain/utils/tracing"
 	"github.com/sei-protocol/sei-chain/x/dex/keeper"
 	"github.com/sei-protocol/sei-chain/x/dex/keeper/msgserver"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 )
 
 // NewHandler ...
-func NewHandler(k keeper.Keeper, tracingInfo *tracing.Info) sdk.Handler {
-	msgServer := msgserver.NewMsgServerImpl(k, tracingInfo)
+func NewHandler(k keeper.Keeper) sdk.Handler {
+	msgServer := msgserver.NewMsgServerImpl(k)
 
 	return func(ctx sdk.Context, msg sdk.Msg) (*sdk.Result, error) {
 		ctx = ctx.WithEventManager(sdk.NewEventManager())

--- a/x/dex/keeper/contract.go
+++ b/x/dex/keeper/contract.go
@@ -9,12 +9,12 @@ import (
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 )
 
-const PrefixKey = "x-wasm-contract"
+const ContractPrefixKey = "x-wasm-contract"
 
 func (k Keeper) SetContract(ctx sdk.Context, contract *types.ContractInfo) error {
 	store := prefix.NewStore(
 		ctx.KVStore(k.storeKey),
-		[]byte(PrefixKey),
+		[]byte(ContractPrefixKey),
 	)
 	bz, err := contract.Marshal()
 	if err != nil {
@@ -25,8 +25,24 @@ func (k Keeper) SetContract(ctx sdk.Context, contract *types.ContractInfo) error
 	return nil
 }
 
+func (k Keeper) GetContract(ctx sdk.Context, contractAddr string) (types.ContractInfo, error) {
+	store := prefix.NewStore(
+		ctx.KVStore(k.storeKey),
+		[]byte(ContractPrefixKey),
+	)
+	key := contractKey(contractAddr)
+	res := types.ContractInfo{}
+	if !store.Has(key) {
+		return res, errors.New("cannot find contract info")
+	}
+	if err := res.Unmarshal(store.Get(key)); err != nil {
+		return res, errors.New("cannot parse contract info")
+	}
+	return res, nil
+}
+
 func (k Keeper) GetAllContractInfo(ctx sdk.Context) []types.ContractInfo {
-	store := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(PrefixKey))
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(ContractPrefixKey))
 	iterator := sdk.KVStorePrefixIterator(store, []byte{})
 
 	defer iterator.Close()

--- a/x/dex/keeper/msgserver/msg_server.go
+++ b/x/dex/keeper/msgserver/msg_server.go
@@ -1,20 +1,18 @@
 package msgserver
 
 import (
-	"github.com/sei-protocol/sei-chain/utils/tracing"
 	"github.com/sei-protocol/sei-chain/x/dex/keeper"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 )
 
 type msgServer struct {
 	keeper.Keeper
-	tracingInfo *tracing.Info
 }
 
 // NewMsgServerImpl returns an implementation of the MsgServer interface
 // for the provided Keeper.
-func NewMsgServerImpl(keeper keeper.Keeper, tracingInfo *tracing.Info) types.MsgServer {
-	return &msgServer{Keeper: keeper, tracingInfo: tracingInfo}
+func NewMsgServerImpl(keeper keeper.Keeper) types.MsgServer {
+	return &msgServer{Keeper: keeper}
 }
 
 var _ types.MsgServer = msgServer{}

--- a/x/dex/keeper/msgserver/msg_server_cancel_orders.go
+++ b/x/dex/keeper/msgserver/msg_server_cancel_orders.go
@@ -10,9 +10,6 @@ import (
 )
 
 func (k msgServer) CancelOrders(goCtx context.Context, msg *types.MsgCancelOrders) (*types.MsgCancelOrdersResponse, error) {
-	_, span := (*k.tracingInfo.Tracer).Start(goCtx, "CancelOrders")
-	defer span.End()
-
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	activeOrderIDSet := utils.NewUInt64Set(k.GetAccountActiveOrders(ctx, msg.ContractAddr, msg.Creator).Ids)

--- a/x/dex/keeper/msgserver/msg_server_liquidate.go
+++ b/x/dex/keeper/msgserver/msg_server_liquidate.go
@@ -8,9 +8,6 @@ import (
 )
 
 func (k msgServer) Liquidate(goCtx context.Context, msg *types.MsgLiquidation) (*types.MsgLiquidationResponse, error) {
-	_, span := (*k.tracingInfo.Tracer).Start(goCtx, "PlaceOrders")
-	defer span.End()
-
 	k.MemState.GetLiquidationRequests(
 		typesutils.ContractAddress(msg.GetContractAddr()),
 	).AddNewLiquidationRequest(msg.Creator, msg.AccountToLiquidate)

--- a/x/dex/keeper/msgserver/msg_server_place_orders_fuzz_test.go
+++ b/x/dex/keeper/msgserver/msg_server_place_orders_fuzz_test.go
@@ -59,6 +59,6 @@ func fuzzTargetPlaceOrders(
 		},
 		Funds: []sdk.Coin{fuzzutils.FuzzCoin(priceDenom, fundIsNil, fundAmount)},
 	}
-	server := msgserver.NewMsgServerImpl(*keeper, nil)
+	server := msgserver.NewMsgServerImpl(*keeper)
 	require.NotPanics(t, func() { server.PlaceOrders(wctx, msg) })
 }

--- a/x/dex/keeper/msgserver/msg_server_place_orders_test.go
+++ b/x/dex/keeper/msgserver/msg_server_place_orders_test.go
@@ -44,7 +44,7 @@ func TestPlaceOrder(t *testing.T) {
 	keeper.AddRegisteredPair(ctx, TestContract, keepertest.TestPair)
 	keeper.SetTickSizeForPair(ctx, TestContract, keepertest.TestPair, *keepertest.TestPair.Ticksize)
 	wctx := sdk.WrapSDKContext(ctx)
-	server := msgserver.NewMsgServerImpl(*keeper, nil)
+	server := msgserver.NewMsgServerImpl(*keeper)
 	res, err := server.PlaceOrders(wctx, msg)
 	require.Nil(t, err)
 	require.Equal(t, 2, len(res.OrderIds))
@@ -77,7 +77,7 @@ func TestPlaceInvalidOrder(t *testing.T) {
 			},
 		},
 	}
-	server := msgserver.NewMsgServerImpl(*keeper, nil)
+	server := msgserver.NewMsgServerImpl(*keeper)
 	_, err := server.PlaceOrders(wctx, msg)
 	require.NotNil(t, err)
 
@@ -97,7 +97,7 @@ func TestPlaceInvalidOrder(t *testing.T) {
 			},
 		},
 	}
-	server = msgserver.NewMsgServerImpl(*keeper, nil)
+	server = msgserver.NewMsgServerImpl(*keeper)
 	_, err = server.PlaceOrders(wctx, msg)
 	require.NotNil(t, err)
 
@@ -117,7 +117,7 @@ func TestPlaceInvalidOrder(t *testing.T) {
 			},
 		},
 	}
-	server = msgserver.NewMsgServerImpl(*keeper, nil)
+	server = msgserver.NewMsgServerImpl(*keeper)
 	_, err = server.PlaceOrders(wctx, msg)
 	require.NotNil(t, err)
 
@@ -139,7 +139,7 @@ func TestPlaceInvalidOrder(t *testing.T) {
 			},
 		},
 	}
-	server = msgserver.NewMsgServerImpl(*keeper, nil)
+	server = msgserver.NewMsgServerImpl(*keeper)
 	_, err = server.PlaceOrders(wctx, msg)
 	require.NotNil(t, err)
 
@@ -159,7 +159,7 @@ func TestPlaceInvalidOrder(t *testing.T) {
 			},
 		},
 	}
-	server = msgserver.NewMsgServerImpl(*keeper, nil)
+	server = msgserver.NewMsgServerImpl(*keeper)
 	_, err = server.PlaceOrders(wctx, msg)
 	require.NotNil(t, err)
 
@@ -179,7 +179,7 @@ func TestPlaceInvalidOrder(t *testing.T) {
 			},
 		},
 	}
-	server = msgserver.NewMsgServerImpl(*keeper, nil)
+	server = msgserver.NewMsgServerImpl(*keeper)
 	_, err = server.PlaceOrders(wctx, msg)
 	require.NotNil(t, err)
 }

--- a/x/dex/keeper/msgserver/msg_server_register_contract.go
+++ b/x/dex/keeper/msgserver/msg_server_register_contract.go
@@ -2,8 +2,10 @@ package msgserver
 
 import (
 	"context"
+	"errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/utils"
 	"github.com/sei-protocol/sei-chain/x/dex/contract"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 )
@@ -12,14 +14,183 @@ func (k msgServer) RegisterContract(goCtx context.Context, msg *types.MsgRegiste
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	// TODO: add validation such that only the user who stored the code can register contract
 
-	// always override contract info so that it can be updated
-	if err := k.SetContract(ctx, msg.Contract); err != nil {
+	if err := k.ValidateUniqueDependencies(msg); err != nil {
 		return &types.MsgRegisterContractResponse{}, err
 	}
-
-	if _, err := contract.TopologicalSortContractInfo(k.GetAllContractInfo(ctx)); err != nil {
+	if err := k.RemoveExistingDependencies(ctx, msg); err != nil {
+		return &types.MsgRegisterContractResponse{}, err
+	}
+	if err := k.UpdateOldSiblings(ctx, msg); err != nil {
+		return &types.MsgRegisterContractResponse{}, err
+	}
+	if err := k.UpdateNewDependencies(ctx, msg); err != nil {
+		return &types.MsgRegisterContractResponse{}, err
+	}
+	allContractInfo, err := k.SetNewContract(ctx, msg)
+	if err != nil {
+		return &types.MsgRegisterContractResponse{}, err
+	}
+	if _, err := contract.TopologicalSortContractInfo(allContractInfo); err != nil {
 		return &types.MsgRegisterContractResponse{}, err
 	}
 
 	return &types.MsgRegisterContractResponse{}, nil
+}
+
+func (k msgServer) ValidateUniqueDependencies(msg *types.MsgRegisterContract) error {
+	if msg.Contract.Dependencies == nil {
+		return nil
+	}
+	dependencySet := utils.NewStringSet(utils.Map(
+		msg.Contract.Dependencies, func(c *types.ContractDependencyInfo) string { return c.Dependency },
+	))
+	if dependencySet.Size() < len(msg.Contract.Dependencies) {
+		return errors.New("duplicated contract dependencies")
+	}
+	return nil
+}
+
+func (k msgServer) RemoveExistingDependencies(ctx sdk.Context, msg *types.MsgRegisterContract) error {
+	contractInfo, err := k.GetContract(ctx, msg.Contract.ContractAddr)
+	if err != nil {
+		// contract is being added for the first time
+		return nil
+	}
+	if contractInfo.Dependencies == nil {
+		return nil
+	}
+	// update old dependency's NumIncomingPaths
+	for _, oldDependency := range contractInfo.Dependencies {
+		dependencyInfo, err := k.GetContract(ctx, oldDependency.Dependency)
+		if err != nil {
+			// old dependency doesn't exist. Do nothing.
+			continue
+		}
+		dependencyInfo.NumIncomingDependencies--
+		if err := k.SetContract(ctx, &dependencyInfo); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (k msgServer) UpdateOldSiblings(ctx sdk.Context, msg *types.MsgRegisterContract) error {
+	contractInfo, err := k.GetContract(ctx, msg.Contract.ContractAddr)
+	if err != nil {
+		return nil
+	}
+	// update siblings for old dependencies
+	for _, oldDependency := range contractInfo.Dependencies {
+		elder := oldDependency.ImmediateElderSibling
+		younger := oldDependency.ImmediateYoungerSibling
+		if younger != "" {
+			youngContract, err := k.GetContract(ctx, younger)
+			if err != nil {
+				return err
+			}
+			for _, youngDependency := range youngContract.Dependencies {
+				if youngDependency.Dependency != oldDependency.Dependency {
+					continue
+				}
+				youngDependency.ImmediateElderSibling = elder
+				if err := k.SetContract(ctx, &youngContract); err != nil {
+					return err
+				}
+				break
+			}
+		}
+		if elder != "" {
+			elderContract, err := k.GetContract(ctx, elder)
+			if err != nil {
+				return err
+			}
+			for _, elderDependency := range elderContract.Dependencies {
+				if elderDependency.Dependency != oldDependency.Dependency {
+					continue
+				}
+				elderDependency.ImmediateYoungerSibling = younger
+				if err := k.SetContract(ctx, &elderContract); err != nil {
+					return err
+				}
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func (k msgServer) UpdateNewDependencies(ctx sdk.Context, msg *types.MsgRegisterContract) error {
+	if msg.Contract.Dependencies == nil {
+		return nil
+	}
+
+	for _, dependency := range msg.Contract.Dependencies {
+		contractInfo, err := k.GetContract(ctx, dependency.Dependency)
+		if err != nil {
+			// validate that all dependency contracts exist
+			return err
+		}
+		// update incoming paths for dependency contracts
+		contractInfo.NumIncomingDependencies++
+		if err := k.SetContract(ctx, &contractInfo); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (k msgServer) SetNewContract(ctx sdk.Context, msg *types.MsgRegisterContract) ([]types.ContractInfo, error) {
+	// set incoming paths for new contract
+	newContract := msg.Contract
+	newContract.NumIncomingDependencies = 0
+	allContractInfo := k.GetAllContractInfo(ctx)
+	for _, contractInfo := range allContractInfo {
+		if contractInfo.Dependencies == nil {
+			continue
+		}
+		dependencySet := utils.NewStringSet(utils.Map(
+			contractInfo.Dependencies, func(c *types.ContractDependencyInfo) string { return c.Dependency },
+		))
+		if dependencySet.Contains(msg.Contract.ContractAddr) {
+			newContract.NumIncomingDependencies++
+		}
+	}
+
+	// set immediate siblings
+	for _, dependency := range newContract.Dependencies {
+		// a newly added/updated contract is always the youngest among its siblings
+		dependency.ImmediateYoungerSibling = ""
+		found := false
+		for _, contractInfo := range allContractInfo {
+			for _, otherDependency := range contractInfo.Dependencies {
+				if otherDependency.ImmediateYoungerSibling != "" {
+					continue
+				}
+				if otherDependency.Dependency != dependency.Dependency {
+					continue
+				}
+				dependency.ImmediateElderSibling = contractInfo.ContractAddr
+				otherDependency.ImmediateYoungerSibling = newContract.ContractAddr
+				contractInfo := contractInfo
+				if err := k.SetContract(ctx, &contractInfo); err != nil {
+					return []types.ContractInfo{}, err
+				}
+				found = true
+				break
+			}
+			if found {
+				break
+			}
+		}
+		if !found {
+			dependency.ImmediateElderSibling = ""
+		}
+	}
+
+	// always override contract info so that it can be updated
+	if err := k.SetContract(ctx, newContract); err != nil {
+		return []types.ContractInfo{}, err
+	}
+	allContractInfo = append(allContractInfo, *newContract)
+	return allContractInfo, nil
 }

--- a/x/dex/keeper/msgserver/msg_server_register_contract_test.go
+++ b/x/dex/keeper/msgserver/msg_server_register_contract_test.go
@@ -1,10 +1,12 @@
 package msgserver_test
 
 import (
+	"context"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/utils"
 	"github.com/sei-protocol/sei-chain/x/dex/keeper/msgserver"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 	"github.com/stretchr/testify/require"
@@ -13,56 +15,131 @@ import (
 func TestRegisterContract(t *testing.T) {
 	keeper, ctx := keepertest.DexKeeper(t)
 	wctx := sdk.WrapSDKContext(ctx)
-	server := msgserver.NewMsgServerImpl(*keeper, nil)
-	contractInfo := types.ContractInfo{
-		CodeId:       1,
-		ContractAddr: keepertest.TestContract,
-	}
-	server.RegisterContract(wctx, &types.MsgRegisterContract{
-		Creator:  keepertest.TestAccount,
-		Contract: &contractInfo,
-	})
+	server := msgserver.NewMsgServerImpl(*keeper)
+	registerContract(server, wctx, keepertest.TestContract, nil)
 	storedContracts := keeper.GetAllContractInfo(ctx)
 	require.Equal(t, 1, len(storedContracts))
-	require.Nil(t, storedContracts[0].DependentContractAddrs)
+	require.Nil(t, storedContracts[0].Dependencies)
 
-	contractInfo.DependentContractAddrs = []string{"TEST2"}
-	server.RegisterContract(wctx, &types.MsgRegisterContract{
-		Creator:  keepertest.TestAccount,
-		Contract: &contractInfo,
-	})
+	// dependency doesn't exist
+	err := registerContract(server, wctx, keepertest.TestContract, []string{"TEST2"})
+	require.NotNil(t, err)
 	storedContracts = keeper.GetAllContractInfo(ctx)
 	require.Equal(t, 1, len(storedContracts))
-	require.Equal(t, 1, len(storedContracts[0].DependentContractAddrs))
 }
 
 func TestRegisterContractCircularDependency(t *testing.T) {
 	keeper, ctx := keepertest.DexKeeper(t)
 	wctx := sdk.WrapSDKContext(ctx)
-	server := msgserver.NewMsgServerImpl(*keeper, nil)
-	contractInfo1 := types.ContractInfo{
-		CodeId:                 1,
-		ContractAddr:           "test1",
-		DependentContractAddrs: []string{"test2"},
-	}
-	server.RegisterContract(wctx, &types.MsgRegisterContract{
-		Creator:  keepertest.TestAccount,
-		Contract: &contractInfo1,
-	})
+	server := msgserver.NewMsgServerImpl(*keeper)
+	registerContract(server, wctx, "test1", nil)
 	storedContracts := keeper.GetAllContractInfo(ctx)
 	require.Equal(t, 1, len(storedContracts))
-	require.Equal(t, uint64(1), storedContracts[0].CodeId)
+
+	registerContract(server, wctx, "test2", []string{"test1"})
+	storedContracts = keeper.GetAllContractInfo(ctx)
+	require.Equal(t, 2, len(storedContracts))
 
 	// This contract should fail to be registered because it causes a
 	// circular dependency
-	contractInfo2 := types.ContractInfo{
-		CodeId:                 2,
-		ContractAddr:           "test2",
-		DependentContractAddrs: []string{"test1"},
-	}
-	_, err := server.RegisterContract(wctx, &types.MsgRegisterContract{
-		Creator:  keepertest.TestAccount,
-		Contract: &contractInfo2,
-	})
+	err := registerContract(server, wctx, "test1", []string{"test2"})
 	require.NotNil(t, err)
+}
+
+func TestRegisterContractDuplicateDependency(t *testing.T) {
+	keeper, ctx := keepertest.DexKeeper(t)
+	wctx := sdk.WrapSDKContext(ctx)
+	server := msgserver.NewMsgServerImpl(*keeper)
+	err := registerContract(server, wctx, "test1", []string{"test2", "test2"})
+	require.NotNil(t, err)
+	storedContracts := keeper.GetAllContractInfo(ctx)
+	require.Equal(t, 0, len(storedContracts))
+}
+
+func TestRegisterContractNumIncomingPaths(t *testing.T) {
+	keeper, ctx := keepertest.DexKeeper(t)
+	wctx := sdk.WrapSDKContext(ctx)
+	server := msgserver.NewMsgServerImpl(*keeper)
+	registerContract(server, wctx, "test1", nil)
+	storedContract, err := keeper.GetContract(ctx, "test1")
+	require.Nil(t, err)
+	require.Equal(t, int64(0), storedContract.NumIncomingDependencies)
+
+	registerContract(server, wctx, "test2", []string{"test1"})
+	storedContract, err = keeper.GetContract(ctx, "test1")
+	require.Nil(t, err)
+	require.Equal(t, int64(1), storedContract.NumIncomingDependencies)
+	storedContract, err = keeper.GetContract(ctx, "test2")
+	require.Nil(t, err)
+	require.Equal(t, int64(0), storedContract.NumIncomingDependencies)
+
+	registerContract(server, wctx, "test2", nil)
+	storedContract, err = keeper.GetContract(ctx, "test1")
+	require.Nil(t, err)
+	require.Equal(t, int64(0), storedContract.NumIncomingDependencies)
+	storedContract, err = keeper.GetContract(ctx, "test2")
+	require.Nil(t, err)
+	require.Equal(t, int64(0), storedContract.NumIncomingDependencies)
+}
+
+func TestRegisterContractSetSiblings(t *testing.T) {
+	// A -> X, B -> X, C -> Y
+	keeper, ctx := keepertest.DexKeeper(t)
+	wctx := sdk.WrapSDKContext(ctx)
+	server := msgserver.NewMsgServerImpl(*keeper)
+	registerContract(server, wctx, "X", nil)
+	registerContract(server, wctx, "Y", nil)
+	registerContract(server, wctx, "A", []string{"X"})
+	registerContract(server, wctx, "B", []string{"X"})
+	registerContract(server, wctx, "C", []string{"Y"})
+	// add D -> X, D -> Y
+	registerContract(server, wctx, "D", []string{"X", "Y"})
+	contract, _ := keeper.GetContract(ctx, "A")
+	require.Equal(t, "", contract.Dependencies[0].ImmediateElderSibling)
+	require.Equal(t, "B", contract.Dependencies[0].ImmediateYoungerSibling)
+	contract, _ = keeper.GetContract(ctx, "B")
+	require.Equal(t, "A", contract.Dependencies[0].ImmediateElderSibling)
+	require.Equal(t, "D", contract.Dependencies[0].ImmediateYoungerSibling)
+	contract, _ = keeper.GetContract(ctx, "C")
+	require.Equal(t, "", contract.Dependencies[0].ImmediateElderSibling)
+	require.Equal(t, "D", contract.Dependencies[0].ImmediateYoungerSibling)
+	contract, _ = keeper.GetContract(ctx, "D")
+	require.Equal(t, "B", contract.Dependencies[0].ImmediateElderSibling)
+	require.Equal(t, "", contract.Dependencies[0].ImmediateYoungerSibling)
+	require.Equal(t, "C", contract.Dependencies[1].ImmediateElderSibling)
+	require.Equal(t, "", contract.Dependencies[1].ImmediateYoungerSibling)
+	// update D -> X only
+	registerContract(server, wctx, "D", []string{"X"})
+	contract, _ = keeper.GetContract(ctx, "A")
+	require.Equal(t, "", contract.Dependencies[0].ImmediateElderSibling)
+	require.Equal(t, "B", contract.Dependencies[0].ImmediateYoungerSibling)
+	contract, _ = keeper.GetContract(ctx, "B")
+	require.Equal(t, "A", contract.Dependencies[0].ImmediateElderSibling)
+	require.Equal(t, "D", contract.Dependencies[0].ImmediateYoungerSibling)
+	contract, _ = keeper.GetContract(ctx, "C")
+	require.Equal(t, "", contract.Dependencies[0].ImmediateElderSibling)
+	require.Equal(t, "", contract.Dependencies[0].ImmediateYoungerSibling)
+	contract, _ = keeper.GetContract(ctx, "D")
+	require.Equal(t, 1, len(contract.Dependencies))
+	require.Equal(t, "B", contract.Dependencies[0].ImmediateElderSibling)
+	require.Equal(t, "", contract.Dependencies[0].ImmediateYoungerSibling)
+}
+
+func registerContract(server types.MsgServer, ctx context.Context, contractAddr string, dependencies []string) error {
+	contract := types.ContractInfo{
+		CodeId:       1,
+		ContractAddr: contractAddr,
+	}
+	if dependencies != nil {
+		contract.Dependencies = utils.Map(dependencies, func(addr string) *types.ContractDependencyInfo {
+			return &types.ContractDependencyInfo{
+				Dependency: addr,
+			}
+		})
+	}
+	_, err := server.RegisterContract(ctx, &types.MsgRegisterContract{
+		Creator:  keepertest.TestAccount,
+		Contract: &contract,
+	})
+	return err
 }

--- a/x/dex/keeper/msgserver/msg_server_test.go
+++ b/x/dex/keeper/msgserver/msg_server_test.go
@@ -6,12 +6,11 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
-	"github.com/sei-protocol/sei-chain/utils/tracing"
 	"github.com/sei-protocol/sei-chain/x/dex/keeper/msgserver"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 )
 
 func setupMsgServer(t testing.TB) (types.MsgServer, context.Context) {
 	k, ctx := keepertest.DexKeeper(t)
-	return msgserver.NewMsgServerImpl(*k, &tracing.Info{}), sdk.WrapSDKContext(ctx)
+	return msgserver.NewMsgServerImpl(*k), sdk.WrapSDKContext(ctx)
 }

--- a/x/dex/migrations/v5_to_v6.go
+++ b/x/dex/migrations/v5_to_v6.go
@@ -1,0 +1,57 @@
+package migrations
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/x/dex/keeper"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+)
+
+// This migration updates contract info to match the new data format
+func V5ToV6(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) error {
+	for i := 0; i < 256; i++ {
+		if err := updateContractInfoForBytePrefix(ctx, storeKey, byte(i)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// assuming no dependency exists at the time of this migration
+func updateContractInfoForBytePrefix(ctx sdk.Context, storeKey sdk.StoreKey, b byte) error {
+	store := prefix.NewStore(
+		ctx.KVStore(storeKey),
+		[]byte(keeper.ContractPrefixKey),
+	)
+	iterator := sdk.KVStorePrefixIterator(store, []byte{b})
+	defer iterator.Close()
+	for ; iterator.Valid(); iterator.Next() {
+		oldContractInfoBytes := iterator.Value()
+		oldContractInfo := types.LegacyContractInfo{}
+		if err := oldContractInfo.Unmarshal(oldContractInfoBytes); err != nil {
+			ctx.Logger().Error(fmt.Sprintf("Failed to unmarshal contract info for %s", iterator.Key()))
+			return err
+		}
+		if oldContractInfo.DependentContractAddrs != nil {
+			ctx.Logger().Error(fmt.Sprintf("Contract info of %s has dependencies!", iterator.Key()))
+			return errors.New("contract has unexpected dependencies")
+		}
+		newContractInfo := types.ContractInfo{
+			CodeId:            oldContractInfo.CodeId,
+			ContractAddr:      oldContractInfo.ContractAddr,
+			NeedHook:          oldContractInfo.NeedHook,
+			NeedOrderMatching: oldContractInfo.NeedOrderMatching,
+		}
+		bz, err := newContractInfo.Marshal()
+		if err != nil {
+			ctx.Logger().Error(fmt.Sprintf("Failed to marshal contract info for %s", iterator.Key()))
+			return err
+		}
+		store.Set([]byte(newContractInfo.ContractAddr), bz)
+	}
+	return nil
+}

--- a/x/dex/migrations/v5_to_v6_test.go
+++ b/x/dex/migrations/v5_to_v6_test.go
@@ -1,0 +1,79 @@
+package migrations_test
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/store"
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/x/dex/keeper"
+	"github.com/sei-protocol/sei-chain/x/dex/migrations"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	tmdb "github.com/tendermint/tm-db"
+)
+
+func TestMigrate5to6(t *testing.T) {
+	storeKey := sdk.NewKVStoreKey(types.StoreKey)
+	memStoreKey := storetypes.NewMemoryStoreKey(types.MemStoreKey)
+
+	db := tmdb.NewMemDB()
+	stateStore := store.NewCommitMultiStore(db)
+	stateStore.MountStoreWithDB(storeKey, sdk.StoreTypeIAVL, db)
+	stateStore.MountStoreWithDB(memStoreKey, sdk.StoreTypeMemory, nil)
+	require.NoError(t, stateStore.LoadLatestVersion())
+
+	registry := codectypes.NewInterfaceRegistry()
+	cdc := codec.NewProtoCodec(registry)
+	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())
+	store := prefix.NewStore(
+		ctx.KVStore(storeKey),
+		[]byte(keeper.ContractPrefixKey),
+	)
+
+	oldContractA := types.LegacyContractInfo{
+		CodeId:            1,
+		ContractAddr:      "abc",
+		NeedHook:          true,
+		NeedOrderMatching: false,
+	}
+	oldContractB := types.LegacyContractInfo{
+		CodeId:            2,
+		ContractAddr:      "def",
+		NeedHook:          false,
+		NeedOrderMatching: true,
+	}
+	bzA, _ := oldContractA.Marshal()
+	bzB, _ := oldContractB.Marshal()
+	store.Set([]byte("abc"), bzA)
+	store.Set([]byte("def"), bzB)
+
+	err := migrations.V5ToV6(ctx, storeKey, cdc)
+	require.Nil(t, err)
+
+	newBzA := store.Get([]byte("abc"))
+	newBzB := store.Get([]byte("def"))
+	newContractA := types.ContractInfo{}
+	newContractB := types.ContractInfo{}
+	err = newContractA.Unmarshal(newBzA)
+	require.Nil(t, err)
+	err = newContractB.Unmarshal(newBzB)
+	require.Nil(t, err)
+	require.Equal(t, types.ContractInfo{
+		CodeId:            1,
+		ContractAddr:      "abc",
+		NeedHook:          true,
+		NeedOrderMatching: false,
+	}, newContractA)
+	require.Equal(t, types.ContractInfo{
+		CodeId:            2,
+		ContractAddr:      "def",
+		NeedHook:          false,
+		NeedOrderMatching: true,
+	}, newContractB)
+}

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -149,7 +149,7 @@ func (am AppModule) Name() string {
 
 // Route returns the capability module's message routing key.
 func (am AppModule) Route() sdk.Route {
-	return sdk.NewRoute(types.RouterKey, NewHandler(am.keeper, am.tracingInfo))
+	return sdk.NewRoute(types.RouterKey, NewHandler(am.keeper))
 }
 
 // QuerierRoute returns the capability module's query routing key.
@@ -163,7 +163,7 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 // RegisterServices registers a GRPC query service to respond to the
 // module-specific GRPC queries.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	types.RegisterMsgServer(cfg.MsgServer(), msgserver.NewMsgServerImpl(am.keeper, am.tracingInfo))
+	types.RegisterMsgServer(cfg.MsgServer(), msgserver.NewMsgServerImpl(am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), dexkeeperquery.KeeperWrapper{Keeper: &am.keeper})
 
 	_ = cfg.RegisterMigration(types.ModuleName, 1, func(ctx sdk.Context) error { return nil })
@@ -175,6 +175,9 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	})
 	_ = cfg.RegisterMigration(types.ModuleName, 4, func(ctx sdk.Context) error {
 		return migrations.V4ToV5(ctx, am.keeper.GetStoreKey(), am.keeper.Paramstore)
+	})
+	_ = cfg.RegisterMigration(types.ModuleName, 5, func(ctx sdk.Context) error {
+		return migrations.V5ToV6(ctx, am.keeper.GetStoreKey(), am.keeper.Cdc)
 	})
 }
 
@@ -200,7 +203,7 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 }
 
 // ConsensusVersion implements ConsensusVersion.
-func (AppModule) ConsensusVersion() uint64 { return 5 }
+func (AppModule) ConsensusVersion() uint64 { return 6 }
 
 func (am AppModule) getAllContractInfo(ctx sdk.Context) []types.ContractInfo {
 	unsorted := am.keeper.GetAllContractInfo(ctx)

--- a/x/dex/types/contract.pb.go
+++ b/x/dex/types/contract.pb.go
@@ -23,11 +23,12 @@ var _ = math.Inf
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type ContractInfo struct {
-	CodeId                 uint64   `protobuf:"varint,1,opt,name=codeId,proto3" json:"codeId,omitempty"`
-	ContractAddr           string   `protobuf:"bytes,2,opt,name=contractAddr,proto3" json:"contractAddr,omitempty"`
-	NeedHook               bool     `protobuf:"varint,3,opt,name=NeedHook,proto3" json:"NeedHook,omitempty"`
-	NeedOrderMatching      bool     `protobuf:"varint,4,opt,name=NeedOrderMatching,proto3" json:"NeedOrderMatching,omitempty"`
-	DependentContractAddrs []string `protobuf:"bytes,5,rep,name=dependentContractAddrs,proto3" json:"dependentContractAddrs,omitempty"`
+	CodeId                  uint64                    `protobuf:"varint,1,opt,name=codeId,proto3" json:"codeId,omitempty"`
+	ContractAddr            string                    `protobuf:"bytes,2,opt,name=contractAddr,proto3" json:"contractAddr,omitempty"`
+	NeedHook                bool                      `protobuf:"varint,3,opt,name=needHook,proto3" json:"needHook,omitempty"`
+	NeedOrderMatching       bool                      `protobuf:"varint,4,opt,name=needOrderMatching,proto3" json:"needOrderMatching,omitempty"`
+	Dependencies            []*ContractDependencyInfo `protobuf:"bytes,5,rep,name=dependencies,proto3" json:"dependencies,omitempty"`
+	NumIncomingDependencies int64                     `protobuf:"varint,6,opt,name=numIncomingDependencies,proto3" json:"numIncomingDependencies,omitempty"`
 }
 
 func (m *ContractInfo) Reset()         { *m = ContractInfo{} }
@@ -91,7 +92,150 @@ func (m *ContractInfo) GetNeedOrderMatching() bool {
 	return false
 }
 
-func (m *ContractInfo) GetDependentContractAddrs() []string {
+func (m *ContractInfo) GetDependencies() []*ContractDependencyInfo {
+	if m != nil {
+		return m.Dependencies
+	}
+	return nil
+}
+
+func (m *ContractInfo) GetNumIncomingDependencies() int64 {
+	if m != nil {
+		return m.NumIncomingDependencies
+	}
+	return 0
+}
+
+type ContractDependencyInfo struct {
+	Dependency              string `protobuf:"bytes,1,opt,name=dependency,proto3" json:"dependency,omitempty"`
+	ImmediateElderSibling   string `protobuf:"bytes,2,opt,name=immediateElderSibling,proto3" json:"immediateElderSibling,omitempty"`
+	ImmediateYoungerSibling string `protobuf:"bytes,3,opt,name=immediateYoungerSibling,proto3" json:"immediateYoungerSibling,omitempty"`
+}
+
+func (m *ContractDependencyInfo) Reset()         { *m = ContractDependencyInfo{} }
+func (m *ContractDependencyInfo) String() string { return proto.CompactTextString(m) }
+func (*ContractDependencyInfo) ProtoMessage()    {}
+func (*ContractDependencyInfo) Descriptor() ([]byte, []int) {
+	return fileDescriptor_ee35557664974a8a, []int{1}
+}
+func (m *ContractDependencyInfo) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *ContractDependencyInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_ContractDependencyInfo.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *ContractDependencyInfo) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ContractDependencyInfo.Merge(m, src)
+}
+func (m *ContractDependencyInfo) XXX_Size() int {
+	return m.Size()
+}
+func (m *ContractDependencyInfo) XXX_DiscardUnknown() {
+	xxx_messageInfo_ContractDependencyInfo.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ContractDependencyInfo proto.InternalMessageInfo
+
+func (m *ContractDependencyInfo) GetDependency() string {
+	if m != nil {
+		return m.Dependency
+	}
+	return ""
+}
+
+func (m *ContractDependencyInfo) GetImmediateElderSibling() string {
+	if m != nil {
+		return m.ImmediateElderSibling
+	}
+	return ""
+}
+
+func (m *ContractDependencyInfo) GetImmediateYoungerSibling() string {
+	if m != nil {
+		return m.ImmediateYoungerSibling
+	}
+	return ""
+}
+
+type LegacyContractInfo struct {
+	CodeId                 uint64   `protobuf:"varint,1,opt,name=codeId,proto3" json:"codeId,omitempty"`
+	ContractAddr           string   `protobuf:"bytes,2,opt,name=contractAddr,proto3" json:"contractAddr,omitempty"`
+	NeedHook               bool     `protobuf:"varint,3,opt,name=needHook,proto3" json:"needHook,omitempty"`
+	NeedOrderMatching      bool     `protobuf:"varint,4,opt,name=needOrderMatching,proto3" json:"needOrderMatching,omitempty"`
+	DependentContractAddrs []string `protobuf:"bytes,5,rep,name=dependentContractAddrs,proto3" json:"dependentContractAddrs,omitempty"`
+}
+
+func (m *LegacyContractInfo) Reset()         { *m = LegacyContractInfo{} }
+func (m *LegacyContractInfo) String() string { return proto.CompactTextString(m) }
+func (*LegacyContractInfo) ProtoMessage()    {}
+func (*LegacyContractInfo) Descriptor() ([]byte, []int) {
+	return fileDescriptor_ee35557664974a8a, []int{2}
+}
+func (m *LegacyContractInfo) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *LegacyContractInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_LegacyContractInfo.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *LegacyContractInfo) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LegacyContractInfo.Merge(m, src)
+}
+func (m *LegacyContractInfo) XXX_Size() int {
+	return m.Size()
+}
+func (m *LegacyContractInfo) XXX_DiscardUnknown() {
+	xxx_messageInfo_LegacyContractInfo.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_LegacyContractInfo proto.InternalMessageInfo
+
+func (m *LegacyContractInfo) GetCodeId() uint64 {
+	if m != nil {
+		return m.CodeId
+	}
+	return 0
+}
+
+func (m *LegacyContractInfo) GetContractAddr() string {
+	if m != nil {
+		return m.ContractAddr
+	}
+	return ""
+}
+
+func (m *LegacyContractInfo) GetNeedHook() bool {
+	if m != nil {
+		return m.NeedHook
+	}
+	return false
+}
+
+func (m *LegacyContractInfo) GetNeedOrderMatching() bool {
+	if m != nil {
+		return m.NeedOrderMatching
+	}
+	return false
+}
+
+func (m *LegacyContractInfo) GetDependentContractAddrs() []string {
 	if m != nil {
 		return m.DependentContractAddrs
 	}
@@ -100,28 +244,38 @@ func (m *ContractInfo) GetDependentContractAddrs() []string {
 
 func init() {
 	proto.RegisterType((*ContractInfo)(nil), "seiprotocol.seichain.dex.ContractInfo")
+	proto.RegisterType((*ContractDependencyInfo)(nil), "seiprotocol.seichain.dex.ContractDependencyInfo")
+	proto.RegisterType((*LegacyContractInfo)(nil), "seiprotocol.seichain.dex.LegacyContractInfo")
 }
 
 func init() { proto.RegisterFile("dex/contract.proto", fileDescriptor_ee35557664974a8a) }
 
 var fileDescriptor_ee35557664974a8a = []byte{
-	// 255 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0x4a, 0x49, 0xad, 0xd0,
-	0x4f, 0xce, 0xcf, 0x2b, 0x29, 0x4a, 0x4c, 0x2e, 0xd1, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x92,
-	0x28, 0x4e, 0xcd, 0x04, 0xb3, 0x92, 0xf3, 0x73, 0xf4, 0x8a, 0x53, 0x33, 0x93, 0x33, 0x12, 0x33,
-	0xf3, 0xf4, 0x52, 0x52, 0x2b, 0x94, 0xce, 0x30, 0x72, 0xf1, 0x38, 0x43, 0x15, 0x7b, 0xe6, 0xa5,
-	0xe5, 0x0b, 0x89, 0x71, 0xb1, 0x25, 0xe7, 0xa7, 0xa4, 0x7a, 0xa6, 0x48, 0x30, 0x2a, 0x30, 0x6a,
-	0xb0, 0x04, 0x41, 0x79, 0x42, 0x4a, 0x5c, 0x3c, 0x30, 0x43, 0x1d, 0x53, 0x52, 0x8a, 0x24, 0x98,
-	0x14, 0x18, 0x35, 0x38, 0x83, 0x50, 0xc4, 0x84, 0xa4, 0xb8, 0x38, 0xfc, 0x52, 0x53, 0x53, 0x3c,
-	0xf2, 0xf3, 0xb3, 0x25, 0x98, 0x15, 0x18, 0x35, 0x38, 0x82, 0xe0, 0x7c, 0x21, 0x1d, 0x2e, 0x41,
-	0x10, 0xdb, 0xbf, 0x28, 0x25, 0xb5, 0xc8, 0x37, 0xb1, 0x24, 0x39, 0x23, 0x33, 0x2f, 0x5d, 0x82,
-	0x05, 0xac, 0x08, 0x53, 0x42, 0xc8, 0x8c, 0x4b, 0x2c, 0x25, 0xb5, 0x20, 0x35, 0x2f, 0x25, 0x35,
-	0xaf, 0xc4, 0x19, 0xc9, 0x8a, 0x62, 0x09, 0x56, 0x05, 0x66, 0x0d, 0xce, 0x20, 0x1c, 0xb2, 0x4e,
-	0xee, 0x27, 0x1e, 0xc9, 0x31, 0x5e, 0x78, 0x24, 0xc7, 0xf8, 0xe0, 0x91, 0x1c, 0xe3, 0x84, 0xc7,
-	0x72, 0x0c, 0x17, 0x1e, 0xcb, 0x31, 0xdc, 0x78, 0x2c, 0xc7, 0x10, 0xa5, 0x9b, 0x9e, 0x59, 0x92,
-	0x51, 0x9a, 0xa4, 0x97, 0x9c, 0x9f, 0xab, 0x5f, 0x9c, 0x9a, 0xa9, 0x0b, 0x0b, 0x0e, 0x30, 0x07,
-	0x1c, 0x1e, 0xfa, 0x15, 0xfa, 0xa0, 0xa0, 0x2b, 0xa9, 0x2c, 0x48, 0x2d, 0x4e, 0x62, 0x03, 0xcb,
-	0x1b, 0x03, 0x02, 0x00, 0x00, 0xff, 0xff, 0x5f, 0x29, 0x54, 0x6c, 0x4e, 0x01, 0x00, 0x00,
+	// 378 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x53, 0xc1, 0x4e, 0xc2, 0x40,
+	0x10, 0x65, 0x29, 0x12, 0x58, 0xb9, 0xb8, 0x89, 0xd8, 0x78, 0x68, 0x9a, 0x9e, 0x7a, 0x90, 0xd6,
+	0xa8, 0x31, 0x5e, 0x15, 0x8c, 0x92, 0x68, 0x4c, 0xaa, 0x17, 0xbd, 0x95, 0xdd, 0xb1, 0x6c, 0xa4,
+	0xbb, 0xa4, 0x5d, 0x12, 0xfa, 0x17, 0x7e, 0x84, 0x07, 0x3f, 0xc5, 0x23, 0xf1, 0xe4, 0xd1, 0xc0,
+	0x8f, 0x98, 0x16, 0x8a, 0x10, 0xe9, 0xdd, 0xdb, 0xcc, 0xbc, 0x99, 0x79, 0xfb, 0x66, 0x66, 0x31,
+	0x61, 0x30, 0x76, 0xa9, 0x14, 0x2a, 0xf2, 0xa9, 0x72, 0x86, 0x91, 0x54, 0x92, 0xe8, 0x31, 0xf0,
+	0xcc, 0xa2, 0x72, 0xe0, 0xc4, 0xc0, 0x69, 0xdf, 0xe7, 0xc2, 0x61, 0x30, 0xb6, 0xde, 0xca, 0xb8,
+	0xd1, 0x5e, 0x24, 0x77, 0xc5, 0xb3, 0x24, 0x4d, 0x5c, 0xa5, 0x92, 0x41, 0x97, 0xe9, 0xc8, 0x44,
+	0x76, 0xc5, 0x5b, 0x78, 0xc4, 0xc2, 0x8d, 0xbc, 0xe9, 0x39, 0x63, 0x91, 0x5e, 0x36, 0x91, 0x5d,
+	0xf7, 0xd6, 0x62, 0x64, 0x1f, 0xd7, 0x04, 0x00, 0xbb, 0x96, 0xf2, 0x45, 0xd7, 0x4c, 0x64, 0xd7,
+	0xbc, 0xa5, 0x4f, 0x0e, 0xf0, 0x4e, 0x6a, 0xdf, 0x45, 0x0c, 0xa2, 0x5b, 0x5f, 0xd1, 0x3e, 0x17,
+	0x81, 0x5e, 0xc9, 0x92, 0xfe, 0x02, 0xe4, 0x01, 0x37, 0x18, 0x0c, 0x41, 0x30, 0x10, 0x94, 0x43,
+	0xac, 0x6f, 0x99, 0x9a, 0xbd, 0x7d, 0x74, 0xe8, 0x14, 0xe9, 0x70, 0x72, 0x0d, 0x9d, 0xbc, 0x2a,
+	0x49, 0xd5, 0x78, 0x6b, 0x5d, 0xc8, 0x19, 0xde, 0x13, 0xa3, 0xb0, 0x2b, 0xa8, 0x0c, 0xb9, 0x08,
+	0x3a, 0xab, 0x04, 0x55, 0x13, 0xd9, 0x9a, 0x57, 0x04, 0x5b, 0xef, 0x08, 0x37, 0x37, 0x53, 0x10,
+	0x03, 0xe3, 0x25, 0x49, 0x92, 0x0d, 0xad, 0xee, 0xad, 0x44, 0xc8, 0x09, 0xde, 0xe5, 0x61, 0x08,
+	0x8c, 0xfb, 0x0a, 0x2e, 0x07, 0x0c, 0xa2, 0x7b, 0xde, 0x1b, 0xa4, 0xe2, 0xe7, 0x13, 0xdc, 0x0c,
+	0xa6, 0x4f, 0x5d, 0x02, 0x8f, 0x72, 0x24, 0x82, 0xdf, 0x3a, 0x2d, 0xab, 0x2b, 0x82, 0xad, 0x4f,
+	0x84, 0xc9, 0x0d, 0x04, 0x3e, 0x4d, 0xfe, 0xe1, 0x5e, 0x4f, 0x71, 0x33, 0x1f, 0x8d, 0x6a, 0xaf,
+	0x50, 0xcc, 0x37, 0x5c, 0xf7, 0x0a, 0xd0, 0x8b, 0xab, 0x8f, 0xa9, 0x81, 0x26, 0x53, 0x03, 0x7d,
+	0x4f, 0x0d, 0xf4, 0x3a, 0x33, 0x4a, 0x93, 0x99, 0x51, 0xfa, 0x9a, 0x19, 0xa5, 0xa7, 0x56, 0xc0,
+	0x55, 0x7f, 0xd4, 0x73, 0xa8, 0x0c, 0xdd, 0x18, 0x78, 0x2b, 0x3f, 0x8f, 0xcc, 0xc9, 0xee, 0xc3,
+	0x1d, 0xbb, 0xe9, 0x97, 0x50, 0xc9, 0x10, 0xe2, 0x5e, 0x35, 0xc3, 0x8f, 0x7f, 0x02, 0x00, 0x00,
+	0xff, 0xff, 0xe1, 0x25, 0x79, 0xa4, 0x26, 0x03, 0x00, 0x00,
 }
 
 func (m *ContractInfo) Marshal() (dAtA []byte, err error) {
@@ -140,6 +294,124 @@ func (m *ContractInfo) MarshalTo(dAtA []byte) (int, error) {
 }
 
 func (m *ContractInfo) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.NumIncomingDependencies != 0 {
+		i = encodeVarintContract(dAtA, i, uint64(m.NumIncomingDependencies))
+		i--
+		dAtA[i] = 0x30
+	}
+	if len(m.Dependencies) > 0 {
+		for iNdEx := len(m.Dependencies) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Dependencies[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintContract(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x2a
+		}
+	}
+	if m.NeedOrderMatching {
+		i--
+		if m.NeedOrderMatching {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.NeedHook {
+		i--
+		if m.NeedHook {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x18
+	}
+	if len(m.ContractAddr) > 0 {
+		i -= len(m.ContractAddr)
+		copy(dAtA[i:], m.ContractAddr)
+		i = encodeVarintContract(dAtA, i, uint64(len(m.ContractAddr)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.CodeId != 0 {
+		i = encodeVarintContract(dAtA, i, uint64(m.CodeId))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ContractDependencyInfo) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ContractDependencyInfo) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ContractDependencyInfo) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.ImmediateYoungerSibling) > 0 {
+		i -= len(m.ImmediateYoungerSibling)
+		copy(dAtA[i:], m.ImmediateYoungerSibling)
+		i = encodeVarintContract(dAtA, i, uint64(len(m.ImmediateYoungerSibling)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.ImmediateElderSibling) > 0 {
+		i -= len(m.ImmediateElderSibling)
+		copy(dAtA[i:], m.ImmediateElderSibling)
+		i = encodeVarintContract(dAtA, i, uint64(len(m.ImmediateElderSibling)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Dependency) > 0 {
+		i -= len(m.Dependency)
+		copy(dAtA[i:], m.Dependency)
+		i = encodeVarintContract(dAtA, i, uint64(len(m.Dependency)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *LegacyContractInfo) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *LegacyContractInfo) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *LegacyContractInfo) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -218,6 +490,58 @@ func (m *ContractInfo) Size() (n int) {
 	if m.NeedOrderMatching {
 		n += 2
 	}
+	if len(m.Dependencies) > 0 {
+		for _, e := range m.Dependencies {
+			l = e.Size()
+			n += 1 + l + sovContract(uint64(l))
+		}
+	}
+	if m.NumIncomingDependencies != 0 {
+		n += 1 + sovContract(uint64(m.NumIncomingDependencies))
+	}
+	return n
+}
+
+func (m *ContractDependencyInfo) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Dependency)
+	if l > 0 {
+		n += 1 + l + sovContract(uint64(l))
+	}
+	l = len(m.ImmediateElderSibling)
+	if l > 0 {
+		n += 1 + l + sovContract(uint64(l))
+	}
+	l = len(m.ImmediateYoungerSibling)
+	if l > 0 {
+		n += 1 + l + sovContract(uint64(l))
+	}
+	return n
+}
+
+func (m *LegacyContractInfo) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.CodeId != 0 {
+		n += 1 + sovContract(uint64(m.CodeId))
+	}
+	l = len(m.ContractAddr)
+	if l > 0 {
+		n += 1 + l + sovContract(uint64(l))
+	}
+	if m.NeedHook {
+		n += 2
+	}
+	if m.NeedOrderMatching {
+		n += 2
+	}
 	if len(m.DependentContractAddrs) > 0 {
 		for _, s := range m.DependentContractAddrs {
 			l = len(s)
@@ -260,6 +584,346 @@ func (m *ContractInfo) Unmarshal(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: ContractInfo: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CodeId", wireType)
+			}
+			m.CodeId = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowContract
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.CodeId |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ContractAddr", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowContract
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthContract
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthContract
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ContractAddr = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NeedHook", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowContract
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.NeedHook = bool(v != 0)
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NeedOrderMatching", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowContract
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.NeedOrderMatching = bool(v != 0)
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Dependencies", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowContract
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthContract
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthContract
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Dependencies = append(m.Dependencies, &ContractDependencyInfo{})
+			if err := m.Dependencies[len(m.Dependencies)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NumIncomingDependencies", wireType)
+			}
+			m.NumIncomingDependencies = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowContract
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.NumIncomingDependencies |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipContract(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthContract
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ContractDependencyInfo) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowContract
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ContractDependencyInfo: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ContractDependencyInfo: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Dependency", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowContract
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthContract
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthContract
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Dependency = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ImmediateElderSibling", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowContract
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthContract
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthContract
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ImmediateElderSibling = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ImmediateYoungerSibling", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowContract
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthContract
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthContract
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ImmediateYoungerSibling = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipContract(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthContract
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *LegacyContractInfo) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowContract
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: LegacyContractInfo: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: LegacyContractInfo: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:


### PR DESCRIPTION
According to parallelization design discussed in https://www.notion.so/3pgv/RFC-dex-EndBlock-Parallelization-96188f5904f94172a7fdd7d2bac196f3#5937b9bab86e46dc97b8cc7d8b516007 , we will now maintain the immediate sibling (both younger and elder) for each inter-contract dependency. This PR:
- replaces `ContractInfo`'s existing field of `DependentContractAddrs` with a new `Dependencies` field which is an array of struct `ContractDependencyInfo` that keeps track of siblings. The old `ContractInfo` is renamed to `LegavcyContractInfo` for migration purposes.
- adds a `numIncomingDependencies` field to record the number of contracts that depend on the current contract.
- adds logics in `msg_server_register_contract` to keep the new fields updated whenever a contract is added/updated
- adds `dex` migration handler (v5 -> v6) to transform legacy contract info into the new format 