### PR TITLE
Refactor Loadtest script

### DIFF
--- a/loadtest/config.json
+++ b/loadtest/config.json
@@ -1,7 +1,7 @@
 {
-    "batch_size": 10,
+    "msgs_per_tx": 10,
     "chain_id": "sei-loadtest-testnet",
-    "orders_per_block": 400,
+    "txs_per_block": 6000,
     "rounds": 5,
     "price_distribution": {
         "min": "45",

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -13,14 +13,14 @@ import (
 )
 
 type LoadTestClient struct {
-	LoadTestConfig Config
-	TestConfig 	EncodingConfig
-	TxClient   typestx.ServiceClient
-	SignerClient *SignerClient
-	ChainID    string
-	TxHashList []string
+	LoadTestConfig  Config
+	TestConfig      EncodingConfig
+	TxClient        typestx.ServiceClient
+	SignerClient    *SignerClient
+	ChainID         string
+	TxHashList      []string
 	TxHashListMutex *sync.Mutex
-	GrpcConn *grpc.ClientConn
+	GrpcConn        *grpc.ClientConn
 }
 
 func NewLoadTestClient() *LoadTestClient {
@@ -38,14 +38,14 @@ func NewLoadTestClient() *LoadTestClient {
 	}
 
 	return &LoadTestClient{
-		LoadTestConfig: config,
-		TestConfig: TestConfig,
-		TxClient: TxClient,
-		SignerClient: NewSignerClient(),
-		ChainID: config.ChainID,
-		TxHashList: []string{},
+		LoadTestConfig:  config,
+		TestConfig:      TestConfig,
+		TxClient:        TxClient,
+		SignerClient:    NewSignerClient(),
+		ChainID:         config.ChainID,
+		TxHashList:      []string{},
 		TxHashListMutex: &sync.Mutex{},
-		GrpcConn: grpcConn,
+		GrpcConn:        grpcConn,
 	}
 }
 
@@ -74,7 +74,7 @@ func (c *LoadTestClient) WriteTxHashToFile() {
 	}
 }
 
-func (c *LoadTestClient) BuildTxs() (workgroups []*sync.WaitGroup, sendersList [][]func()){
+func (c *LoadTestClient) BuildTxs() (workgroups []*sync.WaitGroup, sendersList [][]func()) {
 	config := c.LoadTestConfig
 	numberOfAccounts := config.TxsPerBlock / config.MsgsPerTx * 2 // * 2 because we need two sets of accounts
 	activeAccounts := []int{}

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -1,35 +1,48 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	typestx "github.com/cosmos/cosmos-sdk/types/tx"
 	"google.golang.org/grpc"
 )
 
 type LoadTestClient struct {
+	LoadTestConfig Config
 	TestConfig 	EncodingConfig
 	TxClient   typestx.ServiceClient
+	SignerClient *SignerClient
 	ChainID    string
 	TxHashList []string
 	TxHashListMutex *sync.Mutex
 	GrpcConn *grpc.ClientConn
 }
 
-func NewLoadTestClient(chainId string) *LoadTestClient {
+func NewLoadTestClient() *LoadTestClient {
 	grpcConn, _ := grpc.Dial(
 		"127.0.0.1:9090",
 		grpc.WithInsecure(),
 	)
 	TxClient := typestx.NewServiceClient(grpcConn)
 
+	config := Config{}
+	pwd, _ := os.Getwd()
+	file, _ := os.ReadFile(pwd + "/loadtest/config.json")
+	if err := json.Unmarshal(file, &config); err != nil {
+		panic(err)
+	}
+
 	return &LoadTestClient{
+		LoadTestConfig: config,
 		TestConfig: TestConfig,
 		TxClient: TxClient,
-		ChainID: chainId,
+		SignerClient: NewSignerClient(),
+		ChainID: config.ChainID,
 		TxHashList: []string{},
 		TxHashListMutex: &sync.Mutex{},
 		GrpcConn: grpcConn,
@@ -47,17 +60,84 @@ func (c *LoadTestClient) AppendTxHash(txHash string) {
 	c.TxHashList = append(c.TxHashList, txHash)
 }
 
-
-func (c *LoadTestClient) WriteTxHashToFile(txHash string) {
+func (c *LoadTestClient) WriteTxHashToFile() {
 	userHomeDir, _ := os.UserHomeDir()
 	_ = os.Mkdir(filepath.Join(userHomeDir, "outputs"), os.ModePerm)
 	filename := filepath.Join(userHomeDir, "outputs", "test_tx_hash")
 	_ = os.Remove(filename)
 	file, _ := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-	for txHash := range c.TxHashList {
-		if _, err := file.WriteString(fmt.Sprintf("%s\n", txHash)); err != nil {
+	for _, txHash := range c.TxHashList {
+		txHashLine := fmt.Sprintf("%s\n", txHash)
+		if _, err := file.WriteString(txHashLine); err != nil {
 			panic(err)
 		}
 	}
+}
 
+func (c *LoadTestClient) BuildTxs() (workgroups []*sync.WaitGroup, sendersList [][]func()){
+	config := c.LoadTestConfig
+	numberOfAccounts := config.TxsPerBlock / config.MsgsPerTx * 2 // * 2 because we need two sets of accounts
+	activeAccounts := []int{}
+	inactiveAccounts := []int{}
+
+	for i := 0; i < int(numberOfAccounts); i++ {
+		if i%2 == 0 {
+			activeAccounts = append(activeAccounts, i)
+		} else {
+			inactiveAccounts = append(inactiveAccounts, i)
+		}
+	}
+
+	for i := 0; i < int(config.Rounds); i++ {
+		fmt.Printf("Preparing %d-th round\n", i)
+
+		wg := &sync.WaitGroup{}
+		var senders []func()
+		workgroups = append(workgroups, wg)
+
+		for _, account := range activeAccounts {
+			key := c.SignerClient.GetKey(uint64(account))
+
+			msg := generateMessage(config, key, config.MsgsPerTx)
+			txBuilder := TestConfig.TxConfig.NewTxBuilder()
+			_ = txBuilder.SetMsgs(msg)
+			seqDelta := uint64(i / 2)
+			mode := typestx.BroadcastMode_BROADCAST_MODE_SYNC
+
+			// Note: There is a potential race condition here with seqnos
+			// in which a later seqno is delievered before an earlier seqno
+			// In practice, we haven't run into this issue so we'll leave this
+			// as is.
+			sender := SendTx(key, &txBuilder, mode, seqDelta, *c)
+			wg.Add(1)
+			senders = append(senders, func() {
+				defer wg.Done()
+				sender()
+			})
+		}
+
+		sendersList = append(sendersList, senders)
+		inactiveAccounts, activeAccounts = activeAccounts, inactiveAccounts
+	}
+
+	return workgroups, sendersList
+}
+
+func (c *LoadTestClient) SendTxs(workgroups []*sync.WaitGroup, sendersList [][]func()) {
+	lastHeight := getLastHeight()
+	for i := 0; i < int(c.LoadTestConfig.Rounds); i++ {
+		newHeight := getLastHeight()
+		for newHeight == lastHeight {
+			time.Sleep(10 * time.Millisecond)
+			newHeight = getLastHeight()
+		}
+		fmt.Printf("Sending %d-th block\n", i)
+		senders := sendersList[i]
+		wg := workgroups[i]
+		for _, sender := range senders {
+			go sender()
+		}
+		wg.Wait()
+		lastHeight = newHeight
+	}
 }

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	typestx "github.com/cosmos/cosmos-sdk/types/tx"
+	"google.golang.org/grpc"
+)
+
+type LoadTestClient struct {
+	TestConfig 	EncodingConfig
+	TxClient   typestx.ServiceClient
+	ChainID    string
+	TxHashList []string
+	TxHashListMutex *sync.Mutex
+	GrpcConn *grpc.ClientConn
+}
+
+func NewLoadTestClient(chainId string) *LoadTestClient {
+	grpcConn, _ := grpc.Dial(
+		"127.0.0.1:9090",
+		grpc.WithInsecure(),
+	)
+	TxClient := typestx.NewServiceClient(grpcConn)
+
+	return &LoadTestClient{
+		TestConfig: TestConfig,
+		TxClient: TxClient,
+		ChainID: chainId,
+		TxHashList: []string{},
+		TxHashListMutex: &sync.Mutex{},
+		GrpcConn: grpcConn,
+	}
+}
+
+func (c *LoadTestClient) Close() {
+	c.GrpcConn.Close()
+}
+
+func (c *LoadTestClient) AppendTxHash(txHash string) {
+	c.TxHashListMutex.Lock()
+	defer c.TxHashListMutex.Unlock()
+
+	c.TxHashList = append(c.TxHashList, txHash)
+}
+
+
+func (c *LoadTestClient) WriteTxHashToFile(txHash string) {
+	userHomeDir, _ := os.UserHomeDir()
+	_ = os.Mkdir(filepath.Join(userHomeDir, "outputs"), os.ModePerm)
+	filename := filepath.Join(userHomeDir, "outputs", "test_tx_hash")
+	_ = os.Remove(filename)
+	file, _ := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	for txHash := range c.TxHashList {
+		if _, err := file.WriteString(fmt.Sprintf("%s\n", txHash)); err != nil {
+			panic(err)
+		}
+	}
+
+}

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -53,7 +53,7 @@ func run() {
 	defer client.Close()
 
 	if config.TxsPerBlock < config.MsgsPerTx {
-		panic("Must have more orders per block than batch size")
+		panic("Must have more TxsPerBlock than MsgsPerTx")
 	}
 
 	configString, _ := json.Marshal(config)

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -21,9 +21,7 @@ import (
 	dextypes "github.com/sei-protocol/sei-chain/x/dex/types"
 )
 
-var (
-	TestConfig EncodingConfig
-)
+var TestConfig EncodingConfig
 
 const (
 	VortexData = "{\"position_effect\":\"Open\",\"leverage\":\"1\"}"
@@ -69,7 +67,6 @@ func run() {
 	// Records the resulting TxHash to file
 	client.WriteTxHashToFile()
 	fmt.Printf("%s - Finished\n", time.Now().Format("2006-01-02T15:04:05"))
-
 }
 
 func generateMessage(config Config, key cryptotypes.PrivKey, msgPerTx uint64) sdk.Msg {

--- a/loadtest/sign.go
+++ b/loadtest/sign.go
@@ -51,7 +51,7 @@ func GetKey(accountIdx uint64) cryptotypes.PrivKey {
 	return algo.Generate()(derivedPriv)
 }
 
-func SignTx(txBuilder *client.TxBuilder, privKey cryptotypes.PrivKey, seqDelta uint64) {
+func SignTx(ChainID string, txBuilder *client.TxBuilder, privKey cryptotypes.PrivKey, seqDelta uint64) {
 	var sigsV2 []signing.SignatureV2
 	accountNum, seqNum := GetAccountNumberSequenceNumber(privKey)
 	seqNum += seqDelta

--- a/loadtest/sign.go
+++ b/loadtest/sign.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -26,7 +27,43 @@ type AccountInfo struct {
 	Mnemonic string `json:"mnemonic"`
 }
 
-func GetKey(accountIdx uint64) cryptotypes.PrivKey {
+type SignerInfo struct {
+	AccountNumber  uint64
+	SequenceNumber uint64
+	mutex *sync.Mutex
+}
+
+func NewSignerInfo(accountNumber uint64, sequenceNumber uint64) *SignerInfo {
+	return &SignerInfo{
+		AccountNumber: accountNumber,
+		SequenceNumber: sequenceNumber,
+		mutex: &sync.Mutex{},
+	}
+}
+
+func (si *SignerInfo) IncrementAccountNumber() {
+	si.mutex.Lock()
+	defer si.mutex.Unlock()
+	si.AccountNumber++
+}
+
+type SignerClient struct {
+	CachedAccountSeqNum *sync.Map
+	CachedAccountKey *sync.Map
+}
+
+func NewSignerClient() *SignerClient {
+	return &SignerClient{
+		CachedAccountSeqNum: &sync.Map{},
+		CachedAccountKey: &sync.Map{},
+	}
+}
+
+func (sc *SignerClient) GetKey(accountIdx uint64) cryptotypes.PrivKey {
+	if val, ok := sc.CachedAccountKey.Load(accountIdx); ok {
+		privKey := val.(cryptotypes.PrivKey)
+		return privKey
+	}
 	userHomeDir, _ := os.UserHomeDir()
 	accountKeyFilePath := filepath.Join(userHomeDir, "test_accounts", fmt.Sprintf("ta%d.json", accountIdx))
 	jsonFile, err := os.Open(accountKeyFilePath)
@@ -48,12 +85,19 @@ func GetKey(accountIdx uint64) cryptotypes.PrivKey {
 	algo, _ := keyring.NewSigningAlgoFromString(algoStr, keyringAlgos)
 	hdpath := hd.CreateHDPath(sdk.GetConfig().GetCoinType(), 0, 0).String()
 	derivedPriv, _ := algo.Derive()(accountInfo.Mnemonic, "", hdpath)
-	return algo.Generate()(derivedPriv)
+	privKey := algo.Generate()(derivedPriv)
+
+	// Cache this so we don't need to regenerate it
+	sc.CachedAccountKey.Store(accountIdx, privKey)
+	return privKey
 }
 
-func SignTx(ChainID string, txBuilder *client.TxBuilder, privKey cryptotypes.PrivKey, seqDelta uint64) {
+func (sc *SignerClient) SignTx(chainID string, txBuilder *client.TxBuilder, privKey cryptotypes.PrivKey, seqDelta uint64) {
 	var sigsV2 []signing.SignatureV2
-	accountNum, seqNum := GetAccountNumberSequenceNumber(privKey)
+	signerInfo := sc.GetAccountNumberSequenceNumber(privKey)
+	accountNum := signerInfo.AccountNumber
+	seqNum := signerInfo.SequenceNumber
+
 	seqNum += seqDelta
 	sigV2 := signing.SignatureV2{
 		PubKey: privKey.PubKey(),
@@ -67,7 +111,7 @@ func SignTx(ChainID string, txBuilder *client.TxBuilder, privKey cryptotypes.Pri
 	_ = (*txBuilder).SetSignatures(sigsV2...)
 	sigsV2 = []signing.SignatureV2{}
 	signerData := xauthsigning.SignerData{
-		ChainID:       ChainID,
+		ChainID:       chainID,
 		AccountNumber: accountNum,
 		Sequence:      seqNum,
 	}
@@ -83,7 +127,13 @@ func SignTx(ChainID string, txBuilder *client.TxBuilder, privKey cryptotypes.Pri
 	_ = (*txBuilder).SetSignatures(sigsV2...)
 }
 
-func GetAccountNumberSequenceNumber(privKey cryptotypes.PrivKey) (uint64, uint64) {
+func (sc *SignerClient) GetAccountNumberSequenceNumber(privKey cryptotypes.PrivKey) SignerInfo {
+	if val, ok := sc.CachedAccountSeqNum.Load(privKey); ok {
+		signerinfo := val.(SignerInfo)
+		signerinfo.IncrementAccountNumber()
+		return signerinfo
+	}
+
 	hexAccount := privKey.PubKey().Address()
 	address, err := sdk.AccAddressFromHex(hexAccount.String())
 	if err != nil {
@@ -110,5 +160,8 @@ func GetAccountNumberSequenceNumber(privKey cryptotypes.PrivKey) (uint64, uint64
 			panic(err)
 		}
 	}
-	return account, seq
+
+	signerInfo := *NewSignerInfo(account, seq)
+	sc.CachedAccountSeqNum.Store(privKey, signerInfo)
+	return signerInfo
 }

--- a/loadtest/sign.go
+++ b/loadtest/sign.go
@@ -30,14 +30,14 @@ type AccountInfo struct {
 type SignerInfo struct {
 	AccountNumber  uint64
 	SequenceNumber uint64
-	mutex *sync.Mutex
+	mutex          *sync.Mutex
 }
 
 func NewSignerInfo(accountNumber uint64, sequenceNumber uint64) *SignerInfo {
 	return &SignerInfo{
-		AccountNumber: accountNumber,
+		AccountNumber:  accountNumber,
 		SequenceNumber: sequenceNumber,
-		mutex: &sync.Mutex{},
+		mutex:          &sync.Mutex{},
 	}
 }
 
@@ -49,13 +49,13 @@ func (si *SignerInfo) IncrementAccountNumber() {
 
 type SignerClient struct {
 	CachedAccountSeqNum *sync.Map
-	CachedAccountKey *sync.Map
+	CachedAccountKey    *sync.Map
 }
 
 func NewSignerClient() *SignerClient {
 	return &SignerClient{
 		CachedAccountSeqNum: &sync.Map{},
-		CachedAccountKey: &sync.Map{},
+		CachedAccountKey:    &sync.Map{},
 	}
 }
 

--- a/loadtest/tx.go
+++ b/loadtest/tx.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -18,16 +17,16 @@ func SendTx(
 	txBuilder *client.TxBuilder,
 	mode typestx.BroadcastMode,
 	seqDelta uint64,
-	mu *sync.Mutex,
+	loadtestClient LoadTestClient,
 ) func() {
 	(*txBuilder).SetGasLimit(200000000)
 	(*txBuilder).SetFeeAmount([]sdk.Coin{
 		sdk.NewCoin("usei", sdk.NewInt(10000000)),
 	})
-	SignTx(txBuilder, key, seqDelta)
+	SignTx(loadtestClient.ChainID, txBuilder, key, seqDelta)
 	txBytes, _ := TestConfig.TxConfig.TxEncoder()((*txBuilder).GetTx())
 	return func() {
-		grpcRes, err := TxClient.BroadcastTx(
+		grpcRes, err := loadtestClient.TxClient.BroadcastTx(
 			context.Background(),
 			&typestx.BroadcastTxRequest{
 				Mode:    mode,
@@ -41,7 +40,7 @@ func SendTx(
 			// retry after a second until either succeed or fail for some other reason
 			fmt.Printf("Mempool full\n")
 			time.Sleep(1 * time.Second)
-			grpcRes, err = TxClient.BroadcastTx(
+			grpcRes, err = loadtestClient.TxClient.BroadcastTx(
 				context.Background(),
 				&typestx.BroadcastTxRequest{
 					Mode:    mode,
@@ -55,11 +54,7 @@ func SendTx(
 		if grpcRes.TxResponse.Code != 0 {
 			fmt.Printf("Error: %d, %s\n", grpcRes.TxResponse.Code, grpcRes.TxResponse.RawLog)
 		} else {
-			mu.Lock()
-			defer mu.Unlock()
-			if _, err := TxHashFile.WriteString(fmt.Sprintf("%s\n", grpcRes.TxResponse.TxHash)); err != nil {
-				panic(err)
-			}
+			loadtestClient.AppendTxHash(grpcRes.TxResponse.TxHash)
 		}
 	}
 }

--- a/loadtest/tx.go
+++ b/loadtest/tx.go
@@ -34,8 +34,7 @@ func SendTx(
 			},
 		)
 		if err != nil {
-			// panic(err)
-			return
+			panic(err)
 		}
 		for grpcRes.TxResponse.Code == sdkerrors.ErrMempoolIsFull.ABCICode() {
 			// retry after a second until either succeed or fail for some other reason

--- a/loadtest/tx.go
+++ b/loadtest/tx.go
@@ -23,7 +23,7 @@ func SendTx(
 	(*txBuilder).SetFeeAmount([]sdk.Coin{
 		sdk.NewCoin("usei", sdk.NewInt(10000000)),
 	})
-	SignTx(loadtestClient.ChainID, txBuilder, key, seqDelta)
+	loadtestClient.SignerClient.SignTx(loadtestClient.ChainID, txBuilder, key, seqDelta)
 	txBytes, _ := TestConfig.TxConfig.TxEncoder()((*txBuilder).GetTx())
 	return func() {
 		grpcRes, err := loadtestClient.TxClient.BroadcastTx(
@@ -34,7 +34,8 @@ func SendTx(
 			},
 		)
 		if err != nil {
-			panic(err)
+			// panic(err)
+			return
 		}
 		for grpcRes.TxResponse.Code == sdkerrors.ErrMempoolIsFull.ABCICode() {
 			// retry after a second until either succeed or fail for some other reason

--- a/loadtest/types.go
+++ b/loadtest/types.go
@@ -12,15 +12,15 @@ import (
 )
 
 type Config struct {
-	ChainID        string                `json:"chain_id"`
-	TxsPerBlock uint64                	 `json:"txs_per_block"`
-	MsgsPerTx      uint64                `json:"msgs_per_tx"`
-	Rounds         uint64                `json:"rounds"`
-	MessageType    string                `json:"message_type"`
-	PriceDistr     NumericDistribution   `json:"price_distribution"`
-	QuantityDistr  NumericDistribution   `json:"quantity_distribution"`
-	MsgTypeDistr   MsgTypeDistribution   `json:"message_type_distribution"`
-	ContractDistr  ContractDistributions `json:"contract_distribution"`
+	ChainID       string                `json:"chain_id"`
+	TxsPerBlock   uint64                `json:"txs_per_block"`
+	MsgsPerTx     uint64                `json:"msgs_per_tx"`
+	Rounds        uint64                `json:"rounds"`
+	MessageType   string                `json:"message_type"`
+	PriceDistr    NumericDistribution   `json:"price_distribution"`
+	QuantityDistr NumericDistribution   `json:"quantity_distribution"`
+	MsgTypeDistr  MsgTypeDistribution   `json:"message_type_distribution"`
+	ContractDistr ContractDistributions `json:"contract_distribution"`
 }
 
 type EncodingConfig struct {

--- a/loadtest/types.go
+++ b/loadtest/types.go
@@ -11,14 +11,6 @@ import (
 	"github.com/sei-protocol/sei-chain/utils"
 )
 
-type EncodingConfig struct {
-	InterfaceRegistry types.InterfaceRegistry
-	// NOTE: this field will be renamed to Codec
-	Marshaler codec.Codec
-	TxConfig  client.TxConfig
-	Amino     *codec.LegacyAmino
-}
-
 type Config struct {
 	ChainID        string                `json:"chain_id"`
 	TxsPerBlock uint64                	 `json:"txs_per_block"`
@@ -29,6 +21,14 @@ type Config struct {
 	QuantityDistr  NumericDistribution   `json:"quantity_distribution"`
 	MsgTypeDistr   MsgTypeDistribution   `json:"message_type_distribution"`
 	ContractDistr  ContractDistributions `json:"contract_distribution"`
+}
+
+type EncodingConfig struct {
+	InterfaceRegistry types.InterfaceRegistry
+	// NOTE: this field will be renamed to Codec
+	Marshaler codec.Codec
+	TxConfig  client.TxConfig
+	Amino     *codec.LegacyAmino
 }
 
 type NumericDistribution struct {

--- a/loadtest/types.go
+++ b/loadtest/types.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/utils"
+)
+
+type EncodingConfig struct {
+	InterfaceRegistry types.InterfaceRegistry
+	// NOTE: this field will be renamed to Codec
+	Marshaler codec.Codec
+	TxConfig  client.TxConfig
+	Amino     *codec.LegacyAmino
+}
+
+type Config struct {
+	ChainID        string                `json:"chain_id"`
+	TxsPerBlock uint64                	 `json:"txs_per_block"`
+	MsgsPerTx      uint64                `json:"msgs_per_tx"`
+	Rounds         uint64                `json:"rounds"`
+	MessageType    string                `json:"message_type"`
+	PriceDistr     NumericDistribution   `json:"price_distribution"`
+	QuantityDistr  NumericDistribution   `json:"quantity_distribution"`
+	MsgTypeDistr   MsgTypeDistribution   `json:"message_type_distribution"`
+	ContractDistr  ContractDistributions `json:"contract_distribution"`
+}
+
+type NumericDistribution struct {
+	Min         sdk.Dec `json:"min"`
+	Max         sdk.Dec `json:"max"`
+	NumDistinct int64   `json:"number_of_distinct_values"`
+}
+
+func (d *NumericDistribution) Sample() sdk.Dec {
+	steps := sdk.NewDec(rand.Int63n(d.NumDistinct))
+	return d.Min.Add(d.Max.Sub(d.Min).QuoInt64(d.NumDistinct).Mul(steps))
+}
+
+type MsgTypeDistribution struct {
+	LimitOrderPct  sdk.Dec `json:"limit_order_percentage"`
+	MarketOrderPct sdk.Dec `json:"market_order_percentage"`
+}
+
+func (d *MsgTypeDistribution) Sample() string {
+	if !d.LimitOrderPct.Add(d.MarketOrderPct).Equal(sdk.OneDec()) {
+		panic("Distribution percentages must add up to 1")
+	}
+	randNum := sdk.MustNewDecFromStr(fmt.Sprintf("%f", rand.Float64()))
+	if randNum.LT(d.LimitOrderPct) {
+		return "limit"
+	}
+	return "market"
+}
+
+type ContractDistributions []ContractDistribution
+
+func (d *ContractDistributions) Sample() string {
+	if !utils.Reduce(*d, func(i ContractDistribution, o sdk.Dec) sdk.Dec { return o.Add(i.Percentage) }, sdk.ZeroDec()).Equal(sdk.OneDec()) {
+		panic("Distribution percentages must add up to 1")
+	}
+	randNum := sdk.MustNewDecFromStr(fmt.Sprintf("%f", rand.Float64()))
+	cumPct := sdk.ZeroDec()
+	for _, dist := range *d {
+		cumPct = cumPct.Add(dist.Percentage)
+		if randNum.LTE(cumPct) {
+			return dist.ContractAddr
+		}
+	}
+	panic("this should never be triggered")
+}
+
+type ContractDistribution struct {
+	ContractAddr string  `json:"contract_address"`
+	Percentage   sdk.Dec `json:"percentage"`
+}

--- a/scripts/old_initialize_local.sh
+++ b/scripts/old_initialize_local.sh
@@ -1,42 +1,48 @@
 #!/bin/bash
 
-keyname=admin
-#docker stop jaeger
-#docker rm jaeger
-#docker run -d --name jaeger \
-#  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
-#  -p 5775:5775/udp \
-#  -p 6831:6831/udp \
-#  -p 6832:6832/udp \
-#  -p 5778:5778 \
-#  -p 16686:16686 \
-#  -p 14250:14250 \
-#  -p 14268:14268 \
-#  -p 14269:14269 \
-#  -p 9411:9411 \
-#  jaegertracing/all-in-one:1.33
+echo -n OS Password:
+read -s password
+echo
+echo -n Key Name:
+read keyname
+echo
+echo -n Number of Test Accounts:
+read numtestaccount
+echo
 
-rm -rf ~/.sei
+docker stop jaeger
+docker rm jaeger
+docker run -d --name jaeger \
+  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
+  -p 5775:5775/udp \
+  -p 6831:6831/udp \
+  -p 6832:6832/udp \
+  -p 5778:5778 \
+  -p 16686:16686 \
+  -p 14250:14250 \
+  -p 14268:14268 \
+  -p 14269:14269 \
+  -p 9411:9411 \
+  jaegertracing/all-in-one:1.33
+
 echo "Building..."
 make install
-#echo $password | sudo -S rm -r ~/.sei/
-#echo $password | sudo -S rm -r ~/test_accounts/
+echo $password | sudo -S rm -r ~/.sei/
+echo $password | sudo -S rm -r ~/test_accounts/
 ~/go/bin/seid init demo --chain-id sei-chain
-~/go/bin/seid keys add $keyname --keyring-backend test
-#yes | ~/go/bin/seid keys add faucet
-~/go/bin/seid add-genesis-account $(~/go/bin/seid keys show $keyname -a --keyring-backend test) 100000000000000000000usei,100000000000000000000uusdc,100000000000000000000uatom
-~/go/bin/seid gentx $keyname 70000000000000000000usei --chain-id sei-chain --keyring-backend test
-sed -i '' 's/mode = "full"/mode = "validator"/g' $HOME/.sei/config/config.toml
-sed -i '' 's/indexer = \["null"\]/indexer = \["kv"\]/g' $HOME/.sei/config/config.toml
+yes | ~/go/bin/seid keys add $keyname
+yes | ~/go/bin/seid keys add faucet
+printf '12345678\n' | ~/go/bin/seid add-genesis-account $(~/go/bin/seid keys show $keyname -a) 100000000000000000000usei,100000000000000000000uusdc,100000000000000000000uatom
+printf '12345678\n' | ~/go/bin/seid add-genesis-account $(~/go/bin/seid keys show faucet -a) 100000000000000000000usei,100000000000000000000uusdc,100000000000000000000uatom
+python3 ./loadtest/scripts/populate_genesis_accounts.py $numtestaccount loc
+printf '12345678\n' | ~/go/bin/seid gentx $keyname 70000000000000000000usei --chain-id sei-chain
+sed -i 's/mode = "full"/mode = "validator"/g' $HOME/.sei/config/config.toml
+sed -i 's/indexer = \["null"\]/indexer = \["kv"\]/g' $HOME/.sei/config/config.toml
 KEY=$(jq '.pub_key' ~/.sei/config/priv_validator_key.json -c)
 jq '.validators = [{}]' ~/.sei/config/genesis.json > ~/.sei/config/tmp_genesis.json
 jq '.validators[0] += {"power":"70000000000000"}' ~/.sei/config/tmp_genesis.json > ~/.sei/config/tmp_genesis_2.json
 jq '.validators[0] += {"pub_key":'$KEY'}' ~/.sei/config/tmp_genesis_2.json > ~/.sei/config/tmp_genesis_3.json
 mv ~/.sei/config/tmp_genesis_3.json ~/.sei/config/genesis.json && rm ~/.sei/config/tmp_genesis.json && rm ~/.sei/config/tmp_genesis_2.json
-
-echo "Creating Accounts"
-python3  loadtest/scripts/populate_genesis_accounts.py 10000 loc
-
 ~/go/bin/seid collect-gentxs
 cat ~/.sei/config/genesis.json | jq '.app_state["crisis"]["constant_fee"]["denom"]="usei"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 cat ~/.sei/config/genesis.json | jq '.app_state["gov"]["deposit_params"]["min_deposit"][0]["denom"]="usei"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json

--- a/scripts/old_initialize_local.sh
+++ b/scripts/old_initialize_local.sh
@@ -1,48 +1,42 @@
 #!/bin/bash
 
-echo -n OS Password:
-read -s password
-echo
-echo -n Key Name:
-read keyname
-echo
-echo -n Number of Test Accounts:
-read numtestaccount
-echo
+keyname=admin
+#docker stop jaeger
+#docker rm jaeger
+#docker run -d --name jaeger \
+#  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
+#  -p 5775:5775/udp \
+#  -p 6831:6831/udp \
+#  -p 6832:6832/udp \
+#  -p 5778:5778 \
+#  -p 16686:16686 \
+#  -p 14250:14250 \
+#  -p 14268:14268 \
+#  -p 14269:14269 \
+#  -p 9411:9411 \
+#  jaegertracing/all-in-one:1.33
 
-docker stop jaeger
-docker rm jaeger
-docker run -d --name jaeger \
-  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
-  -p 5775:5775/udp \
-  -p 6831:6831/udp \
-  -p 6832:6832/udp \
-  -p 5778:5778 \
-  -p 16686:16686 \
-  -p 14250:14250 \
-  -p 14268:14268 \
-  -p 14269:14269 \
-  -p 9411:9411 \
-  jaegertracing/all-in-one:1.33
-
+rm -rf ~/.sei
 echo "Building..."
 make install
-echo $password | sudo -S rm -r ~/.sei/
-echo $password | sudo -S rm -r ~/test_accounts/
+#echo $password | sudo -S rm -r ~/.sei/
+#echo $password | sudo -S rm -r ~/test_accounts/
 ~/go/bin/seid init demo --chain-id sei-chain
-yes | ~/go/bin/seid keys add $keyname
-yes | ~/go/bin/seid keys add faucet
-printf '12345678\n' | ~/go/bin/seid add-genesis-account $(~/go/bin/seid keys show $keyname -a) 100000000000000000000usei,100000000000000000000uusdc,100000000000000000000uatom
-printf '12345678\n' | ~/go/bin/seid add-genesis-account $(~/go/bin/seid keys show faucet -a) 100000000000000000000usei,100000000000000000000uusdc,100000000000000000000uatom
-python3 ./loadtest/scripts/populate_genesis_accounts.py $numtestaccount loc
-printf '12345678\n' | ~/go/bin/seid gentx $keyname 70000000000000000000usei --chain-id sei-chain
-sed -i 's/mode = "full"/mode = "validator"/g' $HOME/.sei/config/config.toml
-sed -i 's/indexer = \["null"\]/indexer = \["kv"\]/g' $HOME/.sei/config/config.toml
+~/go/bin/seid keys add $keyname --keyring-backend test
+#yes | ~/go/bin/seid keys add faucet
+~/go/bin/seid add-genesis-account $(~/go/bin/seid keys show $keyname -a --keyring-backend test) 100000000000000000000usei,100000000000000000000uusdc,100000000000000000000uatom
+~/go/bin/seid gentx $keyname 70000000000000000000usei --chain-id sei-chain --keyring-backend test
+sed -i '' 's/mode = "full"/mode = "validator"/g' $HOME/.sei/config/config.toml
+sed -i '' 's/indexer = \["null"\]/indexer = \["kv"\]/g' $HOME/.sei/config/config.toml
 KEY=$(jq '.pub_key' ~/.sei/config/priv_validator_key.json -c)
 jq '.validators = [{}]' ~/.sei/config/genesis.json > ~/.sei/config/tmp_genesis.json
 jq '.validators[0] += {"power":"70000000000000"}' ~/.sei/config/tmp_genesis.json > ~/.sei/config/tmp_genesis_2.json
 jq '.validators[0] += {"pub_key":'$KEY'}' ~/.sei/config/tmp_genesis_2.json > ~/.sei/config/tmp_genesis_3.json
 mv ~/.sei/config/tmp_genesis_3.json ~/.sei/config/genesis.json && rm ~/.sei/config/tmp_genesis.json && rm ~/.sei/config/tmp_genesis_2.json
+
+echo "Creating Accounts"
+python3  loadtest/scripts/populate_genesis_accounts.py 10000 loc
+
 ~/go/bin/seid collect-gentxs
 cat ~/.sei/config/genesis.json | jq '.app_state["crisis"]["constant_fee"]["denom"]="usei"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 cat ~/.sei/config/genesis.json | jq '.app_state["gov"]["deposit_params"]["min_deposit"][0]["denom"]="usei"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json

--- a/x/oracle/simulation/operations.go
+++ b/x/oracle/simulation/operations.go
@@ -83,7 +83,7 @@ func WeightedOperations(
 }
 
 // SimulateMsgAggregateExchangeRatePrevote generates a MsgAggregateExchangeRatePrevote with random values.
-// nolint: funlen
+//nolint: funlen
 func SimulateMsgAggregateExchangeRatePrevote(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
@@ -146,7 +146,7 @@ func SimulateMsgAggregateExchangeRatePrevote(ak types.AccountKeeper, bk types.Ba
 }
 
 // SimulateMsgAggregateExchangeRateVote generates a MsgAggregateExchangeRateVote with random values.
-// nolint: funlen
+//nolint: funlen
 func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
@@ -213,7 +213,7 @@ func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankK
 }
 
 // SimulateMsgDelegateFeedConsent generates a MsgDelegateFeedConsent with random values.
-// nolint: funlen
+//nolint: funlen
 func SimulateMsgDelegateFeedConsent(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,


### PR DESCRIPTION
## Describe your changes and provide context
Concurrency didn't seem to be the bottleneck. 

* Refactored the script 
* Made a cache for the signer/account seqno responses
   * Instead of querying for each Seq No, we will just manage it locally
* For opening test account files, it will be the same, and read it from memory instead of from file each time 


## Testing performed to validate your change
Went from ~5 minutes -> 2 minutes

The first two rounds take the longest (active/inactive accounts fetching live info) then the remaining 3 rounds are super fast since it's just reading from the cache. 
![image](https://user-images.githubusercontent.com/18161326/197549710-83a50d54-1688-427e-a12b-4c70d445cc0e.png)


Without this change:
![image](https://user-images.githubusercontent.com/18161326/197551875-bedd53bb-f5cc-4927-b67f-9e930f4f0eab.png)


