### PR TITLE
Add tokenfactory keeper migration

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -3,11 +3,12 @@ package app
 import (
 	"context"
 	"fmt"
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 
 	appparams "github.com/sei-protocol/sei-chain/app/params"
 	"github.com/sei-protocol/sei-chain/wasmbinding"
@@ -763,7 +764,6 @@ func (app *App) SetStoreUpgradeHandlers() {
 		// configure store loader that checks if version == upgradeHeight and applies store upgrades
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}
-
 }
 
 // AppName returns the name of the App

--- a/app/app.go
+++ b/app/app.go
@@ -3,12 +3,11 @@ package app
 import (
 	"context"
 	"fmt"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
-
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 
 	appparams "github.com/sei-protocol/sei-chain/app/params"
 	"github.com/sei-protocol/sei-chain/wasmbinding"
@@ -676,19 +675,7 @@ func New(
 	app.sm.RegisterStoreDecoders()
 
 	app.RegisterUpgradeHandlers()
-	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
-	if err != nil {
-		panic(err)
-	}
-
-	if upgradeInfo.Name == "1.0.4beta" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
-		storeUpgrades := storetypes.StoreUpgrades{
-			Added: []string{oracletypes.StoreKey},
-		}
-
-		// configure store loader that checks if version == upgradeHeight and applies store upgrades
-		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
-	}
+	app.SetStoreUpgradeHandlers()
 
 	// initialize stores
 	app.MountKVStores(keys)
@@ -750,6 +737,33 @@ func New(
 	// this line is used by starport scaffolding # stargate/app/beforeInitReturn
 
 	return app
+}
+
+// Add (or remove) keepers when they are introduced / removed in different versions
+func (app *App) SetStoreUpgradeHandlers() {
+	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
+	if err != nil {
+		panic(err)
+	}
+
+	if upgradeInfo.Name == "1.0.4beta" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		storeUpgrades := storetypes.StoreUpgrades{
+			Added: []string{oracletypes.StoreKey},
+		}
+
+		// configure store loader that checks if version == upgradeHeight and applies store upgrades
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+	}
+
+	if upgradeInfo.Name == "1.2.0beta" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		storeUpgrades := storetypes.StoreUpgrades{
+			Added: []string{tokenfactorytypes.StoreKey},
+		}
+
+		// configure store loader that checks if version == upgradeHeight and applies store upgrades
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+	}
+
 }
 
 // AppName returns the name of the App


### PR DESCRIPTION
When new modules / keepers are introduced, a store migration must be introduced otherwise it will lead to state-sync consensus failures.
Tested in internal testnet, verified that upgrade works with this patch.