### PR TITLE
Add Metrics to measure sudo calls 

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -49,7 +49,8 @@ func (app *App) ExportAppStateAndValidators(
 
 // prepare for fresh start at zero height
 // NOTE zero height genesis is a temporary feature which will be deprecated
-//      in favour of export at a block height
+//
+//	in favour of export at a block height
 func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []string) {
 	applyAllowedAddrs := false
 

--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -41,6 +41,7 @@ import (
 type Option func(*rootOptions)
 
 // scaffoldingOptions keeps set of options to apply scaffolding.
+//
 //nolint:unused // preserving this becase don't know if it is needed.
 type rootOptions struct {
 	addSubCmds         []*cobra.Command

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/CosmWasm/wasmd v0.27.0
 	github.com/CosmWasm/wasmvm v1.0.0
+	github.com/armon/go-metrics v0.3.10
 	github.com/cosmos/cosmos-sdk v0.45.4
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/ibc-go/v3 v3.0.0
@@ -13,6 +14,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/pkg/errors v0.9.1
+	github.com/regen-network/cosmos-proto v0.3.1
 	github.com/spf13/cast v1.4.1
 	github.com/spf13/cobra v1.4.0
 	github.com/stretchr/testify v1.7.1
@@ -33,7 +35,6 @@ require (
 	github.com/99designs/keyring v1.1.6 // indirect
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d // indirect
 	github.com/Workiva/go-datastructures v1.0.53 // indirect
-	github.com/armon/go-metrics v0.3.10 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/btcsuite/btcd v0.22.0-beta // indirect
@@ -55,7 +56,6 @@ require (
 	github.com/dvsekhvalnov/jose2go v0.0.0-20200901110807-248326c1351b // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-kit/kit v0.12.0 // indirect
 	github.com/go-kit/log v0.2.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
@@ -74,7 +74,6 @@ require (
 	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.2 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/gtank/merlin v0.1.1 // indirect
 	github.com/gtank/ristretto255 v0.1.2 // indirect
@@ -107,7 +106,6 @@ require (
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/rakyll/statik v0.1.7 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 // indirect
-	github.com/regen-network/cosmos-proto v0.3.1 // indirect
 	github.com/rs/cors v1.8.2 // indirect
 	github.com/rs/zerolog v1.26.0 // indirect
 	github.com/sasha-s/go-deadlock v0.2.1-0.20190427202633-1595213edefa // indirect

--- a/go.sum
+++ b/go.sum
@@ -321,7 +321,6 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
@@ -504,14 +503,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.3 h1:BGNSrTRW4rwfhJiFwvwF4XQ0Y72Jj9YEgxVrtovbD5o=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.3/go.mod h1:VHn7KgNsRriXa4mcgtkpR00OXyQY6g67JWMvn+R27A4=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.0 h1:Ghn7copILfeIg0y8sTGRppI1bd8I4l2VN3cob0Xeqwg=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.0/go.mod h1:dnjr4snxnhRSn5GWqJUva2AoMbeaxyAcepvc0Tg8lXk=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.1 h1:/sDbPb60SusIXjiJGYLUoS/rAQurQmvGWmwn2bBPM9c=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.1/go.mod h1:G+WkljZi4mflcqVxYSgvt8MNctRQHjEH8ubKtt1Ka3w=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.2 h1:BqHID5W5qnMkug0Z8UmL8tN0gAy4jQ+B4WFt8cCgluU=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.2/go.mod h1:ZbS3MZTZq/apAfAEHGoB5HbsQQstoqP92SjAqtQ9zeg=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/gtank/merlin v0.1.1-0.20191105220539-8318aed1a79f/go.mod h1:T86dnYJhcGOh5BjZFCJWTDeTK7XW8uE+E21Cy/bIQ+s=
@@ -1186,8 +1177,6 @@ golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210903162142-ad29c8ab022f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210917221730-978cfadd31cf/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211208012354-db4efeb81f4b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20220412020605-290c469a71a5 h1:bRb386wvrE+oBNdF1d/Xh9mQrfQ4ecYhW5qJ5GvTGT4=
-golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e h1:TsQ7F31D3bUCLeqPT0u+yjp1guoArKaNKmCr22PYgTQ=
 golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1318,8 +1307,6 @@ golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211210111614-af8b64212486/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d h1:Zu/JngovGLVi6t2J3nmAf3AoTDwuzw85YZ3b9o4yU7s=
 golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -1525,12 +1512,6 @@ google.golang.org/genproto v0.0.0-20211028162531-8db9c33dc351/go.mod h1:5CzLGKJ6
 google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20211206160659-862468c7d6e0/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
-google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd h1:e0TwkXOdbnH/1x5rc5MZ/VYyiZ4v+RdVfrGMqEwT68I=
-google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
-google.golang.org/genproto v0.0.0-20220719170305-83ca9fad585f h1:P8EiVSxZwC6xH2niv2N66aqwMtYFg+D54gbjpcqKJtM=
-google.golang.org/genproto v0.0.0-20220719170305-83ca9fad585f/go.mod h1:GkXuJDJ6aQ7lnJcRF+SJVgFdQhypqgl3LB1C9vabdRE=
-google.golang.org/genproto v0.0.0-20220728213248-dd149ef739b9 h1:d3fKQZK+1rWQMg3xLKQbPMirUCo29I/NRdI2WarSzTg=
-google.golang.org/genproto v0.0.0-20220728213248-dd149ef739b9/go.mod h1:iHe1svFLAZg9VWz891+QbRMwUv9O/1Ww+/mngYeThbc=
 google.golang.org/genproto v0.0.0-20220805133916-01dd62135a58 h1:sRT5xdTkj1Kbk30qbYC7VyMj73N5pZYsw6v+Nrzdhno=
 google.golang.org/genproto v0.0.0-20220805133916-01dd62135a58/go.mod h1:iHe1svFLAZg9VWz891+QbRMwUv9O/1Ww+/mngYeThbc=
 google.golang.org/grpc v1.33.2 h1:EQyQC3sa8M+p6Ulc8yy9SWSS2GVwyRc83gAbG8lrl4o=
@@ -1549,8 +1530,6 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
-google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/utils/metrics/README.md
+++ b/utils/metrics/README.md
@@ -1,0 +1,5 @@
+# Sei Metrics
+
+This is intended to be an utility library to expose additional metrics that's useful for monitoring a given Sei chain. It buils ontop of the existing [Cosmos SDK telemetry library](https://docs.cosmos.network/master/core/telemetry.html)
+
+Note: In-memory sink is always attached (when the telemetry is enabled) with 10 second interval and 1 minute retention. This means that metrics will be aggregated over 10 seconds, and metrics will be kept alive for 1 minute.

--- a/utils/metrics/metrics_util.go
+++ b/utils/metrics/metrics_util.go
@@ -7,18 +7,28 @@ import (
 	"github.com/cosmos/cosmos-sdk/telemetry"
 )
 
-func MeasureSudoExecutionDuration(msg_type string) {
+// Measures the time taken to execute a sudo msg
+// Metric Names:
+//
+//	sei_sudo_duration_miliseconds
+//	sei_sudo_duration_miliseconds_count
+//	sei_sudo_duration_miliseconds_sum
+func MeasureSudoExecutionDuration(start time.Time, msgType string) {
 	metrics.MeasureSinceWithLabels(
 		[]string{"sei", "sudo", "duration", "milliseconds"},
-		time.Now(),
-		[]metrics.Label{telemetry.NewLabel("type", msg_type)},
+		start.UTC(),
+		[]metrics.Label{telemetry.NewLabel("type", msgType)},
 	)
 }
 
-func IncrementSudoFailCount(msg_type string) {
+// Measures failed sudo execution count
+// Metric Name:
+//
+//	sei_sudo_error_count
+func IncrementSudoFailCount(msgType string) {
 	telemetry.IncrCounterWithLabels(
 		[]string{"sei", "sudo", "error", "count"},
 		1,
-		[]metrics.Label{telemetry.NewLabel("type", msg_type)},
+		[]metrics.Label{telemetry.NewLabel("type", msgType)},
 	)
 }

--- a/utils/metrics/metrics_util.go
+++ b/utils/metrics/metrics_util.go
@@ -1,0 +1,24 @@
+package metrics
+
+import (
+	"time"
+
+	metrics "github.com/armon/go-metrics"
+	"github.com/cosmos/cosmos-sdk/telemetry"
+)
+
+func MeasureSudoExecutionDuration(msg_type string) {
+	metrics.MeasureSinceWithLabels(
+		[]string{"sei", "sudo", "duration", "milliseconds"},
+		time.Now(),
+		[]metrics.Label{telemetry.NewLabel("type", msg_type)},
+	)
+}
+
+func IncrementSudoFailCount(msg_type string) {
+	telemetry.IncrCounterWithLabels(
+		[]string{"sei", "sudo", "error", "count"},
+		1,
+		[]metrics.Label{telemetry.NewLabel("type", msg_type)},
+	)
+}

--- a/wasmbinding/bindings/msg.go
+++ b/wasmbinding/bindings/msg.go
@@ -5,18 +5,18 @@ import (
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 )
 
-/// CreateDenom creates a new factory denom, of denomination:
-/// factory/{creating contract address}/{Subdenom}
-/// Subdenom can be of length at most 44 characters, in [0-9a-zA-Z./]
-/// The (creating contract address, subdenom) pair must be unique.
-/// The created denom's admin is the creating contract address,
-/// but this admin can be changed using the ChangeAdmin binding.
+// / CreateDenom creates a new factory denom, of denomination:
+// / factory/{creating contract address}/{Subdenom}
+// / Subdenom can be of length at most 44 characters, in [0-9a-zA-Z./]
+// / The (creating contract address, subdenom) pair must be unique.
+// / The created denom's admin is the creating contract address,
+// / but this admin can be changed using the ChangeAdmin binding.
 type CreateDenom struct {
 	Subdenom string `json:"subdenom"`
 }
 
-/// ChangeAdmin changes the admin for a factory denom.
-/// If the NewAdminAddress is empty, the denom has no admin.
+// / ChangeAdmin changes the admin for a factory denom.
+// / If the NewAdminAddress is empty, the denom has no admin.
 type ChangeAdmin struct {
 	Denom           string `json:"denom"`
 	NewAdminAddress string `json:"new_admin_address"`

--- a/x/dex/contract/runner.go
+++ b/x/dex/contract/runner.go
@@ -41,10 +41,11 @@ func NewParallelRunner(runnable func(contract types.ContractInfo), contracts []t
 }
 
 // We define "frontier contract" as a contract which:
-// 1. Has not finished running yet, and
-// 2. either:
-//    a. has no other contracts depending on it, or
-//    b. for which all contracts that depend on it have already finished.
+//  1. Has not finished running yet, and
+//  2. either:
+//     a. has no other contracts depending on it, or
+//     b. for which all contracts that depend on it have already finished.
+//
 // Consequently, the set of frontier contracts will mutate throughout the
 // `Run` method, until all contracts finish their runs.
 // The key principle here is that at any moment, we can have all frontier
@@ -53,26 +54,32 @@ func NewParallelRunner(runnable func(contract types.ContractInfo), contracts []t
 // The simplest implementation would be:
 // ```
 // while there is any contract left:
-//     run all frontier contracts concurrently
-//     wait for all runs to finish
-//     update the frontier set
+//
+//	run all frontier contracts concurrently
+//	wait for all runs to finish
+//	update the frontier set
+//
 // ```
 // We can illustrate why this implementation is not optimal with the following
 // example:
-//     Suppose we have four contracts, where A depends on B, and C depends on
-//     D. The run for A, B, C, D takes 5s, 5s, 8s, 2s, respectively.
-//     With the implementation above, the first iteration would take 8s since
-//     it runs A and C, and the second iteration would take 5s since it runs
-//     B and D. However C doesn't actually need to wait for B to finish, and
-//     if C runs immediately after A finishes, the whole process would take
-//     max(5 + 5, 8 + 2) = 10s, which is 3s faster than the implementation
-//     above.
+//
+//	Suppose we have four contracts, where A depends on B, and C depends on
+//	D. The run for A, B, C, D takes 5s, 5s, 8s, 2s, respectively.
+//	With the implementation above, the first iteration would take 8s since
+//	it runs A and C, and the second iteration would take 5s since it runs
+//	B and D. However C doesn't actually need to wait for B to finish, and
+//	if C runs immediately after A finishes, the whole process would take
+//	max(5 + 5, 8 + 2) = 10s, which is 3s faster than the implementation
+//	above.
+//
 // So we can optimize the implementation to be:
 // ```
 // while there is any contract left:
-//     run all frontier contracts concurrently
-//     wait for any existing run (could be from previous iteration) to finish
-//     update the frontier set
+//
+//	run all frontier contracts concurrently
+//	wait for any existing run (could be from previous iteration) to finish
+//	update the frontier set
+//
 // ```
 // With the example above, the whole process would take 3 iterations:
 // Iter 1 (A, C run): 5s since it finishes when A finishes

--- a/x/dex/keeper/utils/wasm.go
+++ b/x/dex/keeper/utils/wasm.go
@@ -4,8 +4,36 @@ import (
 	"encoding/json"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/utils/metrics"
 	"github.com/sei-protocol/sei-chain/x/dex/keeper"
+	dextypeswasm "github.com/sei-protocol/sei-chain/x/dex/types/wasm"
 )
+
+func getMsgType(msg interface{}) string {
+	switch msg.(type) {
+	case dextypeswasm.SudoNewBlockMsg:
+		return "new_block"
+	case dextypeswasm.SudoSettlementMsg:
+		return "settlement"
+	case dextypeswasm.SudoOrderPlacementMsg:
+		return "bulk_order_placements"
+	case dextypeswasm.SudoOrderCancellationMsg:
+		return "bulk_order_cancellations"
+	case dextypeswasm.SudoLiquidationMsg:
+		return "liquidation"
+	default:
+		return "unknown"
+	}
+}
+
+func sudo(sdkCtx sdk.Context, k *keeper.Keeper, contractAddress []byte, wasmMsg []byte, msgType string) ([]byte, error) {
+	// Measure the time it takes to execute the contract in WASM
+	defer metrics.MeasureSudoExecutionDuration(msgType)
+	data, err := k.WasmKeeper.Sudo(
+		sdkCtx, contractAddress, wasmMsg,
+	)
+	return data, err
+}
 
 func CallContractSudo(sdkCtx sdk.Context, k *keeper.Keeper, contractAddr string, msg interface{}) ([]byte, error) {
 	contractAddress, err := sdk.AccAddressFromBech32(contractAddr)
@@ -18,10 +46,10 @@ func CallContractSudo(sdkCtx sdk.Context, k *keeper.Keeper, contractAddr string,
 		sdkCtx.Logger().Error(err.Error())
 		return []byte{}, err
 	}
-	data, err := k.WasmKeeper.Sudo(
-		sdkCtx, contractAddress, wasmMsg,
-	)
+	msgType := getMsgType(msg)
+	data, err := sudo(sdkCtx, k, contractAddress, wasmMsg, msgType)
 	if err != nil {
+		metrics.IncrementSudoFailCount(msgType)
 		sdkCtx.Logger().Error(err.Error())
 		return []byte{}, err
 	}

--- a/x/dex/keeper/utils/wasm.go
+++ b/x/dex/keeper/utils/wasm.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"encoding/json"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/sei-protocol/sei-chain/utils/metrics"
@@ -13,6 +14,10 @@ func getMsgType(msg interface{}) string {
 	switch msg.(type) {
 	case dextypeswasm.SudoNewBlockMsg:
 		return "new_block"
+	case dextypeswasm.SudoFinalizeBlockMsg:
+		return "finalize_block"
+	case *dextypeswasm.SudoFinalizeBlockMsg:
+		return "finalize_block"
 	case dextypeswasm.SudoSettlementMsg:
 		return "settlement"
 	case dextypeswasm.SudoOrderPlacementMsg:
@@ -28,7 +33,7 @@ func getMsgType(msg interface{}) string {
 
 func sudo(sdkCtx sdk.Context, k *keeper.Keeper, contractAddress []byte, wasmMsg []byte, msgType string) ([]byte, error) {
 	// Measure the time it takes to execute the contract in WASM
-	defer metrics.MeasureSudoExecutionDuration(msgType)
+	defer metrics.MeasureSudoExecutionDuration(time.Now(), msgType)
 	data, err := k.WasmKeeper.Sudo(
 		sdkCtx, contractAddress, wasmMsg,
 	)

--- a/x/oracle/simulation/operations.go
+++ b/x/oracle/simulation/operations.go
@@ -20,6 +20,7 @@ import (
 )
 
 // Simulation operation weights constants
+//
 //nolint:gosec
 const (
 	OpWeightMsgAggregateExchangeRatePrevote = "op_weight_msg_exchange_rate_aggregate_prevote"


### PR DESCRIPTION
Adds custom metrics to measure sei-specific logic, similar to measuring request duration in Web2. In this case, we need to measure the E2E latency on the client side as we are unable to export time-based metrics from WASM 

This is a more repeatable way of measuring the latency without manually adding print statements and parsing the query in an excel sheet

From http://grafana.sei-loadtest-testnet.seinetwork.io/d/ellgRxZ4k/sei-custom-metrics?orgId=1&var-instance=18.219.201.246:26660: 

Spikes line up with when I ran the load test 
![image](https://user-images.githubusercontent.com/18161326/187044601-12f4ddd8-bbc6-4626-afbc-5274dac559d5.png)
* One thing to call out here is that there are a lot more bulk_cancel order calls here (almost 1-1 with the bulk order placements), which I believe is why there's no settlements 
