### PR TITLE
[ante] Add ante deps for gas meter setter

### DIFF
--- a/aclmapping/bank/mappings.go
+++ b/aclmapping/bank/mappings.go
@@ -1,6 +1,7 @@
 package aclbankmapping
 
 import (
+	"encoding/hex"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -65,19 +66,19 @@ func MsgSendDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context, msg sd
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
-			IdentifierTemplate: string(authtypes.CreateAddressStoreKeyFromBech32(msgSend.ToAddress)),
+			IdentifierTemplate: hex.EncodeToString(authtypes.CreateAddressStoreKeyFromBech32(msgSend.ToAddress)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
-			IdentifierTemplate: string(authtypes.CreateAddressStoreKeyFromBech32(msgSend.ToAddress)),
+			IdentifierTemplate: hex.EncodeToString(authtypes.CreateAddressStoreKeyFromBech32(msgSend.ToAddress)),
 		},
 
 		// Gets Account Info for the sender
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
-			IdentifierTemplate: string(authtypes.CreateAddressStoreKeyFromBech32(msgSend.FromAddress)),
+			IdentifierTemplate: hex.EncodeToString(authtypes.CreateAddressStoreKeyFromBech32(msgSend.FromAddress)),
 		},
 
 		{

--- a/aclmapping/bank/mappings.go
+++ b/aclmapping/bank/mappings.go
@@ -30,8 +30,8 @@ func MsgSendDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context, msg sd
 	if !ok {
 		return []sdkacltypes.AccessOperation{}, ErrorInvalidMsgType
 	}
-	fromAddrIdentifier := string(banktypes.CreateAccountBalancesPrefixFromBech32(msgSend.FromAddress))
-	toAddrIdentifier := string(banktypes.CreateAccountBalancesPrefixFromBech32(msgSend.ToAddress))
+	fromAddrIdentifier := hex.EncodeToString(banktypes.CreateAccountBalancesPrefixFromBech32(msgSend.FromAddress))
+	toAddrIdentifier := hex.EncodeToString(banktypes.CreateAccountBalancesPrefixFromBech32(msgSend.ToAddress))
 
 	accessOperations := []sdkacltypes.AccessOperation{
 		// MsgSend also checks if the coin denom is enabled, but the information is from the params.

--- a/aclmapping/dex/mappings.go
+++ b/aclmapping/dex/mappings.go
@@ -34,12 +34,12 @@ func GetDexMemReadWrite(contract string) []sdkacltypes.AccessOperation {
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_DexMem,
-			IdentifierTemplate: contract,
+			IdentifierTemplate: hex.EncodeToString([]byte(contract)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_DexMem,
-			IdentifierTemplate: contract,
+			IdentifierTemplate: hex.EncodeToString([]byte(contract)),
 		},
 	}
 }

--- a/aclmapping/dex/mappings.go
+++ b/aclmapping/dex/mappings.go
@@ -1,6 +1,7 @@
 package acldexmapping
 
 import (
+	"encoding/hex"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -48,13 +49,13 @@ func GetLongShortOrderBookOps(contractAddr string, priceDenom string, assetDenom
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DEX_CONTRACT_LONGBOOK,
-			IdentifierTemplate: string(dextypes.OrderBookPrefix(true, contractAddr, priceDenom, assetDenom)),
+			IdentifierTemplate: hex.EncodeToString(dextypes.OrderBookPrefix(true, contractAddr, priceDenom, assetDenom)),
 		},
 
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DEX_CONTRACT_SHORTBOOK,
-			IdentifierTemplate: string(dextypes.OrderBookPrefix(false, contractAddr, priceDenom, assetDenom)),
+			IdentifierTemplate: hex.EncodeToString(dextypes.OrderBookPrefix(false, contractAddr, priceDenom, assetDenom)),
 		},
 	}
 }
@@ -73,22 +74,22 @@ func DexPlaceOrdersDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context,
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DEX_NEXT_ORDER_ID,
-			IdentifierTemplate: string(dextypes.NextOrderIDPrefix(contractAddr)),
+			IdentifierTemplate: hex.EncodeToString(dextypes.NextOrderIDPrefix(contractAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_DEX_NEXT_ORDER_ID,
-			IdentifierTemplate: string(dextypes.NextOrderIDPrefix(contractAddr)),
+			IdentifierTemplate: hex.EncodeToString(dextypes.NextOrderIDPrefix(contractAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DEX_PRICE_TICK_SIZE,
-			IdentifierTemplate: string(dextypes.PriceTickSizeKeyPrefix(contractAddr)),
+			IdentifierTemplate: hex.EncodeToString(dextypes.PriceTickSizeKeyPrefix(contractAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DEX_QUANTITY_TICK_SIZE,
-			IdentifierTemplate: string(dextypes.QuantityTickSizeKeyPrefix(contractAddr)),
+			IdentifierTemplate: hex.EncodeToString(dextypes.QuantityTickSizeKeyPrefix(contractAddr)),
 		},
 	}...)
 

--- a/aclmapping/oracle/mappings.go
+++ b/aclmapping/oracle/mappings.go
@@ -1,6 +1,7 @@
 package acloraclemapping
 
 import (
+	"encoding/hex"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -37,7 +38,7 @@ func MsgVoteDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context, msg sd
 		{
 			ResourceType:       sdkacltypes.ResourceType_KV_ORACLE_FEEDERS,
 			AccessType:         sdkacltypes.AccessType_READ,
-			IdentifierTemplate: string(oracletypes.GetFeederDelegationKey(valAddr)),
+			IdentifierTemplate: hex.EncodeToString(oracletypes.GetFeederDelegationKey(valAddr)),
 		},
 		// read validator from staking - READ
 		// validator is bonded check - READ
@@ -45,7 +46,7 @@ func MsgVoteDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context, msg sd
 		{
 			ResourceType:       sdkacltypes.ResourceType_KV_STAKING_VALIDATOR,
 			AccessType:         sdkacltypes.AccessType_READ,
-			IdentifierTemplate: string(stakingtypes.GetValidatorKey(valAddr)),
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.GetValidatorKey(valAddr)),
 		},
 
 		// get vote target (for all exchange rate tuples) -> blanket read on that prefix - READ
@@ -59,7 +60,7 @@ func MsgVoteDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context, msg sd
 		{
 			ResourceType:       sdkacltypes.ResourceType_KV_ORACLE_AGGREGATE_VOTES,
 			AccessType:         sdkacltypes.AccessType_WRITE,
-			IdentifierTemplate: string(oracletypes.GetAggregateExchangeRateVoteKey(valAddr)),
+			IdentifierTemplate: hex.EncodeToString(oracletypes.GetAggregateExchangeRateVoteKey(valAddr)),
 		},
 
 		// Last Operation should always be a commit

--- a/aclmapping/staking/mappings.go
+++ b/aclmapping/staking/mappings.go
@@ -1,6 +1,7 @@
 package aclstakingmapping
 
 import (
+	"encoding/hex"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -71,91 +72,91 @@ func MsgDelegateDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context, ms
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_STAKING_VALIDATORS_BY_POWER,
-			IdentifierTemplate: string(stakingtypes.GetValidatorsByPowerIndexKey(validator, keeper.StakingKeeper.PowerReduction(ctx))),
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.GetValidatorsByPowerIndexKey(validator, keeper.StakingKeeper.PowerReduction(ctx))),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_STAKING_VALIDATORS_BY_POWER,
-			IdentifierTemplate: string(stakingtypes.GetValidatorsByPowerIndexKey(validator, keeper.StakingKeeper.PowerReduction(ctx))),
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.GetValidatorsByPowerIndexKey(validator, keeper.StakingKeeper.PowerReduction(ctx))),
 		},
 
 		// Before Unbond Distribution Hook
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_DELEGATOR_STARTING_INFO,
-			IdentifierTemplate: string(distributiontypes.GetDelegatorStartingInfoKey(validatorAddr, delegateAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetDelegatorStartingInfoKey(validatorAddr, delegateAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_DELEGATOR_STARTING_INFO,
-			IdentifierTemplate: string(distributiontypes.GetDelegatorStartingInfoKey(validatorAddr, delegateAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetDelegatorStartingInfoKey(validatorAddr, delegateAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_VAL_CURRENT_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorCurrentRewardsKey(validatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorCurrentRewardsKey(validatorAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_VAL_CURRENT_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorCurrentRewardsKey(validatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorCurrentRewardsKey(validatorAddr)),
 		},
 
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_OUTSTANDING_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorOutstandingRewardsKey(validatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorOutstandingRewardsKey(validatorAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_OUTSTANDING_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorOutstandingRewardsKey(validatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorOutstandingRewardsKey(validatorAddr)),
 		},
 
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_FEE_POOL,
-			IdentifierTemplate: string(distributiontypes.FeePoolKey),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.FeePoolKey),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_FEE_POOL,
-			IdentifierTemplate: string(distributiontypes.FeePoolKey),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.FeePoolKey),
 		},
 
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_VAL_HISTORICAL_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorHistoricalRewardsPrefix(validatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorHistoricalRewardsPrefix(validatorAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_VAL_HISTORICAL_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorHistoricalRewardsPrefix(validatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorHistoricalRewardsPrefix(validatorAddr)),
 		},
 
 		// Gets Module Account information
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
-			IdentifierTemplate: string(authtypes.AddressStoreKey(bondedModuleAdr)),
+			IdentifierTemplate: hex.EncodeToString(authtypes.AddressStoreKey(bondedModuleAdr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
-			IdentifierTemplate: string(authtypes.AddressStoreKey(notBondedModuleAdr)),
+			IdentifierTemplate: hex.EncodeToString(authtypes.AddressStoreKey(notBondedModuleAdr)),
 		},
 
 		// Get Delegator Acc Info
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
-			IdentifierTemplate: string(authtypes.AddressStoreKey(delegateAddr)),
+			IdentifierTemplate: hex.EncodeToString(authtypes.AddressStoreKey(delegateAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
-			IdentifierTemplate: string(authtypes.AddressStoreKey(delegateAddr)),
+			IdentifierTemplate: hex.EncodeToString(authtypes.AddressStoreKey(delegateAddr)),
 		},
 
 		// Update the delegator and validator account balances
@@ -239,22 +240,22 @@ func MsgUndelegateDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context, 
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_STAKING_UNBONDING_DELEGATION,
-			IdentifierTemplate: string(stakingtypes.GetUBDKey(delegateAddr, validatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.GetUBDKey(delegateAddr, validatorAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_STAKING_UNBONDING_DELEGATION,
-			IdentifierTemplate: string(stakingtypes.GetUBDKey(delegateAddr, validatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.GetUBDKey(delegateAddr, validatorAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_STAKING_UNBONDING_DELEGATION_VAL,
-			IdentifierTemplate: string(stakingtypes.GetUBDsByValIndexKey(validatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.GetUBDsByValIndexKey(validatorAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_STAKING_UNBONDING_DELEGATION_VAL,
-			IdentifierTemplate: string(stakingtypes.GetUBDsByValIndexKey(validatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.GetUBDsByValIndexKey(validatorAddr)),
 		},
 
 		// Testing
@@ -267,12 +268,12 @@ func MsgUndelegateDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context, 
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_STAKING_UNBONDING,
-			IdentifierTemplate: string(stakingtypes.UnbondingQueueKey),
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.UnbondingQueueKey),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_STAKING_UNBONDING,
-			IdentifierTemplate: string(stakingtypes.UnbondingQueueKey),
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.UnbondingQueueKey),
 		},
 
 		{
@@ -283,84 +284,84 @@ func MsgUndelegateDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context, 
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_STAKING_VALIDATORS_CON_ADDR,
-			IdentifierTemplate: string(stakingtypes.GetUBDsByValIndexKey(validatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.GetUBDsByValIndexKey(validatorAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_STAKING_VALIDATORS_BY_POWER,
-			IdentifierTemplate: string(stakingtypes.GetValidatorsByPowerIndexKey(validator, keeper.StakingKeeper.PowerReduction(ctx))),
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.GetValidatorsByPowerIndexKey(validator, keeper.StakingKeeper.PowerReduction(ctx))),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_STAKING_VALIDATORS_BY_POWER,
-			IdentifierTemplate: string(stakingtypes.GetValidatorsByPowerIndexKey(validator, keeper.StakingKeeper.PowerReduction(ctx))),
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.GetValidatorsByPowerIndexKey(validator, keeper.StakingKeeper.PowerReduction(ctx))),
 		},
 
 		// Before Unbond Distribution Hook
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_DELEGATOR_STARTING_INFO,
-			IdentifierTemplate: string(distributiontypes.GetDelegatorStartingInfoKey(validatorAddr, delegateAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetDelegatorStartingInfoKey(validatorAddr, delegateAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_VAL_CURRENT_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorCurrentRewardsKey(validatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorCurrentRewardsKey(validatorAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_VAL_CURRENT_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorCurrentRewardsKey(validatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorCurrentRewardsKey(validatorAddr)),
 		},
 
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_OUTSTANDING_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorOutstandingRewardsKey(validatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorOutstandingRewardsKey(validatorAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_OUTSTANDING_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorOutstandingRewardsKey(validatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorOutstandingRewardsKey(validatorAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_FEE_POOL,
-			IdentifierTemplate: string(distributiontypes.FeePoolKey),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.FeePoolKey),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_FEE_POOL,
-			IdentifierTemplate: string(distributiontypes.FeePoolKey),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.FeePoolKey),
 		},
 
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_VAL_HISTORICAL_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorHistoricalRewardsPrefix(validatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorHistoricalRewardsPrefix(validatorAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_VAL_HISTORICAL_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorHistoricalRewardsPrefix(validatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorHistoricalRewardsPrefix(validatorAddr)),
 		},
 
 		// Gets Module Account information
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
-			IdentifierTemplate: string(authtypes.AddressStoreKey(bondedModuleAdr)),
+			IdentifierTemplate: hex.EncodeToString(authtypes.AddressStoreKey(bondedModuleAdr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
-			IdentifierTemplate: string(authtypes.AddressStoreKey(notBondedModuleAdr)),
+			IdentifierTemplate: hex.EncodeToString(authtypes.AddressStoreKey(notBondedModuleAdr)),
 		},
 
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_DELEGATOR_STARTING_INFO,
-			IdentifierTemplate: string(distributiontypes.GetDelegatorStartingInfoKey(validatorAddr, delegateAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetDelegatorStartingInfoKey(validatorAddr, delegateAddr)),
 		},
 
 		// Update the delegator and validator account balances
@@ -445,12 +446,12 @@ func MsgBeginRedelegateDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Cont
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_STAKING_REDELEGATION,
-			IdentifierTemplate: string(stakingtypes.GetREDsKey(delegateAddr)),
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.GetREDsKey(delegateAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_STAKING_REDELEGATION,
-			IdentifierTemplate: string(stakingtypes.GetREDsKey(delegateAddr)),
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.GetREDsKey(delegateAddr)),
 		},
 
 		// Update/delete delegation and update redelegation
@@ -464,132 +465,132 @@ func MsgBeginRedelegateDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Cont
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_STAKING_VALIDATORS_BY_POWER,
-			IdentifierTemplate: string(stakingtypes.GetValidatorsByPowerIndexKey(srcValidator, keeper.StakingKeeper.PowerReduction(ctx))),
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.GetValidatorsByPowerIndexKey(srcValidator, keeper.StakingKeeper.PowerReduction(ctx))),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_STAKING_VALIDATORS_BY_POWER,
-			IdentifierTemplate: string(stakingtypes.GetValidatorsByPowerIndexKey(srcValidator, keeper.StakingKeeper.PowerReduction(ctx))),
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.GetValidatorsByPowerIndexKey(srcValidator, keeper.StakingKeeper.PowerReduction(ctx))),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_STAKING_VALIDATORS_BY_POWER,
-			IdentifierTemplate: string(stakingtypes.GetValidatorsByPowerIndexKey(dstValidator, keeper.StakingKeeper.PowerReduction(ctx))),
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.GetValidatorsByPowerIndexKey(dstValidator, keeper.StakingKeeper.PowerReduction(ctx))),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_STAKING_VALIDATORS_BY_POWER,
-			IdentifierTemplate: string(stakingtypes.GetValidatorsByPowerIndexKey(dstValidator, keeper.StakingKeeper.PowerReduction(ctx))),
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.GetValidatorsByPowerIndexKey(dstValidator, keeper.StakingKeeper.PowerReduction(ctx))),
 		},
 
 		// Before Unbond Distribution Hook
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_DELEGATOR_STARTING_INFO,
-			IdentifierTemplate: string(distributiontypes.GetDelegatorStartingInfoKey(srcValidatorAddr, delegateAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetDelegatorStartingInfoKey(srcValidatorAddr, delegateAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_DELEGATOR_STARTING_INFO,
-			IdentifierTemplate: string(distributiontypes.GetDelegatorStartingInfoKey(dstValidatorAddr, delegateAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetDelegatorStartingInfoKey(dstValidatorAddr, delegateAddr)),
 		},
 
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_VAL_CURRENT_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorCurrentRewardsKey(srcValidatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorCurrentRewardsKey(srcValidatorAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_VAL_CURRENT_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorCurrentRewardsKey(srcValidatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorCurrentRewardsKey(srcValidatorAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_VAL_CURRENT_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorCurrentRewardsKey(dstValidatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorCurrentRewardsKey(dstValidatorAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_VAL_CURRENT_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorCurrentRewardsKey(dstValidatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorCurrentRewardsKey(dstValidatorAddr)),
 		},
 
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_OUTSTANDING_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorOutstandingRewardsKey(srcValidatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorOutstandingRewardsKey(srcValidatorAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_OUTSTANDING_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorOutstandingRewardsKey(srcValidatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorOutstandingRewardsKey(srcValidatorAddr)),
 		},
 
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_FEE_POOL,
-			IdentifierTemplate: string(distributiontypes.FeePoolKey),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.FeePoolKey),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_FEE_POOL,
-			IdentifierTemplate: string(distributiontypes.FeePoolKey),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.FeePoolKey),
 		},
 
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_VAL_HISTORICAL_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorHistoricalRewardsPrefix(srcValidatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorHistoricalRewardsPrefix(srcValidatorAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_VAL_HISTORICAL_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorHistoricalRewardsPrefix(srcValidatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorHistoricalRewardsPrefix(srcValidatorAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_VAL_HISTORICAL_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorHistoricalRewardsPrefix(dstValidatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorHistoricalRewardsPrefix(dstValidatorAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_VAL_HISTORICAL_REWARDS,
-			IdentifierTemplate: string(distributiontypes.GetValidatorHistoricalRewardsPrefix(dstValidatorAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetValidatorHistoricalRewardsPrefix(dstValidatorAddr)),
 		},
 
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_STAKING_REDELEGATION_QUEUE,
-			IdentifierTemplate: string(stakingtypes.RedelegationQueueKey),
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.RedelegationQueueKey),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_STAKING_REDELEGATION_QUEUE,
-			IdentifierTemplate: string(stakingtypes.RedelegationQueueKey),
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.RedelegationQueueKey),
 		},
 
 		// Gets Module Account information
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
-			IdentifierTemplate: string(authtypes.AddressStoreKey(bondedModuleAdr)),
+			IdentifierTemplate: hex.EncodeToString(authtypes.AddressStoreKey(bondedModuleAdr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
-			IdentifierTemplate: string(authtypes.AddressStoreKey(notBondedModuleAdr)),
+			IdentifierTemplate: hex.EncodeToString(authtypes.AddressStoreKey(notBondedModuleAdr)),
 		},
 
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_DELEGATOR_STARTING_INFO,
-			IdentifierTemplate: string(distributiontypes.GetDelegatorStartingInfoKey(srcValidatorAddr, delegateAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetDelegatorStartingInfoKey(srcValidatorAddr, delegateAddr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_DISTRIBUTION_DELEGATOR_STARTING_INFO,
-			IdentifierTemplate: string(distributiontypes.GetDelegatorStartingInfoKey(dstValidatorAddr, delegateAddr)),
+			IdentifierTemplate: hex.EncodeToString(distributiontypes.GetDelegatorStartingInfoKey(dstValidatorAddr, delegateAddr)),
 		},
 
 		// Update the delegator and validator account balances
@@ -608,7 +609,7 @@ func MsgBeginRedelegateDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Cont
 		{
 			AccessType:   sdkacltypes.AccessType_WRITE,
 			ResourceType: sdkacltypes.ResourceType_KV_STAKING_REDELEGATION_VAL_SRC,
-			IdentifierTemplate: string(stakingtypes.GetREDByValSrcIndexKey(
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.GetREDByValSrcIndexKey(
 				delegateAddr,
 				srcValidatorAddr,
 				dstValidatorAddr,
@@ -617,7 +618,7 @@ func MsgBeginRedelegateDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Cont
 		{
 			AccessType:   sdkacltypes.AccessType_WRITE,
 			ResourceType: sdkacltypes.ResourceType_KV_STAKING_REDELEGATION_VAL_DST,
-			IdentifierTemplate: string(stakingtypes.GetREDByValDstIndexKey(
+			IdentifierTemplate: hex.EncodeToString(stakingtypes.GetREDByValDstIndexKey(
 				delegateAddr,
 				srcValidatorAddr,
 				dstValidatorAddr,

--- a/aclmapping/staking/mappings.go
+++ b/aclmapping/staking/mappings.go
@@ -46,10 +46,10 @@ func MsgDelegateDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context, ms
 	// validatorAddrCons := string(stakingtypes.GetValidatorByConsAddrKey(validatorCons))
 	// validatorOperatorAddr := validator.GetOperator().String()
 
-	delegationKey := string(stakingtypes.GetDelegationKey(delegateAddr, validatorAddr))
-	validatorKey := string(stakingtypes.GetValidatorKey(validatorAddr))
-	delegatorBalanceKey := string(banktypes.CreateAccountBalancesPrefixFromBech32(msgDelegate.DelegatorAddress))
-	validatorBalanceKey := string(banktypes.CreateAccountBalancesPrefixFromBech32(msgDelegate.ValidatorAddress))
+	delegationKey := hex.EncodeToString(stakingtypes.GetDelegationKey(delegateAddr, validatorAddr))
+	validatorKey := hex.EncodeToString(stakingtypes.GetValidatorKey(validatorAddr))
+	delegatorBalanceKey := hex.EncodeToString(banktypes.CreateAccountBalancesPrefixFromBech32(msgDelegate.DelegatorAddress))
+	validatorBalanceKey := hex.EncodeToString(banktypes.CreateAccountBalancesPrefixFromBech32(msgDelegate.ValidatorAddress))
 	// validatorOperatorBalanceKey := string(banktypes.CreateAccountBalancesPrefixFromBech32(validatorOperatorAddr))
 
 	accessOperations := []sdkacltypes.AccessOperation{
@@ -213,12 +213,12 @@ func MsgUndelegateDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context, 
 
 	validator, _ := keeper.StakingKeeper.GetValidator(ctx, validatorAddr)
 	validatorCons, _ := validator.GetConsAddr()
-	validatorAddrCons := string(stakingtypes.GetValidatorByConsAddrKey(validatorCons))
+	validatorAddrCons := hex.EncodeToString(stakingtypes.GetValidatorByConsAddrKey(validatorCons))
 
-	delegationKey := string(stakingtypes.GetDelegationKey(delegateAddr, validatorAddr))
-	validatorKey := string(stakingtypes.GetValidatorKey(validatorAddr))
-	delegatorBalanceKey := string(banktypes.CreateAccountBalancesPrefixFromBech32(msgUndelegate.DelegatorAddress))
-	validatorBalanceKey := string(banktypes.CreateAccountBalancesPrefixFromBech32(msgUndelegate.ValidatorAddress))
+	delegationKey := hex.EncodeToString(stakingtypes.GetDelegationKey(delegateAddr, validatorAddr))
+	validatorKey := hex.EncodeToString(stakingtypes.GetValidatorKey(validatorAddr))
+	delegatorBalanceKey := hex.EncodeToString(banktypes.CreateAccountBalancesPrefixFromBech32(msgUndelegate.DelegatorAddress))
+	validatorBalanceKey := hex.EncodeToString(banktypes.CreateAccountBalancesPrefixFromBech32(msgUndelegate.ValidatorAddress))
 
 	accessOperations := []sdkacltypes.AccessOperation{
 		// Treat Delegations and Undelegations to have the same ACL since they are highly coupled, no point in finer granularization
@@ -421,13 +421,13 @@ func MsgBeginRedelegateDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Cont
 	srcValidator, _ := keeper.StakingKeeper.GetValidator(ctx, srcValidatorAddr)
 	dstValidator, _ := keeper.StakingKeeper.GetValidator(ctx, dstValidatorAddr)
 
-	srcDelegationKey := string(stakingtypes.GetDelegationKey(delegateAddr, srcValidatorAddr))
-	dstDelegationKey := string(stakingtypes.GetDelegationKey(delegateAddr, dstValidatorAddr))
+	srcDelegationKey := hex.EncodeToString(stakingtypes.GetDelegationKey(delegateAddr, srcValidatorAddr))
+	dstDelegationKey := hex.EncodeToString(stakingtypes.GetDelegationKey(delegateAddr, dstValidatorAddr))
 
-	srcValidatorKey := string(stakingtypes.GetValidatorKey(srcValidatorAddr))
-	dstValidatorKey := string(stakingtypes.GetValidatorKey(dstValidatorAddr))
+	srcValidatorKey := hex.EncodeToString(stakingtypes.GetValidatorKey(srcValidatorAddr))
+	dstValidatorKey := hex.EncodeToString(stakingtypes.GetValidatorKey(dstValidatorAddr))
 
-	dstValidatorBalanceKey := string(banktypes.CreateAccountBalancesPrefixFromBech32(msgBeingRedelegate.ValidatorDstAddress))
+	dstValidatorBalanceKey := hex.EncodeToString(banktypes.CreateAccountBalancesPrefixFromBech32(msgBeingRedelegate.ValidatorDstAddress))
 
 	accessOperations := []sdkacltypes.AccessOperation{
 		// Treat Delegations and Undelegations to have the same ACL since they are highly coupled, no point in finer granularization

--- a/aclmapping/tokenfactory/mappings.go
+++ b/aclmapping/tokenfactory/mappings.go
@@ -37,7 +37,7 @@ func TokenFactoryMintDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Contex
 	denomMetaDataKey := append([]byte(tfktypes.DenomAuthorityMetadataKey), []byte(denom)...)
 	tokenfactoryDenomKey := tfktypes.GetDenomPrefixStore(denom)
 	bankDenomMetaDataKey := banktypes.DenomMetadataKey(denom)
-	supplyKey := string(append(banktypes.SupplyKey, []byte(denom)...))
+	supplyKey := hex.EncodeToString(append(banktypes.SupplyKey, []byte(denom)...))
 
 	return []sdkacltypes.AccessOperation{
 		// Reads denom data From BankKeeper
@@ -127,7 +127,7 @@ func TokenFactoryBurnDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Contex
 	denomMetaDataKey := append([]byte(tfktypes.DenomAuthorityMetadataKey), []byte(denom)...)
 	tokenfactoryDenomKey := tfktypes.GetDenomPrefixStore(denom)
 	bankDenomMetaDataKey := banktypes.DenomMetadataKey(denom)
-	supplyKey := string(append(banktypes.SupplyKey, []byte(denom)...))
+	supplyKey := hex.EncodeToString(append(banktypes.SupplyKey, []byte(denom)...))
 	return []sdkacltypes.AccessOperation{
 		// Reads denom data From BankKeeper
 		{

--- a/aclmapping/tokenfactory/mappings.go
+++ b/aclmapping/tokenfactory/mappings.go
@@ -1,6 +1,7 @@
 package aclTokenFactorymapping
 
 import (
+	"encoding/hex"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -43,45 +44,45 @@ func TokenFactoryMintDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Contex
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_BANK_DENOM,
-			IdentifierTemplate: string(bankDenomMetaDataKey),
+			IdentifierTemplate: hex.EncodeToString(bankDenomMetaDataKey),
 		},
 
 		// Gets Authoritity data related to the denom
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_TOKENFACTORY_METADATA,
-			IdentifierTemplate: string(denomMetaDataKey),
+			IdentifierTemplate: hex.EncodeToString(denomMetaDataKey),
 		},
 
 		// Gets Authoritity data related to the denom
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_TOKENFACTORY_DENOM,
-			IdentifierTemplate: string(tokenfactoryDenomKey),
+			IdentifierTemplate: hex.EncodeToString(tokenfactoryDenomKey),
 		},
 
 		// Gets Module Account information
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
-			IdentifierTemplate: string(authtypes.AddressStoreKey(moduleAdr)),
+			IdentifierTemplate: hex.EncodeToString(authtypes.AddressStoreKey(moduleAdr)),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_BANK_BALANCES,
-			IdentifierTemplate: string(banktypes.CreateAccountBalancesPrefix(moduleAdr)),
+			IdentifierTemplate: hex.EncodeToString(banktypes.CreateAccountBalancesPrefix(moduleAdr)),
 		},
 
 		// Deposit into Sender's Bank Balance
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_BANK_BALANCES,
-			IdentifierTemplate: string(banktypes.CreateAccountBalancesPrefixFromBech32(mintMsg.GetSender())),
+			IdentifierTemplate: hex.EncodeToString(banktypes.CreateAccountBalancesPrefixFromBech32(mintMsg.GetSender())),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_BANK_BALANCES,
-			IdentifierTemplate: string(banktypes.CreateAccountBalancesPrefixFromBech32(mintMsg.GetSender())),
+			IdentifierTemplate: hex.EncodeToString(banktypes.CreateAccountBalancesPrefixFromBech32(mintMsg.GetSender())),
 		},
 
 		// Read and update supply after burn
@@ -99,12 +100,12 @@ func TokenFactoryMintDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Contex
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
-			IdentifierTemplate: string(authtypes.CreateAddressStoreKeyFromBech32(mintMsg.GetSender())),
+			IdentifierTemplate: hex.EncodeToString(authtypes.CreateAddressStoreKeyFromBech32(mintMsg.GetSender())),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
-			IdentifierTemplate: string(authtypes.CreateAddressStoreKeyFromBech32(mintMsg.GetSender())),
+			IdentifierTemplate: hex.EncodeToString(authtypes.CreateAddressStoreKeyFromBech32(mintMsg.GetSender())),
 		},
 
 		// Coins removed from Module account (Deferred)
@@ -132,28 +133,28 @@ func TokenFactoryBurnDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Contex
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_BANK_DENOM,
-			IdentifierTemplate: string(bankDenomMetaDataKey),
+			IdentifierTemplate: hex.EncodeToString(bankDenomMetaDataKey),
 		},
 
 		// Gets Authoritity data related to the denom
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_TOKENFACTORY_METADATA,
-			IdentifierTemplate: string(denomMetaDataKey),
+			IdentifierTemplate: hex.EncodeToString(denomMetaDataKey),
 		},
 
 		// Gets Authoritity data related to the denom
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_TOKENFACTORY_DENOM,
-			IdentifierTemplate: string(tokenfactoryDenomKey),
+			IdentifierTemplate: hex.EncodeToString(tokenfactoryDenomKey),
 		},
 
 		// Gets Module Account Balance
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
-			IdentifierTemplate: string(authtypes.AddressStoreKey(moduleAdr)),
+			IdentifierTemplate: hex.EncodeToString(authtypes.AddressStoreKey(moduleAdr)),
 		},
 
 		// Sends from Sender to Module account (deferred deposit)
@@ -161,12 +162,12 @@ func TokenFactoryBurnDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Contex
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_BANK_BALANCES,
-			IdentifierTemplate: string(banktypes.CreateAccountBalancesPrefixFromBech32(burnMsg.GetSender())),
+			IdentifierTemplate: hex.EncodeToString(banktypes.CreateAccountBalancesPrefixFromBech32(burnMsg.GetSender())),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_BANK_BALANCES,
-			IdentifierTemplate: string(banktypes.CreateAccountBalancesPrefixFromBech32(burnMsg.GetSender())),
+			IdentifierTemplate: hex.EncodeToString(banktypes.CreateAccountBalancesPrefixFromBech32(burnMsg.GetSender())),
 		},
 
 		// Read and update supply after burn
@@ -184,12 +185,12 @@ func TokenFactoryBurnDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Contex
 		{
 			AccessType:         sdkacltypes.AccessType_READ,
 			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
-			IdentifierTemplate: string(authtypes.CreateAddressStoreKeyFromBech32(burnMsg.GetSender())),
+			IdentifierTemplate: hex.EncodeToString(authtypes.CreateAddressStoreKeyFromBech32(burnMsg.GetSender())),
 		},
 		{
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
-			IdentifierTemplate: string(authtypes.CreateAddressStoreKeyFromBech32(burnMsg.GetSender())),
+			IdentifierTemplate: hex.EncodeToString(authtypes.CreateAddressStoreKeyFromBech32(burnMsg.GetSender())),
 		},
 
 		// Coins removed from Module account (Deferred)

--- a/aclmapping/utils/resource_type.go
+++ b/aclmapping/utils/resource_type.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	aclsdktypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
 	acltypes "github.com/cosmos/cosmos-sdk/x/accesscontrol/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -19,10 +20,9 @@ const (
 
 var StoreKeyToResourceTypePrefixMap = aclsdktypes.StoreKeyToResourceTypePrefixMap{
 	aclsdktypes.ParentNodeKey: {
-		aclsdktypes.ResourceType_ANY:     aclsdktypes.EmptyPrefix,
-		aclsdktypes.ResourceType_KV:      aclsdktypes.EmptyPrefix,
-		aclsdktypes.ResourceType_Mem:     aclsdktypes.EmptyPrefix,
-		aclsdktypes.ResourceType_KV_WASM: aclsdktypes.EmptyPrefix,
+		aclsdktypes.ResourceType_ANY: aclsdktypes.EmptyPrefix,
+		aclsdktypes.ResourceType_KV:  aclsdktypes.EmptyPrefix,
+		aclsdktypes.ResourceType_Mem: aclsdktypes.EmptyPrefix,
 	},
 	dextypes.StoreKey: {
 		aclsdktypes.ResourceType_KV_DEX:                    aclsdktypes.EmptyPrefix,
@@ -112,5 +112,15 @@ var StoreKeyToResourceTypePrefixMap = aclsdktypes.StoreKeyToResourceTypePrefixMa
 	acltypes.StoreKey: {
 		aclsdktypes.ResourceType_KV_ACCESSCONTROL:                         aclsdktypes.EmptyPrefix,
 		aclsdktypes.ResourceType_KV_ACCESSCONTROL_WASM_DEPENDENCY_MAPPING: acltypes.GetWasmMappingKey(),
+	},
+	wasmtypes.StoreKey: {
+		aclsdktypes.ResourceType_KV_WASM:                       aclsdktypes.EmptyPrefix,
+		aclsdktypes.ResourceType_KV_WASM_CODE:                  wasmtypes.CodeKeyPrefix,
+		aclsdktypes.ResourceType_KV_WASM_CONTRACT_ADDRESS:      wasmtypes.ContractKeyPrefix,
+		aclsdktypes.ResourceType_KV_WASM_CONTRACT_STORE:        wasmtypes.ContractStorePrefix,
+		aclsdktypes.ResourceType_KV_WASM_SEQUENCE_KEY:          wasmtypes.SequenceKeyPrefix,
+		aclsdktypes.ResourceType_KV_WASM_CONTRACT_CODE_HISTORY: wasmtypes.ContractCodeHistoryElementPrefix,
+		aclsdktypes.ResourceType_KV_WASM_CONTRACT_BY_CODE_ID:   wasmtypes.ContractByCodeIDAndCreatedSecondaryIndexPrefix,
+		aclsdktypes.ResourceType_KV_WASM_PINNED_CODE_INDEX:     wasmtypes.PinnedCodeIndexPrefix,
 	},
 }

--- a/aclmapping/utils/resource_type.go
+++ b/aclmapping/utils/resource_type.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	aclsdktypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
+	acltypes "github.com/cosmos/cosmos-sdk/x/accesscontrol/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
@@ -107,5 +108,9 @@ var StoreKeyToResourceTypePrefixMap = aclsdktypes.StoreKeyToResourceTypePrefixMa
 	},
 	epochtypes.StoreKey: {
 		aclsdktypes.ResourceType_KV_EPOCH: aclsdktypes.EmptyPrefix,
+	},
+	acltypes.StoreKey: {
+		aclsdktypes.ResourceType_KV_ACCESSCONTROL:                         aclsdktypes.EmptyPrefix,
+		aclsdktypes.ResourceType_KV_ACCESSCONTROL_WASM_DEPENDENCY_MAPPING: acltypes.GetWasmMappingKey(),
 	},
 }

--- a/app/ante.go
+++ b/app/ante.go
@@ -75,7 +75,7 @@ func NewAnteHandlerAndDepGenerator(options HandlerOptions) (sdk.AnteHandler, sdk
 	// }
 
 	anteDecorators := []sdk.AnteFullDecorator{
-		sdk.DefaultWrappedAnteDecorator(ante.NewSetUpContextDecorator(antedecorators.GetGasMeterSetter(*options.AccessControlKeeper))), // outermost AnteDecorator. SetUpContext must be called first
+		sdk.CustomDepWrappedAnteDecorator(ante.NewSetUpContextDecorator(antedecorators.GetGasMeterSetter(*options.AccessControlKeeper)), depdecorators.GasMeterSetterDecorator{}), // outermost AnteDecorator. SetUpContext must be called first
 		// TODO: have dex antehandler separate, and then call the individual antehandlers FROM the gasless antehandler decorator wrapper
 		antedecorators.NewGaslessDecorator([]sdk.AnteFullDecorator{ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TxFeeChecker)}, *options.OracleKeeper, *options.NitroKeeper),
 		sdk.DefaultWrappedAnteDecorator(wasmkeeper.NewLimitSimulationGasDecorator(options.WasmConfig.SimulationGasLimit)), // after setup context to enforce limits early

--- a/app/antedecorators/depdecorators/gas.go
+++ b/app/antedecorators/depdecorators/gas.go
@@ -1,6 +1,8 @@
 package depdecorators
 
 import (
+	"encoding/hex"
+
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
@@ -21,7 +23,7 @@ func (d GasMeterSetterDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, 
 			txDeps = append(txDeps, sdkacltypes.AccessOperation{
 				AccessType:         sdkacltypes.AccessType_READ,
 				ResourceType:       sdkacltypes.ResourceType_KV_ACCESSCONTROL_WASM_DEPENDENCY_MAPPING,
-				IdentifierTemplate: string(acltypes.GetWasmContractAddressKey(accAddr)),
+				IdentifierTemplate: hex.EncodeToString(acltypes.GetWasmContractAddressKey(accAddr)),
 			})
 		}
 	}

--- a/app/antedecorators/depdecorators/gas.go
+++ b/app/antedecorators/depdecorators/gas.go
@@ -1,0 +1,29 @@
+package depdecorators
+
+import (
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
+	acltypes "github.com/cosmos/cosmos-sdk/x/accesscontrol/types"
+)
+
+type GasMeterSetterDecorator struct {
+}
+
+func (d GasMeterSetterDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
+	for _, msg := range tx.GetMsgs() {
+		if wasmExecuteMsg, ok := msg.(*wasmtypes.MsgExecuteContract); ok {
+			// if we have a wasm execute message, we need to declare the dependency to read accesscontrol for giving gas discount
+			accAddr, err := sdk.AccAddressFromBech32(wasmExecuteMsg.Contract)
+			if err != nil {
+				return txDeps, err
+			}
+			txDeps = append(txDeps, sdkacltypes.AccessOperation{
+				AccessType:         sdkacltypes.AccessType_READ,
+				ResourceType:       sdkacltypes.ResourceType_KV_ACCESSCONTROL_WASM_DEPENDENCY_MAPPING,
+				IdentifierTemplate: string(acltypes.GetWasmContractAddressKey(accAddr)),
+			})
+		}
+	}
+	return next(txDeps, tx)
+}

--- a/app/antedecorators/depdecorators/signers.go
+++ b/app/antedecorators/depdecorators/signers.go
@@ -1,6 +1,8 @@
 package depdecorators
 
 import (
+	"encoding/hex"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -27,7 +29,7 @@ func (d SignerDepDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sd
 		txDeps = append(txDeps, sdkacltypes.AccessOperation{
 			AccessType:         accessType,
 			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
-			IdentifierTemplate: string(authtypes.AddressStoreKey(signer)),
+			IdentifierTemplate: hex.EncodeToString(authtypes.AddressStoreKey(signer)),
 		})
 	}
 	return next(txDeps, tx)

--- a/app/antedecorators/gasless.go
+++ b/app/antedecorators/gasless.go
@@ -2,6 +2,7 @@ package antedecorators
 
 import (
 	"bytes"
+	"encoding/hex"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
@@ -75,19 +76,19 @@ func (gd GaslessDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk
 				{
 					ResourceType:       sdkacltypes.ResourceType_KV_ORACLE_FEEDERS,
 					AccessType:         sdkacltypes.AccessType_READ,
-					IdentifierTemplate: string(oracletypes.GetFeederDelegationKey(valAddr)),
+					IdentifierTemplate: hex.EncodeToString(oracletypes.GetFeederDelegationKey(valAddr)),
 				},
 				// read validator from staking - READ
 				{
 					ResourceType:       sdkacltypes.ResourceType_KV_STAKING_VALIDATOR,
 					AccessType:         sdkacltypes.AccessType_READ,
-					IdentifierTemplate: string(stakingtypes.GetValidatorKey(valAddr)),
+					IdentifierTemplate: hex.EncodeToString(stakingtypes.GetValidatorKey(valAddr)),
 				},
 				// check exchange rate vote exists - READ
 				{
 					ResourceType:       sdkacltypes.ResourceType_KV_ORACLE_AGGREGATE_VOTES,
 					AccessType:         sdkacltypes.AccessType_READ,
-					IdentifierTemplate: string(oracletypes.GetAggregateExchangeRateVoteKey(valAddr)),
+					IdentifierTemplate: hex.EncodeToString(oracletypes.GetAggregateExchangeRateVoteKey(valAddr)),
 				},
 			}...)
 		default:

--- a/go.mod
+++ b/go.mod
@@ -266,7 +266,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.295
+	github.com/cosmos/cosmos-sdk => ../sei-cosmos //github.com/sei-protocol/sei-cosmos v0.1.295
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.91

--- a/go.mod
+++ b/go.mod
@@ -266,7 +266,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => ../sei-cosmos //github.com/sei-protocol/sei-cosmos v0.1.295
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.304
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.91

--- a/go.sum
+++ b/go.sum
@@ -1222,8 +1222,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.1.295 h1:4wmtTsvxNxUDlRqn1nCbdsZJwBPkX9bkVc5EqYpAS5Y=
-github.com/sei-protocol/sei-cosmos v0.1.295/go.mod h1:bxExI8MhmuYbZTqgdxvmYtJWe5TQAdsDqXjig+Ah2rk=
+github.com/sei-protocol/sei-cosmos v0.1.304 h1:P+78hqBYfAyZKLvpJPDExd7BoMGncelwg+bWQObOEwU=
+github.com/sei-protocol/sei-cosmos v0.1.304/go.mod h1:bxExI8MhmuYbZTqgdxvmYtJWe5TQAdsDqXjig+Ah2rk=
 github.com/sei-protocol/sei-tendermint v0.1.91 h1:FXIAAXZoVUOw0srE71giPy5Kt2lI54RjvwZi7pTF5V4=
 github.com/sei-protocol/sei-tendermint v0.1.91/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=

--- a/x/oracle/ante.go
+++ b/x/oracle/ante.go
@@ -1,6 +1,7 @@
 package oracle
 
 import (
+	"encoding/hex"
 	"sync"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -60,19 +61,19 @@ func (spd SpammingPreventionDecorator) AnteDeps(txDeps []sdkacltypes.AccessOpera
 				{
 					ResourceType:       sdkacltypes.ResourceType_KV_ORACLE_FEEDERS,
 					AccessType:         sdkacltypes.AccessType_READ,
-					IdentifierTemplate: string(types.GetFeederDelegationKey(valAddr)),
+					IdentifierTemplate: hex.EncodeToString(types.GetFeederDelegationKey(valAddr)),
 				},
 				// read validator from staking - READ
 				{
 					ResourceType:       sdkacltypes.ResourceType_KV_STAKING_VALIDATOR,
 					AccessType:         sdkacltypes.AccessType_READ,
-					IdentifierTemplate: string(stakingtypes.GetValidatorKey(valAddr)),
+					IdentifierTemplate: hex.EncodeToString(stakingtypes.GetValidatorKey(valAddr)),
 				},
 				// check exchange rate vote exists - READ
 				{
 					ResourceType:       sdkacltypes.ResourceType_KV_ORACLE_AGGREGATE_VOTES,
 					AccessType:         sdkacltypes.AccessType_READ,
-					IdentifierTemplate: string(types.GetAggregateExchangeRateVoteKey(valAddr)),
+					IdentifierTemplate: hex.EncodeToString(types.GetAggregateExchangeRateVoteKey(valAddr)),
 				},
 			}...)
 		default:


### PR DESCRIPTION
## Describe your changes and provide context
This properly adds the READ resource dependency on the wasm dependency mapping in the ante decorators for the gas meter setter. This is needed when we see wasm execute messages because the ante handler then reads from accesscontrol to get the dependencies to determine whether to allow gas discounts.

This also refactors identifier templates to use hex encoded strings

## Testing performed to validate your change
Tested with local sei to ensure that no more concurrent execution errors due to this access op being excluded