### PR TITLE
Fix Statesync with snapshot manager

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -703,7 +703,7 @@ func New(
 	// Register snapshot extensions to enable state-sync for wasm.
 	if manager := app.SnapshotManager(); manager != nil {
 		err := manager.RegisterExtensions(
-			wasmkeeper.NewWasmSnapshotter(app.CommitMultiStore(), app.WasmKeeper),
+			wasmkeeper.NewWasmSnapshotter(app.CommitMultiStore(), &app.WasmKeeper),
 		)
 		if err != nil {
 			panic(fmt.Errorf("failed to register snapshot extension: %s", err))


### PR DESCRIPTION
Enables snapshot manager to fix statesync 

For the node I wanted to catch up, i just followed this to set the block height and the hash (including setting perisstent peer and restarting the seid daemon)
https://docs.seinetwork.io/nodes-and-validators/statesync

Then for the node0, that I used as a persistent peer i updated `~/.sei/config/app.toml`  to set the snapshot-interval as it was disabled in the past (set to 0)
![image](https://user-images.githubusercontent.com/18161326/182772584-e1b64dc5-427a-42f1-847d-40db7f6bf257.png)

Restarted seid service on node0 with `systemctl restart seid` and see that the new node was able to find a snapshot and caught up 
![image](https://user-images.githubusercontent.com/18161326/182772750-9e28e27a-2171-468d-9ca1-0da757e5cee2.png)

See that both have the same wasm folder:
![image](https://user-images.githubusercontent.com/18161326/182773789-c3fa50fc-f443-4e39-9bad-ea54f19b8f14.png)
![image](https://user-images.githubusercontent.com/18161326/182773799-e65f1a9d-d218-4147-903a-ed0900831e46.png)



 Note:
Juno and Osmosis had the same PR:
https://github.com/osmosis-labs/osmosis/commit/8e1b6201a514fb3970c3d6537342d66f38ba0446
https://github.com/CosmosContracts/juno/commit/375c9015c7db73f54b320d6004e8c49638c8e33e 