### PR TITLE
Add constant loadtesting back and export metrics for transactions 

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1073,7 +1073,7 @@ func (app *App) ProcessBlockConcurrent(
 	}
 
 	var waitGroup sync.WaitGroup
-	resultChan := make(chan ChannelResult)
+	resultChan := make(chan ChannelResult, len(txs))
 	// For each transaction, start goroutine and deliver TX
 	for txIndex, txBytes := range txs {
 		waitGroup.Add(1)

--- a/loadtest/config.json
+++ b/loadtest/config.json
@@ -24,6 +24,8 @@
             "begin_redelegate_percentage": "0.25"
         }
     },
+    "constant": true,
+    "const_load_interval": 600,
     "message_type": "bank,dex,staking,tokenfactory",
     "run_oracle": true,
     "contract_distribution": [

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -27,7 +27,7 @@ type LoadTestClient struct {
 	SignerClient       *SignerClient
 	ChainID            string
 	TxHashList         []string
-	TxResponseChan	   chan *string
+	TxResponseChan     chan *string
 	TxHashListMutex    *sync.Mutex
 	GrpcConn           *grpc.ClientConn
 	StakingQueryClient stakingtypes.QueryClient
@@ -60,7 +60,7 @@ func NewLoadTestClient(config Config) *LoadTestClient {
 		SignerClient:           NewSignerClient(),
 		ChainID:                config.ChainID,
 		TxHashList:             []string{},
-		TxResponseChan: 		make(chan *string),
+		TxResponseChan:         make(chan *string),
 		TxHashListMutex:        &sync.Mutex{},
 		GrpcConn:               grpcConn,
 		StakingQueryClient:     stakingtypes.NewQueryClient(grpcConn),
@@ -247,7 +247,6 @@ func (c *LoadTestClient) ValidateTxs() {
 		responseStringMap[codeString]++
 		responseCodeMap[int(code)]++
 	}
-
 
 	fmt.Printf("Transactions not committed: %d\n", notCommittedTxs)
 	pp.Printf("Response Code Mapping: \n %s \n", responseStringMap)

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,8 +10,12 @@ import (
 	"time"
 
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	typestx "github.com/cosmos/cosmos-sdk/types/tx"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	"github.com/k0kubun/pp/v3"
 	"google.golang.org/grpc"
 )
 
@@ -24,6 +27,7 @@ type LoadTestClient struct {
 	SignerClient       *SignerClient
 	ChainID            string
 	TxHashList         []string
+	TxResponseChan	   chan *string
 	TxHashListMutex    *sync.Mutex
 	GrpcConn           *grpc.ClientConn
 	StakingQueryClient stakingtypes.QueryClient
@@ -35,19 +39,12 @@ type LoadTestClient struct {
 	TokenFactoryDenomOwner map[string]string
 }
 
-func NewLoadTestClient() *LoadTestClient {
+func NewLoadTestClient(config Config) *LoadTestClient {
 	grpcConn, _ := grpc.Dial(
 		"127.0.0.1:9090",
 		grpc.WithInsecure(),
 	)
 	TxClient := typestx.NewServiceClient(grpcConn)
-
-	config := Config{}
-	pwd, _ := os.Getwd()
-	file, _ := os.ReadFile(pwd + "/loadtest/config.json")
-	if err := json.Unmarshal(file, &config); err != nil {
-		panic(err)
-	}
 
 	// setup output files
 	userHomeDir, _ := os.UserHomeDir()
@@ -55,7 +52,6 @@ func NewLoadTestClient() *LoadTestClient {
 	filename := filepath.Join(userHomeDir, "outputs", "test_tx_hash")
 	_ = os.Remove(filename)
 	outputFile, _ := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-
 	return &LoadTestClient{
 		LoadTestConfig:         config,
 		TestConfig:             TestConfig,
@@ -64,6 +60,7 @@ func NewLoadTestClient() *LoadTestClient {
 		SignerClient:           NewSignerClient(),
 		ChainID:                config.ChainID,
 		TxHashList:             []string{},
+		TxResponseChan: 		make(chan *string),
 		TxHashListMutex:        &sync.Mutex{},
 		GrpcConn:               grpcConn,
 		StakingQueryClient:     stakingtypes.NewQueryClient(grpcConn),
@@ -87,13 +84,11 @@ func (c *LoadTestClient) Close() {
 }
 
 func (c *LoadTestClient) AppendTxHash(txHash string) {
-	c.TxHashListMutex.Lock()
-	defer c.TxHashListMutex.Unlock()
-
-	c.TxHashList = append(c.TxHashList, txHash)
+	c.TxResponseChan <- &txHash
 }
 
 func (c *LoadTestClient) WriteTxHashToFile() {
+	fmt.Printf("Writing Tx Hashes to: %s \n", c.TxHashFile.Name())
 	file := c.TxHashFile
 	for _, txHash := range c.TxHashList {
 		txHashLine := fmt.Sprintf("%s\n", txHash)
@@ -180,6 +175,8 @@ func (c *LoadTestClient) GenerateOracleSenders(i int, config Config, valKeys []c
 }
 
 func (c *LoadTestClient) SendTxs(workgroups []*sync.WaitGroup, sendersList [][]func() string) {
+	defer close(c.TxResponseChan)
+
 	lastHeight := getLastHeight()
 	for i := 0; i < int(c.LoadTestConfig.Rounds); i++ {
 		newHeight := getLastHeight()
@@ -196,4 +193,81 @@ func (c *LoadTestClient) SendTxs(workgroups []*sync.WaitGroup, sendersList [][]f
 		wg.Wait()
 		lastHeight = newHeight
 	}
+}
+
+func (c *LoadTestClient) GatherTxHashes() {
+	for txHash := range c.TxResponseChan {
+		c.TxHashList = append(c.TxHashList, *txHash)
+	}
+	fmt.Printf("Transactions Sent=%d\n", len(c.TxHashList))
+}
+
+func (c *LoadTestClient) ValidateTxs() {
+	defer c.Close()
+	numTxs := len(c.TxHashList)
+	resultChan := make(chan *types.TxResponse, numTxs)
+	var waitGroup sync.WaitGroup
+
+	if numTxs == 0 {
+		return
+	}
+
+	for _, txHash := range c.TxHashList {
+		waitGroup.Add(1)
+		go func(txHash string) {
+			defer waitGroup.Done()
+			resultChan <- c.GetTxResponse(txHash)
+		}(txHash)
+	}
+
+	go func() {
+		waitGroup.Wait()
+		close(resultChan)
+	}()
+
+	fmt.Printf("Validating %d Transactions... \n", len(c.TxHashList))
+	waitGroup.Wait()
+
+	notCommittedTxs := 0
+	responseCodeMap := map[int]int{}
+	responseStringMap := map[string]int{}
+	for result := range resultChan {
+		// If the result is nil then that means the transaction was not committed
+		if result == nil {
+			notCommittedTxs++
+			continue
+		}
+		code := result.Code
+		codeString := "ok"
+		if code != 0 {
+			codespace := result.Codespace
+			error := sdkerrors.ABCIError(codespace, code, fmt.Sprintf("Error code=%d ", code))
+			codeString = error.Error()
+		}
+		responseStringMap[codeString]++
+		responseCodeMap[int(code)]++
+	}
+
+
+	fmt.Printf("Transactions not committed: %d\n", notCommittedTxs)
+	pp.Printf("Response Code Mapping: \n %s \n", responseStringMap)
+	IncrTxNotCommitted(notCommittedTxs)
+	for reason, count := range responseStringMap {
+		IncrTxProcessCode(reason, count)
+	}
+}
+
+func (c *LoadTestClient) GetTxResponse(hash string) *types.TxResponse {
+	grpcRes, err := c.TxClient.GetTx(
+		context.Background(),
+		&typestx.GetTxRequest{
+			Hash: hash,
+		},
+	)
+	fmt.Printf("Validated: %s\n", hash)
+	if err != nil {
+		fmt.Println(err)
+		return nil
+	}
+	return grpcRes.TxResponse
 }

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -154,7 +154,7 @@ func (c *LoadTestClient) BuildTxs() (workgroups []*sync.WaitGroup, sendersList [
 }
 
 func (c *LoadTestClient) GenerateOracleSenders(i int, config Config, valKeys []cryptotypes.PrivKey, waitGroup *sync.WaitGroup) []func() {
-	senders := []func() {}
+	senders := []func(){}
 	if config.RunOracle && i%2 == 0 {
 		for _, valKey := range valKeys {
 			// generate oracle tx

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -97,7 +97,7 @@ func runOnce(config Config) {
 	fmt.Printf("%s - Finished\n", time.Now().Format("2006-01-02T15:04:05"))
 
 	// Validate Tx will close the connection when it's done
-	client.ValidateTxs()
+	go client.ValidateTxs()
 }
 
 func (c *LoadTestClient) generateMessage(config Config, key cryptotypes.PrivKey, msgPerTx uint64) (sdk.Msg, bool) {

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"math/rand"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -51,12 +53,29 @@ func init() {
 	app.ModuleBasics.RegisterInterfaces(TestConfig.InterfaceRegistry)
 }
 
-func run() {
-	client := NewLoadTestClient()
-	client.SetValidators()
-	config := client.LoadTestConfig
+func run(config Config) {
+	// Start metrics collector in another thread
+	metricsServer := MetricsServer{}
+	go metricsServer.StartMetricsClient()
 
-	defer client.Close()
+	if config.Constant {
+		fmt.Printf("Running in constant mode with interval=%d\n", config.ConstLoadInterval)
+		sleepDuration := time.Duration(config.ConstLoadInterval) * time.Second
+
+		for {
+			runOnce(config)
+			fmt.Printf("Sleeping for %f seconds before next run...\n", sleepDuration.Seconds())
+			time.Sleep(sleepDuration)
+
+		}
+	} else {
+		runOnce(config)
+	}
+}
+
+func runOnce(config Config) {
+	client := NewLoadTestClient(config)
+	client.SetValidators()
 
 	if config.TxsPerBlock < config.MsgsPerTx {
 		panic("Must have more TxsPerBlock than MsgsPerTx")
@@ -68,11 +87,17 @@ func run() {
 	fmt.Printf("%s - Starting block prepare\n", time.Now().Format("2006-01-02T15:04:05"))
 	workgroups, sendersList := client.BuildTxs()
 
-	client.SendTxs(workgroups, sendersList)
+	go client.SendTxs(workgroups, sendersList)
+
+	// Waits until SendTx is done processing before proceeding to write and validate TXs
+	client.GatherTxHashes()
 
 	// Records the resulting TxHash to file
 	client.WriteTxHashToFile()
 	fmt.Printf("%s - Finished\n", time.Now().Format("2006-01-02T15:04:05"))
+
+	// Validate Tx will close the connection when it's done
+	client.ValidateTxs()
 }
 
 func (c *LoadTestClient) generateMessage(config Config, key cryptotypes.PrivKey, msgPerTx uint64) (sdk.Msg, bool) {
@@ -137,7 +162,7 @@ func (c *LoadTestClient) generateMessage(config Config, key cryptotypes.PrivKey,
 		case randNum <= 0.66:
 			msg = &tokenfactorytypes.MsgMint{
 				Sender: denomCreatorAddr,
-				Amount: sdk.Coin{Denom: denom, Amount: sdk.NewInt(10000000000000)},
+				Amount: sdk.Coin{Denom: denom, Amount: sdk.NewInt(10)},
 			}
 		default:
 			msg = &tokenfactorytypes.MsgBurn{
@@ -327,6 +352,22 @@ func getLastHeight() int {
 	return height
 }
 
+func GetDefaultConfigFilePath() string {
+	pwd, _ := os.Getwd()
+	return pwd + "/loadtest/config.json"
+}
+
+func ReadConfig(path string) Config {
+	config := Config{}
+	file, _ := os.ReadFile(path)
+	if err := json.Unmarshal(file, &config); err != nil {
+		panic(err)
+	}
+	return config
+}
+
 func main() {
-	run()
+	configFilePath := flag.String("config-file", GetDefaultConfigFilePath(), "Path to the config.json file to use for this run")
+	config := ReadConfig(*configFilePath)
+	run(config)
 }

--- a/loadtest/metrics.go
+++ b/loadtest/metrics.go
@@ -64,7 +64,7 @@ func (s *MetricsServer) healthzHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-# loadtest_client_sei_tx_code
+// loadtest_client_sei_tx_code
 func IncrTxProcessCode(reason string, count int) {
 	metrics.IncrCounterWithLabels(
 		[]string{"sei", "tx", "code"},
@@ -73,7 +73,7 @@ func IncrTxProcessCode(reason string, count int) {
 	)
 }
 
-# loadtest_client_sei_tx_failed
+// loadtest_client_sei_tx_failed
 func IncrTxNotCommitted(count int) {
 	metrics.IncrCounterWithLabels(
 		[]string{"sei", "tx", "failed"},

--- a/loadtest/metrics.go
+++ b/loadtest/metrics.go
@@ -58,7 +58,10 @@ func (s *MetricsServer) StartMetricsClient() {
 }
 
 func (s *MetricsServer) healthzHandler(w http.ResponseWriter, r *http.Request) {
-	io.WriteString(w, "ok\n")
+	_, err := io.WriteString(w, "ok\n")
+	if err != nil {
+		panic(err)
+	}
 }
 
 func IncrTxProcessCode(reason string, count int) {

--- a/loadtest/metrics.go
+++ b/loadtest/metrics.go
@@ -64,17 +64,19 @@ func (s *MetricsServer) healthzHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+# loadtest_client_sei_tx_code
 func IncrTxProcessCode(reason string, count int) {
 	metrics.IncrCounterWithLabels(
-		[]string{"sei", "load_test", "tx", "code"},
+		[]string{"sei", "tx", "code"},
 		float32(count),
 		[]metrics.Label{telemetry.NewLabel("reason", reason)},
 	)
 }
 
+# loadtest_client_sei_tx_failed
 func IncrTxNotCommitted(count int) {
 	metrics.IncrCounterWithLabels(
-		[]string{"sei", "load_test", "tx", "failed"},
+		[]string{"sei", "tx", "failed"},
 		float32(count),
 		[]metrics.Label{telemetry.NewLabel("reason", "not_committed")},
 	)

--- a/loadtest/tx.go
+++ b/loadtest/tx.go
@@ -19,14 +19,14 @@ func SendTx(
 	seqDelta uint64,
 	failureExpected bool,
 	loadtestClient LoadTestClient,
-) func() string { // TODO: do we need to return string?
+) func() {
 	(*txBuilder).SetGasLimit(200000000)
 	(*txBuilder).SetFeeAmount([]sdk.Coin{
 		sdk.NewCoin("usei", sdk.NewInt(10000000)),
 	})
 	loadtestClient.SignerClient.SignTx(loadtestClient.ChainID, txBuilder, key, seqDelta)
 	txBytes, _ := TestConfig.TxConfig.TxEncoder()((*txBuilder).GetTx())
-	return func() string {
+	return func() {
 		grpcRes, err := loadtestClient.TxClient.BroadcastTx(
 			context.Background(),
 			&typestx.BroadcastTxRequest{
@@ -64,8 +64,6 @@ func SendTx(
 			fmt.Printf("Error: %d, %s\n", grpcRes.TxResponse.Code, grpcRes.TxResponse.RawLog)
 		} else {
 			loadtestClient.AppendTxHash(grpcRes.TxResponse.TxHash)
-			return grpcRes.TxResponse.TxHash
 		}
-		return ""
 	}
 }

--- a/loadtest/tx.go
+++ b/loadtest/tx.go
@@ -20,9 +20,9 @@ func SendTx(
 	failureExpected bool,
 	loadtestClient LoadTestClient,
 ) func() {
-	(*txBuilder).SetGasLimit(200000000)
+	(*txBuilder).SetGasLimit(200000)
 	(*txBuilder).SetFeeAmount([]sdk.Coin{
-		sdk.NewCoin("usei", sdk.NewInt(10000000)),
+		sdk.NewCoin("usei", sdk.NewInt(10000)),
 	})
 	loadtestClient.SignerClient.SignTx(loadtestClient.ChainID, txBuilder, key, seqDelta)
 	txBytes, _ := TestConfig.TxConfig.TxEncoder()((*txBuilder).GetTx())

--- a/x/oracle/simulation/operations.go
+++ b/x/oracle/simulation/operations.go
@@ -65,7 +65,7 @@ func WeightedOperations(
 }
 
 // SimulateMsgAggregateExchangeRateVote generates a MsgAggregateExchangeRateVote with random values.
-//nolint: funlen
+// nolint: funlen
 func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
@@ -122,7 +122,7 @@ func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankK
 }
 
 // SimulateMsgDelegateFeedConsent generates a MsgDelegateFeedConsent with random values.
-//nolint: funlen
+// nolint: funlen
 func SimulateMsgDelegateFeedConsent(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,

--- a/x/oracle/simulation/operations.go
+++ b/x/oracle/simulation/operations.go
@@ -65,7 +65,7 @@ func WeightedOperations(
 }
 
 // SimulateMsgAggregateExchangeRateVote generates a MsgAggregateExchangeRateVote with random values.
-// nolint: funlen
+//nolint: funlen
 func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
@@ -122,7 +122,7 @@ func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankK
 }
 
 // SimulateMsgDelegateFeedConsent generates a MsgDelegateFeedConsent with random values.
-// nolint: funlen
+//nolint: funlen
 func SimulateMsgDelegateFeedConsent(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,


### PR DESCRIPTION
## Describe your changes and provide context
It looks like some of the constant load testing changes might've gotten lost during the rebase, this PR adds it back and also adds support for exporting metrics. We need to have a thread to listen and return the metrics 

Will make another PR for the wrapper on this to run different configurations 

Note: one issue we'll have with running constant load tests is that the accounts eventually run out of tokens due to the gas fees, we'll need to think of a way to constantly supply these accounts with sei 

## Testing performed to validate your change
Had a constant load test running every 10 mins and see that the metrics are exported:
![image](https://user-images.githubusercontent.com/18161326/200093079-3b92826c-ebd0-4d1f-b228-618da98b3026.png)

![image](https://user-images.githubusercontent.com/18161326/200093296-e7337ec1-308d-4ef2-816f-200497fe8fc7.png)


Example output at the end
```
Transactions not committed: 18
Response Code Mapping:
 map[string]int{
  "Error code=5 : insufficient funds": 1,
  "ok":                                193,
}
```