### PR TITLE
Update seid start script with nitro lib build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,10 @@ ldflags := $(strip $(ldflags))
 BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags)'
 
 #### Command List ####
+# Make sure you are using latest nitro replayer library before make install:
+# 1. git clone https://github.com/sei-protocol/nitro-replayer
+# 2. cd nitro-replayer && cargo build --release && cd ..
+# 3. cp nitro-replayer/target/release/libnitro_replayer.dylib sei-chain/x/nitro/replay
 
 all: lint install
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+SEI_ROOT=$(git rev-parse --show-toplevel)
+
+display_usage() {
+  echo "This script support build or install seid."
+  echo "Usage: ./build.sh [seid, seid-nitro]"
+}
+
+build_nitro_replayer() {
+  NITRO_ROOT="$SEI_ROOT/../nitro-replayer/"
+  if [ ! -d "${NITRO_ROOT}" ]; then
+    cd "${SEI_ROOT}/../" || exit
+    git clone https://github.com/sei-protocol/nitro-replayer
+  fi
+  cd "${NITRO_ROOT}" || exit
+  cargo build --release
+  cp ${NITRO_ROOT}/target/release/libnitro_replayer.dylib "${SEI_ROOT}/x/nitro/replay"
+}
+
+# Add helper to display usage
+if [[ ( $1 == "--help") ||  $1 == "-h" ]]
+then
+  display_usage
+  exit 0
+fi
+
+if [  $# -ne 1 ]
+then
+  display_usage
+  exit 1
+fi
+
+# Take cmd input
+OPTION=$1
+
+# Display usage if input is a bad option
+case $OPTION in
+  "seid" )
+    ;;
+  "seid-nitro" )
+    build_nitro_replayer
+    ;;
+  * )
+   echo "Unrecognized option: $OPTION"
+   display_usage
+   exit 1
+   ;;
+esac
+
+cd "$SEI_ROOT" || exit
+go build -o ./build/seid ./cmd/seid
+make install

--- a/scripts/initialize_local.sh
+++ b/scripts/initialize_local.sh
@@ -1,7 +1,6 @@
 # min go compiler version >=1.18.2
 # gvm use go1.18.2
-# build seid
-go build -o build/seid ./cmd/seid/
+
 # bootstrap from scratch
 rm -rf ~/.sei/
 rm -rf ~/test_accounts/


### PR DESCRIPTION
## Describe your changes and provide context
**Problem:**
The current master was broken after building and running seid locally. It is complaining about not able to find some nitro libraries.

`dyld[78984]: Library not loaded: /Users/tonychen/repos/nitro-replayer/target/release/deps/libnitro_replayer.dylib
  Referenced from: /Users/kartikbhat/go/bin/seid
  Reason: tried: '/Users/tonychen/repos/nitro-replayer/target/release/deps/libnitro_replayer.dylib' (no such file), '/usr/local/lib/libnitro_replayer.dylib' (no such file), '/usr/lib/libnitro_replayer.dylib' (no such file)
zsh: abort      seid`

**Fix:**
The way to fix it is to build from the latest nitro-replayer repo, and copy the latest library over to sei-chain.
This change fix the issue by:
1. Adding a new bash script to automate the whole process
2. Fix the existing initialize scripts to use the new build.sh script
3. Add some instructions in make file

## Testing performed to validate your change
Manually run and tested build.sh, initialize_local.sh

This should fail:
`./scripts/build.sh seid && ./build/seid` 

This should succeed:
`./scripts/build.sh seid-nitro && ./build/seid`
