### PR TITLE
Increase gas limit for loadtest TXs

### DIFF
--- a/loadtest/config.json
+++ b/loadtest/config.json
@@ -30,45 +30,45 @@
     "run_oracle": true,
     "metrics_port": 9696,
     "contract_distribution": [
-            {
-              "contract_address":"sei14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sh9m79m",
-              "percentage":"0.1"
-            },
-            {
-              "contract_address":"sei1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrqms7u8a",
-              "percentage":"0.1"
-            },
-            {
-              "contract_address":"sei17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgsrtqewe",
-              "percentage":"0.1"
-            },
-            {
-              "contract_address":"sei1yw4xvtc43me9scqfr2jr2gzvcxd3a9y4eq7gaukreugw2yd2f8tsy4qgdm",
-              "percentage":"0.1"
-            },
-            {
-              "contract_address":"sei1hulx7cgvpfcvg83wk5h96sedqgn72n026w6nl47uht554xhvj9nstdktte",
-              "percentage":"0.1"
-            },
-            {
-              "contract_address":"sei1fzm6gzyccl8jvdv3qq6hp9vs6ylaruervs4m06c7k0ntzn2f8faq8un0p6",
-              "percentage":"0.1"
-            },
-            {
-              "contract_address":"sei1wl59k23zngj34l7d42y9yltask7rjlnxgccawc7ltrknp6n52fpsj6ctln",
-              "percentage":"0.1"
-            },
-            {
-              "contract_address":"sei182nff4ttmvshn6yjlqj5czapfcav9434l2qzz8aahf5pxnyd33ts2pdy3l",
-              "percentage":"0.1"
-            },
-            {
-              "contract_address":"sei1k8re7jwz6rnnwrktnejdwkwnncte7ek7gt29gvnl3sdrg9mtnqksw4tqd9",
-              "percentage":"0.1"
-            },
-            {
-              "contract_address":"sei1nwnejwsdpqktusvh8qhxe5arsznjd5asdwutmaz9n5qcpl3dcmhs9eeuca",
-              "percentage":"0.1"
-            }
-          ]
+      {
+        "contract_address": "sei1zwv6feuzhy6a9wekh96cd57lsarmqlwxdypdsplw6zhfncqw6ftqr428wx",
+        "percentage": "0.1"
+      },
+      {
+        "contract_address": "sei1436kxs0w2es6xlqpp9rd35e3d0cjnw4sv8j3a7483sgks29jqwgs5z6axv",
+        "percentage": "0.1"
+      },
+      {
+        "contract_address": "sei1mf6ptkssddfmxvhdx0ech0k03ktp6kf9yk59renau2gvht3nq2gqw4umh9",
+        "percentage": "0.1"
+      },
+      {
+        "contract_address": "sei1kj8q8g2pmhnagmfepp9jh9g2mda7gzd0m5zdq0s08ulvac8ck4dqky7tlh",
+        "percentage": "0.1"
+      },
+      {
+        "contract_address": "sei1sthrn5ep8ls5vzz8f9gp89khhmedahhdqd244dh9uqzk3hx2pzrsfgf5u9",
+        "percentage": "0.1"
+      },
+      {
+        "contract_address": "sei1sr06m8yqg0wzqqyqvzvp5t07dj4nevx9u8qc7j4qa72qu8e3ct8q6c6arh",
+        "percentage": "0.1"
+      },
+      {
+        "contract_address": "sei1w798gp0zqv3s9hjl3jlnwxtwhykga6rn93p46q2crsdqhaj3y4gslx7gpp",
+        "percentage": "0.1"
+      },
+      {
+        "contract_address": "sei149ltwdnpxrhx9al42s359glcjnsuc6x3dalz28f04dsxhlu7jhmq8ymcll",
+        "percentage": "0.1"
+      },
+      {
+        "contract_address": "sei1qu43pvag5hu95hmml7y658t3k8sd9plnmpj8xmw9qgy0t458nyrqdcjxxz",
+        "percentage": "0.1"
+      },
+      {
+        "contract_address": "sei1nwp0ynjv84wxysf2f5ctvysl6dpm8ngm70hss6jeqt8q7e7u345s8zru6u",
+        "percentage": "0.1"
+      }
+  ]
 }

--- a/loadtest/tx.go
+++ b/loadtest/tx.go
@@ -20,7 +20,7 @@ func SendTx(
 	failureExpected bool,
 	loadtestClient LoadTestClient,
 ) func() {
-	(*txBuilder).SetGasLimit(200000)
+	(*txBuilder).SetGasLimit(300000)
 	(*txBuilder).SetFeeAmount([]sdk.Coin{
 		sdk.NewCoin("usei", sdk.NewInt(10000)),
 	})


### PR DESCRIPTION
## Describe your changes and provide context
Seeing some `out of gas in location: WriteFlat; gasWanted: 200000, gasUsed: 201581: out of gas` in the latest client, looks like we need to bump up the gas for some of these transactions

Also updates contract addr based on recent changes, it might still be different between runs 
## Testing performed to validate your change

