### PR TITLE
[dex] improve dex EndBlock logs

### DIFF
--- a/x/dex/contract/abci.go
+++ b/x/dex/contract/abci.go
@@ -199,7 +199,7 @@ func orderMatchingRunnable(ctx context.Context, sdkContext sdk.Context, env *env
 	}
 	parentSdkContext := sdkContext
 	sdkContext = decorateContextForContract(sdkContext, contractInfo)
-	sdkContext.Logger().Info(fmt.Sprintf("End block for %s", contractInfo.ContractAddr))
+	sdkContext.Logger().Info(fmt.Sprintf("End block for %s with balance of %d", contractInfo.ContractAddr, contractInfo.RentBalance))
 	pairs, pairFound := env.registeredPairs.Load(contractInfo.ContractAddr)
 	orderBooks, found := env.orderBooks.Load(contractInfo.ContractAddr)
 

--- a/x/dex/keeper/abci/end_block_place_orders.go
+++ b/x/dex/keeper/abci/end_block_place_orders.go
@@ -41,7 +41,9 @@ func (w KeeperWrapper) HandleEBPlaceOrders(ctx context.Context, sdkCtx sdk.Conte
 			sdkCtx.Logger().Error("Failed to parse order placement response")
 			return err
 		}
-		sdkCtx.Logger().Info(fmt.Sprintf("Sudo response data: %s", response))
+		if len(response.UnsuccessfulOrders) > 0 {
+			sdkCtx.Logger().Info(fmt.Sprintf("%s has %d unsuccessful order placements", contractAddr, len(response.UnsuccessfulOrders)))
+		}
 		responses = append(responses, response)
 	}
 

--- a/x/dex/keeper/contract.go
+++ b/x/dex/keeper/contract.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -20,7 +19,6 @@ func (k Keeper) SetContract(ctx sdk.Context, contract *types.ContractInfoV2) err
 	if err != nil {
 		return errors.New("failed to marshal contract info")
 	}
-	ctx.Logger().Info(fmt.Sprintf("Setting contract address %s", contract.ContractAddr))
 	store.Set(types.ContractKey(contract.ContractAddr), bz)
 	return nil
 }


### PR DESCRIPTION
## Describe your changes and provide context
- Removed uninformational logs inside `SetContract`
- Added gas consumption log for each wasm call
- Added a log for initial rent balance when EndBlock starts

## Testing performed to validate your change
local sei

