### PR TITLE
Add unit test for dex module

### DIFF
--- a/x/dex/cache/cache_test.go
+++ b/x/dex/cache/cache_test.go
@@ -91,6 +91,35 @@ func TestClear(t *testing.T) {
 	require.Equal(t, 0, len(stateOne.GetBlockCancels(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Get()))
 }
 
+func TestClearCancellationForPair(t *testing.T) {
+	keeper, ctx := keepertest.DexKeeper(t)
+	stateOne := dex.NewMemState(keeper.GetStoreKey())
+	stateOne.GetBlockCancels(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Add(&types.Cancellation{
+		Id:           1,
+		ContractAddr: TEST_CONTRACT,
+		PriceDenom: "USDC",
+		AssetDenom: "ATOM",
+	})
+	stateOne.GetBlockCancels(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Add(&types.Cancellation{
+		Id:           2,
+		ContractAddr: TEST_CONTRACT,
+		PriceDenom: "USDC",
+		AssetDenom: "ATOM",
+	})
+	stateOne.GetBlockCancels(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Add(&types.Cancellation{
+		Id:           3,
+		ContractAddr: TEST_CONTRACT,
+		PriceDenom: "USDC",
+		AssetDenom: "SEI",
+	})
+	stateOne.ClearCancellationForPair(ctx, TEST_CONTRACT, utils.GetPairString(&types.Pair{
+		PriceDenom: "USDC",
+		AssetDenom: "ATOM",
+	}))
+	require.Equal(t, 1, len(stateOne.GetBlockCancels(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Get()))
+	require.Equal(t, uint64(3), stateOne.GetBlockCancels(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Get()[0].Id)
+}
+
 func TestSynchronization(t *testing.T) {
 	_, ctx := keepertest.DexKeeper(t)
 	stateOne := dex.NewMemState(sdk.NewKVStoreKey(types.StoreKey))

--- a/x/dex/contract/execution_test.go
+++ b/x/dex/contract/execution_test.go
@@ -1,9 +1,11 @@
 package contract_test
 
 import (
-	dexutils "github.com/sei-protocol/sei-chain/x/dex/utils"
 	"testing"
 	"time"
+
+	"github.com/sei-protocol/sei-chain/utils/datastructures"
+	dexutils "github.com/sei-protocol/sei-chain/x/dex/utils"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
@@ -11,6 +13,7 @@ import (
 	"github.com/sei-protocol/sei-chain/x/dex/exchange"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 	"github.com/sei-protocol/sei-chain/x/dex/types/utils"
+	dextypesutils "github.com/sei-protocol/sei-chain/x/dex/types/utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,10 +25,362 @@ func TEST_PAIR() types.Pair {
 }
 
 const (
+	TEST_ACCOUNT         = "test_account"
 	TEST_CONTRACT        = "test"
 	TestTimestamp uint64 = 10000
 	TestHeight    uint64 = 1
 )
+
+func TestExecutePair(t *testing.T) {
+	pair := types.Pair{
+		PriceDenom: "USDC",
+		AssetDenom: "ATOM",
+	}
+	dexkeeper, ctx := keepertest.DexKeeper(t)
+	ctx = ctx.WithBlockHeight(int64(TestHeight)).WithBlockTime(time.Unix(int64(TestTimestamp), 0))
+	longBook := []types.OrderBookEntry{
+		&types.LongBook{
+			Price: sdk.NewDec(98),
+			Entry: &types.OrderEntry{
+				Price:    sdk.NewDec(98),
+				Quantity: sdk.NewDec(5),
+				Allocations: []*types.Allocation{{
+					OrderId:  5,
+					Account:  "abc",
+					Quantity: sdk.NewDec(5),
+				}},
+				PriceDenom: "USDC",
+				AssetDenom: "ATOM",
+			},
+		},
+		&types.LongBook{
+			Price: sdk.NewDec(100),
+			Entry: &types.OrderEntry{
+				Price:    sdk.NewDec(100),
+				Quantity: sdk.NewDec(3),
+				Allocations: []*types.Allocation{{
+					OrderId:  6,
+					Account:  "def",
+					Quantity: sdk.NewDec(3),
+				}},
+				PriceDenom: "USDC",
+				AssetDenom: "ATOM",
+			},
+		},
+	}
+	shortBook := []types.OrderBookEntry{
+		&types.ShortBook{
+			Price: sdk.NewDec(101),
+			Entry: &types.OrderEntry{
+				Price:    sdk.NewDec(101),
+				Quantity: sdk.NewDec(5),
+				Allocations: []*types.Allocation{{
+					OrderId:  7,
+					Account:  "abc",
+					Quantity: sdk.NewDec(5),
+				}},
+				PriceDenom: "USDC",
+				AssetDenom: "ATOM",
+			},
+		},
+		&types.ShortBook{
+			Price: sdk.NewDec(115),
+			Entry: &types.OrderEntry{
+				Price:    sdk.NewDec(115),
+				Quantity: sdk.NewDec(3),
+				Allocations: []*types.Allocation{{
+					OrderId:  8,
+					Account:  "def",
+					Quantity: sdk.NewDec(3),
+				}},
+				PriceDenom: "USDC",
+				AssetDenom: "ATOM",
+			},
+		},
+	}
+	orderbook := &types.OrderBook{
+		Longs: &types.CachedSortedOrderBookEntries{
+			Entries:      longBook,
+			DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
+		},
+		Shorts: &types.CachedSortedOrderBookEntries{
+			Entries:      shortBook,
+			DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
+		},
+	}
+
+	settlements := contract.ExecutePair(
+		ctx,
+		TEST_CONTRACT,
+		pair,
+		dexkeeper,
+		orderbook,
+	)
+	require.Equal(t, len(settlements), 0)
+
+	// add Market orders to the orderbook
+	dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.GetPairString(&pair)).Add(
+		&types.Order{
+			Id:                1,
+			Account:           TEST_ACCOUNT,
+			ContractAddr:      TEST_CONTRACT,
+			Price:             sdk.MustNewDecFromStr("97"),
+			Quantity:          sdk.MustNewDecFromStr("1"),
+			PriceDenom:        pair.PriceDenom,
+			AssetDenom:        pair.AssetDenom,
+			OrderType:         types.OrderType_LIMIT,
+			PositionDirection: types.PositionDirection_LONG,
+			Data:              "{\"position_effect\":\"Open\",\"leverage\":\"1\"}",
+		},
+	)
+	dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.GetPairString(&pair)).Add(
+		&types.Order{
+			Id:                2,
+			Account:           TEST_ACCOUNT,
+			ContractAddr:      TEST_CONTRACT,
+			Price:             sdk.MustNewDecFromStr("100"),
+			Quantity:          sdk.MustNewDecFromStr("1"),
+			PriceDenom:        pair.PriceDenom,
+			AssetDenom:        pair.AssetDenom,
+			OrderType:         types.OrderType_LIMIT,
+			PositionDirection: types.PositionDirection_LONG,
+			Data:              "{\"position_effect\":\"Open\",\"leverage\":\"1\"}",
+		},
+	)
+	dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.GetPairString(&pair)).Add(
+		&types.Order{
+			Id:                3,
+			Account:           TEST_ACCOUNT,
+			ContractAddr:      TEST_CONTRACT,
+			Price:             sdk.MustNewDecFromStr("200"),
+			Quantity:          sdk.MustNewDecFromStr("1"),
+			PriceDenom:        pair.PriceDenom,
+			AssetDenom:        pair.AssetDenom,
+			OrderType:         types.OrderType_MARKET,
+			PositionDirection: types.PositionDirection_LONG,
+			Data:              "{\"position_effect\":\"Open\",\"leverage\":\"1\"}",
+		},
+	)
+
+	settlements = contract.ExecutePair(
+		ctx,
+		TEST_CONTRACT,
+		pair,
+		dexkeeper,
+		orderbook,
+	)
+
+	require.Equal(t, 2, len(settlements))
+	require.Equal(t, uint64(7), settlements[0].OrderId)
+	require.Equal(t, uint64(3), settlements[1].OrderId)
+
+	// get match results
+	matches, cancels := contract.GetMatchResults(
+		ctx,
+		TEST_CONTRACT,
+		utils.GetPairString(&pair),
+	)
+	require.Equal(t, 3, len(matches))
+	require.Equal(t, 0, len(cancels))
+}
+
+func TestExecutePairInParallel(t *testing.T) {
+	pair := types.Pair{
+		PriceDenom: "USDC",
+		AssetDenom: "ATOM",
+	}
+	dexkeeper, ctx := keepertest.DexKeeper(t)
+	ctx = ctx.WithBlockHeight(int64(TestHeight)).WithBlockTime(time.Unix(int64(TestTimestamp), 0))
+	longBook := []types.OrderBookEntry{
+		&types.LongBook{
+			Price: sdk.NewDec(98),
+			Entry: &types.OrderEntry{
+				Price:    sdk.NewDec(98),
+				Quantity: sdk.NewDec(5),
+				Allocations: []*types.Allocation{{
+					OrderId:  5,
+					Account:  "abc",
+					Quantity: sdk.NewDec(5),
+				}},
+				PriceDenom: "USDC",
+				AssetDenom: "ATOM",
+			},
+		},
+		&types.LongBook{
+			Price: sdk.NewDec(100),
+			Entry: &types.OrderEntry{
+				Price:    sdk.NewDec(100),
+				Quantity: sdk.NewDec(3),
+				Allocations: []*types.Allocation{{
+					OrderId:  6,
+					Account:  "def",
+					Quantity: sdk.NewDec(3),
+				}},
+				PriceDenom: "USDC",
+				AssetDenom: "ATOM",
+			},
+		},
+	}
+	shortBook := []types.OrderBookEntry{
+		&types.ShortBook{
+			Price: sdk.NewDec(101),
+			Entry: &types.OrderEntry{
+				Price:    sdk.NewDec(101),
+				Quantity: sdk.NewDec(5),
+				Allocations: []*types.Allocation{{
+					OrderId:  7,
+					Account:  "abc",
+					Quantity: sdk.NewDec(5),
+				}},
+				PriceDenom: "USDC",
+				AssetDenom: "ATOM",
+			},
+		},
+		&types.ShortBook{
+			Price: sdk.NewDec(115),
+			Entry: &types.OrderEntry{
+				Price:    sdk.NewDec(115),
+				Quantity: sdk.NewDec(3),
+				Allocations: []*types.Allocation{{
+					OrderId:  8,
+					Account:  "def",
+					Quantity: sdk.NewDec(3),
+				}},
+				PriceDenom: "USDC",
+				AssetDenom: "ATOM",
+			},
+		},
+	}
+	orderbook := &types.OrderBook{
+		Longs: &types.CachedSortedOrderBookEntries{
+			Entries:      longBook,
+			DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
+		},
+		Shorts: &types.CachedSortedOrderBookEntries{
+			Entries:      shortBook,
+			DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
+		},
+	}
+
+	// execute in parallel simple path
+	orderbooks := datastructures.NewTypedSyncMap[dextypesutils.PairString, *types.OrderBook]()
+	orderbooks.Store(utils.GetPairString(&pair), orderbook)
+	settlements, cancels := contract.ExecutePairsInParallel(
+		ctx,
+		TEST_CONTRACT,
+		dexkeeper,
+		[]types.Pair{pair},
+		orderbooks,
+	)
+
+	require.Equal(t, len(settlements), 0)
+	require.Equal(t, len(cancels), 0)
+
+	// add Market orders to the orderbook
+	dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.GetPairString(&pair)).Add(
+		&types.Order{
+			Id:                1,
+			Account:           TEST_ACCOUNT,
+			ContractAddr:      TEST_CONTRACT,
+			Price:             sdk.MustNewDecFromStr("97"),
+			Quantity:          sdk.MustNewDecFromStr("1"),
+			PriceDenom:        pair.PriceDenom,
+			AssetDenom:        pair.AssetDenom,
+			OrderType:         types.OrderType_LIMIT,
+			PositionDirection: types.PositionDirection_LONG,
+			Data:              "{\"position_effect\":\"Open\",\"leverage\":\"1\"}",
+		},
+	)
+	dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.GetPairString(&pair)).Add(
+		&types.Order{
+			Id:                2,
+			Account:           TEST_ACCOUNT,
+			ContractAddr:      TEST_CONTRACT,
+			Price:             sdk.MustNewDecFromStr("100"),
+			Quantity:          sdk.MustNewDecFromStr("1"),
+			PriceDenom:        pair.PriceDenom,
+			AssetDenom:        pair.AssetDenom,
+			OrderType:         types.OrderType_LIMIT,
+			PositionDirection: types.PositionDirection_LONG,
+			Data:              "{\"position_effect\":\"Open\",\"leverage\":\"1\"}",
+		},
+	)
+	dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.GetPairString(&pair)).Add(
+		&types.Order{
+			Id:                3,
+			Account:           TEST_ACCOUNT,
+			ContractAddr:      TEST_CONTRACT,
+			Price:             sdk.MustNewDecFromStr("200"),
+			Quantity:          sdk.MustNewDecFromStr("1"),
+			PriceDenom:        pair.PriceDenom,
+			AssetDenom:        pair.AssetDenom,
+			OrderType:         types.OrderType_MARKET,
+			PositionDirection: types.PositionDirection_LONG,
+			Data:              "{\"position_effect\":\"Open\",\"leverage\":\"1\"}",
+		},
+	)
+	dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.GetPairString(&pair)).Add(
+		&types.Order{
+			Id:                11,
+			Account:           TEST_ACCOUNT,
+			ContractAddr:      TEST_CONTRACT,
+			Price:             sdk.MustNewDecFromStr("20"),
+			Quantity:          sdk.MustNewDecFromStr("1"),
+			PriceDenom:        pair.PriceDenom,
+			AssetDenom:        pair.AssetDenom,
+			OrderType:         types.OrderType_MARKET,
+			PositionDirection: types.PositionDirection_LONG,
+			Data:              "{\"position_effect\":\"Open\",\"leverage\":\"1\"}",
+		},
+	)
+
+	settlements, cancels = contract.ExecutePairsInParallel(
+		ctx,
+		TEST_CONTRACT,
+		dexkeeper,
+		[]types.Pair{pair},
+		orderbooks,
+	)
+
+	require.Equal(t, 2, len(settlements))
+	require.Equal(t, 1, len(cancels))
+	require.Equal(t, uint64(7), settlements[0].OrderId)
+	require.Equal(t, uint64(3), settlements[1].OrderId)
+}
+
+func TestGetOrderIDToSettledQuantities(t *testing.T) {
+	settlements := []*types.SettlementEntry{
+		{
+			OrderId:  1,
+			Quantity: sdk.MustNewDecFromStr("100"),
+		},
+		{
+			OrderId:  2,
+			Quantity: sdk.MustNewDecFromStr("200"),
+		},
+	}
+
+	idMapping := contract.GetOrderIDToSettledQuantities(settlements)
+
+	require.Equal(t, 2, len(idMapping))
+	require.Equal(t, sdk.MustNewDecFromStr("100"), idMapping[1])
+	require.Equal(t, sdk.MustNewDecFromStr("200"), idMapping[2])
+}
+
+func TestEmitSettlementMetrics(t *testing.T) {
+	settlements := []*types.SettlementEntry{
+		{
+			OrderId:  1,
+			Quantity: sdk.MustNewDecFromStr("100"),
+		},
+		{
+			OrderId:  2,
+			Quantity: sdk.MustNewDecFromStr("200"),
+		},
+	}
+
+	contract.EmitSettlementMetrics(settlements)
+}
 
 func TestMoveTriggeredOrderIntoMemState(t *testing.T) {
 	pair := TEST_PAIR()

--- a/x/dex/keeper/contract_test.go
+++ b/x/dex/keeper/contract_test.go
@@ -29,4 +29,36 @@ func TestChargeRentForGas(t *testing.T) {
 	contract, err = keeper.GetContract(ctx, keepertest.TestContract)
 	require.Nil(t, err)
 	require.Equal(t, uint64(0), contract.RentBalance)
+
+	// delete contract
+	keeper.DeleteContract(ctx, keepertest.TestContract)
+	_, err = keeper.GetContract(ctx, keepertest.TestContract)
+	require.NotNil(t, err)
+}
+
+func TestGetAllContractInfo(t *testing.T) {
+	keeper, ctx := keepertest.DexKeeper(t)
+	keeper.SetParams(ctx, types.Params{SudoCallGasPrice: sdk.NewDecWithPrec(1, 1), PriceSnapshotRetention: 1})
+	keeper.SetContract(ctx, &types.ContractInfoV2{
+		Creator:      keepertest.TestAccount,
+		ContractAddr: keepertest.TestContract,
+		CodeId:       1,
+		RentBalance:  1000000,
+	})
+	keeper.SetContract(ctx, &types.ContractInfoV2{
+		Creator:      "ta2",
+		ContractAddr: "tc2",
+		CodeId:       2,
+		RentBalance:  1000000,
+	})
+	contracts := keeper.GetAllContractInfo(ctx)
+	require.Equal(t, uint64(1000000), contracts[0].RentBalance)
+	require.Equal(t, uint64(1000000), contracts[1].RentBalance)
+	require.Equal(t, uint64(1), contracts[0].CodeId)
+	require.Equal(t, uint64(2), contracts[1].CodeId)
+	require.Equal(t, keepertest.TestAccount, contracts[0].Creator)
+	require.Equal(t, keepertest.TestContract, contracts[0].ContractAddr)
+	require.Equal(t, "ta2", contracts[1].Creator)
+	require.Equal(t, "tc2", contracts[1].ContractAddr)
+
 }

--- a/x/dex/types/utils/enums_test.go
+++ b/x/dex/types/utils/enums_test.go
@@ -1,0 +1,54 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+	"github.com/sei-protocol/sei-chain/x/dex/types/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPositionEffectFromStr(t *testing.T) {
+	effect := "Close"
+	expected := types.PositionEffect_CLOSE
+	actual, err := utils.GetPositionEffectFromStr(effect)
+
+	require.Nil(t, err)
+	require.Equal(t, expected, actual)
+
+	// unidentified effect
+	effect = "invalid_effect"
+	_, err = utils.GetPositionEffectFromStr(effect)
+
+	require.NotNil(t, err)
+}
+
+func TestGetPositionDirectionFromStr(t *testing.T) {
+	direction := "Long"
+	expected := types.PositionDirection_LONG
+	actual, err := utils.GetPositionDirectionFromStr(direction)
+
+	require.Nil(t, err)
+	require.Equal(t, expected, actual)
+
+	// unidentified direction
+	direction = "invalid_direction"
+	_, err = utils.GetPositionEffectFromStr(direction)
+
+	require.NotNil(t, err)
+}
+
+func TestGetOrderTypeFromStr(t *testing.T) {
+	orderType := "Market"
+	expected := types.OrderType_MARKET
+	actual, err := utils.GetOrderTypeFromStr(orderType)
+
+	require.Nil(t, err)
+	require.Equal(t, expected, actual)
+
+	// unidentified direction
+	orderType = "invalid"
+	_, err = utils.GetPositionEffectFromStr(orderType)
+
+	require.NotNil(t, err)
+}

--- a/x/dex/types/utils/unit_test.go
+++ b/x/dex/types/utils/unit_test.go
@@ -1,0 +1,16 @@
+package utils_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+	"github.com/sei-protocol/sei-chain/x/dex/types/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertDecToStandard(t *testing.T) {
+	actual := utils.ConvertDecToStandard(types.Unit_NANO, sdk.MustNewDecFromStr("1"))
+
+	require.Equal(t, sdk.MustNewDecFromStr("0.000000001"), actual)
+}

--- a/x/dex/types/wasm/block_hooks_test.go
+++ b/x/dex/types/wasm/block_hooks_test.go
@@ -1,6 +1,7 @@
 package wasm_test
 
 import (
+	"sync"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -8,6 +9,19 @@ import (
 	"github.com/sei-protocol/sei-chain/x/dex/types/wasm"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAddContractResult(t *testing.T) {
+	sudoFinalizeBlockMsg := wasm.NewSudoFinalizeBlockMsg()
+	result := wasm.NewContractOrderResult("TEST_CONTRACT")
+	mu := &sync.Mutex{}
+
+	sudoFinalizeBlockMsg.AddContractResult(result, mu)
+	require.Equal(t, wasm.ContractOrderResult{
+		ContractAddr:          "TEST_CONTRACT",
+		OrderPlacementResults: []wasm.OrderPlacementResult{},
+		OrderExecutionResults: []wasm.OrderExecutionResult{},
+	}, result)
+}
 
 func TestPopulateOrderPlacementResults(t *testing.T) {
 	account := "test"

--- a/x/dex/types/wasm/settlement_test.go
+++ b/x/dex/types/wasm/settlement_test.go
@@ -1,0 +1,32 @@
+package wasm_test
+
+import (
+	"testing"
+
+	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+	"github.com/sei-protocol/sei-chain/x/dex/types/wasm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSettlementEntry(t *testing.T) {
+	_, ctx := keepertest.DexKeeper(t)
+	ctx = ctx.WithBlockHeight(100)
+	sudoFinalizeBlockMsg := wasm.NewSettlementEntry(
+		ctx,
+		1,
+		"TEST_ACCOUNT",
+		types.PositionDirection_LONG,
+		"USDC",
+		"ATOM",
+		sdk.MustNewDecFromStr("1"),
+		sdk.MustNewDecFromStr("2"),
+		sdk.MustNewDecFromStr("3"),
+		types.OrderType_MARKET,
+	)
+
+	require.Equal(t, "Long", sudoFinalizeBlockMsg.PositionDirection)
+	require.Equal(t, "Market", sudoFinalizeBlockMsg.OrderType)
+	require.Equal(t, uint64(100), sudoFinalizeBlockMsg.Height)
+}


### PR DESCRIPTION
## Describe your changes and provide context
Bump unit test coverage rate for dex module core functionality. 
Note that
- the `abci` in both /contract and /keeper is covered by integration test (`module_test.go`) instead.
- some files are already fully covered but % shows not or even < 50%
- unit test is not included for /dex/client 

## TODO After Audit
- Bump x/dex/types coverage rate
- Bump x/dex/keeper coverage rate
- Integrate coverage rate graph to github CI

## Testing performed to validate your change
Coverage report before:
```
ok  	github.com/sei-protocol/sei-chain/x/dex/cache	5.905s	coverage: 76.4% of statements
ok  	github.com/sei-protocol/sei-chain/x/dex/client/cli/query	64.795s	coverage: 23.1% of statements
?   	github.com/sei-protocol/sei-chain/x/dex/client/cli/tx	[no test files]
?   	github.com/sei-protocol/sei-chain/x/dex/client/utils	[no test files]
?   	github.com/sei-protocol/sei-chain/x/dex/client/wasm	[no test files]
?   	github.com/sei-protocol/sei-chain/x/dex/client/wasm/bindings	[no test files]
ok  	github.com/sei-protocol/sei-chain/x/dex/contract	6.714s	coverage: 25.3% of statements
ok  	github.com/sei-protocol/sei-chain/x/dex/exchange	1.266s	coverage: 89.1% of statements
ok  	github.com/sei-protocol/sei-chain/x/dex/keeper	2.061s	coverage: 57.2% of statements
ok  	github.com/sei-protocol/sei-chain/x/dex/keeper/abci	3.293s	coverage: 31.1% of statements
ok  	github.com/sei-protocol/sei-chain/x/dex/keeper/msgserver	3.864s	coverage: 78.2% of statements
ok  	github.com/sei-protocol/sei-chain/x/dex/keeper/query	0.592s	coverage: 82.2% of statements
?   	github.com/sei-protocol/sei-chain/x/dex/keeper/utils	[no test files]
ok  	github.com/sei-protocol/sei-chain/x/dex/migrations	1.542s	coverage: 85.0% of statements
?   	github.com/sei-protocol/sei-chain/x/dex/simulation	[no test files]
ok  	github.com/sei-protocol/sei-chain/x/dex/types	0.450s	coverage: 0.9% of statements
ok  	github.com/sei-protocol/sei-chain/x/dex/types/utils	0.810s	coverage: 21.4% of statements
ok  	github.com/sei-protocol/sei-chain/x/dex/types/wasm	1.354s	coverage: 58.6% of statements
?   	github.com/sei-protocol/sei-chain/x/dex/utils	[no test files]
```

After
```
ok  	github.com/sei-protocol/sei-chain/x/dex/cache	6.040s	coverage: 86.3% of statements
ok  	github.com/sei-protocol/sei-chain/x/dex/client/cli/query	68.164s	coverage: 23.1% of statements
?   	github.com/sei-protocol/sei-chain/x/dex/client/cli/tx	[no test files]
?   	github.com/sei-protocol/sei-chain/x/dex/client/utils	[no test files]
?   	github.com/sei-protocol/sei-chain/x/dex/client/wasm	[no test files]
?   	github.com/sei-protocol/sei-chain/x/dex/client/wasm/bindings	[no test files]
ok  	github.com/sei-protocol/sei-chain/x/dex/contract	8.794s	coverage: 51.5% of statements
ok  	github.com/sei-protocol/sei-chain/x/dex/exchange	1.538s	coverage: 89.1% of statements
ok  	github.com/sei-protocol/sei-chain/x/dex/keeper	1.342s	coverage: 61.0% of statements
ok  	github.com/sei-protocol/sei-chain/x/dex/keeper/abci	4.223s	coverage: 31.1% of statements
ok  	github.com/sei-protocol/sei-chain/x/dex/keeper/msgserver	5.730s	coverage: 78.2% of statements
ok  	github.com/sei-protocol/sei-chain/x/dex/keeper/query	2.019s	coverage: 82.2% of statements
?   	github.com/sei-protocol/sei-chain/x/dex/keeper/utils	[no test files]
ok  	github.com/sei-protocol/sei-chain/x/dex/migrations	2.448s	coverage: 85.0% of statements
?   	github.com/sei-protocol/sei-chain/x/dex/simulation	[no test files]
ok  	github.com/sei-protocol/sei-chain/x/dex/types	0.902s	coverage: 0.9% of statements
ok  	github.com/sei-protocol/sei-chain/x/dex/types/utils	0.761s	coverage: 100.0% of statements
ok  	github.com/sei-protocol/sei-chain/x/dex/types/wasm	2.718s	coverage: 82.8% of statements
?   	github.com/sei-protocol/sei-chain/x/dex/utils	[no test files]
```
