### PR TITLE
Fix market order by nominal type order status

### DIFF
--- a/x/dex/contract/market_order.go
+++ b/x/dex/contract/market_order.go
@@ -41,8 +41,13 @@ func getUnfulfilledPlacedMarketOrderIds(
 			continue
 		}
 		if order.OrderType == types.OrderType_MARKET || order.OrderType == types.OrderType_LIQUIDATION ||
-			order.OrderType == types.OrderType_FOKMARKET || order.OrderType == types.OrderType_FOKMARKETBYVALUE {
+			order.OrderType == types.OrderType_FOKMARKET {
 			if settledQuantity, ok := orderIDToSettledQuantities[order.Id]; !ok || settledQuantity.LT(order.Quantity) {
+				res = append(res, order.Id)
+			}
+		} else if order.OrderType == types.OrderType_FOKMARKETBYVALUE {
+			// cancel market order by nominal if zero quantity is executed
+			if _, ok := orderIDToSettledQuantities[order.Id]; !ok {
 				res = append(res, order.Id)
 			}
 		}


### PR DESCRIPTION
This PR fixes the market order by nominal type order status. This order type's executed quantity follows the real time settlement price and nominal requested, which may not always be the same as the order.quantity. So in the cancellation check, we only need to cancel it when zero quantity is executed.

TODO:
- add unit test for the FOKMARKETBYVALUE type after the dex/module_test.go is updated