### PR TITLE
add mock server provider

### DIFF
--- a/oracle/price-feeder/oracle/provider/gate_test.go
+++ b/oracle/price-feeder/oracle/provider/gate_test.go
@@ -13,10 +13,19 @@ import (
 )
 
 func TestGateProvider_GetTickerPrices(t *testing.T) {
+	// use mock provider server
+	server := NewMockProviderServer()
+	server.Start()
+	defer server.Close()
+
 	p, err := NewGateProvider(
 		context.TODO(),
 		zerolog.Nop(),
-		config.ProviderEndpoint{},
+		config.ProviderEndpoint{
+			Name:      config.ProviderGate,
+			Rest:      "",
+			Websocket: server.GetBaseURL(),
+		},
 		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
 	)
 	require.NoError(t, err)
@@ -81,10 +90,19 @@ func TestGateProvider_GetTickerPrices(t *testing.T) {
 }
 
 func TestGateProvider_SubscribeCurrencyPairs(t *testing.T) {
+	// // use mock provider server
+	server := NewMockProviderServer()
+	server.Start()
+	defer server.Close()
+
 	p, err := NewGateProvider(
 		context.TODO(),
 		zerolog.Nop(),
-		config.ProviderEndpoint{},
+		config.ProviderEndpoint{
+			Name:      config.ProviderGate,
+			Rest:      "",
+			Websocket: server.GetBaseURL(),
+		},
 		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
 	)
 	require.NoError(t, err)

--- a/oracle/price-feeder/oracle/provider/mock_server.go
+++ b/oracle/price-feeder/oracle/provider/mock_server.go
@@ -1,0 +1,54 @@
+package provider
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/gorilla/websocket"
+)
+
+type MockProviderServer struct {
+	handlerFunc http.HandlerFunc
+	server      *httptest.Server
+}
+
+func NewMockServer() MockProviderServer {
+	mockProvider := MockProviderServer{}
+	// default to echo handler
+	mockProvider.SetHandler(echo)
+	return mockProvider
+}
+
+func (m *MockProviderServer) SetHandler(handler http.HandlerFunc) {
+	m.Close()
+	m.handlerFunc = handler
+	m.Start()
+}
+
+func (m *MockProviderServer) Start() {
+	m.server = httptest.NewServer(http.HandlerFunc(m.handlerFunc))
+}
+
+func (m *MockProviderServer) Close() {
+	m.server.Close()
+}
+
+var upgrader = websocket.Upgrader{}
+
+func echo(w http.ResponseWriter, r *http.Request) {
+	c, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer c.Close()
+	for {
+		mt, message, err := c.ReadMessage()
+		if err != nil {
+			break
+		}
+		err = c.WriteMessage(mt, message)
+		if err != nil {
+			break
+		}
+	}
+}

--- a/oracle/price-feeder/oracle/provider/mock_server_test.go
+++ b/oracle/price-feeder/oracle/provider/mock_server_test.go
@@ -1,0 +1,40 @@
+package provider
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestMockServer(t *testing.T) {
+	// Create test server with the echo handler.
+	s := httptest.NewServer(http.HandlerFunc(echo))
+	defer s.Close()
+
+	// Convert http://127.0.0.1 to ws://127.0.0.
+	u := "ws" + strings.TrimPrefix(s.URL, "http")
+
+	// Connect to the server
+	ws, _, err := websocket.DefaultDialer.Dial(u, nil)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	defer ws.Close()
+
+	// Send message to server, read response and check to see if it's what we expect.
+	for i := 0; i < 10; i++ {
+		if err := ws.WriteMessage(websocket.TextMessage, []byte("hello")); err != nil {
+			t.Fatalf("%v", err)
+		}
+		_, p, err := ws.ReadMessage()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+		if string(p) != "hello" {
+			t.Fatalf("bad message")
+		}
+	}
+}

--- a/oracle/price-feeder/oracle/provider/mock_server_test.go
+++ b/oracle/price-feeder/oracle/provider/mock_server_test.go
@@ -1,24 +1,18 @@
 package provider
 
 import (
-	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/gorilla/websocket"
 )
 
 func TestMockServer(t *testing.T) {
-	// Create test server with the echo handler.
-	s := httptest.NewServer(http.HandlerFunc(echo))
+	s := NewMockProviderServer()
+	s.Start()
 	defer s.Close()
 
-	// Convert http://127.0.0.1 to ws://127.0.0.
-	u := "ws" + strings.TrimPrefix(s.URL, "http")
-
 	// Connect to the server
-	ws, _, err := websocket.DefaultDialer.Dial(u, nil)
+	ws, _, err := websocket.DefaultDialer.Dial(s.GetWebsocketURL(), nil)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}


### PR DESCRIPTION
## Describe your changes and provide context
This adds a mock websocket server for mocking providers more robustly in unit testing.

## Testing performed to validate your change
Added unit tests for mock server, and tested the flaky gate provider unit tests with -count 10 to ensure it was no longer flaky
