### PR TITLE
Remove signer in dex wasmbinding messages

### DIFF
--- a/wasmbinding/bindings/msg.go
+++ b/wasmbinding/bindings/msg.go
@@ -33,7 +33,7 @@ type BurnTokens struct {
 // Dex Module msgs
 type PlaceOrders struct {
 	Orders []*types.Order `json:"orders"`
-	Funds sdk.Coins `json:"funds"`
+	Funds  sdk.Coins      `json:"funds"`
 }
 
 type CancelOrders struct {

--- a/wasmbinding/bindings/msg.go
+++ b/wasmbinding/bindings/msg.go
@@ -32,10 +32,12 @@ type BurnTokens struct {
 
 // Dex Module msgs
 type PlaceOrders struct {
-	Orders []*types.Order `json:"orders"`
-	Funds  sdk.Coins      `json:"funds"`
+	Orders       []*types.Order `json:"orders"`
+	Funds        sdk.Coins      `json:"funds"`
+	ContractAddr string         `json:"contract_address"`
 }
 
 type CancelOrders struct {
-	OrderIds []uint64 `json:"order_ids"`
+	OrderIds     []uint64 `json:"order_ids"`
+	ContractAddr string   `json:"contract_address"`
 }

--- a/wasmbinding/bindings/msg.go
+++ b/wasmbinding/bindings/msg.go
@@ -1,6 +1,9 @@
 package bindings
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+)
 
 /// CreateDenom creates a new factory denom, of denomination:
 /// factory/{creating contract address}/{Subdenom}
@@ -25,4 +28,14 @@ type MintTokens struct {
 
 type BurnTokens struct {
 	Amount sdk.Coin `json:"amount"`
+}
+
+// Dex Module msgs
+type PlaceOrders struct {
+	Orders []*types.Order `json:"orders"`
+	Funds sdk.Coins `json:"funds"`
+}
+
+type CancelOrders struct {
+	OrderIds []uint64 `json:"order_ids"`
 }

--- a/wasmbinding/encoder.go
+++ b/wasmbinding/encoder.go
@@ -26,9 +26,9 @@ func CustomEncoder(sender sdk.AccAddress, msg json.RawMessage) ([]sdk.Msg, error
 	}
 	switch {
 	case parsedMessage.PlaceOrders != nil:
-		return dexwasm.EncodeDexPlaceOrders(parsedMessage.PlaceOrders)
+		return dexwasm.EncodeDexPlaceOrders(parsedMessage.PlaceOrders, sender)
 	case parsedMessage.CancelOrders != nil:
-		return dexwasm.EncodeDexCancelOrders(parsedMessage.CancelOrders)
+		return dexwasm.EncodeDexCancelOrders(parsedMessage.CancelOrders, sender)
 	case parsedMessage.CreateDenom != nil:
 		return tokenfactorywasm.EncodeTokenFactoryCreateDenom(parsedMessage.CreateDenom, sender)
 	case parsedMessage.Mint != nil:

--- a/wasmbinding/test/encoder_test.go
+++ b/wasmbinding/test/encoder_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	TEST_TARGET_CONTRACT = "sei1y3pxq5dp900czh0mkudhjdqjq5m8cpmmps8yjw"
+	TEST_TARGET_CONTRACT = "sei14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sh9m79m"
 	TEST_CREATOR         = "sei1y3pxq5dp900czh0mkudhjdqjq5m8cpmmps8yjw"
 )
 
@@ -31,8 +31,9 @@ func TestEncodePlaceOrder(t *testing.T) {
 	}
 	fund := sdk.NewCoin("usei", sdk.NewInt(1000000000))
 	msg := bindings.PlaceOrders{
-		Orders: []*dextypes.Order{&order},
-		Funds:  []sdk.Coin{fund},
+		Orders:       []*dextypes.Order{&order},
+		Funds:        []sdk.Coin{fund},
+		ContractAddr: TEST_TARGET_CONTRACT,
 	}
 	serialized, _ := json.Marshal(msg)
 	msgData := wasmbinding.SeiWasmMessage{
@@ -58,7 +59,8 @@ func TestDecodeOrderCancellation(t *testing.T) {
 	contractAddr, err := sdk.AccAddressFromBech32("sei1y3pxq5dp900czh0mkudhjdqjq5m8cpmmps8yjw")
 	require.NoError(t, err)
 	msg := bindings.CancelOrders{
-		OrderIds: []uint64{1},
+		OrderIds:     []uint64{1},
+		ContractAddr: TEST_TARGET_CONTRACT,
 	}
 	serialized, _ := json.Marshal(msg)
 	msgData := wasmbinding.SeiWasmMessage{

--- a/wasmbinding/test/encoder_test.go
+++ b/wasmbinding/test/encoder_test.go
@@ -7,9 +7,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/sei-protocol/sei-chain/wasmbinding"
 	"github.com/sei-protocol/sei-chain/wasmbinding/bindings"
-	"github.com/stretchr/testify/require"
 	dextypes "github.com/sei-protocol/sei-chain/x/dex/types"
 	tokenfactorytypes "github.com/sei-protocol/sei-chain/x/tokenfactory/types"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -31,8 +31,8 @@ func TestEncodePlaceOrder(t *testing.T) {
 	}
 	fund := sdk.NewCoin("usei", sdk.NewInt(1000000000))
 	msg := bindings.PlaceOrders{
-		Orders:       []*dextypes.Order{&order},
-		Funds:        []sdk.Coin{fund},
+		Orders: []*dextypes.Order{&order},
+		Funds:  []sdk.Coin{fund},
 	}
 	serialized, _ := json.Marshal(msg)
 	msgData := wasmbinding.SeiWasmMessage{
@@ -58,7 +58,7 @@ func TestDecodeOrderCancellation(t *testing.T) {
 	contractAddr, err := sdk.AccAddressFromBech32("sei1y3pxq5dp900czh0mkudhjdqjq5m8cpmmps8yjw")
 	require.NoError(t, err)
 	msg := bindings.CancelOrders{
-		OrderIds:     []uint64{1},
+		OrderIds: []uint64{1},
 	}
 	serialized, _ := json.Marshal(msg)
 	msgData := wasmbinding.SeiWasmMessage{
@@ -97,7 +97,7 @@ func TestEncodeCreateDenom(t *testing.T) {
 	typedDecodedMsg, ok := decodedMsgs[0].(*tokenfactorytypes.MsgCreateDenom)
 	require.True(t, ok)
 	expectedMsg := tokenfactorytypes.MsgCreateDenom{
-		Sender: "sei1y3pxq5dp900czh0mkudhjdqjq5m8cpmmps8yjw",
+		Sender:   "sei1y3pxq5dp900czh0mkudhjdqjq5m8cpmmps8yjw",
 		Subdenom: "subdenom",
 	}
 	require.Equal(t, expectedMsg, *typedDecodedMsg)
@@ -155,7 +155,7 @@ func TestEncodeChangeAdmin(t *testing.T) {
 	contractAddr, err := sdk.AccAddressFromBech32("sei1y3pxq5dp900czh0mkudhjdqjq5m8cpmmps8yjw")
 	require.NoError(t, err)
 	msg := bindings.ChangeAdmin{
-		Denom: "factory/sei1y3pxq5dp900czh0mkudhjdqjq5m8cpmmps8yjw/subdenom",
+		Denom:           "factory/sei1y3pxq5dp900czh0mkudhjdqjq5m8cpmmps8yjw/subdenom",
 		NewAdminAddress: "sei1hjfwcza3e3uzeznf3qthhakdr9juetl7g6esl4",
 	}
 	serialized, _ := json.Marshal(msg)
@@ -170,8 +170,8 @@ func TestEncodeChangeAdmin(t *testing.T) {
 	typedDecodedMsg, ok := decodedMsgs[0].(*tokenfactorytypes.MsgChangeAdmin)
 	require.True(t, ok)
 	expectedMsg := tokenfactorytypes.MsgChangeAdmin{
-		Sender: "sei1y3pxq5dp900czh0mkudhjdqjq5m8cpmmps8yjw",
-		Denom: "factory/sei1y3pxq5dp900czh0mkudhjdqjq5m8cpmmps8yjw/subdenom",
+		Sender:   "sei1y3pxq5dp900czh0mkudhjdqjq5m8cpmmps8yjw",
+		Denom:    "factory/sei1y3pxq5dp900czh0mkudhjdqjq5m8cpmmps8yjw/subdenom",
 		NewAdmin: "sei1hjfwcza3e3uzeznf3qthhakdr9juetl7g6esl4",
 	}
 	require.Equal(t, expectedMsg, *typedDecodedMsg)

--- a/x/dex/client/wasm/encoder.go
+++ b/x/dex/client/wasm/encoder.go
@@ -16,7 +16,7 @@ func EncodeDexPlaceOrders(rawMsg json.RawMessage, sender sdk.AccAddress) ([]sdk.
 	placeOrdersMsg := types.MsgPlaceOrders{
 		Creator:      sender.String(),
 		Orders:       encodedPlaceOrdersMsg.Orders,
-		ContractAddr: sender.String(),
+		ContractAddr: encodedPlaceOrdersMsg.ContractAddr,
 		Funds:        encodedPlaceOrdersMsg.Funds,
 	}
 	return []sdk.Msg{&placeOrdersMsg}, nil
@@ -30,7 +30,7 @@ func EncodeDexCancelOrders(rawMsg json.RawMessage, sender sdk.AccAddress) ([]sdk
 	cancelOrdersMsg := types.MsgCancelOrders{
 		Creator:      sender.String(),
 		OrderIds:     encodedCancelOrdersMsg.OrderIds,
-		ContractAddr: sender.String(),
+		ContractAddr: encodedCancelOrdersMsg.ContractAddr,
 	}
 	return []sdk.Msg{&cancelOrdersMsg}, nil
 }

--- a/x/dex/client/wasm/encoder.go
+++ b/x/dex/client/wasm/encoder.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/sei-protocol/sei-chain/x/dex/types"
 	"github.com/sei-protocol/sei-chain/wasmbinding/bindings"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
 )
 
 func EncodeDexPlaceOrders(rawMsg json.RawMessage, sender sdk.AccAddress) ([]sdk.Msg, error) {
@@ -14,10 +14,10 @@ func EncodeDexPlaceOrders(rawMsg json.RawMessage, sender sdk.AccAddress) ([]sdk.
 		return []sdk.Msg{}, err
 	}
 	placeOrdersMsg := types.MsgPlaceOrders{
-		Creator: sender.String(),
-		Orders: encodedPlaceOrdersMsg.Orders,
+		Creator:      sender.String(),
+		Orders:       encodedPlaceOrdersMsg.Orders,
 		ContractAddr: sender.String(),
-		Funds: encodedPlaceOrdersMsg.Funds,
+		Funds:        encodedPlaceOrdersMsg.Funds,
 	}
 	return []sdk.Msg{&placeOrdersMsg}, nil
 }
@@ -28,8 +28,8 @@ func EncodeDexCancelOrders(rawMsg json.RawMessage, sender sdk.AccAddress) ([]sdk
 		return []sdk.Msg{}, err
 	}
 	cancelOrdersMsg := types.MsgCancelOrders{
-		Creator: sender.String(),
-		OrderIds: encodedCancelOrdersMsg.OrderIds,
+		Creator:      sender.String(),
+		OrderIds:     encodedCancelOrdersMsg.OrderIds,
 		ContractAddr: sender.String(),
 	}
 	return []sdk.Msg{&cancelOrdersMsg}, nil

--- a/x/dex/client/wasm/encoder.go
+++ b/x/dex/client/wasm/encoder.go
@@ -5,20 +5,32 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
+	"github.com/sei-protocol/sei-chain/wasmbinding/bindings"
 )
 
-func EncodeDexPlaceOrders(rawMsg json.RawMessage) ([]sdk.Msg, error) {
-	placeOrdersMsg := types.MsgPlaceOrders{}
-	if err := json.Unmarshal(rawMsg, &placeOrdersMsg); err != nil {
+func EncodeDexPlaceOrders(rawMsg json.RawMessage, sender sdk.AccAddress) ([]sdk.Msg, error) {
+	encodedPlaceOrdersMsg := bindings.PlaceOrders{}
+	if err := json.Unmarshal(rawMsg, &encodedPlaceOrdersMsg); err != nil {
 		return []sdk.Msg{}, err
+	}
+	placeOrdersMsg := types.MsgPlaceOrders{
+		Creator: sender.String(),
+		Orders: encodedPlaceOrdersMsg.Orders,
+		ContractAddr: sender.String(),
+		Funds: encodedPlaceOrdersMsg.Funds,
 	}
 	return []sdk.Msg{&placeOrdersMsg}, nil
 }
 
-func EncodeDexCancelOrders(rawMsg json.RawMessage) ([]sdk.Msg, error) {
-	cancelOrdersMsg := types.MsgCancelOrders{}
-	if err := json.Unmarshal(rawMsg, &cancelOrdersMsg); err != nil {
+func EncodeDexCancelOrders(rawMsg json.RawMessage, sender sdk.AccAddress) ([]sdk.Msg, error) {
+	encodedCancelOrdersMsg := bindings.CancelOrders{}
+	if err := json.Unmarshal(rawMsg, &encodedCancelOrdersMsg); err != nil {
 		return []sdk.Msg{}, err
+	}
+	cancelOrdersMsg := types.MsgCancelOrders{
+		Creator: sender.String(),
+		OrderIds: encodedCancelOrdersMsg.OrderIds,
+		ContractAddr: sender.String(),
 	}
 	return []sdk.Msg{&cancelOrdersMsg}, nil
 }


### PR DESCRIPTION
- Removes the `Creator` and `ContractAddr` field from wasmbinding messages in dex