### PR TITLE
Add dependencies for ante handlers that read/write accounts

### DIFF
--- a/aclmapping/utils/identifier_templates.go
+++ b/aclmapping/utils/identifier_templates.go
@@ -3,6 +3,7 @@ package util
 import "fmt"
 
 const (
+	ACCOUNT           = "acc"
 	BANK              = "bank"
 	AUTH              = "auth"
 	DefaultIDTemplate = "*"
@@ -10,4 +11,8 @@ const (
 
 func GetIdentifierTemplatePerModule(module string, identifier string) string {
 	return fmt.Sprintf("%s/%s", module, identifier)
+}
+
+func GetPrefixedIdentifierTemplatePerModule(module string, identifier string, prefix string) string {
+	return fmt.Sprintf("%s/%s/%s", module, prefix, identifier)
 }

--- a/app/ante.go
+++ b/app/ante.go
@@ -9,6 +9,7 @@ import (
 	ibcante "github.com/cosmos/ibc-go/v3/modules/core/ante"
 	ibckeeper "github.com/cosmos/ibc-go/v3/modules/core/keeper"
 	"github.com/sei-protocol/sei-chain/app/antedecorators"
+	"github.com/sei-protocol/sei-chain/app/antedecorators/depdecorators"
 	"github.com/sei-protocol/sei-chain/utils/tracing"
 	"github.com/sei-protocol/sei-chain/x/dex"
 	dexkeeper "github.com/sei-protocol/sei-chain/x/dex/keeper"
@@ -72,16 +73,16 @@ func NewAnteHandlerAndDepGenerator(options HandlerOptions) (sdk.AnteHandler, sdk
 		sdk.DefaultWrappedAnteDecorator(ante.NewValidateBasicDecorator()),
 		sdk.DefaultWrappedAnteDecorator(ante.NewTxTimeoutHeightDecorator()),
 		sdk.DefaultWrappedAnteDecorator(ante.NewValidateMemoDecorator(options.AccountKeeper)),
-		sdk.DefaultWrappedAnteDecorator(ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper)),
+		sdk.CustomDepWrappedAnteDecorator(ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper), depdecorators.SignerDepDecorator{ReadOnly: true}),
 		sdk.DefaultWrappedAnteDecorator(ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TxFeeChecker)),
 		// PriorityDecorator must be called after DeductFeeDecorator which sets tx priority based on tx fees
 		sdk.DefaultWrappedAnteDecorator(antedecorators.NewPriorityDecorator()),
 		// SetPubKeyDecorator must be called before all signature verification decorators
-		sdk.DefaultWrappedAnteDecorator(ante.NewSetPubKeyDecorator(options.AccountKeeper)),
+		sdk.CustomDepWrappedAnteDecorator(ante.NewSetPubKeyDecorator(options.AccountKeeper), depdecorators.SignerDepDecorator{ReadOnly: false}),
 		sdk.DefaultWrappedAnteDecorator(ante.NewValidateSigCountDecorator(options.AccountKeeper)),
-		sdk.DefaultWrappedAnteDecorator(ante.NewSigGasConsumeDecorator(options.AccountKeeper, sigGasConsumer)),
-		sdk.DefaultWrappedAnteDecorator(sequentialVerifyDecorator),
-		sdk.DefaultWrappedAnteDecorator(ante.NewIncrementSequenceDecorator(options.AccountKeeper)),
+		sdk.CustomDepWrappedAnteDecorator(ante.NewSigGasConsumeDecorator(options.AccountKeeper, sigGasConsumer), depdecorators.SignerDepDecorator{ReadOnly: true}),
+		sdk.CustomDepWrappedAnteDecorator(sequentialVerifyDecorator, depdecorators.SignerDepDecorator{ReadOnly: true}),
+		sdk.CustomDepWrappedAnteDecorator(ante.NewIncrementSequenceDecorator(options.AccountKeeper), depdecorators.SignerDepDecorator{ReadOnly: false}),
 		sdk.DefaultWrappedAnteDecorator(ibcante.NewAnteDecorator(options.IBCKeeper)),
 		sdk.DefaultWrappedAnteDecorator(dex.NewTickSizeMultipleDecorator(*options.DexKeeper)),
 	}

--- a/app/antedecorators/depdecorators/signers.go
+++ b/app/antedecorators/depdecorators/signers.go
@@ -1,0 +1,35 @@
+package depdecorators
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	utils "github.com/sei-protocol/sei-chain/aclmapping/utils"
+)
+
+type SignerDepDecorator struct {
+	ReadOnly bool
+}
+
+func (d SignerDepDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
+	sigTx, ok := tx.(authsigning.SigVerifiableTx)
+	if !ok {
+		return txDeps, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid tx type")
+	}
+	var accessType sdkacltypes.AccessType
+	if d.ReadOnly {
+		accessType = sdkacltypes.AccessType_READ
+	} else {
+		accessType = sdkacltypes.AccessType_WRITE
+	}
+	for _, signer := range sigTx.GetSigners() {
+		txDeps = append(txDeps, sdkacltypes.AccessOperation{
+			AccessType:         accessType,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetPrefixedIdentifierTemplatePerModule(utils.ACCOUNT, signer.String(), string(authtypes.AddressStoreKeyPrefix)),
+		})
+	}
+	return next(txDeps, tx)
+}

--- a/app/params/config.go
+++ b/app/params/config.go
@@ -21,7 +21,7 @@ const (
 	Bech32PrefixAccAddr = "sei"
 )
 
-var UnsafeBypassCommitTimeoutOverride bool = true
+var UnsafeBypassCommitTimeoutOverride = true
 
 var (
 	// Bech32PrefixAccPub defines the Bech32 prefix of an account's public key.


### PR DESCRIPTION
## Describe your changes and provide context
The following ante handlers access individual account KV states:
- `ConsumeGasForTxSizeDecorator` -> read only
- `SetPubKeyDecorator` -> read/write
- `SigGasConsumeDecorator` -> read only
- `SigVerificationDecorator` -> read only
- `IncrementSequenceDecorator` -> read/write
Since handlers above are applicable to all message types, it could potentially cause race condition for even bank send type (whose loadtest was only run with one msg per account per block). This PR adds dependencies on accounts for these handlers.

## Testing performed to validate your change
ran sei locally
