### PR TITLE
Update market order status for each block

### DIFF
--- a/x/dex/cache/order.go
+++ b/x/dex/cache/order.go
@@ -28,7 +28,7 @@ func (o *BlockOrders) Add(newItem *types.Order) {
 	}
 }
 
-func (o *BlockOrders) GetById(id uint64) *types.Order {
+func (o *BlockOrders) GetByID(id uint64) *types.Order {
 	keybz := make([]byte, 8)
 	binary.BigEndian.PutUint64(keybz, id)
 	var val types.Order

--- a/x/dex/cache/order.go
+++ b/x/dex/cache/order.go
@@ -18,6 +18,26 @@ func NewOrders(orderStore prefix.Store) *BlockOrders {
 	return &BlockOrders{orderStore: &orderStore}
 }
 
+func (o *BlockOrders) Add(newItem *types.Order) {
+	keybz := make([]byte, 8)
+	binary.BigEndian.PutUint64(keybz, newItem.Id)
+	if valbz, err := newItem.Marshal(); err != nil {
+		panic(err)
+	} else {
+		o.orderStore.Set(keybz, valbz)
+	}
+}
+
+func (o *BlockOrders) GetById(id uint64) *types.Order {
+	keybz := make([]byte, 8)
+	binary.BigEndian.PutUint64(keybz, id)
+	var val types.Order
+	if err := val.Unmarshal(o.orderStore.Get(keybz)); err != nil {
+		panic(err)
+	}
+	return &val
+}
+
 func (o *BlockOrders) Get() (list []*types.Order) {
 	iterator := sdk.KVStorePrefixIterator(o.orderStore, []byte{})
 	defer iterator.Close()
@@ -146,14 +166,4 @@ func (o *BlockOrders) getOrdersByCriteriaMap(orderType map[types.OrderType]bool,
 		res = append(res, &val)
 	}
 	return res
-}
-
-func (o *BlockOrders) Add(newItem *types.Order) {
-	keybz := make([]byte, 8)
-	binary.BigEndian.PutUint64(keybz, newItem.Id)
-	if valbz, err := newItem.Marshal(); err != nil {
-		panic(err)
-	} else {
-		o.orderStore.Set(keybz, valbz)
-	}
 }

--- a/x/dex/cache/order_test.go
+++ b/x/dex/cache/order_test.go
@@ -31,7 +31,7 @@ func TestMarkFailedToPlace(t *testing.T) {
 		stateOne.GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Get()[0].StatusDescription)
 }
 
-func TestGetById(t *testing.T) {
+func TestGetByID(t *testing.T) {
 	keeper, ctx := keepertest.DexKeeper(t)
 	stateOne := dex.NewMemState(keeper.GetStoreKey())
 	stateOne.GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Add(&types.Order{
@@ -52,9 +52,9 @@ func TestGetById(t *testing.T) {
 	})
 
 	order1 := stateOne.GetBlockOrders(
-		ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).GetById(uint64(1))
+		ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).GetByID(uint64(1))
 	order2 := stateOne.GetBlockOrders(
-		ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).GetById(uint64(2))
+		ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).GetByID(uint64(2))
 	require.Equal(t, uint64(1), order1.Id)
 	require.Equal(t, uint64(2), order2.Id)
 	require.Equal(t, "test1", order1.Account)

--- a/x/dex/cache/order_test.go
+++ b/x/dex/cache/order_test.go
@@ -31,6 +31,44 @@ func TestMarkFailedToPlace(t *testing.T) {
 		stateOne.GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Get()[0].StatusDescription)
 }
 
+func TestGetById(t *testing.T) {
+	keeper, ctx := keepertest.DexKeeper(t)
+	stateOne := dex.NewMemState(keeper.GetStoreKey())
+	stateOne.GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Add(&types.Order{
+		Id:                1,
+		Account:           "test1",
+		ContractAddr:      TEST_CONTRACT,
+		PositionDirection: types.PositionDirection_LONG,
+		OrderType:         types.OrderType_LIMIT,
+		Price:             sdk.MustNewDecFromStr("150"),
+	})
+	stateOne.GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Add(&types.Order{
+		Id:                2,
+		Account:           "test2",
+		ContractAddr:      TEST_CONTRACT,
+		PositionDirection: types.PositionDirection_SHORT,
+		OrderType:         types.OrderType_MARKET,
+		Price:             sdk.MustNewDecFromStr("100"),
+	})
+
+	order1 := stateOne.GetBlockOrders(
+		ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).GetById(uint64(1))
+	order2 := stateOne.GetBlockOrders(
+		ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).GetById(uint64(2))
+	require.Equal(t, uint64(1), order1.Id)
+	require.Equal(t, uint64(2), order2.Id)
+	require.Equal(t, "test1", order1.Account)
+	require.Equal(t, "test2", order2.Account)
+	require.Equal(t, TEST_CONTRACT, order1.ContractAddr)
+	require.Equal(t, TEST_CONTRACT, order2.ContractAddr)
+	require.Equal(t, types.PositionDirection_LONG, order1.PositionDirection)
+	require.Equal(t, types.PositionDirection_SHORT, order2.PositionDirection)
+	require.Equal(t, types.OrderType_LIMIT, order1.OrderType)
+	require.Equal(t, types.OrderType_MARKET, order2.OrderType)
+	require.Equal(t, sdk.MustNewDecFromStr("150"), order1.Price)
+	require.Equal(t, sdk.MustNewDecFromStr("100"), order2.Price)
+}
+
 func TestGetSortedMarketOrders(t *testing.T) {
 	keeper, ctx := keepertest.DexKeeper(t)
 	stateOne := dex.NewMemState(keeper.GetStoreKey())

--- a/x/dex/contract/execution.go
+++ b/x/dex/contract/execution.go
@@ -100,12 +100,14 @@ func matchMarketOrderForPair(
 		marketBuys,
 		orderbook.Shorts,
 		types.PositionDirection_LONG,
+		orders,
 	)
 	marketSellOutcome := exchange.MatchMarketOrders(
 		ctx,
 		marketSells,
 		orderbook.Longs,
 		types.PositionDirection_SHORT,
+		orders,
 	)
 	return marketBuyOutcome.Merge(&marketSellOutcome)
 }
@@ -169,16 +171,7 @@ func GetMatchResults(
 	typedContractAddr dextypesutils.ContractAddress,
 	typedPairStr dextypesutils.PairString,
 ) ([]*types.Order, []*types.Cancellation) {
-	orderResults := []*types.Order{}
-	orders := dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, typedContractAddr, typedPairStr)
-	// First add any new order, whether successfully placed or not, to the store
-	for _, order := range orders.Get() {
-		if order.Quantity.IsZero() {
-			order.Status = types.OrderStatus_FULFILLED
-		}
-		orderResults = append(orderResults, order)
-	}
-	// Then update order status and insert cancel record for any cancellation
+	orderResults := dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, typedContractAddr, typedPairStr).Get()
 	cancelResults := dexutils.GetMemState(ctx.Context()).GetBlockCancels(ctx, typedContractAddr, typedPairStr).Get()
 	return orderResults, cancelResults
 }

--- a/x/dex/exchange/market_order_fuzz_test.go
+++ b/x/dex/exchange/market_order_fuzz_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sei-protocol/sei-chain/testutil/fuzzing"
 	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/utils/datastructures"
+	dex "github.com/sei-protocol/sei-chain/x/dex/cache"
 	"github.com/sei-protocol/sei-chain/x/dex/exchange"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 	"github.com/stretchr/testify/require"
@@ -70,6 +71,6 @@ func fuzzTargetMatchMarketOrders(
 		exchange.MatchMarketOrders(TestFuzzMarketCtx, orders, &types.CachedSortedOrderBookEntries{
 			Entries:      entries,
 			DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
-		}, direction)
+		}, direction, &dex.BlockOrders{})
 	})
 }

--- a/x/dex/exchange/market_order_test.go
+++ b/x/dex/exchange/market_order_test.go
@@ -6,6 +6,8 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/sei-protocol/sei-chain/utils/datastructures"
+	dex "github.com/sei-protocol/sei-chain/x/dex/cache"
+	dexutils "github.com/sei-protocol/sei-chain/x/dex/utils"
 	"github.com/sei-protocol/sei-chain/x/dex/exchange"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 	"github.com/stretchr/testify/assert"
@@ -50,12 +52,25 @@ func TestMatchFoKMarketOrderFromShortBookNotEnoughLiquidity(t *testing.T) {
 			},
 		},
 	}
+	blockOrders := dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, "testAccount", "USDC|ATOM")
+	blockOrders.Add(&types.Order{
+		Id:                1,
+		Account:           "abc",
+		ContractAddr:      "test",
+		Price:             sdk.NewDec(100),
+		Quantity:          sdk.NewDec(5),
+		PriceDenom:        "USDC",
+		AssetDenom:        "ATOM",
+		OrderType:         types.OrderType_FOKMARKET,
+		PositionDirection: types.PositionDirection_LONG,
+		Data:              "{\"position_effect\":\"Open\",\"leverage\":\"1\"}",
+	})
 	entries := &types.CachedSortedOrderBookEntries{
 		Entries:      shortBook,
 		DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
 	}
 	outcome := exchange.MatchMarketOrders(
-		ctx, longOrders, entries, types.PositionDirection_LONG,
+		ctx, longOrders, entries, types.PositionDirection_LONG, blockOrders,
 	)
 	totalPrice := outcome.TotalNotional
 	totalExecuted := outcome.TotalQuantity
@@ -68,6 +83,8 @@ func TestMatchFoKMarketOrderFromShortBookNotEnoughLiquidity(t *testing.T) {
 	assert.Equal(t, shortBook[0].GetEntry().Price, sdk.NewDec(100))
 	assert.Equal(t, shortBook[0].GetEntry().Quantity, sdk.NewDec(4))
 	assert.Equal(t, len(settlements), 0)
+	assert.Equal(t, blockOrders.Get()[0].Quantity, sdk.NewDec(5))
+	assert.Equal(t, blockOrders.Get()[0].Status, types.OrderStatus_PLACED)
 }
 
 func TestMatchFoKMarketOrderFromShortBookHappyPath(t *testing.T) {
@@ -106,8 +123,21 @@ func TestMatchFoKMarketOrderFromShortBookHappyPath(t *testing.T) {
 		Entries:      shortBook,
 		DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
 	}
+	blockOrders := dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, "testAccount", "USDC|ATOM")
+	blockOrders.Add(&types.Order{
+		Id:                1,
+		Account:           "abc",
+		ContractAddr:      "test",
+		Price:             sdk.NewDec(100),
+		Quantity:          sdk.NewDec(5),
+		PriceDenom:        "USDC",
+		AssetDenom:        "ATOM",
+		OrderType:         types.OrderType_FOKMARKET,
+		PositionDirection: types.PositionDirection_LONG,
+		Data:              "{\"position_effect\":\"Open\",\"leverage\":\"1\"}",
+	})
 	outcome := exchange.MatchMarketOrders(
-		ctx, longOrders, entries, types.PositionDirection_LONG,
+		ctx, longOrders, entries, types.PositionDirection_LONG, blockOrders,
 	)
 	totalPrice := outcome.TotalNotional
 	totalExecuted := outcome.TotalQuantity
@@ -148,6 +178,8 @@ func TestMatchFoKMarketOrderFromShortBookHappyPath(t *testing.T) {
 		Timestamp:              TestTimestamp,
 		Height:                 TestHeight,
 	})
+	assert.Equal(t, blockOrders.Get()[0].Quantity, sdk.ZeroDec())
+	assert.Equal(t, blockOrders.Get()[0].Status, types.OrderStatus_FULFILLED)
 }
 
 func TestMatchByValueFOKMarketOrderFromShortBookNotEnoughLiquidity(t *testing.T) {
@@ -197,12 +229,14 @@ func TestMatchByValueFOKMarketOrderFromShortBookNotEnoughLiquidity(t *testing.T)
 			},
 		},
 	}
+	blockOrders := dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, "testAccount", "USDC|ATOM")
+	blockOrders.Add(longOrders[0])
 	entries := &types.CachedSortedOrderBookEntries{
 		Entries:      shortBook,
 		DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
 	}
 	outcome := exchange.MatchMarketOrders(
-		ctx, longOrders, entries, types.PositionDirection_LONG,
+		ctx, longOrders, entries, types.PositionDirection_LONG, &dex.BlockOrders{},
 	)
 	totalPrice := outcome.TotalNotional
 	totalExecuted := outcome.TotalQuantity
@@ -215,9 +249,11 @@ func TestMatchByValueFOKMarketOrderFromShortBookNotEnoughLiquidity(t *testing.T)
 	assert.Equal(t, shortBook[0].GetEntry().Price, sdk.NewDec(90))
 	assert.Equal(t, shortBook[0].GetEntry().Quantity, sdk.NewDec(5))
 	assert.Equal(t, len(settlements), 0)
+	assert.Equal(t, blockOrders.Get()[0].Quantity, sdk.NewDec(5))
+	assert.Equal(t, blockOrders.Get()[0].Status, types.OrderStatus_PLACED)
 }
 
-func TestMatcByValueFOKMarketOrderFromShortBookHappyPath(t *testing.T) {
+func TestMatchByValueFOKMarketOrderFromShortBookHappyPath(t *testing.T) {
 	_, ctx := keepertest.DexKeeper(t)
 	ctx = ctx.WithBlockHeight(int64(TestHeight)).WithBlockTime(time.Unix(int64(TestTimestamp), 0))
 	longOrders := []*types.Order{
@@ -264,12 +300,14 @@ func TestMatcByValueFOKMarketOrderFromShortBookHappyPath(t *testing.T) {
 			},
 		},
 	}
+	blockOrders := dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, "testAccount", "USDC|ATOM")
+	blockOrders.Add(longOrders[0])
 	entries := &types.CachedSortedOrderBookEntries{
 		Entries:      shortBook,
 		DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
 	}
 	outcome := exchange.MatchMarketOrders(
-		ctx, longOrders, entries, types.PositionDirection_LONG,
+		ctx, longOrders, entries, types.PositionDirection_LONG, blockOrders,
 	)
 	totalPrice := outcome.TotalNotional
 	totalExecuted := outcome.TotalQuantity
@@ -307,6 +345,8 @@ func TestMatcByValueFOKMarketOrderFromShortBookHappyPath(t *testing.T) {
 		Timestamp:              TestTimestamp,
 		Height:                 TestHeight,
 	})
+	assert.Equal(t, blockOrders.Get()[0].Quantity, sdk.MustNewDecFromStr("0.5"))
+	assert.Equal(t, blockOrders.Get()[0].Status, types.OrderStatus_FULFILLED)
 }
 
 func TestMatchSingleMarketOrderFromShortBook(t *testing.T) {
@@ -341,12 +381,14 @@ func TestMatchSingleMarketOrderFromShortBook(t *testing.T) {
 			},
 		},
 	}
+	blockOrders := dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, "testAccount", "USDC|ATOM")
+	blockOrders.Add(longOrders[0])
 	entries := &types.CachedSortedOrderBookEntries{
 		Entries:      shortBook,
 		DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
 	}
 	outcome := exchange.MatchMarketOrders(
-		ctx, longOrders, entries, types.PositionDirection_LONG,
+		ctx, longOrders, entries, types.PositionDirection_LONG, blockOrders,
 	)
 	totalPrice := outcome.TotalNotional
 	totalExecuted := outcome.TotalQuantity
@@ -387,6 +429,8 @@ func TestMatchSingleMarketOrderFromShortBook(t *testing.T) {
 		Timestamp:              TestTimestamp,
 		Height:                 TestHeight,
 	})
+	assert.Equal(t, blockOrders.Get()[0].Quantity, sdk.ZeroDec())
+	assert.Equal(t, blockOrders.Get()[0].Status, types.OrderStatus_FULFILLED)
 }
 
 func TestMatchSingleMarketOrderFromLongBook(t *testing.T) {
@@ -421,12 +465,14 @@ func TestMatchSingleMarketOrderFromLongBook(t *testing.T) {
 			},
 		},
 	}
+	blockOrders := dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, "testAccount", "USDC|ATOM")
+	blockOrders.Add(shortOrders[0])
 	entries := &types.CachedSortedOrderBookEntries{
 		Entries:      longBook,
 		DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
 	}
 	outcome := exchange.MatchMarketOrders(
-		ctx, shortOrders, entries, types.PositionDirection_SHORT,
+		ctx, shortOrders, entries, types.PositionDirection_SHORT, blockOrders,
 	)
 	totalPrice := outcome.TotalNotional
 	totalExecuted := outcome.TotalQuantity
@@ -467,6 +513,8 @@ func TestMatchSingleMarketOrderFromLongBook(t *testing.T) {
 		Timestamp:              TestTimestamp,
 		Height:                 TestHeight,
 	})
+	assert.Equal(t, blockOrders.Get()[0].Quantity, sdk.ZeroDec())
+	assert.Equal(t, blockOrders.Get()[0].Status, types.OrderStatus_FULFILLED)
 }
 
 func TestMatchSingleMarketOrderFromMultipleShortBook(t *testing.T) {
@@ -519,12 +567,14 @@ func TestMatchSingleMarketOrderFromMultipleShortBook(t *testing.T) {
 			},
 		},
 	}
+	blockOrders := dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, "testAccount", "USDC|ATOM")
+	blockOrders.Add(longOrders[0])
 	entries := &types.CachedSortedOrderBookEntries{
 		Entries:      shortBook,
 		DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
 	}
 	outcome := exchange.MatchMarketOrders(
-		ctx, longOrders, entries, types.PositionDirection_LONG,
+		ctx, longOrders, entries, types.PositionDirection_LONG, blockOrders,
 	)
 	totalPrice := outcome.TotalNotional
 	totalExecuted := outcome.TotalQuantity
@@ -609,6 +659,8 @@ func TestMatchSingleMarketOrderFromMultipleShortBook(t *testing.T) {
 		Timestamp:              TestTimestamp,
 		Height:                 TestHeight,
 	})
+	assert.Equal(t, blockOrders.Get()[0].Quantity, sdk.ZeroDec())
+	assert.Equal(t, blockOrders.Get()[0].Status, types.OrderStatus_FULFILLED)
 }
 
 func TestMatchSingleMarketOrderFromMultipleLongBook(t *testing.T) {
@@ -661,12 +713,14 @@ func TestMatchSingleMarketOrderFromMultipleLongBook(t *testing.T) {
 			},
 		},
 	}
+	blockOrders := dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, "testAccount", "USDC|ATOM")
+	blockOrders.Add(shortOrders[0])
 	entries := &types.CachedSortedOrderBookEntries{
 		Entries:      longBook,
 		DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
 	}
 	outcome := exchange.MatchMarketOrders(
-		ctx, shortOrders, entries, types.PositionDirection_SHORT,
+		ctx, shortOrders, entries, types.PositionDirection_SHORT, blockOrders,
 	)
 	totalPrice := outcome.TotalNotional
 	totalExecuted := outcome.TotalQuantity
@@ -751,6 +805,8 @@ func TestMatchSingleMarketOrderFromMultipleLongBook(t *testing.T) {
 		Timestamp:              TestTimestamp,
 		Height:                 TestHeight,
 	})
+	assert.Equal(t, blockOrders.Get()[0].Quantity, sdk.ZeroDec())
+	assert.Equal(t, blockOrders.Get()[0].Status, types.OrderStatus_FULFILLED)
 }
 
 func TestMatchMultipleMarketOrderFromMultipleShortBook(t *testing.T) {
@@ -825,12 +881,16 @@ func TestMatchMultipleMarketOrderFromMultipleShortBook(t *testing.T) {
 			},
 		},
 	}
+	blockOrders := dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, "testAccount", "USDC|ATOM")
+	blockOrders.Add(longOrders[0])
+	blockOrders.Add(longOrders[1])
+	blockOrders.Add(longOrders[2])
 	entries := &types.CachedSortedOrderBookEntries{
 		Entries:      shortBook,
 		DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
 	}
 	outcome := exchange.MatchMarketOrders(
-		ctx, longOrders, entries, types.PositionDirection_LONG,
+		ctx, longOrders, entries, types.PositionDirection_LONG, blockOrders,
 	)
 	totalPrice := outcome.TotalNotional
 	totalExecuted := outcome.TotalQuantity
@@ -937,6 +997,12 @@ func TestMatchMultipleMarketOrderFromMultipleShortBook(t *testing.T) {
 		Timestamp:              TestTimestamp,
 		Height:                 TestHeight,
 	})
+	assert.Equal(t, blockOrders.Get()[0].Quantity, sdk.ZeroDec())
+	assert.Equal(t, blockOrders.Get()[0].Status, types.OrderStatus_FULFILLED)
+	assert.Equal(t, blockOrders.Get()[1].Quantity, sdk.ZeroDec())
+	assert.Equal(t, blockOrders.Get()[1].Status, types.OrderStatus_FULFILLED)
+	assert.Equal(t, blockOrders.Get()[2].Quantity, sdk.NewDec(2))
+	assert.Equal(t, blockOrders.Get()[2].Status, types.OrderStatus_PLACED)
 }
 
 func TestMatchMultipleMarketOrderFromMultipleLongBook(t *testing.T) {
@@ -1011,12 +1077,16 @@ func TestMatchMultipleMarketOrderFromMultipleLongBook(t *testing.T) {
 			},
 		},
 	}
+	blockOrders := dexutils.GetMemState(ctx.Context()).GetBlockOrders(ctx, "testAccount", "USDC|ATOM")
+	blockOrders.Add(shortOrders[0])
+	blockOrders.Add(shortOrders[1])
+	blockOrders.Add(shortOrders[2])
 	entries := &types.CachedSortedOrderBookEntries{
 		Entries:      longBook,
 		DirtyEntries: datastructures.NewTypedSyncMap[string, types.OrderBookEntry](),
 	}
 	outcome := exchange.MatchMarketOrders(
-		ctx, shortOrders, entries, types.PositionDirection_SHORT,
+		ctx, shortOrders, entries, types.PositionDirection_SHORT, blockOrders,
 	)
 	totalPrice := outcome.TotalNotional
 	totalExecuted := outcome.TotalQuantity
@@ -1127,4 +1197,10 @@ func TestMatchMultipleMarketOrderFromMultipleLongBook(t *testing.T) {
 		Timestamp:              TestTimestamp,
 		Height:                 TestHeight,
 	})
+	assert.Equal(t, blockOrders.Get()[0].Quantity, sdk.ZeroDec())
+	assert.Equal(t, blockOrders.Get()[0].Status, types.OrderStatus_FULFILLED)
+	assert.Equal(t, blockOrders.Get()[1].Quantity, sdk.ZeroDec())
+	assert.Equal(t, blockOrders.Get()[1].Status, types.OrderStatus_FULFILLED)
+	assert.Equal(t, blockOrders.Get()[2].Quantity, sdk.NewDec(2))
+	assert.Equal(t, blockOrders.Get()[2].Status, types.OrderStatus_PLACED)
 }

--- a/x/dex/exchange/settlement.go
+++ b/x/dex/exchange/settlement.go
@@ -111,7 +111,7 @@ func UpdateOrderData(
 	blockOrders *cache.BlockOrders,
 ) {
 	// update order data in the memstate
-	orderStored := blockOrders.GetById(takerOrder.Id)
+	orderStored := blockOrders.GetByID(takerOrder.Id)
 	orderStored.Quantity = orderStored.Quantity.Sub(quantityTaken)
 	if orderStored.OrderType == types.OrderType_FOKMARKET || orderStored.OrderType == types.OrderType_FOKMARKETBYVALUE || orderStored.Quantity.IsZero() {
 		orderStored.Status = types.OrderStatus_FULFILLED

--- a/x/dex/exchange/settlement.go
+++ b/x/dex/exchange/settlement.go
@@ -2,6 +2,7 @@ package exchange
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	cache "github.com/sei-protocol/sei-chain/x/dex/cache"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 	"github.com/sei-protocol/sei-chain/x/dex/types/utils"
 	"github.com/sei-protocol/sei-chain/x/dex/types/wasm"
@@ -13,12 +14,14 @@ type ToSettle struct {
 	account string
 }
 
+// this function helps to settle market orders
 func Settle(
 	ctx sdk.Context,
 	takerOrder *types.Order,
 	quantityTaken sdk.Dec,
 	order types.OrderBookEntry,
 	worstPrice sdk.Dec,
+	blockOrders *cache.BlockOrders,
 ) ([]*types.SettlementEntry, []*types.SettlementEntry) {
 	// settlement of one liquidity taker's order is allocated to all liquidity
 	// providers at the matched price level, propotional to the amount of liquidity
@@ -93,7 +96,27 @@ func Settle(
 			types.OrderType_LIMIT,
 		))
 	}
+
+	// update the status of order in the memState
+	UpdateOrderData(takerOrder, quantityTaken, blockOrders)
+
 	return takerSettlements, makerSettlements
+}
+
+// this function update the order data in the memState
+// to be noted that the order status will only reflect for market orders that are settled
+func UpdateOrderData(
+	takerOrder *types.Order,
+	quantityTaken sdk.Dec,
+	blockOrders *cache.BlockOrders,
+) {
+	// update order data in the memstate
+	orderStored := blockOrders.GetById(takerOrder.Id)
+	orderStored.Quantity = orderStored.Quantity.Sub(quantityTaken)
+	if orderStored.OrderType == types.OrderType_FOKMARKET || orderStored.OrderType == types.OrderType_FOKMARKETBYVALUE || orderStored.Quantity.IsZero() {
+		orderStored.Status = types.OrderStatus_FULFILLED
+	}
+	blockOrders.Add(orderStored)
 }
 
 func SettleFromBook(

--- a/x/dex/exchange/settlement_fuzz_test.go
+++ b/x/dex/exchange/settlement_fuzz_test.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/sei-protocol/sei-chain/testutil/fuzzing"
 	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
+	dex "github.com/sei-protocol/sei-chain/x/dex/cache"
 	"github.com/sei-protocol/sei-chain/x/dex/exchange"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 	"github.com/stretchr/testify/require"
@@ -52,7 +53,7 @@ func fuzzTargetSettle(
 
 	for i, entry := range entries {
 		require.NotPanics(t, func() {
-			exchange.Settle(TestFuzzSettleCtx, orders[i], quantity, entry, price)
+			exchange.Settle(TestFuzzSettleCtx, orders[i], quantity, entry, price, &dex.BlockOrders{})
 		})
 	}
 }


### PR DESCRIPTION
## Describe your changes and provide context
In the previous testing we found the market order status is not updated correctly after the memstate refactor (always show ORDER_PLACED instead of ORDER_FULFILLED for fillled market orders). 
In this PR we update the order quantity and status in the memState (KVstore) for each settlement. 

To be noted that FOK market orders can only be settled when they're fulfilled so we don't need to check their quantity for fulfilled or not.

## Testing performed to validate your change
unit test
