### PR TITLE
Add fuzz testing for exchange logics

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -26,16 +26,16 @@ jobs:
       run: go test github.com/sei-protocol/sei-chain/x/dex/keeper/msgserver -fuzz FuzzPlaceOrders -fuzztime 30s
 
     - name: Fuzz Limit Order Matching
-      run: go test github.com/sei-protocol/sei-chain/x/dex/keeper/exchange -fuzz FuzzMatchLimitOrders -fuzztime 30s
+      run: go test github.com/sei-protocol/sei-chain/x/dex/exchange -fuzz FuzzMatchLimitOrders -fuzztime 30s
 
     - name: Fuzz Market Order Matching
-      run: go test github.com/sei-protocol/sei-chain/x/dex/keeper/exchange -fuzz FuzzMatchMarketOrders -fuzztime 30s
+      run: go test github.com/sei-protocol/sei-chain/x/dex/exchange -fuzz FuzzMatchMarketOrders -fuzztime 30s
 
     - name: Fuzz Rebalance
-      run: go test github.com/sei-protocol/sei-chain/x/dex/keeper/exchange -fuzz FuzzRebalance -fuzztime 30s
+      run: go test github.com/sei-protocol/sei-chain/x/dex/exchange -fuzz FuzzRebalance -fuzztime 30s
 
     - name: Fuzz Limit Order Settlement
-      run: go test github.com/sei-protocol/sei-chain/x/dex/keeper/exchange -fuzz FuzzSettleFromBook -fuzztime 30s
+      run: go test github.com/sei-protocol/sei-chain/x/dex/exchange -fuzz FuzzSettleLimitOrder -fuzztime 30s
 
     - name: Fuzz Market Order Settlement
-      run: go test github.com/sei-protocol/sei-chain/x/dex/keeper/exchange -fuzz FuzzSettle -fuzztime 30s
+      run: go test github.com/sei-protocol/sei-chain/x/dex/exchange -fuzz FuzzSettleMarketOrder -fuzztime 30s

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -24,3 +24,18 @@ jobs:
 
     - name: Fuzz Place Order Msg
       run: go test github.com/sei-protocol/sei-chain/x/dex/keeper/msgserver -fuzz FuzzPlaceOrders -fuzztime 30s
+
+    - name: Fuzz Limit Order Matching
+      run: go test github.com/sei-protocol/sei-chain/x/dex/keeper/exchange -fuzz FuzzMatchLimitOrders -fuzztime 30s
+
+    - name: Fuzz Market Order Matching
+      run: go test github.com/sei-protocol/sei-chain/x/dex/keeper/exchange -fuzz FuzzMatchMarketOrders -fuzztime 30s
+
+    - name: Fuzz Rebalance
+      run: go test github.com/sei-protocol/sei-chain/x/dex/keeper/exchange -fuzz FuzzRebalance -fuzztime 30s
+
+    - name: Fuzz Limit Order Settlement
+      run: go test github.com/sei-protocol/sei-chain/x/dex/keeper/exchange -fuzz FuzzSettleFromBook -fuzztime 30s
+
+    - name: Fuzz Market Order Settlement
+      run: go test github.com/sei-protocol/sei-chain/x/dex/keeper/exchange -fuzz FuzzSettle -fuzztime 30s

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ package-lock.json
 c.out
 
 # fuzz test data
-*/testdata/fuzz/*
+**/testdata/fuzz/**

--- a/testutil/fuzzing/dex.go
+++ b/testutil/fuzzing/dex.go
@@ -203,7 +203,7 @@ func GetAllocations(totalQuantity int64, accountIndices []byte, weights []byte) 
 	quantityDec := sdk.NewDec(totalQuantity)
 	totalWeightDec := sdk.NewDec(int64(totalWeight))
 	res := []*types.Allocation{}
-	orderId := 0
+	orderID := 0
 	for account, weight := range aggregatedAccountsToWeights {
 		var quantity sdk.Dec
 		if totalWeightDec.IsZero() {
@@ -212,11 +212,11 @@ func GetAllocations(totalQuantity int64, accountIndices []byte, weights []byte) 
 			quantity = quantityDec.Mul(sdk.NewDec(int64(weight))).Quo(totalWeightDec)
 		}
 		res = append(res, &types.Allocation{
-			OrderId:  uint64(orderId),
+			OrderId:  uint64(orderID),
 			Account:  account,
 			Quantity: quantity,
 		})
-		orderId++
+		orderID++
 	}
 	return res
 }

--- a/testutil/fuzzing/dex.go
+++ b/testutil/fuzzing/dex.go
@@ -137,6 +137,9 @@ func GetOrderBookEntries(buy bool, priceDenom string, assetDenom string, entryWe
 	for _, entryWeight := range entryWeights {
 		totalPriceWeights += uint64(entryWeight)
 	}
+	if totalPriceWeights == uint64(0) {
+		return res
+	}
 	sliceStartAccnt, sliceStartWeights := 0, 0
 	cumWeights := uint64(0)
 	for i, entryWeight := range entryWeights {
@@ -200,11 +203,20 @@ func GetAllocations(totalQuantity int64, accountIndices []byte, weights []byte) 
 	quantityDec := sdk.NewDec(totalQuantity)
 	totalWeightDec := sdk.NewDec(int64(totalWeight))
 	res := []*types.Allocation{}
+	orderId := 0
 	for account, weight := range aggregatedAccountsToWeights {
+		var quantity sdk.Dec
+		if totalWeightDec.IsZero() {
+			quantity = sdk.ZeroDec()
+		} else {
+			quantity = quantityDec.Mul(sdk.NewDec(int64(weight))).Quo(totalWeightDec)
+		}
 		res = append(res, &types.Allocation{
+			OrderId:  uint64(orderId),
 			Account:  account,
-			Quantity: quantityDec.Mul(sdk.NewDec(int64(weight))).Quo(totalWeightDec),
+			Quantity: quantity,
 		})
+		orderId++
 	}
 	return res
 }

--- a/x/dex/exchange/cancel_order.go
+++ b/x/dex/exchange/cancel_order.go
@@ -11,8 +11,10 @@ func CancelOrders(
 	originalOrders map[uint64]types.Order,
 ) {
 	for _, cancel := range cancels {
-		cancelOrder(originalOrders[cancel.Id], orderbook.Longs)
-		cancelOrder(originalOrders[cancel.Id], orderbook.Shorts)
+		if originalOrder, ok := originalOrders[cancel.Id]; ok {
+			cancelOrder(originalOrder, orderbook.Longs)
+			cancelOrder(originalOrder, orderbook.Shorts)
+		}
 	}
 }
 

--- a/x/dex/exchange/limit_order_fuzz_test.go
+++ b/x/dex/exchange/limit_order_fuzz_test.go
@@ -1,0 +1,45 @@
+package exchange_test
+
+import (
+	"testing"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/testutil/fuzzing"
+	"github.com/sei-protocol/sei-chain/x/dex/exchange"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+	"github.com/stretchr/testify/require"
+
+	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
+)
+
+var TestFuzzLimitCtx = sdk.Context{}
+
+func FuzzMatchLimitOrders(f *testing.F) {
+	TestFuzzLimitCtx = TestFuzzLimitCtx.WithBlockHeight(1).WithBlockTime(time.Now())
+	f.Fuzz(fuzzTargetMatchLimitOrders)
+}
+
+func fuzzTargetMatchLimitOrders(
+	t *testing.T,
+	buyPrices []byte,
+	sellPrices []byte,
+	buyQuantities []byte,
+	sellQuantities []byte,
+	buyEntryWeights []byte,
+	sellEntryWeights []byte,
+	buyAccountIndices []byte,
+	sellAccountIndices []byte,
+	buyAllocationWeights []byte,
+	sellAllocationWeights []byte,
+) {
+	buyEntries := fuzzing.GetOrderBookEntries(true, keepertest.TestPriceDenom, keepertest.TestAssetDenom, buyEntryWeights, buyAccountIndices, buyAllocationWeights)
+	sellEntries := fuzzing.GetOrderBookEntries(false, keepertest.TestPriceDenom, keepertest.TestAssetDenom, sellEntryWeights, sellAccountIndices, sellAllocationWeights)
+	buyOrders := fuzzing.GetPlacedOrders(types.PositionDirection_LONG, types.OrderType_LIMIT, keepertest.TestPair, buyPrices, buyQuantities)
+	sellOrders := fuzzing.GetPlacedOrders(types.PositionDirection_SHORT, types.OrderType_LIMIT, keepertest.TestPair, sellPrices, sellQuantities)
+	orderBook := types.OrderBook{
+		Longs:  &types.CachedSortedOrderBookEntries{Entries: buyEntries, DirtyEntries: map[string]types.OrderBookEntry{}},
+		Shorts: &types.CachedSortedOrderBookEntries{Entries: sellEntries, DirtyEntries: map[string]types.OrderBookEntry{}},
+	}
+	require.NotPanics(t, func() { exchange.MatchLimitOrders(TestFuzzLimitCtx, buyOrders, sellOrders, &orderBook) })
+}

--- a/x/dex/exchange/market_order_fuzz_test.go
+++ b/x/dex/exchange/market_order_fuzz_test.go
@@ -1,0 +1,74 @@
+package exchange_test
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/testutil/fuzzing"
+	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/x/dex/exchange"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+	"github.com/stretchr/testify/require"
+)
+
+var TestFuzzMarketCtx = sdk.Context{}
+
+func FuzzMatchMarketOrders(f *testing.F) {
+	TestFuzzMarketCtx = TestFuzzMarketCtx.WithBlockHeight(1).WithBlockTime(time.Now())
+	f.Fuzz(fuzzTargetMatchMarketOrders)
+}
+
+func fuzzTargetMatchMarketOrders(
+	t *testing.T,
+	takerLong bool,
+	orderSorted bool,
+	orderbookSorted bool,
+	prices []byte,
+	quantities []byte,
+	entryWeights []byte,
+	accountIndices []byte,
+	allocationWeights []byte,
+) {
+	entries := fuzzing.GetOrderBookEntries(!takerLong, keepertest.TestPriceDenom, keepertest.TestAssetDenom, entryWeights, accountIndices, allocationWeights)
+	var direction types.PositionDirection
+	if takerLong {
+		direction = types.PositionDirection_LONG
+	} else {
+		direction = types.PositionDirection_SHORT
+	}
+	orders := fuzzing.GetPlacedOrders(direction, types.OrderType_MARKET, keepertest.TestPair, prices, quantities)
+
+	if orderSorted {
+		sort.Slice(orders, func(i, j int) bool {
+			// a price of 0 indicates that there is no worst price for the order, so it should
+			// always be ranked at the top.
+			if orders[i].Price.IsZero() {
+				return true
+			} else if orders[j].Price.IsZero() {
+				return false
+			}
+			switch direction {
+			case types.PositionDirection_LONG:
+				return orders[i].Price.GT(orders[j].Price)
+			case types.PositionDirection_SHORT:
+				return orders[i].Price.LT(orders[j].Price)
+			default:
+				panic("Unknown direction")
+			}
+		})
+	}
+	if orderbookSorted {
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].GetPrice().LT(entries[j].GetPrice())
+		})
+	}
+
+	require.NotPanics(t, func() {
+		exchange.MatchMarketOrders(TestFuzzMarketCtx, orders, &types.CachedSortedOrderBookEntries{
+			Entries:      entries,
+			DirtyEntries: map[string]types.OrderBookEntry{},
+		}, direction)
+	})
+}

--- a/x/dex/exchange/rebalance.go
+++ b/x/dex/exchange/rebalance.go
@@ -11,11 +11,11 @@ func RebalanceAllocations(order types.OrderBookEntry) map[uint64]sdk.Dec {
 	for _, allo := range order.GetEntry().Allocations {
 		oldTotal = oldTotal.Add(allo.Quantity)
 	}
-	ratio := newTotal.Quo(oldTotal)
 	res := map[uint64]sdk.Dec{}
 	if oldTotal.IsZero() {
 		return res
 	}
+	ratio := newTotal.Quo(oldTotal)
 	acc := sdk.ZeroDec()
 	for _, allocation := range order.GetEntry().Allocations {
 		res[allocation.OrderId] = allocation.Quantity.Mul(ratio)

--- a/x/dex/exchange/rebalance_fuzz_test.go
+++ b/x/dex/exchange/rebalance_fuzz_test.go
@@ -1,0 +1,29 @@
+package exchange_test
+
+import (
+	"testing"
+
+	"github.com/sei-protocol/sei-chain/testutil/fuzzing"
+	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/x/dex/exchange"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzRebalance(f *testing.F) {
+	f.Fuzz(fuzzTargetMatchMarketOrders)
+}
+
+func fuzzTargetRebalance(
+	t *testing.T,
+	long bool,
+	entryWeights []byte,
+	accountIndices []byte,
+	allocationWeights []byte,
+) {
+	entries := fuzzing.GetOrderBookEntries(long, keepertest.TestPriceDenom, keepertest.TestAssetDenom, entryWeights, accountIndices, allocationWeights)
+	for _, entry := range entries {
+		require.NotPanics(t, func() {
+			exchange.RebalanceAllocations(entry)
+		})
+	}
+}

--- a/x/dex/exchange/settlement.go
+++ b/x/dex/exchange/settlement.go
@@ -33,6 +33,9 @@ func Settle(
 	newToSettle := []ToSettle{}
 	nonZeroNewAllocations := []*types.Allocation{}
 	for _, allocation := range order.GetEntry().Allocations {
+		if allocation.Quantity.IsZero() {
+			continue
+		}
 		newToSettle = append(newToSettle, ToSettle{
 			amount:  allocation.Quantity.Sub(newAllocations[allocation.OrderId]),
 			orderID: allocation.OrderId,
@@ -97,6 +100,9 @@ func SettleFromBook(
 	newShortToSettle := []ToSettle{}
 	nonZeroNewLongAllocations, nonZeroNewShortAllocations := []*types.Allocation{}, []*types.Allocation{}
 	for _, allocation := range longOrder.GetEntry().Allocations {
+		if allocation.Quantity.IsZero() {
+			continue
+		}
 		newLongToSettle = append(newLongToSettle, ToSettle{
 			amount:  allocation.Quantity.Sub(newLongAllocations[allocation.OrderId]),
 			account: allocation.Account,
@@ -112,6 +118,9 @@ func SettleFromBook(
 	}
 	longOrder.GetEntry().Allocations = nonZeroNewLongAllocations
 	for _, allocation := range shortOrder.GetEntry().Allocations {
+		if allocation.Quantity.IsZero() {
+			continue
+		}
 		newShortToSettle = append(newShortToSettle, ToSettle{
 			amount:  allocation.Quantity.Sub(newShortAllocations[allocation.OrderId]),
 			account: allocation.Account,

--- a/x/dex/exchange/settlement_fuzz_test.go
+++ b/x/dex/exchange/settlement_fuzz_test.go
@@ -14,7 +14,7 @@ import (
 
 var TestFuzzSettleCtx = sdk.Context{}
 
-func FuzzSettle(f *testing.F) {
+func FuzzSettleMarketOrder(f *testing.F) {
 	TestFuzzSettleCtx = TestFuzzSettleCtx.WithBlockHeight(1).WithBlockTime(time.Now())
 	f.Fuzz(fuzzTargetMatchMarketOrders)
 }
@@ -57,7 +57,7 @@ func fuzzTargetSettle(
 	}
 }
 
-func FuzzSettleFromBook(f *testing.F) {
+func FuzzSettleLimitOrder(f *testing.F) {
 	TestFuzzSettleCtx = TestFuzzSettleCtx.WithBlockHeight(1).WithBlockTime(time.Now())
 	f.Fuzz(fuzzTargetMatchMarketOrders)
 }

--- a/x/dex/exchange/settlement_fuzz_test.go
+++ b/x/dex/exchange/settlement_fuzz_test.go
@@ -1,0 +1,92 @@
+package exchange_test
+
+import (
+	"testing"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/testutil/fuzzing"
+	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/x/dex/exchange"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+	"github.com/stretchr/testify/require"
+)
+
+var TestFuzzSettleCtx = sdk.Context{}
+
+func FuzzSettle(f *testing.F) {
+	TestFuzzSettleCtx = TestFuzzSettleCtx.WithBlockHeight(1).WithBlockTime(time.Now())
+	f.Fuzz(fuzzTargetMatchMarketOrders)
+}
+
+func fuzzTargetSettle(
+	t *testing.T,
+	long bool,
+	prices []byte,
+	quantities []byte,
+	entryWeights []byte,
+	accountIndices []byte,
+	allocationWeights []byte,
+	priceI int64,
+	priceIsNil bool,
+	quantityI int64,
+	quantityIsNil bool,
+) {
+	entries := fuzzing.GetOrderBookEntries(!long, keepertest.TestPriceDenom, keepertest.TestAssetDenom, entryWeights, accountIndices, allocationWeights)
+	var direction types.PositionDirection
+	if long {
+		direction = types.PositionDirection_LONG
+	} else {
+		direction = types.PositionDirection_SHORT
+	}
+	orders := fuzzing.GetPlacedOrders(direction, types.OrderType_MARKET, keepertest.TestPair, prices, quantities)
+
+	price := fuzzing.FuzzDec(priceI, priceIsNil)
+	quantity := fuzzing.FuzzDec(quantityI, quantityIsNil)
+
+	if len(entries) > len(orders) {
+		entries = entries[:len(orders)]
+	} else {
+		orders = orders[:len(entries)]
+	}
+
+	for i, entry := range entries {
+		require.NotPanics(t, func() {
+			exchange.Settle(TestFuzzSettleCtx, orders[i], quantity, entry, price)
+		})
+	}
+}
+
+func FuzzSettleFromBook(f *testing.F) {
+	TestFuzzSettleCtx = TestFuzzSettleCtx.WithBlockHeight(1).WithBlockTime(time.Now())
+	f.Fuzz(fuzzTargetMatchMarketOrders)
+}
+
+func fuzzTargetSettleFromBook(
+	t *testing.T,
+	buyEntryWeights []byte,
+	sellEntryWeights []byte,
+	buyAccountIndices []byte,
+	sellAccountIndices []byte,
+	buyAllocationWeights []byte,
+	sellAllocationWeights []byte,
+	quantityI int64,
+	quantityIsNil bool,
+) {
+	buyEntries := fuzzing.GetOrderBookEntries(true, keepertest.TestPriceDenom, keepertest.TestAssetDenom, buyEntryWeights, buyAccountIndices, buyAllocationWeights)
+	sellEntries := fuzzing.GetOrderBookEntries(false, keepertest.TestPriceDenom, keepertest.TestAssetDenom, sellEntryWeights, sellAccountIndices, sellAllocationWeights)
+
+	quantity := fuzzing.FuzzDec(quantityI, quantityIsNil)
+
+	if len(buyEntries) > len(sellEntries) {
+		buyEntries = buyEntries[:len(sellEntries)]
+	} else {
+		sellEntries = sellEntries[:len(buyEntries)]
+	}
+
+	for i, longEntry := range buyEntries {
+		require.NotPanics(t, func() {
+			exchange.SettleFromBook(TestFuzzSettleCtx, longEntry, sellEntries[i], quantity)
+		})
+	}
+}


### PR DESCRIPTION
Add fuzz testing for
- limit order matching
- market order matching
- limit order settlement
- market order settlement
- rebalance

and fixed issues found during fuzzing