### PR TITLE
Partition oracle votes

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -86,6 +86,7 @@ func NewAnteHandlerAndDepGenerator(options HandlerOptions) (sdk.AnteHandler, sdk
 		sdk.DefaultWrappedAnteDecorator(wasmkeeper.NewLimitSimulationGasDecorator(options.WasmConfig.SimulationGasLimit)), // after setup context to enforce limits early
 		sdk.DefaultWrappedAnteDecorator(ante.NewRejectExtensionOptionsDecorator()),
 		oracle.NewSpammingPreventionDecorator(*options.OracleKeeper),
+		oracle.NewOracleVoteAloneDecorator(),
 		sdk.DefaultWrappedAnteDecorator(ante.NewValidateBasicDecorator()),
 		sdk.DefaultWrappedAnteDecorator(ante.NewTxTimeoutHeightDecorator()),
 		sdk.DefaultWrappedAnteDecorator(ante.NewValidateMemoDecorator(options.AccountKeeper)),

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -25,6 +25,22 @@ import (
 
 const TestContract = "TEST"
 
+type TestTx struct {
+	msgs []sdk.Msg
+}
+
+func NewTestTx(msgs []sdk.Msg) TestTx {
+	return TestTx{msgs: msgs}
+}
+
+func (t TestTx) GetMsgs() []sdk.Msg {
+	return t.msgs
+}
+
+func (t TestTx) ValidateBasic() error {
+	return nil
+}
+
 type TestWrapper struct {
 	suite.Suite
 

--- a/x/oracle/ante.go
+++ b/x/oracle/ante.go
@@ -121,3 +121,35 @@ func (spd SpammingPreventionDecorator) CheckOracleSpamming(ctx sdk.Context, msgs
 
 	return nil
 }
+
+type OracleVoteAloneDecorator struct{}
+
+func NewOracleVoteAloneDecorator() OracleVoteAloneDecorator {
+	return OracleVoteAloneDecorator{}
+}
+
+// AnteHandle handles msg tax fee checking
+func (OracleVoteAloneDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	oracleVote := false
+	otherMsg := false
+	for _, msg := range tx.GetMsgs() {
+		switch msg.(type) {
+		case *types.MsgAggregateExchangeRateVote:
+			oracleVote = true
+
+		default:
+			otherMsg = true
+		}
+	}
+
+	if oracleVote && otherMsg {
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "oracle votes cannot be in the same tx as other messages")
+	}
+
+	return next(ctx, tx, simulate)
+}
+
+func (OracleVoteAloneDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
+	// requires no dependencies
+	return next(txDeps, tx)
+}

--- a/x/oracle/ante_test.go
+++ b/x/oracle/ante_test.go
@@ -1,0 +1,43 @@
+package oracle_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/sei-protocol/sei-chain/app"
+	"github.com/sei-protocol/sei-chain/x/oracle"
+	oracletypes "github.com/sei-protocol/sei-chain/x/oracle/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOracleVoteAloneAnteHandler(t *testing.T) {
+
+	testOracleMsg := oracletypes.MsgAggregateExchangeRateVote{}
+	testNonOracleMsg := banktypes.MsgSend{}
+	testNonOracleMsg2 := banktypes.MsgSend{}
+
+	decorator := oracle.NewOracleVoteAloneDecorator()
+	anteHandler, _ := sdk.ChainAnteDecorators(decorator)
+
+	testCases := []struct {
+		name   string
+		expErr bool
+		tx     sdk.Tx
+	}{
+		{"only oracle vote", false, app.NewTestTx([]sdk.Msg{&testOracleMsg})},
+		{"only non-oracle msgs", false, app.NewTestTx([]sdk.Msg{&testNonOracleMsg, &testNonOracleMsg2})},
+		{"mixed messages", true, app.NewTestTx([]sdk.Msg{&testNonOracleMsg, &testOracleMsg, &testNonOracleMsg2})},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := anteHandler(sdk.Context{}, tc.tx, false)
+			if tc.expErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Describe your changes and provide context
This adds functionality for partitioning txs with oracle votes from other txs, and executing them separately. This will allow us to compute oracle prices in Midblock in a future commit.

## Testing performed to validate your change
Added unit tests for partitioning as well as processing block and verifying ALL txs were executed.
