### PR TITLE
integrate with sei-cosmos changes

### DIFF
--- a/aclmapping/wasm/mappings.go
+++ b/aclmapping/wasm/mappings.go
@@ -8,6 +8,7 @@ import (
 	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
 	aclkeeper "github.com/cosmos/cosmos-sdk/x/accesscontrol/keeper"
 	acltypes "github.com/cosmos/cosmos-sdk/x/accesscontrol/types"
+	"github.com/sei-protocol/sei-chain/utils"
 )
 
 var (
@@ -41,12 +42,12 @@ func (wasmDepGen WasmDependencyGenerator) WasmExecuteContractGenerator(keeper ac
 	if err != nil {
 		return []sdkacltypes.AccessOperation{}, err
 	}
-	wasmDependencyMapping, err := keeper.GetWasmDependencyMapping(ctx, contractAddr)
+	wasmDependencyMapping, err := keeper.GetWasmDependencyMapping(ctx, contractAddr, executeContractMsg.Msg, true)
 	if err != nil {
 		return []sdkacltypes.AccessOperation{}, err
 	}
 	if !wasmDependencyMapping.Enabled {
 		return []sdkacltypes.AccessOperation{}, ErrWasmFunctionDependenciesDisabled
 	}
-	return wasmDependencyMapping.AccessOps, nil
+	return utils.Map(wasmDependencyMapping.AccessOps, func(op sdkacltypes.AccessOperationWithSelector) sdkacltypes.AccessOperation { return *op.Operation }), nil
 }

--- a/app/antedecorators/gas.go
+++ b/app/antedecorators/gas.go
@@ -1,0 +1,57 @@
+package antedecorators
+
+import (
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	"github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
+	aclkeeper "github.com/cosmos/cosmos-sdk/x/accesscontrol/keeper"
+)
+
+const (
+	WasmCorrectDependencyDiscountNumerator   uint64 = 1
+	WasmCorrectDependencyDiscountDenominator uint64 = 2
+)
+
+func GetGasMeterSetter(aclkeeper aclkeeper.Keeper) func(bool, sdk.Context, uint64, sdk.Tx) sdk.Context {
+	return func(simulate bool, ctx sdk.Context, gasLimit uint64, tx sdk.Tx) sdk.Context {
+		if simulate || ctx.BlockHeight() == 0 {
+			return ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
+		}
+
+		numerator, denominator := uint64(0), uint64(1)
+		for _, msg := range tx.GetMsgs() {
+			candidateNumerator, candidateDenominator := getMessageMultiplier(ctx, msg, aclkeeper)
+			numerator, denominator = maxMultiplier(numerator, denominator, candidateNumerator, candidateDenominator)
+		}
+		return ctx.WithGasMeter(types.NewMultiplierGasMeter(gasLimit, numerator, denominator))
+	}
+}
+
+func getMessageMultiplier(ctx sdk.Context, msg sdk.Msg, aclkeeper aclkeeper.Keeper) (uint64, uint64) {
+	if wasmExecuteMsg, ok := msg.(*wasmtypes.MsgExecuteContract); ok {
+		addr, err := sdk.AccAddressFromBech32(wasmExecuteMsg.Contract)
+		if err != nil {
+			return 1, 1
+		}
+		mapping, err := aclkeeper.GetWasmDependencyMapping(ctx, addr, []byte{}, false)
+		if err != nil {
+			return 1, 1
+		}
+		// only give gas discount if none of the dependency (except COMMIT) has id "*"
+		for _, op := range mapping.AccessOps {
+			if op.Operation.AccessType != sdkacltypes.AccessType_COMMIT && op.Operation.IdentifierTemplate == "*" {
+				return 1, 1
+			}
+		}
+		return WasmCorrectDependencyDiscountNumerator, WasmCorrectDependencyDiscountDenominator
+	}
+	return 1, 1
+}
+
+func maxMultiplier(n1 uint64, d1 uint64, n2 uint64, d2 uint64) (uint64, uint64) {
+	if n1*d2 < d1*n2 {
+		return n2, d2
+	}
+	return n1, d1
+}

--- a/app/antedecorators/gas.go
+++ b/app/antedecorators/gas.go
@@ -51,10 +51,3 @@ func getMessageMultiplierDenominator(ctx sdk.Context, msg sdk.Msg, aclkeeper acl
 	}
 	return DefaultGasMultiplierDenominator
 }
-
-func maxMultiplier(n1 uint64, d1 uint64, n2 uint64, d2 uint64) (uint64, uint64) {
-	if n1*d2 < d1*n2 {
-		return n2, d2
-	}
-	return n1, d1
-}

--- a/app/antedecorators/gas_test.go
+++ b/app/antedecorators/gas_test.go
@@ -1,0 +1,77 @@
+package antedecorators_test
+
+import (
+	"testing"
+
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/accesscontrol"
+	acltypes "github.com/cosmos/cosmos-sdk/x/accesscontrol/types"
+	"github.com/sei-protocol/sei-chain/app"
+	"github.com/sei-protocol/sei-chain/app/antedecorators"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/proto/tendermint/types"
+)
+
+type TestTx struct {
+	msgs []sdk.Msg
+}
+
+func (t TestTx) GetMsgs() []sdk.Msg {
+	return t.msgs
+}
+
+func (t TestTx) ValidateBasic() error {
+	return nil
+}
+
+func TestMultiplierGasSetter(t *testing.T) {
+	app := app.Setup(false)
+	contractAddr, err := sdk.AccAddressFromBech32("sei1y3pxq5dp900czh0mkudhjdqjq5m8cpmmps8yjw")
+	require.NoError(t, err)
+	ctx := app.NewContext(false, types.Header{}).WithBlockHeight(2)
+	testMsg := wasmtypes.MsgExecuteContract{
+		Contract: "sei1y3pxq5dp900czh0mkudhjdqjq5m8cpmmps8yjw",
+		Msg:      []byte("{}"),
+	}
+	testTx := TestTx{msgs: []sdk.Msg{&testMsg}}
+	// discounted mapping
+	app.AccessControlKeeper.SetWasmDependencyMapping(ctx, contractAddr, accesscontrol.WasmDependencyMapping{
+		Enabled: true,
+		AccessOps: []accesscontrol.AccessOperationWithSelector{
+			{
+				Operation: &accesscontrol.AccessOperation{
+					AccessType:         accesscontrol.AccessType_READ,
+					ResourceType:       accesscontrol.ResourceType_KV,
+					IdentifierTemplate: "something",
+				},
+			},
+			{
+				Operation: acltypes.CommitAccessOp(),
+			},
+		},
+	})
+	gasMeterSetter := antedecorators.GetGasMeterSetter(app.AccessControlKeeper)
+	ctxWithGasMeter := gasMeterSetter(false, ctx, 1000, testTx)
+	ctxWithGasMeter.GasMeter().ConsumeGas(2, "")
+	require.Equal(t, uint64(1), ctxWithGasMeter.GasMeter().GasConsumed())
+	// not discounted mapping
+	app.AccessControlKeeper.SetWasmDependencyMapping(ctx, contractAddr, accesscontrol.WasmDependencyMapping{
+		Enabled: true,
+		AccessOps: []accesscontrol.AccessOperationWithSelector{
+			{
+				Operation: &accesscontrol.AccessOperation{
+					AccessType:         accesscontrol.AccessType_READ,
+					ResourceType:       accesscontrol.ResourceType_KV,
+					IdentifierTemplate: "*",
+				},
+			},
+			{
+				Operation: acltypes.CommitAccessOp(),
+			},
+		},
+	})
+	ctxWithGasMeter = gasMeterSetter(false, ctx, 1000, testTx)
+	ctxWithGasMeter.GasMeter().ConsumeGas(2, "")
+	require.Equal(t, uint64(2), ctxWithGasMeter.GasMeter().GasConsumed())
+}

--- a/app/app.go
+++ b/app/app.go
@@ -40,6 +40,7 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	aclmodule "github.com/cosmos/cosmos-sdk/x/accesscontrol"
 	aclclient "github.com/cosmos/cosmos-sdk/x/accesscontrol/client"
+	aclconstants "github.com/cosmos/cosmos-sdk/x/accesscontrol/constants"
 	aclkeeper "github.com/cosmos/cosmos-sdk/x/accesscontrol/keeper"
 	acltypes "github.com/cosmos/cosmos-sdk/x/accesscontrol/types"
 	authrest "github.com/cosmos/cosmos-sdk/x/auth/client/rest"
@@ -759,11 +760,12 @@ func New(
 				SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
 				// BatchVerifier:   app.batchVerifier,
 			},
-			IBCKeeper:    app.IBCKeeper,
-			WasmConfig:   &wasmConfig,
-			OracleKeeper: &app.OracleKeeper,
-			DexKeeper:    &app.DexKeeper,
-			TracingInfo:  app.tracingInfo,
+			IBCKeeper:           app.IBCKeeper,
+			WasmConfig:          &wasmConfig,
+			OracleKeeper:        &app.OracleKeeper,
+			DexKeeper:           &app.DexKeeper,
+			AccessControlKeeper: &app.AccessControlKeeper,
+			TracingInfo:         app.tracingInfo,
 		},
 	)
 	if err != nil {
@@ -1161,6 +1163,7 @@ func (app *App) ProcessBlock(ctx sdk.Context, txs [][]byte, req BlockProcessRequ
 	lazyWriteEvents := app.BankKeeper.WriteDeferredDepositsToModuleAccounts(ctx)
 	events = append(events, lazyWriteEvents...)
 
+	ctx = app.enrichContextWithTxResults(ctx, txResults)
 	endBlockResp := app.EndBlock(ctx, abci.RequestEndBlock{
 		Height: req.GetHeight(),
 	})
@@ -1168,6 +1171,27 @@ func (app *App) ProcessBlock(ctx sdk.Context, txs [][]byte, req BlockProcessRequ
 	events = append(events, endBlockResp.Events...)
 
 	return events, txResults, endBlockResp, nil
+}
+
+func (app *App) enrichContextWithTxResults(ctx sdk.Context, txResults []*abci.ExecTxResult) sdk.Context {
+	wasmContractsWithIncorrectDependencies := []sdk.AccAddress{}
+	for _, txResult := range txResults {
+		if txResult.Codespace == acltypes.ModuleName && txResult.Code == 2 {
+			for _, event := range txResult.Events {
+				if event.Type == wasmbinding.EventTypeWasmContractWithIncorrectDependency {
+					for _, attr := range event.Attributes {
+						if attr.Key == wasmbinding.AttributeKeyWasmContractAddress {
+							addr, err := sdk.AccAddressFromBech32(attr.Value)
+							if err == nil {
+								wasmContractsWithIncorrectDependencies = append(wasmContractsWithIncorrectDependencies, addr)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return ctx.WithContext(context.WithValue(ctx.Context(), aclconstants.BadWasmDependencyAddressesKey, wasmContractsWithIncorrectDependencies))
 }
 
 func (app *App) getFinalizeBlockResponse(appHash []byte, events []abci.Event, txResults []*abci.ExecTxResult, endBlockResp abci.ResponseEndBlock) abci.ResponseFinalizeBlock {

--- a/go.mod
+++ b/go.mod
@@ -132,7 +132,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.240
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.243
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.59

--- a/go.mod
+++ b/go.mod
@@ -106,6 +106,7 @@ require (
 	github.com/rs/cors v1.8.2 // indirect
 	github.com/rs/zerolog v1.26.1 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
+	github.com/savaki/jq v0.0.0-20161209013833-0e6baecebbf8 // indirect
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
@@ -122,7 +123,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
 	golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e // indirect
 	golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 // indirect
-	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
+	golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 // indirect
 	golang.org/x/term v0.0.0-20220411215600-e5f449aeb171 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect
@@ -131,7 +132,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.239
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.240
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.59

--- a/go.sum
+++ b/go.sum
@@ -1100,8 +1100,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.1.240 h1:sXRnBIUlM2pvI1zDeYbguRAjLVpH5nzxlinwDuZVZCg=
-github.com/sei-protocol/sei-cosmos v0.1.240/go.mod h1:b1phyIbXp/tEo7+XsgyoZKMAx301iEC/AA0tJRloP2E=
+github.com/sei-protocol/sei-cosmos v0.1.243 h1:61ZYGaE/bdzgR3sknuAn+p3wQA0wcmLNZ4OQjvtZL5o=
+github.com/sei-protocol/sei-cosmos v0.1.243/go.mod h1:KPV8lFdD2Ki/M2wZTpfX3LCcuMAZnmcUzYJycjbmOYM=
 github.com/sei-protocol/sei-tendermint v0.1.59 h1:POGL60PumMQHF4EzAHzvkGfDnodQJLHpl65LuiwSO/Y=
 github.com/sei-protocol/sei-tendermint v0.1.59/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/go.sum
+++ b/go.sum
@@ -1094,12 +1094,14 @@ github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0
 github.com/sanposhiho/wastedassign/v2 v2.0.6/go.mod h1:KyZ0MWTwxxBmfwn33zh3k1dmsbF2ud9pAAGfoLfjhtI=
 github.com/sasha-s/go-deadlock v0.3.1 h1:sqv7fDNShgjcaxkO0JNcOAlr8B9+cV5Ey/OB71efZx0=
 github.com/sasha-s/go-deadlock v0.3.1/go.mod h1:F73l+cr82YSh10GxyRI6qZiCgK64VaZjwesgfQ1/iLM=
+github.com/savaki/jq v0.0.0-20161209013833-0e6baecebbf8 h1:ajJQhvqPSQFJJ4aV5mDAMx8F7iFi6Dxfo6y62wymLNs=
+github.com/savaki/jq v0.0.0-20161209013833-0e6baecebbf8/go.mod h1:Nw/CCOXNyF5JDd6UpYxBwG5WWZ2FOJ/d5QnXL4KQ6vY=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.1.239 h1:IuWt2PVB6kDVA7NHBRp5BGwgjw1Lg4dJT91yb4VmEZI=
-github.com/sei-protocol/sei-cosmos v0.1.239/go.mod h1:c2dhT0+W9l83qjFJrQ6CcjhtHwHOoha5K1rtt4LeDBU=
+github.com/sei-protocol/sei-cosmos v0.1.240 h1:sXRnBIUlM2pvI1zDeYbguRAjLVpH5nzxlinwDuZVZCg=
+github.com/sei-protocol/sei-cosmos v0.1.240/go.mod h1:b1phyIbXp/tEo7+XsgyoZKMAx301iEC/AA0tJRloP2E=
 github.com/sei-protocol/sei-tendermint v0.1.59 h1:POGL60PumMQHF4EzAHzvkGfDnodQJLHpl65LuiwSO/Y=
 github.com/sei-protocol/sei-tendermint v0.1.59/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
@@ -1632,8 +1634,9 @@ golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220502124256-b6088ccd6cba/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 h1:v6hYoSR9T5oet+pMXwUWkbiVqx/63mlHjefrHmxwfeY=
+golang.org/x/sys v0.0.0-20220829200755-d48e67d00261/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/wasmbinding/message_plugin.go
+++ b/wasmbinding/message_plugin.go
@@ -1,19 +1,17 @@
 package wasmbinding
 
 import (
-	"fmt"
-
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
+	"github.com/cosmos/cosmos-sdk/x/accesscontrol"
 	aclkeeper "github.com/cosmos/cosmos-sdk/x/accesscontrol/keeper"
 	acltypes "github.com/cosmos/cosmos-sdk/x/accesscontrol/types"
+	"github.com/sei-protocol/sei-chain/utils"
 )
-
-var ErrUnexpectedWasmDependency = fmt.Errorf("unexpected wasm dependency detected")
 
 // forked from wasm
 func CustomMessageHandler(
@@ -123,7 +121,9 @@ func (decorator SDKMessageDependencyDecorator) DispatchMsg(ctx sdk.Context, cont
 		return nil, nil, err
 	}
 	// get the dependencies for the contract to validate against
-	wasmDependency, err := decorator.aclKeeper.GetWasmDependencyMapping(ctx, contractAddr)
+	// TODO: we need to carry wasmDependency in ctx instead of loading again here since here has no access to original msg payload
+	//       which is required for populating id correctly.
+	wasmDependency, err := decorator.aclKeeper.GetWasmDependencyMapping(ctx, contractAddr, []byte{}, false)
 	// If no mapping exists, or mapping is disabled, this message would behave as blocking for all resources
 	if err == aclkeeper.ErrWasmDependencyMappingNotFound {
 		// no mapping, we can just continue
@@ -138,7 +138,9 @@ func (decorator SDKMessageDependencyDecorator) DispatchMsg(ctx sdk.Context, cont
 		return decorator.wrapped.DispatchMsg(ctx, contractAddr, contractIBCPortID, msg)
 	}
 	// convert wasm dependency to a map of resource access and identifier we can look up in
-	lookupMap := BuildWasmDependencyLookupMap(wasmDependency.AccessOps)
+	lookupMap := BuildWasmDependencyLookupMap(
+		utils.Map(wasmDependency.AccessOps, func(op sdkacltypes.AccessOperationWithSelector) sdkacltypes.AccessOperation { return *op.Operation }),
+	)
 	// wasm dependency enabled, we need to validate the message dependencies
 	for _, msg := range sdkMsgs {
 		accessOps := decorator.aclKeeper.GetMessageDependencies(ctx, msg)
@@ -147,7 +149,8 @@ func (decorator SDKMessageDependencyDecorator) DispatchMsg(ctx sdk.Context, cont
 			// first check for our specific resource access AND identifier template
 			depsFulfilled := AreDependenciesFulfilled(lookupMap, accessOp)
 			if !depsFulfilled {
-				return nil, nil, ErrUnexpectedWasmDependency
+				emitIncorrectDependencyWasmEvent(ctx, contractAddr.String())
+				return nil, nil, accesscontrol.ErrUnexpectedWasmDependency
 			}
 		}
 	}

--- a/wasmbinding/query_plugin.go
+++ b/wasmbinding/query_plugin.go
@@ -8,7 +8,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/accesscontrol"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	acl "github.com/cosmos/cosmos-sdk/x/accesscontrol"
 	aclkeeper "github.com/cosmos/cosmos-sdk/x/accesscontrol/keeper"
+	"github.com/sei-protocol/sei-chain/utils"
 )
 
 const (
@@ -49,7 +51,9 @@ type CustomQueryHandler struct {
 }
 
 func (queryHandler CustomQueryHandler) HandleQuery(ctx sdk.Context, caller sdk.AccAddress, request wasmvmtypes.QueryRequest) ([]byte, error) {
-	wasmDependency, err := queryHandler.aclKeeper.GetWasmDependencyMapping(ctx, caller)
+	// TODO: we need to carry wasmDependency in ctx instead of loading again here since here has no access to original msg payload
+	//       which is required for populating id correctly.
+	wasmDependency, err := queryHandler.aclKeeper.GetWasmDependencyMapping(ctx, caller, []byte{}, false)
 	// If no mapping exists, or mapping is disabled, this message would behave as blocking for all resources
 	needToCheckDependencies := true
 	if err == aclkeeper.ErrWasmDependencyMappingNotFound {
@@ -62,17 +66,21 @@ func (queryHandler CustomQueryHandler) HandleQuery(ctx sdk.Context, caller sdk.A
 	if !wasmDependency.Enabled {
 		needToCheckDependencies = false
 	}
-	lookupMap := BuildWasmDependencyLookupMap(wasmDependency.AccessOps)
+	lookupMap := BuildWasmDependencyLookupMap(
+		utils.Map(wasmDependency.AccessOps, func(op accesscontrol.AccessOperationWithSelector) accesscontrol.AccessOperation { return *op.Operation }),
+	)
 	if request.Bank != nil {
 		// check for BANK resource type
 		accessOp := accesscontrol.AccessOperation{
-			ResourceType:       accesscontrol.ResourceType_KV_BANK,
-			AccessType:         accesscontrol.AccessType_READ,
+			ResourceType: accesscontrol.ResourceType_KV_BANK,
+			AccessType:   accesscontrol.AccessType_READ,
+			// TODO: should IdentifierTemplate be based on the actual request?
 			IdentifierTemplate: "*",
 		}
 		if needToCheckDependencies {
 			if !AreDependenciesFulfilled(lookupMap, accessOp) {
-				return nil, ErrUnexpectedWasmDependency
+				emitIncorrectDependencyWasmEvent(ctx, caller.String())
+				return nil, acl.ErrUnexpectedWasmDependency
 			}
 		}
 		return queryHandler.QueryPlugins.Bank(ctx, request.Bank)
@@ -100,7 +108,8 @@ func (queryHandler CustomQueryHandler) HandleQuery(ctx sdk.Context, caller sdk.A
 		}
 		if needToCheckDependencies {
 			if !AreDependenciesFulfilled(lookupMap, accessOp) {
-				return nil, ErrUnexpectedWasmDependency
+				emitIncorrectDependencyWasmEvent(ctx, caller.String())
+				return nil, acl.ErrUnexpectedWasmDependency
 			}
 		}
 		return queryHandler.QueryPlugins.Custom(ctx, request.Custom)
@@ -115,7 +124,8 @@ func (queryHandler CustomQueryHandler) HandleQuery(ctx sdk.Context, caller sdk.A
 		}
 		if needToCheckDependencies {
 			if !AreDependenciesFulfilled(lookupMap, accessOp) {
-				return nil, ErrUnexpectedWasmDependency
+				emitIncorrectDependencyWasmEvent(ctx, caller.String())
+				return nil, acl.ErrUnexpectedWasmDependency
 			}
 		}
 		return queryHandler.QueryPlugins.IBC(ctx, caller, request.IBC)
@@ -129,7 +139,8 @@ func (queryHandler CustomQueryHandler) HandleQuery(ctx sdk.Context, caller sdk.A
 		}
 		if needToCheckDependencies {
 			if !AreDependenciesFulfilled(lookupMap, accessOp) {
-				return nil, ErrUnexpectedWasmDependency
+				emitIncorrectDependencyWasmEvent(ctx, caller.String())
+				return nil, acl.ErrUnexpectedWasmDependency
 			}
 		}
 		return queryHandler.QueryPlugins.Staking(ctx, request.Staking)
@@ -144,7 +155,8 @@ func (queryHandler CustomQueryHandler) HandleQuery(ctx sdk.Context, caller sdk.A
 		}
 		if needToCheckDependencies {
 			if !AreDependenciesFulfilled(lookupMap, accessOp) {
-				return nil, ErrUnexpectedWasmDependency
+				emitIncorrectDependencyWasmEvent(ctx, caller.String())
+				return nil, acl.ErrUnexpectedWasmDependency
 			}
 		}
 		return queryHandler.QueryPlugins.Stargate(ctx, request.Stargate)
@@ -158,7 +170,8 @@ func (queryHandler CustomQueryHandler) HandleQuery(ctx sdk.Context, caller sdk.A
 		}
 		if needToCheckDependencies {
 			if !AreDependenciesFulfilled(lookupMap, accessOp) {
-				return nil, ErrUnexpectedWasmDependency
+				emitIncorrectDependencyWasmEvent(ctx, caller.String())
+				return nil, acl.ErrUnexpectedWasmDependency
 			}
 		}
 		return queryHandler.QueryPlugins.Wasm(ctx, request.Wasm)

--- a/wasmbinding/test/query_test.go
+++ b/wasmbinding/test/query_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/accesscontrol"
+	acl "github.com/cosmos/cosmos-sdk/x/accesscontrol"
 	acltypes "github.com/cosmos/cosmos-sdk/x/accesscontrol/types"
 	"github.com/sei-protocol/sei-chain/app"
 	"github.com/sei-protocol/sei-chain/wasmbinding"
@@ -263,13 +264,16 @@ func TestQueryHandlerDependencyDecoratorBank(t *testing.T) {
 	// setup the wasm contract's dependency mapping
 	err = app.AccessControlKeeper.SetWasmDependencyMapping(testContext, contractAddr, accesscontrol.WasmDependencyMapping{
 		Enabled: true,
-		AccessOps: []accesscontrol.AccessOperation{
+		AccessOps: []accesscontrol.AccessOperationWithSelector{
 			{
-				AccessType:         accesscontrol.AccessType_READ,
-				ResourceType:       accesscontrol.ResourceType_KV_BANK,
-				IdentifierTemplate: "*",
+				Operation: &accesscontrol.AccessOperation{
+					AccessType:         accesscontrol.AccessType_READ,
+					ResourceType:       accesscontrol.ResourceType_KV_BANK,
+					IdentifierTemplate: "*",
+				},
+			}, {
+				Operation: acltypes.CommitAccessOp(),
 			},
-			acltypes.CommitAccessOp(),
 		},
 	})
 	require.NoError(t, err)
@@ -281,13 +285,16 @@ func TestQueryHandlerDependencyDecoratorBank(t *testing.T) {
 
 	err = app.AccessControlKeeper.SetWasmDependencyMapping(testContext, contractAddr, accesscontrol.WasmDependencyMapping{
 		Enabled: true,
-		AccessOps: []accesscontrol.AccessOperation{
+		AccessOps: []accesscontrol.AccessOperationWithSelector{
 			{
-				AccessType:         accesscontrol.AccessType_WRITE,
-				ResourceType:       accesscontrol.ResourceType_KV_DEX,
-				IdentifierTemplate: "*",
+				Operation: &accesscontrol.AccessOperation{
+					AccessType:         accesscontrol.AccessType_WRITE,
+					ResourceType:       accesscontrol.ResourceType_KV_DEX,
+					IdentifierTemplate: "*",
+				},
+			}, {
+				Operation: acltypes.CommitAccessOp(),
 			},
-			acltypes.CommitAccessOp(),
 		},
 	})
 	require.NoError(t, err)
@@ -295,7 +302,7 @@ func TestQueryHandlerDependencyDecoratorBank(t *testing.T) {
 	_, err = queryDecorator.HandleQuery(testContext, contractAddr, wasmvmtypes.QueryRequest{
 		Bank: &wasmvmtypes.BankQuery{},
 	})
-	require.Error(t, wasmbinding.ErrUnexpectedWasmDependency, err)
+	require.Error(t, acl.ErrUnexpectedWasmDependency, err)
 }
 
 func TestQueryHandlerDependencyDecoratorIBC(t *testing.T) {
@@ -308,13 +315,16 @@ func TestQueryHandlerDependencyDecoratorIBC(t *testing.T) {
 	// setup the wasm contract's dependency mapping
 	err = app.AccessControlKeeper.SetWasmDependencyMapping(testContext, contractAddr, accesscontrol.WasmDependencyMapping{
 		Enabled: true,
-		AccessOps: []accesscontrol.AccessOperation{
+		AccessOps: []accesscontrol.AccessOperationWithSelector{
 			{
-				AccessType:         accesscontrol.AccessType_READ,
-				ResourceType:       accesscontrol.ResourceType_ANY,
-				IdentifierTemplate: "*",
+				Operation: &accesscontrol.AccessOperation{
+					AccessType:         accesscontrol.AccessType_READ,
+					ResourceType:       accesscontrol.ResourceType_ANY,
+					IdentifierTemplate: "*",
+				},
+			}, {
+				Operation: acltypes.CommitAccessOp(),
 			},
-			acltypes.CommitAccessOp(),
 		},
 	})
 	require.NoError(t, err)
@@ -326,13 +336,16 @@ func TestQueryHandlerDependencyDecoratorIBC(t *testing.T) {
 
 	err = app.AccessControlKeeper.SetWasmDependencyMapping(testContext, contractAddr, accesscontrol.WasmDependencyMapping{
 		Enabled: true,
-		AccessOps: []accesscontrol.AccessOperation{
+		AccessOps: []accesscontrol.AccessOperationWithSelector{
 			{
-				AccessType:         accesscontrol.AccessType_WRITE,
-				ResourceType:       accesscontrol.ResourceType_KV,
-				IdentifierTemplate: "*",
+				Operation: &accesscontrol.AccessOperation{
+					AccessType:         accesscontrol.AccessType_WRITE,
+					ResourceType:       accesscontrol.ResourceType_KV,
+					IdentifierTemplate: "*",
+				},
+			}, {
+				Operation: acltypes.CommitAccessOp(),
 			},
-			acltypes.CommitAccessOp(),
 		},
 	})
 	require.NoError(t, err)
@@ -340,7 +353,7 @@ func TestQueryHandlerDependencyDecoratorIBC(t *testing.T) {
 	_, err = queryDecorator.HandleQuery(testContext, contractAddr, wasmvmtypes.QueryRequest{
 		IBC: &wasmvmtypes.IBCQuery{},
 	})
-	require.Error(t, wasmbinding.ErrUnexpectedWasmDependency, err)
+	require.Error(t, acl.ErrUnexpectedWasmDependency, err)
 }
 
 func TestQueryHandlerDependencyDecoratorStaking(t *testing.T) {
@@ -353,13 +366,16 @@ func TestQueryHandlerDependencyDecoratorStaking(t *testing.T) {
 	// setup the wasm contract's dependency mapping
 	err = app.AccessControlKeeper.SetWasmDependencyMapping(testContext, contractAddr, accesscontrol.WasmDependencyMapping{
 		Enabled: true,
-		AccessOps: []accesscontrol.AccessOperation{
+		AccessOps: []accesscontrol.AccessOperationWithSelector{
 			{
-				AccessType:         accesscontrol.AccessType_READ,
-				ResourceType:       accesscontrol.ResourceType_KV_STAKING,
-				IdentifierTemplate: "*",
+				Operation: &accesscontrol.AccessOperation{
+					AccessType:         accesscontrol.AccessType_READ,
+					ResourceType:       accesscontrol.ResourceType_KV_STAKING,
+					IdentifierTemplate: "*",
+				},
+			}, {
+				Operation: acltypes.CommitAccessOp(),
 			},
-			acltypes.CommitAccessOp(),
 		},
 	})
 	require.NoError(t, err)
@@ -371,13 +387,16 @@ func TestQueryHandlerDependencyDecoratorStaking(t *testing.T) {
 
 	err = app.AccessControlKeeper.SetWasmDependencyMapping(testContext, contractAddr, accesscontrol.WasmDependencyMapping{
 		Enabled: true,
-		AccessOps: []accesscontrol.AccessOperation{
+		AccessOps: []accesscontrol.AccessOperationWithSelector{
 			{
-				AccessType:         accesscontrol.AccessType_WRITE,
-				ResourceType:       accesscontrol.ResourceType_KV_DEX,
-				IdentifierTemplate: "*",
+				Operation: &accesscontrol.AccessOperation{
+					AccessType:         accesscontrol.AccessType_WRITE,
+					ResourceType:       accesscontrol.ResourceType_KV_DEX,
+					IdentifierTemplate: "*",
+				},
+			}, {
+				Operation: acltypes.CommitAccessOp(),
 			},
-			acltypes.CommitAccessOp(),
 		},
 	})
 	require.NoError(t, err)
@@ -385,7 +404,7 @@ func TestQueryHandlerDependencyDecoratorStaking(t *testing.T) {
 	_, err = queryDecorator.HandleQuery(testContext, contractAddr, wasmvmtypes.QueryRequest{
 		Staking: &wasmvmtypes.StakingQuery{},
 	})
-	require.Error(t, wasmbinding.ErrUnexpectedWasmDependency, err)
+	require.Error(t, acl.ErrUnexpectedWasmDependency, err)
 }
 
 func TestQueryHandlerDependencyDecoratorStargate(t *testing.T) {
@@ -398,13 +417,16 @@ func TestQueryHandlerDependencyDecoratorStargate(t *testing.T) {
 	// setup the wasm contract's dependency mapping
 	err = app.AccessControlKeeper.SetWasmDependencyMapping(testContext, contractAddr, accesscontrol.WasmDependencyMapping{
 		Enabled: true,
-		AccessOps: []accesscontrol.AccessOperation{
+		AccessOps: []accesscontrol.AccessOperationWithSelector{
 			{
-				AccessType:         accesscontrol.AccessType_READ,
-				ResourceType:       accesscontrol.ResourceType_ANY,
-				IdentifierTemplate: "*",
+				Operation: &accesscontrol.AccessOperation{
+					AccessType:         accesscontrol.AccessType_READ,
+					ResourceType:       accesscontrol.ResourceType_ANY,
+					IdentifierTemplate: "*",
+				},
+			}, {
+				Operation: acltypes.CommitAccessOp(),
 			},
-			acltypes.CommitAccessOp(),
 		},
 	})
 	require.NoError(t, err)
@@ -416,13 +438,16 @@ func TestQueryHandlerDependencyDecoratorStargate(t *testing.T) {
 
 	err = app.AccessControlKeeper.SetWasmDependencyMapping(testContext, contractAddr, accesscontrol.WasmDependencyMapping{
 		Enabled: true,
-		AccessOps: []accesscontrol.AccessOperation{
+		AccessOps: []accesscontrol.AccessOperationWithSelector{
 			{
-				AccessType:         accesscontrol.AccessType_WRITE,
-				ResourceType:       accesscontrol.ResourceType_KV,
-				IdentifierTemplate: "*",
+				Operation: &accesscontrol.AccessOperation{
+					AccessType:         accesscontrol.AccessType_WRITE,
+					ResourceType:       accesscontrol.ResourceType_KV,
+					IdentifierTemplate: "*",
+				},
+			}, {
+				Operation: acltypes.CommitAccessOp(),
 			},
-			acltypes.CommitAccessOp(),
 		},
 	})
 	require.NoError(t, err)
@@ -430,7 +455,7 @@ func TestQueryHandlerDependencyDecoratorStargate(t *testing.T) {
 	_, err = queryDecorator.HandleQuery(testContext, contractAddr, wasmvmtypes.QueryRequest{
 		Stargate: &wasmvmtypes.StargateQuery{},
 	})
-	require.Error(t, wasmbinding.ErrUnexpectedWasmDependency, err)
+	require.Error(t, acl.ErrUnexpectedWasmDependency, err)
 }
 
 func TestQueryHandlerDependencyDecoratorWasm(t *testing.T) {
@@ -443,13 +468,16 @@ func TestQueryHandlerDependencyDecoratorWasm(t *testing.T) {
 	// setup the wasm contract's dependency mapping
 	err = app.AccessControlKeeper.SetWasmDependencyMapping(testContext, contractAddr, accesscontrol.WasmDependencyMapping{
 		Enabled: true,
-		AccessOps: []accesscontrol.AccessOperation{
+		AccessOps: []accesscontrol.AccessOperationWithSelector{
 			{
-				AccessType:         accesscontrol.AccessType_READ,
-				ResourceType:       accesscontrol.ResourceType_KV_WASM,
-				IdentifierTemplate: "*",
+				Operation: &accesscontrol.AccessOperation{
+					AccessType:         accesscontrol.AccessType_READ,
+					ResourceType:       accesscontrol.ResourceType_KV_WASM,
+					IdentifierTemplate: "*",
+				},
+			}, {
+				Operation: acltypes.CommitAccessOp(),
 			},
-			acltypes.CommitAccessOp(),
 		},
 	})
 	require.NoError(t, err)
@@ -461,13 +489,16 @@ func TestQueryHandlerDependencyDecoratorWasm(t *testing.T) {
 
 	err = app.AccessControlKeeper.SetWasmDependencyMapping(testContext, contractAddr, accesscontrol.WasmDependencyMapping{
 		Enabled: true,
-		AccessOps: []accesscontrol.AccessOperation{
+		AccessOps: []accesscontrol.AccessOperationWithSelector{
 			{
-				AccessType:         accesscontrol.AccessType_WRITE,
-				ResourceType:       accesscontrol.ResourceType_KV_DEX,
-				IdentifierTemplate: "*",
+				Operation: &accesscontrol.AccessOperation{
+					AccessType:         accesscontrol.AccessType_WRITE,
+					ResourceType:       accesscontrol.ResourceType_KV_DEX,
+					IdentifierTemplate: "*",
+				},
+			}, {
+				Operation: acltypes.CommitAccessOp(),
 			},
-			acltypes.CommitAccessOp(),
 		},
 	})
 	require.NoError(t, err)
@@ -475,7 +506,7 @@ func TestQueryHandlerDependencyDecoratorWasm(t *testing.T) {
 	_, err = queryDecorator.HandleQuery(testContext, contractAddr, wasmvmtypes.QueryRequest{
 		Wasm: &wasmvmtypes.WasmQuery{},
 	})
-	require.Error(t, wasmbinding.ErrUnexpectedWasmDependency, err)
+	require.Error(t, acl.ErrUnexpectedWasmDependency, err)
 }
 
 func TestQueryHandlerDependencyDecoratorDex(t *testing.T) {
@@ -488,13 +519,16 @@ func TestQueryHandlerDependencyDecoratorDex(t *testing.T) {
 	// setup the wasm contract's dependency mapping
 	err = app.AccessControlKeeper.SetWasmDependencyMapping(testContext, contractAddr, accesscontrol.WasmDependencyMapping{
 		Enabled: true,
-		AccessOps: []accesscontrol.AccessOperation{
+		AccessOps: []accesscontrol.AccessOperationWithSelector{
 			{
-				AccessType:         accesscontrol.AccessType_READ,
-				ResourceType:       accesscontrol.ResourceType_KV_DEX,
-				IdentifierTemplate: "*",
+				Operation: &accesscontrol.AccessOperation{
+					AccessType:         accesscontrol.AccessType_READ,
+					ResourceType:       accesscontrol.ResourceType_KV_DEX,
+					IdentifierTemplate: "*",
+				},
+			}, {
+				Operation: acltypes.CommitAccessOp(),
 			},
-			acltypes.CommitAccessOp(),
 		},
 	})
 	require.NoError(t, err)
@@ -510,13 +544,16 @@ func TestQueryHandlerDependencyDecoratorDex(t *testing.T) {
 
 	err = app.AccessControlKeeper.SetWasmDependencyMapping(testContext, contractAddr, accesscontrol.WasmDependencyMapping{
 		Enabled: true,
-		AccessOps: []accesscontrol.AccessOperation{
+		AccessOps: []accesscontrol.AccessOperationWithSelector{
 			{
-				AccessType:         accesscontrol.AccessType_READ,
-				ResourceType:       accesscontrol.ResourceType_KV_ORACLE,
-				IdentifierTemplate: "*",
+				Operation: &accesscontrol.AccessOperation{
+					AccessType:         accesscontrol.AccessType_READ,
+					ResourceType:       accesscontrol.ResourceType_KV_ORACLE,
+					IdentifierTemplate: "*",
+				},
+			}, {
+				Operation: acltypes.CommitAccessOp(),
 			},
-			acltypes.CommitAccessOp(),
 		},
 	})
 	require.NoError(t, err)
@@ -524,7 +561,7 @@ func TestQueryHandlerDependencyDecoratorDex(t *testing.T) {
 	_, err = queryDecorator.HandleQuery(testContext, contractAddr, wasmvmtypes.QueryRequest{
 		Custom: customQuery,
 	})
-	require.Error(t, wasmbinding.ErrUnexpectedWasmDependency, err)
+	require.Error(t, acl.ErrUnexpectedWasmDependency, err)
 }
 
 func TestQueryHandlerDependencyDecoratorOracle(t *testing.T) {
@@ -537,13 +574,16 @@ func TestQueryHandlerDependencyDecoratorOracle(t *testing.T) {
 	// setup the wasm contract's dependency mapping
 	err = app.AccessControlKeeper.SetWasmDependencyMapping(testContext, contractAddr, accesscontrol.WasmDependencyMapping{
 		Enabled: true,
-		AccessOps: []accesscontrol.AccessOperation{
+		AccessOps: []accesscontrol.AccessOperationWithSelector{
 			{
-				AccessType:         accesscontrol.AccessType_READ,
-				ResourceType:       accesscontrol.ResourceType_KV_ORACLE,
-				IdentifierTemplate: "*",
+				Operation: &accesscontrol.AccessOperation{
+					AccessType:         accesscontrol.AccessType_READ,
+					ResourceType:       accesscontrol.ResourceType_KV_ORACLE,
+					IdentifierTemplate: "*",
+				},
+			}, {
+				Operation: acltypes.CommitAccessOp(),
 			},
-			acltypes.CommitAccessOp(),
 		},
 	})
 	require.NoError(t, err)
@@ -559,13 +599,16 @@ func TestQueryHandlerDependencyDecoratorOracle(t *testing.T) {
 
 	err = app.AccessControlKeeper.SetWasmDependencyMapping(testContext, contractAddr, accesscontrol.WasmDependencyMapping{
 		Enabled: true,
-		AccessOps: []accesscontrol.AccessOperation{
+		AccessOps: []accesscontrol.AccessOperationWithSelector{
 			{
-				AccessType:         accesscontrol.AccessType_READ,
-				ResourceType:       accesscontrol.ResourceType_KV_BANK,
-				IdentifierTemplate: "*",
+				Operation: &accesscontrol.AccessOperation{
+					AccessType:         accesscontrol.AccessType_READ,
+					ResourceType:       accesscontrol.ResourceType_KV_BANK,
+					IdentifierTemplate: "*",
+				},
+			}, {
+				Operation: acltypes.CommitAccessOp(),
 			},
-			acltypes.CommitAccessOp(),
 		},
 	})
 	require.NoError(t, err)
@@ -573,7 +616,7 @@ func TestQueryHandlerDependencyDecoratorOracle(t *testing.T) {
 	_, err = queryDecorator.HandleQuery(testContext, contractAddr, wasmvmtypes.QueryRequest{
 		Custom: customQuery,
 	})
-	require.Error(t, wasmbinding.ErrUnexpectedWasmDependency, err)
+	require.Error(t, acl.ErrUnexpectedWasmDependency, err)
 }
 
 func TestQueryHandlerDependencyDecoratorEpoch(t *testing.T) {
@@ -586,13 +629,16 @@ func TestQueryHandlerDependencyDecoratorEpoch(t *testing.T) {
 	// setup the wasm contract's dependency mapping
 	err = app.AccessControlKeeper.SetWasmDependencyMapping(testContext, contractAddr, accesscontrol.WasmDependencyMapping{
 		Enabled: true,
-		AccessOps: []accesscontrol.AccessOperation{
+		AccessOps: []accesscontrol.AccessOperationWithSelector{
 			{
-				AccessType:         accesscontrol.AccessType_READ,
-				ResourceType:       accesscontrol.ResourceType_KV_EPOCH,
-				IdentifierTemplate: "*",
+				Operation: &accesscontrol.AccessOperation{
+					AccessType:         accesscontrol.AccessType_READ,
+					ResourceType:       accesscontrol.ResourceType_KV_EPOCH,
+					IdentifierTemplate: "*",
+				},
+			}, {
+				Operation: acltypes.CommitAccessOp(),
 			},
-			acltypes.CommitAccessOp(),
 		},
 	})
 	require.NoError(t, err)
@@ -608,13 +654,16 @@ func TestQueryHandlerDependencyDecoratorEpoch(t *testing.T) {
 
 	err = app.AccessControlKeeper.SetWasmDependencyMapping(testContext, contractAddr, accesscontrol.WasmDependencyMapping{
 		Enabled: true,
-		AccessOps: []accesscontrol.AccessOperation{
+		AccessOps: []accesscontrol.AccessOperationWithSelector{
 			{
-				AccessType:         accesscontrol.AccessType_READ,
-				ResourceType:       accesscontrol.ResourceType_KV_BANK,
-				IdentifierTemplate: "*",
+				Operation: &accesscontrol.AccessOperation{
+					AccessType:         accesscontrol.AccessType_READ,
+					ResourceType:       accesscontrol.ResourceType_KV_BANK,
+					IdentifierTemplate: "*",
+				},
+			}, {
+				Operation: acltypes.CommitAccessOp(),
 			},
-			acltypes.CommitAccessOp(),
 		},
 	})
 	require.NoError(t, err)
@@ -622,5 +671,5 @@ func TestQueryHandlerDependencyDecoratorEpoch(t *testing.T) {
 	_, err = queryDecorator.HandleQuery(testContext, contractAddr, wasmvmtypes.QueryRequest{
 		Custom: customQuery,
 	})
-	require.Error(t, wasmbinding.ErrUnexpectedWasmDependency, err)
+	require.Error(t, acl.ErrUnexpectedWasmDependency, err)
 }

--- a/wasmbinding/utils.go
+++ b/wasmbinding/utils.go
@@ -1,0 +1,14 @@
+package wasmbinding
+
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
+const (
+	EventTypeWasmContractWithIncorrectDependency = "wasm-incorrect-dep"
+	AttributeKeyWasmContractAddress              = "contract-addr"
+)
+
+func emitIncorrectDependencyWasmEvent(ctx sdk.Context, contractAddr string) {
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(EventTypeWasmContractWithIncorrectDependency, sdk.NewAttribute(AttributeKeyWasmContractAddress, contractAddr)),
+	)
+}


### PR DESCRIPTION
## Describe your changes and provide context
Integrate with the following sei-cosmos changes
- Allow fine-grained Wasm dependency specification
- Apply gas discount for Wasm contracts which specify non-* dependencies
- Pass "bad" contract addresses (the ones which specify wrong dependencies) to EndBlock context (which will be used by accesscontrol's EndBlock to reset dependencies for those contracts)

## Testing performed to validate your change
The gas change is tested with unit tests, the rest are tested with manual e2e test on a single node loadtest cluster

