### PR TITLE
Optimize settlements storage

### DIFF
--- a/x/dex/keeper/query/grpc_query_settlements.go
+++ b/x/dex/keeper/query/grpc_query_settlements.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -19,10 +18,7 @@ func (k KeeperWrapper) GetSettlements(c context.Context, req *types.QueryGetSett
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	settlements, found := k.GetSettlementsState(ctx, req.ContractAddr, req.PriceDenom, req.AssetDenom, req.Account, req.OrderId)
-	if !found {
-		return &types.QueryGetSettlementsResponse{}, sdkerrors.ErrKeyNotFound
-	}
+	settlements := k.GetSettlementsState(ctx, req.ContractAddr, req.PriceDenom, req.AssetDenom, req.Account, req.OrderId)
 
 	return &types.QueryGetSettlementsResponse{Settlements: settlements}, nil
 }

--- a/x/dex/keeper/query/grpc_query_settlements_test.go
+++ b/x/dex/keeper/query/grpc_query_settlements_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -37,9 +36,9 @@ func TestSettlementsQuerySingle(t *testing.T) {
 			response: &types.QueryGetSettlementsResponse{Settlements: msgs[1]},
 		},
 		{
-			desc:    "KeyNotFound",
-			request: &types.QueryGetSettlementsRequest{ContractAddr: keepertest.TestContract, PriceDenom: "btc", AssetDenom: "sei", OrderId: 2, Account: "test_account2"},
-			err:     sdkerrors.ErrKeyNotFound,
+			desc:     "Empty",
+			request:  &types.QueryGetSettlementsRequest{ContractAddr: keepertest.TestContract, PriceDenom: "btc", AssetDenom: "sei", OrderId: 2, Account: "test_account2"},
+			response: &types.QueryGetSettlementsResponse{Settlements: types.Settlements{}},
 		},
 		{
 			desc: "InvalidRequest",

--- a/x/dex/keeper/settlement.go
+++ b/x/dex/keeper/settlement.go
@@ -11,32 +11,36 @@ import (
 func (k Keeper) SetSettlements(ctx sdk.Context, contractAddr string, priceDenom string, assetDenom string, settlements types.Settlements) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.SettlementEntryPrefix(contractAddr, priceDenom, assetDenom))
 	for _, settlement := range settlements.GetEntries() {
-		existing, found := k.GetSettlementsState(ctx, contractAddr, priceDenom, assetDenom, settlement.Account, settlement.OrderId)
-		if found {
-			existing.Entries = append(existing.Entries, settlement)
-		} else {
-			existing = types.Settlements{
-				Epoch:   settlements.Epoch,
-				Entries: []*types.SettlementEntry{settlement},
-			}
+		nextSettlementID := k.GetNextSettlementID(ctx, contractAddr, priceDenom, assetDenom, settlement.OrderId)
+		settlementBytes, err := settlement.Marshal()
+		if err != nil {
+			panic("invalid settlement")
 		}
-
-		b := k.Cdc.MustMarshal(&existing)
-		store.Set(getSettlementKey(settlement.OrderId, settlement.Account), b)
+		store.Set(GetSettlementKey(settlement.OrderId, settlement.Account, nextSettlementID), settlementBytes)
+		k.SetNextSettlementID(ctx, contractAddr, priceDenom, assetDenom, settlement.OrderId, nextSettlementID+1)
 	}
 }
 
-func (k Keeper) GetSettlementsState(ctx sdk.Context, contractAddr string, priceDenom string, assetDenom string, account string, orderID uint64) (val types.Settlements, found bool) {
+// used by grpc query
+func (k Keeper) GetSettlementsState(ctx sdk.Context, contractAddr string, priceDenom string, assetDenom string, account string, orderID uint64) types.Settlements {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.SettlementEntryPrefix(contractAddr, priceDenom, assetDenom))
-	b := store.Get(getSettlementKey(orderID, account))
-	val = types.Settlements{}
-	if b == nil {
-		return val, false
+	res := []*types.SettlementEntry{}
+	iterator := sdk.KVStorePrefixIterator(store, GetSettlementOrderIDPrefix(orderID, account))
+
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		var val types.SettlementEntry
+		if err := val.Unmarshal(iterator.Value()); err != nil {
+			panic("invalid settlement entry")
+		}
+		res = append(res, &val)
 	}
-	k.Cdc.MustUnmarshal(b, &val)
-	return val, true
+
+	return types.Settlements{Entries: res}
 }
 
+// used by grpc query
 func (k Keeper) GetSettlementsStateForAccount(ctx sdk.Context, contractAddr string, priceDenom string, assetDenom string, account string) []types.Settlements {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.SettlementEntryPrefix(contractAddr, priceDenom, assetDenom))
 	res := []types.Settlements{}
@@ -45,14 +49,17 @@ func (k Keeper) GetSettlementsStateForAccount(ctx sdk.Context, contractAddr stri
 	defer iterator.Close()
 
 	for ; iterator.Valid(); iterator.Next() {
-		var val types.Settlements
-		k.Cdc.MustUnmarshal(iterator.Value(), &val)
-		res = append(res, val)
+		var val types.SettlementEntry
+		if err := val.Unmarshal(iterator.Value()); err != nil {
+			panic("invalid settlement entry")
+		}
+		res = append(res, types.Settlements{Entries: []*types.SettlementEntry{&val}})
 	}
 
 	return res
 }
 
+// used by grpc query
 func (k Keeper) GetAllSettlementsState(ctx sdk.Context, contractAddr string, priceDenom string, assetDenom string, limit int) []types.Settlements {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.SettlementEntryPrefix(contractAddr, priceDenom, assetDenom))
 	res := []types.Settlements{}
@@ -61,9 +68,11 @@ func (k Keeper) GetAllSettlementsState(ctx sdk.Context, contractAddr string, pri
 	defer iterator.Close()
 
 	for ; iterator.Valid(); iterator.Next() {
-		var val types.Settlements
-		k.Cdc.MustUnmarshal(iterator.Value(), &val)
-		res = append(res, val)
+		var val types.SettlementEntry
+		if err := val.Unmarshal(iterator.Value()); err != nil {
+			panic("invalid settlement entry")
+		}
+		res = append(res, types.Settlements{Entries: []*types.SettlementEntry{&val}})
 		if len(res) >= limit {
 			break
 		}
@@ -72,9 +81,34 @@ func (k Keeper) GetAllSettlementsState(ctx sdk.Context, contractAddr string, pri
 	return res
 }
 
-func getSettlementKey(orderID uint64, account string) []byte {
+func (k Keeper) GetNextSettlementID(ctx sdk.Context, contractAddr string, priceDenom string, assetDenom string, orderID uint64) uint64 {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.NextSettlementIDPrefix(contractAddr, priceDenom, assetDenom))
+	key := make([]byte, 8)
+	binary.BigEndian.PutUint64(key, orderID)
+	if !store.Has(key) {
+		return 0
+	}
+	return binary.BigEndian.Uint64(store.Get(key))
+}
+
+func (k Keeper) SetNextSettlementID(ctx sdk.Context, contractAddr string, priceDenom string, assetDenom string, orderID uint64, nextSettlementID uint64) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.NextSettlementIDPrefix(contractAddr, priceDenom, assetDenom))
+	key := make([]byte, 8)
+	binary.BigEndian.PutUint64(key, orderID)
+	value := make([]byte, 8)
+	binary.BigEndian.PutUint64(value, nextSettlementID)
+	store.Set(key, value)
+}
+
+func GetSettlementOrderIDPrefix(orderID uint64, account string) []byte {
 	accountBytes := append([]byte(account), []byte("|")...)
 	orderIDBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(orderIDBytes, orderID)
 	return append(accountBytes, orderIDBytes...)
+}
+
+func GetSettlementKey(orderID uint64, account string, settlementID uint64) []byte {
+	settlementIDBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(settlementIDBytes, settlementID)
+	return append(GetSettlementOrderIDPrefix(orderID, account), settlementIDBytes...)
 }

--- a/x/dex/keeper/settlements_test.go
+++ b/x/dex/keeper/settlements_test.go
@@ -38,10 +38,12 @@ func TestSetSettlements(t *testing.T) {
 		},
 	}
 	keeper.SetSettlements(ctx, keepertest.TestContract, keepertest.TestPriceDenom, keepertest.TestAssetDenom, settlements)
-	settlementsOrder1, found := keeper.GetSettlementsState(ctx, keepertest.TestContract, keepertest.TestPriceDenom, keepertest.TestAssetDenom, "abc", 1)
-	require.True(t, found)
+	settlementsOrder1 := keeper.GetSettlementsState(ctx, keepertest.TestContract, keepertest.TestPriceDenom, keepertest.TestAssetDenom, "abc", 1)
 	require.Equal(t, 1, len(settlementsOrder1.Entries))
-	settlementsOrder2, found := keeper.GetSettlementsState(ctx, keepertest.TestContract, keepertest.TestPriceDenom, keepertest.TestAssetDenom, "def", 2)
-	require.True(t, found)
+	settlementsOrder2 := keeper.GetSettlementsState(ctx, keepertest.TestContract, keepertest.TestPriceDenom, keepertest.TestAssetDenom, "def", 2)
 	require.Equal(t, 1, len(settlementsOrder2.Entries))
+	nextSettlementID1 := keeper.GetNextSettlementID(ctx, keepertest.TestContract, keepertest.TestPriceDenom, keepertest.TestAssetDenom, 1)
+	require.Equal(t, uint64(1), nextSettlementID1)
+	nextSettlementID2 := keeper.GetNextSettlementID(ctx, keepertest.TestContract, keepertest.TestPriceDenom, keepertest.TestAssetDenom, 2)
+	require.Equal(t, uint64(1), nextSettlementID2)
 }

--- a/x/dex/migrations/v7_to_v8.go
+++ b/x/dex/migrations/v7_to_v8.go
@@ -1,0 +1,87 @@
+package migrations
+
+import (
+	"encoding/binary"
+
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/x/dex/keeper"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+)
+
+func V7ToV8(ctx sdk.Context, storeKey sdk.StoreKey) error {
+	return flattenSettlements(ctx, storeKey)
+}
+
+func flattenSettlements(ctx sdk.Context, storeKey sdk.StoreKey) error {
+	contractStore := prefix.NewStore(ctx.KVStore(storeKey), []byte(keeper.ContractPrefixKey))
+	iterator := sdk.KVStorePrefixIterator(contractStore, []byte{})
+
+	defer iterator.Close()
+	for ; iterator.Valid(); iterator.Next() {
+		contract := types.ContractInfo{}
+		if err := contract.Unmarshal(iterator.Value()); err != nil {
+			return err
+		}
+		pairStore := prefix.NewStore(ctx.KVStore(storeKey), types.RegisteredPairPrefix(contract.ContractAddr))
+		pairIterator := sdk.KVStorePrefixIterator(pairStore, []byte{})
+		for ; pairIterator.Valid(); pairIterator.Next() {
+			pair := types.Pair{}
+			if err := pair.Unmarshal(pairIterator.Value()); err != nil {
+				pairIterator.Close()
+				return err
+			}
+			settlementStore := prefix.NewStore(
+				ctx.KVStore(storeKey),
+				types.SettlementEntryPrefix(contract.ContractAddr, pair.PriceDenom, pair.AssetDenom),
+			)
+			settlementIterator := sdk.KVStorePrefixIterator(settlementStore, []byte{})
+
+			oldKeys := [][]byte{}
+			newKeys := [][]byte{}
+			newVals := [][]byte{}
+			for ; settlementIterator.Valid(); settlementIterator.Next() {
+				var val types.Settlements
+				if err := val.Unmarshal(settlementIterator.Value()); err != nil {
+					pairIterator.Close()
+					settlementIterator.Close()
+					return err
+				}
+				for i, settlementEntry := range val.Entries {
+					settlementBytes, err := settlementEntry.Marshal()
+					if err != nil {
+						pairIterator.Close()
+						settlementIterator.Close()
+						return err
+					}
+					newKeys = append(newKeys, keeper.GetSettlementKey(settlementEntry.OrderId, settlementEntry.Account, uint64(i)))
+					newVals = append(newVals, settlementBytes)
+				}
+
+				if len(val.Entries) > 0 {
+					settlementIDStore := prefix.NewStore(
+						ctx.KVStore(storeKey),
+						types.NextSettlementIDPrefix(contract.ContractAddr, pair.PriceDenom, pair.AssetDenom),
+					)
+					key := make([]byte, 8)
+					binary.BigEndian.PutUint64(key, val.Entries[0].OrderId)
+					value := make([]byte, 8)
+					binary.BigEndian.PutUint64(value, uint64(len(val.Entries)))
+					settlementIDStore.Set(key, value)
+				}
+				oldKeys = append(oldKeys, settlementIterator.Key())
+			}
+
+			settlementIterator.Close()
+
+			for _, oldKey := range oldKeys {
+				settlementStore.Delete(oldKey)
+			}
+			for i, newKey := range newKeys {
+				settlementStore.Set(newKey, newVals[i])
+			}
+		}
+		pairIterator.Close()
+	}
+	return nil
+}

--- a/x/dex/migrations/v7_to_v8_test.go
+++ b/x/dex/migrations/v7_to_v8_test.go
@@ -1,0 +1,98 @@
+package migrations_test
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/store"
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/x/dex/keeper"
+	"github.com/sei-protocol/sei-chain/x/dex/migrations"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	tmdb "github.com/tendermint/tm-db"
+)
+
+func TestMigrate7to8(t *testing.T) {
+	storeKey := sdk.NewKVStoreKey(types.StoreKey)
+	memStoreKey := storetypes.NewMemoryStoreKey(types.MemStoreKey)
+
+	db := tmdb.NewMemDB()
+	stateStore := store.NewCommitMultiStore(db)
+	stateStore.MountStoreWithDB(storeKey, sdk.StoreTypeIAVL, db)
+	stateStore.MountStoreWithDB(memStoreKey, sdk.StoreTypeMemory, nil)
+	require.NoError(t, stateStore.LoadLatestVersion())
+
+	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())
+
+	// write old settlements
+	store := prefix.NewStore(
+		ctx.KVStore(storeKey),
+		types.SettlementEntryPrefix(keepertest.TestContract, keepertest.TestPriceDenom, keepertest.TestAssetDenom),
+	)
+	settlements := types.Settlements{
+		Entries: []*types.SettlementEntry{
+			{
+				Account:  keepertest.TestAccount,
+				OrderId:  1,
+				Quantity: sdk.MustNewDecFromStr("0.3"),
+			},
+			{
+				Account:  keepertest.TestAccount,
+				OrderId:  1,
+				Quantity: sdk.MustNewDecFromStr("0.7"),
+			},
+		},
+	}
+	bz, _ := settlements.Marshal()
+	store.Set(keeper.GetSettlementOrderIDPrefix(1, keepertest.TestAccount), bz)
+
+	// register contract / pair
+	store = prefix.NewStore(
+		ctx.KVStore(storeKey),
+		[]byte(keeper.ContractPrefixKey),
+	)
+	contract := types.ContractInfo{
+		CodeId:            1,
+		ContractAddr:      keepertest.TestContract,
+		NeedOrderMatching: true,
+	}
+	contractBytes, _ := contract.Marshal()
+	store.Set([]byte(contract.ContractAddr), contractBytes)
+
+	store = prefix.NewStore(ctx.KVStore(storeKey), types.RegisteredPairPrefix(keepertest.TestContract))
+	keyBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(keyBytes, 0)
+	pairBytes, _ := keepertest.TestPair.Marshal()
+	store.Set(keyBytes, pairBytes)
+
+	err := migrations.V7ToV8(ctx, storeKey)
+	require.Nil(t, err)
+
+	store = prefix.NewStore(
+		ctx.KVStore(storeKey),
+		types.SettlementEntryPrefix(keepertest.TestContract, keepertest.TestPriceDenom, keepertest.TestAssetDenom),
+	)
+	settlementEntry1Key := keeper.GetSettlementKey(1, keepertest.TestAccount, 0)
+	settlementEntry1 := types.SettlementEntry{}
+	settlementEntry1Bytes := store.Get(settlementEntry1Key)
+	_ = settlementEntry1.Unmarshal(settlementEntry1Bytes)
+	require.Equal(t, sdk.MustNewDecFromStr("0.3"), settlementEntry1.Quantity)
+	settlementEntry2Key := keeper.GetSettlementKey(1, keepertest.TestAccount, 1)
+	settlementEntry2 := types.SettlementEntry{}
+	settlementEntry2Bytes := store.Get(settlementEntry2Key)
+	_ = settlementEntry2.Unmarshal(settlementEntry2Bytes)
+	require.Equal(t, sdk.MustNewDecFromStr("0.7"), settlementEntry2.Quantity)
+
+	require.False(t, store.Has(keeper.GetSettlementOrderIDPrefix(1, keepertest.TestAccount)))
+
+	store = prefix.NewStore(ctx.KVStore(storeKey), types.NextSettlementIDPrefix(keepertest.TestContract, keepertest.TestPriceDenom, keepertest.TestAssetDenom))
+	key := make([]byte, 8)
+	binary.BigEndian.PutUint64(key, uint64(1))
+	require.Equal(t, uint64(2), binary.BigEndian.Uint64(store.Get(key)))
+}

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -178,6 +178,9 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	_ = cfg.RegisterMigration(types.ModuleName, 6, func(ctx sdk.Context) error {
 		return migrations.V6ToV7(ctx, am.keeper.GetStoreKey())
 	})
+	_ = cfg.RegisterMigration(types.ModuleName, 7, func(ctx sdk.Context) error {
+		return migrations.V7ToV8(ctx, am.keeper.GetStoreKey())
+	})
 }
 
 // RegisterInvariants registers the capability module's invariants.
@@ -202,7 +205,7 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 }
 
 // ConsensusVersion implements ConsensusVersion.
-func (AppModule) ConsensusVersion() uint64 { return 7 }
+func (AppModule) ConsensusVersion() uint64 { return 8 }
 
 func (am AppModule) getAllContractInfo(ctx sdk.Context) []types.ContractInfo {
 	return am.keeper.GetAllContractInfo(ctx)

--- a/x/dex/module_test.go
+++ b/x/dex/module_test.go
@@ -131,8 +131,7 @@ func TestEndBlockMarketOrder(t *testing.T) {
 	require.Equal(t, types.OrderStatus_FULFILLED, marketOrder.Status)
 	require.True(t, marketOrder.Quantity.IsZero())
 
-	settlements, found := dexkeeper.GetSettlementsState(ctx, contractAddr.String(), pair.PriceDenom, pair.AssetDenom, testAccount.String(), 2)
-	require.True(t, found)
+	settlements := dexkeeper.GetSettlementsState(ctx, contractAddr.String(), pair.PriceDenom, pair.AssetDenom, testAccount.String(), 2)
 	require.Equal(t, 1, len(settlements.Entries))
 
 	dexkeeper.MemState.Clear()

--- a/x/dex/types/keys.go
+++ b/x/dex/types/keys.go
@@ -104,6 +104,13 @@ func NextOrderIDPrefix(contractAddr string) []byte {
 	return append(KeyPrefix(NextOrderIDKey), KeyPrefix(contractAddr)...)
 }
 
+func NextSettlementIDPrefix(contractAddr string, priceDenom string, assetDenom string) []byte {
+	return append(
+		append(KeyPrefix(NextSettlementIDKey), KeyPrefix(contractAddr)...),
+		PairPrefix(priceDenom, assetDenom)...,
+	)
+}
+
 const (
 	DefaultPriceDenom = "stake"
 	DefaultAssetDenom = "dummy"
@@ -121,6 +128,7 @@ const (
 	TwapKey             = "TWAP-"
 	PriceKey            = "Price-"
 	SettlementEntryKey  = "SettlementEntry-"
+	NextSettlementIDKey = "NextSettlementID-"
 	NextOrderIDKey      = "noid"
 	RegisteredPairKey   = "rp"
 	RegisteredPairCount = "rpcnt"


### PR DESCRIPTION
Previously, settlement entries for the same order ID are stored as a list under a single KV store entry. This becomes inefficient as the list grows for certain large orders, as the chain would need to read and write some very large lists even if there is only one settlement entry added in a particular block.

We optimize this by storing settlement entries as individual KV store entries. Specifically, each `contract-pair-orderID` combo now has an associated incrementing counter that provides a settlement ID for each settlement entry in a deterministic way. There is no need to read all historical settlement entries during `dex` EndBlock anymore. Corresponding migration handler is also included in this PR.

For frontend queries, we will add pagination for settlement entries in a separate PR.