### PR TITLE
Change Order Processing

### DIFF
--- a/x/dex/contract/execution.go
+++ b/x/dex/contract/execution.go
@@ -59,7 +59,10 @@ func ExecutePair(
 	// First cancel orders
 	cancelForPair(ctx, typedContractAddr, typedPairStr, dexkeeper, orderbook)
 	// Add all limit orders to the orderbook
-	exchange.AddOutstandingLimitOrdersToOrderbook(ctx, typedContractAddr, typedPairStr, dexkeeper, orderbook)
+	orders := dexkeeper.MemState.GetBlockOrders(ctx, typedContractAddr, typedPairStr)
+	limitBuys := orders.GetLimitOrders(types.PositionDirection_LONG)
+	limitSells := orders.GetLimitOrders(types.PositionDirection_SHORT)
+	exchange.AddOutstandingLimitOrdersToOrderbook(orderbook, limitBuys, limitSells)
 	// Fill market orders
 	marketOrderOutcome := matchMarketOrderForPair(ctx, typedContractAddr, typedPairStr, dexkeeper, orderbook)
 	// Fill limit orders

--- a/x/dex/contract/execution.go
+++ b/x/dex/contract/execution.go
@@ -56,9 +56,14 @@ func ExecutePair(
 	typedContractAddr := dextypesutils.ContractAddress(contractAddr)
 	typedPairStr := dextypesutils.GetPairString(&pair)
 
+	// First cancel orders
 	cancelForPair(ctx, typedContractAddr, typedPairStr, dexkeeper, orderbook)
+	// Add all limit orders to the orderbook
+	exchange.AddOutstandingLimitOrdersToOrderbook(ctx, typedContractAddr, typedPairStr, dexkeeper, orderbook)
+	// Fill market orders
 	marketOrderOutcome := matchMarketOrderForPair(ctx, typedContractAddr, typedPairStr, dexkeeper, orderbook)
-	limitOrderOutcome := matchLimitOrderForPair(ctx, typedContractAddr, typedPairStr, dexkeeper, orderbook)
+	// Fill limit orders
+	limitOrderOutcome := exchange.MatchLimitOrders(ctx, orderbook)
 	totalOutcome := marketOrderOutcome.Merge(&limitOrderOutcome)
 
 	dexkeeperutils.SetPriceStateFromExecutionOutcome(ctx, dexkeeper, typedContractAddr, pair, totalOutcome)
@@ -101,24 +106,6 @@ func matchMarketOrderForPair(
 		types.PositionDirection_SHORT,
 	)
 	return marketBuyOutcome.Merge(&marketSellOutcome)
-}
-
-func matchLimitOrderForPair(
-	ctx sdk.Context,
-	typedContractAddr dextypesutils.ContractAddress,
-	typedPairStr dextypesutils.PairString,
-	dexkeeper *keeper.Keeper,
-	orderbook *types.OrderBook,
-) exchange.ExecutionOutcome {
-	orders := dexkeeper.MemState.GetBlockOrders(ctx, typedContractAddr, typedPairStr)
-	limitBuys := orders.GetLimitOrders(types.PositionDirection_LONG)
-	limitSells := orders.GetLimitOrders(types.PositionDirection_SHORT)
-	return exchange.MatchLimitOrders(
-		ctx,
-		limitBuys,
-		limitSells,
-		orderbook,
-	)
 }
 
 func GetMatchResults(

--- a/x/dex/exchange/limit_order.go
+++ b/x/dex/exchange/limit_order.go
@@ -2,9 +2,7 @@ package exchange
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/sei-protocol/sei-chain/x/dex/keeper"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
-	dextypesutils "github.com/sei-protocol/sei-chain/x/dex/types/utils"
 )
 
 func MatchLimitOrders(
@@ -111,15 +109,10 @@ func addOrderToOrderBookEntry(
 }
 
 func AddOutstandingLimitOrdersToOrderbook(
-	ctx sdk.Context,
-	typedContractAddr dextypesutils.ContractAddress,
-	typedPairStr dextypesutils.PairString,
-	dexkeeper *keeper.Keeper,
 	orderbook *types.OrderBook,
+	limitBuys []*types.Order,
+	limitSells []*types.Order,
 ) {
-	orders := dexkeeper.MemState.GetBlockOrders(ctx, typedContractAddr, typedPairStr)
-	limitBuys := orders.GetLimitOrders(types.PositionDirection_LONG)
-	limitSells := orders.GetLimitOrders(types.PositionDirection_SHORT)
 	for _, order := range limitBuys {
 		addOrderToOrderBookEntry(order, orderbook.Longs)
 	}

--- a/x/dex/exchange/limit_order_fuzz_test.go
+++ b/x/dex/exchange/limit_order_fuzz_test.go
@@ -42,5 +42,6 @@ func fuzzTargetMatchLimitOrders(
 		Longs:  &types.CachedSortedOrderBookEntries{Entries: buyEntries, DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry]()},
 		Shorts: &types.CachedSortedOrderBookEntries{Entries: sellEntries, DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry]()},
 	}
-	require.NotPanics(t, func() { exchange.MatchLimitOrders(TestFuzzLimitCtx, buyOrders, sellOrders, &orderBook) })
+	exchange.AddOutstandingLimitOrdersToOrderbook(&orderBook, buyOrders, sellOrders)
+	require.NotPanics(t, func() { exchange.MatchLimitOrders(TestFuzzLimitCtx, &orderBook) })
 }

--- a/x/dex/exchange/limit_order_test.go
+++ b/x/dex/exchange/limit_order_test.go
@@ -61,8 +61,9 @@ func TestMatchSingleOrder(t *testing.T) {
 			DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
 		},
 	}
+	exchange.AddOutstandingLimitOrdersToOrderbook(&orderbook, longOrders, shortOrders)
 	outcome := exchange.MatchLimitOrders(
-		ctx, longOrders, shortOrders, &orderbook,
+		ctx, &orderbook,
 	)
 	totalPrice := outcome.TotalNotional
 	totalExecuted := outcome.TotalQuantity
@@ -235,8 +236,10 @@ func TestAddOrders(t *testing.T) {
 			DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
 		},
 	}
+
+	exchange.AddOutstandingLimitOrdersToOrderbook(&orderbook, longOrders, shortOrders)
 	outcome := exchange.MatchLimitOrders(
-		ctx, longOrders, shortOrders, &orderbook,
+		ctx, &orderbook,
 	)
 	totalPrice := outcome.TotalNotional
 	totalExecuted := outcome.TotalQuantity
@@ -384,8 +387,10 @@ func TestMatchSingleOrderFromShortBook(t *testing.T) {
 			DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
 		},
 	}
+
+	exchange.AddOutstandingLimitOrdersToOrderbook(&orderbook, longOrders, shortOrders)
 	outcome := exchange.MatchLimitOrders(
-		ctx, longOrders, shortOrders, &orderbook,
+		ctx, &orderbook,
 	)
 	totalPrice := outcome.TotalNotional
 	totalExecuted := outcome.TotalQuantity
@@ -481,8 +486,10 @@ func TestMatchSingleOrderFromLongBook(t *testing.T) {
 			DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
 		},
 	}
+
+	exchange.AddOutstandingLimitOrdersToOrderbook(&orderbook, longOrders, shortOrders)
 	outcome := exchange.MatchLimitOrders(
-		ctx, longOrders, shortOrders, &orderbook,
+		ctx, &orderbook,
 	)
 	totalPrice := outcome.TotalNotional
 	totalExecuted := outcome.TotalQuantity
@@ -596,8 +603,10 @@ func TestMatchSingleOrderFromMultipleShortBook(t *testing.T) {
 			DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
 		},
 	}
+
+	exchange.AddOutstandingLimitOrdersToOrderbook(&orderbook, longOrders, shortOrders)
 	outcome := exchange.MatchLimitOrders(
-		ctx, longOrders, shortOrders, &orderbook,
+		ctx, &orderbook,
 	)
 	totalPrice := outcome.TotalNotional
 	totalExecuted := outcome.TotalQuantity
@@ -755,8 +764,10 @@ func TestMatchSingleOrderFromMultipleLongBook(t *testing.T) {
 			DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
 		},
 	}
+
+	exchange.AddOutstandingLimitOrdersToOrderbook(&orderbook, longOrders, shortOrders)
 	outcome := exchange.MatchLimitOrders(
-		ctx, longOrders, shortOrders, &orderbook,
+		ctx, &orderbook,
 	)
 	totalPrice := outcome.TotalNotional
 	totalExecuted := outcome.TotalQuantity
@@ -936,8 +947,10 @@ func TestMatchMultipleOrderFromMultipleShortBook(t *testing.T) {
 			DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
 		},
 	}
+
+	exchange.AddOutstandingLimitOrdersToOrderbook(&orderbook, longOrders, shortOrders)
 	outcome := exchange.MatchLimitOrders(
-		ctx, longOrders, shortOrders, &orderbook,
+		ctx, &orderbook,
 	)
 	totalPrice := outcome.TotalNotional
 	totalExecuted := outcome.TotalQuantity
@@ -1158,8 +1171,10 @@ func TestMatchMultipleOrderFromMultipleLongBook(t *testing.T) {
 			DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
 		},
 	}
+
+	exchange.AddOutstandingLimitOrdersToOrderbook(&orderbook, longOrders, shortOrders)
 	outcome := exchange.MatchLimitOrders(
-		ctx, longOrders, shortOrders, &orderbook,
+		ctx, &orderbook,
 	)
 	totalPrice := outcome.TotalNotional
 	totalExecuted := outcome.TotalQuantity


### PR DESCRIPTION
Update the order of the dex module processing to add limit orders to order book before matching. Order is now:
```
1) cancel trades

2) add all limit orders to the orderbook

3) fill market orders with the more liquid orderbook

4) fill matching buys and sell limit orders
```

- Updated `limit_order_test` and `exchange_test` 

