### PR TITLE
Add wrapper for load tests to run in different modes

### DIFF
--- a/loadtest/config.json
+++ b/loadtest/config.json
@@ -25,9 +25,10 @@
         }
     },
     "constant": true,
-    "const_load_interval": 600,
+    "loadtest_interval": 600,
     "message_type": "bank,dex,staking,tokenfactory",
     "run_oracle": true,
+    "metrics_port": 9696,
     "contract_distribution": [
             {
               "contract_address":"sei14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sh9m79m",

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -56,20 +56,20 @@ func init() {
 func run(config Config) {
 	// Start metrics collector in another thread
 	metricsServer := MetricsServer{}
-	go metricsServer.StartMetricsClient()
+	go metricsServer.StartMetricsClient(config)
+	sleepDuration := time.Duration(config.LoadInterval) * time.Second
 
 	if config.Constant {
-		fmt.Printf("Running in constant mode with interval=%d\n", config.ConstLoadInterval)
-		sleepDuration := time.Duration(config.ConstLoadInterval) * time.Second
-
+		fmt.Printf("Running in constant mode with interval=%d\n", config.LoadInterval)
 		for {
 			runOnce(config)
 			fmt.Printf("Sleeping for %f seconds before next run...\n", sleepDuration.Seconds())
 			time.Sleep(sleepDuration)
-
 		}
 	} else {
 		runOnce(config)
+		fmt.Print("Sleeping for 60 seconds for metrics to be scraped...\n")
+		time.Sleep(time.Duration(60))
 	}
 }
 
@@ -368,6 +368,9 @@ func ReadConfig(path string) Config {
 
 func main() {
 	configFilePath := flag.String("config-file", GetDefaultConfigFilePath(), "Path to the config.json file to use for this run")
+	flag.Parse()
+
 	config := ReadConfig(*configFilePath)
+	fmt.Printf("Using config file: %s\n", *configFilePath)
 	run(config)
 }

--- a/loadtest/scripts/run_tests.py
+++ b/loadtest/scripts/run_tests.py
@@ -1,0 +1,113 @@
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+
+from dataclasses import dataclass
+
+
+# This strategy is used to simulate sudden spikes or bursts of load on the on the chain.
+# Burst load testing is done to ensure that the chain hub is able to handle such sudden
+# spikes in traffic.
+BURST = 'BURST'
+
+#  This is used to simulate a "steady-state" scenario where there is a constant load.
+STEADY = 'STEADY'
+
+
+@dataclass
+class LoadTestConfig:
+    config_file_path: str
+    loadtest_binary_file_path: str
+
+
+def write_to_temp_json_file(data):
+    with tempfile.NamedTemporaryFile(mode='w', encoding='utf-8', delete=False) as tmp:
+        json.dump(data, tmp, ensure_ascii=False)
+        return tmp
+
+def create_burst_loadtest_config(base_config_json):
+    new_config = base_config_json.copy()
+    new_config["constant"] = True
+    new_config["metrics_port"] = 9697
+    new_config["txs_per_block"] = 2000
+    # Run every 20 mins
+    new_config["loadtest_interval"] = 1200
+    return new_config
+
+
+def create_steady_loadtest_config(base_config_json):
+    new_config = base_config_json.copy()
+    new_config["constant"] = True
+    new_config["metrics_port"] = 9696
+    new_config["txs_per_block"] = 100
+    # Run every 5 mins
+    new_config["loadtest_interval"] = 60
+    return new_config
+
+
+def read_config_json(config_json_file_path):
+    # Default path for running on EC2 instances
+    file_path = "/home/ubuntu/sei-chain/loadtest/config.json"
+
+    if config_json_file_path is not None:
+        file_path = config_json_file_path
+
+    with open(file_path, 'r', encoding="utf-8") as file:
+        return json.load(file)
+
+
+def run_go_loadtest_client(config_file_path, binary_path):
+    # Default path for running on EC2 instances
+    cmd = ["/home/ubuntu/sei-chain/build/loadtest", "-config-file", config_file_path]
+    if binary_path is not None:
+       cmd[0] = binary_path
+
+    print(f'Running {" ".join(cmd)}')
+    subprocess.run(cmd, check=True)
+
+def run_test(test_type, loadtest_config):
+    config = base_config_json = read_config_json(loadtest_config.config_file_path)
+    if test_type == BURST:
+        config = create_burst_loadtest_config(base_config_json)
+    elif test_type == STEADY:
+        config = create_steady_loadtest_config(base_config_json)
+
+    tmpfile = write_to_temp_json_file(config)
+    run_go_loadtest_client(tmpfile.name, binary_path=loadtest_config.loadtest_binary_file_path)
+    os.remove(tmpfile.name)
+
+def run():
+    parser = argparse.ArgumentParser(
+                        prog = 'Loadtest Client',
+                        description = 'Wrapper for the golang client to run loadtests with different configs')
+    parser.add_argument(
+        'type',
+        help='Type of loadtest to run (e.g constant, burst)',
+        type = lambda s : s.upper(),
+        choices=[BURST, STEADY],
+    )
+    parser.add_argument(
+        '--config-file',
+        help='Base config file to modify',
+        required=False,
+    )
+    parser.add_argument(
+        '--loadtest-binary',
+        help='binary of the loadtest client to run',
+        required=False,
+    )
+
+    args = parser.parse_args()
+    test_type = args.type
+    print(f'type={test_type} loadtests')
+
+    run_test(
+        test_type=test_type,
+        loadtest_config=LoadTestConfig(args.config_file, args.loadtest_binary)
+    )
+
+
+if __name__ == '__main__':
+    run()

--- a/loadtest/scripts/run_tests.py
+++ b/loadtest/scripts/run_tests.py
@@ -79,7 +79,7 @@ def run_test(test_type, loadtest_config):
     try:
         run_go_loadtest_client(temp_file.name, binary_path=loadtest_config.loadtest_binary_file_path)
     finally:
-        os.delete(temp_file.name)
+        os.remove(temp_file.name)
 
 def run():
     parser = argparse.ArgumentParser(

--- a/loadtest/scripts/run_tests.py
+++ b/loadtest/scripts/run_tests.py
@@ -41,8 +41,8 @@ def create_steady_loadtest_config(base_config_json):
     new_config = base_config_json.copy()
     new_config["constant"] = True
     new_config["metrics_port"] = 9696
-    new_config["txs_per_block"] = 100
-    # Run every 5 mins
+    new_config["txs_per_block"] = 10
+    # Run every min
     new_config["loadtest_interval"] = 60
     return new_config
 

--- a/loadtest/scripts/run_tests.py
+++ b/loadtest/scripts/run_tests.py
@@ -41,7 +41,7 @@ def create_steady_loadtest_config(base_config_json):
     new_config = base_config_json.copy()
     new_config["constant"] = True
     new_config["metrics_port"] = 9696
-    new_config["txs_per_block"] = 10
+    new_config["txs_per_block"] = 100
     # Run every min
     new_config["loadtest_interval"] = 60
     return new_config

--- a/loadtest/scripts/run_tests.py
+++ b/loadtest/scripts/run_tests.py
@@ -25,7 +25,7 @@ class LoadTestConfig:
 def write_to_temp_json_file(data):
     with tempfile.NamedTemporaryFile(mode='w', encoding='utf-8', delete=False) as tmp:
         json.dump(data, tmp, ensure_ascii=False)
-        return tmp
+        return tmp.name
 
 def create_burst_loadtest_config(base_config_json):
     new_config = base_config_json.copy()
@@ -74,9 +74,9 @@ def run_test(test_type, loadtest_config):
     elif test_type == STEADY:
         config = create_steady_loadtest_config(base_config_json)
 
-    tmpfile = write_to_temp_json_file(config)
-    run_go_loadtest_client(tmpfile.name, binary_path=loadtest_config.loadtest_binary_file_path)
-    os.remove(tmpfile.name)
+    tempfile_path = write_to_temp_json_file(config)
+    run_go_loadtest_client(tempfile_path, binary_path=loadtest_config.loadtest_binary_file_path)
+    os.remove(tempfile_path)
 
 def run():
     parser = argparse.ArgumentParser(

--- a/loadtest/scripts/run_tests.py
+++ b/loadtest/scripts/run_tests.py
@@ -23,9 +23,9 @@ class LoadTestConfig:
 
 
 def write_to_temp_json_file(data):
-    with tempfile.NamedTemporaryFile(mode='w', encoding='utf-8', delete=False) as tmp:
-        json.dump(data, tmp, ensure_ascii=False)
-        return tmp.name
+    temp_file = tempfile.NamedTemporaryFile(mode='w', encoding='utf-8', delete=False)
+    json.dump(data, temp_file, ensure_ascii=False)
+    return temp_file
 
 def create_burst_loadtest_config(base_config_json):
     new_config = base_config_json.copy()
@@ -74,9 +74,11 @@ def run_test(test_type, loadtest_config):
     elif test_type == STEADY:
         config = create_steady_loadtest_config(base_config_json)
 
-    tempfile_path = write_to_temp_json_file(config)
-    run_go_loadtest_client(tempfile_path, binary_path=loadtest_config.loadtest_binary_file_path)
-    os.remove(tempfile_path)
+    temp_file = write_to_temp_json_file(config)
+    try:
+        run_go_loadtest_client(temp_file.name, binary_path=loadtest_config.loadtest_binary_file_path)
+    finally:
+        temp_file.close()
 
 def run():
     parser = argparse.ArgumentParser(

--- a/loadtest/scripts/run_tests.py
+++ b/loadtest/scripts/run_tests.py
@@ -75,10 +75,11 @@ def run_test(test_type, loadtest_config):
         config = create_steady_loadtest_config(base_config_json)
 
     temp_file = write_to_temp_json_file(config)
+    temp_file.close()
     try:
         run_go_loadtest_client(temp_file.name, binary_path=loadtest_config.loadtest_binary_file_path)
     finally:
-        temp_file.close()
+        os.delete(temp_file.name)
 
 def run():
     parser = argparse.ArgumentParser(

--- a/loadtest/scripts/run_tests.py
+++ b/loadtest/scripts/run_tests.py
@@ -23,9 +23,9 @@ class LoadTestConfig:
 
 
 def write_to_temp_json_file(data):
-    temp_file = tempfile.NamedTemporaryFile(mode='w', encoding='utf-8', delete=False)
-    json.dump(data, temp_file, ensure_ascii=False)
-    return temp_file
+    with tempfile.NamedTemporaryFile(mode='w', encoding='utf-8', delete=False) as temp_file:
+        json.dump(data, temp_file, ensure_ascii=False)
+        return temp_file.name
 
 def create_burst_loadtest_config(base_config_json):
     new_config = base_config_json.copy()
@@ -74,12 +74,11 @@ def run_test(test_type, loadtest_config):
     elif test_type == STEADY:
         config = create_steady_loadtest_config(base_config_json)
 
-    temp_file = write_to_temp_json_file(config)
-    temp_file.close()
+    temp_file_path = write_to_temp_json_file(config)
     try:
-        run_go_loadtest_client(temp_file.name, binary_path=loadtest_config.loadtest_binary_file_path)
+        run_go_loadtest_client(temp_file_path, binary_path=loadtest_config.loadtest_binary_file_path)
     finally:
-        os.remove(temp_file.name)
+        os.remove(temp_file_path)
 
 def run():
     parser = argparse.ArgumentParser(

--- a/loadtest/types.go
+++ b/loadtest/types.go
@@ -25,18 +25,19 @@ const (
 )
 
 type Config struct {
-	ChainID           string                `json:"chain_id"`
-	TxsPerBlock       uint64                `json:"txs_per_block"`
-	MsgsPerTx         uint64                `json:"msgs_per_tx"`
-	Rounds            uint64                `json:"rounds"`
-	MessageType       string                `json:"message_type"`
-	RunOracle         bool                  `json:"run_oracle"`
-	PriceDistr        NumericDistribution   `json:"price_distribution"`
-	QuantityDistr     NumericDistribution   `json:"quantity_distribution"`
-	MsgTypeDistr      MsgTypeDistribution   `json:"message_type_distribution"`
-	ContractDistr     ContractDistributions `json:"contract_distribution"`
-	Constant          bool                  `json:"constant"`
-	ConstLoadInterval int64                 `json:"const_load_interval"`
+	ChainID       string                `json:"chain_id"`
+	TxsPerBlock   uint64                `json:"txs_per_block"`
+	MsgsPerTx     uint64                `json:"msgs_per_tx"`
+	Rounds        uint64                `json:"rounds"`
+	MessageType   string                `json:"message_type"`
+	RunOracle     bool                  `json:"run_oracle"`
+	PriceDistr    NumericDistribution   `json:"price_distribution"`
+	QuantityDistr NumericDistribution   `json:"quantity_distribution"`
+	MsgTypeDistr  MsgTypeDistribution   `json:"message_type_distribution"`
+	ContractDistr ContractDistributions `json:"contract_distribution"`
+	MetricsPort   uint64                `json:"metrics_port"`
+	Constant      bool                  `json:"constant"`
+	LoadInterval  int64                 `json:"loadtest_interval"`
 }
 
 type EncodingConfig struct {

--- a/x/oracle/simulation/operations.go
+++ b/x/oracle/simulation/operations.go
@@ -65,7 +65,7 @@ func WeightedOperations(
 }
 
 // SimulateMsgAggregateExchangeRateVote generates a MsgAggregateExchangeRateVote with random values.
-// nolint: funlen
+//nolint: funlen
 func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
@@ -122,7 +122,7 @@ func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankK
 }
 
 // SimulateMsgDelegateFeedConsent generates a MsgDelegateFeedConsent with random values.
-// nolint: funlen
+//nolint: funlen
 func SimulateMsgDelegateFeedConsent(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,


### PR DESCRIPTION
## Describe your changes and provide context
Adding a python script wrapper to be able to run load tests with different configurations, it uses the existing loadtest/config.json as the base and creates a copy of it with different 

Will make another PR to create service config files for these to run internally

Burst:
* Much larger tx per block but less cadence

Steady:
* Less TX per block but the higher cadence 

## Testing performed to validate your change
Steady Mode
![image](https://user-images.githubusercontent.com/18161326/200626650-3262ddb3-5aa8-40a0-8878-8d620d6b68e4.png)

Burst mode 
![image](https://user-images.githubusercontent.com/18161326/200626695-9171005d-3d62-4595-b23a-dcd10f08527d.png)