### PR TITLE
Refund gas fees if concurrent TX fails

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1157,7 +1157,8 @@ func (app *App) ProcessTxs(
 
 	ctx.Logger().Error("Concurrent Execution failed, retrying with Synchronous")
 	// Clear the memcache context from the previous state as it failed, we no longer need to commit the data
-	ctx = ctx.WithContextMemCache(sdk.NewContextMemCache())
+	ctx.ContextMemCache().Clear()
+
 	txResults := app.ProcessBlockSynchronous(ctx, txs)
 	processBlockCache.Write()
 	return txResults

--- a/app/app.go
+++ b/app/app.go
@@ -1058,11 +1058,11 @@ func (app *App) ProcessTxConcurrent(
 }
 
 type ProcessBlockConcurrentFunction func(
-		ctx sdk.Context,
-		txs [][]byte,
-		completionSignalingMap map[int]acltypes.MessageCompletionSignalMapping,
-		blockingSignalsMap map[int]acltypes.MessageCompletionSignalMapping,
-		txMsgAccessOpMapping map[int]acltypes.MsgIndexToAccessOpMapping,
+	ctx sdk.Context,
+	txs [][]byte,
+	completionSignalingMap map[int]acltypes.MessageCompletionSignalMapping,
+	blockingSignalsMap map[int]acltypes.MessageCompletionSignalMapping,
+	txMsgAccessOpMapping map[int]acltypes.MsgIndexToAccessOpMapping,
 ) ([]*abci.ExecTxResult, bool)
 
 func (app *App) ProcessBlockConcurrent(

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -118,7 +118,6 @@ func TestProcessTxsSuccess(t *testing.T) {
 		Denom:  "test",
 		Amount: sdk.NewInt(1),
 	}))
-	// It should be reset if it fails to prevent any values from being written
 	require.Equal(t, 1, len(testWrapper.Ctx.ContextMemCache().GetDeferredSends().GetSortedKeys()))
 	testWrapper.App.ProcessTxs(
 		testWrapper.Ctx,

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -114,10 +114,12 @@ func TestProcessTxsSuccess(t *testing.T) {
 		Denom:  "test",
 		Amount: sdk.NewInt(1),
 	}))
-	testWrapper.Ctx.ContextMemCache().UpsertDeferredWithdrawals("Some Account", sdk.NewCoins(sdk.Coin{
+	testWrapper.Ctx.ContextMemCache().UpsertDeferredWithdrawals("Some Other Account", sdk.NewCoins(sdk.Coin{
 		Denom:  "test",
 		Amount: sdk.NewInt(1),
 	}))
+	// It should be reset if it fails to prevent any values from being written
+	require.Equal(t, 1, len(testWrapper.Ctx.ContextMemCache().GetDeferredSends().GetSortedKeys()))
 	testWrapper.App.ProcessTxs(
 		testWrapper.Ctx,
 		[][]byte{},

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
 	acltypes "github.com/cosmos/cosmos-sdk/x/accesscontrol/types"
 	"github.com/k0kubun/pp/v3"
@@ -75,4 +76,86 @@ func TestGetChannelsFromSignalMapping(t *testing.T) {
 
 	require.True(t, len(resultCompletionSignalsMap) > 1)
 	require.True(t, len(resultBlockingSignalsMap) > 1)
+}
+
+
+// Mock method to fail
+func MockProcessBlockConcurrentFunctionFail(
+	ctx sdk.Context,
+	txs [][]byte,
+	completionSignalingMap map[int]acltypes.MessageCompletionSignalMapping,
+	blockingSignalsMap map[int]acltypes.MessageCompletionSignalMapping,
+	txMsgAccessOpMapping map[int]acltypes.MsgIndexToAccessOpMapping,
+) ([]*abci.ExecTxResult, bool) {
+	return []*abci.ExecTxResult{}, false
+}
+
+func MockProcessBlockConcurrentFunctionSuccess(
+	ctx sdk.Context,
+	txs [][]byte,
+	completionSignalingMap map[int]acltypes.MessageCompletionSignalMapping,
+	blockingSignalsMap map[int]acltypes.MessageCompletionSignalMapping,
+	txMsgAccessOpMapping map[int]acltypes.MsgIndexToAccessOpMapping,
+) ([]*abci.ExecTxResult, bool) {
+	return []*abci.ExecTxResult{}, true
+}
+
+
+func TestProcessTxsSuccess(t *testing.T) {
+	tm := time.Now().UTC()
+	valPub := secp256k1.GenPrivKey().PubKey()
+
+
+	testWrapper := app.NewTestWrapper(t, tm, valPub)
+	dag := acltypes.NewDag()
+
+	// Set some test context mem cache values
+	testWrapper.Ctx.ContextMemCache().UpsertDeferredSends("Some Account", sdk.NewCoins(sdk.Coin{
+		Denom:  "test",
+		Amount: sdk.NewInt(1),
+	}))
+	testWrapper.Ctx.ContextMemCache().UpsertDeferredWithdrawals("Some Account", sdk.NewCoins(sdk.Coin{
+		Denom:  "test",
+		Amount: sdk.NewInt(1),
+	}))
+	testWrapper.App.ProcessTxs(
+		testWrapper.Ctx,
+		[][]byte{},
+		&dag,
+		MockProcessBlockConcurrentFunctionSuccess,
+	)
+
+	// It should be reset if it fails to prevent any values from being written
+	require.Equal(t, 1, len(testWrapper.Ctx.ContextMemCache().GetDeferredWithdrawals().GetSortedKeys()))
+	require.Equal(t, 1, len(testWrapper.Ctx.ContextMemCache().GetDeferredSends().GetSortedKeys()))
+}
+
+
+func TestProcessTxsClearCacheOnFail(t *testing.T) {
+	tm := time.Now().UTC()
+	valPub := secp256k1.GenPrivKey().PubKey()
+
+
+	testWrapper := app.NewTestWrapper(t, tm, valPub)
+	dag := acltypes.NewDag()
+
+	// Set some test context mem cache values
+	testWrapper.Ctx.ContextMemCache().UpsertDeferredSends("Some Account", sdk.NewCoins(sdk.Coin{
+		Denom:  "test",
+		Amount: sdk.NewInt(1),
+	}))
+	testWrapper.Ctx.ContextMemCache().UpsertDeferredWithdrawals("Some Account", sdk.NewCoins(sdk.Coin{
+		Denom:  "test",
+		Amount: sdk.NewInt(1),
+	}))
+	testWrapper.App.ProcessTxs(
+		testWrapper.Ctx,
+		[][]byte{},
+		&dag,
+		MockProcessBlockConcurrentFunctionFail,
+	)
+
+	// It should be reset if it fails to prevent any values from being written
+	require.Equal(t, 0, len(testWrapper.Ctx.ContextMemCache().GetDeferredWithdrawals().GetSortedKeys()))
+	require.Equal(t, 0, len(testWrapper.Ctx.ContextMemCache().GetDeferredSends().GetSortedKeys()))
 }

--- a/go.mod
+++ b/go.mod
@@ -266,7 +266,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.318
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.319
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.91

--- a/go.sum
+++ b/go.sum
@@ -1067,8 +1067,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.1.318 h1:hDTSYGuHdrN+nioJ6pWjL2u28BM/WVJC3MlBU/+vYAM=
-github.com/sei-protocol/sei-cosmos v0.1.318/go.mod h1:N3OGX0WV/5fdWHZ5BavvrrRBr3SqUUwuwjvHnWinLss=
+github.com/sei-protocol/sei-cosmos v0.1.319 h1:gynHm7kA52ElGNu5xYfC5j0OanhNTIp92KcMC7aGyqA=
+github.com/sei-protocol/sei-cosmos v0.1.319/go.mod h1:N3OGX0WV/5fdWHZ5BavvrrRBr3SqUUwuwjvHnWinLss=
 github.com/sei-protocol/sei-tendermint v0.1.91 h1:FXIAAXZoVUOw0srE71giPy5Kt2lI54RjvwZi7pTF5V4=
 github.com/sei-protocol/sei-tendermint v0.1.91/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=

--- a/x/oracle/keeper/test_utils.go
+++ b/x/oracle/keeper/test_utils.go
@@ -1,4 +1,4 @@
-// nolint
+//nolint
 package keeper
 
 import (

--- a/x/oracle/simulation/operations.go
+++ b/x/oracle/simulation/operations.go
@@ -65,7 +65,7 @@ func WeightedOperations(
 }
 
 // SimulateMsgAggregateExchangeRateVote generates a MsgAggregateExchangeRateVote with random values.
-// nolint: funlen
+//nolint: funlen
 func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
@@ -122,7 +122,7 @@ func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankK
 }
 
 // SimulateMsgDelegateFeedConsent generates a MsgDelegateFeedConsent with random values.
-// nolint: funlen
+//nolint: funlen
 func SimulateMsgDelegateFeedConsent(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,


### PR DESCRIPTION
## Describe your changes and provide context
We already reset the cacheKv (by not writing it) if the transactions fail, but we also need to reset the in-mem values to as those are different from the store 

Previously we didn't clear the state so the deferred sends from the previous call carried over 

## Testing performed to validate your change
Unit tests 
