### PR TITLE
Fix Begin/EndBlock stuck at infinite loop in contracts

### DIFF
--- a/x/dex/keeper/abci/begin_block_new_block_test.go
+++ b/x/dex/keeper/abci/begin_block_new_block_test.go
@@ -3,9 +3,8 @@ package abci_test
 import (
 	"testing"
 
-	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/sei-protocol/sei-chain/x/dex/keeper"
+	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/x/dex/keeper/abci"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 )
@@ -18,14 +17,12 @@ const (
 func TestHandleBBNewBlock(t *testing.T) {
 	// this test only ensures that HandleBBNewBlock doesn't crash. The actual logic
 	// is tested in module_test.go where an actual wasm file is deployed and invoked.
-	wasmkeeper.TestingStakeParams.MinCommissionRate = sdk.NewDecWithPrec(5, 2)
-	ctx, wasmkeepers := wasmkeeper.CreateTestInput(t, false, SupportedFeatures)
+	keeper, ctx := keepertest.DexKeeper(t)
 	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
-	dexKeeper := keeper.Keeper{WasmKeeper: *wasmkeepers.WasmKeeper}
-	dexKeeper.SetContract(ctx, &types.ContractInfoV2{
+	keeper.SetContract(ctx, &types.ContractInfoV2{
 		ContractAddr: TestContract,
 		RentBalance:  100000000,
 	})
-	wrapper := abci.KeeperWrapper{Keeper: &dexKeeper}
+	wrapper := abci.KeeperWrapper{Keeper: keeper}
 	wrapper.HandleBBNewBlock(ctx, TestContract, 1)
 }

--- a/x/dex/keeper/abci/begin_block_new_block_test.go
+++ b/x/dex/keeper/abci/begin_block_new_block_test.go
@@ -1,12 +1,17 @@
 package abci_test
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
+	dexcache "github.com/sei-protocol/sei-chain/x/dex/cache"
 	"github.com/sei-protocol/sei-chain/x/dex/keeper/abci"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
+	dexutils "github.com/sei-protocol/sei-chain/x/dex/utils"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
 const (
@@ -17,12 +22,15 @@ const (
 func TestHandleBBNewBlock(t *testing.T) {
 	// this test only ensures that HandleBBNewBlock doesn't crash. The actual logic
 	// is tested in module_test.go where an actual wasm file is deployed and invoked.
-	keeper, ctx := keepertest.DexKeeper(t)
+	testApp := keepertest.TestApp()
+	ctx := testApp.BaseApp.NewContext(false, tmproto.Header{Time: time.Now()})
+	ctx = ctx.WithContext(context.WithValue(ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState(testApp.GetKey(types.StoreKey))))
+	keeper := testApp.DexKeeper
 	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
 	keeper.SetContract(ctx, &types.ContractInfoV2{
 		ContractAddr: TestContract,
 		RentBalance:  100000000,
 	})
-	wrapper := abci.KeeperWrapper{Keeper: keeper}
+	wrapper := abci.KeeperWrapper{Keeper: &keeper}
 	wrapper.HandleBBNewBlock(ctx, TestContract, 1)
 }

--- a/x/dex/keeper/abci/begin_block_new_block_test.go
+++ b/x/dex/keeper/abci/begin_block_new_block_test.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/sei-protocol/sei-chain/x/dex/keeper"
 	"github.com/sei-protocol/sei-chain/x/dex/keeper/abci"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
 )
 
 const (
@@ -21,6 +22,10 @@ func TestHandleBBNewBlock(t *testing.T) {
 	ctx, wasmkeepers := wasmkeeper.CreateTestInput(t, false, SupportedFeatures)
 	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
 	dexKeeper := keeper.Keeper{WasmKeeper: *wasmkeepers.WasmKeeper}
+	dexKeeper.SetContract(ctx, &types.ContractInfoV2{
+		ContractAddr: TestContract,
+		RentBalance:  100000000,
+	})
 	wrapper := abci.KeeperWrapper{Keeper: &dexKeeper}
 	wrapper.HandleBBNewBlock(ctx, TestContract, 1)
 }

--- a/x/dex/keeper/abci/begin_block_new_block_test.go
+++ b/x/dex/keeper/abci/begin_block_new_block_test.go
@@ -19,6 +19,7 @@ func TestHandleBBNewBlock(t *testing.T) {
 	// is tested in module_test.go where an actual wasm file is deployed and invoked.
 	wasmkeeper.TestingStakeParams.MinCommissionRate = sdk.NewDecWithPrec(5, 2)
 	ctx, wasmkeepers := wasmkeeper.CreateTestInput(t, false, SupportedFeatures)
+	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
 	dexKeeper := keeper.Keeper{WasmKeeper: *wasmkeepers.WasmKeeper}
 	wrapper := abci.KeeperWrapper{Keeper: &dexKeeper}
 	wrapper.HandleBBNewBlock(ctx, TestContract, 1)

--- a/x/dex/keeper/utils/wasm.go
+++ b/x/dex/keeper/utils/wasm.go
@@ -39,12 +39,16 @@ func sudo(sdkCtx sdk.Context, k *keeper.Keeper, contractAddress []byte, wasmMsg 
 	// Measure the time it takes to execute the contract in WASM
 	defer metrics.MeasureSudoExecutionDuration(time.Now(), msgType)
 	// set up a tmp context to prevent race condition in reading gas consumed
-	tmpCtx := sdkCtx.WithGasMeter(sdk.NewInfiniteGasMeter())
+	tmpCtx := sdkCtx.WithGasMeter(sdk.NewGasMeter(sdkCtx.GasMeter().Limit()))
+	initialGasLevel := sdkCtx.GasMeter().GasConsumedToLimit() // gas consumed so far
+	tmpCtx.GasMeter().ConsumeGas(initialGasLevel, "initialize temp")
 	data, err := k.WasmKeeper.Sudo(
 		tmpCtx, contractAddress, wasmMsg,
 	)
-	gasConsumed := tmpCtx.GasMeter().GasConsumed()
-	sdkCtx.GasMeter().ConsumeGas(gasConsumed, "sudo")
+	gasConsumed := tmpCtx.GasMeter().GasConsumed() - initialGasLevel
+	if gasConsumed > 0 {
+		sdkCtx.GasMeter().ConsumeGas(gasConsumed, "sudo")
+	}
 	if hasErrInstantiatingWasmModuleDueToCPUFeature(err) {
 		panic(utils.DecorateHardFailError(err))
 	}

--- a/x/dex/keeper/utils/wasm.go
+++ b/x/dex/keeper/utils/wasm.go
@@ -39,6 +39,9 @@ func sudo(sdkCtx sdk.Context, k *keeper.Keeper, contractAddress []byte, wasmMsg 
 	// Measure the time it takes to execute the contract in WASM
 	defer metrics.MeasureSudoExecutionDuration(time.Now(), msgType)
 	// set up a tmp context to prevent race condition in reading gas consumed
+	// Note that the limit will effectively serve as a soft limit since it's
+	// possible for the actual computation to go above the specified limit, but
+	// the associated contract would be charged corresponding rent.
 	tmpCtx := sdkCtx.WithGasMeter(sdk.NewGasMeter(sdkCtx.GasMeter().Limit()))
 	data, err := sudoWithoutOutOfGasPanic(tmpCtx, k, contractAddress, wasmMsg)
 	gasConsumed := tmpCtx.GasMeter().GasConsumed()

--- a/x/dex/keeper/utils/wasm.go
+++ b/x/dex/keeper/utils/wasm.go
@@ -40,12 +40,10 @@ func sudo(sdkCtx sdk.Context, k *keeper.Keeper, contractAddress []byte, wasmMsg 
 	defer metrics.MeasureSudoExecutionDuration(time.Now(), msgType)
 	// set up a tmp context to prevent race condition in reading gas consumed
 	tmpCtx := sdkCtx.WithGasMeter(sdk.NewGasMeter(sdkCtx.GasMeter().Limit()))
-	initialGasLevel := sdkCtx.GasMeter().GasConsumedToLimit() // gas consumed so far
-	tmpCtx.GasMeter().ConsumeGas(initialGasLevel, "initialize temp")
 	data, err := k.WasmKeeper.Sudo(
 		tmpCtx, contractAddress, wasmMsg,
 	)
-	gasConsumed := tmpCtx.GasMeter().GasConsumed() - initialGasLevel
+	gasConsumed := tmpCtx.GasMeter().GasConsumed()
 	if gasConsumed > 0 {
 		sdkCtx.GasMeter().ConsumeGas(gasConsumed, "sudo")
 	}

--- a/x/oracle/simulation/operations.go
+++ b/x/oracle/simulation/operations.go
@@ -65,7 +65,7 @@ func WeightedOperations(
 }
 
 // SimulateMsgAggregateExchangeRateVote generates a MsgAggregateExchangeRateVote with random values.
-//nolint: funlen
+// nolint: funlen
 func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
@@ -122,7 +122,7 @@ func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankK
 }
 
 // SimulateMsgDelegateFeedConsent generates a MsgDelegateFeedConsent with random values.
-//nolint: funlen
+// nolint: funlen
 func SimulateMsgDelegateFeedConsent(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,


### PR DESCRIPTION
## Describe your changes and provide context
The `wasm` module would allow contracts to run forever if `ctx.GasMeter()` doesn't have a limit. So instead of using an infinite meter as the temporary meter (which was originally added to prevent race conditions between concurrent calls), we will use one that inherits the limit depending on whether it's called within BeginBlock or EndBlock (inferred from `ctx.GasMeter().Limit()`.

## Testing performed to validate your change
Tested on local chain with contract that has infinite loop in hooks

