### PR TITLE
Fix panic metrics

### DIFF
--- a/utils/panic.go
+++ b/utils/panic.go
@@ -19,10 +19,11 @@ func PanicHandler(recoverCallback func(any)) func() {
 func MetricsPanicCallback(err any, ctx sdk.Context, key string) {
 	ctx.Logger().Error(fmt.Sprintf("panic %s occurred during order matching for: %s", err, key))
 	telemetry.IncrCounterWithLabels(
-		[]string{key},
+		[]string{"endblockpanic"},
 		1,
 		[]metrics.Label{
 			telemetry.NewLabel("error", fmt.Sprintf("%s", err)),
+			telemetry.NewLabel("module", key),
 		},
 	)
 }

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -220,10 +220,11 @@ func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
 		if err := recover(); err != nil {
 			ctx.Logger().Error(fmt.Sprintf("panic occurred in %s BeginBlock: %s", types.ModuleName, err))
 			telemetry.IncrCounterWithLabels(
-				[]string{fmt.Sprintf("%s%s", types.ModuleName, "beginblockpanic")},
+				[]string{"beginblockpanic"},
 				1,
 				[]metrics.Label{
 					telemetry.NewLabel("error", fmt.Sprintf("%s", err)),
+					telemetry.NewLabel("module", types.ModuleName),
 				},
 			)
 		}
@@ -273,7 +274,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) (ret []abc
 		if err := recover(); err != nil {
 			ctx.Logger().Error(fmt.Sprintf("panic occurred in %s EndBlock: %s", types.ModuleName, err))
 			telemetry.IncrCounterWithLabels(
-				[]string{("endblockpanic")},
+				[]string{"endblockpanic"},
 				1,
 				[]metrics.Label{
 					telemetry.NewLabel("error", fmt.Sprintf("%s", err)),

--- a/x/epoch/module.go
+++ b/x/epoch/module.go
@@ -177,10 +177,11 @@ func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
 		if err := recover(); err != nil {
 			ctx.Logger().Error(fmt.Sprintf("panic occurred in %s BeginBlock: %s", types.ModuleName, err))
 			telemetry.IncrCounterWithLabels(
-				[]string{fmt.Sprintf("%s%s", types.ModuleName, "beginblockpanic")},
+				[]string{"beginblockpanic"},
 				1,
 				[]metrics.Label{
 					telemetry.NewLabel("error", fmt.Sprintf("%s", err)),
+					telemetry.NewLabel("module", types.ModuleName),
 				},
 			)
 		}

--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -155,10 +155,11 @@ func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
 		if err := recover(); err != nil {
 			ctx.Logger().Error(fmt.Sprintf("panic occurred in %s BeginBlock: %s", types.ModuleName, err))
 			telemetry.IncrCounterWithLabels(
-				[]string{fmt.Sprintf("%s%s", types.ModuleName, "beginblockpanic")},
+				[]string{"beginblockpanic"},
 				1,
 				[]metrics.Label{
 					telemetry.NewLabel("error", fmt.Sprintf("%s", err)),
+					telemetry.NewLabel("module", types.ModuleName),
 				},
 			)
 		}

--- a/x/oracle/module.go
+++ b/x/oracle/module.go
@@ -176,10 +176,11 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) (ret []abc
 		if err := recover(); err != nil {
 			ctx.Logger().Error(fmt.Sprintf("panic occurred in %s EndBlock: %s", types.ModuleName, err))
 			telemetry.IncrCounterWithLabels(
-				[]string{fmt.Sprintf("%s%s", types.ModuleName, "endblockpanic")},
+				[]string{"endblockpanic"},
 				1,
 				[]metrics.Label{
 					telemetry.NewLabel("error", fmt.Sprintf("%s", err)),
+					telemetry.NewLabel("module", types.ModuleName),
 				},
 			)
 			ret = []abci.ValidatorUpdate{}


### PR DESCRIPTION
In order to create an alert, the metric name needs to be consistent. We make all of the alerts "end/begin"blockpanic and add module name to albels.