### PR TITLE
Move Parallel TX Signalling to SeiChain DeliverTx call

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.82
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.102
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.56

--- a/go.mod
+++ b/go.mod
@@ -134,6 +134,6 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.102
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
-	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.56
+	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.59
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1099,8 +1099,8 @@ github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+f
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sei-protocol/sei-cosmos v0.1.102 h1:UG9Lgw/qmOlwHv9iX2A3e8HLKtY7MlLKHh5klTARUNY=
 github.com/sei-protocol/sei-cosmos v0.1.102/go.mod h1:L4fVgFVReigFZAe+43UNhaCf3DQzUZvpN6LlBsWkub4=
-github.com/sei-protocol/sei-tendermint v0.1.56 h1:iRVhiIetj+GSwpBzaR9lqgvmgcOqmShfACS6x3tuBIw=
-github.com/sei-protocol/sei-tendermint v0.1.56/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
+github.com/sei-protocol/sei-tendermint v0.1.59 h1:POGL60PumMQHF4EzAHzvkGfDnodQJLHpl65LuiwSO/Y=
+github.com/sei-protocol/sei-tendermint v0.1.59/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c/go.mod h1:/PevMnwAxekIXwN8qQyfc5gl2NlkB3CQlkizAbOkeBs=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/go.sum
+++ b/go.sum
@@ -1097,8 +1097,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.1.82 h1:vGsbp35KOZzP3YQoJ8T0MuWpLuC8Ea+6+F5QvHy9a5c=
-github.com/sei-protocol/sei-cosmos v0.1.82/go.mod h1:L4fVgFVReigFZAe+43UNhaCf3DQzUZvpN6LlBsWkub4=
+github.com/sei-protocol/sei-cosmos v0.1.102 h1:UG9Lgw/qmOlwHv9iX2A3e8HLKtY7MlLKHh5klTARUNY=
+github.com/sei-protocol/sei-cosmos v0.1.102/go.mod h1:L4fVgFVReigFZAe+43UNhaCf3DQzUZvpN6LlBsWkub4=
 github.com/sei-protocol/sei-tendermint v0.1.56 h1:iRVhiIetj+GSwpBzaR9lqgvmgcOqmShfACS6x3tuBIw=
 github.com/sei-protocol/sei-tendermint v0.1.56/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=


### PR DESCRIPTION
## Describe your changes and provide context

Previously we were signaling and blocking for each handler in the message. In theory, this is fine as we are supposed to be processed synchronously based on the access operation. However, due to us not having enough granularity in the resource dependency mapping, blocking on messages is not sufficient as the ordering for when each message is unblocked (between different TXs) could be different. This results in different gas fees or different bank AVL tree shapes as the node insertion order matters.

Therefore, as we do not have more granular support for per-message concurrency, we should be okay with just blocking on the entire transaction and ensuring that no r/w can occur unless the entire TX is ready to be processed.

Note that the Gas used is based on the size of the data returned, depending on the ordering of the message process it's possible that some may result in the same bank data being returned with less digits, and therefore costing different gas. 

With these PRs merged, we should be able to then define more granular access operations for the message types we want to support e.g Bank Send should have access operations for read to sender, writing to both sender and receiver, and the contractAddr. This is operating on the assumption that the majority of transactions will not have overlapping resources. If it doesn't achieve the results we desire then we can spend more time optimizing for this 

https://github.com/sei-protocol/sei-cosmos/pull/35
https://github.com/sei-protocol/sei-cosmos/pull/37
https://github.com/sei-protocol/sei-chain/pull/287

## Testing performed to validate your change
Ran the load test 20 iterations with 5 rounds each and saw that the chain didn't get stuck and from previous outputs of the delivered, the messages are being processed sequentially as expected 

