### PR TITLE
Revert wasm whitelist prefix

### DIFF
--- a/x/dex/contract/whitelist.go
+++ b/x/dex/contract/whitelist.go
@@ -3,6 +3,7 @@ package contract
 import (
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/sei-protocol/sei-chain/utils"
 	"github.com/sei-protocol/sei-chain/x/dex/keeper"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
@@ -57,9 +58,10 @@ func GetDexWhitelistedPrefixes(contractAddr string) []string {
 }
 
 func GetWasmWhitelistedPrefixes(contractAddr string) []string {
+	addr, _ := sdk.AccAddressFromBech32(contractAddr)
 	return utils.Map(WasmWhitelistedKeys, func(key string) string {
 		return string(append(
-			[]byte(key), types.AddressKeyPrefix(contractAddr)...,
+			[]byte(key), addr...,
 		))
 	})
 }

--- a/x/dex/contract/whitelist_test.go
+++ b/x/dex/contract/whitelist_test.go
@@ -1,0 +1,29 @@
+package contract_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/x/dex/contract"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetWasmPrefixes(t *testing.T) {
+	wasmWhitelistedPrefixes := contract.GetWasmWhitelistedPrefixes("sei14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sh9m79m")
+
+	wasmPrefixBytes, _ := hex.DecodeString("03" + "ade4a5f5803a439835c636395a8d648dee57b2fc90d98dc17fa887159b69638b")
+	require.Equal(t, []byte(wasmWhitelistedPrefixes[0]), wasmPrefixBytes)
+}
+
+
+func TestGetDexPrefixes(t *testing.T) {
+	dexWhitelistedPrefixes := contract.GetDexWhitelistedPrefixes("sei14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sh9m79m")
+	addr, _ := sdk.AccAddressFromBech32("sei14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sh9m79m")
+
+	for i, dexKeys := range contract.DexWhitelistedKeys {
+		len := []byte{byte(32)}
+		prefix := append(append([]byte(dexKeys), len...), addr...)
+		require.Equal(t, string(prefix), dexWhitelistedPrefixes[i])
+	}
+}


### PR DESCRIPTION
## Describe your changes and provide context
This PR reverts the wasm prefix change as it conflicted with the current prefix used in the x/wasmd module (i.e. plain sdk.AccAddress). 

## Testing performed to validate your change
e2e test and unit test
