### PR TITLE
Fix local initialization script

### DIFF
--- a/scripts/initialize_local.sh
+++ b/scripts/initialize_local.sh
@@ -1,5 +1,19 @@
 # min go compiler version >=1.18.2
 # gvm use go1.18.2
+
+#########################################################
+## How to submitting a proposal after chain is running ##
+#########################################################
+# To submit a new proposal:
+# ./build/seid tx gov submit-proposal param-change proposal.json --from alice --chain-id sei --fees 2000usei -b block -y
+# To vote a proposal:
+# ./build/seid tx gov vote <proposal_id> yes --from alice --chain-id sei --fees 2000usei -b block -y
+# To query a proposal status:
+# ./build/seid q gov proposal <proposal_id>
+# To query a transaction status:
+# ./build/seid q tx --type=hash <tx_hash>
+#########################################################
+
 # build seid
 go build -o build/seid ./cmd/seid/
 # bootstrap from scratch
@@ -10,12 +24,12 @@ rm -rf ~/test_accounts/
 ./build/seid init demo --chain-id sei
 test_account_name=alice
 # add test_account_name to keys
-./build/seid keys add $test_account_name
-printf '00000000\n' | ./build/seid add-genesis-account $(./build/seid keys show $test_account_name -a) 100000000000000000000usei
+./build/seid keys add $test_account_name --keyring-backend test
+./build/seid add-genesis-account $(./build/seid keys show $test_account_name -a) 100000000000000000000usei
 # generate genesis tx
-printf '00000000\n' | ./build/seid gentx $test_account_name 70000000000000000000usei --chain-id sei
-sed -i'.bak' -e 's/mode = "full"/mode = "validator"/g' $HOME/.sei/config/config.toml
-sed -i'.bak' -e 's/indexer = \["null"\]/indexer = \["kv"\]/g' $HOME/.sei/config/config.toml
+./build/seid gentx $test_account_name 70000000000000000000usei --chain-id sei
+sed -i'' -e 's/mode = "full"/mode = "validator"/g' $HOME/.sei/config/config.toml
+sed -i'' -e 's/indexer = \["null"\]/indexer = \["kv"\]/g' $HOME/.sei/config/config.toml
 KEY=$(jq '.pub_key' ~/.sei/config/priv_validator_key.json -c)
 jq '.validators = [{}]' ~/.sei/config/genesis.json > ~/.sei/config/tmp_genesis.json
 jq '.validators[0] += {"power":"70000000000000"}' ~/.sei/config/tmp_genesis.json > ~/.sei/config/tmp_genesis_2.json
@@ -26,8 +40,8 @@ cat ~/.sei/config/genesis.json | jq '.app_state["crisis"]["constant_fee"]["denom
 cat ~/.sei/config/genesis.json | jq '.app_state["gov"]["deposit_params"]["min_deposit"][0]["denom"]="usei"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 cat ~/.sei/config/genesis.json | jq '.app_state["mint"]["params"]["mint_denom"]="usei"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 cat ~/.sei/config/genesis.json | jq '.app_state["staking"]["params"]["bond_denom"]="usei"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
-cat ~/.sei/config/genesis.json | jq '.app_state["gov"]["deposit_params"]["max_deposit_period"]="30s"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
-cat ~/.sei/config/genesis.json | jq '.app_state["gov"]["voting_params"]["voting_period"]="30s"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
+cat ~/.sei/config/genesis.json | jq '.app_state["gov"]["deposit_params"]["max_deposit_period"]="300s"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
+cat ~/.sei/config/genesis.json | jq '.app_state["gov"]["voting_params"]["voting_period"]="120s"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 cat ~/.sei/config/genesis.json | jq '.consensus_params["block"]["time_iota_ms"]="30"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 cat ~/.sei/config/genesis.json | jq '.app_state["distribution"]["params"]["community_tax"]="0.000000000000000000"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
-printf '00000000\n' | ./build/seid start  --chain-id sei-chain
+./build/seid start  --chain-id sei-chain

--- a/scripts/initialize_local.sh
+++ b/scripts/initialize_local.sh
@@ -14,8 +14,8 @@ test_account_name=alice
 printf '00000000\n' | ./build/seid add-genesis-account $(./build/seid keys show $test_account_name -a) 100000000000000000000usei
 # generate genesis tx
 printf '00000000\n' | ./build/seid gentx $test_account_name 70000000000000000000usei --chain-id sei
-sed -i 's/mode = "full"/mode = "validator"/g' $HOME/.sei/config/config.toml
-sed -i 's/indexer = \["null"\]/indexer = \["kv"\]/g' $HOME/.sei/config/config.toml
+sed -i'.bak' -e 's/mode = "full"/mode = "validator"/g' $HOME/.sei/config/config.toml
+sed -i'.bak' -e 's/indexer = \["null"\]/indexer = \["kv"\]/g' $HOME/.sei/config/config.toml
 KEY=$(jq '.pub_key' ~/.sei/config/priv_validator_key.json -c)
 jq '.validators = [{}]' ~/.sei/config/genesis.json > ~/.sei/config/tmp_genesis.json
 jq '.validators[0] += {"power":"70000000000000"}' ~/.sei/config/tmp_genesis.json > ~/.sei/config/tmp_genesis_2.json
@@ -30,4 +30,4 @@ cat ~/.sei/config/genesis.json | jq '.app_state["gov"]["deposit_params"]["max_de
 cat ~/.sei/config/genesis.json | jq '.app_state["gov"]["voting_params"]["voting_period"]="30s"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 cat ~/.sei/config/genesis.json | jq '.consensus_params["block"]["time_iota_ms"]="30"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 cat ~/.sei/config/genesis.json | jq '.app_state["distribution"]["params"]["community_tax"]="0.000000000000000000"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
-printf '00000000\n' | ./build/seid start --log_level warn --chain-id sei-chain
+printf '00000000\n' | ./build/seid start  --chain-id sei-chain


### PR DESCRIPTION
## Describe your changes and provide context
Problem:
Initialize_local.sh is broken on Mac because sed command is not working on latest MacOS:
```
sed -i 's/mode = "full"/mode = "validator"/g' $HOME/.sei/config/config.toml
sed: 1: "/Users/yzang/.sei/confi ...": unterminated transform source string
```

Fix:
sed is little bit different on Mac compared to Linux GNU, we need to change the command to this
`sed -i'.bak' -e 's/something/else'g' filepath`

## Testing performed to validate your change
Tested on Mac and Ubuntu
