### PR TITLE
[ante] Fix gasless ante and allow for specifying gas with gasless txs

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sei-protocol/sei-chain/x/dex"
 	dexkeeper "github.com/sei-protocol/sei-chain/x/dex/keeper"
 	nitrokeeper "github.com/sei-protocol/sei-chain/x/nitro/keeper"
-	"github.com/sei-protocol/sei-chain/x/oracle"
 	oraclekeeper "github.com/sei-protocol/sei-chain/x/oracle/keeper"
 )
 
@@ -80,7 +79,7 @@ func NewAnteHandlerAndDepGenerator(options HandlerOptions) (sdk.AnteHandler, sdk
 		antedecorators.NewGaslessDecorator([]sdk.AnteFullDecorator{ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TxFeeChecker)}, *options.OracleKeeper, *options.NitroKeeper),
 		sdk.DefaultWrappedAnteDecorator(wasmkeeper.NewLimitSimulationGasDecorator(options.WasmConfig.SimulationGasLimit)), // after setup context to enforce limits early
 		sdk.DefaultWrappedAnteDecorator(ante.NewRejectExtensionOptionsDecorator()),
-		oracle.NewSpammingPreventionDecorator(*options.OracleKeeper),
+		// oracle.NewSpammingPreventionDecorator(*options.OracleKeeper), // TODO: UNDO THIS
 		sdk.DefaultWrappedAnteDecorator(ante.NewValidateBasicDecorator()),
 		sdk.DefaultWrappedAnteDecorator(ante.NewTxTimeoutHeightDecorator()),
 		sdk.DefaultWrappedAnteDecorator(ante.NewValidateMemoDecorator(options.AccountKeeper)),

--- a/app/ante.go
+++ b/app/ante.go
@@ -77,7 +77,7 @@ func NewAnteHandlerAndDepGenerator(options HandlerOptions) (sdk.AnteHandler, sdk
 	anteDecorators := []sdk.AnteFullDecorator{
 		sdk.DefaultWrappedAnteDecorator(ante.NewSetUpContextDecorator(antedecorators.GetGasMeterSetter(*options.AccessControlKeeper))), // outermost AnteDecorator. SetUpContext must be called first
 		// TODO: have dex antehandler separate, and then call the individual antehandlers FROM the gasless antehandler decorator wrapper
-		antedecorators.NewGaslessDecorator([]sdk.AnteDecorator{}, *options.OracleKeeper, *options.NitroKeeper),
+		antedecorators.NewGaslessDecorator([]sdk.AnteFullDecorator{ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TxFeeChecker)}, *options.OracleKeeper, *options.NitroKeeper),
 		sdk.DefaultWrappedAnteDecorator(wasmkeeper.NewLimitSimulationGasDecorator(options.WasmConfig.SimulationGasLimit)), // after setup context to enforce limits early
 		sdk.DefaultWrappedAnteDecorator(ante.NewRejectExtensionOptionsDecorator()),
 		oracle.NewSpammingPreventionDecorator(*options.OracleKeeper),
@@ -85,7 +85,6 @@ func NewAnteHandlerAndDepGenerator(options HandlerOptions) (sdk.AnteHandler, sdk
 		sdk.DefaultWrappedAnteDecorator(ante.NewTxTimeoutHeightDecorator()),
 		sdk.DefaultWrappedAnteDecorator(ante.NewValidateMemoDecorator(options.AccountKeeper)),
 		ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
-		ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TxFeeChecker),
 		// PriorityDecorator must be called after DeductFeeDecorator which sets tx priority based on tx fees
 		sdk.DefaultWrappedAnteDecorator(antedecorators.NewPriorityDecorator()),
 		// SetPubKeyDecorator must be called before all signature verification decorators

--- a/app/ante.go
+++ b/app/ante.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sei-protocol/sei-chain/x/dex"
 	dexkeeper "github.com/sei-protocol/sei-chain/x/dex/keeper"
 	nitrokeeper "github.com/sei-protocol/sei-chain/x/nitro/keeper"
+	"github.com/sei-protocol/sei-chain/x/oracle"
 	oraclekeeper "github.com/sei-protocol/sei-chain/x/oracle/keeper"
 )
 
@@ -79,7 +80,7 @@ func NewAnteHandlerAndDepGenerator(options HandlerOptions) (sdk.AnteHandler, sdk
 		antedecorators.NewGaslessDecorator([]sdk.AnteFullDecorator{ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TxFeeChecker)}, *options.OracleKeeper, *options.NitroKeeper),
 		sdk.DefaultWrappedAnteDecorator(wasmkeeper.NewLimitSimulationGasDecorator(options.WasmConfig.SimulationGasLimit)), // after setup context to enforce limits early
 		sdk.DefaultWrappedAnteDecorator(ante.NewRejectExtensionOptionsDecorator()),
-		// oracle.NewSpammingPreventionDecorator(*options.OracleKeeper), // TODO: UNDO THIS
+		oracle.NewSpammingPreventionDecorator(*options.OracleKeeper),
 		sdk.DefaultWrappedAnteDecorator(ante.NewValidateBasicDecorator()),
 		sdk.DefaultWrappedAnteDecorator(ante.NewTxTimeoutHeightDecorator()),
 		sdk.DefaultWrappedAnteDecorator(ante.NewValidateMemoDecorator(options.AccountKeeper)),

--- a/go.mod
+++ b/go.mod
@@ -275,7 +275,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.276
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.278
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.84

--- a/go.sum
+++ b/go.sum
@@ -1294,8 +1294,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.1.276 h1:SN9J0EWrMrg3Dg9eKDyMcxr036sN5p/Novao3KXb3RU=
-github.com/sei-protocol/sei-cosmos v0.1.276/go.mod h1:pA+I9RlleRsLFcoiQgXoJ+zQYasHHViYYsAASfRFpGw=
+github.com/sei-protocol/sei-cosmos v0.1.278 h1:C0Rlvy8ABJAtA4MpoR9xSN8b7KdCHDN8fLsfMQdTOGs=
+github.com/sei-protocol/sei-cosmos v0.1.278/go.mod h1:pA+I9RlleRsLFcoiQgXoJ+zQYasHHViYYsAASfRFpGw=
 github.com/sei-protocol/sei-tendermint v0.1.84 h1:fJBxYSCAFV3xfsFcdFUVwsR+065NxYM/bjwup7Eyuec=
 github.com/sei-protocol/sei-tendermint v0.1.84/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/oracle/price-feeder/oracle/client/client.go
+++ b/oracle/price-feeder/oracle/client/client.go
@@ -283,7 +283,7 @@ func (oc OracleClient) CreateTxFactory() (tx.Factory, error) {
 		WithChainID(oc.ChainID).
 		WithTxConfig(clientCtx.TxConfig).
 		WithGasAdjustment(oc.GasAdjustment).
-		// WithGasPrices(oc.GasPrices).
+		WithGasPrices(oc.GasPrices).
 		WithKeybase(clientCtx.Keyring).
 		WithSignMode(signing.SignMode_SIGN_MODE_DIRECT).
 		WithSimulateAndExecute(true)

--- a/oracle/price-feeder/oracle/client/client.go
+++ b/oracle/price-feeder/oracle/client/client.go
@@ -283,7 +283,7 @@ func (oc OracleClient) CreateTxFactory() (tx.Factory, error) {
 		WithChainID(oc.ChainID).
 		WithTxConfig(clientCtx.TxConfig).
 		WithGasAdjustment(oc.GasAdjustment).
-		WithGasPrices(oc.GasPrices).
+		// WithGasPrices(oc.GasPrices).
 		WithKeybase(clientCtx.Keyring).
 		WithSignMode(signing.SignMode_SIGN_MODE_DIRECT).
 		WithSimulateAndExecute(true)

--- a/oracle/price-feeder/oracle/client/tx.go
+++ b/oracle/price-feeder/oracle/client/tx.go
@@ -19,12 +19,8 @@ func BroadcastTx(clientCtx client.Context, txf tx.Factory, msgs ...sdk.Msg) (*sd
 		return nil, err
 	}
 
-	// _, adjusted, err := tx.CalculateGas(clientCtx, txf, msgs...)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// txf = txf.WithGas(adjusted)
+	txf = txf.WithGas(0)
+	// txf = txf.WithFees("0usei")
 
 	unsignedTx, err := tx.BuildUnsignedTx(txf, msgs...)
 	if err != nil {
@@ -32,7 +28,7 @@ func BroadcastTx(clientCtx client.Context, txf tx.Factory, msgs ...sdk.Msg) (*sd
 	}
 
 	// unsignedTx.SetFeeGranter(clientCtx.GetFeeGranterAddress())
-	unsignedTx.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(0))))
+	// unsignedTx.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(0))))
 	// unsignedTx.SetFeePayer(clientCtx.GetFeePayerAddress())
 
 	if err = tx.Sign(txf, clientCtx.GetFromName(), unsignedTx, true); err != nil {

--- a/oracle/price-feeder/oracle/client/tx.go
+++ b/oracle/price-feeder/oracle/client/tx.go
@@ -19,6 +19,12 @@ func BroadcastTx(clientCtx client.Context, txf tx.Factory, msgs ...sdk.Msg) (*sd
 		return nil, err
 	}
 
+	// _, adjusted, err := tx.CalculateGas(clientCtx, txf, msgs...)
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	// txf = txf.WithGas(adjusted)
 	txf = txf.WithGas(0)
 	// txf = txf.WithFees("0usei")
 
@@ -27,9 +33,7 @@ func BroadcastTx(clientCtx client.Context, txf tx.Factory, msgs ...sdk.Msg) (*sd
 		return nil, err
 	}
 
-	// unsignedTx.SetFeeGranter(clientCtx.GetFeeGranterAddress())
-	// unsignedTx.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(0))))
-	// unsignedTx.SetFeePayer(clientCtx.GetFeePayerAddress())
+	// unsignedTx.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(2000))))
 
 	if err = tx.Sign(txf, clientCtx.GetFromName(), unsignedTx, true); err != nil {
 		return nil, err

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -29,7 +29,7 @@ import (
 // and broadcast pre-vote and vote transactions such that they're committed in
 // at least one block during each voting period.
 const (
-	tickerSleep = 250 * time.Millisecond
+	tickerSleep = 100 * time.Millisecond
 )
 
 // Oracle implements the core component responsible for fetching exchange rates

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -544,6 +544,7 @@ func (o *Oracle) tick(ctx context.Context) error {
 		Str("exchange_rates", voteMsg.ExchangeRates).
 		Str("validator", voteMsg.Validator).
 		Str("feeder", voteMsg.Feeder).
+		Int64("vote_period", oracleVotePeriod).
 		Msg("broadcasting vote")
 	if err := o.oracleClient.BroadcastTx(
 		nextBlockHeight,

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -29,7 +29,7 @@ import (
 // and broadcast pre-vote and vote transactions such that they're committed in
 // at least one block during each voting period.
 const (
-	tickerSleep = 1000 * time.Millisecond
+	tickerSleep = 100 * time.Millisecond
 )
 
 // Oracle implements the core component responsible for fetching exchange rates

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -29,7 +29,7 @@ import (
 // and broadcast pre-vote and vote transactions such that they're committed in
 // at least one block during each voting period.
 const (
-	tickerSleep = 500 * time.Millisecond
+	tickerSleep = 250 * time.Millisecond
 )
 
 // Oracle implements the core component responsible for fetching exchange rates

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -29,7 +29,7 @@ import (
 // and broadcast pre-vote and vote transactions such that they're committed in
 // at least one block during each voting period.
 const (
-	tickerSleep = 1000 * time.Millisecond
+	tickerSleep = 500 * time.Millisecond
 )
 
 // Oracle implements the core component responsible for fetching exchange rates

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -29,7 +29,7 @@ import (
 // and broadcast pre-vote and vote transactions such that they're committed in
 // at least one block during each voting period.
 const (
-	tickerSleep = 100 * time.Millisecond
+	tickerSleep = 1000 * time.Millisecond
 )
 
 // Oracle implements the core component responsible for fetching exchange rates

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -544,7 +544,7 @@ func (o *Oracle) tick(ctx context.Context) error {
 		Str("exchange_rates", voteMsg.ExchangeRates).
 		Str("validator", voteMsg.Validator).
 		Str("feeder", voteMsg.Feeder).
-		Int64("vote_period", oracleVotePeriod).
+		Float64("vote_period", currentVotePeriod).
 		Msg("broadcasting vote")
 	if err := o.oracleClient.BroadcastTx(
 		nextBlockHeight,

--- a/scripts/old_initialize_local.sh
+++ b/scripts/old_initialize_local.sh
@@ -46,6 +46,7 @@ cat ~/.sei/config/genesis.json | jq '.app_state["mint"]["params"]["mint_denom"]=
 cat ~/.sei/config/genesis.json | jq '.app_state["staking"]["params"]["bond_denom"]="usei"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 cat ~/.sei/config/genesis.json | jq '.app_state["gov"]["deposit_params"]["max_deposit_period"]="300s"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 cat ~/.sei/config/genesis.json | jq '.app_state["gov"]["voting_params"]["voting_period"]="5s"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
+cat ~/.sei/config/genesis.json | jq '.app_state["oracle"]["params"]["vote_period"]="1"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 cat ~/.sei/config/genesis.json | jq '.consensus_params["block"]["time_iota_ms"]="50"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 cat ~/.sei/config/genesis.json | jq '.app_state["distribution"]["params"]["community_tax"]="0.000000000000000000"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 


### PR DESCRIPTION
## Describe your changes and provide context
This fixes the regression with gasless TXs, once again allowing them to be executed without spending any gas. One change here is that gasless TXs NEED to specify zero gas in the tx to be processed as gasless. Otherwise, we will treat them as non-gasless in order to allow for tx prioritization via higher gas prices.
## Testing performed to validate your change
Verified gasless and gas enabled oracle txs

