### PR TITLE
Hard fail on wasmer instantiation error caused by missing CPU features

### DIFF
--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -268,7 +267,7 @@ func getLastHeight() int {
 func main() {
 	config := Config{}
 	pwd, _ := os.Getwd()
-	file, _ := ioutil.ReadFile(pwd + "/loadtest/config.json")
+	file, _ := os.ReadFile(pwd + "/loadtest/config.json")
 	if err := json.Unmarshal(file, &config); err != nil {
 		panic(err)
 	}

--- a/loadtest/sign.go
+++ b/loadtest/sign.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -34,7 +34,7 @@ func GetKey(accountIdx uint64) cryptotypes.PrivKey {
 		panic(err)
 	}
 	var accountInfo AccountInfo
-	byteVal, err := ioutil.ReadAll(jsonFile)
+	byteVal, err := io.ReadAll(jsonFile)
 	if err != nil {
 		panic(err)
 	}

--- a/utils/panic.go
+++ b/utils/panic.go
@@ -2,15 +2,21 @@ package utils
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/armon/go-metrics"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+const HardFailPrefix = "hard fail error occurred"
+
 func PanicHandler(recoverCallback func(any)) func() {
 	return func() {
 		if err := recover(); err != nil {
+			if shouldErrorHardFail(fmt.Sprintf("%s", err)) {
+				panic(err)
+			}
 			recoverCallback(err)
 		}
 	}
@@ -19,11 +25,20 @@ func PanicHandler(recoverCallback func(any)) func() {
 func MetricsPanicCallback(err any, ctx sdk.Context, key string) {
 	ctx.Logger().Error(fmt.Sprintf("panic %s occurred during order matching for: %s", err, key))
 	telemetry.IncrCounterWithLabels(
-		[]string{"endblockpanic"},
+		[]string{"panic"},
 		1,
 		[]metrics.Label{
 			telemetry.NewLabel("error", fmt.Sprintf("%s", err)),
 			telemetry.NewLabel("module", key),
 		},
 	)
+}
+
+func DecorateHardFailError(err error) error {
+	return fmt.Errorf("%s:%s", HardFailPrefix, err.Error())
+}
+
+func shouldErrorHardFail(err string) bool {
+	// use Contains instead of HasPrefix in case the error is further decorated
+	return strings.Contains(err, HardFailPrefix)
 }

--- a/utils/panic_test.go
+++ b/utils/panic_test.go
@@ -1,0 +1,20 @@
+package utils_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sei-protocol/sei-chain/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHardFail(t *testing.T) {
+	hardFailer := func() {
+		panic(utils.DecorateHardFailError(errors.New("some error")))
+	}
+	panicHandlingFn := func() {
+		defer utils.PanicHandler(func(_ any) {})()
+		hardFailer()
+	}
+	require.Panics(t, panicHandlingFn)
+}

--- a/x/dex/client/utils/utils.go
+++ b/x/dex/client/utils/utils.go
@@ -2,7 +2,7 @@ package utils
 
 import (
 	"errors"
-	"io/ioutil"
+	"os"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -125,7 +125,7 @@ func (tss TickSizesJSON) ToTickSizes() ([]dextypes.TickSize, error) {
 func ParseRegisterPairsProposalJSON(cdc *codec.LegacyAmino, proposalFile string) (RegisterPairsProposalJSON, error) {
 	proposal := RegisterPairsProposalJSON{}
 
-	contents, err := ioutil.ReadFile(proposalFile)
+	contents, err := os.ReadFile(proposalFile)
 	if err != nil {
 		return proposal, err
 	}
@@ -142,7 +142,7 @@ func ParseRegisterPairsProposalJSON(cdc *codec.LegacyAmino, proposalFile string)
 func ParseUpdateTickSizeProposalJSON(cdc *codec.LegacyAmino, proposalFile string) (UpdateTickSizeProposalJSON, error) {
 	proposal := UpdateTickSizeProposalJSON{}
 
-	contents, err := ioutil.ReadFile(proposalFile)
+	contents, err := os.ReadFile(proposalFile)
 	if err != nil {
 		return proposal, err
 	}
@@ -159,7 +159,7 @@ func ParseUpdateTickSizeProposalJSON(cdc *codec.LegacyAmino, proposalFile string
 func ParseAddAssetMetadataProposalJSON(cdc *codec.LegacyAmino, proposalFile string) (AddAssetMetadataProposalJSON, error) {
 	proposal := AddAssetMetadataProposalJSON{}
 
-	contents, err := ioutil.ReadFile(proposalFile)
+	contents, err := os.ReadFile(proposalFile)
 	if err != nil {
 		return proposal, err
 	}

--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/armon/go-metrics"
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
@@ -15,10 +14,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
-	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/sei-protocol/sei-chain/utils"
 	"github.com/sei-protocol/sei-chain/x/mint/client/cli"
 	"github.com/sei-protocol/sei-chain/x/mint/client/rest"
 	"github.com/sei-protocol/sei-chain/x/mint/keeper"
@@ -155,19 +154,7 @@ func (AppModule) ConsensusVersion() uint64 { return 2 }
 // BeginBlock returns the begin blocker for the mint module.
 func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
 	// TODO (codchen): Revert before mainnet so we don't silently fail on errors
-	defer func() {
-		if err := recover(); err != nil {
-			ctx.Logger().Error(fmt.Sprintf("panic occurred in %s BeginBlock: %s", types.ModuleName, err))
-			telemetry.IncrCounterWithLabels(
-				[]string{"beginblockpanic"},
-				1,
-				[]metrics.Label{
-					telemetry.NewLabel("error", fmt.Sprintf("%s", err)),
-					telemetry.NewLabel("module", types.ModuleName),
-				},
-			)
-		}
-	}()
+	defer utils.PanicHandler(func(err any) { utils.MetricsPanicCallback(err, ctx, types.ModuleName) })()
 }
 
 // EndBlock returns the end blocker for the mint module. It returns no validator


### PR DESCRIPTION
In the case where the host of a sei chain deployment has its underlying architecture updated, `wasmer` VM instantiation will throw error. Right now we print out errors received during `sudo` calls since we thought they are all deterministic, but the aforementioned error type is not deterministic (as in, it will only happen to nodes that undergo such system level update). So to prevent the chain from ending up in a bad state, we would like it to crash when in such cases.