### PR TITLE
Fix invalid contract sig fault

### DIFF
--- a/x/dex/contract/runner.go
+++ b/x/dex/contract/runner.go
@@ -120,7 +120,11 @@ func (r *ParallelRunner) wrapRunnable(contractAddr utils.ContractAddress) {
 		for _, dependency := range contractInfo.Dependencies {
 			dependentContract := dependency.Dependency
 			typedDependentContract := utils.ContractAddress(dependentContract)
-			dependentInfo, _ := r.contractAddrToInfo.Load(typedDependentContract)
+			dependentInfo, ok := r.contractAddrToInfo.Load(typedDependentContract)
+			if !ok {
+				// If we cannot find the dependency in the contract address info, then it's not a valid contract in this round
+				continue
+			}
 			// It's okay to mutate ContractInfo here since it's a copy made in the runner's
 			// constructor.
 			newNumIncomingPaths := atomic.AddInt64(&dependentInfo.NumIncomingDependencies, -1)

--- a/x/dex/contract/runner_test.go
+++ b/x/dex/contract/runner_test.go
@@ -95,3 +95,29 @@ func TestRunnerParallelContractWithDependency(t *testing.T) {
 	_, hasC := dependencyCheck.Load("C")
 	require.True(t, hasC)
 }
+
+func TestRunnerParallelContractWithInvalidDependency(t *testing.T) {
+	counter = 0
+	contractInfoA := types.ContractInfo{
+		ContractAddr:            "A",
+		NumIncomingDependencies: 0,
+		Dependencies: []*types.ContractDependencyInfo{
+			{
+				Dependency: "C",
+			},
+		},
+	}
+	contractInfoB := types.ContractInfo{
+		ContractAddr:            "B",
+		NumIncomingDependencies: 0,
+		Dependencies: []*types.ContractDependencyInfo{
+			{
+				Dependency: "C",
+			},
+		},
+	}
+	runner := contract.NewParallelRunner(dependencyCheckRunnable, []types.ContractInfo{contractInfoB, contractInfoA})
+	runner.Run()
+	_, hasC := dependencyCheck.Load("C")
+	require.False(t, hasC)
+}


### PR DESCRIPTION
When a contract is removed from the `validContractsInfo` its dependent contracts cannot find it in the runner, causing a nil pointer exception. This PR fixes this issue by ignoring any contract that is removed from the contract address info map.