### PR TITLE
Validate Concurrent Messages + Update BankSend 

### DIFF
--- a/aclmapping/bank/mapping_test.go
+++ b/aclmapping/bank/mapping_test.go
@@ -1,0 +1,155 @@
+package aclbankmapping
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/cosmos/cosmos-sdk/simapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
+	acltypes "github.com/cosmos/cosmos-sdk/x/accesscontrol/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/cosmos-sdk/x/bank"
+	"github.com/cosmos/cosmos-sdk/x/bank/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	oracletypes "github.com/sei-protocol/sei-chain/x/oracle/types"
+	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+)
+
+
+func cacheTxContext(ctx sdk.Context) (sdk.Context, sdk.CacheMultiStore) {
+	ms := ctx.MultiStore()
+	// TODO: https://github.com/cosmos/cosmos-sdk/issues/2824
+	msCache := ms.CacheMultiStore()
+	return ctx.WithMultiStore(msCache), msCache
+}
+
+func TestMsgBankSendAclOps(t *testing.T) {
+	priv1 := secp256k1.GenPrivKey()
+	addr1 := sdk.AccAddress(priv1.PubKey().Address())
+	priv2 := secp256k1.GenPrivKey()
+	addr2 := sdk.AccAddress(priv2.PubKey().Address())
+	coins     := sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}
+
+	tests := []struct {
+		name          string
+		expectedError error
+		msg           *types.MsgSend
+		dynamicDep 	  bool
+	}{
+		{
+			name:          "default send",
+			msg:           types.NewMsgSend(addr1, addr2, coins),
+			expectedError: nil,
+			dynamicDep: true,
+		},
+		{
+			name:          "dont check synchronous",
+			msg:           types.NewMsgSend(addr1, addr2, coins),
+			expectedError: nil,
+			dynamicDep: false,
+		},
+	}
+
+	acc1 := &authtypes.BaseAccount{
+		Address: addr1.String(),
+	}
+	acc2 := &authtypes.BaseAccount{
+		Address: addr2.String(),
+	}
+	accs := authtypes.GenesisAccounts{acc1, acc2}
+	balances := []types.Balance{
+		{
+			Address: addr1.String(),
+			Coins:   coins,
+		},
+		{
+			Address: addr2.String(),
+			Coins:   coins,
+		},
+	}
+
+	app := simapp.SetupWithGenesisAccounts(accs, balances...)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+
+	handler := bank.NewHandler(app.BankKeeper)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handlerCtx, cms := cacheTxContext(ctx)
+			_, err := handler(handlerCtx, tc.msg)
+
+			depdenencies , _ := MsgSendDependencyGenerator(app.AccessControlKeeper, handlerCtx, tc.msg)
+
+			if !tc.dynamicDep {
+				depdenencies = sdkacltypes.SynchronousAccessOps()
+			}
+
+			if tc.expectedError != nil {
+				require.EqualError(t, err, tc.expectedError.Error())
+			} else {
+				require.NoError(t, err)
+			}
+			missing := (sdkacltypes.ValidateAccessOperations(depdenencies, cms.GetEvents()))
+			require.Empty(t, missing)
+		})
+	}
+}
+
+func TestGeneratorInvalidMessageTypes(t *testing.T) {
+	accs := authtypes.GenesisAccounts{}
+	balances := []types.Balance{}
+
+	app := simapp.SetupWithGenesisAccounts(accs, balances...)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+
+	oracleVote := oracletypes.MsgAggregateExchangeRateVote{
+		ExchangeRates: "1usei",
+		Feeder:        "test",
+		Validator:     "validator",
+	}
+
+	_, err := MsgSendDependencyGenerator(app.AccessControlKeeper, ctx, &oracleVote)
+	require.Error(t, err)
+}
+
+func TestMsgBeginBankSendGenerator(t *testing.T) {
+	priv1 := secp256k1.GenPrivKey()
+	addr1 := sdk.AccAddress(priv1.PubKey().Address())
+	priv2 := secp256k1.GenPrivKey()
+	addr2 := sdk.AccAddress(priv2.PubKey().Address())
+	coins     := sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}
+
+	acc1 := &authtypes.BaseAccount{
+		Address: addr1.String(),
+	}
+	acc2 := &authtypes.BaseAccount{
+		Address: addr2.String(),
+	}
+	accs := authtypes.GenesisAccounts{acc1, acc2}
+	balances := []types.Balance{
+		{
+			Address: addr1.String(),
+			Coins:   coins,
+		},
+		{
+			Address: addr2.String(),
+			Coins:   coins,
+		},
+	}
+
+	app := simapp.SetupWithGenesisAccounts(accs, balances...)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+
+	sendMsg := banktypes.MsgSend{
+		FromAddress: addr1.String(),
+		ToAddress: addr2.String(),
+		Amount: coins,
+	}
+
+	accessOps, err := MsgSendDependencyGenerator(app.AccessControlKeeper, ctx, &sendMsg)
+	require.NoError(t, err)
+	err = acltypes.ValidateAccessOps(accessOps)
+	require.NoError(t, err)
+}

--- a/aclmapping/bank/mapping_test.go
+++ b/aclmapping/bank/mapping_test.go
@@ -20,7 +20,6 @@ import (
 
 func cacheTxContext(ctx sdk.Context) (sdk.Context, sdk.CacheMultiStore) {
 	ms := ctx.MultiStore()
-	// TODO: https://github.com/cosmos/cosmos-sdk/issues/2824
 	msCache := ms.CacheMultiStore()
 	return ctx.WithMultiStore(msCache), msCache
 }

--- a/aclmapping/bank/mappings.go
+++ b/aclmapping/bank/mappings.go
@@ -39,25 +39,25 @@ func MsgSendDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context, msg sd
 		// Checks balance of sender
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
-			ResourceType:       sdkacltypes.ResourceType_KV_BANK,
+			ResourceType:       sdkacltypes.ResourceType_KV_BANK_BALANCES,
 			IdentifierTemplate: fromAddrIdentifier,
 		},
 		// Reduce the amount from the sender's balance
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
-			ResourceType:       sdkacltypes.ResourceType_KV_BANK,
+			ResourceType:       sdkacltypes.ResourceType_KV_BANK_BALANCES,
 			IdentifierTemplate: fromAddrIdentifier,
 		},
 
 		// Checks balance for receiver
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
-			ResourceType:       sdkacltypes.ResourceType_KV_BANK,
+			ResourceType:       sdkacltypes.ResourceType_KV_BANK_BALANCES,
 			IdentifierTemplate: toAddrIdentifier,
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
-			ResourceType:       sdkacltypes.ResourceType_KV_BANK,
+			ResourceType:       sdkacltypes.ResourceType_KV_BANK_BALANCES,
 			IdentifierTemplate: toAddrIdentifier,
 		},
 

--- a/aclmapping/bank/mappings.go
+++ b/aclmapping/bank/mappings.go
@@ -7,9 +7,23 @@ import (
 	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
 	aclkeeper "github.com/cosmos/cosmos-sdk/x/accesscontrol/keeper"
 	acltypes "github.com/cosmos/cosmos-sdk/x/accesscontrol/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	utils "github.com/sei-protocol/sei-chain/aclmapping/utils"
 )
+
+func CreateAddressStoreKeyFromBech32(addr string) []byte {
+	accAdrr, _ := sdk.AccAddressFromBech32(addr)
+	accAdrrWithPrefix := authtypes.AddressStoreKey(accAdrr)
+	return accAdrrWithPrefix
+}
+
+func CreateAccountBalancesPrefixFromBech32(addr string) []byte {
+	accAdrr, _ := sdk.AccAddressFromBech32(addr)
+	accAdrrPrefix := banktypes.CreateAccountBalancesPrefix(accAdrr)
+	return accAdrrPrefix
+}
+
 
 var ErrorInvalidMsgType = fmt.Errorf("invalid message received for bank module")
 
@@ -23,12 +37,13 @@ func GetBankDepedencyGenerator() aclkeeper.DependencyGeneratorMap {
 	return dependencyGeneratorMap
 }
 
-// TODO:: we can make resource types more granular  (e.g KV_PARAM or KV_BANK_BALANCE)
 func MsgSendDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context, msg sdk.Msg) ([]sdkacltypes.AccessOperation, error) {
 	msgSend, ok := msg.(*banktypes.MsgSend)
 	if !ok {
 		return []sdkacltypes.AccessOperation{}, ErrorInvalidMsgType
 	}
+	fromAddrIdentifier := string(CreateAccountBalancesPrefixFromBech32(msgSend.FromAddress))
+	toAddrIdentifier := string(CreateAccountBalancesPrefixFromBech32(msgSend.ToAddress))
 
 	accessOperations := []sdkacltypes.AccessOperation{
 		// MsgSend also checks if the coin denom is enabled, but the information is from the params.
@@ -37,46 +52,53 @@ func MsgSendDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context, msg sd
 		// Checks balance of sender
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
-			ResourceType:       sdkacltypes.ResourceType_KV,
-			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.BANK, msgSend.FromAddress),
+			ResourceType:       sdkacltypes.ResourceType_KV_BANK,
+			IdentifierTemplate: fromAddrIdentifier,
 		},
 		// Reduce the amount from the sender's balance
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
-			ResourceType:       sdkacltypes.ResourceType_KV,
-			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.BANK, msgSend.FromAddress),
+			ResourceType:       sdkacltypes.ResourceType_KV_BANK,
+			IdentifierTemplate: fromAddrIdentifier,
 		},
 
 		// Checks balance for receiver
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
-			ResourceType:       sdkacltypes.ResourceType_KV,
-			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.BANK, msgSend.ToAddress),
+			ResourceType:       sdkacltypes.ResourceType_KV_BANK,
+			IdentifierTemplate: toAddrIdentifier,
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
-			ResourceType:       sdkacltypes.ResourceType_KV,
-			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.BANK, msgSend.ToAddress),
+			ResourceType:       sdkacltypes.ResourceType_KV_BANK,
+			IdentifierTemplate: toAddrIdentifier,
 		},
 
 		// Tries to create the reciever's account if it doesn't exist
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV,
-			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.AUTH, msgSend.ToAddress),
+			IdentifierTemplate: string(CreateAddressStoreKeyFromBech32(msgSend.ToAddress)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV,
-			IdentifierTemplate: utils.GetIdentifierTemplatePerModule(utils.AUTH, msgSend.ToAddress),
+			IdentifierTemplate: string(CreateAddressStoreKeyFromBech32(msgSend.ToAddress)),
 		},
 
-		// Last Operation should always be a commit
+		// Gets Account Info for the sender
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV,
+			IdentifierTemplate: string(CreateAddressStoreKeyFromBech32(msgSend.FromAddress)),
+		},
+
 		{
 			ResourceType:       sdkacltypes.ResourceType_ANY,
 			AccessType:         sdkacltypes.AccessType_COMMIT,
 			IdentifierTemplate: utils.DefaultIDTemplate,
 		},
 	}
+
 	return accessOperations, nil
 }

--- a/aclmapping/bank/mappings.go
+++ b/aclmapping/bank/mappings.go
@@ -12,19 +12,6 @@ import (
 	utils "github.com/sei-protocol/sei-chain/aclmapping/utils"
 )
 
-func CreateAddressStoreKeyFromBech32(addr string) []byte {
-	accAdrr, _ := sdk.AccAddressFromBech32(addr)
-	accAdrrWithPrefix := authtypes.AddressStoreKey(accAdrr)
-	return accAdrrWithPrefix
-}
-
-func CreateAccountBalancesPrefixFromBech32(addr string) []byte {
-	accAdrr, _ := sdk.AccAddressFromBech32(addr)
-	accAdrrPrefix := banktypes.CreateAccountBalancesPrefix(accAdrr)
-	return accAdrrPrefix
-}
-
-
 var ErrorInvalidMsgType = fmt.Errorf("invalid message received for bank module")
 
 func GetBankDepedencyGenerator() aclkeeper.DependencyGeneratorMap {
@@ -42,8 +29,8 @@ func MsgSendDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context, msg sd
 	if !ok {
 		return []sdkacltypes.AccessOperation{}, ErrorInvalidMsgType
 	}
-	fromAddrIdentifier := string(CreateAccountBalancesPrefixFromBech32(msgSend.FromAddress))
-	toAddrIdentifier := string(CreateAccountBalancesPrefixFromBech32(msgSend.ToAddress))
+	fromAddrIdentifier := string(banktypes.CreateAccountBalancesPrefixFromBech32(msgSend.FromAddress))
+	toAddrIdentifier := string(banktypes.CreateAccountBalancesPrefixFromBech32(msgSend.ToAddress))
 
 	accessOperations := []sdkacltypes.AccessOperation{
 		// MsgSend also checks if the coin denom is enabled, but the information is from the params.
@@ -77,20 +64,20 @@ func MsgSendDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context, msg sd
 		// Tries to create the reciever's account if it doesn't exist
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
-			ResourceType:       sdkacltypes.ResourceType_KV,
-			IdentifierTemplate: string(CreateAddressStoreKeyFromBech32(msgSend.ToAddress)),
+			ResourceType:       sdkacltypes.ResourceType_KV_AUTH,
+			IdentifierTemplate: string(authtypes.CreateAddressStoreKeyFromBech32(msgSend.ToAddress)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
-			ResourceType:       sdkacltypes.ResourceType_KV,
-			IdentifierTemplate: string(CreateAddressStoreKeyFromBech32(msgSend.ToAddress)),
+			ResourceType:       sdkacltypes.ResourceType_KV_AUTH,
+			IdentifierTemplate: string(authtypes.CreateAddressStoreKeyFromBech32(msgSend.ToAddress)),
 		},
 
 		// Gets Account Info for the sender
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
-			ResourceType:       sdkacltypes.ResourceType_KV,
-			IdentifierTemplate: string(CreateAddressStoreKeyFromBech32(msgSend.FromAddress)),
+			ResourceType:       sdkacltypes.ResourceType_KV_AUTH,
+			IdentifierTemplate: string(authtypes.CreateAddressStoreKeyFromBech32(msgSend.FromAddress)),
 		},
 
 		{

--- a/aclmapping/bank/mappings.go
+++ b/aclmapping/bank/mappings.go
@@ -64,19 +64,19 @@ func MsgSendDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context, msg sd
 		// Tries to create the reciever's account if it doesn't exist
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
-			ResourceType:       sdkacltypes.ResourceType_KV_AUTH,
+			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
 			IdentifierTemplate: string(authtypes.CreateAddressStoreKeyFromBech32(msgSend.ToAddress)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
-			ResourceType:       sdkacltypes.ResourceType_KV_AUTH,
+			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
 			IdentifierTemplate: string(authtypes.CreateAddressStoreKeyFromBech32(msgSend.ToAddress)),
 		},
 
 		// Gets Account Info for the sender
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
-			ResourceType:       sdkacltypes.ResourceType_KV_AUTH,
+			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
 			IdentifierTemplate: string(authtypes.CreateAddressStoreKeyFromBech32(msgSend.FromAddress)),
 		},
 

--- a/aclmapping/bank/mappings_test.go
+++ b/aclmapping/bank/mappings_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/bank"
 	"github.com/cosmos/cosmos-sdk/x/bank/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	pp "github.com/k0kubun/pp/v3"
 	aclutils "github.com/sei-protocol/sei-chain/aclmapping/utils"
 	oracletypes "github.com/sei-protocol/sei-chain/x/oracle/types"
 	"github.com/stretchr/testify/require"
@@ -52,8 +51,6 @@ func TestMsgBankSendAclOps(t *testing.T) {
 			dynamicDep: false,
 		},
 	}
-
-	pp.Printf("FROM: %s, TO:", addr1.String(), addr2.String())
 
 	acc1 := &authtypes.BaseAccount{
 		Address: addr1.String(),
@@ -98,7 +95,6 @@ func TestMsgBankSendAclOps(t *testing.T) {
 				require.NoError(t, err)
 			}
 			missing := handlerCtx.MsgValidator().ValidateAccessOperations(depdenencies, cms.GetEvents())
-			pp.Println(missing)
 			require.Empty(t, missing)
 		})
 	}

--- a/aclmapping/bank/mappings_test.go
+++ b/aclmapping/bank/mappings_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/bank"
 	"github.com/cosmos/cosmos-sdk/x/bank/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	pp "github.com/k0kubun/pp/v3"
 	aclutils "github.com/sei-protocol/sei-chain/aclmapping/utils"
 	oracletypes "github.com/sei-protocol/sei-chain/x/oracle/types"
 	"github.com/stretchr/testify/require"
@@ -51,6 +52,8 @@ func TestMsgBankSendAclOps(t *testing.T) {
 			dynamicDep: false,
 		},
 	}
+
+	pp.Printf("FROM: %s, TO:", addr1.String(), addr2.String())
 
 	acc1 := &authtypes.BaseAccount{
 		Address: addr1.String(),
@@ -95,6 +98,7 @@ func TestMsgBankSendAclOps(t *testing.T) {
 				require.NoError(t, err)
 			}
 			missing := handlerCtx.MsgValidator().ValidateAccessOperations(depdenencies, cms.GetEvents())
+			pp.Println(missing)
 			require.Empty(t, missing)
 		})
 	}

--- a/aclmapping/utils/identifier_templates.go
+++ b/aclmapping/utils/identifier_templates.go
@@ -1,4 +1,4 @@
-package util
+package utils
 
 import (
 	"fmt"

--- a/aclmapping/utils/resource_type.go
+++ b/aclmapping/utils/resource_type.go
@@ -13,9 +13,9 @@ import (
 
 var StoreKeyToResourceTypePrefixMap = aclsdktypes.StoreKeyToResourceTypePrefixMap{
 	aclsdktypes.ParentNodeKey: {
-		aclsdktypes.ResourceType_ANY:     aclsdktypes.EmptyPrefix,
-		aclsdktypes.ResourceType_KV:      aclsdktypes.EmptyPrefix,
-		aclsdktypes.ResourceType_Mem:     aclsdktypes.EmptyPrefix,
+		aclsdktypes.ResourceType_ANY: aclsdktypes.EmptyPrefix,
+		aclsdktypes.ResourceType_KV:  aclsdktypes.EmptyPrefix,
+		aclsdktypes.ResourceType_Mem: aclsdktypes.EmptyPrefix,
 	},
 	dextypes.StoreKey: {
 		aclsdktypes.ResourceType_KV_DEX: aclsdktypes.EmptyPrefix,

--- a/aclmapping/utils/resource_type.go
+++ b/aclmapping/utils/resource_type.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	aclsdktypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	dextypes "github.com/sei-protocol/sei-chain/x/dex/types"
+	epochtypes "github.com/sei-protocol/sei-chain/x/epoch/types"
+	oracletypes "github.com/sei-protocol/sei-chain/x/oracle/types"
+	tokenfactorytypes "github.com/sei-protocol/sei-chain/x/tokenfactory/types"
+)
+
+var StoreKeyToResourceTypePrefixMap = aclsdktypes.StoreKeyToResourceTypePrefixMap{
+	aclsdktypes.ParentNodeKey: {
+		aclsdktypes.ResourceType_ANY:     aclsdktypes.EmptyPrefix,
+		aclsdktypes.ResourceType_KV:      aclsdktypes.EmptyPrefix,
+		aclsdktypes.ResourceType_Mem:     aclsdktypes.EmptyPrefix,
+	},
+	dextypes.StoreKey: {
+		aclsdktypes.ResourceType_KV_DEX: aclsdktypes.EmptyPrefix,
+		aclsdktypes.ResourceType_DexMem: aclsdktypes.EmptyPrefix,
+	},
+	banktypes.StoreKey: {
+		aclsdktypes.ResourceType_KV_BANK:          aclsdktypes.EmptyPrefix,
+		aclsdktypes.ResourceType_KV_BANK_BALANCES: banktypes.BalancesPrefix,
+		aclsdktypes.ResourceType_KV_BANK_SUPPLY:   banktypes.SupplyKey,
+		aclsdktypes.ResourceType_KV_BANK_DENOM:    banktypes.DenomMetadataPrefix,
+	},
+	authtypes.StoreKey: {
+		aclsdktypes.ResourceType_KV_AUTH:               aclsdktypes.EmptyPrefix,
+		aclsdktypes.ResourceType_KV_AUTH_ADDRESS_STORE: authtypes.AddressStoreKeyPrefix,
+	},
+	oracletypes.StoreKey: {
+		aclsdktypes.ResourceType_KV_ORACLE:                 aclsdktypes.EmptyPrefix,
+		aclsdktypes.ResourceType_KV_ORACLE_VOTE_TARGETS:    oracletypes.VoteTargetKey,
+		aclsdktypes.ResourceType_KV_ORACLE_AGGREGATE_VOTES: oracletypes.AggregateExchangeRateVoteKey,
+		aclsdktypes.ResourceType_KV_ORACLE_FEEDERS:         oracletypes.FeederDelegationKey,
+	},
+	stakingtypes.StoreKey: {
+		aclsdktypes.ResourceType_KV_STAKING:            aclsdktypes.EmptyPrefix,
+		aclsdktypes.ResourceType_KV_STAKING_DELEGATION: stakingtypes.DelegationKey,
+		aclsdktypes.ResourceType_KV_STAKING_VALIDATOR:  stakingtypes.ValidatorsKey,
+	},
+	tokenfactorytypes.StoreKey: {
+		aclsdktypes.ResourceType_KV_TOKENFACTORY: aclsdktypes.EmptyPrefix,
+	},
+	epochtypes.StoreKey: {
+		aclsdktypes.ResourceType_KV_EPOCH: aclsdktypes.EmptyPrefix,
+	},
+}

--- a/app/app.go
+++ b/app/app.go
@@ -37,11 +37,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	aclmodule "github.com/cosmos/cosmos-sdk/x/accesscontrol"
 	aclclient "github.com/cosmos/cosmos-sdk/x/accesscontrol/client"
 	aclkeeper "github.com/cosmos/cosmos-sdk/x/accesscontrol/keeper"
 	acltypes "github.com/cosmos/cosmos-sdk/x/accesscontrol/types"
-
 	authrest "github.com/cosmos/cosmos-sdk/x/auth/client/rest"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authsims "github.com/cosmos/cosmos-sdk/x/auth/simulation"
@@ -996,11 +996,13 @@ func (app *App) ProcessTxConcurrent(
 	resultChan chan<- ChannelResult,
 	txCompletionSignalingMap acltypes.MessageCompletionSignalMapping,
 	txBlockingSignalsMap acltypes.MessageCompletionSignalMapping,
+	txMsgAccessOpMapping acltypes.MsgIndexToAccessOpMapping,
 ) {
 	defer wg.Done()
 	// Store the Channels in the Context Object for each transaction
 	ctx = ctx.WithTxBlockingChannels(getChannelsFromSignalMapping(txBlockingSignalsMap))
 	ctx = ctx.WithTxCompletionChannels(getChannelsFromSignalMapping(txCompletionSignalingMap))
+	ctx = ctx.WithTxMsgAccessOps(txMsgAccessOpMapping)
 
 	// Deliver the transaction and store the result in the channel
 
@@ -1013,18 +1015,18 @@ func (app *App) ProcessBlockConcurrent(
 	txs [][]byte,
 	completionSignalingMap map[int]acltypes.MessageCompletionSignalMapping,
 	blockingSignalsMap map[int]acltypes.MessageCompletionSignalMapping,
-) []*abci.ExecTxResult {
+	txMsgAccessOpMapping map[int]acltypes.MsgIndexToAccessOpMapping,
+) ([]*abci.ExecTxResult, bool){
 	defer metrics.BlockProcessLatency(time.Now(), metrics.CONCURRENT)
+
+	txResults := []*abci.ExecTxResult{}
+	// If there's no transactions then return empty results
+	if len(txs) == 0 {
+		return txResults, true
+	}
 
 	var waitGroup sync.WaitGroup
 	resultChan := make(chan ChannelResult)
-	txResults := []*abci.ExecTxResult{}
-
-	// If there's no transactions then return empty results
-	if len(txs) == 0 {
-		return txResults
-	}
-
 	// For each transaction, start goroutine and deliver TX
 	for txIndex, txBytes := range txs {
 		waitGroup.Add(1)
@@ -1036,6 +1038,7 @@ func (app *App) ProcessBlockConcurrent(
 			resultChan,
 			completionSignalingMap[txIndex],
 			blockingSignalsMap[txIndex],
+			txMsgAccessOpMapping[txIndex],
 		)
 	}
 
@@ -1059,7 +1062,15 @@ func (app *App) ProcessBlockConcurrent(
 		txResults = append(txResults, txResultsMap[txIndex])
 	}
 
-	return txResults
+	ok := true
+	for _, result := range txResults {
+		if result.GetCode() == sdkerrors.ErrInvalidConcurrencyExecution.ABCICode() {
+			ctx.Logger().Error(fmt.Sprintf("Invalid concurrent execution of deliverTx: %s", result.GetLog()))
+			ok = false
+		}
+	}
+
+	return txResults, ok
 }
 
 func (app *App) ProcessBlock(ctx sdk.Context, txs [][]byte, req BlockProcessRequest, lastCommit abci.CommitInfo) ([]abci.Event, []*abci.ExecTxResult, abci.ResponseEndBlock, error) {
@@ -1115,7 +1126,24 @@ func (app *App) ProcessBlock(ctx sdk.Context, txs [][]byte, req BlockProcessRequ
 		// CacheMultiStore where it writes the data to the parent store (DeliverState) in sorted Key order to maintain
 		// deterministic ordering between validators in the case of concurrent deliverTXs
 		processBlockCtx, processBlockCache := app.CacheContext(ctx)
-		txResults = app.ProcessBlockConcurrent(processBlockCtx, txs, dependencyDag.CompletionSignalingMap, dependencyDag.BlockingSignalsMap)
+		concurrentResults, ok := app.ProcessBlockConcurrent(
+			processBlockCtx,
+			txs,
+			dependencyDag.CompletionSignalingMap,
+			dependencyDag.BlockingSignalsMap,
+			dependencyDag.TxMsgAccessOpMapping,
+		)
+		if ok {
+			ctx.Logger().Info("Concurrent Execution succeeded, proceeding to commit block")
+			txResults = concurrentResults
+			// Write the results back to the concurrent contexts - if concurrent execution fails,
+			// this should not be called and the state is rolled back and retried with synchronous execution
+			processBlockCache.Write()
+		} else {
+			ctx.Logger().Error("Concurrent Execution failed, retrying with Synchronous")
+			txResults = app.ProcessBlockSynchronous(ctx, txs)
+		}
+
 		// Write the results back to the concurrent contexts
 		processBlockCache.Write()
 	case acltypes.ErrGovMsgInBlock:

--- a/app/app.go
+++ b/app/app.go
@@ -1016,7 +1016,7 @@ func (app *App) ProcessBlockConcurrent(
 	completionSignalingMap map[int]acltypes.MessageCompletionSignalMapping,
 	blockingSignalsMap map[int]acltypes.MessageCompletionSignalMapping,
 	txMsgAccessOpMapping map[int]acltypes.MsgIndexToAccessOpMapping,
-) ([]*abci.ExecTxResult, bool){
+) ([]*abci.ExecTxResult, bool) {
 	defer metrics.BlockProcessLatency(time.Now(), metrics.CONCURRENT)
 
 	txResults := []*abci.ExecTxResult{}

--- a/app/app.go
+++ b/app/app.go
@@ -1066,6 +1066,7 @@ func (app *App) ProcessBlockConcurrent(
 	for i, result := range txResults {
 		if result.GetCode() == sdkerrors.ErrInvalidConcurrencyExecution.ABCICode() {
 			ctx.Logger().Error(fmt.Sprintf("Invalid concurrent execution of deliverTx index=%d", i))
+			metrics.IncrFailedConcurrentDeliverTxCounter()
 			ok = false
 		}
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -1063,9 +1063,9 @@ func (app *App) ProcessBlockConcurrent(
 	}
 
 	ok := true
-	for _, result := range txResults {
+	for i, result := range txResults {
 		if result.GetCode() == sdkerrors.ErrInvalidConcurrencyExecution.ABCICode() {
-			ctx.Logger().Error(fmt.Sprintf("Invalid concurrent execution of deliverTx: %s", result.GetLog()))
+			ctx.Logger().Error(fmt.Sprintf("Invalid concurrent execution of deliverTx index=%d", i))
 			ok = false
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.238
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.239
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.59

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
-	github.com/k0kubun/pp/v3 v3.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/regen-network/cosmos-proto v0.3.1
 	github.com/spf13/cast v1.5.0
@@ -89,7 +88,6 @@ require (
 	github.com/lib/pq v1.10.6 // indirect
 	github.com/libp2p/go-buffer-pool v0.0.2 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
@@ -133,7 +131,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => ../sei-cosmos //github.com/sei-protocol/sei-cosmos v0.1.232
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.237
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.59

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.228
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.229
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.59

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.200
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.227
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.59

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.237
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.238
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.59

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.232
+	github.com/cosmos/cosmos-sdk => ../sei-cosmos //github.com/sei-protocol/sei-cosmos v0.1.232
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.59

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.229
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.230
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.59

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.227
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.228
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.59

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.230
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.232
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.59

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
+	github.com/k0kubun/pp/v3 v3.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/regen-network/cosmos-proto v0.3.1
 	github.com/spf13/cast v1.5.0
@@ -88,6 +89,7 @@ require (
 	github.com/lib/pq v1.10.6 // indirect
 	github.com/libp2p/go-buffer-pool v0.0.2 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1098,8 +1098,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.1.227 h1:/V+GC2ZlaO3udUmKJhwXB+I2LTtrqWLqo3tEk37FSGk=
-github.com/sei-protocol/sei-cosmos v0.1.227/go.mod h1:8ccWQxpBkWbpvBos/T4QO9K9gQxFs0duTqKRnagKo+0=
+github.com/sei-protocol/sei-cosmos v0.1.228 h1:T913qo9Q8wT6hXB65QlcagLrVgEGRMuOt5NVlsQaAfg=
+github.com/sei-protocol/sei-cosmos v0.1.228/go.mod h1:8ccWQxpBkWbpvBos/T4QO9K9gQxFs0duTqKRnagKo+0=
 github.com/sei-protocol/sei-tendermint v0.1.59 h1:POGL60PumMQHF4EzAHzvkGfDnodQJLHpl65LuiwSO/Y=
 github.com/sei-protocol/sei-tendermint v0.1.59/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/go.sum
+++ b/go.sum
@@ -1098,8 +1098,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.1.229 h1:+8CQbv+P6bzbIB9q7Hx4VIjdAuPMrloWXx5cfwSxUqk=
-github.com/sei-protocol/sei-cosmos v0.1.229/go.mod h1:8ccWQxpBkWbpvBos/T4QO9K9gQxFs0duTqKRnagKo+0=
+github.com/sei-protocol/sei-cosmos v0.1.230 h1:s6NXreWacakRgtdWbVgynoX8lipmttqfo7p5eyuePdE=
+github.com/sei-protocol/sei-cosmos v0.1.230/go.mod h1:8ccWQxpBkWbpvBos/T4QO9K9gQxFs0duTqKRnagKo+0=
 github.com/sei-protocol/sei-tendermint v0.1.59 h1:POGL60PumMQHF4EzAHzvkGfDnodQJLHpl65LuiwSO/Y=
 github.com/sei-protocol/sei-tendermint v0.1.59/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/go.sum
+++ b/go.sum
@@ -734,8 +734,6 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/julz/importas v0.1.0/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
-github.com/k0kubun/pp/v3 v3.2.0 h1:h33hNTZ9nVFNP3u2Fsgz8JXiF5JINoZfFq4SvKJwNcs=
-github.com/k0kubun/pp/v3 v3.2.0/go.mod h1:ODtJQbQcIRfAD3N+theGCV1m/CBxweERz2dapdz1EwA=
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/errcheck v1.6.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -802,8 +800,6 @@ github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
-github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
-github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
 github.com/mattn/go-ieproxy v0.0.0-20190702010315-6dee0af9227d/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
@@ -1102,6 +1098,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
+github.com/sei-protocol/sei-cosmos v0.1.237 h1:jddoEV3yGqRZezpXYmGWCcyd6+9oTtGqLAhvj5HkcKA=
+github.com/sei-protocol/sei-cosmos v0.1.237/go.mod h1:r2yN7zERSjvq7pn7QFyWpLKu6Qk0Vs7x8hQkrtyrkzw=
 github.com/sei-protocol/sei-tendermint v0.1.59 h1:POGL60PumMQHF4EzAHzvkGfDnodQJLHpl65LuiwSO/Y=
 github.com/sei-protocol/sei-tendermint v0.1.59/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/go.sum
+++ b/go.sum
@@ -734,6 +734,8 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/julz/importas v0.1.0/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
+github.com/k0kubun/pp/v3 v3.2.0 h1:h33hNTZ9nVFNP3u2Fsgz8JXiF5JINoZfFq4SvKJwNcs=
+github.com/k0kubun/pp/v3 v3.2.0/go.mod h1:ODtJQbQcIRfAD3N+theGCV1m/CBxweERz2dapdz1EwA=
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/errcheck v1.6.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -800,6 +802,8 @@ github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
 github.com/mattn/go-ieproxy v0.0.0-20190702010315-6dee0af9227d/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=

--- a/go.sum
+++ b/go.sum
@@ -1098,8 +1098,6 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.1.232 h1:YXFv4Dyks6U7RvwzMkfMCGSjJ7gLijQA03leC0hoBdY=
-github.com/sei-protocol/sei-cosmos v0.1.232/go.mod h1:8ccWQxpBkWbpvBos/T4QO9K9gQxFs0duTqKRnagKo+0=
 github.com/sei-protocol/sei-tendermint v0.1.59 h1:POGL60PumMQHF4EzAHzvkGfDnodQJLHpl65LuiwSO/Y=
 github.com/sei-protocol/sei-tendermint v0.1.59/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/go.sum
+++ b/go.sum
@@ -1098,8 +1098,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.1.237 h1:jddoEV3yGqRZezpXYmGWCcyd6+9oTtGqLAhvj5HkcKA=
-github.com/sei-protocol/sei-cosmos v0.1.237/go.mod h1:r2yN7zERSjvq7pn7QFyWpLKu6Qk0Vs7x8hQkrtyrkzw=
+github.com/sei-protocol/sei-cosmos v0.1.238 h1:20ojgSCKBMJnDEJ5f6U0hMMUgOCz8cmwsSUiyiuKGZI=
+github.com/sei-protocol/sei-cosmos v0.1.238/go.mod h1:r2yN7zERSjvq7pn7QFyWpLKu6Qk0Vs7x8hQkrtyrkzw=
 github.com/sei-protocol/sei-tendermint v0.1.59 h1:POGL60PumMQHF4EzAHzvkGfDnodQJLHpl65LuiwSO/Y=
 github.com/sei-protocol/sei-tendermint v0.1.59/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/go.sum
+++ b/go.sum
@@ -1098,8 +1098,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.1.200 h1:EbHDzt0aAASO7fy8Dac04lLzm0xhF1O1ILiA+UD3w98=
-github.com/sei-protocol/sei-cosmos v0.1.200/go.mod h1:8ccWQxpBkWbpvBos/T4QO9K9gQxFs0duTqKRnagKo+0=
+github.com/sei-protocol/sei-cosmos v0.1.227 h1:/V+GC2ZlaO3udUmKJhwXB+I2LTtrqWLqo3tEk37FSGk=
+github.com/sei-protocol/sei-cosmos v0.1.227/go.mod h1:8ccWQxpBkWbpvBos/T4QO9K9gQxFs0duTqKRnagKo+0=
 github.com/sei-protocol/sei-tendermint v0.1.59 h1:POGL60PumMQHF4EzAHzvkGfDnodQJLHpl65LuiwSO/Y=
 github.com/sei-protocol/sei-tendermint v0.1.59/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/go.sum
+++ b/go.sum
@@ -1098,8 +1098,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.1.228 h1:T913qo9Q8wT6hXB65QlcagLrVgEGRMuOt5NVlsQaAfg=
-github.com/sei-protocol/sei-cosmos v0.1.228/go.mod h1:8ccWQxpBkWbpvBos/T4QO9K9gQxFs0duTqKRnagKo+0=
+github.com/sei-protocol/sei-cosmos v0.1.229 h1:+8CQbv+P6bzbIB9q7Hx4VIjdAuPMrloWXx5cfwSxUqk=
+github.com/sei-protocol/sei-cosmos v0.1.229/go.mod h1:8ccWQxpBkWbpvBos/T4QO9K9gQxFs0duTqKRnagKo+0=
 github.com/sei-protocol/sei-tendermint v0.1.59 h1:POGL60PumMQHF4EzAHzvkGfDnodQJLHpl65LuiwSO/Y=
 github.com/sei-protocol/sei-tendermint v0.1.59/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/go.sum
+++ b/go.sum
@@ -1098,8 +1098,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.1.238 h1:20ojgSCKBMJnDEJ5f6U0hMMUgOCz8cmwsSUiyiuKGZI=
-github.com/sei-protocol/sei-cosmos v0.1.238/go.mod h1:r2yN7zERSjvq7pn7QFyWpLKu6Qk0Vs7x8hQkrtyrkzw=
+github.com/sei-protocol/sei-cosmos v0.1.239 h1:IuWt2PVB6kDVA7NHBRp5BGwgjw1Lg4dJT91yb4VmEZI=
+github.com/sei-protocol/sei-cosmos v0.1.239/go.mod h1:c2dhT0+W9l83qjFJrQ6CcjhtHwHOoha5K1rtt4LeDBU=
 github.com/sei-protocol/sei-tendermint v0.1.59 h1:POGL60PumMQHF4EzAHzvkGfDnodQJLHpl65LuiwSO/Y=
 github.com/sei-protocol/sei-tendermint v0.1.59/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/go.sum
+++ b/go.sum
@@ -1098,8 +1098,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.1.230 h1:s6NXreWacakRgtdWbVgynoX8lipmttqfo7p5eyuePdE=
-github.com/sei-protocol/sei-cosmos v0.1.230/go.mod h1:8ccWQxpBkWbpvBos/T4QO9K9gQxFs0duTqKRnagKo+0=
+github.com/sei-protocol/sei-cosmos v0.1.232 h1:YXFv4Dyks6U7RvwzMkfMCGSjJ7gLijQA03leC0hoBdY=
+github.com/sei-protocol/sei-cosmos v0.1.232/go.mod h1:8ccWQxpBkWbpvBos/T4QO9K9gQxFs0duTqKRnagKo+0=
 github.com/sei-protocol/sei-tendermint v0.1.59 h1:POGL60PumMQHF4EzAHzvkGfDnodQJLHpl65LuiwSO/Y=
 github.com/sei-protocol/sei-tendermint v0.1.59/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/store/testutils.go
+++ b/store/testutils.go
@@ -11,7 +11,7 @@ import (
 
 func NewTestKVStore() types.KVStore {
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
-	return cachekv.NewStore(mem)
+	return cachekv.NewStore(mem, nil)
 }
 
 func NewTestCacheMultiStore(stores map[types.StoreKey]types.CacheWrapper) types.CacheMultiStore {

--- a/utils/metrics/metrics_util.go
+++ b/utils/metrics/metrics_util.go
@@ -45,6 +45,19 @@ func IncrDagBuildErrorCounter(reason string) {
 	)
 }
 
+// Counts the number of concurrent transactions that failed
+// Metric Names:
+//
+//	sei_tx_concurrent_delivertx_error
+func IncrFailedConcurrentDeliverTxCounter() {
+	metrics.IncrCounterWithLabels(
+		[]string{"sei", "tx", "concurrent", "delievertx", "error"},
+		1,
+		[]metrics.Label{},
+	)
+}
+
+
 // Measures the time taken to execute a sudo msg
 // Metric Names:
 //

--- a/utils/metrics/metrics_util.go
+++ b/utils/metrics/metrics_util.go
@@ -57,7 +57,6 @@ func IncrFailedConcurrentDeliverTxCounter() {
 	)
 }
 
-
 // Measures the time taken to execute a sudo msg
 // Metric Names:
 //

--- a/x/oracle/simulation/operations.go
+++ b/x/oracle/simulation/operations.go
@@ -65,7 +65,7 @@ func WeightedOperations(
 }
 
 // SimulateMsgAggregateExchangeRateVote generates a MsgAggregateExchangeRateVote with random values.
-//nolint: funlen
+// nolint: funlen
 func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
@@ -122,7 +122,7 @@ func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankK
 }
 
 // SimulateMsgDelegateFeedConsent generates a MsgDelegateFeedConsent with random values.
-//nolint: funlen
+// nolint: funlen
 func SimulateMsgDelegateFeedConsent(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,

--- a/x/oracle/simulation/operations.go
+++ b/x/oracle/simulation/operations.go
@@ -65,7 +65,7 @@ func WeightedOperations(
 }
 
 // SimulateMsgAggregateExchangeRateVote generates a MsgAggregateExchangeRateVote with random values.
-// nolint: funlen
+//nolint: funlen
 func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
@@ -122,7 +122,7 @@ func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankK
 }
 
 // SimulateMsgDelegateFeedConsent generates a MsgDelegateFeedConsent with random values.
-// nolint: funlen
+//nolint: funlen
 func SimulateMsgDelegateFeedConsent(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,


### PR DESCRIPTION
## Describe your changes and provide context

* Updates the banksend acl mapping to use the prefix/storekeys as the identifiers rather than arbitrary ones
* Adds logic for handling failovers in the case when concurrent executions fail 
* Adds metric to count failed TX counts, we should add alerting on this in the future 

Will need to update the mapping for all the other modules

## Testing performed to validate your change
Unit tests

Deployed to load test cluster and was able to run bank sends e2e and verified that the height increases
![image](https://user-images.githubusercontent.com/18161326/198453757-ab2885a4-3cb8-42e6-9c18-7ee841ba14cb.png)

Also manually forced failure scenario
![image](https://user-images.githubusercontent.com/18161326/198303645-2a9dbdf1-f2a1-4fe7-8027-eebac0b19d1a.png)

