### PR TITLE
Ezhu/staking dep gen mappings v2 rebase

### DIFF
--- a/aclmapping/staking/mappings.go
+++ b/aclmapping/staking/mappings.go
@@ -1,0 +1,260 @@
+package aclstakingmapping
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
+	aclkeeper "github.com/cosmos/cosmos-sdk/x/accesscontrol/keeper"
+	acltypes "github.com/cosmos/cosmos-sdk/x/accesscontrol/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	utils "github.com/sei-protocol/sei-chain/aclmapping/utils"
+)
+
+var ErrorInvalidMsgType = fmt.Errorf("invalid message received for staking module")
+
+func GetStakingDependencyGenerator() aclkeeper.DependencyGeneratorMap {
+	dependencyGeneratorMap := make(aclkeeper.DependencyGeneratorMap)
+
+	delegateKey := acltypes.GenerateMessageKey(&stakingtypes.MsgDelegate{})
+	undelegateKey := acltypes.GenerateMessageKey(&stakingtypes.MsgUndelegate{})
+	beginRedelegateKey := acltypes.GenerateMessageKey(&stakingtypes.MsgBeginRedelegate{})
+	dependencyGeneratorMap[delegateKey] = MsgDelegateDependencyGenerator
+	dependencyGeneratorMap[undelegateKey] = MsgUndelegateDependencyGenerator
+	dependencyGeneratorMap[beginRedelegateKey] = MsgBeginRedelegateDependencyGenerator
+
+	return dependencyGeneratorMap
+}
+
+func MsgDelegateDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context, msg sdk.Msg) ([]sdkacltypes.AccessOperation, error) {
+	msgDelegate, ok := msg.(*stakingtypes.MsgDelegate)
+	if !ok {
+		return []sdkacltypes.AccessOperation{}, ErrorInvalidMsgType
+	}
+
+	accessOperations := []sdkacltypes.AccessOperation{
+		// Checks if the delegator exists
+		// Checks if there is a delegation object that already exists for (delegatorAddr, validatorAddr)
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.STAKING, msgDelegate.DelegatorAddress+msgDelegate.ValidatorAddress),
+		},
+		// Store new delegator for (delegator, validator)
+		{
+			AccessType:         sdkacltypes.AccessType_WRITE,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.STAKING, msgDelegate.DelegatorAddress+msgDelegate.ValidatorAddress),
+		},
+
+		// delegate coins from account validator account
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.BANK, msgDelegate.DelegatorAddress),
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_WRITE,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.BANK, msgDelegate.DelegatorAddress),
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.BANK, msgDelegate.ValidatorAddress),
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_WRITE,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.BANK, msgDelegate.ValidatorAddress),
+		},
+
+		// Checks if the validators exchange rate is valid
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.STAKING, msgDelegate.ValidatorAddress),
+		},
+		// Update validator shares and power index
+		{
+			AccessType:         sdkacltypes.AccessType_WRITE,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.STAKING, msgDelegate.ValidatorAddress),
+		},
+
+		// Last Operation should always be a commit
+		{
+			ResourceType:       sdkacltypes.ResourceType_ANY,
+			AccessType:         sdkacltypes.AccessType_COMMIT,
+			IdentifierTemplate: utils.DefaultIDTemplate,
+		},
+	}
+
+	return accessOperations, nil
+}
+
+func MsgUndelegateDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context, msg sdk.Msg) ([]sdkacltypes.AccessOperation, error) {
+	msgUndelegate, ok := msg.(*stakingtypes.MsgUndelegate)
+	if !ok {
+		return []sdkacltypes.AccessOperation{}, ErrorInvalidMsgType
+	}
+
+	accessOperations := []sdkacltypes.AccessOperation{
+		// Treat Delegations and Undelegations to have the same ACL since they are highly coupled, no point in finer granularization
+
+		// Get delegation/redelegations and error checking
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.STAKING, msgUndelegate.DelegatorAddress+msgUndelegate.ValidatorAddress),
+		},
+		// Update/delete delegation and update redelegation
+		{
+			AccessType:         sdkacltypes.AccessType_WRITE,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.STAKING, msgUndelegate.DelegatorAddress+msgUndelegate.ValidatorAddress),
+		},
+
+		// Update the delegator and validator account balances
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.BANK, msgUndelegate.DelegatorAddress),
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_WRITE,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.BANK, msgUndelegate.DelegatorAddress),
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.BANK, msgUndelegate.ValidatorAddress),
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_WRITE,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.BANK, msgUndelegate.ValidatorAddress),
+		},
+
+		// Checks if the validators exchange rate is valid
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.STAKING, msgUndelegate.ValidatorAddress),
+		},
+		// Update validator shares and power index
+		{
+			AccessType:         sdkacltypes.AccessType_WRITE,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.STAKING, msgUndelegate.ValidatorAddress),
+		},
+
+		// Last Operation should always be a commit
+		{
+			ResourceType:       sdkacltypes.ResourceType_ANY,
+			AccessType:         sdkacltypes.AccessType_COMMIT,
+			IdentifierTemplate: utils.DefaultIDTemplate,
+		},
+	}
+
+	return accessOperations, nil
+}
+
+func MsgBeginRedelegateDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context, msg sdk.Msg) ([]sdkacltypes.AccessOperation, error) {
+	msgBeingRedelegate, ok := msg.(*stakingtypes.MsgBeginRedelegate)
+	if !ok {
+		return []sdkacltypes.AccessOperation{}, ErrorInvalidMsgType
+	}
+
+	accessOperations := []sdkacltypes.AccessOperation{
+		// Treat Delegations and Redelegations to have the same ACL since they are highly coupled, no point in finer granularization
+
+		// Get src delegation to verify it has sufficient funds to undelegate
+		// Get dest delegation to see if it already exists
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.STAKING, msgBeingRedelegate.DelegatorAddress+msgBeingRedelegate.ValidatorSrcAddress),
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.STAKING, msgBeingRedelegate.DelegatorAddress+msgBeingRedelegate.ValidatorDstAddress),
+		},
+		// Update/delete src and destination delegation after tokens have been unbonded
+		{
+			AccessType:         sdkacltypes.AccessType_WRITE,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.STAKING, msgBeingRedelegate.DelegatorAddress+msgBeingRedelegate.ValidatorSrcAddress),
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_WRITE,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.STAKING, msgBeingRedelegate.DelegatorAddress+msgBeingRedelegate.ValidatorDstAddress),
+		},
+
+		// Update the delegator, src validator and dest validator account balances
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.BANK, msgBeingRedelegate.DelegatorAddress),
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_WRITE,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.BANK, msgBeingRedelegate.DelegatorAddress),
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.BANK, msgBeingRedelegate.ValidatorSrcAddress),
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_WRITE,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.BANK, msgBeingRedelegate.ValidatorSrcAddress),
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.BANK, msgBeingRedelegate.ValidatorDstAddress),
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_WRITE,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.BANK, msgBeingRedelegate.ValidatorDstAddress),
+		},
+
+		// Update validators staking shares and power index
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.STAKING, msgBeingRedelegate.ValidatorSrcAddress),
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_WRITE,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.STAKING, msgBeingRedelegate.ValidatorSrcAddress),
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.STAKING, msgBeingRedelegate.ValidatorDstAddress),
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_WRITE,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.STAKING, msgBeingRedelegate.ValidatorDstAddress),
+		},
+
+		// Last Operation should always be a commit
+		{
+			ResourceType:       sdkacltypes.ResourceType_ANY,
+			AccessType:         sdkacltypes.AccessType_COMMIT,
+			IdentifierTemplate: utils.DefaultIDTemplate,
+		},
+	}
+
+	return accessOperations, nil
+}

--- a/aclmapping/utils/identifier_templates.go
+++ b/aclmapping/utils/identifier_templates.go
@@ -11,6 +11,7 @@ const (
 	ACCOUNT           = "acc"
 	BANK              = "bank"
 	AUTH              = "auth"
+	STAKING           = "staking"
 	DefaultIDTemplate = "*"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.176
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.192
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.59

--- a/go.sum
+++ b/go.sum
@@ -1098,8 +1098,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.1.176 h1:6UgAcryRx6C+UlouHDjxuY7T7hj3nck91QoeppyPdLc=
-github.com/sei-protocol/sei-cosmos v0.1.176/go.mod h1:8ccWQxpBkWbpvBos/T4QO9K9gQxFs0duTqKRnagKo+0=
+github.com/sei-protocol/sei-cosmos v0.1.192 h1:qrrzr2qHrj7zMDmU7KizOjlXm2uLROUtz8ogEYSxfSE=
+github.com/sei-protocol/sei-cosmos v0.1.192/go.mod h1:8ccWQxpBkWbpvBos/T4QO9K9gQxFs0duTqKRnagKo+0=
 github.com/sei-protocol/sei-tendermint v0.1.59 h1:POGL60PumMQHF4EzAHzvkGfDnodQJLHpl65LuiwSO/Y=
 github.com/sei-protocol/sei-tendermint v0.1.59/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/loadtest/config.json
+++ b/loadtest/config.json
@@ -20,7 +20,7 @@
         "undelegate_percentage": "0.25",
         "begin_redelegate_percentage": "0.25"
     },
-    "message_type": "basic",
+    "message_type": "staking",
     "contract_distribution": [
         {
             "contract_address": "sei1yw4xvtc43me9scqfr2jr2gzvcxd3a9y4eq7gaukreugw2yd2f8tsy4qgdm",

--- a/loadtest/config.json
+++ b/loadtest/config.json
@@ -24,7 +24,7 @@
             "begin_redelegate_percentage": "0.25"
         }
     },
-    "message_type": "staking",
+    "message_type": "basic",
     "contract_distribution": [
         {
             "contract_address": "sei1yw4xvtc43me9scqfr2jr2gzvcxd3a9y4eq7gaukreugw2yd2f8tsy4qgdm",

--- a/loadtest/config.json
+++ b/loadtest/config.json
@@ -1,7 +1,7 @@
 {
     "msgs_per_tx": 10,
     "chain_id": "sei-loadtest-testnet",
-    "txs_per_block": 6000,
+    "txs_per_block": 400,
     "rounds": 5,
     "price_distribution": {
         "min": "45",

--- a/loadtest/config.json
+++ b/loadtest/config.json
@@ -15,7 +15,10 @@
     },
     "message_type_distribution": {
         "limit_order_percentage": "0.2",
-        "market_order_percentage": "0.8"
+        "market_order_percentage": "0.8",
+        "delegate_percentage": "0.5",
+        "undelegate_percentage": "0.25",
+        "begin_redelegate_percentage": "0.25"
     },
     "message_type": "basic",
     "contract_distribution": [

--- a/loadtest/config.json
+++ b/loadtest/config.json
@@ -14,11 +14,15 @@
         "number_of_distinct_values": 20
     },
     "message_type_distribution": {
-        "limit_order_percentage": "0.2",
-        "market_order_percentage": "0.8",
-        "delegate_percentage": "0.5",
-        "undelegate_percentage": "0.25",
-        "begin_redelegate_percentage": "0.25"
+        "dex": {
+            "limit_order_percentage": "0.2",
+            "market_order_percentage": "0.8"
+        },
+        "staking": {
+            "delegate_percentage": "0.5",
+            "undelegate_percentage": "0.25",
+            "begin_redelegate_percentage": "0.25"
+        }
     },
     "message_type": "staking",
     "contract_distribution": [

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -79,6 +79,7 @@ func (c *LoadTestClient) BuildTxs() (workgroups []*sync.WaitGroup, sendersList [
 	numberOfAccounts := config.TxsPerBlock / config.MsgsPerTx * 2 // * 2 because we need two sets of accounts
 	activeAccounts := []int{}
 	inactiveAccounts := []int{}
+	qv := GetValidators()
 
 	for i := 0; i < int(numberOfAccounts); i++ {
 		if i%2 == 0 {
@@ -98,7 +99,7 @@ func (c *LoadTestClient) BuildTxs() (workgroups []*sync.WaitGroup, sendersList [
 		for _, account := range activeAccounts {
 			key := c.SignerClient.GetKey(uint64(account))
 
-			msg := generateMessage(config, key, config.MsgsPerTx)
+			msg := generateMessage(config, key, config.MsgsPerTx, qv.Validators)
 			txBuilder := TestConfig.TxConfig.NewTxBuilder()
 			_ = txBuilder.SetMsgs(msg)
 			seqDelta := uint64(i / 2)

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/sei-protocol/sei-chain/app"
 	dextypes "github.com/sei-protocol/sei-chain/x/dex/types"
 )
@@ -69,7 +70,7 @@ func run() {
 	fmt.Printf("%s - Finished\n", time.Now().Format("2006-01-02T15:04:05"))
 }
 
-func generateMessage(config Config, key cryptotypes.PrivKey, msgPerTx uint64) sdk.Msg {
+func generateMessage(config Config, key cryptotypes.PrivKey, batchSize uint64, validators []Validator) sdk.Msg {
 	var msg sdk.Msg
 	switch config.MessageType {
 	case "basic":
@@ -81,8 +82,34 @@ func generateMessage(config Config, key cryptotypes.PrivKey, msgPerTx uint64) sd
 				Amount: sdk.NewInt(1),
 			}),
 		}
+	case "staking":
+		msgType := config.MsgTypeDistr.SampleStakingMsgs()
+
+		switch msgType {
+		case "delegate":
+			msg = &stakingtypes.MsgDelegate{
+				DelegatorAddress: sdk.AccAddress(key.PubKey().Address()).String(),
+				ValidatorAddress: validators[rand.Intn(len(validators))].OpperatorAddr,
+				Amount:           sdk.Coin{Denom: "usei", Amount: sdk.NewInt(5)},
+			}
+		case "undelegate":
+			msg = &stakingtypes.MsgUndelegate{
+				DelegatorAddress: sdk.AccAddress(key.PubKey().Address()).String(),
+				ValidatorAddress: validators[rand.Intn(len(validators))].OpperatorAddr,
+				Amount:           sdk.Coin{Denom: "usei", Amount: sdk.NewInt(1)},
+			}
+		case "begin_redelegate":
+			msg = &stakingtypes.MsgBeginRedelegate{
+				DelegatorAddress:    sdk.AccAddress(key.PubKey().Address()).String(),
+				ValidatorSrcAddress: validators[rand.Intn(len(validators))].OpperatorAddr,
+				ValidatorDstAddress: validators[rand.Intn(len(validators))].OpperatorAddr,
+				Amount:              sdk.Coin{Denom: "usei", Amount: sdk.NewInt(1)},
+			}
+		default:
+			panic("Unknown message type")
+		}
 	case "dex":
-		msgType := config.MsgTypeDistr.Sample()
+		msgType := config.MsgTypeDistr.SampleDexMsgs()
 		orderPlacements := []*dextypes.Order{}
 		var orderType dextypes.OrderType
 		if msgType == "limit" {

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -70,7 +70,7 @@ func run() {
 	fmt.Printf("%s - Finished\n", time.Now().Format("2006-01-02T15:04:05"))
 }
 
-func generateMessage(config Config, key cryptotypes.PrivKey, batchSize uint64, validators []Validator) sdk.Msg {
+func generateMessage(config Config, key cryptotypes.PrivKey, msgPerTx uint64, validators []Validator) sdk.Msg {
 	var msg sdk.Msg
 	switch config.MessageType {
 	case "basic":

--- a/loadtest/sign.go
+++ b/loadtest/sign.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sync"
 	"time"
@@ -57,6 +58,29 @@ func NewSignerClient() *SignerClient {
 		CachedAccountSeqNum: &sync.Map{},
 		CachedAccountKey:    &sync.Map{},
 	}
+}
+
+type Validator struct {
+	OpperatorAddr string `json:"operator_address"`
+}
+
+type QueryValidators struct {
+	Validators []Validator `json:"validators"`
+}
+
+func GetValidators() QueryValidators {
+	seid_query, err := exec.Command("seid", "query", "staking", "validators", "--output", "json").Output()
+
+	if err != nil {
+		panic(err)
+	}
+
+	qv := QueryValidators{}
+	if err := json.Unmarshal(seid_query, &qv); err != nil {
+		panic(err)
+	}
+
+	return qv
 }
 
 func (sc *SignerClient) GetKey(accountIdx uint64) cryptotypes.PrivKey {

--- a/loadtest/sign.go
+++ b/loadtest/sign.go
@@ -69,14 +69,13 @@ type QueryValidators struct {
 }
 
 func GetValidators() QueryValidators {
-	seid_query, err := exec.Command("seid", "query", "staking", "validators", "--output", "json").Output()
-
+	seidQuery, err := exec.Command("seid", "query", "staking", "validators", "--output", "json").Output()
 	if err != nil {
 		panic(err)
 	}
 
 	qv := QueryValidators{}
-	if err := json.Unmarshal(seid_query, &qv); err != nil {
+	if err := json.Unmarshal(seidQuery, &qv); err != nil {
 		panic(err)
 	}
 

--- a/loadtest/types.go
+++ b/loadtest/types.go
@@ -42,33 +42,40 @@ func (d *NumericDistribution) Sample() sdk.Dec {
 	return d.Min.Add(d.Max.Sub(d.Min).QuoInt64(d.NumDistinct).Mul(steps))
 }
 
-type MsgTypeDistribution struct {
-	LimitOrderPct      sdk.Dec `json:"limit_order_percentage"`
-	MarketOrderPct     sdk.Dec `json:"market_order_percentage"`
+type DexMsgTypeDistribution struct {
+	LimitOrderPct  sdk.Dec `json:"limit_order_percentage"`
+	MarketOrderPct sdk.Dec `json:"market_order_percentage"`
+}
+
+type StakingMsgTypeDistribution struct {
 	DelegatePct        sdk.Dec `json:"delegate_percentage"`
 	UndelegatePct      sdk.Dec `json:"undelegate_percentage"`
 	BeginRedelegatePct sdk.Dec `json:"begin_redelegate_percentage"`
 }
+type MsgTypeDistribution struct {
+	Dex     DexMsgTypeDistribution     `json:"dex"`
+	Staking StakingMsgTypeDistribution `json:"staking"`
+}
 
 func (d *MsgTypeDistribution) SampleDexMsgs() string {
-	if !d.LimitOrderPct.Add(d.MarketOrderPct).Equal(sdk.OneDec()) {
+	if !d.Dex.LimitOrderPct.Add(d.Dex.MarketOrderPct).Equal(sdk.OneDec()) {
 		panic("Distribution percentages must add up to 1")
 	}
 	randNum := sdk.MustNewDecFromStr(fmt.Sprintf("%f", rand.Float64()))
-	if randNum.LT(d.LimitOrderPct) {
+	if randNum.LT(d.Dex.LimitOrderPct) {
 		return "limit"
 	}
 	return "market"
 }
 
 func (d *MsgTypeDistribution) SampleStakingMsgs() string {
-	if !d.DelegatePct.Add(d.UndelegatePct).Add(d.BeginRedelegatePct).Equal(sdk.OneDec()) {
+	if !d.Staking.DelegatePct.Add(d.Staking.UndelegatePct).Add(d.Staking.BeginRedelegatePct).Equal(sdk.OneDec()) {
 		panic("Distribution percentages must add up to 1")
 	}
 	randNum := sdk.MustNewDecFromStr(fmt.Sprintf("%f", rand.Float64()))
-	if randNum.LT(d.DelegatePct) {
+	if randNum.LT(d.Staking.DelegatePct) {
 		return "delegate"
-	} else if randNum.LT(d.DelegatePct.Add(d.UndelegatePct)) {
+	} else if randNum.LT(d.Staking.DelegatePct.Add(d.Staking.UndelegatePct)) {
 		return "undelegate"
 	}
 	return "begin_redelegate"

--- a/loadtest/types.go
+++ b/loadtest/types.go
@@ -43,11 +43,14 @@ func (d *NumericDistribution) Sample() sdk.Dec {
 }
 
 type MsgTypeDistribution struct {
-	LimitOrderPct  sdk.Dec `json:"limit_order_percentage"`
-	MarketOrderPct sdk.Dec `json:"market_order_percentage"`
+	LimitOrderPct      sdk.Dec `json:"limit_order_percentage"`
+	MarketOrderPct     sdk.Dec `json:"market_order_percentage"`
+	DelegatePct        sdk.Dec `json:"delegate_percentage"`
+	UndelegatePct      sdk.Dec `json:"undelegate_percentage"`
+	BeginRedelegatePct sdk.Dec `json:"begin_redelegate_percentage"`
 }
 
-func (d *MsgTypeDistribution) Sample() string {
+func (d *MsgTypeDistribution) SampleDexMsgs() string {
 	if !d.LimitOrderPct.Add(d.MarketOrderPct).Equal(sdk.OneDec()) {
 		panic("Distribution percentages must add up to 1")
 	}
@@ -56,6 +59,19 @@ func (d *MsgTypeDistribution) Sample() string {
 		return "limit"
 	}
 	return "market"
+}
+
+func (d *MsgTypeDistribution) SampleStakingMsgs() string {
+	if !d.DelegatePct.Add(d.UndelegatePct).Add(d.BeginRedelegatePct).Equal(sdk.OneDec()) {
+		panic("Distribution percentages must add up to 1")
+	}
+	randNum := sdk.MustNewDecFromStr(fmt.Sprintf("%f", rand.Float64()))
+	if randNum.LT(d.DelegatePct) {
+		return "delegate"
+	} else if randNum.LT(d.DelegatePct.Add(d.UndelegatePct)) {
+		return "undelegate"
+	}
+	return "begin_redelegate"
 }
 
 type ContractDistributions []ContractDistribution


### PR DESCRIPTION
Branched off `2.0.0beta` newer version to avoid rebasing since there were a lot of refactors for the loadtesting framework. The code should be the same as the original pull request 
https://github.com/sei-protocol/sei-chain/pull/328.

Copied the comments from the other PR
## Describe your changes and provide context
Added staking dep gen mappings.

## Testing performed to validate your change
Ran loadtesting on a distribution of `Delegate, Undelegate, BeginRedelegate` messages
![image](https://user-images.githubusercontent.com/19614993/197642704-82c4c429-dbfb-417f-877d-5e91cb94b5e4.png)

Verified the following details:
1. Checked that the height continues to grow `seid q block | jq ".block.last_commit.height"` which implies a consensus is reached and the validators agree on an apphash
2. Verified that the `Delegation` message correctly submits the delegations for validator, account pairing `seid query staking delegations-to <validator_addr>`
3. Verified that `Undelegate` and `BeginRedelegate` messages are correctly submitted. This is a little more tricky to test since the delegation will only stay in the `Unbonding,Redelegate` state for a short period of time. However, you can verify this immediately after you run the loadtest script with `seid query staking redelegations-from <validator_addr>` and `seid query staking unbonding-delegations-from <validator_addr>`. 

If you want to try and test the changes locally, utilize my `sei-infra` [branch](https://github.com/sei-protocol/sei-infra/tree/ezhu-5-nodes). 

## To Do
- rebase off `2.0.0beta`
- Evaluate the performance impact of the parallelization's - will need to sync with @BrandonWeng on how to do this.
- Move the resource mappings to a more granularized/standardized configurations once @udpatil  pushes his change since my `sei-cosmos` [branch](https://github.com/sei-protocol/sei-cosmos/pull/69/files ) needs to merge into his [branch](https://github.com/sei-protocol/sei-cosmos/tree/oracle-resources).


