### PR TITLE
Update market order status at the end of block execution

### DIFF
--- a/x/dex/types/wasm/block_hooks.go
+++ b/x/dex/types/wasm/block_hooks.go
@@ -53,15 +53,27 @@ func NewContractOrderResult(contractAddr string) ContractOrderResult {
 	}
 }
 
-func PopulateOrderPlacementResults(contractAddr string, orders []*types.Order, resultMap map[string]ContractOrderResult) {
+func PopulateOrderPlacementResults(contractAddr string, orders []*types.Order, cancellations []*types.Cancellation, resultMap map[string]ContractOrderResult) {
+	// get cancelled order ids 
+	cancels := make(map[uint64]bool)
+	for _, cancel := range cancellations {
+		cancels[cancel.Id] = true
+	}
+
+
 	for _, order := range orders {
+		orderStatus := order.Status
+		if _, ok := cancels[order.Id]; ok {
+			orderStatus = types.OrderStatus_CANCELLED
+		}
+
 		if _, ok := resultMap[order.Account]; !ok {
 			resultMap[order.Account] = NewContractOrderResult(contractAddr)
 		}
 		resultsForAccount := resultMap[order.Account]
 		resultsForAccount.OrderPlacementResults = append(resultsForAccount.OrderPlacementResults, OrderPlacementResult{
 			OrderID: order.Id,
-			Status:  order.Status,
+			Status:  orderStatus,
 		},
 		)
 		resultMap[order.Account] = resultsForAccount

--- a/x/dex/types/wasm/block_hooks_test.go
+++ b/x/dex/types/wasm/block_hooks_test.go
@@ -25,7 +25,7 @@ func TestPopulateOrderPlacementResults(t *testing.T) {
 		Data:              "{\"position_effect\":\"Open\",\"leverage\":\"1\"}",
 	}
 	resultsMap := map[string]wasm.ContractOrderResult{}
-	wasm.PopulateOrderPlacementResults(contract, []*types.Order{&orderToPopulate}, resultsMap)
+	wasm.PopulateOrderPlacementResults(contract, []*types.Order{&orderToPopulate}, []*types.Cancellation{}, resultsMap)
 	require.Equal(t, 1, len(resultsMap))
 	require.Equal(t, contract, resultsMap[account].ContractAddr)
 	require.Equal(t, 1, len(resultsMap[account].OrderPlacementResults))


### PR DESCRIPTION
This PR updates market order status at the end of block execution.

Verified in local E2E test.
