### PR TITLE
Validate order placement message

### DIFF
--- a/x/dex/keeper/msgserver/msg_server_place_orders.go
+++ b/x/dex/keeper/msgserver/msg_server_place_orders.go
@@ -50,6 +50,10 @@ func (k msgServer) transferFunds(goCtx context.Context, msg *types.MsgPlaceOrder
 func (k msgServer) PlaceOrders(goCtx context.Context, msg *types.MsgPlaceOrders) (*types.MsgPlaceOrdersResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
+	if len(msg.Orders) == 0 {
+		return nil, errors.New("At least one order needs to be placed")
+	}
+
 	for _, order := range msg.Orders {
 		if err := k.validateOrder(order); err != nil {
 			return nil, err

--- a/x/dex/keeper/msgserver/msg_server_place_orders.go
+++ b/x/dex/keeper/msgserver/msg_server_place_orders.go
@@ -51,7 +51,7 @@ func (k msgServer) PlaceOrders(goCtx context.Context, msg *types.MsgPlaceOrders)
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	if len(msg.Orders) == 0 {
-		return nil, errors.New("At least one order needs to be placed")
+		return nil, errors.New("at least one order needs to be placed")
 	}
 
 	for _, order := range msg.Orders {

--- a/x/dex/keeper/msgserver/msg_server_place_orders_test.go
+++ b/x/dex/keeper/msgserver/msg_server_place_orders_test.go
@@ -195,3 +195,16 @@ func TestPlaceInvalidOrder(t *testing.T) {
 	_, err = server.PlaceOrders(wctx, msg)
 	require.NotNil(t, err)
 }
+
+func TestPlaceNoOrder(t *testing.T) {
+	msg := &types.MsgPlaceOrders{
+		Creator:      TestCreator,
+		ContractAddr: TestContract,
+		Orders:       []*types.Order{},
+	}
+	keeper, ctx := keepertest.DexKeeper(t)
+	wctx := sdk.WrapSDKContext(ctx)
+	server := msgserver.NewMsgServerImpl(*keeper)
+	_, err := server.PlaceOrders(wctx, msg)
+	require.NotNil(t, err)
+}


### PR DESCRIPTION
## Describe your changes and provide context
In order to prevent users from abusing order placement message's gasless feature, we need to validate order placement messages such that it's not possible to send an empty message.

## Testing performed to validate your change
unit test

