### PR TITLE
Nitro: trim \x prefix in data passed to replayer

### DIFF
--- a/x/nitro/replay/replay.go
+++ b/x/nitro/replay/replay.go
@@ -109,16 +109,17 @@ func writeTransactionToFile(directory string, tx []byte) (string, error) {
 		)
 		serialized += header
 		serialized += ","
-		serialized += strings.Join(transactionData.LegacyMessage.AccountKeys, "-")
+		serialized += strings.Join(
+			utils.Map(transactionData.LegacyMessage.AccountKeys, trimHexPrefix), "-")
 		serialized += ","
-		serialized += transactionData.LegacyMessage.RecentBlockhash
+		serialized += trimHexPrefix(transactionData.LegacyMessage.RecentBlockhash)
 		serialized += ","
 		instructions := utils.Map(transactionData.LegacyMessage.Instructions, func(i *types.CompiledInstruction) string {
 			return fmt.Sprintf(
 				"%d_%s_%s",
 				i.ProgramIdIndex,
 				strings.Join(utils.Map(i.Accounts, func(a uint32) string { return fmt.Sprintf("%d", a) }), ":"),
-				i.Data,
+				trimHexPrefix(i.Data),
 			)
 		})
 		serialized += strings.Join(instructions, "-")
@@ -133,16 +134,17 @@ func writeTransactionToFile(directory string, tx []byte) (string, error) {
 		)
 		serialized += header
 		serialized += ","
-		serialized += strings.Join(transactionData.V0LoadedMessage.Message.AccountKeys, "-")
+		serialized += strings.Join(
+			utils.Map(transactionData.V0LoadedMessage.Message.AccountKeys, trimHexPrefix), "-")
 		serialized += ","
-		serialized += transactionData.V0LoadedMessage.Message.RecentBlockhash
+		serialized += trimHexPrefix(transactionData.V0LoadedMessage.Message.RecentBlockhash)
 		serialized += ","
 		instructions := utils.Map(transactionData.V0LoadedMessage.Message.Instructions, func(i *types.CompiledInstruction) string {
 			return fmt.Sprintf(
 				"%d_%s_%s",
 				i.ProgramIdIndex,
 				strings.Join(utils.Map(i.Accounts, func(a uint32) string { return fmt.Sprintf("%d", a) }), ":"),
-				i.Data,
+				trimHexPrefix(i.Data),
 			)
 		})
 		serialized += strings.Join(instructions, "-")
@@ -184,4 +186,15 @@ func writeAccountToFile(directory string, account types.Account) (string, error)
 	serialized += account.Data
 	filepath := fmt.Sprintf("%s%s", directory, account.Pubkey)
 	return filepath, os.WriteFile(filepath, []byte(serialized), 0644)
+}
+
+// input: \x1234 output: 1234
+func trimHexPrefix(s string) string {
+	if len(s) < 2 {
+		return s
+	}
+	if s[:2] != "\\x" {
+		return s
+	}
+	return s[2:]
 }

--- a/x/nitro/replay/replay_test.go
+++ b/x/nitro/replay/replay_test.go
@@ -93,3 +93,12 @@ func TestWriteTransactionToFile(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, "0|1-2-3,a1-a2,recent,1_4:5:6_d1-2_7:8:9_d2|message|f|s1,s2", string(bz))
 }
+
+func TestTrimHexPrefix(t *testing.T) {
+	require.Equal(t, "", trimHexPrefix(""))
+	require.Equal(t, "a", trimHexPrefix("a"))
+	require.Equal(t, "\\y", trimHexPrefix("\\y"))
+	require.Equal(t, "", trimHexPrefix("\\x"))
+	require.Equal(t, "abc", trimHexPrefix("abc"))
+	require.Equal(t, "1234", trimHexPrefix("\\x1234"))
+}


### PR DESCRIPTION
## Describe your changes and provide context
The indexer sends account keys, recent blockhash, and instruction data with a `\x` prefix, which the replayer does not expect. So here we trim it off it such prefix is present before sending data to the replayer.

## Testing performed to validate your change
unit tests

