### PR TITLE
Loadtest client fixes

### DIFF
--- a/app/params/config.go
+++ b/app/params/config.go
@@ -82,6 +82,7 @@ func SetTendermintConfigs(config *tmcfg.Config) {
 	config.P2P.SendRate = 20480000
 	config.P2P.RecvRate = 20480000
 	config.P2P.MaxPacketMsgPayloadSize = 10240
+	config.P2P.FlushThrottleTimeout = 10 * time.Millisecond
 	// Mempool configs
 	config.Mempool.Size = 5000
 	config.Mempool.MaxTxsBytes = 10737418240

--- a/loadtest/config.json
+++ b/loadtest/config.json
@@ -2,7 +2,7 @@
     "chain_id": "sei-chain",
     "contract_address": "sei14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sh9m79m",
     "orders_per_block": 10000,
-    "number_of_blocks": 5,
+    "rounds": 5,
     "price_distribution": {
         "min": "45",
         "max": "55",

--- a/loadtest/config.json
+++ b/loadtest/config.json
@@ -2,7 +2,7 @@
     "chain_id": "sei-chain",
     "contract_address": "sei14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sh9m79m",
     "orders_per_block": 10000,
-    "rounds": 5,
+    "number_of_blocks": 5,
     "price_distribution": {
         "min": "45",
         "max": "55",

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -126,7 +126,7 @@ func run(config Config) {
 	}
 	wgs := []*sync.WaitGroup{}
 	sendersList := [][]func(){}
-	fmt.Printf("%s - Starting block prepare\n", time.Now().String())
+	fmt.Printf("%s - Starting block prepare\n", time.Now().Format("2006-01-02T15:04:05"))
 	for i := 0; i < int(config.Rounds); i++ {
 		fmt.Printf("Preparing %d-th block\n", i)
 		wg := &sync.WaitGroup{}
@@ -199,6 +199,7 @@ func run(config Config) {
 		}
 		wg.Wait()
 	}
+	fmt.Printf("%s - Finished\n", time.Now().Format("2006-01-02T15:04:05"))
 }
 
 func main() {

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -6,9 +6,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strconv"
 	"sync"
 	"time"
 
@@ -201,23 +199,6 @@ func run(config Config) {
 		}
 		wg.Wait()
 	}
-}
-
-func getLastHeight() int {
-	out, err := exec.Command("curl", "http://localhost:26657/blockchain").Output()
-	if err != nil {
-		panic(err)
-	}
-	var dat map[string]interface{}
-	if err := json.Unmarshal(out, &dat); err != nil {
-		panic(err)
-	}
-	result := dat["result"].(map[string]interface{})
-	height, err := strconv.Atoi(result["last_height"].(string))
-	if err != nil {
-		panic(err)
-	}
-	return height
 }
 
 func main() {

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -33,8 +33,8 @@ type EncodingConfig struct {
 type Config struct {
 	ChainID        string              `json:"chain_id"`
 	ContractAddr   string              `json:"contract_address"`
+	OrdersPerBlock uint64              `json:"orders_per_block"`
 	Rounds         uint64              `json:"rounds"`
-	NumberOfBlocks uint64              `json:"number_of_blocks"`
 	PriceDistr     NumericDistribution `json:"price_distribution"`
 	QuantityDistr  NumericDistribution `json:"quantity_distribution"`
 	MsgTypeDistr   MsgTypeDistribution `json:"message_type_distribution"`
@@ -114,7 +114,7 @@ func run(config Config) {
 	TxHashFile = file
 	var mu sync.Mutex
 
-	numberOfAccounts := config.Rounds / BatchSize * 2 // * 2 because we need two sets of accounts
+	numberOfAccounts := config.OrdersPerBlock / BatchSize * 2 // * 2 because we need two sets of accounts
 	activeAccounts := []int{}
 	inactiveAccounts := []int{}
 	for i := 0; i < int(numberOfAccounts); i++ {
@@ -127,7 +127,7 @@ func run(config Config) {
 	wgs := []*sync.WaitGroup{}
 	sendersList := [][]func(){}
 	fmt.Printf("%s - Starting block prepare\n", time.Now().String())
-	for i := 0; i < int(config.NumberOfBlocks); i++ {
+	for i := 0; i < int(config.Rounds); i++ {
 		fmt.Printf("Preparing %d-th block\n", i)
 		wg := &sync.WaitGroup{}
 		var senders []func()
@@ -190,7 +190,7 @@ func run(config Config) {
 		inactiveAccounts, activeAccounts = activeAccounts, inactiveAccounts
 	}
 
-	for i := 0; i < int(config.NumberOfBlocks); i++ {
+	for i := 0; i < int(config.Rounds); i++ {
 
 		senders := sendersList[i]
 		wg := wgs[i]

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -134,7 +134,7 @@ func run(config Config) {
 		wg := &sync.WaitGroup{}
 		var senders []func()
 		wgs = append(wgs, wg)
-		for j, account := range activeAccounts {
+		for _, account := range activeAccounts {
 			key := GetKey(uint64(account))
 			var msg sdk.Msg
 			msgType := config.MsgTypeDistr.Sample()

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -35,7 +35,7 @@ type EncodingConfig struct {
 type Config struct {
 	ChainID        string              `json:"chain_id"`
 	ContractAddr   string              `json:"contract_address"`
-	OrdersPerBlock uint64              `json:"orders_per_block"`
+	Rounds         uint64              `json:"rounds"`
 	NumberOfBlocks uint64              `json:"number_of_blocks"`
 	PriceDistr     NumericDistribution `json:"price_distribution"`
 	QuantityDistr  NumericDistribution `json:"quantity_distribution"`
@@ -116,7 +116,7 @@ func run(config Config) {
 	TxHashFile = file
 	var mu sync.Mutex
 
-	numberOfAccounts := config.OrdersPerBlock / BatchSize * 2 // * 2 because we need two sets of accounts
+	numberOfAccounts := config.Rounds / BatchSize * 2 // * 2 because we need two sets of accounts
 	activeAccounts := []int{}
 	inactiveAccounts := []int{}
 	for i := 0; i < int(numberOfAccounts); i++ {

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -128,7 +128,7 @@ func run(config Config) {
 	sendersList := [][]func(){}
 	fmt.Printf("%s - Starting block prepare\n", time.Now().Format("2006-01-02T15:04:05"))
 	for i := 0; i < int(config.Rounds); i++ {
-		fmt.Printf("Preparing %d-th block\n", i)
+		fmt.Printf("Preparing %d-th round\n", i)
 		wg := &sync.WaitGroup{}
 		var senders []func()
 		wgs = append(wgs, wg)
@@ -178,6 +178,10 @@ func run(config Config) {
 			_ = txBuilder.SetMsgs(msg)
 			seqDelta := uint64(i / 2)
 			mode := typestx.BroadcastMode_BROADCAST_MODE_SYNC
+			// Note: There is a potential race condition here with seqnos
+			// in which a later seqno is delievered before an earlier seqno
+			// In practice, we haven't run into this issue so we'll leave this
+			// as is.
 			sender := SendTx(key, &txBuilder, mode, seqDelta, &mu)
 			wg.Add(1)
 			senders = append(senders, func() {

--- a/loadtest/scripts/metrics.py
+++ b/loadtest/scripts/metrics.py
@@ -6,7 +6,6 @@ def get_block_height_and_timestamp(tx_hash_str):
     res = requests.get(f"http://0.0.0.0:1317/txs/{tx_hash_str}")
     body = res.json()
     if "height" not in body:
-        print(tx_hash_str)
         return
     height = int(body["height"])
     return height

--- a/store/whitelist/cachemulti/store_test.go
+++ b/store/whitelist/cachemulti/store_test.go
@@ -10,11 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var WhitelistedStoreKey = storetypes.NewKVStoreKey("whitelisted")
-var NotWhitelistedStoreKey = storetypes.NewKVStoreKey("not-whitelisted")
-var TestStoreKeyToWriteWhitelist = map[storetypes.StoreKey][]string{
-	WhitelistedStoreKey: {"foo"},
-}
+var (
+	WhitelistedStoreKey          = storetypes.NewKVStoreKey("whitelisted")
+	NotWhitelistedStoreKey       = storetypes.NewKVStoreKey("not-whitelisted")
+	TestStoreKeyToWriteWhitelist = map[storetypes.StoreKey][]string{
+		WhitelistedStoreKey: {"foo"},
+	}
+)
 
 func TestWhitelistEnabledStore(t *testing.T) {
 	stores := map[types.StoreKey]types.CacheWrapper{

--- a/store/whitelist/multi/store_test.go
+++ b/store/whitelist/multi/store_test.go
@@ -10,11 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var WhitelistedStoreKey = storetypes.NewKVStoreKey("whitelisted")
-var NotWhitelistedStoreKey = storetypes.NewKVStoreKey("not-whitelisted")
-var TestStoreKeyToWriteWhitelist = map[storetypes.StoreKey][]string{
-	WhitelistedStoreKey: {"foo"},
-}
+var (
+	WhitelistedStoreKey          = storetypes.NewKVStoreKey("whitelisted")
+	NotWhitelistedStoreKey       = storetypes.NewKVStoreKey("not-whitelisted")
+	TestStoreKeyToWriteWhitelist = map[storetypes.StoreKey][]string{
+		WhitelistedStoreKey: {"foo"},
+	}
+)
 
 func TestWhitelistEnabledStore(t *testing.T) {
 	stores := map[types.StoreKey]types.CacheWrapper{

--- a/x/dex/ante.go
+++ b/x/dex/ante.go
@@ -2,7 +2,6 @@ package dex
 
 import (
 	"errors"
-	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"

--- a/x/dex/ante.go
+++ b/x/dex/ante.go
@@ -52,7 +52,6 @@ func (tsmd TickSizeMultipleDecorator) CheckTickSizeMultiple(ctx sdk.Context, msg
 						PriceDenom: order.PriceDenom,
 						AssetDenom: order.AssetDenom,
 					})
-				fmt.Println(contractAddr)
 				// todo may not need to throw err if ticksize unfound?
 				if !found {
 					return sdkerrors.Wrapf(sdkerrors.ErrKeyNotFound, "the pair {price:%s,asset:%s} has no ticksize configured", order.PriceDenom, order.AssetDenom)

--- a/x/dex/module_test.go
+++ b/x/dex/module_test.go
@@ -337,7 +337,6 @@ func TestEndBlockPanicHandling(t *testing.T) {
 	dexkeeper.AddRegisteredPair(ctx, contractAddr.String(), pair)
 	dexkeeper.MemState.GetBlockOrders(utils.ContractAddress(contractAddr.String()), utils.GetPairString(&pair)).AddOrder(
 		&types.Order{
-
 			Id:                1,
 			Account:           testAccount.String(),
 			ContractAddr:      contractAddr.String(),


### PR DESCRIPTION
This PR changes it so that the client doesn't limit the number of txns / block since that's ultimately what we're trying to benchmark. Instead, we now send as many txns as possible and specify `rounds` - which is the number of times the accounts should loop and send txns. Includes other optimizations (see inline comments).