### PR TITLE
Fix spans and endblockpanic alert

### DIFF
--- a/x/dex/contract/abci.go
+++ b/x/dex/contract/abci.go
@@ -3,8 +3,9 @@ package contract
 import (
 	"context"
 	"fmt"
-	"github.com/sei-protocol/sei-chain/utils/tracing"
 	"sync"
+
+	"github.com/sei-protocol/sei-chain/utils/tracing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/sei-protocol/sei-chain/store/whitelist/multi"

--- a/x/dex/contract/execution.go
+++ b/x/dex/contract/execution.go
@@ -49,18 +49,18 @@ func CallPreExecutionHooks(
 }
 
 func CancelUnfulfilledMarketOrders(
-	ctx sdk.Context,
+	ctx context.Context,
+	sdkCtx sdk.Context,
 	contractAddr string,
 	dexkeeper *keeper.Keeper,
 	tracer *otrace.Tracer,
-	parentSpanCtx context.Context,
 ) error {
-	spanCtx, span := (*tracer).Start(parentSpanCtx, "CancelUnfulfilledMarketOrders")
+	spanCtx, span := (*tracer).Start(ctx, "CancelUnfulfilledMarketOrders")
 	span.SetAttributes(attribute.String("contract", contractAddr))
 	defer span.End()
 	abciWrapper := dexkeeperabci.KeeperWrapper{Keeper: dexkeeper}
-	registeredPairs := dexkeeper.GetAllRegisteredPairs(ctx, contractAddr)
-	if err := abciWrapper.HandleEBCancelOrders(spanCtx, ctx, tracer, contractAddr, registeredPairs); err != nil {
+	registeredPairs := dexkeeper.GetAllRegisteredPairs(sdkCtx, contractAddr)
+	if err := abciWrapper.HandleEBCancelOrders(spanCtx, sdkCtx, tracer, contractAddr, registeredPairs); err != nil {
 		return err
 	}
 	return nil
@@ -278,7 +278,7 @@ func HandleExecutionForContract(
 		orderUpdater()
 	}
 	// Cancel unfilled market orders
-	if err := CancelUnfulfilledMarketOrders(ctx, contractAddr, dexkeeper, tracer, spanCtx); err != nil {
+	if err := CancelUnfulfilledMarketOrders(spanCtx, ctx, contractAddr, dexkeeper, tracer); err != nil {
 		return orderResults, settlements, err
 	}
 

--- a/x/dex/contract/execution.go
+++ b/x/dex/contract/execution.go
@@ -3,9 +3,10 @@ package contract
 import (
 	"context"
 	"fmt"
-	otrace "go.opentelemetry.io/otel/trace"
 	"sync"
 	"time"
+
+	otrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/cosmos/cosmos-sdk/telemetry"
 

--- a/x/dex/keeper/abci/end_block_deposit.go
+++ b/x/dex/keeper/abci/end_block_deposit.go
@@ -14,9 +14,9 @@ import (
 )
 
 func (w KeeperWrapper) HandleEBDeposit(ctx context.Context, sdkCtx sdk.Context, tracer *otrace.Tracer, contractAddr string) error {
-	_, span := (*tracer).Start(ctx, "SudoPlaceOrders")
-	defer span.End()
+	_, span := (*tracer).Start(ctx, "SudoDeposit")
 	span.SetAttributes(attribute.String("contractAddr", contractAddr))
+	defer span.End()
 
 	typedContractAddr := typesutils.ContractAddress(contractAddr)
 	msg := w.GetDepositSudoMsg(sdkCtx, typedContractAddr)

--- a/x/dex/keeper/abci/end_block_place_orders.go
+++ b/x/dex/keeper/abci/end_block_place_orders.go
@@ -19,14 +19,18 @@ import (
 const MaxOrdersPerSudoCall = 50000
 
 func (w KeeperWrapper) HandleEBPlaceOrders(ctx context.Context, sdkCtx sdk.Context, tracer *otrace.Tracer, contractAddr string, registeredPairs []types.Pair) error {
-	_, span := (*tracer).Start(ctx, "SudoPlaceOrders")
+	spanCtx, span := (*tracer).Start(ctx, "SudoPlaceOrders")
 	span.SetAttributes(attribute.String("contractAddr", contractAddr))
+	defer span.End()
 
 	typedContractAddr := typesutils.ContractAddress(contractAddr)
 	msgs := w.GetPlaceSudoMsg(sdkCtx, typedContractAddr, registeredPairs)
 
 	responses := []wasm.SudoOrderPlacementResponse{}
+
+	fmt.Println("Num messages: ", len(msgs))
 	for _, msg := range msgs {
+		_, span := (*tracer).Start(spanCtx, "CallContractSudo")
 		data, err := utils.CallContractSudo(sdkCtx, w.Keeper, contractAddr, msg)
 		if err != nil {
 			sdkCtx.Logger().Error(fmt.Sprintf("Error during order placement: %s", err.Error()))
@@ -39,15 +43,18 @@ func (w KeeperWrapper) HandleEBPlaceOrders(ctx context.Context, sdkCtx sdk.Conte
 		}
 		sdkCtx.Logger().Info(fmt.Sprintf("Sudo response data: %s", response))
 		responses = append(responses, response)
+		span.End()
 	}
 
+	fmt.Println("Num responses: ", len(responses))
 	for _, pair := range registeredPairs {
 		typedPairStr := typesutils.GetPairString(&pair) //nolint:gosec // USING THE POINTER HERE COULD BE BAD, LET'S CHECK IT.
 		for _, response := range responses {
+			_, span := (*tracer).Start(spanCtx, "GetBlockOrders")
 			w.MemState.GetBlockOrders(sdkCtx, typedContractAddr, typedPairStr).MarkFailedToPlace(response.UnsuccessfulOrders)
+			span.End()
 		}
 	}
-	span.End()
 	return nil
 }
 

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -273,10 +273,11 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) (ret []abc
 		if err := recover(); err != nil {
 			ctx.Logger().Error(fmt.Sprintf("panic occurred in %s EndBlock: %s", types.ModuleName, err))
 			telemetry.IncrCounterWithLabels(
-				[]string{fmt.Sprintf("%s%s", types.ModuleName, "endblockpanic")},
+				[]string{fmt.Sprintf("endblockpanic")},
 				1,
 				[]metrics.Label{
 					telemetry.NewLabel("error", fmt.Sprintf("%s", err)),
+					telemetry.NewLabel("module", types.ModuleName),
 				},
 			)
 			ret = []abci.ValidatorUpdate{}

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -215,7 +215,7 @@ func (am AppModule) getAllContractInfo(ctx sdk.Context) []types.ContractInfo {
 func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
 	// TODO (codchen): Revert before mainnet so we don't silently fail on errors
 	defer func() {
-		_, span := (*am.tracingInfo.Tracer).Start(am.tracingInfo.TracerContext, "DexEndBlockRollback")
+		_, span := (*am.tracingInfo.Tracer).Start(am.tracingInfo.TracerContext, "DexBeginBlockRollback")
 		defer span.End()
 		if err := recover(); err != nil {
 			ctx.Logger().Error(fmt.Sprintf("panic occurred in %s BeginBlock: %s", types.ModuleName, err))
@@ -264,8 +264,12 @@ func (am AppModule) beginBlockForContract(ctx sdk.Context, contract types.Contra
 // EndBlock executes all ABCI EndBlock logic respective to the capability module. It
 // returns no validator updates.
 func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) (ret []abci.ValidatorUpdate) {
+	_, span := (*am.tracingInfo.Tracer).Start(am.tracingInfo.TracerContext, "DexEndBlock")
+	defer span.End()
 	// TODO (codchen): Revert https://github.com/sei-protocol/sei-chain/pull/176/files before mainnet so we don't silently fail on errors
 	defer func() {
+		_, span := (*am.tracingInfo.Tracer).Start(am.tracingInfo.TracerContext, "DexEndBlockRollback")
+		defer span.End()
 		if err := recover(); err != nil {
 			ctx.Logger().Error(fmt.Sprintf("panic occurred in %s EndBlock: %s", types.ModuleName, err))
 			telemetry.IncrCounterWithLabels(
@@ -286,7 +290,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) (ret []abc
 	// `validContractAddresses` will always decrease in size every iteration.
 	iterCounter := len(validContractsInfo)
 	for len(validContractsInfo) > 0 {
-		newValidContractsInfo, ok := contract.EndBlockerAtomic(ctx, &am.keeper, validContractsInfo, am.tracingInfo.Tracer)
+		newValidContractsInfo, ok := contract.EndBlockerAtomic(ctx, &am.keeper, validContractsInfo, am.tracingInfo)
 		if ok {
 			break
 		}

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -273,7 +273,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) (ret []abc
 		if err := recover(); err != nil {
 			ctx.Logger().Error(fmt.Sprintf("panic occurred in %s EndBlock: %s", types.ModuleName, err))
 			telemetry.IncrCounterWithLabels(
-				[]string{fmt.Sprintf("endblockpanic")},
+				[]string{("endblockpanic")},
 				1,
 				[]metrics.Label{
 					telemetry.NewLabel("error", fmt.Sprintf("%s", err)),


### PR DESCRIPTION
Fix spans so they use the same context (otherwise they don't show up under the same request).
Additionally, fix the endblockpanic alert since we cannot glob over titles (only labels).
Span: <img width="1892" alt="image" src="https://user-images.githubusercontent.com/3821073/183821536-7663f607-9684-434a-a1ea-28e1661632a1.png">
Page: https://seinetwork.pagerduty.com/incidents/Q3UV2GHWDHQWQR
