### PR TITLE
[aclmapping] Update to use the refactored arguments for GetWasmDependencyMapping

### DIFF
--- a/aclmapping/wasm/mappings.go
+++ b/aclmapping/wasm/mappings.go
@@ -42,7 +42,8 @@ func (wasmDepGen WasmDependencyGenerator) WasmExecuteContractGenerator(keeper ac
 	if err != nil {
 		return []sdkacltypes.AccessOperation{}, err
 	}
-	wasmDependencyMapping, err := keeper.GetWasmDependencyMapping(ctx, contractAddr, executeContractMsg.Sender, executeContractMsg.Msg, true)
+	// TODO: need to test how errors from here affect the disabling of wasm execute dynamic dependencies
+	wasmDependencyMapping, err := keeper.GetWasmDependencyMapping(ctx, contractAddr, executeContractMsg.Sender, executeContractMsg.Msg, true, make(aclkeeper.ContractReferenceLookupMap))
 	if err != nil {
 		return []sdkacltypes.AccessOperation{}, err
 	}

--- a/app/antedecorators/gas.go
+++ b/app/antedecorators/gas.go
@@ -31,13 +31,13 @@ func GetGasMeterSetter(aclkeeper aclkeeper.Keeper) func(bool, sdk.Context, uint6
 	}
 }
 
-func getMessageMultiplierDenominator(ctx sdk.Context, msg sdk.Msg, aclkeeper aclkeeper.Keeper) uint64 {
+func getMessageMultiplierDenominator(ctx sdk.Context, msg sdk.Msg, aclKeeper aclkeeper.Keeper) uint64 {
 	if wasmExecuteMsg, ok := msg.(*wasmtypes.MsgExecuteContract); ok {
 		addr, err := sdk.AccAddressFromBech32(wasmExecuteMsg.Contract)
 		if err != nil {
 			return DefaultGasMultiplierDenominator
 		}
-		mapping, err := aclkeeper.GetWasmDependencyMapping(ctx, addr, "", []byte{}, false)
+		mapping, err := aclKeeper.GetWasmDependencyMapping(ctx, addr, "", []byte{}, false, make(aclkeeper.ContractReferenceLookupMap))
 		if err != nil {
 			return DefaultGasMultiplierDenominator
 		}

--- a/go.mod
+++ b/go.mod
@@ -267,7 +267,7 @@ require (
 
 replace (
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.377
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.383
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.132

--- a/go.sum
+++ b/go.sum
@@ -1067,8 +1067,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.1.377 h1:WGLoFwgvUOf30URiOTibeOBNwUvr0NkxezaP3nmPckg=
-github.com/sei-protocol/sei-cosmos v0.1.377/go.mod h1:lX+jDZ9u+afukL4Gc76YtKFEeCe9HfrAOCYAzSevAPw=
+github.com/sei-protocol/sei-cosmos v0.1.383 h1:fjI/ej+L/+QNMMNJBzCM4axe39orFXmDnveINOozQ3w=
+github.com/sei-protocol/sei-cosmos v0.1.383/go.mod h1:lX+jDZ9u+afukL4Gc76YtKFEeCe9HfrAOCYAzSevAPw=
 github.com/sei-protocol/sei-tendermint v0.1.132 h1:bGzvArngcXgZ0PZSif2Qqp7p/YLd+fBxsYnH6Lqc0E4=
 github.com/sei-protocol/sei-tendermint v0.1.132/go.mod h1:ubqjn2T/nvqmQYjgpOTV7uSyUvdfvJCepc7zNYL2mkw=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=


### PR DESCRIPTION

## Describe your changes and provide context
This updates the calls to pass in the appropriate arguments. Also added a TODO not within scope for this change but a reminder to test some edge cases around wasm dependency generation failure and how it might affect other wasm dependency generation.

## Testing performed to validate your change
Existing tests