### PR TITLE
Fix upgrade handler

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -791,7 +791,7 @@ func (app *App) SetStoreUpgradeHandlers() {
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}
 
-	if upgradeInfo.Name == "1.2.1beta" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+	if upgradeInfo.Name == "1.2.2beta" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{
 			Added: []string{nitrotypes.StoreKey},
 		}


### PR DESCRIPTION
## Describe your changes and provide context
Upgrade handler for nitro store should be set at 1.2.2beta not 1.2.1beta. This caused the state sync issue described in https://discord.com/channels/973057323805311026/978080988422893619/1026619126363455620

## Testing performed to validate your change
Performed upgrade with 1.2.2beta locally and in internal testnet. Verified it work. 1.2.2beta binary has this fix already: https://github.com/sei-protocol/sei-chain/commit/92472c4f0b7482c97690e9803de434d0d55eb344