### PR TITLE
Remove sends to community pool

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -104,10 +104,7 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 
 	// reinitialize all validators
 	app.StakingKeeper.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
-		// donate any unwithdrawn outstanding reward fraction tokens to the community pool
-		scraps := app.DistrKeeper.GetValidatorOutstandingRewardsCoins(ctx, val.GetOperator())
 		feePool := app.DistrKeeper.GetFeePool(ctx)
-		feePool.CommunityPool = feePool.CommunityPool.Add(scraps...)
 		app.DistrKeeper.SetFeePool(ctx, feePool)
 
 		app.DistrKeeper.Hooks().AfterValidatorCreated(ctx, val.GetOperator())


### PR DESCRIPTION
- Removes any sends to fund the community pool: Sending to community pool when charging a tokenfactory denom creation fee + sending to community pool scraps from unwithdrawn validator fees
- Tested locally by querying `seid query distribution community-pool` and verifying its empty

