### PR TITLE
Add ContractInfoV2 that supports rent deposit

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -486,6 +486,7 @@ func New(
 		app.GetSubspace(dexmoduletypes.ModuleName),
 		app.EpochKeeper,
 		app.BankKeeper,
+		app.AccountKeeper,
 	)
 	app.TokenFactoryKeeper = tokenfactorykeeper.NewKeeper(
 		appCodec,

--- a/app/app.go
+++ b/app/app.go
@@ -221,7 +221,7 @@ var (
 	EmptyWasmOpts []wasm.Option
 
 	// Boolean to only emit seid version and git commit metric once per chain initialization
-	EmittedSeidVersionMetric bool = false
+	EmittedSeidVersionMetric = false
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/dvsekhvalnov/jose2go v0.0.0-20200901110807-248326c1351b // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-kit/kit v0.12.0 // indirect
 	github.com/go-kit/log v0.2.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
@@ -75,6 +76,7 @@ require (
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.12.0 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -373,6 +373,7 @@ github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmV
 github.com/fullstorydev/grpcurl v1.6.0/go.mod h1:ZQ+ayqbKMJNhzLmbpCiurTVlaK2M/3nqZCxaQ2Ze/sM=
 github.com/fzipp/gocyclo v0.5.1/go.mod h1:rXPyn8fnlpa0R2csP/31uerbiVBugk5whMdlyaLkLoA=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
@@ -613,6 +614,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.12.1/go.mod h1:8XEsbTttt/W+VvjtQhLACqCisSPWTxCZ7sBRjU6iH9c=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.12.0 h1:kr3j8iIMR4ywO/O0rvksXaJvauGGCMg2zAZIiNZ9uIQ=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.12.0/go.mod h1:ummNFgdgLhhX7aIiy35vVmQNS0rWXknfPE0qe6fmFXg=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=

--- a/proto/dex/contract.proto
+++ b/proto/dex/contract.proto
@@ -12,6 +12,17 @@ message ContractInfo {
   int64 numIncomingDependencies = 6;
 }
 
+message ContractInfoV2 {
+  uint64 codeId = 1;
+  string contractAddr = 2;
+  bool needHook = 3;
+  bool needOrderMatching = 4;
+  repeated ContractDependencyInfo dependencies = 5;
+  int64 numIncomingDependencies = 6;
+  string creator = 7;
+  uint64 rentBalance = 8;
+}
+
 message ContractDependencyInfo {
   string dependency = 1;
   string immediateElderSibling = 2;

--- a/proto/dex/tx.proto
+++ b/proto/dex/tx.proto
@@ -15,6 +15,8 @@ service Msg {
   rpc PlaceOrders(MsgPlaceOrders) returns (MsgPlaceOrdersResponse);
   rpc CancelOrders(MsgCancelOrders) returns (MsgCancelOrdersResponse);
   rpc RegisterContract(MsgRegisterContract) returns(MsgRegisterContractResponse);
+  rpc ContractDepositRent(MsgContractDepositRent) returns(MsgContractDepositRentResponse);
+  rpc UnregisterContract(MsgUnregisterContract) returns(MsgUnregisterContractResponse);
   // privileged endpoints below
 
 // this line is used by starport scaffolding # proto/tx/rpc
@@ -60,9 +62,34 @@ message MsgCancelOrdersResponse {}
 
 message MsgRegisterContract {
   string creator = 1;
-  ContractInfo contract = 2;
+  ContractInfoV2 contract = 2;
 }
 
 message MsgRegisterContractResponse {}
+
+message MsgContractDepositRent {
+  string contractAddr = 1 [
+    (gogoproto.jsontag) = "contract_address"
+  ];
+  uint64 amount = 2 [
+    (gogoproto.jsontag) = "amount"
+  ];
+  string sender = 3 [
+    (gogoproto.jsontag) = "sender"
+  ];
+}
+
+message MsgContractDepositRentResponse {}
+
+message MsgUnregisterContract {
+  string creator = 1 [
+    (gogoproto.jsontag) = "creator"
+  ];
+  string contractAddr = 2 [
+    (gogoproto.jsontag) = "contract_address"
+  ];
+}
+
+message MsgUnregisterContractResponse {}
 
 // this line is used by starport scaffolding # proto/tx/message

--- a/testutil/keeper/dex.go
+++ b/testutil/keeper/dex.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/codec"
-	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/store"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -22,6 +21,7 @@ import (
 	dexutils "github.com/sei-protocol/sei-chain/x/dex/utils"
 	epochkeeper "github.com/sei-protocol/sei-chain/x/epoch/keeper"
 	epochtypes "github.com/sei-protocol/sei-chain/x/epoch/types"
+	minttypes "github.com/sei-protocol/sei-chain/x/mint/types"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -59,7 +59,10 @@ func DexKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
 
 	blackListAddrs := map[string]bool{}
 
-	maccPerms := map[string][]string{}
+	maccPerms := map[string][]string{
+		types.ModuleName:     nil,
+		minttypes.ModuleName: {authtypes.Minter},
+	}
 
 	db := tmdb.NewMemDB()
 	stateStore := store.NewCommitMultiStore(db)
@@ -72,8 +75,7 @@ func DexKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
 	stateStore.MountStoreWithDB(keyParams, sdk.StoreTypeIAVL, db)
 	require.NoError(t, stateStore.LoadLatestVersion())
 
-	registry := codectypes.NewInterfaceRegistry()
-	cdc := codec.NewProtoCodec(registry)
+	cdc := codec.NewProtoCodec(app.MakeEncodingConfig().InterfaceRegistry)
 
 	paramsSubspace := typesparams.NewSubspace(cdc,
 		types.Amino,
@@ -92,9 +94,11 @@ func DexKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
 		paramsSubspace,
 		*epochKeeper,
 		bankKeeper,
+		accountKeeper,
 	)
 
 	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())
+	k.CreateModuleAccount(ctx)
 
 	// Initialize params
 	k.SetParams(ctx, types.DefaultParams())

--- a/testutil/keeper/dex.go
+++ b/testutil/keeper/dex.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	TestAccount    = "accnt"
+	TestAccount    = "sei1yezq49upxhunjjhudql2fnj5dgvcwjj87pn2wx"
 	TestContract   = "tc"
 	TestPriceDenom = "usdc"
 	TestAssetDenom = "atom"

--- a/x/dex/cache/cache_test.go
+++ b/x/dex/cache/cache_test.go
@@ -94,7 +94,7 @@ func TestSynchronization(t *testing.T) {
 	ctx = ctx.WithContext(goCtx)
 	require.NotPanics(t, func() { stateOne.SynchronizeAccess(ctx, targetContract) })
 	// executing contract same as target contract
-	executingContract := types.ContractInfo{ContractAddr: TEST_CONTRACT}
+	executingContract := types.ContractInfoV2{ContractAddr: TEST_CONTRACT}
 	ctx = ctx.WithContext(context.WithValue(goCtx, dex.CtxKeyExecutingContract, executingContract))
 	require.NotPanics(t, func() { stateOne.SynchronizeAccess(ctx, targetContract) })
 	// executing contract attempting to access non-dependency

--- a/x/dex/cache/context.go
+++ b/x/dex/cache/context.go
@@ -13,7 +13,7 @@ const (
 	CtxKeyExecutingContract = CtxKeyType("executing-contract")
 )
 
-func GetExecutingContract(ctx sdk.Context) *types.ContractInfo {
+func GetExecutingContract(ctx sdk.Context) *types.ContractInfoV2 {
 	if ctx.Context() == nil {
 		return nil
 	}
@@ -21,7 +21,7 @@ func GetExecutingContract(ctx sdk.Context) *types.ContractInfo {
 	if executingContract == nil {
 		return nil
 	}
-	contract, ok := executingContract.(types.ContractInfo)
+	contract, ok := executingContract.(types.ContractInfoV2)
 	if !ok {
 		return nil
 	}

--- a/x/dex/client/cli/tx/tx.go
+++ b/x/dex/client/cli/tx/tx.go
@@ -31,6 +31,8 @@ func GetTxCmd() *cobra.Command {
 	cmd.AddCommand(CmdPlaceOrders())
 	cmd.AddCommand(CmdCancelOrders())
 	cmd.AddCommand(CmdRegisterContract())
+	cmd.AddCommand(CmdUnregisterContract())
+	cmd.AddCommand(CmdContractDepositRent())
 	cmd.AddCommand(NewRegisterPairsProposalTxCmd())
 	cmd.AddCommand(NewUpdateTickSizeProposalTxCmd())
 	cmd.AddCommand(NewAddAssetProposalTxCmd())

--- a/x/dex/client/cli/tx/tx_contract_deposit_rent.go
+++ b/x/dex/client/cli/tx/tx_contract_deposit_rent.go
@@ -1,0 +1,48 @@
+package tx
+
+import (
+	"strconv"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+	"github.com/spf13/cast"
+	"github.com/spf13/cobra"
+)
+
+var _ = strconv.Itoa(0)
+
+func CmdContractDepositRent() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "contract-deposit-rent [contract address] [amount]",
+		Short: "Unregister exchange contract",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			argContractAddr := args[0]
+			argDeposit, err := cast.ToUint64E(args[1])
+			if err != nil {
+				return err
+			}
+
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgContractDepositRent(
+				argContractAddr,
+				argDeposit,
+				clientCtx.GetFromAddress().String(),
+			)
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/dex/client/cli/tx/tx_register_contract.go
+++ b/x/dex/client/cli/tx/tx_register_contract.go
@@ -15,9 +15,9 @@ var _ = strconv.Itoa(0)
 
 func CmdRegisterContract() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "register-contract [contract address] [code id] [need hook] [need order matching] [dependency1,dependency2,...]",
+		Use:   "register-contract [contract address] [code id] [need hook] [need order matching] [deposit] [dependency1,dependency2,...]",
 		Short: "Register exchange contract",
-		Args:  cobra.MinimumNArgs(4),
+		Args:  cobra.MinimumNArgs(5),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argContractAddr := args[0]
 			argCodeID, err := cast.ToUint64E(args[1])
@@ -26,8 +26,12 @@ func CmdRegisterContract() *cobra.Command {
 			}
 			argNeedHook := args[2] == "true"
 			argNeedMatching := args[3] == "true"
+			argDeposit, err := cast.ToUint64E(args[4])
+			if err != nil {
+				return err
+			}
 			dependencies := []*types.ContractDependencyInfo{}
-			for _, dependency := range args[4:] {
+			for _, dependency := range args[5:] {
 				dependencies = append(dependencies, &types.ContractDependencyInfo{Dependency: dependency})
 			}
 
@@ -43,6 +47,7 @@ func CmdRegisterContract() *cobra.Command {
 				argNeedHook,
 				argNeedMatching,
 				dependencies,
+				argDeposit,
 			)
 			if err := msg.ValidateBasic(); err != nil {
 				return err

--- a/x/dex/client/cli/tx/tx_unregister_contract.go
+++ b/x/dex/client/cli/tx/tx_unregister_contract.go
@@ -1,0 +1,42 @@
+package tx
+
+import (
+	"strconv"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+	"github.com/spf13/cobra"
+)
+
+var _ = strconv.Itoa(0)
+
+func CmdUnregisterContract() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unregister-contract [contract address]",
+		Short: "Unregister exchange contract",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			argContractAddr := args[0]
+
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgUnregisterContract(
+				clientCtx.GetFromAddress().String(),
+				argContractAddr,
+			)
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/dex/contract/dag.go
+++ b/x/dex/contract/dag.go
@@ -11,13 +11,13 @@ type node struct {
 }
 
 // Kahn's algorithm
-func TopologicalSortContractInfo(contracts []types.ContractInfo) ([]types.ContractInfo, error) {
-	contractAddrToContractInfo := map[string]types.ContractInfo{}
+func TopologicalSortContractInfo(contracts []types.ContractInfoV2) ([]types.ContractInfoV2, error) {
+	contractAddrToContractInfo := map[string]types.ContractInfoV2{}
 	for _, contract := range contracts {
 		contractAddrToContractInfo[contract.ContractAddr] = contract
 	}
 
-	res := []types.ContractInfo{}
+	res := []types.ContractInfoV2{}
 	nodes := initNodes(contracts)
 	frontierNodes, nonFrontierNodes := splitNodesByFrontier(nodes)
 	for len(frontierNodes) > 0 {
@@ -32,12 +32,12 @@ func TopologicalSortContractInfo(contracts []types.ContractInfo) ([]types.Contra
 		frontierNodes, nonFrontierNodes = splitNodesByFrontier(nonFrontierNodes)
 	}
 	if len(nonFrontierNodes) > 0 {
-		return []types.ContractInfo{}, types.ErrCircularContractDependency
+		return []types.ContractInfoV2{}, types.ErrCircularContractDependency
 	}
 	return res, nil
 }
 
-func initNodes(contracts []types.ContractInfo) map[string]node {
+func initNodes(contracts []types.ContractInfoV2) map[string]node {
 	res := map[string]node{}
 	for _, contract := range contracts {
 		if _, ok := res[contract.ContractAddr]; !ok {

--- a/x/dex/contract/dag_test.go
+++ b/x/dex/contract/dag_test.go
@@ -10,7 +10,7 @@ import (
 
 // A -> B -> C
 func TestTopologicalSortContractInfoSimple(t *testing.T) {
-	a := types.ContractInfo{
+	a := types.ContractInfoV2{
 		ContractAddr: "A",
 		Dependencies: []*types.ContractDependencyInfo{
 			{
@@ -18,7 +18,7 @@ func TestTopologicalSortContractInfoSimple(t *testing.T) {
 			},
 		},
 	}
-	b := types.ContractInfo{
+	b := types.ContractInfoV2{
 		ContractAddr: "B",
 		Dependencies: []*types.ContractDependencyInfo{
 			{
@@ -26,10 +26,10 @@ func TestTopologicalSortContractInfoSimple(t *testing.T) {
 			},
 		},
 	}
-	c := types.ContractInfo{
+	c := types.ContractInfoV2{
 		ContractAddr: "C",
 	}
-	res, err := contract.TopologicalSortContractInfo([]types.ContractInfo{b, c, a})
+	res, err := contract.TopologicalSortContractInfo([]types.ContractInfoV2{b, c, a})
 	require.Nil(t, err)
 	require.Equal(t, "A", res[0].ContractAddr)
 	require.Equal(t, "B", res[1].ContractAddr)
@@ -38,7 +38,7 @@ func TestTopologicalSortContractInfoSimple(t *testing.T) {
 
 // A -> B, C -> D
 func TestTopologicalSortContractInfoIsolated(t *testing.T) {
-	a := types.ContractInfo{
+	a := types.ContractInfoV2{
 		ContractAddr: "A",
 		Dependencies: []*types.ContractDependencyInfo{
 			{
@@ -46,10 +46,10 @@ func TestTopologicalSortContractInfoIsolated(t *testing.T) {
 			},
 		},
 	}
-	b := types.ContractInfo{
+	b := types.ContractInfoV2{
 		ContractAddr: "B",
 	}
-	c := types.ContractInfo{
+	c := types.ContractInfoV2{
 		ContractAddr: "C",
 		Dependencies: []*types.ContractDependencyInfo{
 			{
@@ -57,10 +57,10 @@ func TestTopologicalSortContractInfoIsolated(t *testing.T) {
 			},
 		},
 	}
-	d := types.ContractInfo{
+	d := types.ContractInfoV2{
 		ContractAddr: "D",
 	}
-	res, err := contract.TopologicalSortContractInfo([]types.ContractInfo{b, c, a, d})
+	res, err := contract.TopologicalSortContractInfo([]types.ContractInfoV2{b, c, a, d})
 	require.Nil(t, err)
 	aidx, bidx, cidx, didx := -1, -1, -1, -1
 	for i, c := range res {
@@ -80,7 +80,7 @@ func TestTopologicalSortContractInfoIsolated(t *testing.T) {
 
 // A -> B -> C -> A
 func TestTopologicalSortContractInfoCircular(t *testing.T) {
-	a := types.ContractInfo{
+	a := types.ContractInfoV2{
 		ContractAddr: "A",
 		Dependencies: []*types.ContractDependencyInfo{
 			{
@@ -88,7 +88,7 @@ func TestTopologicalSortContractInfoCircular(t *testing.T) {
 			},
 		},
 	}
-	b := types.ContractInfo{
+	b := types.ContractInfoV2{
 		ContractAddr: "B",
 		Dependencies: []*types.ContractDependencyInfo{
 			{
@@ -96,7 +96,7 @@ func TestTopologicalSortContractInfoCircular(t *testing.T) {
 			},
 		},
 	}
-	c := types.ContractInfo{
+	c := types.ContractInfoV2{
 		ContractAddr: "C",
 		Dependencies: []*types.ContractDependencyInfo{
 			{
@@ -104,7 +104,7 @@ func TestTopologicalSortContractInfoCircular(t *testing.T) {
 			},
 		},
 	}
-	res, err := contract.TopologicalSortContractInfo([]types.ContractInfo{b, c, a})
+	res, err := contract.TopologicalSortContractInfo([]types.ContractInfoV2{b, c, a})
 	require.NotNil(t, err)
 	require.Equal(t, 0, len(res))
 }

--- a/x/dex/contract/execution.go
+++ b/x/dex/contract/execution.go
@@ -253,7 +253,7 @@ func ExecutePairsInParallel(ctx sdk.Context, contractAddr string, dexkeeper *kee
 func HandleExecutionForContract(
 	ctx context.Context,
 	sdkCtx sdk.Context,
-	contract types.ContractInfo,
+	contract types.ContractInfoV2,
 	dexkeeper *keeper.Keeper,
 	registeredPairs []types.Pair,
 	orderBooks *datastructures.TypedSyncMap[dextypesutils.PairString, *types.OrderBook],

--- a/x/dex/contract/runner.go
+++ b/x/dex/contract/runner.go
@@ -11,9 +11,9 @@ import (
 )
 
 type ParallelRunner struct {
-	runnable func(contract types.ContractInfo)
+	runnable func(contract types.ContractInfoV2)
 
-	contractAddrToInfo   *datastructures.TypedSyncMap[utils.ContractAddress, *types.ContractInfo]
+	contractAddrToInfo   *datastructures.TypedSyncMap[utils.ContractAddress, *types.ContractInfoV2]
 	readyContracts       *datastructures.TypedSyncMap[utils.ContractAddress, struct{}]
 	readyCnt             int64
 	inProgressCnt        int64
@@ -21,8 +21,8 @@ type ParallelRunner struct {
 	sdkCtx               sdk.Context
 }
 
-func NewParallelRunner(runnable func(contract types.ContractInfo), contracts []types.ContractInfo, ctx sdk.Context) ParallelRunner {
-	contractAddrToInfo := datastructures.NewTypedSyncMap[utils.ContractAddress, *types.ContractInfo]()
+func NewParallelRunner(runnable func(contract types.ContractInfoV2), contracts []types.ContractInfoV2, ctx sdk.Context) ParallelRunner {
+	contractAddrToInfo := datastructures.NewTypedSyncMap[utils.ContractAddress, *types.ContractInfoV2]()
 	contractsFrontier := datastructures.NewTypedSyncMap[utils.ContractAddress, struct{}]()
 	for _, contract := range contracts {
 		// runner will mutate ContractInfo fields

--- a/x/dex/genesis.go
+++ b/x/dex/genesis.go
@@ -9,6 +9,8 @@ import (
 // InitGenesis initializes the capability module's state from a provided genesis
 // state.
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
+	k.CreateModuleAccount(ctx)
+
 	// Set all the longBook
 	for _, elem := range genState.LongBookList {
 		k.SetLongBook(ctx, "genesis", elem)

--- a/x/dex/keeper/contract.go
+++ b/x/dex/keeper/contract.go
@@ -11,7 +11,7 @@ import (
 
 const ContractPrefixKey = "x-wasm-contract"
 
-func (k Keeper) SetContract(ctx sdk.Context, contract *types.ContractInfo) error {
+func (k Keeper) SetContract(ctx sdk.Context, contract *types.ContractInfoV2) error {
 	store := prefix.NewStore(
 		ctx.KVStore(k.storeKey),
 		[]byte(ContractPrefixKey),
@@ -25,13 +25,22 @@ func (k Keeper) SetContract(ctx sdk.Context, contract *types.ContractInfo) error
 	return nil
 }
 
-func (k Keeper) GetContract(ctx sdk.Context, contractAddr string) (types.ContractInfo, error) {
+func (k Keeper) DeleteContract(ctx sdk.Context, contractAddr string) {
 	store := prefix.NewStore(
 		ctx.KVStore(k.storeKey),
 		[]byte(ContractPrefixKey),
 	)
 	key := contractKey(contractAddr)
-	res := types.ContractInfo{}
+	store.Delete(key)
+}
+
+func (k Keeper) GetContract(ctx sdk.Context, contractAddr string) (types.ContractInfoV2, error) {
+	store := prefix.NewStore(
+		ctx.KVStore(k.storeKey),
+		[]byte(ContractPrefixKey),
+	)
+	key := contractKey(contractAddr)
+	res := types.ContractInfoV2{}
 	if !store.Has(key) {
 		return res, errors.New("cannot find contract info")
 	}
@@ -41,15 +50,15 @@ func (k Keeper) GetContract(ctx sdk.Context, contractAddr string) (types.Contrac
 	return res, nil
 }
 
-func (k Keeper) GetAllContractInfo(ctx sdk.Context) []types.ContractInfo {
+func (k Keeper) GetAllContractInfo(ctx sdk.Context) []types.ContractInfoV2 {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(ContractPrefixKey))
 	iterator := sdk.KVStorePrefixIterator(store, []byte{})
 
 	defer iterator.Close()
 
-	list := []types.ContractInfo{}
+	list := []types.ContractInfoV2{}
 	for ; iterator.Valid(); iterator.Next() {
-		contract := types.ContractInfo{}
+		contract := types.ContractInfoV2{}
 		if err := contract.Unmarshal(iterator.Value()); err == nil {
 			list = append(list, contract)
 		}

--- a/x/dex/keeper/msgserver/msg_server_contract_deposit_rent.go
+++ b/x/dex/keeper/msgserver/msg_server_contract_deposit_rent.go
@@ -22,6 +22,9 @@ func (k msgServer) ContractDepositRent(goCtx context.Context, msg *types.MsgCont
 	}
 	// deposit
 	creatorAddr, err := sdk.AccAddressFromBech32(contract.Creator)
+	if err != nil {
+		return nil, err
+	}
 	if err := k.BankKeeper.SendCoins(ctx, creatorAddr, k.AccountKeeper.GetModuleAddress(types.ModuleName), sdk.NewCoins(sdk.NewCoin(appparams.BaseCoinUnit, sdk.NewInt(int64(msg.Amount))))); err != nil {
 		return nil, err
 	}

--- a/x/dex/keeper/msgserver/msg_server_contract_deposit_rent.go
+++ b/x/dex/keeper/msgserver/msg_server_contract_deposit_rent.go
@@ -1,0 +1,34 @@
+package msgserver
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	appparams "github.com/sei-protocol/sei-chain/app/params"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+)
+
+func (k msgServer) ContractDepositRent(goCtx context.Context, msg *types.MsgContractDepositRent) (*types.MsgContractDepositRentResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	contract, err := k.GetContract(ctx, msg.ContractAddr)
+	if err != nil {
+		return nil, err
+	}
+	if contract.RentBalance > 0 && contract.Creator != msg.Sender {
+		// a sender can only "claim" the contract if the rent balance is 0
+		return nil, sdkerrors.ErrUnauthorized
+	}
+	// deposit
+	creatorAddr, err := sdk.AccAddressFromBech32(contract.Creator)
+	if err := k.BankKeeper.SendCoins(ctx, creatorAddr, k.AccountKeeper.GetModuleAddress(types.ModuleName), sdk.NewCoins(sdk.NewCoin(appparams.BaseCoinUnit, sdk.NewInt(int64(msg.Amount))))); err != nil {
+		return nil, err
+	}
+	contract.Creator = msg.Sender
+	contract.RentBalance += msg.Amount
+	if err := k.SetContract(ctx, &contract); err != nil {
+		return nil, err
+	}
+	return &types.MsgContractDepositRentResponse{}, nil
+}

--- a/x/dex/keeper/msgserver/msg_server_contract_deposit_rent_test.go
+++ b/x/dex/keeper/msgserver/msg_server_contract_deposit_rent_test.go
@@ -1,0 +1,49 @@
+package msgserver_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/x/dex/keeper/msgserver"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+	minttypes "github.com/sei-protocol/sei-chain/x/mint/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDepositRent(t *testing.T) {
+	keeper, ctx := keepertest.DexKeeper(t)
+	wctx := sdk.WrapSDKContext(ctx)
+	testAccount, _ := sdk.AccAddressFromBech32("sei1yezq49upxhunjjhudql2fnj5dgvcwjj87pn2wx")
+	amounts := sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(10000000)))
+	bankkeeper := keeper.BankKeeper
+	bankkeeper.MintCoins(ctx, minttypes.ModuleName, amounts)
+	bankkeeper.SendCoinsFromModuleToAccount(ctx, minttypes.ModuleName, testAccount, amounts)
+
+	server := msgserver.NewMsgServerImpl(*keeper)
+	contract := types.ContractInfoV2{
+		CodeId:       1,
+		ContractAddr: keepertest.TestContract,
+		Creator:      testAccount.String(),
+		RentBalance:  1000000,
+	}
+	_, err := server.RegisterContract(wctx, &types.MsgRegisterContract{
+		Creator:  testAccount.String(),
+		Contract: &contract,
+	})
+	require.NoError(t, err)
+	_, err = keeper.GetContract(ctx, keepertest.TestContract)
+	require.NoError(t, err)
+	balance := keeper.BankKeeper.GetBalance(ctx, testAccount, "usei")
+	require.Equal(t, int64(9000000), balance.Amount.Int64())
+	_, err = server.ContractDepositRent(wctx, &types.MsgContractDepositRent{
+		Sender:       testAccount.String(),
+		ContractAddr: keepertest.TestContract,
+		Amount:       1000000,
+	})
+	require.NoError(t, err)
+	_, err = keeper.GetContract(ctx, keepertest.TestContract)
+	require.NoError(t, err)
+	balance = keeper.BankKeeper.GetBalance(ctx, testAccount, "usei")
+	require.Equal(t, int64(8000000), balance.Amount.Int64())
+}

--- a/x/dex/keeper/msgserver/msg_server_register_contract_test.go
+++ b/x/dex/keeper/msgserver/msg_server_register_contract_test.go
@@ -126,7 +126,7 @@ func TestRegisterContractSetSiblings(t *testing.T) {
 }
 
 func registerContract(server types.MsgServer, ctx context.Context, contractAddr string, dependencies []string) error {
-	contract := types.ContractInfo{
+	contract := types.ContractInfoV2{
 		CodeId:       1,
 		ContractAddr: contractAddr,
 	}

--- a/x/dex/keeper/msgserver/msg_server_register_contract_test.go
+++ b/x/dex/keeper/msgserver/msg_server_register_contract_test.go
@@ -16,13 +16,14 @@ func TestRegisterContract(t *testing.T) {
 	keeper, ctx := keepertest.DexKeeper(t)
 	wctx := sdk.WrapSDKContext(ctx)
 	server := msgserver.NewMsgServerImpl(*keeper)
-	registerContract(server, wctx, keepertest.TestContract, nil)
+	err := registerContract(server, wctx, keepertest.TestContract, nil)
+	require.NoError(t, err)
 	storedContracts := keeper.GetAllContractInfo(ctx)
 	require.Equal(t, 1, len(storedContracts))
 	require.Nil(t, storedContracts[0].Dependencies)
 
 	// dependency doesn't exist
-	err := registerContract(server, wctx, keepertest.TestContract, []string{"TEST2"})
+	err = registerContract(server, wctx, keepertest.TestContract, []string{"TEST2"})
 	require.NotNil(t, err)
 	storedContracts = keeper.GetAllContractInfo(ctx)
 	require.Equal(t, 1, len(storedContracts))

--- a/x/dex/keeper/msgserver/msg_server_unregister_contract.go
+++ b/x/dex/keeper/msgserver/msg_server_unregister_contract.go
@@ -1,0 +1,29 @@
+package msgserver
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	appparams "github.com/sei-protocol/sei-chain/app/params"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+)
+
+func (k msgServer) UnregisterContract(goCtx context.Context, msg *types.MsgUnregisterContract) (*types.MsgUnregisterContractResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	contract, err := k.GetContract(ctx, msg.ContractAddr)
+	if err != nil {
+		return nil, err
+	}
+	if contract.Creator != msg.Creator {
+		return nil, sdkerrors.ErrUnauthorized
+	}
+	// refund remaining rent to the creator
+	creatorAddr, err := sdk.AccAddressFromBech32(contract.Creator)
+	if err := k.BankKeeper.SendCoins(ctx, k.AccountKeeper.GetModuleAddress(types.ModuleName), creatorAddr, sdk.NewCoins(sdk.NewCoin(appparams.BaseCoinUnit, sdk.NewInt(int64(contract.RentBalance))))); err != nil {
+		return nil, err
+	}
+	k.DeleteContract(ctx, msg.ContractAddr)
+	return &types.MsgUnregisterContractResponse{}, nil
+}

--- a/x/dex/keeper/msgserver/msg_server_unregister_contract.go
+++ b/x/dex/keeper/msgserver/msg_server_unregister_contract.go
@@ -21,6 +21,9 @@ func (k msgServer) UnregisterContract(goCtx context.Context, msg *types.MsgUnreg
 	}
 	// refund remaining rent to the creator
 	creatorAddr, err := sdk.AccAddressFromBech32(contract.Creator)
+	if err != nil {
+		return nil, err
+	}
 	if err := k.BankKeeper.SendCoins(ctx, k.AccountKeeper.GetModuleAddress(types.ModuleName), creatorAddr, sdk.NewCoins(sdk.NewCoin(appparams.BaseCoinUnit, sdk.NewInt(int64(contract.RentBalance))))); err != nil {
 		return nil, err
 	}

--- a/x/dex/keeper/msgserver/msg_server_unregister_contract_test.go
+++ b/x/dex/keeper/msgserver/msg_server_unregister_contract_test.go
@@ -1,0 +1,48 @@
+package msgserver_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/x/dex/keeper/msgserver"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+	minttypes "github.com/sei-protocol/sei-chain/x/mint/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnregisterContractSetSiblings(t *testing.T) {
+	keeper, ctx := keepertest.DexKeeper(t)
+	wctx := sdk.WrapSDKContext(ctx)
+	testAccount, _ := sdk.AccAddressFromBech32("sei1yezq49upxhunjjhudql2fnj5dgvcwjj87pn2wx")
+	amounts := sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(10000000)))
+	bankkeeper := keeper.BankKeeper
+	bankkeeper.MintCoins(ctx, minttypes.ModuleName, amounts)
+	bankkeeper.SendCoinsFromModuleToAccount(ctx, minttypes.ModuleName, testAccount, amounts)
+
+	server := msgserver.NewMsgServerImpl(*keeper)
+	contract := types.ContractInfoV2{
+		CodeId:       1,
+		ContractAddr: keepertest.TestContract,
+		Creator:      testAccount.String(),
+		RentBalance:  1000000,
+	}
+	_, err := server.RegisterContract(wctx, &types.MsgRegisterContract{
+		Creator:  testAccount.String(),
+		Contract: &contract,
+	})
+	require.NoError(t, err)
+	_, err = keeper.GetContract(ctx, keepertest.TestContract)
+	require.NoError(t, err)
+	balance := keeper.BankKeeper.GetBalance(ctx, testAccount, "usei")
+	require.Equal(t, int64(9000000), balance.Amount.Int64())
+	_, err = server.UnregisterContract(wctx, &types.MsgUnregisterContract{
+		Creator:      testAccount.String(),
+		ContractAddr: keepertest.TestContract,
+	})
+	require.NoError(t, err)
+	_, err = keeper.GetContract(ctx, keepertest.TestContract)
+	require.Error(t, err)
+	balance = keeper.BankKeeper.GetBalance(ctx, testAccount, "usei")
+	require.Equal(t, int64(10000000), balance.Amount.Int64())
+}

--- a/x/dex/migrations/v8_to_v9.go
+++ b/x/dex/migrations/v8_to_v9.go
@@ -1,0 +1,37 @@
+package migrations
+
+import (
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/x/dex/keeper"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+)
+
+func V8ToV9(ctx sdk.Context, dexkeeper keeper.Keeper) error {
+	dexkeeper.CreateModuleAccount(ctx)
+
+	contractStore := prefix.NewStore(ctx.KVStore(dexkeeper.GetStoreKey()), []byte(keeper.ContractPrefixKey))
+	iterator := sdk.KVStorePrefixIterator(contractStore, []byte{})
+
+	defer iterator.Close()
+	for ; iterator.Valid(); iterator.Next() {
+		contract := types.ContractInfo{}
+		if err := contract.Unmarshal(iterator.Value()); err != nil {
+			return err
+		}
+		contractV2 := types.ContractInfoV2{
+			CodeId:                  contract.CodeId,
+			ContractAddr:            contract.ContractAddr,
+			NeedHook:                contract.NeedHook,
+			NeedOrderMatching:       contract.NeedOrderMatching,
+			Dependencies:            contract.Dependencies,
+			NumIncomingDependencies: contract.NumIncomingDependencies,
+		}
+		bz, err := contractV2.Marshal()
+		if err != nil {
+			return err
+		}
+		contractStore.Set(iterator.Key(), bz)
+	}
+	return nil
+}

--- a/x/dex/migrations/v8_to_v9_test.go
+++ b/x/dex/migrations/v8_to_v9_test.go
@@ -1,0 +1,42 @@
+package migrations_test
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/x/dex/keeper"
+	"github.com/sei-protocol/sei-chain/x/dex/migrations"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrate8to9(t *testing.T) {
+	dexkeeper, ctx := keepertest.DexKeeper(t)
+	// write old contract
+	store := prefix.NewStore(
+		ctx.KVStore(dexkeeper.GetStoreKey()),
+		[]byte(keeper.ContractPrefixKey),
+	)
+	contract := types.ContractInfo{
+		CodeId:            1,
+		ContractAddr:      keepertest.TestContract,
+		NeedOrderMatching: true,
+	}
+	contractBytes, _ := contract.Marshal()
+	store.Set([]byte(contract.ContractAddr), contractBytes)
+
+	err := migrations.V8ToV9(ctx, *dexkeeper)
+	require.NoError(t, err)
+
+	contractV2, err := dexkeeper.GetContract(ctx, keepertest.TestContract)
+	require.NoError(t, err)
+	require.Equal(t, types.ContractInfoV2{
+		CodeId:            1,
+		ContractAddr:      keepertest.TestContract,
+		NeedOrderMatching: true,
+	}, contractV2)
+
+	moduleAccount := dexkeeper.AccountKeeper.GetModuleAccount(ctx, types.ModuleName)
+	require.NotNil(t, moduleAccount)
+}

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -181,6 +181,9 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	_ = cfg.RegisterMigration(types.ModuleName, 7, func(ctx sdk.Context) error {
 		return migrations.V7ToV8(ctx, am.keeper.GetStoreKey())
 	})
+	_ = cfg.RegisterMigration(types.ModuleName, 8, func(ctx sdk.Context) error {
+		return migrations.V8ToV9(ctx, am.keeper)
+	})
 }
 
 // RegisterInvariants registers the capability module's invariants.
@@ -205,9 +208,9 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 }
 
 // ConsensusVersion implements ConsensusVersion.
-func (AppModule) ConsensusVersion() uint64 { return 8 }
+func (AppModule) ConsensusVersion() uint64 { return 9 }
 
-func (am AppModule) getAllContractInfo(ctx sdk.Context) []types.ContractInfo {
+func (am AppModule) getAllContractInfo(ctx sdk.Context) []types.ContractInfoV2 {
 	return am.keeper.GetAllContractInfo(ctx)
 }
 
@@ -230,7 +233,7 @@ func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
 	}
 }
 
-func (am AppModule) beginBlockForContract(ctx sdk.Context, contract types.ContractInfo, epoch int64) {
+func (am AppModule) beginBlockForContract(ctx sdk.Context, contract types.ContractInfoV2, epoch int64) {
 	_, span := (*am.tracingInfo.Tracer).Start(am.tracingInfo.TracerContext, "DexBeginBlock")
 	contractAddr := contract.ContractAddr
 	span.SetAttributes(attribute.String("contract", contractAddr))

--- a/x/dex/module_test.go
+++ b/x/dex/module_test.go
@@ -74,7 +74,7 @@ func TestEndBlockMarketOrder(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	dexkeeper.SetContract(ctx, &types.ContractInfo{CodeId: 123, ContractAddr: contractAddr.String(), NeedHook: false, NeedOrderMatching: true})
+	dexkeeper.SetContract(ctx, &types.ContractInfoV2{CodeId: 123, ContractAddr: contractAddr.String(), NeedHook: false, NeedOrderMatching: true})
 	dexkeeper.AddRegisteredPair(ctx, contractAddr.String(), pair)
 	dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, utils.ContractAddress(contractAddr.String()), utils.GetPairString(&pair)).Add(
 		&types.Order{
@@ -201,7 +201,8 @@ func TestEndBlockLimitOrder(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	dexkeeper.SetContract(ctx, &types.ContractInfo{CodeId: 123, ContractAddr: contractAddr.String(), NeedHook: true, NeedOrderMatching: true})
+
+	dexkeeper.SetContract(ctx, &types.ContractInfoV2{CodeId: 123, ContractAddr: contractAddr.String(), NeedHook: true, NeedOrderMatching: true})
 	dexkeeper.AddRegisteredPair(ctx, contractAddr.String(), pair)
 	dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, utils.ContractAddress(contractAddr.String()), utils.GetPairString(&pair)).Add(
 		&types.Order{
@@ -346,7 +347,7 @@ func TestEndBlockRollback(t *testing.T) {
 	dexkeeper := testApp.DexKeeper
 	pair := TEST_PAIR()
 	// register contract and pair
-	dexkeeper.SetContract(ctx, &types.ContractInfo{CodeId: 123, ContractAddr: keepertest.TestContract, NeedHook: false, NeedOrderMatching: true})
+	dexkeeper.SetContract(ctx, &types.ContractInfoV2{CodeId: 123, ContractAddr: keepertest.TestContract, NeedHook: false, NeedOrderMatching: true})
 	dexkeeper.AddRegisteredPair(ctx, keepertest.TestContract, pair)
 	// place one order to a nonexistent contract
 	dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, utils.ContractAddress(keepertest.TestContract), utils.GetPairString(&pair)).Add(
@@ -377,7 +378,7 @@ func TestEndBlockPartialRollback(t *testing.T) {
 	dexkeeper := testApp.DexKeeper
 	pair := TEST_PAIR()
 	// register contract and pair
-	dexkeeper.SetContract(ctx, &types.ContractInfo{CodeId: 123, ContractAddr: keepertest.TestContract, NeedHook: false, NeedOrderMatching: true})
+	dexkeeper.SetContract(ctx, &types.ContractInfoV2{CodeId: 123, ContractAddr: keepertest.TestContract, NeedHook: false, NeedOrderMatching: true})
 	dexkeeper.AddRegisteredPair(ctx, keepertest.TestContract, pair)
 	// place one order to a nonexistent contract
 	dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, utils.ContractAddress(keepertest.TestContract), utils.GetPairString(&pair)).Add(
@@ -415,7 +416,7 @@ func TestEndBlockPartialRollback(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	dexkeeper.SetContract(ctx, &types.ContractInfo{CodeId: 123, ContractAddr: contractAddr.String(), NeedHook: false, NeedOrderMatching: true})
+	dexkeeper.SetContract(ctx, &types.ContractInfoV2{CodeId: 123, ContractAddr: contractAddr.String(), NeedHook: false, NeedOrderMatching: true})
 	dexkeeper.AddRegisteredPair(ctx, contractAddr.String(), pair)
 	// place one order to a nonexistent contract
 	dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, utils.ContractAddress(contractAddr.String()), utils.GetPairString(&pair)).Add(
@@ -479,7 +480,7 @@ func TestBeginBlock(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	dexkeeper.SetContract(ctx, &types.ContractInfo{CodeId: 123, ContractAddr: contractAddr.String(), NeedHook: false, NeedOrderMatching: true})
+	dexkeeper.SetContract(ctx, &types.ContractInfoV2{CodeId: 123, ContractAddr: contractAddr.String(), NeedHook: false, NeedOrderMatching: true})
 
 	// right now just make sure it doesn't crash since it doesn't register any state to be checked against
 	testApp.BeginBlocker(ctx, abci.RequestBeginBlock{})
@@ -519,7 +520,7 @@ func TestEndBlockPanicHandling(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	dexkeeper.SetContract(ctx, &types.ContractInfo{CodeId: 123, ContractAddr: contractAddr.String(), NeedHook: false, NeedOrderMatching: true})
+	dexkeeper.SetContract(ctx, &types.ContractInfoV2{CodeId: 123, ContractAddr: contractAddr.String(), NeedHook: false, NeedOrderMatching: true})
 	dexkeeper.AddRegisteredPair(ctx, contractAddr.String(), pair)
 	dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, utils.ContractAddress(contractAddr.String()), utils.GetPairString(&pair)).Add(
 		&types.Order{

--- a/x/dex/types/contract.pb.go
+++ b/x/dex/types/contract.pb.go
@@ -106,6 +106,106 @@ func (m *ContractInfo) GetNumIncomingDependencies() int64 {
 	return 0
 }
 
+type ContractInfoV2 struct {
+	CodeId                  uint64                    `protobuf:"varint,1,opt,name=codeId,proto3" json:"codeId,omitempty"`
+	ContractAddr            string                    `protobuf:"bytes,2,opt,name=contractAddr,proto3" json:"contractAddr,omitempty"`
+	NeedHook                bool                      `protobuf:"varint,3,opt,name=needHook,proto3" json:"needHook,omitempty"`
+	NeedOrderMatching       bool                      `protobuf:"varint,4,opt,name=needOrderMatching,proto3" json:"needOrderMatching,omitempty"`
+	Dependencies            []*ContractDependencyInfo `protobuf:"bytes,5,rep,name=dependencies,proto3" json:"dependencies,omitempty"`
+	NumIncomingDependencies int64                     `protobuf:"varint,6,opt,name=numIncomingDependencies,proto3" json:"numIncomingDependencies,omitempty"`
+	Creator                 string                    `protobuf:"bytes,7,opt,name=creator,proto3" json:"creator,omitempty"`
+	RentBalance             uint64                    `protobuf:"varint,8,opt,name=rentBalance,proto3" json:"rentBalance,omitempty"`
+}
+
+func (m *ContractInfoV2) Reset()         { *m = ContractInfoV2{} }
+func (m *ContractInfoV2) String() string { return proto.CompactTextString(m) }
+func (*ContractInfoV2) ProtoMessage()    {}
+func (*ContractInfoV2) Descriptor() ([]byte, []int) {
+	return fileDescriptor_ee35557664974a8a, []int{1}
+}
+func (m *ContractInfoV2) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *ContractInfoV2) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_ContractInfoV2.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *ContractInfoV2) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ContractInfoV2.Merge(m, src)
+}
+func (m *ContractInfoV2) XXX_Size() int {
+	return m.Size()
+}
+func (m *ContractInfoV2) XXX_DiscardUnknown() {
+	xxx_messageInfo_ContractInfoV2.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ContractInfoV2 proto.InternalMessageInfo
+
+func (m *ContractInfoV2) GetCodeId() uint64 {
+	if m != nil {
+		return m.CodeId
+	}
+	return 0
+}
+
+func (m *ContractInfoV2) GetContractAddr() string {
+	if m != nil {
+		return m.ContractAddr
+	}
+	return ""
+}
+
+func (m *ContractInfoV2) GetNeedHook() bool {
+	if m != nil {
+		return m.NeedHook
+	}
+	return false
+}
+
+func (m *ContractInfoV2) GetNeedOrderMatching() bool {
+	if m != nil {
+		return m.NeedOrderMatching
+	}
+	return false
+}
+
+func (m *ContractInfoV2) GetDependencies() []*ContractDependencyInfo {
+	if m != nil {
+		return m.Dependencies
+	}
+	return nil
+}
+
+func (m *ContractInfoV2) GetNumIncomingDependencies() int64 {
+	if m != nil {
+		return m.NumIncomingDependencies
+	}
+	return 0
+}
+
+func (m *ContractInfoV2) GetCreator() string {
+	if m != nil {
+		return m.Creator
+	}
+	return ""
+}
+
+func (m *ContractInfoV2) GetRentBalance() uint64 {
+	if m != nil {
+		return m.RentBalance
+	}
+	return 0
+}
+
 type ContractDependencyInfo struct {
 	Dependency              string `protobuf:"bytes,1,opt,name=dependency,proto3" json:"dependency,omitempty"`
 	ImmediateElderSibling   string `protobuf:"bytes,2,opt,name=immediateElderSibling,proto3" json:"immediateElderSibling,omitempty"`
@@ -116,7 +216,7 @@ func (m *ContractDependencyInfo) Reset()         { *m = ContractDependencyInfo{}
 func (m *ContractDependencyInfo) String() string { return proto.CompactTextString(m) }
 func (*ContractDependencyInfo) ProtoMessage()    {}
 func (*ContractDependencyInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ee35557664974a8a, []int{1}
+	return fileDescriptor_ee35557664974a8a, []int{2}
 }
 func (m *ContractDependencyInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -178,7 +278,7 @@ func (m *LegacyContractInfo) Reset()         { *m = LegacyContractInfo{} }
 func (m *LegacyContractInfo) String() string { return proto.CompactTextString(m) }
 func (*LegacyContractInfo) ProtoMessage()    {}
 func (*LegacyContractInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ee35557664974a8a, []int{2}
+	return fileDescriptor_ee35557664974a8a, []int{3}
 }
 func (m *LegacyContractInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -244,6 +344,7 @@ func (m *LegacyContractInfo) GetDependentContractAddrs() []string {
 
 func init() {
 	proto.RegisterType((*ContractInfo)(nil), "seiprotocol.seichain.dex.ContractInfo")
+	proto.RegisterType((*ContractInfoV2)(nil), "seiprotocol.seichain.dex.ContractInfoV2")
 	proto.RegisterType((*ContractDependencyInfo)(nil), "seiprotocol.seichain.dex.ContractDependencyInfo")
 	proto.RegisterType((*LegacyContractInfo)(nil), "seiprotocol.seichain.dex.LegacyContractInfo")
 }
@@ -251,31 +352,34 @@ func init() {
 func init() { proto.RegisterFile("dex/contract.proto", fileDescriptor_ee35557664974a8a) }
 
 var fileDescriptor_ee35557664974a8a = []byte{
-	// 378 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x53, 0xc1, 0x4e, 0xc2, 0x40,
-	0x10, 0x65, 0x29, 0x12, 0x58, 0xb9, 0xb8, 0x89, 0xd8, 0x78, 0x68, 0x9a, 0x9e, 0x7a, 0x90, 0xd6,
-	0xa8, 0x31, 0x5e, 0x15, 0x8c, 0x92, 0x68, 0x4c, 0xaa, 0x17, 0xbd, 0x95, 0xdd, 0xb1, 0x6c, 0xa4,
-	0xbb, 0xa4, 0x5d, 0x12, 0xfa, 0x17, 0x7e, 0x84, 0x07, 0x3f, 0xc5, 0x23, 0xf1, 0xe4, 0xd1, 0xc0,
-	0x8f, 0x98, 0x16, 0x8a, 0x10, 0xe9, 0xdd, 0xdb, 0xcc, 0xbc, 0x99, 0x79, 0xfb, 0x66, 0x66, 0x31,
-	0x61, 0x30, 0x76, 0xa9, 0x14, 0x2a, 0xf2, 0xa9, 0x72, 0x86, 0x91, 0x54, 0x92, 0xe8, 0x31, 0xf0,
-	0xcc, 0xa2, 0x72, 0xe0, 0xc4, 0xc0, 0x69, 0xdf, 0xe7, 0xc2, 0x61, 0x30, 0xb6, 0xde, 0xca, 0xb8,
-	0xd1, 0x5e, 0x24, 0x77, 0xc5, 0xb3, 0x24, 0x4d, 0x5c, 0xa5, 0x92, 0x41, 0x97, 0xe9, 0xc8, 0x44,
-	0x76, 0xc5, 0x5b, 0x78, 0xc4, 0xc2, 0x8d, 0xbc, 0xe9, 0x39, 0x63, 0x91, 0x5e, 0x36, 0x91, 0x5d,
-	0xf7, 0xd6, 0x62, 0x64, 0x1f, 0xd7, 0x04, 0x00, 0xbb, 0x96, 0xf2, 0x45, 0xd7, 0x4c, 0x64, 0xd7,
-	0xbc, 0xa5, 0x4f, 0x0e, 0xf0, 0x4e, 0x6a, 0xdf, 0x45, 0x0c, 0xa2, 0x5b, 0x5f, 0xd1, 0x3e, 0x17,
-	0x81, 0x5e, 0xc9, 0x92, 0xfe, 0x02, 0xe4, 0x01, 0x37, 0x18, 0x0c, 0x41, 0x30, 0x10, 0x94, 0x43,
-	0xac, 0x6f, 0x99, 0x9a, 0xbd, 0x7d, 0x74, 0xe8, 0x14, 0xe9, 0x70, 0x72, 0x0d, 0x9d, 0xbc, 0x2a,
-	0x49, 0xd5, 0x78, 0x6b, 0x5d, 0xc8, 0x19, 0xde, 0x13, 0xa3, 0xb0, 0x2b, 0xa8, 0x0c, 0xb9, 0x08,
-	0x3a, 0xab, 0x04, 0x55, 0x13, 0xd9, 0x9a, 0x57, 0x04, 0x5b, 0xef, 0x08, 0x37, 0x37, 0x53, 0x10,
-	0x03, 0xe3, 0x25, 0x49, 0x92, 0x0d, 0xad, 0xee, 0xad, 0x44, 0xc8, 0x09, 0xde, 0xe5, 0x61, 0x08,
-	0x8c, 0xfb, 0x0a, 0x2e, 0x07, 0x0c, 0xa2, 0x7b, 0xde, 0x1b, 0xa4, 0xe2, 0xe7, 0x13, 0xdc, 0x0c,
-	0xa6, 0x4f, 0x5d, 0x02, 0x8f, 0x72, 0x24, 0x82, 0xdf, 0x3a, 0x2d, 0xab, 0x2b, 0x82, 0xad, 0x4f,
-	0x84, 0xc9, 0x0d, 0x04, 0x3e, 0x4d, 0xfe, 0xe1, 0x5e, 0x4f, 0x71, 0x33, 0x1f, 0x8d, 0x6a, 0xaf,
-	0x50, 0xcc, 0x37, 0x5c, 0xf7, 0x0a, 0xd0, 0x8b, 0xab, 0x8f, 0xa9, 0x81, 0x26, 0x53, 0x03, 0x7d,
-	0x4f, 0x0d, 0xf4, 0x3a, 0x33, 0x4a, 0x93, 0x99, 0x51, 0xfa, 0x9a, 0x19, 0xa5, 0xa7, 0x56, 0xc0,
-	0x55, 0x7f, 0xd4, 0x73, 0xa8, 0x0c, 0xdd, 0x18, 0x78, 0x2b, 0x3f, 0x8f, 0xcc, 0xc9, 0xee, 0xc3,
-	0x1d, 0xbb, 0xe9, 0x97, 0x50, 0xc9, 0x10, 0xe2, 0x5e, 0x35, 0xc3, 0x8f, 0x7f, 0x02, 0x00, 0x00,
-	0xff, 0xff, 0xe1, 0x25, 0x79, 0xa4, 0x26, 0x03, 0x00, 0x00,
+	// 428 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xec, 0x94, 0x41, 0x8b, 0x13, 0x31,
+	0x14, 0xc7, 0x9b, 0x76, 0xed, 0xb6, 0x6f, 0x8b, 0x60, 0xc0, 0x1a, 0x3c, 0x0c, 0xc3, 0x9c, 0xe6,
+	0xe0, 0x4e, 0x65, 0x15, 0xf1, 0xea, 0xee, 0x8a, 0x16, 0x14, 0x61, 0x14, 0x41, 0x6f, 0x69, 0xf2,
+	0x9c, 0x06, 0x3b, 0x49, 0xc9, 0xa4, 0xd0, 0x7e, 0x0b, 0x3f, 0x84, 0x07, 0x3f, 0x8a, 0xc7, 0xc5,
+	0x93, 0x47, 0x99, 0x7e, 0x11, 0x99, 0xec, 0x4e, 0x9d, 0x62, 0xe7, 0xee, 0xc1, 0x5b, 0xfe, 0xef,
+	0x97, 0x97, 0xe4, 0xff, 0xe7, 0xcd, 0x00, 0x95, 0xb8, 0x9e, 0x08, 0xa3, 0x9d, 0xe5, 0xc2, 0x25,
+	0x4b, 0x6b, 0x9c, 0xa1, 0xac, 0x40, 0xe5, 0x57, 0xc2, 0x2c, 0x92, 0x02, 0x95, 0x98, 0x73, 0xa5,
+	0x13, 0x89, 0xeb, 0xe8, 0x6b, 0x17, 0x46, 0x17, 0x37, 0x9b, 0xa7, 0xfa, 0x93, 0xa1, 0x63, 0xe8,
+	0x0b, 0x23, 0x71, 0x2a, 0x19, 0x09, 0x49, 0x7c, 0x94, 0xde, 0x28, 0x1a, 0xc1, 0xa8, 0x3e, 0xf4,
+	0x99, 0x94, 0x96, 0x75, 0x43, 0x12, 0x0f, 0xd3, 0xbd, 0x1a, 0xbd, 0x0f, 0x03, 0x8d, 0x28, 0x5f,
+	0x1a, 0xf3, 0x99, 0xf5, 0x42, 0x12, 0x0f, 0xd2, 0x9d, 0xa6, 0x0f, 0xe0, 0x4e, 0xb5, 0x7e, 0x63,
+	0x25, 0xda, 0xd7, 0xdc, 0x89, 0xb9, 0xd2, 0x19, 0x3b, 0xf2, 0x9b, 0xfe, 0x06, 0xf4, 0x1d, 0x8c,
+	0x24, 0x2e, 0x51, 0x4b, 0xd4, 0x42, 0x61, 0xc1, 0x6e, 0x85, 0xbd, 0xf8, 0xe4, 0xec, 0x61, 0xd2,
+	0xe6, 0x23, 0xa9, 0x3d, 0x5c, 0xd6, 0x5d, 0x9b, 0xca, 0x4d, 0xba, 0x77, 0x0a, 0x7d, 0x0a, 0xf7,
+	0xf4, 0x2a, 0x9f, 0x6a, 0x61, 0x72, 0xa5, 0xb3, 0xcb, 0xe6, 0x05, 0xfd, 0x90, 0xc4, 0xbd, 0xb4,
+	0x0d, 0x47, 0x65, 0x17, 0x6e, 0x37, 0x63, 0x7a, 0x7f, 0xf6, 0x3f, 0xa8, 0x43, 0x98, 0x32, 0x38,
+	0x16, 0x16, 0xb9, 0x33, 0x96, 0x1d, 0x7b, 0xe3, 0xb5, 0xa4, 0x21, 0x9c, 0x58, 0xd4, 0xee, 0x9c,
+	0x2f, 0xb8, 0x16, 0xc8, 0x06, 0x3e, 0xb4, 0x66, 0x29, 0xfa, 0x46, 0x60, 0x7c, 0xf8, 0x79, 0x34,
+	0x00, 0xd8, 0x3d, 0x70, 0xe3, 0x03, 0x1f, 0xa6, 0x8d, 0x0a, 0x7d, 0x0c, 0x77, 0x55, 0x9e, 0xa3,
+	0x54, 0xdc, 0xe1, 0xf3, 0x85, 0x44, 0xfb, 0x56, 0xcd, 0x16, 0x55, 0x70, 0xd7, 0xe9, 0x1f, 0x86,
+	0x95, 0xcd, 0x1d, 0xf8, 0x60, 0x56, 0x3a, 0xfb, 0xd3, 0xd7, 0xf3, 0x7d, 0x6d, 0x38, 0xfa, 0x41,
+	0x80, 0xbe, 0xc2, 0x8c, 0x8b, 0xcd, 0x3f, 0xf8, 0xf1, 0x3c, 0x81, 0x71, 0x1d, 0x8d, 0xbb, 0x68,
+	0x5c, 0x71, 0x3d, 0x1d, 0xc3, 0xb4, 0x85, 0x9e, 0xbf, 0xf8, 0x5e, 0x06, 0xe4, 0xaa, 0x0c, 0xc8,
+	0xaf, 0x32, 0x20, 0x5f, 0xb6, 0x41, 0xe7, 0x6a, 0x1b, 0x74, 0x7e, 0x6e, 0x83, 0xce, 0xc7, 0xd3,
+	0x4c, 0xb9, 0xf9, 0x6a, 0x96, 0x08, 0x93, 0x4f, 0x0a, 0x54, 0xa7, 0xf5, 0x68, 0x79, 0xe1, 0x67,
+	0x6b, 0xb2, 0x9e, 0x54, 0xff, 0x1d, 0xb7, 0x59, 0x62, 0x31, 0xeb, 0x7b, 0xfe, 0xe8, 0x77, 0x00,
+	0x00, 0x00, 0xff, 0xff, 0xbc, 0x41, 0xfd, 0x83, 0x8b, 0x04, 0x00, 0x00,
 }
 
 func (m *ContractInfo) Marshal() (dAtA []byte, err error) {
@@ -298,6 +402,92 @@ func (m *ContractInfo) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.NumIncomingDependencies != 0 {
+		i = encodeVarintContract(dAtA, i, uint64(m.NumIncomingDependencies))
+		i--
+		dAtA[i] = 0x30
+	}
+	if len(m.Dependencies) > 0 {
+		for iNdEx := len(m.Dependencies) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Dependencies[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintContract(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x2a
+		}
+	}
+	if m.NeedOrderMatching {
+		i--
+		if m.NeedOrderMatching {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.NeedHook {
+		i--
+		if m.NeedHook {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x18
+	}
+	if len(m.ContractAddr) > 0 {
+		i -= len(m.ContractAddr)
+		copy(dAtA[i:], m.ContractAddr)
+		i = encodeVarintContract(dAtA, i, uint64(len(m.ContractAddr)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.CodeId != 0 {
+		i = encodeVarintContract(dAtA, i, uint64(m.CodeId))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ContractInfoV2) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ContractInfoV2) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ContractInfoV2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.RentBalance != 0 {
+		i = encodeVarintContract(dAtA, i, uint64(m.RentBalance))
+		i--
+		dAtA[i] = 0x40
+	}
+	if len(m.Creator) > 0 {
+		i -= len(m.Creator)
+		copy(dAtA[i:], m.Creator)
+		i = encodeVarintContract(dAtA, i, uint64(len(m.Creator)))
+		i--
+		dAtA[i] = 0x3a
+	}
 	if m.NumIncomingDependencies != 0 {
 		i = encodeVarintContract(dAtA, i, uint64(m.NumIncomingDependencies))
 		i--
@@ -498,6 +688,44 @@ func (m *ContractInfo) Size() (n int) {
 	}
 	if m.NumIncomingDependencies != 0 {
 		n += 1 + sovContract(uint64(m.NumIncomingDependencies))
+	}
+	return n
+}
+
+func (m *ContractInfoV2) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.CodeId != 0 {
+		n += 1 + sovContract(uint64(m.CodeId))
+	}
+	l = len(m.ContractAddr)
+	if l > 0 {
+		n += 1 + l + sovContract(uint64(l))
+	}
+	if m.NeedHook {
+		n += 2
+	}
+	if m.NeedOrderMatching {
+		n += 2
+	}
+	if len(m.Dependencies) > 0 {
+		for _, e := range m.Dependencies {
+			l = e.Size()
+			n += 1 + l + sovContract(uint64(l))
+		}
+	}
+	if m.NumIncomingDependencies != 0 {
+		n += 1 + sovContract(uint64(m.NumIncomingDependencies))
+	}
+	l = len(m.Creator)
+	if l > 0 {
+		n += 1 + l + sovContract(uint64(l))
+	}
+	if m.RentBalance != 0 {
+		n += 1 + sovContract(uint64(m.RentBalance))
 	}
 	return n
 }
@@ -726,6 +954,251 @@ func (m *ContractInfo) Unmarshal(dAtA []byte) error {
 				b := dAtA[iNdEx]
 				iNdEx++
 				m.NumIncomingDependencies |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipContract(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthContract
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ContractInfoV2) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowContract
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ContractInfoV2: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ContractInfoV2: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CodeId", wireType)
+			}
+			m.CodeId = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowContract
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.CodeId |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ContractAddr", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowContract
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthContract
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthContract
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ContractAddr = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NeedHook", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowContract
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.NeedHook = bool(v != 0)
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NeedOrderMatching", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowContract
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.NeedOrderMatching = bool(v != 0)
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Dependencies", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowContract
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthContract
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthContract
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Dependencies = append(m.Dependencies, &ContractDependencyInfo{})
+			if err := m.Dependencies[len(m.Dependencies)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NumIncomingDependencies", wireType)
+			}
+			m.NumIncomingDependencies = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowContract
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.NumIncomingDependencies |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Creator", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowContract
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthContract
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthContract
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Creator = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 8:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RentBalance", wireType)
+			}
+			m.RentBalance = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowContract
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.RentBalance |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}

--- a/x/dex/types/message_contract_deposit_rent.go
+++ b/x/dex/types/message_contract_deposit_rent.go
@@ -1,0 +1,51 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+const TypeMsgContractDepositRent = "contract_deposit_rent"
+
+var _ sdk.Msg = &MsgContractDepositRent{}
+
+func NewMsgContractDepositRent(
+	contractAddr string,
+	amount uint64,
+	sender string,
+) *MsgContractDepositRent {
+	return &MsgContractDepositRent{
+		Sender:       sender,
+		ContractAddr: contractAddr,
+		Amount:       amount,
+	}
+}
+
+func (msg *MsgContractDepositRent) Route() string {
+	return RouterKey
+}
+
+func (msg *MsgContractDepositRent) Type() string {
+	return TypeMsgContractDepositRent
+}
+
+func (msg *MsgContractDepositRent) GetSigners() []sdk.AccAddress {
+	creator, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{creator}
+}
+
+func (msg *MsgContractDepositRent) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
+}
+
+func (msg *MsgContractDepositRent) ValidateBasic() error {
+	_, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+	}
+	return nil
+}

--- a/x/dex/types/message_register_contract.go
+++ b/x/dex/types/message_register_contract.go
@@ -16,15 +16,18 @@ func NewMsgRegisterContract(
 	needHook bool,
 	needOrderMatching bool,
 	dependencies []*ContractDependencyInfo,
+	deposit uint64,
 ) *MsgRegisterContract {
 	return &MsgRegisterContract{
 		Creator: creator,
-		Contract: &ContractInfo{
+		Contract: &ContractInfoV2{
 			CodeId:            codeID,
 			ContractAddr:      contractAddr,
 			NeedHook:          needHook,
 			NeedOrderMatching: needOrderMatching,
 			Dependencies:      dependencies,
+			Creator:           creator,
+			RentBalance:       deposit,
 		},
 	}
 }

--- a/x/dex/types/message_unregister_contract.go
+++ b/x/dex/types/message_unregister_contract.go
@@ -1,0 +1,49 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+const TypeMsgUnregisterContract = "unregister_contract"
+
+var _ sdk.Msg = &MsgUnregisterContract{}
+
+func NewMsgUnregisterContract(
+	creator string,
+	contractAddr string,
+) *MsgUnregisterContract {
+	return &MsgUnregisterContract{
+		Creator:      creator,
+		ContractAddr: contractAddr,
+	}
+}
+
+func (msg *MsgUnregisterContract) Route() string {
+	return RouterKey
+}
+
+func (msg *MsgUnregisterContract) Type() string {
+	return TypeMsgUnregisterContract
+}
+
+func (msg *MsgUnregisterContract) GetSigners() []sdk.AccAddress {
+	creator, err := sdk.AccAddressFromBech32(msg.Creator)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{creator}
+}
+
+func (msg *MsgUnregisterContract) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
+}
+
+func (msg *MsgUnregisterContract) ValidateBasic() error {
+	_, err := sdk.AccAddressFromBech32(msg.Creator)
+	if err != nil {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+	}
+	return nil
+}

--- a/x/dex/types/tx.pb.go
+++ b/x/dex/types/tx.pb.go
@@ -239,8 +239,8 @@ func (m *MsgCancelOrdersResponse) XXX_DiscardUnknown() {
 var xxx_messageInfo_MsgCancelOrdersResponse proto.InternalMessageInfo
 
 type MsgRegisterContract struct {
-	Creator  string        `protobuf:"bytes,1,opt,name=creator,proto3" json:"creator,omitempty"`
-	Contract *ContractInfo `protobuf:"bytes,2,opt,name=contract,proto3" json:"contract,omitempty"`
+	Creator  string          `protobuf:"bytes,1,opt,name=creator,proto3" json:"creator,omitempty"`
+	Contract *ContractInfoV2 `protobuf:"bytes,2,opt,name=contract,proto3" json:"contract,omitempty"`
 }
 
 func (m *MsgRegisterContract) Reset()         { *m = MsgRegisterContract{} }
@@ -283,7 +283,7 @@ func (m *MsgRegisterContract) GetCreator() string {
 	return ""
 }
 
-func (m *MsgRegisterContract) GetContract() *ContractInfo {
+func (m *MsgRegisterContract) GetContract() *ContractInfoV2 {
 	if m != nil {
 		return m.Contract
 	}
@@ -326,6 +326,190 @@ func (m *MsgRegisterContractResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgRegisterContractResponse proto.InternalMessageInfo
 
+type MsgContractDepositRent struct {
+	ContractAddr string `protobuf:"bytes,1,opt,name=contractAddr,proto3" json:"contract_address"`
+	Amount       uint64 `protobuf:"varint,2,opt,name=amount,proto3" json:"amount"`
+	Sender       string `protobuf:"bytes,3,opt,name=sender,proto3" json:"sender"`
+}
+
+func (m *MsgContractDepositRent) Reset()         { *m = MsgContractDepositRent{} }
+func (m *MsgContractDepositRent) String() string { return proto.CompactTextString(m) }
+func (*MsgContractDepositRent) ProtoMessage()    {}
+func (*MsgContractDepositRent) Descriptor() ([]byte, []int) {
+	return fileDescriptor_463701e671e5a5e0, []int{6}
+}
+func (m *MsgContractDepositRent) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgContractDepositRent) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgContractDepositRent.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgContractDepositRent) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgContractDepositRent.Merge(m, src)
+}
+func (m *MsgContractDepositRent) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgContractDepositRent) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgContractDepositRent.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgContractDepositRent proto.InternalMessageInfo
+
+func (m *MsgContractDepositRent) GetContractAddr() string {
+	if m != nil {
+		return m.ContractAddr
+	}
+	return ""
+}
+
+func (m *MsgContractDepositRent) GetAmount() uint64 {
+	if m != nil {
+		return m.Amount
+	}
+	return 0
+}
+
+func (m *MsgContractDepositRent) GetSender() string {
+	if m != nil {
+		return m.Sender
+	}
+	return ""
+}
+
+type MsgContractDepositRentResponse struct {
+}
+
+func (m *MsgContractDepositRentResponse) Reset()         { *m = MsgContractDepositRentResponse{} }
+func (m *MsgContractDepositRentResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgContractDepositRentResponse) ProtoMessage()    {}
+func (*MsgContractDepositRentResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_463701e671e5a5e0, []int{7}
+}
+func (m *MsgContractDepositRentResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgContractDepositRentResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgContractDepositRentResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgContractDepositRentResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgContractDepositRentResponse.Merge(m, src)
+}
+func (m *MsgContractDepositRentResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgContractDepositRentResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgContractDepositRentResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgContractDepositRentResponse proto.InternalMessageInfo
+
+type MsgUnregisterContract struct {
+	Creator      string `protobuf:"bytes,1,opt,name=creator,proto3" json:"creator"`
+	ContractAddr string `protobuf:"bytes,2,opt,name=contractAddr,proto3" json:"contract_address"`
+}
+
+func (m *MsgUnregisterContract) Reset()         { *m = MsgUnregisterContract{} }
+func (m *MsgUnregisterContract) String() string { return proto.CompactTextString(m) }
+func (*MsgUnregisterContract) ProtoMessage()    {}
+func (*MsgUnregisterContract) Descriptor() ([]byte, []int) {
+	return fileDescriptor_463701e671e5a5e0, []int{8}
+}
+func (m *MsgUnregisterContract) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgUnregisterContract) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgUnregisterContract.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgUnregisterContract) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgUnregisterContract.Merge(m, src)
+}
+func (m *MsgUnregisterContract) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgUnregisterContract) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgUnregisterContract.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgUnregisterContract proto.InternalMessageInfo
+
+func (m *MsgUnregisterContract) GetCreator() string {
+	if m != nil {
+		return m.Creator
+	}
+	return ""
+}
+
+func (m *MsgUnregisterContract) GetContractAddr() string {
+	if m != nil {
+		return m.ContractAddr
+	}
+	return ""
+}
+
+type MsgUnregisterContractResponse struct {
+}
+
+func (m *MsgUnregisterContractResponse) Reset()         { *m = MsgUnregisterContractResponse{} }
+func (m *MsgUnregisterContractResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgUnregisterContractResponse) ProtoMessage()    {}
+func (*MsgUnregisterContractResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_463701e671e5a5e0, []int{9}
+}
+func (m *MsgUnregisterContractResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgUnregisterContractResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgUnregisterContractResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgUnregisterContractResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgUnregisterContractResponse.Merge(m, src)
+}
+func (m *MsgUnregisterContractResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgUnregisterContractResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgUnregisterContractResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgUnregisterContractResponse proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*MsgPlaceOrders)(nil), "seiprotocol.seichain.dex.MsgPlaceOrders")
 	proto.RegisterType((*MsgPlaceOrdersResponse)(nil), "seiprotocol.seichain.dex.MsgPlaceOrdersResponse")
@@ -333,48 +517,60 @@ func init() {
 	proto.RegisterType((*MsgCancelOrdersResponse)(nil), "seiprotocol.seichain.dex.MsgCancelOrdersResponse")
 	proto.RegisterType((*MsgRegisterContract)(nil), "seiprotocol.seichain.dex.MsgRegisterContract")
 	proto.RegisterType((*MsgRegisterContractResponse)(nil), "seiprotocol.seichain.dex.MsgRegisterContractResponse")
+	proto.RegisterType((*MsgContractDepositRent)(nil), "seiprotocol.seichain.dex.MsgContractDepositRent")
+	proto.RegisterType((*MsgContractDepositRentResponse)(nil), "seiprotocol.seichain.dex.MsgContractDepositRentResponse")
+	proto.RegisterType((*MsgUnregisterContract)(nil), "seiprotocol.seichain.dex.MsgUnregisterContract")
+	proto.RegisterType((*MsgUnregisterContractResponse)(nil), "seiprotocol.seichain.dex.MsgUnregisterContractResponse")
 }
 
 func init() { proto.RegisterFile("dex/tx.proto", fileDescriptor_463701e671e5a5e0) }
 
 var fileDescriptor_463701e671e5a5e0 = []byte{
-	// 570 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x54, 0xc1, 0x6e, 0xd3, 0x4a,
-	0x14, 0x8d, 0x93, 0xbe, 0xbe, 0x76, 0x12, 0x68, 0x30, 0x15, 0xb8, 0x41, 0xd8, 0xc1, 0x12, 0x28,
-	0x2c, 0x62, 0x93, 0x22, 0x24, 0x40, 0x62, 0x81, 0xb3, 0x40, 0x5d, 0x44, 0x20, 0x6f, 0x90, 0xd8,
-	0x44, 0xce, 0xcc, 0xd4, 0x1d, 0x70, 0x3c, 0x91, 0xaf, 0x8b, 0xd2, 0xbf, 0xe0, 0x1b, 0x58, 0xf2,
-	0x25, 0x5d, 0x56, 0x62, 0xd3, 0x95, 0x41, 0xc9, 0xce, 0x4b, 0xbe, 0x00, 0x79, 0xec, 0x09, 0x71,
-	0x20, 0xa5, 0x65, 0xe5, 0xeb, 0x93, 0x73, 0xce, 0x9d, 0x7b, 0xae, 0x27, 0xa8, 0x41, 0xe8, 0xd4,
-	0x8e, 0xa7, 0xd6, 0x24, 0xe2, 0x31, 0x57, 0x35, 0xa0, 0x4c, 0x54, 0x98, 0x07, 0x16, 0x50, 0x86,
-	0x8f, 0x3c, 0x16, 0x5a, 0x84, 0x4e, 0x5b, 0x3a, 0xe6, 0x30, 0xe6, 0x60, 0x8f, 0x3c, 0xa0, 0xf6,
-	0xc7, 0xde, 0x88, 0xc6, 0x5e, 0xcf, 0xc6, 0x9c, 0x85, 0xb9, 0xb2, 0xb5, 0xeb, 0x73, 0x9f, 0x8b,
-	0xd2, 0xce, 0xaa, 0x02, 0x55, 0x33, 0x77, 0xcc, 0xc3, 0x38, 0xf2, 0x70, 0x5c, 0x60, 0x3b, 0x19,
-	0xc6, 0x23, 0x42, 0xa3, 0x1c, 0x30, 0x3f, 0x57, 0xd1, 0xf5, 0x01, 0xf8, 0x6f, 0x02, 0x0f, 0xd3,
-	0xd7, 0x19, 0x0e, 0xea, 0x7d, 0xf4, 0x3f, 0x8e, 0xa8, 0x17, 0xf3, 0x48, 0x53, 0xda, 0x4a, 0x67,
-	0xdb, 0xa9, 0xa7, 0x89, 0x21, 0x21, 0x57, 0x16, 0x6a, 0x1f, 0x6d, 0x0a, 0x23, 0xd0, 0xaa, 0xed,
-	0x5a, 0xa7, 0xbe, 0x6f, 0x58, 0xeb, 0xce, 0x6f, 0x09, 0x63, 0x07, 0xa5, 0x89, 0x51, 0x48, 0xdc,
-	0xe2, 0xa9, 0x3e, 0x45, 0x0d, 0x79, 0xc2, 0x97, 0x84, 0x44, 0x5a, 0x4d, 0x34, 0xdc, 0x4d, 0x13,
-	0xa3, 0x29, 0xf1, 0xa1, 0x47, 0x48, 0x44, 0x01, 0xdc, 0x12, 0x53, 0x7d, 0x8f, 0xfe, 0x3b, 0x3c,
-	0x0e, 0x09, 0x68, 0x1b, 0xa2, 0xfb, 0x9e, 0x95, 0x67, 0x64, 0x65, 0x19, 0x59, 0x45, 0x46, 0x56,
-	0x9f, 0xb3, 0xd0, 0x79, 0x76, 0x9a, 0x18, 0x95, 0x34, 0x31, 0x72, 0xfe, 0x97, 0x6f, 0x46, 0xc7,
-	0x67, 0xf1, 0xd1, 0xf1, 0xc8, 0xc2, 0x7c, 0x6c, 0x17, 0xc9, 0xe6, 0x8f, 0x2e, 0x90, 0x0f, 0x76,
-	0x7c, 0x32, 0xa1, 0x20, 0x94, 0xe0, 0xe6, 0x12, 0xf3, 0x2d, 0xba, 0x55, 0xce, 0xc8, 0xa5, 0x30,
-	0xe1, 0x21, 0x50, 0xf5, 0x05, 0xda, 0x12, 0x93, 0x1c, 0x10, 0xd0, 0x94, 0x76, 0xad, 0xb3, 0xe1,
-	0xdc, 0x4b, 0x13, 0x63, 0x5b, 0x60, 0x43, 0x46, 0xe0, 0x47, 0x62, 0x34, 0x4f, 0xbc, 0x71, 0xf0,
-	0xdc, 0x5c, 0x40, 0xa6, 0xbb, 0x90, 0x98, 0x5f, 0x15, 0xb4, 0x33, 0x00, 0xbf, 0xef, 0x85, 0x98,
-	0x06, 0x57, 0x8b, 0x7f, 0x88, 0xae, 0x61, 0x21, 0x0b, 0xbc, 0x98, 0xf1, 0x50, 0x6e, 0xe1, 0xc1,
-	0xfa, 0x2d, 0xf4, 0x97, 0xe8, 0xce, 0x8d, 0x34, 0x31, 0xca, 0x06, 0x6e, 0xf9, 0xf5, 0xdf, 0x57,
-	0x63, 0xee, 0xa1, 0xdb, 0x2b, 0x43, 0xc9, 0xbc, 0x4c, 0x40, 0x37, 0x07, 0xe0, 0xbb, 0xd4, 0x67,
-	0x10, 0xd3, 0xa8, 0x5f, 0xa8, 0x54, 0x6d, 0x65, 0xe6, 0x5f, 0x63, 0x3a, 0x68, 0x4b, 0x7a, 0x6b,
-	0xd5, 0xb6, 0xf2, 0x97, 0x09, 0x0b, 0xe6, 0x41, 0x78, 0xc8, 0xdd, 0x85, 0xce, 0xbc, 0x8b, 0xee,
-	0xfc, 0xa1, 0xa9, 0x3c, 0xd3, 0xfe, 0x79, 0x15, 0xd5, 0x06, 0xe0, 0xab, 0x0c, 0xd5, 0x97, 0xaf,
-	0x41, 0x67, 0x7d, 0x9f, 0xf2, 0xc7, 0xd0, 0x7a, 0x74, 0x59, 0xe6, 0xe2, 0xb3, 0x09, 0x50, 0xa3,
-	0xb4, 0xf3, 0x87, 0x17, 0x3a, 0x2c, 0x53, 0x5b, 0xbd, 0x4b, 0x53, 0x17, 0xdd, 0xa6, 0xa8, 0xf9,
-	0x5b, 0xe2, 0xdd, 0x0b, 0x6d, 0x56, 0xe9, 0xad, 0x27, 0x57, 0xa2, 0xcb, 0xce, 0xce, 0xab, 0xd3,
-	0x99, 0xae, 0x9c, 0xcd, 0x74, 0xe5, 0xfb, 0x4c, 0x57, 0x3e, 0xcd, 0xf5, 0xca, 0xd9, 0x5c, 0xaf,
-	0x9c, 0xcf, 0xf5, 0xca, 0xbb, 0xee, 0xd2, 0x1d, 0x04, 0xca, 0xba, 0xd2, 0x5b, 0xbc, 0x08, 0x73,
-	0x7b, 0x6a, 0x8b, 0xbf, 0xc7, 0xec, 0x3a, 0x8e, 0x36, 0xc5, 0xef, 0x8f, 0x7f, 0x06, 0x00, 0x00,
-	0xff, 0xff, 0x91, 0xb6, 0x4e, 0x15, 0x32, 0x05, 0x00, 0x00,
+	// 693 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x55, 0x3d, 0x6f, 0xd3, 0x50,
+	0x14, 0x8d, 0x93, 0x50, 0xda, 0x9b, 0x42, 0x8b, 0x5b, 0xc0, 0x35, 0xaa, 0x1d, 0x2c, 0x81, 0xc2,
+	0x10, 0x9b, 0x06, 0x21, 0x0a, 0x12, 0x03, 0x49, 0x25, 0xd4, 0x21, 0x02, 0x59, 0x02, 0x24, 0x96,
+	0xca, 0xb1, 0x5f, 0x5d, 0x43, 0xf2, 0x5e, 0xe4, 0xeb, 0xa0, 0x74, 0x41, 0xe2, 0x1f, 0x30, 0x33,
+	0x32, 0xf2, 0x4b, 0x3a, 0x56, 0x62, 0x61, 0x40, 0x06, 0xb5, 0x5b, 0x46, 0x7e, 0x01, 0xf2, 0xf3,
+	0x07, 0xf9, 0x6a, 0x94, 0x30, 0xbd, 0xe7, 0x93, 0x73, 0xee, 0xc7, 0xb9, 0xd7, 0x0e, 0xac, 0x3a,
+	0xa4, 0x6f, 0x04, 0x7d, 0xbd, 0xeb, 0xb3, 0x80, 0x89, 0x12, 0x12, 0x8f, 0xdf, 0x6c, 0xd6, 0xd6,
+	0x91, 0x78, 0xf6, 0x91, 0xe5, 0x51, 0xdd, 0x21, 0x7d, 0x59, 0xb1, 0x19, 0x76, 0x18, 0x1a, 0x2d,
+	0x0b, 0x89, 0xf1, 0x61, 0xa7, 0x45, 0x02, 0x6b, 0xc7, 0xb0, 0x99, 0x47, 0x63, 0xa5, 0xbc, 0xe9,
+	0x32, 0x97, 0xf1, 0xab, 0x11, 0xdd, 0x12, 0x54, 0x8c, 0xa2, 0xdb, 0x8c, 0x06, 0xbe, 0x65, 0x07,
+	0x09, 0xb6, 0x16, 0x61, 0xcc, 0x77, 0x88, 0x1f, 0x03, 0xda, 0xd7, 0x3c, 0x5c, 0x6d, 0xa2, 0xfb,
+	0xb2, 0x6d, 0xd9, 0xe4, 0x45, 0x84, 0xa3, 0x78, 0x07, 0x2e, 0xdb, 0x3e, 0xb1, 0x02, 0xe6, 0x4b,
+	0x42, 0x59, 0xa8, 0xac, 0xd4, 0x4b, 0x83, 0x50, 0x4d, 0x21, 0x33, 0xbd, 0x88, 0x0d, 0x58, 0xe2,
+	0x81, 0x50, 0xca, 0x97, 0x0b, 0x95, 0x52, 0x4d, 0xd5, 0x2f, 0xaa, 0x5f, 0xe7, 0x81, 0xeb, 0x30,
+	0x08, 0xd5, 0x44, 0x62, 0x26, 0xa7, 0xb8, 0x0b, 0xab, 0x69, 0x85, 0xcf, 0x1c, 0xc7, 0x97, 0x0a,
+	0x3c, 0xe1, 0xe6, 0x20, 0x54, 0xd7, 0x53, 0xfc, 0xc0, 0x72, 0x1c, 0x9f, 0x20, 0x9a, 0x23, 0x4c,
+	0xf1, 0x1d, 0x5c, 0x3a, 0xec, 0x51, 0x07, 0xa5, 0x22, 0xcf, 0xbe, 0xa5, 0xc7, 0x1e, 0xe9, 0x91,
+	0x47, 0x7a, 0xe2, 0x91, 0xde, 0x60, 0x1e, 0xad, 0x3f, 0x3e, 0x09, 0xd5, 0xdc, 0x20, 0x54, 0x63,
+	0xfe, 0xb7, 0x5f, 0x6a, 0xc5, 0xf5, 0x82, 0xa3, 0x5e, 0x4b, 0xb7, 0x59, 0xc7, 0x48, 0x9c, 0x8d,
+	0x8f, 0x2a, 0x3a, 0xef, 0x8d, 0xe0, 0xb8, 0x4b, 0x90, 0x2b, 0xd1, 0x8c, 0x25, 0xda, 0x1b, 0xb8,
+	0x31, 0xea, 0x91, 0x49, 0xb0, 0xcb, 0x28, 0x12, 0xf1, 0x29, 0x2c, 0xf3, 0x4e, 0xf6, 0x1d, 0x94,
+	0x84, 0x72, 0xa1, 0x52, 0xac, 0xdf, 0x1e, 0x84, 0xea, 0x0a, 0xc7, 0x0e, 0x3c, 0x07, 0xff, 0x84,
+	0xea, 0xfa, 0xb1, 0xd5, 0x69, 0x3f, 0xd1, 0x32, 0x48, 0x33, 0x33, 0x89, 0xf6, 0x5d, 0x80, 0xb5,
+	0x26, 0xba, 0x0d, 0x8b, 0xda, 0xa4, 0xbd, 0x98, 0xfd, 0x07, 0x70, 0xc5, 0xe6, 0xb2, 0xb6, 0x15,
+	0x78, 0x8c, 0xa6, 0x53, 0xb8, 0x7b, 0xf1, 0x14, 0x1a, 0x43, 0xf4, 0xfa, 0xb5, 0x41, 0xa8, 0x8e,
+	0x06, 0x30, 0x47, 0x1f, 0xff, 0x7f, 0x34, 0xda, 0x16, 0xdc, 0x1c, 0x6b, 0x2a, 0xf5, 0x4b, 0xeb,
+	0xc1, 0x46, 0x13, 0x5d, 0x93, 0xb8, 0x1e, 0x06, 0xc4, 0x6f, 0x24, 0x2a, 0x51, 0x1a, 0xeb, 0xf9,
+	0x5f, 0x9b, 0x7b, 0xb0, 0x9c, 0xc6, 0x96, 0xf2, 0x65, 0xa1, 0x52, 0xaa, 0x55, 0x66, 0x74, 0x98,
+	0x30, 0xf7, 0xe9, 0x21, 0x7b, 0x5d, 0x33, 0x33, 0xa5, 0xb6, 0x0d, 0xb7, 0xa6, 0xa4, 0xcd, 0xaa,
+	0xfa, 0x22, 0xf0, 0x01, 0xa7, 0xf8, 0x1e, 0xe9, 0x32, 0xf4, 0x02, 0x93, 0xd0, 0x60, 0xc2, 0x05,
+	0x61, 0xee, 0x05, 0xd5, 0x60, 0xc9, 0xea, 0xb0, 0x1e, 0x8d, 0xeb, 0x2e, 0xc6, 0xeb, 0x1f, 0x23,
+	0x66, 0x72, 0x46, 0x1c, 0x24, 0xd4, 0x21, 0xa9, 0xbb, 0x9c, 0x13, 0x23, 0x66, 0x72, 0x6a, 0x65,
+	0x50, 0xa6, 0xd7, 0x96, 0x95, 0xdf, 0x87, 0xeb, 0x4d, 0x74, 0x5f, 0x51, 0x7f, 0xdc, 0xd6, 0x39,
+	0x57, 0x69, 0xbc, 0xc7, 0xfc, 0xdc, 0x93, 0x56, 0x61, 0x7b, 0x6a, 0xe6, 0xb4, 0xb4, 0xda, 0xcf,
+	0x22, 0x14, 0x9a, 0xe8, 0x8a, 0x1e, 0x94, 0x86, 0x3f, 0x31, 0x33, 0x66, 0x38, 0xfa, 0xa2, 0xc9,
+	0xf7, 0xe7, 0x65, 0x66, 0xaf, 0x64, 0x1b, 0x56, 0x47, 0xde, 0xa7, 0x7b, 0x33, 0x23, 0x0c, 0x53,
+	0xe5, 0x9d, 0xb9, 0xa9, 0x59, 0xb6, 0x3e, 0xac, 0x4f, 0x6c, 0x73, 0x75, 0x66, 0x98, 0x71, 0xba,
+	0xfc, 0x70, 0x21, 0x7a, 0x96, 0xf9, 0x93, 0x00, 0x1b, 0xd3, 0x36, 0x76, 0xb6, 0x63, 0x53, 0x14,
+	0xf2, 0xee, 0xa2, 0x8a, 0xac, 0x86, 0x8f, 0x20, 0x4e, 0x59, 0x3b, 0x63, 0x66, 0xbc, 0x49, 0x81,
+	0xfc, 0x68, 0x41, 0x41, 0x9a, 0xbf, 0xfe, 0xfc, 0xe4, 0x4c, 0x11, 0x4e, 0xcf, 0x14, 0xe1, 0xf7,
+	0x99, 0x22, 0x7c, 0x3e, 0x57, 0x72, 0xa7, 0xe7, 0x4a, 0xee, 0xc7, 0xb9, 0x92, 0x7b, 0x5b, 0x1d,
+	0xfa, 0xc6, 0x23, 0xf1, 0xaa, 0x69, 0x74, 0xfe, 0xc0, 0xc3, 0x1b, 0x7d, 0x83, 0xff, 0xfd, 0x46,
+	0x9f, 0xfb, 0xd6, 0x12, 0xff, 0xfd, 0xc1, 0xdf, 0x00, 0x00, 0x00, 0xff, 0xff, 0xda, 0xfa, 0x73,
+	0x6b, 0x92, 0x07, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -392,6 +588,8 @@ type MsgClient interface {
 	PlaceOrders(ctx context.Context, in *MsgPlaceOrders, opts ...grpc.CallOption) (*MsgPlaceOrdersResponse, error)
 	CancelOrders(ctx context.Context, in *MsgCancelOrders, opts ...grpc.CallOption) (*MsgCancelOrdersResponse, error)
 	RegisterContract(ctx context.Context, in *MsgRegisterContract, opts ...grpc.CallOption) (*MsgRegisterContractResponse, error)
+	ContractDepositRent(ctx context.Context, in *MsgContractDepositRent, opts ...grpc.CallOption) (*MsgContractDepositRentResponse, error)
+	UnregisterContract(ctx context.Context, in *MsgUnregisterContract, opts ...grpc.CallOption) (*MsgUnregisterContractResponse, error)
 }
 
 type msgClient struct {
@@ -429,11 +627,31 @@ func (c *msgClient) RegisterContract(ctx context.Context, in *MsgRegisterContrac
 	return out, nil
 }
 
+func (c *msgClient) ContractDepositRent(ctx context.Context, in *MsgContractDepositRent, opts ...grpc.CallOption) (*MsgContractDepositRentResponse, error) {
+	out := new(MsgContractDepositRentResponse)
+	err := c.cc.Invoke(ctx, "/seiprotocol.seichain.dex.Msg/ContractDepositRent", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *msgClient) UnregisterContract(ctx context.Context, in *MsgUnregisterContract, opts ...grpc.CallOption) (*MsgUnregisterContractResponse, error) {
+	out := new(MsgUnregisterContractResponse)
+	err := c.cc.Invoke(ctx, "/seiprotocol.seichain.dex.Msg/UnregisterContract", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
 	PlaceOrders(context.Context, *MsgPlaceOrders) (*MsgPlaceOrdersResponse, error)
 	CancelOrders(context.Context, *MsgCancelOrders) (*MsgCancelOrdersResponse, error)
 	RegisterContract(context.Context, *MsgRegisterContract) (*MsgRegisterContractResponse, error)
+	ContractDepositRent(context.Context, *MsgContractDepositRent) (*MsgContractDepositRentResponse, error)
+	UnregisterContract(context.Context, *MsgUnregisterContract) (*MsgUnregisterContractResponse, error)
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.
@@ -448,6 +666,12 @@ func (*UnimplementedMsgServer) CancelOrders(ctx context.Context, req *MsgCancelO
 }
 func (*UnimplementedMsgServer) RegisterContract(ctx context.Context, req *MsgRegisterContract) (*MsgRegisterContractResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RegisterContract not implemented")
+}
+func (*UnimplementedMsgServer) ContractDepositRent(ctx context.Context, req *MsgContractDepositRent) (*MsgContractDepositRentResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ContractDepositRent not implemented")
+}
+func (*UnimplementedMsgServer) UnregisterContract(ctx context.Context, req *MsgUnregisterContract) (*MsgUnregisterContractResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UnregisterContract not implemented")
 }
 
 func RegisterMsgServer(s grpc1.Server, srv MsgServer) {
@@ -508,6 +732,42 @@ func _Msg_RegisterContract_Handler(srv interface{}, ctx context.Context, dec fun
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Msg_ContractDepositRent_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgContractDepositRent)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).ContractDepositRent(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/seiprotocol.seichain.dex.Msg/ContractDepositRent",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).ContractDepositRent(ctx, req.(*MsgContractDepositRent))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Msg_UnregisterContract_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgUnregisterContract)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).UnregisterContract(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/seiprotocol.seichain.dex.Msg/UnregisterContract",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).UnregisterContract(ctx, req.(*MsgUnregisterContract))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Msg_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "seiprotocol.seichain.dex.Msg",
 	HandlerType: (*MsgServer)(nil),
@@ -523,6 +783,14 @@ var _Msg_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RegisterContract",
 			Handler:    _Msg_RegisterContract_Handler,
+		},
+		{
+			MethodName: "ContractDepositRent",
+			Handler:    _Msg_ContractDepositRent_Handler,
+		},
+		{
+			MethodName: "UnregisterContract",
+			Handler:    _Msg_UnregisterContract_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -774,6 +1042,131 @@ func (m *MsgRegisterContractResponse) MarshalToSizedBuffer(dAtA []byte) (int, er
 	return len(dAtA) - i, nil
 }
 
+func (m *MsgContractDepositRent) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgContractDepositRent) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgContractDepositRent) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Sender) > 0 {
+		i -= len(m.Sender)
+		copy(dAtA[i:], m.Sender)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Sender)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.Amount != 0 {
+		i = encodeVarintTx(dAtA, i, uint64(m.Amount))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.ContractAddr) > 0 {
+		i -= len(m.ContractAddr)
+		copy(dAtA[i:], m.ContractAddr)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.ContractAddr)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgContractDepositRentResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgContractDepositRentResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgContractDepositRentResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgUnregisterContract) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgUnregisterContract) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgUnregisterContract) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.ContractAddr) > 0 {
+		i -= len(m.ContractAddr)
+		copy(dAtA[i:], m.ContractAddr)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.ContractAddr)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Creator) > 0 {
+		i -= len(m.Creator)
+		copy(dAtA[i:], m.Creator)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Creator)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgUnregisterContractResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgUnregisterContractResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgUnregisterContractResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTx(v)
 	base := offset
@@ -880,6 +1273,61 @@ func (m *MsgRegisterContract) Size() (n int) {
 }
 
 func (m *MsgRegisterContractResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *MsgContractDepositRent) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.ContractAddr)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	if m.Amount != 0 {
+		n += 1 + sovTx(uint64(m.Amount))
+	}
+	l = len(m.Sender)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	return n
+}
+
+func (m *MsgContractDepositRentResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *MsgUnregisterContract) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Creator)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.ContractAddr)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	return n
+}
+
+func (m *MsgUnregisterContractResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1491,7 +1939,7 @@ func (m *MsgRegisterContract) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Contract == nil {
-				m.Contract = &ContractInfo{}
+				m.Contract = &ContractInfoV2{}
 			}
 			if err := m.Contract.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1545,6 +1993,353 @@ func (m *MsgRegisterContractResponse) Unmarshal(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: MsgRegisterContractResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgContractDepositRent) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgContractDepositRent: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgContractDepositRent: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ContractAddr", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ContractAddr = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Amount", wireType)
+			}
+			m.Amount = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Amount |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Sender", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Sender = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgContractDepositRentResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgContractDepositRentResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgContractDepositRentResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgUnregisterContract) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgUnregisterContract: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgUnregisterContract: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Creator", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Creator = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ContractAddr", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ContractAddr = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgUnregisterContractResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgUnregisterContractResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgUnregisterContractResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:


### PR DESCRIPTION
## Describe your changes and provide context
We want contracts that register with `dex` module to be able to deposit rent which will be spent for the contract's sudo endpoint invocations. This PR adds a new ContractInfoV2 type that holds a rent balance of `usei`. The actual `usei` is transferred from the contract registerer to `dex`'s module account. The contract registerer can deposit more rent to his contract through the new `ContractDepositRent` message type. The contract registerer can also unregister his contract and get his `usei` refunded.

## Testing performed to validate your change
unit tests
