### PR TITLE
Optimize genesis account creation script

### DIFF
--- a/loadtest/scripts/populate_genesis_accounts.py
+++ b/loadtest/scripts/populate_genesis_accounts.py
@@ -7,7 +7,11 @@ import time
 
 PARALLEISM=32
 
-def add_genesis_account(account_name, lock, local=False):
+# Global Variable used for accounts
+# Does not need to be thread safe, each thread should only be writing to its own index
+global_accounts_mapping = {}
+
+def add_key(account_name, local=False):
     if local:
         add_key_cmd = f"yes | ~/go/bin/seid keys add {account_name} --keyring-backend test"
     else:
@@ -17,9 +21,14 @@ def add_genesis_account(account_name, lock, local=False):
         stderr=subprocess.STDOUT,
         shell=True,
     ).decode()
+
     splitted_outputs = add_key_output.split('\n')
     address = splitted_outputs[3].split(': ')[1]
     mnemonic = splitted_outputs[11]
+    return address, mnemonic
+
+
+def add_account(account_name, address, mnemonic, local=False):
     if local:
         add_account_cmd = f"~/go/bin/seid add-genesis-account {address} 1000000000usei --keyring-backend test"
     else:
@@ -34,29 +43,82 @@ def add_genesis_account(account_name, lock, local=False):
             "mnemonic": mnemonic,
         }
         json.dump(data, f)
-    success = False
-    retry_counter = 5
+
+    return add_account_cmd
+
+
+def create_genesis_account(account_index, account_name, local=False):
+    address, mnemonic = add_key(account_name=account_name, local=local)
+    add_account_cmd = add_account(account_name=account_name, address=address, mnemonic=mnemonic, local=local)
+
+    retry_counter = 50
     sleep_time = 1
-    while not success and retry_counter > 0:
+
+    while True:
         try:
-            with lock:
-                subprocess.check_call(
-                    [add_account_cmd],
-                    shell=True,
-                    timeout=20,
-                )
-                success = True
+            print(f'Running: ${add_account_cmd}')
+            subprocess.call(
+                [add_account_cmd],
+                shell=True,
+                timeout=20,
+            )
+            break
         except subprocess.CalledProcessError as e:
             print(f"Encountered error {e}, retrying {retry_counter - 1} times")
             retry_counter -= 1
             sleep_time += 0.5
             time.sleep(sleep_time)
 
+    global_accounts_mapping[account_index] = {
+        "balance": {
+            "address": address,
+            "coins": [
+                {
+                    "denom": "usei",
+                    "amount": "1000000000"
+                }
+            ]
+        },
+        "account": {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": address,
+          "pub_key": None,
+          "account_number": "0",
+          "sequence": "0"
+        }
+    }
 
-def bulk_create_genesis_accounts(number_of_accounts, start_idx, lock, is_local=False):
+
+def bulk_create_genesis_accounts(number_of_accounts, start_idx, is_local=False):
     for i in range(start_idx, start_idx + number_of_accounts):
-        print(f"Creating account {i}")
-        add_genesis_account(f"ta{i}", lock, is_local)
+        create_genesis_account(i, f"ta{i}", is_local)
+        print(f"Created account {i}")
+
+
+def update_genesis_file(old_genesis_json):
+    sorted_keys = sorted(list(global_accounts_mapping.keys()))
+    account_info = [0] * len(sorted_keys)
+    balances = [0] * len(sorted_keys)
+    for key in sorted_keys:
+        balances[i] = global_accounts_mapping[key]["balance"]
+        account_info[i] = global_accounts_mapping[key]["account"]
+
+    old_genesis_json["app_state"]["bank"]["balances"] = old_genesis_json["app_state"]["bank"]["balances"] + balances
+    old_genesis_json["app_state"]["auth"]["accounts"] = old_genesis_json["app_state"]["auth"]["accounts"] + account_info
+    print(f'Writing {len(account_info)} and {len(balances)}')
+    write_genesis_file(old_genesis_json)
+
+
+def read_genesis_file():
+    with open("/root/.sei/config/genesis.json", 'r') as f:
+        return json.load(f)
+
+
+def write_genesis_file(data):
+    print("Writing results to genesis file")
+    with open("/root/.sei/config/genesis.json", 'w') as f:
+        json.dump(data, f, indent=4)
+
 
 def main():
     args = sys.argv[1:]
@@ -64,15 +126,37 @@ def main():
     is_local = False
     if len(args) > 1 and args[1] == "loc":
         is_local = True
+
+    genesis_file = read_genesis_file()
+
     num_threads = number_of_accounts // PARALLEISM
     threads = []
-    lock=threading.Lock()
     for i in range(0, number_of_accounts, num_threads):
-        threads.append(threading.Thread(target=bulk_create_genesis_accounts, args=(num_threads, i, lock, is_local)))
+        threads.append(threading.Thread(target=bulk_create_genesis_accounts, args=(num_threads, i, is_local)))
+
+    print("Starting threads account")
     for t in threads:
         t.start()
+
+    print("Waiting for threads")
     for t in threads:
         t.join()
+
+    sorted_keys = sorted(list(global_accounts_mapping.keys()))
+    account_info = [0] * len(sorted_keys)
+    balances = [0] * len(sorted_keys)
+    for key in sorted_keys:
+        balances[key] = global_accounts_mapping[key]["balance"]
+        account_info[key] = global_accounts_mapping[key]["account"]
+
+    genesis_file["app_state"]["bank"]["balances"] = genesis_file["app_state"]["bank"]["balances"] + balances
+    genesis_file["app_state"]["auth"]["accounts"] = genesis_file["app_state"]["auth"]["accounts"] + account_info
+
+    num_accounts_created = len([account for account in account_info if account != 0])
+    print(f'Created {num_accounts_created} accounts')
+
+    assert num_accounts_created > number_of_accounts
+    write_genesis_file(genesis_file)
 
 if __name__ == "__main__":
     main()

--- a/loadtest/scripts/populate_genesis_accounts.py
+++ b/loadtest/scripts/populate_genesis_accounts.py
@@ -54,7 +54,7 @@ def create_genesis_account(account_index, account_name, local=False):
     retry_counter = 0
     sleep_time = 1
 
-    while True:
+    while True and retry_counter < 1000:
         try:
             print(f'Running: ${add_account_cmd}')
             subprocess.call(
@@ -68,7 +68,10 @@ def create_genesis_account(account_index, account_name, local=False):
             retry_counter += 1
             sleep_time += 0.5
             time.sleep(sleep_time)
-
+    
+    if retry_counter >= 1000:
+        exit(-1)
+    
     global_accounts_mapping[account_index] = {
         "balance": {
             "address": address,
@@ -141,7 +144,7 @@ def main():
     num_accounts_created = len([account for account in account_info if account != 0])
     print(f'Created {num_accounts_created} accounts')
 
-    assert num_accounts_created > number_of_accounts
+    assert num_accounts_created >= number_of_accounts
     write_genesis_file(genesis_file)
 
 if __name__ == "__main__":

--- a/loadtest/scripts/populate_genesis_accounts.py
+++ b/loadtest/scripts/populate_genesis_accounts.py
@@ -95,20 +95,6 @@ def bulk_create_genesis_accounts(number_of_accounts, start_idx, is_local=False):
         print(f"Created account {i}")
 
 
-def update_genesis_file(old_genesis_json):
-    sorted_keys = sorted(list(global_accounts_mapping.keys()))
-    account_info = [0] * len(sorted_keys)
-    balances = [0] * len(sorted_keys)
-    for key in sorted_keys:
-        balances[i] = global_accounts_mapping[key]["balance"]
-        account_info[i] = global_accounts_mapping[key]["account"]
-
-    old_genesis_json["app_state"]["bank"]["balances"] = old_genesis_json["app_state"]["bank"]["balances"] + balances
-    old_genesis_json["app_state"]["auth"]["accounts"] = old_genesis_json["app_state"]["auth"]["accounts"] + account_info
-    print(f'Writing {len(account_info)} and {len(balances)}')
-    write_genesis_file(old_genesis_json)
-
-
 def read_genesis_file():
     with open("/root/.sei/config/genesis.json", 'r') as f:
         return json.load(f)

--- a/loadtest/scripts/populate_genesis_accounts.py
+++ b/loadtest/scripts/populate_genesis_accounts.py
@@ -51,7 +51,7 @@ def create_genesis_account(account_index, account_name, local=False):
     address, mnemonic = add_key(account_name=account_name, local=local)
     add_account_cmd = add_account(account_name=account_name, address=address, mnemonic=mnemonic, local=local)
 
-    retry_counter = 50
+    retry_counter = 0
     sleep_time = 1
 
     while True:
@@ -64,8 +64,8 @@ def create_genesis_account(account_index, account_name, local=False):
             )
             break
         except subprocess.CalledProcessError as e:
-            print(f"Encountered error {e}, retrying {retry_counter - 1} times")
-            retry_counter -= 1
+            print(f"Encountered error {e}, retried {retry_counter} times")
+            retry_counter += 1
             sleep_time += 0.5
             time.sleep(sleep_time)
 


### PR DESCRIPTION
## Describe your changes and provide context
Taking inspiration from work around Parallel Tx,

The create account and adding balance commands don't actually write to any of the data store (AVL trees) (the data folder is empty after genesis accounts are created), the data is persisted in the genesis file.
* https://github.com/sei-protocol/sei-cosmos/blob/63ac1b222e281be5ff25623ade4b93bd61517c1f/simapp/simd/cmd/genaccounts.go#L115-L169

To deal with the race condition for the genesis file, we just store it in memory and flush it to the file at the end when all accounts are complete. 

For 20 nodes, 5000 accounts went from 30mins+ to < ~30 seconds

## Testing performed to validate your change
Created load test cluster and ran 5 rounds of 2k txs per block 

![image](https://user-images.githubusercontent.com/18161326/196820985-bcb54bf1-c56d-40c2-a41b-f41a750bd0a2.png)

![image](https://user-images.githubusercontent.com/18161326/196820560-58d40f9c-7ad7-47c6-82c8-a872dd611991.png)


For 20 nodes, 10k accounts went from 2 hours + to 76 seconds
<img width="874" alt="image" src="https://user-images.githubusercontent.com/18161326/196825179-f4877c9e-2edb-446e-b0f9-d88253c129c5.png">

![image](https://user-images.githubusercontent.com/18161326/196826399-6340b404-637c-4af7-a67c-14d4a8b0d739.png)

