### PR TITLE
[ante] Add ante dep generator default behavior

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -67,27 +67,27 @@ func NewAnteHandlerAndDepGenerator(options HandlerOptions) (sdk.AnteHandler, sdk
 	// }
 
 	anteDecorators := []sdk.AnteFullDecorator{
-		DefaultWrappedAnteDecorator(ante.NewSetUpContextDecorator()), // outermost AnteDecorator. SetUpContext must be called first
+		sdk.DefaultWrappedAnteDecorator(ante.NewSetUpContextDecorator()), // outermost AnteDecorator. SetUpContext must be called first
 		// TODO: have dex antehandler separate, and then call the individual antehandlers FROM the gasless antehandler decorator wrapper
-		DefaultWrappedAnteDecorator(wasmkeeper.NewLimitSimulationGasDecorator(options.WasmConfig.SimulationGasLimit)), // after setup context to enforce limits early
-		DefaultWrappedAnteDecorator(wasmkeeper.NewCountTXDecorator(options.TXCounterStoreKey)),
-		DefaultWrappedAnteDecorator(ante.NewRejectExtensionOptionsDecorator()),
-		DefaultWrappedAnteDecorator(oracle.NewSpammingPreventionDecorator(*options.OracleKeeper)),
-		DefaultWrappedAnteDecorator(ante.NewValidateBasicDecorator()),
-		DefaultWrappedAnteDecorator(ante.NewTxTimeoutHeightDecorator()),
-		DefaultWrappedAnteDecorator(ante.NewValidateMemoDecorator(options.AccountKeeper)),
-		DefaultWrappedAnteDecorator(ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper)),
-		DefaultWrappedAnteDecorator(ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TxFeeChecker)),
+		sdk.DefaultWrappedAnteDecorator(wasmkeeper.NewLimitSimulationGasDecorator(options.WasmConfig.SimulationGasLimit)), // after setup context to enforce limits early
+		sdk.DefaultWrappedAnteDecorator(wasmkeeper.NewCountTXDecorator(options.TXCounterStoreKey)),
+		sdk.DefaultWrappedAnteDecorator(ante.NewRejectExtensionOptionsDecorator()),
+		sdk.DefaultWrappedAnteDecorator(oracle.NewSpammingPreventionDecorator(*options.OracleKeeper)),
+		sdk.DefaultWrappedAnteDecorator(ante.NewValidateBasicDecorator()),
+		sdk.DefaultWrappedAnteDecorator(ante.NewTxTimeoutHeightDecorator()),
+		sdk.DefaultWrappedAnteDecorator(ante.NewValidateMemoDecorator(options.AccountKeeper)),
+		sdk.DefaultWrappedAnteDecorator(ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper)),
+		sdk.DefaultWrappedAnteDecorator(ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TxFeeChecker)),
 		// PriorityDecorator must be called after DeductFeeDecorator which sets tx priority based on tx fees
-		DefaultWrappedAnteDecorator(antedecorators.NewPriorityDecorator()),
+		sdk.DefaultWrappedAnteDecorator(antedecorators.NewPriorityDecorator()),
 		// SetPubKeyDecorator must be called before all signature verification decorators
-		DefaultWrappedAnteDecorator(ante.NewSetPubKeyDecorator(options.AccountKeeper)),
-		DefaultWrappedAnteDecorator(ante.NewValidateSigCountDecorator(options.AccountKeeper)),
-		DefaultWrappedAnteDecorator(ante.NewSigGasConsumeDecorator(options.AccountKeeper, sigGasConsumer)),
-		DefaultWrappedAnteDecorator(sequentialVerifyDecorator),
-		DefaultWrappedAnteDecorator(ante.NewIncrementSequenceDecorator(options.AccountKeeper)),
-		DefaultWrappedAnteDecorator(ibcante.NewAnteDecorator(options.IBCKeeper)),
-		DefaultWrappedAnteDecorator(dex.NewTickSizeMultipleDecorator(*options.DexKeeper)),
+		sdk.DefaultWrappedAnteDecorator(ante.NewSetPubKeyDecorator(options.AccountKeeper)),
+		sdk.DefaultWrappedAnteDecorator(ante.NewValidateSigCountDecorator(options.AccountKeeper)),
+		sdk.DefaultWrappedAnteDecorator(ante.NewSigGasConsumeDecorator(options.AccountKeeper, sigGasConsumer)),
+		sdk.DefaultWrappedAnteDecorator(sequentialVerifyDecorator),
+		sdk.DefaultWrappedAnteDecorator(ante.NewIncrementSequenceDecorator(options.AccountKeeper)),
+		sdk.DefaultWrappedAnteDecorator(ibcante.NewAnteDecorator(options.IBCKeeper)),
+		sdk.DefaultWrappedAnteDecorator(dex.NewTickSizeMultipleDecorator(*options.DexKeeper)),
 	}
 
 	anteHandler, anteDepGenerator := sdk.ChainAnteDecorators(anteDecorators...)

--- a/app/ante.go
+++ b/app/ante.go
@@ -4,6 +4,7 @@ import (
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmTypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	ibcante "github.com/cosmos/ibc-go/v3/modules/core/ante"
@@ -30,27 +31,54 @@ type HandlerOptions struct {
 	TracingInfo *tracing.Info
 }
 
-func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
+type WrappedAnteDecorator struct {
+	Decorator    sdk.AnteDecorator
+	DepDecorator sdk.AnteDepDecorator
+}
+
+func CustomDepWrappedAnteDecorator(decorator sdk.AnteDecorator, depDecorator sdk.AnteDepDecorator) WrappedAnteDecorator {
+	return WrappedAnteDecorator{
+		Decorator:    decorator,
+		DepDecorator: depDecorator,
+	}
+}
+
+func DefaultWrappedAnteDecorator(decorator sdk.AnteDecorator) WrappedAnteDecorator {
+	return WrappedAnteDecorator{
+		Decorator:    decorator,
+		DepDecorator: sdk.DefaultDepDecorator{},
+	}
+}
+
+func (wad WrappedAnteDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	return wad.Decorator.AnteHandle(ctx, tx, simulate, next)
+}
+
+func (wad WrappedAnteDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
+	return wad.DepDecorator.AnteDeps(txDeps, tx, next)
+}
+
+func NewAnteHandlerAndDepGenerator(options HandlerOptions) (sdk.AnteHandler, sdk.AnteDepGenerator, error) {
 	if options.AccountKeeper == nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "account keeper is required for AnteHandler")
+		return nil, nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "account keeper is required for AnteHandler")
 	}
 	if options.BankKeeper == nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "bank keeper is required for AnteHandler")
+		return nil, nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "bank keeper is required for AnteHandler")
 	}
 	if options.SignModeHandler == nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "sign mode handler is required for ante builder")
+		return nil, nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "sign mode handler is required for ante builder")
 	}
 	if options.WasmConfig == nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "wasm config is required for ante builder")
+		return nil, nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "wasm config is required for ante builder")
 	}
 	if options.TXCounterStoreKey == nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "tx counter key is required for ante builder")
+		return nil, nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "tx counter key is required for ante builder")
 	}
 	if options.OracleKeeper == nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "oracle keeper is required for ante builder")
+		return nil, nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "oracle keeper is required for ante builder")
 	}
 	if options.TracingInfo == nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "tracing info is required for ante builder")
+		return nil, nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "tracing info is required for ante builder")
 	}
 
 	sigGasConsumer := options.SigGasConsumer
@@ -66,29 +94,31 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 	// 	sigVerifyDecorator = ante.NewBatchSigVerificationDecorator(options.BatchVerifier, sequentialVerifyDecorator)
 	// }
 
-	anteDecorators := []sdk.AnteDecorator{
-		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
+	anteDecorators := []sdk.AnteFullDecorator{
+		DefaultWrappedAnteDecorator(ante.NewSetUpContextDecorator()), // outermost AnteDecorator. SetUpContext must be called first
 		// TODO: have dex antehandler separate, and then call the individual antehandlers FROM the gasless antehandler decorator wrapper
-		wasmkeeper.NewLimitSimulationGasDecorator(options.WasmConfig.SimulationGasLimit), // after setup context to enforce limits early
-		wasmkeeper.NewCountTXDecorator(options.TXCounterStoreKey),
-		ante.NewRejectExtensionOptionsDecorator(),
-		oracle.NewSpammingPreventionDecorator(*options.OracleKeeper),
-		ante.NewValidateBasicDecorator(),
-		ante.NewTxTimeoutHeightDecorator(),
-		ante.NewValidateMemoDecorator(options.AccountKeeper),
-		ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
-		ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TxFeeChecker),
+		DefaultWrappedAnteDecorator(wasmkeeper.NewLimitSimulationGasDecorator(options.WasmConfig.SimulationGasLimit)), // after setup context to enforce limits early
+		DefaultWrappedAnteDecorator(wasmkeeper.NewCountTXDecorator(options.TXCounterStoreKey)),
+		DefaultWrappedAnteDecorator(ante.NewRejectExtensionOptionsDecorator()),
+		DefaultWrappedAnteDecorator(oracle.NewSpammingPreventionDecorator(*options.OracleKeeper)),
+		DefaultWrappedAnteDecorator(ante.NewValidateBasicDecorator()),
+		DefaultWrappedAnteDecorator(ante.NewTxTimeoutHeightDecorator()),
+		DefaultWrappedAnteDecorator(ante.NewValidateMemoDecorator(options.AccountKeeper)),
+		DefaultWrappedAnteDecorator(ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper)),
+		DefaultWrappedAnteDecorator(ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TxFeeChecker)),
 		// PriorityDecorator must be called after DeductFeeDecorator which sets tx priority based on tx fees
-		antedecorators.NewPriorityDecorator(),
+		DefaultWrappedAnteDecorator(antedecorators.NewPriorityDecorator()),
 		// SetPubKeyDecorator must be called before all signature verification decorators
-		ante.NewSetPubKeyDecorator(options.AccountKeeper),
-		ante.NewValidateSigCountDecorator(options.AccountKeeper),
-		ante.NewSigGasConsumeDecorator(options.AccountKeeper, sigGasConsumer),
-		sequentialVerifyDecorator,
-		ante.NewIncrementSequenceDecorator(options.AccountKeeper),
-		ibcante.NewAnteDecorator(options.IBCKeeper),
-		dex.NewTickSizeMultipleDecorator(*options.DexKeeper),
+		DefaultWrappedAnteDecorator(ante.NewSetPubKeyDecorator(options.AccountKeeper)),
+		DefaultWrappedAnteDecorator(ante.NewValidateSigCountDecorator(options.AccountKeeper)),
+		DefaultWrappedAnteDecorator(ante.NewSigGasConsumeDecorator(options.AccountKeeper, sigGasConsumer)),
+		DefaultWrappedAnteDecorator(sequentialVerifyDecorator),
+		DefaultWrappedAnteDecorator(ante.NewIncrementSequenceDecorator(options.AccountKeeper)),
+		DefaultWrappedAnteDecorator(ibcante.NewAnteDecorator(options.IBCKeeper)),
+		DefaultWrappedAnteDecorator(dex.NewTickSizeMultipleDecorator(*options.DexKeeper)),
 	}
 
-	return sdk.ChainAnteDecorators(anteDecorators...), nil
+	anteHandler, anteDepGenerator := sdk.ChainAnteDecorators(anteDecorators...)
+
+	return anteHandler, anteDepGenerator, nil
 }

--- a/app/ante.go
+++ b/app/ante.go
@@ -4,7 +4,6 @@ import (
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmTypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	ibcante "github.com/cosmos/ibc-go/v3/modules/core/ante"
@@ -29,33 +28,6 @@ type HandlerOptions struct {
 	TXCounterStoreKey sdk.StoreKey
 
 	TracingInfo *tracing.Info
-}
-
-type WrappedAnteDecorator struct {
-	Decorator    sdk.AnteDecorator
-	DepDecorator sdk.AnteDepDecorator
-}
-
-func CustomDepWrappedAnteDecorator(decorator sdk.AnteDecorator, depDecorator sdk.AnteDepDecorator) WrappedAnteDecorator {
-	return WrappedAnteDecorator{
-		Decorator:    decorator,
-		DepDecorator: depDecorator,
-	}
-}
-
-func DefaultWrappedAnteDecorator(decorator sdk.AnteDecorator) WrappedAnteDecorator {
-	return WrappedAnteDecorator{
-		Decorator:    decorator,
-		DepDecorator: sdk.DefaultDepDecorator{},
-	}
-}
-
-func (wad WrappedAnteDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
-	return wad.Decorator.AnteHandle(ctx, tx, simulate, next)
-}
-
-func (wad WrappedAnteDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
-	return wad.DepDecorator.AnteDeps(txDeps, tx, next)
 }
 
 func NewAnteHandlerAndDepGenerator(options HandlerOptions) (sdk.AnteHandler, sdk.AnteDepGenerator, error) {

--- a/app/antedecorators/gasless_test.go
+++ b/app/antedecorators/gasless_test.go
@@ -45,12 +45,12 @@ func (tx FakeTx) ValidateBasic() error {
 
 func TestGaslessDecorator(t *testing.T) {
 	output = ""
-	anteDecorators := []sdk.AnteDecorator{
-		FakeAnteDecoratorOne{},
-		antedecorators.NewGaslessDecorator([]sdk.AnteDecorator{FakeAnteDecoratorTwo{}}, oraclekeeper.Keeper{}),
-		FakeAnteDecoratorThree{},
+	anteDecorators := []sdk.AnteFullDecorator{
+		sdk.DefaultWrappedAnteDecorator(FakeAnteDecoratorOne{}),
+		sdk.DefaultWrappedAnteDecorator(antedecorators.NewGaslessDecorator([]sdk.AnteDecorator{FakeAnteDecoratorTwo{}}, oraclekeeper.Keeper{})),
+		sdk.DefaultWrappedAnteDecorator(FakeAnteDecoratorThree{}),
 	}
-	chainedHandler := sdk.ChainAnteDecorators(anteDecorators...)
+	chainedHandler, _ := sdk.ChainAnteDecorators(anteDecorators...)
 	chainedHandler(sdk.Context{}, FakeTx{}, false)
 	require.Equal(t, "onetwothree", output)
 }

--- a/app/antedecorators/traced_test.go
+++ b/app/antedecorators/traced_test.go
@@ -11,15 +11,15 @@ import (
 
 func TestTracedDecorator(t *testing.T) {
 	output = ""
-	anteDecorators := []sdk.AnteDecorator{
-		FakeAnteDecoratorOne{},
-		FakeAnteDecoratorTwo{},
-		FakeAnteDecoratorThree{},
+	anteDecorators := []sdk.AnteFullDecorator{
+		sdk.DefaultWrappedAnteDecorator(FakeAnteDecoratorOne{}),
+		sdk.DefaultWrappedAnteDecorator(FakeAnteDecoratorTwo{}),
+		sdk.DefaultWrappedAnteDecorator(FakeAnteDecoratorThree{}),
 	}
-	tracedDecorators := utils.Map(anteDecorators, func(d sdk.AnteDecorator) sdk.AnteDecorator {
-		return antedecorators.NewTracedAnteDecorator(d, nil)
+	tracedDecorators := utils.Map(anteDecorators, func(d sdk.AnteFullDecorator) sdk.AnteFullDecorator {
+		return sdk.DefaultWrappedAnteDecorator(antedecorators.NewTracedAnteDecorator(d, nil))
 	})
-	chainedHandler := sdk.ChainAnteDecorators(tracedDecorators...)
+	chainedHandler, _ := sdk.ChainAnteDecorators(tracedDecorators...)
 	chainedHandler(sdk.Context{}, FakeTx{}, false)
 	require.Equal(t, "onetwothree", output)
 }

--- a/app/app.go
+++ b/app/app.go
@@ -732,7 +732,7 @@ func New(
 	signModeHandler := encodingConfig.TxConfig.SignModeHandler()
 	// app.batchVerifier = ante.NewSR25519BatchVerifier(app.AccountKeeper, signModeHandler)
 
-	anteHandler, err := NewAnteHandler(
+	anteHandler, anteDepGenerator, err := NewAnteHandlerAndDepGenerator(
 		HandlerOptions{
 			HandlerOptions: ante.HandlerOptions{
 				AccountKeeper:   app.AccountKeeper,
@@ -755,6 +755,7 @@ func New(
 	}
 
 	app.SetAnteHandler(anteHandler)
+	app.SetAnteDepGenerator(anteDepGenerator)
 	app.SetEndBlocker(app.EndBlocker)
 	app.SetPrepareProposalHandler(app.PrepareProposalHandler)
 	app.SetProcessProposalHandler(app.ProcessProposalHandler)

--- a/app/app.go
+++ b/app/app.go
@@ -1078,7 +1078,7 @@ func (app *App) ProcessBlock(ctx sdk.Context, txs [][]byte, req BlockProcessRequ
 	// }
 	// app.batchVerifier.VerifyTxs(ctx, typedTxs)
 
-	dependencyDag, err := app.AccessControlKeeper.BuildDependencyDag(ctx, app.txDecoder, txs)
+	dependencyDag, err := app.AccessControlKeeper.BuildDependencyDag(ctx, app.txDecoder, app.GetAnteDepGenerator(), txs)
 	var txResults []*abci.ExecTxResult
 
 	switch err {

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.105
+	github.com/cosmos/cosmos-sdk => ../sei-cosmos //github.com/sei-protocol/sei-cosmos v0.1.105
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.59

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => ../sei-cosmos //github.com/sei-protocol/sei-cosmos v0.1.105
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.114
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.59

--- a/go.sum
+++ b/go.sum
@@ -1097,6 +1097,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
+github.com/sei-protocol/sei-cosmos v0.1.114 h1:Cy5MnBdvql5VJw5pC104DsivQxPg0xkvVOuq6VwDiRk=
+github.com/sei-protocol/sei-cosmos v0.1.114/go.mod h1:8ccWQxpBkWbpvBos/T4QO9K9gQxFs0duTqKRnagKo+0=
 github.com/sei-protocol/sei-tendermint v0.1.59 h1:POGL60PumMQHF4EzAHzvkGfDnodQJLHpl65LuiwSO/Y=
 github.com/sei-protocol/sei-tendermint v0.1.59/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/go.sum
+++ b/go.sum
@@ -1097,8 +1097,6 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.1.105 h1:45l/ZNaYrdyU87TNijE1OIciYI4wb3PXd95qr1HPAgE=
-github.com/sei-protocol/sei-cosmos v0.1.105/go.mod h1:8ccWQxpBkWbpvBos/T4QO9K9gQxFs0duTqKRnagKo+0=
 github.com/sei-protocol/sei-tendermint v0.1.59 h1:POGL60PumMQHF4EzAHzvkGfDnodQJLHpl65LuiwSO/Y=
 github.com/sei-protocol/sei-tendermint v0.1.59/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=


### PR DESCRIPTION
## Describe your changes and provide context
This uses the ante dep generator introduced in sei-cosmos and defines a wrapper for compatibility with existing antedecorators to have conservative dependency generation.
## Testing performed to validate your change
Needs testing
