### PR TITLE
Use contract rent to decide sudo call gas limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ loadtest_results.txt
 # nitro-replayer
 nitro-replayer/target
 nitro-replayer/Cargo.lock
+# nitro mac artifact
+x/nitro/replay/libnitro_replayer.dylib

--- a/x/dex/keeper/contract.go
+++ b/x/dex/keeper/contract.go
@@ -50,6 +50,18 @@ func (k Keeper) GetContract(ctx sdk.Context, contractAddr string) (types.Contrac
 	return res, nil
 }
 
+func (k Keeper) GetContractGasLimit(ctx sdk.Context, contractAddr []byte) (uint64, error) {
+	bech32ContractAddr := sdk.AccAddress(contractAddr).String()
+	contract, err := k.GetContract(ctx, bech32ContractAddr)
+	if err != nil {
+		return 0, err
+	}
+	rentBalance := contract.RentBalance
+	gasPrice := k.GetParams(ctx).SudoCallGasPrice
+	gasDec := sdk.NewDec(int64(rentBalance)).Quo(gasPrice)
+	return gasDec.TruncateInt().Uint64(), nil // round down
+}
+
 func (k Keeper) GetAllContractInfo(ctx sdk.Context) []types.ContractInfoV2 {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(ContractPrefixKey))
 	iterator := sdk.KVStorePrefixIterator(store, []byte{})

--- a/x/dex/keeper/contract_test.go
+++ b/x/dex/keeper/contract_test.go
@@ -77,5 +77,19 @@ func TestGetAllContractInfo(t *testing.T) {
 	require.Equal(t, keepertest.TestContract, contracts[0].ContractAddr)
 	require.Equal(t, "ta2", contracts[1].Creator)
 	require.Equal(t, "tc2", contracts[1].ContractAddr)
+}
 
+func TestGetContractGasLimit(t *testing.T) {
+	keeper, ctx := keepertest.DexKeeper(t)
+	contractAddr := sdk.MustAccAddressFromBech32("sei1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrsgshtdj")
+	keeper.SetParams(ctx, types.Params{SudoCallGasPrice: sdk.NewDecWithPrec(1, 1), PriceSnapshotRetention: 1})
+	keeper.SetContract(ctx, &types.ContractInfoV2{
+		Creator:      keepertest.TestAccount,
+		ContractAddr: "sei1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrsgshtdj",
+		CodeId:       1,
+		RentBalance:  1000000,
+	})
+	gasLimit, err := keeper.GetContractGasLimit(ctx, contractAddr)
+	require.Nil(t, err)
+	require.Equal(t, uint64(10000000), gasLimit)
 }

--- a/x/dex/keeper/utils/wasm.go
+++ b/x/dex/keeper/utils/wasm.go
@@ -35,7 +35,7 @@ func getMsgType(msg interface{}) string {
 	}
 }
 
-func sudo(sdkCtx sdk.Context, k *keeper.Keeper, contractAddress []byte, wasmMsg []byte, msgType string) ([]byte, uint64, error) {
+func sudo(sdkCtx sdk.Context, k *keeper.Keeper, contractAddress sdk.AccAddress, wasmMsg []byte, msgType string) ([]byte, uint64, error) {
 	// Measure the time it takes to execute the contract in WASM
 	defer metrics.MeasureSudoExecutionDuration(time.Now(), msgType)
 	// set up a tmp context to prevent race condition in reading gas consumed

--- a/x/dex/keeper/utils/wasm.go
+++ b/x/dex/keeper/utils/wasm.go
@@ -42,7 +42,11 @@ func sudo(sdkCtx sdk.Context, k *keeper.Keeper, contractAddress []byte, wasmMsg 
 	// Note that the limit will effectively serve as a soft limit since it's
 	// possible for the actual computation to go above the specified limit, but
 	// the associated contract would be charged corresponding rent.
-	tmpCtx := sdkCtx.WithGasMeter(sdk.NewGasMeter(sdkCtx.GasMeter().Limit()))
+	gasLimit, err := k.GetContractGasLimit(sdkCtx, contractAddress)
+	if err != nil {
+		return nil, 0, err
+	}
+	tmpCtx := sdkCtx.WithGasMeter(sdk.NewGasMeter(gasLimit))
 	data, err := sudoWithoutOutOfGasPanic(tmpCtx, k, contractAddress, wasmMsg)
 	gasConsumed := tmpCtx.GasMeter().GasConsumed()
 	if gasConsumed > 0 {


### PR DESCRIPTION
## Describe your changes and provide context
Set sudo gas limit based on the remaining rent of a contract instead of overall block gas limit so that the processing may time out sooner without affecting processing outcome. There would also be no race condition since there could be at most one sudo call happening at a time for the same contract.

## Testing performed to validate your change
unit test
local chain test

