### PR TITLE
Fix order cancellation

### DIFF
--- a/x/dex/client/cli/tx/tx_cancel_orders.go
+++ b/x/dex/client/cli/tx/tx_cancel_orders.go
@@ -29,18 +29,22 @@ func CmdCancelOrders() *cobra.Command {
 			for _, cancellation := range args[1:] {
 				newCancel := types.Cancellation{}
 				cancelDetails := strings.Split(cancellation, "?")
-				argPositionDir, err := utils.GetPositionDirectionFromStr(cancelDetails[0])
+				newCancel.Id, err = strconv.ParseUint(cancelDetails[0], 10, 64)
+				if err != nil {
+					return err
+				}
+				argPositionDir, err := utils.GetPositionDirectionFromStr(cancelDetails[1])
 				if err != nil {
 					return err
 				}
 				newCancel.PositionDirection = argPositionDir
-				argPrice, err := sdk.NewDecFromStr(cancelDetails[1])
+				argPrice, err := sdk.NewDecFromStr(cancelDetails[2])
 				if err != nil {
 					return err
 				}
 				newCancel.Price = argPrice
-				newCancel.PriceDenom = cancelDetails[2]
-				newCancel.AssetDenom = cancelDetails[3]
+				newCancel.PriceDenom = cancelDetails[3]
+				newCancel.AssetDenom = cancelDetails[4]
 				cancellations = append(cancellations, &newCancel)
 			}
 

--- a/x/dex/keeper/msgserver/msg_server_cancel_orders_test.go
+++ b/x/dex/keeper/msgserver/msg_server_cancel_orders_test.go
@@ -1,0 +1,150 @@
+package msgserver_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/x/dex/keeper/msgserver"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+	typesutils "github.com/sei-protocol/sei-chain/x/dex/types/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCancelOrder(t *testing.T) {
+	// store a long limit order to the orderbook
+	keeper, ctx := keepertest.DexKeeper(t)
+	keeper.SetLongBook(ctx, keepertest.TestContract, types.LongBook{
+		Price: sdk.OneDec(),
+		Entry: &types.OrderEntry{
+			Price:      sdk.OneDec(),
+			Quantity:   sdk.MustNewDecFromStr("2"),
+			PriceDenom: keepertest.TestPriceDenom,
+			AssetDenom: keepertest.TestAssetDenom,
+			Allocations: []*types.Allocation{
+				{
+					Account:  keepertest.TestAccount,
+					OrderId:  1,
+					Quantity: sdk.MustNewDecFromStr("2"),
+				},
+			},
+		},
+	})
+
+	// cancel order
+	msg := &types.MsgCancelOrders{
+		Creator:      keepertest.TestAccount,
+		ContractAddr: keepertest.TestContract,
+		Cancellations: []*types.Cancellation{
+			{
+				Price:             sdk.OneDec(),
+				PositionDirection: types.PositionDirection_LONG,
+				PriceDenom:        keepertest.TestPriceDenom,
+				AssetDenom:        keepertest.TestAssetDenom,
+				Id:                1,
+			},
+		},
+	}
+	keeper.AddRegisteredPair(ctx, keepertest.TestContract, keepertest.TestPair)
+	keeper.SetTickSizeForPair(ctx, keepertest.TestContract, keepertest.TestPair, *keepertest.TestPair.Ticksize)
+	wctx := sdk.WrapSDKContext(ctx)
+	server := msgserver.NewMsgServerImpl(*keeper)
+	_, err := server.CancelOrders(wctx, msg)
+
+	pairBlockCancellations := keeper.MemState.GetBlockCancels(ctx, keepertest.TestContract, typesutils.GetPairString(&keepertest.TestPair))
+	require.Nil(t, err)
+	require.Equal(t, 1, len(pairBlockCancellations.Get()))
+	require.Equal(t, uint64(1), pairBlockCancellations.Get()[0].Id)
+	require.Equal(t, sdk.OneDec(), pairBlockCancellations.Get()[0].Price)
+	require.Equal(t, "atom", pairBlockCancellations.Get()[0].AssetDenom)
+	require.Equal(t, "usdc", pairBlockCancellations.Get()[0].PriceDenom)
+	require.Equal(t, keepertest.TestAccount, pairBlockCancellations.Get()[0].Creator)
+	require.Equal(t, keepertest.TestContract, pairBlockCancellations.Get()[0].ContractAddr)
+}
+
+func TestInvalidCancels(t *testing.T) {
+	// nil cancel price
+	keeper, ctx := keepertest.DexKeeper(t)
+	msg := &types.MsgCancelOrders{
+		Creator:      keepertest.TestAccount,
+		ContractAddr: keepertest.TestContract,
+		Cancellations: []*types.Cancellation{
+			{
+				PositionDirection: types.PositionDirection_LONG,
+				PriceDenom:        keepertest.TestPriceDenom,
+				AssetDenom:        keepertest.TestAssetDenom,
+				Id:                1,
+			},
+		},
+	}
+	keeper.AddRegisteredPair(ctx, keepertest.TestContract, keepertest.TestPair)
+	keeper.SetTickSizeForPair(ctx, keepertest.TestContract, keepertest.TestPair, *keepertest.TestPair.Ticksize)
+	wctx := sdk.WrapSDKContext(ctx)
+	server := msgserver.NewMsgServerImpl(*keeper)
+	_, err := server.CancelOrders(wctx, msg)
+	require.NotNil(t, err)
+
+	// nil creator
+	msg = &types.MsgCancelOrders{
+		ContractAddr: keepertest.TestContract,
+		Cancellations: []*types.Cancellation{
+			{
+				PositionDirection: types.PositionDirection_LONG,
+				PriceDenom:        keepertest.TestPriceDenom,
+				AssetDenom:        keepertest.TestAssetDenom,
+				Id:                1,
+				Price:             sdk.OneDec(),
+			},
+		},
+	}
+	_, err = server.CancelOrders(wctx, msg)
+	require.NotNil(t, err)
+
+	// nil contract address
+	msg = &types.MsgCancelOrders{
+		Creator:      keepertest.TestAccount,
+		Cancellations: []*types.Cancellation{
+			{
+				Price:             sdk.OneDec(),
+				PositionDirection: types.PositionDirection_LONG,
+				PriceDenom:        keepertest.TestPriceDenom,
+				AssetDenom:        keepertest.TestAssetDenom,
+				Id:                1,
+			},
+		},
+	}
+	_, err = server.CancelOrders(wctx, msg)
+	require.NotNil(t, err)
+
+	// nil price denom
+	msg = &types.MsgCancelOrders{
+		Creator:      keepertest.TestAccount,
+		ContractAddr: keepertest.TestContract,
+		Cancellations: []*types.Cancellation{
+			{
+				Price:             sdk.OneDec(),
+				PositionDirection: types.PositionDirection_LONG,
+				AssetDenom:        keepertest.TestAssetDenom,
+				Id:                1,
+			},
+		},
+	}
+	_, err = server.CancelOrders(wctx, msg)
+	require.NotNil(t, err)
+
+	// nil asset denom
+	msg = &types.MsgCancelOrders{
+		Creator:      keepertest.TestAccount,
+		ContractAddr: keepertest.TestContract,
+		Cancellations: []*types.Cancellation{
+			{
+				Price:             sdk.OneDec(),
+				PositionDirection: types.PositionDirection_LONG,
+				PriceDenom:        keepertest.TestPriceDenom,
+				Id:                1,
+			},
+		},
+	}
+	_, err = server.CancelOrders(wctx, msg)
+	require.NotNil(t, err)
+}


### PR DESCRIPTION
This PR fixes the cancellation msg_server and adds corresponding unit tests. 

Verified e2e locally.