### PR TITLE
Update consensus configs to be less strict

### DIFF
--- a/app/params/config.go
+++ b/app/params/config.go
@@ -21,8 +21,8 @@ const (
 	Bech32PrefixAccAddr = "sei"
 )
 
-// Commits block as soon as we reach consensus instead of waiting for timeout, this may
-// cause validators to not get their votes in time
+// UnsafeBypassCommitTimeoutOverride commits block as soon as we reach consensus instead of waiting
+// for timeout, this may cause validators to not get their votes in time
 var UnsafeBypassCommitTimeoutOverride = false
 
 var (

--- a/app/params/config.go
+++ b/app/params/config.go
@@ -93,11 +93,11 @@ func SetTendermintConfigs(config *tmcfg.Config) {
 	config.Mempool.MaxTxBytes = 2048576
 	// Consensus Configs
 	config.Consensus.GossipTransactionKeyOnly = true
-	config.Consensus.UnsafeProposeTimeoutOverride = 1 * time.Second
+	config.Consensus.UnsafeProposeTimeoutOverride = 5 * time.Second
 	config.Consensus.UnsafeProposeTimeoutDeltaOverride = 500 * time.Millisecond
 	config.Consensus.UnsafeVoteTimeoutOverride = 50 * time.Millisecond
 	config.Consensus.UnsafeVoteTimeoutDeltaOverride = 500 * time.Millisecond
-	config.Consensus.UnsafeCommitTimeoutOverride = 100 * time.Millisecond
+	config.Consensus.UnsafeCommitTimeoutOverride = 50 * time.Millisecond
 	config.Consensus.UnsafeBypassCommitTimeoutOverride = &UnsafeBypassCommitTimeoutOverride
 	// Metrics
 	config.Instrumentation.Prometheus = true

--- a/app/params/config.go
+++ b/app/params/config.go
@@ -97,7 +97,7 @@ func SetTendermintConfigs(config *tmcfg.Config) {
 	config.Consensus.UnsafeProposeTimeoutDeltaOverride = 500 * time.Millisecond
 	config.Consensus.UnsafeVoteTimeoutOverride = 50 * time.Millisecond
 	config.Consensus.UnsafeVoteTimeoutDeltaOverride = 500 * time.Millisecond
-	config.Consensus.UnsafeCommitTimeoutOverride = 50 * time.Millisecond
+	config.Consensus.UnsafeCommitTimeoutOverride = 100 * time.Millisecond
 	config.Consensus.UnsafeBypassCommitTimeoutOverride = &UnsafeBypassCommitTimeoutOverride
 	// Metrics
 	config.Instrumentation.Prometheus = true

--- a/app/params/config.go
+++ b/app/params/config.go
@@ -21,7 +21,9 @@ const (
 	Bech32PrefixAccAddr = "sei"
 )
 
-var UnsafeBypassCommitTimeoutOverride = true
+// Commits block as soon as we reach consensus instead of waiting for timeout, this may
+// cause validators to not get their votes in time
+var UnsafeBypassCommitTimeoutOverride = false
 
 var (
 	// Bech32PrefixAccPub defines the Bech32 prefix of an account's public key.
@@ -93,11 +95,9 @@ func SetTendermintConfigs(config *tmcfg.Config) {
 	config.Consensus.GossipTransactionKeyOnly = true
 	config.Consensus.UnsafeProposeTimeoutOverride = 1 * time.Second
 	config.Consensus.UnsafeProposeTimeoutDeltaOverride = 500 * time.Millisecond
-
 	config.Consensus.UnsafeVoteTimeoutOverride = 50 * time.Millisecond
 	config.Consensus.UnsafeVoteTimeoutDeltaOverride = 500 * time.Millisecond
 	config.Consensus.UnsafeCommitTimeoutOverride = 50 * time.Millisecond
-
 	config.Consensus.UnsafeBypassCommitTimeoutOverride = &UnsafeBypassCommitTimeoutOverride
 	// Metrics
 	config.Instrumentation.Prometheus = true

--- a/x/oracle/simulation/operations.go
+++ b/x/oracle/simulation/operations.go
@@ -65,7 +65,7 @@ func WeightedOperations(
 }
 
 // SimulateMsgAggregateExchangeRateVote generates a MsgAggregateExchangeRateVote with random values.
-//nolint: funlen
+// nolint: funlen
 func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
@@ -122,7 +122,7 @@ func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankK
 }
 
 // SimulateMsgDelegateFeedConsent generates a MsgDelegateFeedConsent with random values.
-//nolint: funlen
+// nolint: funlen
 func SimulateMsgDelegateFeedConsent(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,


### PR DESCRIPTION
## Describe your changes and provide context
Sei-devnet-2 seeing a lot of validators miss blocks, turn off skip `UnsafeBypassCommitTimeoutOverride` and increase commit timeout to 100ms 

Don't need to change TM as this directly overrides whatever is from the config.toml file

## Testing performed to validate your change
local chain with timeout set to 5s, can see that each block height was very slow 
