### PR TITLE
[app] Add midblock functionality to sei-chain and oracle module

### DIFF
--- a/app/abci.go
+++ b/app/abci.go
@@ -20,6 +20,12 @@ func (app *App) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) (res abc
 	return app.BaseApp.BeginBlock(ctx, req)
 }
 
+func (app *App) MidBlock(ctx sdk.Context, height int64) []abci.Event {
+	_, span := (*app.tracingInfo.Tracer).Start(app.tracingInfo.TracerContext, "MidBlock")
+	defer span.End()
+	return app.BaseApp.MidBlock(ctx, height)
+}
+
 func (app *App) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) (res abci.ResponseEndBlock) {
 	_, span := (*app.tracingInfo.Tracer).Start(app.tracingInfo.TracerContext, "EndBlock")
 	defer span.End()

--- a/go.mod
+++ b/go.mod
@@ -267,7 +267,7 @@ require (
 
 replace (
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => ../sei-cosmos //github.com/sei-protocol/sei-cosmos v0.1.356
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.357
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.106

--- a/go.mod
+++ b/go.mod
@@ -267,7 +267,7 @@ require (
 
 replace (
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.356
+	github.com/cosmos/cosmos-sdk => ../sei-cosmos //github.com/sei-protocol/sei-cosmos v0.1.356
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.106

--- a/go.sum
+++ b/go.sum
@@ -1067,8 +1067,6 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.1.356 h1:0IXClgrfdP+QPagFJFUiG9Zi3gLqpLp+2qybty29QyI=
-github.com/sei-protocol/sei-cosmos v0.1.356/go.mod h1:M1mKxSfbIV5rUfzvQ+4A1hSO+L5nl3hsriQB9/qvPV8=
 github.com/sei-protocol/sei-tendermint v0.1.106 h1:CN/jjNxfvZgzL20w3ss8OqtcLIXl8r3WA1B23or7ob4=
 github.com/sei-protocol/sei-tendermint v0.1.106/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=

--- a/go.sum
+++ b/go.sum
@@ -1067,6 +1067,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
+github.com/sei-protocol/sei-cosmos v0.1.357 h1:w6uKzsEYS8ZdQ0DlCF4xDglxRGIl4Fi98uWh5gfQ50U=
+github.com/sei-protocol/sei-cosmos v0.1.357/go.mod h1:pmWgLJxzDS+WMVvBWoncAnlXBjb0lFJvMw5ULbjWVwc=
 github.com/sei-protocol/sei-tendermint v0.1.106 h1:CN/jjNxfvZgzL20w3ss8OqtcLIXl8r3WA1B23or7ob4=
 github.com/sei-protocol/sei-tendermint v0.1.106/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=

--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -11,6 +11,12 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+func MidBlocker(ctx sdk.Context, k keeper.Keeper) {
+	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyMidBlocker)
+	ctx.Logger().Info("Running Oracle MidBlocker")
+	// TODO: this needs to be refactored to perform relevant endblocker logic to finalize oracle prices in a later PR
+}
+
 func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
 	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyEndBlocker)
 

--- a/x/oracle/module.go
+++ b/x/oracle/module.go
@@ -170,6 +170,14 @@ func (AppModule) ConsensusVersion() uint64 { return 5 }
 func (AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}
 
 // EndBlock returns the end blocker for the oracle module.
+func (am AppModule) MidBlock(ctx sdk.Context, _ int64) {
+	// TODO (codchen): Revert before mainnet so we don't silently fail on errors
+	defer utils.PanicHandler(func(err any) { utils.MetricsPanicCallback(err, ctx, types.ModuleName) })()
+
+	MidBlocker(ctx, am.keeper)
+}
+
+// EndBlock returns the end blocker for the oracle module.
 func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) (ret []abci.ValidatorUpdate) {
 	// TODO (codchen): Revert before mainnet so we don't silently fail on errors
 	defer utils.PanicHandler(func(err any) { utils.MetricsPanicCallback(err, ctx, types.ModuleName) })()


### PR DESCRIPTION
## Describe your changes and provide context
This adds midblock functionality to sei-chain, and introduces logic to register midblock handlers with the module manager. As part of this, we are including an oracle Midblock function that no-ops for now (simply outputs an INFO log) that will later be refactored from EndBlock.

## Testing performed to validate your change
Tested with localsei