### PR TITLE
Move order placement in MemState to store

### DIFF
--- a/aclmapping/dex/mappings_test.go
+++ b/aclmapping/dex/mappings_test.go
@@ -146,7 +146,7 @@ func (suite *KeeperTestSuite) TestMsgPlaceOrder() {
 	}
 	for _, tc := range tests {
 		suite.Run(fmt.Sprintf("Test Case: %s", tc.name), func() {
-			goCtx := context.WithValue(suite.Ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState())
+			goCtx := context.WithValue(suite.Ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState(suite.App.GetKey(dextypes.StoreKey)))
 			suite.Ctx = suite.Ctx.WithContext(goCtx)
 
 			handlerCtx, cms := aclutils.CacheTxContext(suite.Ctx)
@@ -202,7 +202,7 @@ func (suite *KeeperTestSuite) TestMsgCancelOrder() {
 	}
 	for _, tc := range tests {
 		suite.Run(fmt.Sprintf("Test Case: %s", tc.name), func() {
-			goCtx := context.WithValue(suite.Ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState())
+			goCtx := context.WithValue(suite.Ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState(suite.App.GetKey(dextypes.StoreKey)))
 			suite.Ctx = suite.Ctx.WithContext(goCtx)
 
 			_, err := suite.msgServer.PlaceOrders(

--- a/app/app.go
+++ b/app/app.go
@@ -1411,7 +1411,7 @@ func (app *App) BlacklistedAccAddrs() map[string]bool {
 }
 
 func (app *App) decorateContextWithDexMemState(base context.Context) context.Context {
-	return context.WithValue(base, dexutils.DexMemStateContextKey, dexcache.NewMemState())
+	return context.WithValue(base, dexutils.DexMemStateContextKey, dexcache.NewMemState(app.GetKey(dexmoduletypes.StoreKey)))
 }
 
 func init() {

--- a/testutil/keeper/dex.go
+++ b/testutil/keeper/dex.go
@@ -111,7 +111,7 @@ func DexKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
 	}
 	bankKeeper.SetParams(ctx, bankParams)
 
-	return k, ctx.WithContext(context.WithValue(ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState()))
+	return k, ctx.WithContext(context.WithValue(ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState(storeKey)))
 }
 
 func CreateAssetMetadata(keeper *keeper.Keeper, ctx sdk.Context) types.AssetMetadata {

--- a/wasmbinding/test/query_test.go
+++ b/wasmbinding/test/query_test.go
@@ -277,7 +277,7 @@ func TestWasmGetOrderSimulation(t *testing.T) {
 	require.NoError(t, err)
 
 	testWrapper.Ctx = testWrapper.Ctx.WithBlockHeight(11).WithBlockTime(time.Unix(3600, 0))
-	testWrapper.Ctx = testWrapper.Ctx.WithContext(context.WithValue(testWrapper.Ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState()))
+	testWrapper.Ctx = testWrapper.Ctx.WithContext(context.WithValue(testWrapper.Ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState(testWrapper.App.GetKey(dextypes.StoreKey))))
 	testWrapper.App.DexKeeper.AddRegisteredPair(
 		testWrapper.Ctx,
 		app.TestContract,
@@ -290,7 +290,7 @@ func TestWasmGetOrderSimulation(t *testing.T) {
 	}, app.TestContract)
 	testWrapper.App.OracleKeeper.SetBaseExchangeRate(testWrapper.Ctx, oracleutils.MicroAtomDenom, sdk.NewDec(12))
 	testWrapper.Ctx = testWrapper.Ctx.WithBlockHeight(14).WithBlockTime(time.Unix(3700, 0))
-	testWrapper.Ctx = testWrapper.Ctx.WithContext(context.WithValue(testWrapper.Ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState()))
+	testWrapper.Ctx = testWrapper.Ctx.WithContext(context.WithValue(testWrapper.Ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState(testWrapper.App.GetKey(dextypes.StoreKey))))
 
 	res, err := customQuerier(testWrapper.Ctx, rawQuery)
 	require.NoError(t, err)

--- a/x/dex/cache/cache_test.go
+++ b/x/dex/cache/cache_test.go
@@ -68,7 +68,7 @@ func TestDeepFilterAccounts(t *testing.T) {
 		Creator: "test2",
 	})
 
-	stateOne.DeepFilterAccount("test")
+	stateOne.DeepFilterAccount(ctx, "test")
 	require.Equal(t, 2, len(stateOne.GetAllBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT))))
 	require.Equal(t, 1, len(stateOne.GetBlockCancels(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Get()))
 	require.Equal(t, 1, len(stateOne.GetDepositInfo(ctx, utils.ContractAddress(TEST_CONTRACT)).Get()))

--- a/x/dex/cache/cache_test.go
+++ b/x/dex/cache/cache_test.go
@@ -69,7 +69,7 @@ func TestDeepFilterAccounts(t *testing.T) {
 	})
 
 	stateOne.DeepFilterAccount(ctx, "test")
-	require.Equal(t, 2, len(stateOne.GetAllBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT))))
+	require.Equal(t, 1, len(stateOne.GetAllBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT))))
 	require.Equal(t, 1, len(stateOne.GetBlockCancels(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Get()))
 	require.Equal(t, 1, len(stateOne.GetDepositInfo(ctx, utils.ContractAddress(TEST_CONTRACT)).Get()))
 }

--- a/x/dex/cache/cache_test.go
+++ b/x/dex/cache/cache_test.go
@@ -5,10 +5,12 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/utils/datastructures"
 	dex "github.com/sei-protocol/sei-chain/x/dex/cache"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 	"github.com/sei-protocol/sei-chain/x/dex/types/utils"
+	"github.com/sei-protocol/sei-chain/x/store"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,15 +20,16 @@ const (
 )
 
 func TestDeepCopy(t *testing.T) {
-	ctx := sdk.Context{}
-	stateOne := dex.NewMemState()
+	keeper, ctx := keepertest.DexKeeper(t)
+	stateOne := dex.NewMemState(keeper.GetStoreKey())
 	stateOne.GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Add(&types.Order{
 		Id:           1,
 		Account:      "test",
 		ContractAddr: TEST_CONTRACT,
 	})
 	stateTwo := stateOne.DeepCopy()
-	stateTwo.GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Add(&types.Order{
+	cachedCtx, _ := store.GetCachedContext(ctx)
+	stateTwo.GetBlockOrders(cachedCtx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Add(&types.Order{
 		Id:           2,
 		Account:      "test",
 		ContractAddr: TEST_CONTRACT,
@@ -34,12 +37,12 @@ func TestDeepCopy(t *testing.T) {
 	// old state must not be changed
 	require.Equal(t, 1, len(stateOne.GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Get()))
 	// new state must be changed
-	require.Equal(t, 2, len(stateTwo.GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Get()))
+	require.Equal(t, 2, len(stateTwo.GetBlockOrders(cachedCtx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Get()))
 }
 
 func TestDeepFilterAccounts(t *testing.T) {
-	ctx := sdk.Context{}
-	stateOne := dex.NewMemState()
+	keeper, ctx := keepertest.DexKeeper(t)
+	stateOne := dex.NewMemState(keeper.GetStoreKey())
 	stateOne.GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Add(&types.Order{
 		Id:           1,
 		Account:      "test",
@@ -66,26 +69,26 @@ func TestDeepFilterAccounts(t *testing.T) {
 	})
 
 	stateOne.DeepFilterAccount("test")
-	require.Equal(t, 1, stateOne.GetAllBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT)).Len())
+	require.Equal(t, 2, len(stateOne.GetAllBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT))))
 	require.Equal(t, 1, len(stateOne.GetBlockCancels(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Get()))
 	require.Equal(t, 1, len(stateOne.GetDepositInfo(ctx, utils.ContractAddress(TEST_CONTRACT)).Get()))
 }
 
 func TestClear(t *testing.T) {
-	ctx := sdk.Context{}
-	stateOne := dex.NewMemState()
+	keeper, ctx := keepertest.DexKeeper(t)
+	stateOne := dex.NewMemState(keeper.GetStoreKey())
 	stateOne.GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Add(&types.Order{
 		Id:           1,
 		Account:      "test",
 		ContractAddr: TEST_CONTRACT,
 	})
-	stateOne.Clear()
+	stateOne.Clear(ctx)
 	require.Equal(t, 0, len(stateOne.GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Get()))
 }
 
 func TestSynchronization(t *testing.T) {
-	ctx := sdk.Context{}
-	stateOne := dex.NewMemState()
+	_, ctx := keepertest.DexKeeper(t)
+	stateOne := dex.NewMemState(sdk.NewKVStoreKey(types.StoreKey))
 	targetContract := utils.ContractAddress(TEST_CONTRACT)
 	// no go context
 	require.NotPanics(t, func() { stateOne.SynchronizeAccess(ctx, targetContract) })

--- a/x/dex/cache/order_test.go
+++ b/x/dex/cache/order_test.go
@@ -3,7 +3,6 @@ package dex_test
 import (
 	"testing"
 
-	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
 	dex "github.com/sei-protocol/sei-chain/x/dex/cache"
@@ -12,23 +11,6 @@ import (
 	"github.com/sei-protocol/sei-chain/x/dex/types/wasm"
 	"github.com/stretchr/testify/require"
 )
-
-func TestOrderFilterByAccount(t *testing.T) {
-	keeper, ctx := keepertest.DexKeeper(t)
-	orders := dex.NewOrders(
-		prefix.NewStore(
-			ctx.KVStore(keeper.GetStoreKey()),
-			[]byte("some prefix"),
-		),
-	)
-	order := types.Order{
-		Id:      1,
-		Account: "abc",
-	}
-	orders.Add(&order)
-	orders.FilterByAccount("abc")
-	require.Equal(t, 0, len(orders.Get()))
-}
 
 func TestMarkFailedToPlace(t *testing.T) {
 	keeper, ctx := keepertest.DexKeeper(t)

--- a/x/dex/cache/order_test.go
+++ b/x/dex/cache/order_test.go
@@ -3,7 +3,9 @@ package dex_test
 import (
 	"testing"
 
+	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
 	dex "github.com/sei-protocol/sei-chain/x/dex/cache"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 	"github.com/sei-protocol/sei-chain/x/dex/types/utils"
@@ -12,7 +14,13 @@ import (
 )
 
 func TestOrderFilterByAccount(t *testing.T) {
-	orders := dex.NewOrders()
+	keeper, ctx := keepertest.DexKeeper(t)
+	orders := dex.NewOrders(
+		prefix.NewStore(
+			ctx.KVStore(keeper.GetStoreKey()),
+			[]byte("some prefix"),
+		),
+	)
 	order := types.Order{
 		Id:      1,
 		Account: "abc",
@@ -23,8 +31,8 @@ func TestOrderFilterByAccount(t *testing.T) {
 }
 
 func TestMarkFailedToPlace(t *testing.T) {
-	ctx := sdk.Context{}
-	stateOne := dex.NewMemState()
+	keeper, ctx := keepertest.DexKeeper(t)
+	stateOne := dex.NewMemState(keeper.GetStoreKey())
 	stateOne.GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Add(&types.Order{
 		Id:           1,
 		Account:      "test",
@@ -42,8 +50,8 @@ func TestMarkFailedToPlace(t *testing.T) {
 }
 
 func TestGetSortedMarketOrders(t *testing.T) {
-	ctx := sdk.Context{}
-	stateOne := dex.NewMemState()
+	keeper, ctx := keepertest.DexKeeper(t)
+	stateOne := dex.NewMemState(keeper.GetStoreKey())
 	stateOne.GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Add(&types.Order{
 		Id:                1,
 		Account:           "test",
@@ -141,8 +149,8 @@ func TestGetSortedMarketOrders(t *testing.T) {
 }
 
 func TestGetTriggeredOrders(t *testing.T) {
-	ctx := sdk.Context{}
-	stateOne := dex.NewMemState()
+	keeper, ctx := keepertest.DexKeeper(t)
+	stateOne := dex.NewMemState(keeper.GetStoreKey())
 	stateOne.GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Add(&types.Order{
 		Id:                1,
 		Account:           "test",

--- a/x/dex/contract/abci.go
+++ b/x/dex/contract/abci.go
@@ -203,7 +203,6 @@ func orderMatchingRunnable(ctx context.Context, sdkContext sdk.Context, env *env
 	sdkContext.Logger().Info(fmt.Sprintf("End block for %s", contractInfo.ContractAddr))
 	pairs, pairFound := env.registeredPairs.Load(contractInfo.ContractAddr)
 	orderBooks, found := env.orderBooks.Load(contractInfo.ContractAddr)
-	fmt.Println(env.failedContractAddresses.Size())
 	if !pairFound || !found {
 		sdkContext.Logger().Error(fmt.Sprintf("No pair or order book for %s", contractInfo.ContractAddr))
 		env.failedContractAddresses.Add(contractInfo.ContractAddr)

--- a/x/dex/contract/abci.go
+++ b/x/dex/contract/abci.go
@@ -203,6 +203,7 @@ func orderMatchingRunnable(ctx context.Context, sdkContext sdk.Context, env *env
 	sdkContext.Logger().Info(fmt.Sprintf("End block for %s", contractInfo.ContractAddr))
 	pairs, pairFound := env.registeredPairs.Load(contractInfo.ContractAddr)
 	orderBooks, found := env.orderBooks.Load(contractInfo.ContractAddr)
+	fmt.Println(env.failedContractAddresses.Size())
 	if !pairFound || !found {
 		sdkContext.Logger().Error(fmt.Sprintf("No pair or order book for %s", contractInfo.ContractAddr))
 		env.failedContractAddresses.Add(contractInfo.ContractAddr)

--- a/x/dex/contract/abci.go
+++ b/x/dex/contract/abci.go
@@ -243,7 +243,7 @@ func filterNewValidContracts(ctx sdk.Context, env *environment) []types.Contract
 		}
 	}
 	for _, failedContractAddress := range env.failedContractAddresses.ToOrderedSlice(datastructures.StringComparator) {
-		dexutils.GetMemState(ctx.Context()).DeepFilterAccount(failedContractAddress)
+		dexutils.GetMemState(ctx.Context()).DeepFilterAccount(ctx, failedContractAddress)
 	}
 	return newValidContracts
 }

--- a/x/dex/contract/execution.go
+++ b/x/dex/contract/execution.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sei-protocol/sei-chain/store/whitelist/multi"
 	"github.com/sei-protocol/sei-chain/utils"
 	"github.com/sei-protocol/sei-chain/utils/datastructures"
-	dexcache "github.com/sei-protocol/sei-chain/x/dex/cache"
 	"github.com/sei-protocol/sei-chain/x/dex/exchange"
 	"github.com/sei-protocol/sei-chain/x/dex/keeper"
 	dexkeeperabci "github.com/sei-protocol/sei-chain/x/dex/keeper/abci"
@@ -274,9 +273,7 @@ func HandleExecutionForContract(
 	defer EmitSettlementMetrics(settlements)
 
 	// populate order placement results for FinalizeBlock hook
-	dexutils.GetMemState(sdkCtx.Context()).GetAllBlockOrders(sdkCtx, typedContractAddr).DeepApply(func(orders *dexcache.BlockOrders) {
-		dextypeswasm.PopulateOrderPlacementResults(contractAddr, orders.Get(), cancellations, orderResults)
-	})
+	dextypeswasm.PopulateOrderPlacementResults(contractAddr, dexutils.GetMemState(sdkCtx.Context()).GetAllBlockOrders(sdkCtx, typedContractAddr), cancellations, orderResults)
 	dextypeswasm.PopulateOrderExecutionResults(contractAddr, settlements, orderResults)
 
 	return orderResults, settlements, nil

--- a/x/dex/contract/whitelist.go
+++ b/x/dex/contract/whitelist.go
@@ -21,6 +21,7 @@ var DexWhitelistedKeys = []string{
 	types.NextOrderIDKey,
 	types.MatchResultKey,
 	keeper.ContractPrefixKey,
+	types.MemOrderKey,
 }
 
 var WasmWhitelistedKeys = []string{

--- a/x/dex/keeper/abci/end_block_place_orders_test.go
+++ b/x/dex/keeper/abci/end_block_place_orders_test.go
@@ -40,7 +40,7 @@ func TestGetPlaceSudoMsg(t *testing.T) {
 func TestGetDepositSudoMsg(t *testing.T) {
 	testApp := keepertest.TestApp()
 	ctx := testApp.BaseApp.NewContext(false, tmproto.Header{})
-	ctx = ctx.WithContext(context.WithValue(ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState()))
+	ctx = ctx.WithContext(context.WithValue(ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState(testApp.GetKey(types.StoreKey))))
 	bankkeeper := testApp.BankKeeper
 	testAccount, _ := sdk.AccAddressFromBech32("sei1yezq49upxhunjjhudql2fnj5dgvcwjj87pn2wx")
 	amounts := sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(1000000)))

--- a/x/dex/keeper/keeper.go
+++ b/x/dex/keeper/keeper.go
@@ -46,7 +46,7 @@ func NewPlainKeeper(
 		storeKey:   storeKey,
 		memKey:     memKey,
 		Paramstore: ps,
-		MemState:   dexcache.NewMemState(),
+		MemState:   dexcache.NewMemState(storeKey),
 	}
 }
 
@@ -71,7 +71,7 @@ func NewKeeper(
 		EpochKeeper:   epochKeeper,
 		BankKeeper:    bankKeeper,
 		AccountKeeper: accountKeeper,
-		MemState:      dexcache.NewMemState(),
+		MemState:      dexcache.NewMemState(storeKey),
 	}
 }
 

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -224,7 +224,7 @@ func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
 	}()
 	defer utils.PanicHandler(func(err any) { utils.MetricsPanicCallback(err, ctx, types.ModuleName) })()
 
-	dexutils.GetMemState(ctx.Context()).Clear()
+	dexutils.GetMemState(ctx.Context()).Clear(ctx)
 	isNewEpoch, currentEpoch := am.keeper.IsNewEpoch(ctx)
 	if isNewEpoch {
 		am.keeper.SetEpoch(ctx, currentEpoch)
@@ -261,6 +261,7 @@ func (am AppModule) beginBlockForContract(ctx sdk.Context, contract types.Contra
 func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) (ret []abci.ValidatorUpdate) {
 	_, span := (*am.tracingInfo.Tracer).Start(am.tracingInfo.TracerContext, "DexEndBlock")
 	defer span.End()
+	defer dexutils.GetMemState(ctx.Context()).Clear(ctx)
 	// TODO (codchen): Revert https://github.com/sei-protocol/sei-chain/pull/176/files before mainnet so we don't silently fail on errors
 	defer utils.PanicHandler(func(err any) {
 		_, span := (*am.tracingInfo.Tracer).Start(am.tracingInfo.TracerContext, "DexEndBlockRollback")

--- a/x/dex/module_test.go
+++ b/x/dex/module_test.go
@@ -49,7 +49,7 @@ const (
 func TestEndBlockMarketOrder(t *testing.T) {
 	testApp := keepertest.TestApp()
 	ctx := testApp.BaseApp.NewContext(false, tmproto.Header{Time: time.Now()})
-	ctx = ctx.WithContext(context.WithValue(ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState()))
+	ctx = ctx.WithContext(context.WithValue(ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState(testApp.GetKey(types.StoreKey))))
 	dexkeeper := testApp.DexKeeper
 	pair := types.Pair{PriceDenom: "SEI", AssetDenom: "ATOM"}
 
@@ -118,7 +118,7 @@ func TestEndBlockMarketOrder(t *testing.T) {
 	// Long book should be populated
 	require.True(t, found)
 
-	dexutils.GetMemState(ctx.Context()).Clear()
+	dexutils.GetMemState(ctx.Context()).Clear(ctx)
 	dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, utils.ContractAddress(contractAddr.String()), utils.GetPairString(&pair)).Add(
 		&types.Order{
 			Id:                3,
@@ -149,7 +149,7 @@ func TestEndBlockMarketOrder(t *testing.T) {
 	require.Equal(t, 1, len(matchResults.Orders))
 	require.Equal(t, 2, len(matchResults.Settlements))
 
-	dexutils.GetMemState(ctx.Context()).Clear()
+	dexutils.GetMemState(ctx.Context()).Clear(ctx)
 	dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, utils.ContractAddress(contractAddr.String()), utils.GetPairString(&pair)).Add(
 		&types.Order{
 			Id:                4,
@@ -176,7 +176,7 @@ func TestEndBlockMarketOrder(t *testing.T) {
 func TestEndBlockLimitOrder(t *testing.T) {
 	testApp := keepertest.TestApp()
 	ctx := testApp.BaseApp.NewContext(false, tmproto.Header{Time: time.Now()})
-	ctx = ctx.WithContext(context.WithValue(ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState()))
+	ctx = ctx.WithContext(context.WithValue(ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState(testApp.GetKey(types.StoreKey))))
 	dexkeeper := testApp.DexKeeper
 	pair := types.Pair{PriceDenom: "SEI", AssetDenom: "ATOM"}
 
@@ -263,7 +263,7 @@ func TestEndBlockLimitOrder(t *testing.T) {
 	_, found = dexkeeper.GetShortBookByPrice(ctx, contractAddr.String(), sdk.MustNewDecFromStr("3"), pair.PriceDenom, pair.AssetDenom)
 	require.True(t, found)
 
-	dexutils.GetMemState(ctx.Context()).Clear()
+	dexutils.GetMemState(ctx.Context()).Clear(ctx)
 	dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, utils.ContractAddress(contractAddr.String()), utils.GetPairString(&pair)).Add(
 		&types.Order{
 			Id:                4,
@@ -309,7 +309,7 @@ func TestEndBlockLimitOrder(t *testing.T) {
 	require.Equal(t, 2, len(matchResults.Orders))
 	require.Equal(t, 4, len(matchResults.Settlements))
 
-	dexutils.GetMemState(ctx.Context()).Clear()
+	dexutils.GetMemState(ctx.Context()).Clear(ctx)
 	dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, utils.ContractAddress(contractAddr.String()), utils.GetPairString(&pair)).Add(
 		&types.Order{
 			Id:                6,
@@ -343,7 +343,7 @@ func TestEndBlockLimitOrder(t *testing.T) {
 func TestEndBlockRollback(t *testing.T) {
 	testApp := keepertest.TestApp()
 	ctx := testApp.BaseApp.NewContext(false, tmproto.Header{})
-	ctx = ctx.WithContext(context.WithValue(ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState()))
+	ctx = ctx.WithContext(context.WithValue(ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState(testApp.GetKey(types.StoreKey))))
 	dexkeeper := testApp.DexKeeper
 	pair := TEST_PAIR()
 	// register contract and pair
@@ -373,7 +373,7 @@ func TestEndBlockRollback(t *testing.T) {
 func TestEndBlockPartialRollback(t *testing.T) {
 	testApp := keepertest.TestApp()
 	ctx := testApp.BaseApp.NewContext(false, tmproto.Header{Time: time.Now()})
-	ctx = ctx.WithContext(context.WithValue(ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState()))
+	ctx = ctx.WithContext(context.WithValue(ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState(testApp.GetKey(types.StoreKey))))
 	// BAD CONTRACT
 	dexkeeper := testApp.DexKeeper
 	pair := TEST_PAIR()
@@ -456,7 +456,7 @@ func TestEndBlockPartialRollback(t *testing.T) {
 func TestBeginBlock(t *testing.T) {
 	testApp := keepertest.TestApp()
 	ctx := testApp.BaseApp.NewContext(false, tmproto.Header{Time: time.Now()})
-	ctx = ctx.WithContext(context.WithValue(ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState()))
+	ctx = ctx.WithContext(context.WithValue(ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState(testApp.GetKey(types.StoreKey))))
 	dexkeeper := testApp.DexKeeper
 
 	testAccount, _ := sdk.AccAddressFromBech32("sei1yezq49upxhunjjhudql2fnj5dgvcwjj87pn2wx")
@@ -495,7 +495,7 @@ func TestBeginBlock(t *testing.T) {
 func TestEndBlockPanicHandling(t *testing.T) {
 	testApp := keepertest.TestApp()
 	ctx := testApp.BaseApp.NewContext(false, tmproto.Header{Time: time.Now()})
-	ctx = ctx.WithContext(context.WithValue(ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState()))
+	ctx = ctx.WithContext(context.WithValue(ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState(testApp.GetKey(types.StoreKey))))
 	dexkeeper := testApp.DexKeeper
 	pair := types.Pair{PriceDenom: "SEI", AssetDenom: "ATOM"}
 

--- a/x/dex/types/keys.go
+++ b/x/dex/types/keys.go
@@ -137,6 +137,17 @@ func GetSettlementKey(orderID uint64, account string, settlementID uint64) []byt
 	return append(GetSettlementOrderIDPrefix(orderID, account), settlementIDBytes...)
 }
 
+func MemOrderPrefixForPair(contractAddr string, pairString string) []byte {
+	return append(
+		append(KeyPrefix(MemOrderKey), KeyPrefix(contractAddr)...),
+		[]byte(pairString)...,
+	)
+}
+
+func MemOrderPrefix(contractAddr string) []byte {
+	return append(KeyPrefix(MemOrderKey), KeyPrefix(contractAddr)...)
+}
+
 const (
 	DefaultPriceDenom = "stake"
 	DefaultAssetDenom = "dummy"
@@ -163,4 +174,6 @@ const (
 	TickSizeKey         = "ticks"
 	AssetListKey        = "AssetList-"
 	MatchResultKey      = "MatchResult-"
+
+	MemOrderKey = "MemOrder-"
 )


### PR DESCRIPTION
## Describe your changes and provide context
Change the underlying data of order placement in MemState to be backed by KV store. Some details to note:
- `GetBlockOrders` always instantiates a new `BlockOrders` which is now just a wrapper over the underlying KV store
- `DeepCopy` of `BlockOrders` don't really do anything
- these order placement KV entries are deleted at the end of each block because they don't need to get written to disk during `Commit()`

## Testing performed to validate your change
unit tests
