### PR TITLE
Change default rent price to 0

### DIFF
--- a/x/dex/keeper/contract_test.go
+++ b/x/dex/keeper/contract_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 	"github.com/stretchr/testify/require"
@@ -10,6 +11,7 @@ import (
 
 func TestChargeRentForGas(t *testing.T) {
 	keeper, ctx := keepertest.DexKeeper(t)
+	keeper.SetParams(ctx, types.Params{SudoCallGasPrice: sdk.NewDecWithPrec(1, 1), PriceSnapshotRetention: 1})
 	err := keeper.SetContract(ctx, &types.ContractInfoV2{
 		Creator:      keepertest.TestAccount,
 		ContractAddr: keepertest.TestContract,

--- a/x/dex/types/params.go
+++ b/x/dex/types/params.go
@@ -17,7 +17,7 @@ const (
 	DefaultPriceSnapshotRetention = 24 * 3600 // default to one day
 )
 
-var DefaultSudoCallGasPrice = sdk.NewDecWithPrec(1, 1) // 0.1
+var DefaultSudoCallGasPrice = sdk.ZeroDec() // 0
 
 var _ paramtypes.ParamSet = (*Params)(nil)
 


### PR DESCRIPTION
## Describe your changes and provide context
This PR does 3 things:
1. Fix a race condition in determining gas consumed by a sudo call. Previously it reads a shared gas meter before and after the `sudo` call, but since the reads and the sudo call are not atomic, race conditions across multiple threads using the same gas meter are possible and observed in loadtest.
2. Fix the rollback logic where the original context (hence the original store) instead of the cached store is returned if the processing fails.
3. We will not launch with sudo rent initially, so setting default sudo gas price to 0.

## Testing performed to validate your change
unit test

