### PR TITLE
Migrate old dex prefix data

### DIFF
--- a/x/dex/migrations/v10_to_v11.go
+++ b/x/dex/migrations/v10_to_v11.go
@@ -1,0 +1,45 @@
+package migrations
+
+import (
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/x/dex/keeper"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+)
+
+var DexPrefixes = []string{
+	types.LongBookKey,
+	types.ShortBookKey,
+	types.TriggerBookKey,
+	types.OrderKey,
+	types.TwapKey,
+	types.RegisteredPairKey,
+	types.OrderKey,
+	types.CancelKey,
+	types.AccountActiveOrdersKey,
+	types.NextOrderIDKey,
+	types.MatchResultKey,
+	types.MemOrderKey,
+	types.MemCancelKey,
+	types.MemDepositKey,
+	types.PriceKey,
+	types.SettlementEntryKey,
+	types.NextSettlementIDKey,
+}
+
+func V10ToV11(ctx sdk.Context, dexkeeper keeper.Keeper) error {
+	dexkeeper.CreateModuleAccount(ctx)
+
+	// this will nuke all old prefixes data in the store
+	for _, prefixKey := range DexPrefixes {
+		store := prefix.NewStore(ctx.KVStore(dexkeeper.GetStoreKey()), []byte(prefixKey))
+		iterator := sdk.KVStorePrefixIterator(store, []byte{})
+
+		defer iterator.Close()
+		for ; iterator.Valid(); iterator.Next() {
+			store.Delete(iterator.Key())
+		}
+	}
+
+	return nil
+}

--- a/x/dex/migrations/v10_to_v11_test.go
+++ b/x/dex/migrations/v10_to_v11_test.go
@@ -1,0 +1,57 @@
+package migrations_test
+
+import (
+	"testing"
+
+	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/x/dex/migrations"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrate10to11(t *testing.T) {
+	dexkeeper, ctx := keepertest.DexKeeper(t)
+	// write old contract
+	store := ctx.KVStore(dexkeeper.GetStoreKey())
+	value := []byte("test_value")
+	store.Set(types.ContractKeyPrefix(types.LongBookKey, keepertest.TestContract), value)
+	store.Set(types.OrderBookPrefix(false, keepertest.TestContract, "USDC", "ATOM"), value)
+	store.Set(types.TriggerOrderBookPrefix(keepertest.TestContract, "USDC", "ATOM"), value)
+	store.Set(types.TwapPrefix(keepertest.TestContract), value)
+	store.Set(types.PricePrefix(keepertest.TestContract, "USDC", "ATOM"), value)
+	store.Set(types.SettlementEntryPrefix(keepertest.TestContract, "USDC", "ATOM"), value)
+	store.Set(types.RegisteredPairPrefix(keepertest.TestContract), value)
+	store.Set(types.OrderPrefix(keepertest.TestContract), value)
+	store.Set(types.Cancel(keepertest.TestContract), value)
+	store.Set(types.AccountActiveOrdersPrefix(keepertest.TestContract), value)
+	store.Set(types.NextOrderIDPrefix(keepertest.TestContract), value)
+	store.Set(types.NextSettlementIDPrefix(keepertest.TestContract, "USDC", "ATOM"), value)
+	store.Set(types.MatchResultPrefix(keepertest.TestContract), value)
+	store.Set(types.MemOrderPrefixForPair(keepertest.TestContract, "USDC|ATOM"), value)
+	store.Set(types.MemCancelPrefixForPair(keepertest.TestContract, "USDC|ATOM"), value)
+	store.Set(types.MemOrderPrefix(keepertest.TestContract), value)
+	store.Set(types.MemCancelPrefix(keepertest.TestContract), value)
+	store.Set(types.MemDepositPrefix(keepertest.TestContract), value)
+
+	err := migrations.V10ToV11(ctx, *dexkeeper)
+	require.NoError(t, err)
+
+	require.False(t, store.Has(types.ContractKeyPrefix(types.LongBookKey, keepertest.TestContract)))
+	require.False(t, store.Has(types.OrderBookPrefix(false, keepertest.TestContract, "USDC", "ATOM")))
+	require.False(t, store.Has(types.TriggerOrderBookPrefix(keepertest.TestContract, "USDC", "ATOM")))
+	require.False(t, store.Has(types.TwapPrefix(keepertest.TestContract)))
+	require.False(t, store.Has(types.PricePrefix(keepertest.TestContract, "USDC", "ATOM")))
+	require.False(t, store.Has(types.SettlementEntryPrefix(keepertest.TestContract, "USDC", "ATOM")))
+	require.False(t, store.Has(types.RegisteredPairPrefix(keepertest.TestContract)))
+	require.False(t, store.Has(types.OrderPrefix(keepertest.TestContract)))
+	require.False(t, store.Has(types.Cancel(keepertest.TestContract)))
+	require.False(t, store.Has(types.AccountActiveOrdersPrefix(keepertest.TestContract)))
+	require.False(t, store.Has(types.NextOrderIDPrefix(keepertest.TestContract)))
+	require.False(t, store.Has(types.NextSettlementIDPrefix(keepertest.TestContract, "USDC", "ATOM")))
+	require.False(t, store.Has(types.MatchResultPrefix(keepertest.TestContract)))
+	require.False(t, store.Has(types.MemOrderPrefixForPair(keepertest.TestContract, "USDC|ATOM")))
+	require.False(t, store.Has(types.MemCancelPrefixForPair(keepertest.TestContract, "USDC|ATOM")))
+	require.False(t, store.Has(types.MemOrderPrefix(keepertest.TestContract)))
+	require.False(t, store.Has(types.MemCancelPrefix(keepertest.TestContract)))
+	require.False(t, store.Has(types.MemDepositPrefix(keepertest.TestContract)))
+}

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -188,6 +188,9 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	_ = cfg.RegisterMigration(types.ModuleName, 9, func(ctx sdk.Context) error {
 		return migrations.V9ToV10(ctx, am.keeper)
 	})
+	_ = cfg.RegisterMigration(types.ModuleName, 10, func(ctx sdk.Context) error {
+		return migrations.V10ToV11(ctx, am.keeper)
+	})
 }
 
 // RegisterInvariants registers the capability module's invariants.
@@ -212,7 +215,7 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 }
 
 // ConsensusVersion implements ConsensusVersion.
-func (AppModule) ConsensusVersion() uint64 { return 10 }
+func (AppModule) ConsensusVersion() uint64 { return 11 }
 
 func (am AppModule) getAllContractInfo(ctx sdk.Context) []types.ContractInfoV2 {
 	// Do not process any contract that has a non-zero rent balance


### PR DESCRIPTION
## Describe your changes and provide context
This PR adds a migration handler for the dex prefixes change here: https://github.com/sei-protocol/sei-chain/pull/483. To be noted that here we will simply nuke the old data as this will only be needed on the devnet-2.

Other option is to replace the existing data like the snippet below, but given there are keys with suffix, either getting all pairs from contracts or assuming the contract address length is 62 in bytes is not as safe as nuking the old data on the devnet-2.
```

	for _, prefixKey := range DexPrefixes {
		store := prefix.NewStore(ctx.KVStore(dexkeeper.GetStoreKey()), []byte(prefixKey))
		iterator := sdk.KVStorePrefixIterator(store, []byte{})

		defer iterator.Close()
		for ; iterator.Valid(); iterator.Next() {
			key := iterator.Key()
			if !bytes.HasPrefix(key, []byte(prefixKey)) {
				panic(fmt.Sprintf("Key %x doesn't has prefix %s\n", key, prefixKey))
			}
			key = bytes.TrimPrefix(key, []byte(prefixKey))

			key = append([]byte(prefixKey), types.AddressKeyPrefix(string(key))...)

			store.Set(key, iterator.Value())
			store.Delete(iterator.Key())
		}
	}

```

## Testing performed to validate your change
- Unit test
- Upgraded the chain locally with the following steps
  - deployed vortex contract to V10
  - placed an order
  - upgraded to V11
  - confirmed the order is nuked and no panic/exception was thrown
