### PR TITLE
Fix contract reference deps for gas discount antehandler

### DIFF
--- a/app/antedecorators/depdecorators/gas.go
+++ b/app/antedecorators/depdecorators/gas.go
@@ -1,12 +1,9 @@
 package depdecorators
 
 import (
-	"encoding/hex"
-
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
-	acltypes "github.com/cosmos/cosmos-sdk/x/accesscontrol/types"
 )
 
 type GasMeterSetterDecorator struct {
@@ -14,16 +11,12 @@ type GasMeterSetterDecorator struct {
 
 func (d GasMeterSetterDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
 	for _, msg := range tx.GetMsgs() {
-		if wasmExecuteMsg, ok := msg.(*wasmtypes.MsgExecuteContract); ok {
+		if _, ok := msg.(*wasmtypes.MsgExecuteContract); ok {
 			// if we have a wasm execute message, we need to declare the dependency to read accesscontrol for giving gas discount
-			accAddr, err := sdk.AccAddressFromBech32(wasmExecuteMsg.Contract)
-			if err != nil {
-				return txDeps, err
-			}
 			txDeps = append(txDeps, sdkacltypes.AccessOperation{
 				AccessType:         sdkacltypes.AccessType_READ,
 				ResourceType:       sdkacltypes.ResourceType_KV_ACCESSCONTROL_WASM_DEPENDENCY_MAPPING,
-				IdentifierTemplate: hex.EncodeToString(acltypes.GetWasmContractAddressKey(accAddr)),
+				IdentifierTemplate: "*",
 			})
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,6 @@ require (
 	github.com/firefart/nonamedreturns v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/fzipp/gocyclo v0.5.1 // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-critic/go-critic v0.6.3 // indirect
 	github.com/go-kit/kit v0.12.0 // indirect
 	github.com/go-kit/log v0.2.0 // indirect
@@ -141,7 +140,6 @@ require (
 	github.com/gostaticanalysis/nilerr v0.1.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
@@ -269,7 +267,7 @@ require (
 
 replace (
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.387
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.389
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.143

--- a/go.sum
+++ b/go.sum
@@ -344,7 +344,6 @@ github.com/fullstorydev/grpcurl v1.6.0/go.mod h1:ZQ+ayqbKMJNhzLmbpCiurTVlaK2M/3n
 github.com/fzipp/gocyclo v0.5.1 h1:L66amyuYogbxl0j2U+vGqJXusPF2IkduvXLnYD5TFgw=
 github.com/fzipp/gocyclo v0.5.1/go.mod h1:rXPyn8fnlpa0R2csP/31uerbiVBugk5whMdlyaLkLoA=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
@@ -600,8 +599,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.12.1/go.mod h1:8XEsbTttt/W+VvjtQhLACqCisSPWTxCZ7sBRjU6iH9c=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0 h1:1JYBfzqrWPcCclBwxFCPAou9n+q86mfnu7NAeHfte7A=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0/go.mod h1:YDZoGHuwE+ov0c8smSH49WLF3F2LaWnYYuDVd+EWrc0=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
@@ -1071,8 +1068,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.1.387 h1:w9vCpVhVPdg76k78Azv+4q/UJ+iPaEvafEd8uQwgtKA=
-github.com/sei-protocol/sei-cosmos v0.1.387/go.mod h1:lX+jDZ9u+afukL4Gc76YtKFEeCe9HfrAOCYAzSevAPw=
+github.com/sei-protocol/sei-cosmos v0.1.389 h1:nudgQw34UZMe0jfaUVKldixUg0Lu3B2OJtTuLapOYaA=
+github.com/sei-protocol/sei-cosmos v0.1.389/go.mod h1:lX+jDZ9u+afukL4Gc76YtKFEeCe9HfrAOCYAzSevAPw=
 github.com/sei-protocol/sei-tendermint v0.1.143 h1:e/Whh9Ixi6YgNODUz+wRtCpCiiYYbBHKKx7D7GxapfU=
 github.com/sei-protocol/sei-tendermint v0.1.143/go.mod h1:+BtDvAwTkE64BlxzpH9ZP7S6vUYT9wRXiZa/WW8/o4g=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=

--- a/scripts/old_initialize_local.sh
+++ b/scripts/old_initialize_local.sh
@@ -58,11 +58,11 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   sed -i 's/timeout_commit =.*/timeout_commit = "2000ms"/g' $CONFIG_PATH
   sed -i 's/skip_timeout_commit =.*/skip_timeout_commit = false/g' $CONFIG_PATH
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-  sed -i '' 's/# unsafe-propose-timeout-override = 0s =.*/unsafe-propose-timeout-override = "10s"/g' $CONFIG_PATH
-  sed -i '' 's/# unsafe-propose-timeout-delta-override = 0s =.*/unsafe-propose-timeout-delta-override = "10s"/g' $CONFIG_PATH
-  sed -i '' 's/# unsafe-vote-timeout-override = 0s =.*/unsafe-vote-timeout-override = "10s"/g' $CONFIG_PATH
-  sed -i '' 's/# unsafe-vote-timeout-delta-override = 0s =.*/unsafe-vote-timeout-delta-override = "10s"/g' $CONFIG_PATH
-  sed -i '' 's/# unsafe-commit-timeout-override = 0s =.*/unsafe-commit-timeout-override = "10s"/g' $CONFIG_PATH
+  sed -i '' 's/unsafe-propose-timeout-override =.*/unsafe-propose-timeout-override = "2s"/g' $CONFIG_PATH
+  sed -i '' 's/unsafe-propose-timeout-delta-override =.*/unsafe-propose-timeout-delta-override = "2s"/g' $CONFIG_PATH
+  sed -i '' 's/unsafe-vote-timeout-override =.*/unsafe-vote-timeout-override = "2s"/g' $CONFIG_PATH
+  sed -i '' 's/unsafe-vote-timeout-delta-override =.*/unsafe-vote-timeout-delta-override = "2s"/g' $CONFIG_PATH
+  sed -i '' 's/unsafe-commit-timeout-override =.*/unsafe-commit-timeout-override = "2s"/g' $CONFIG_PATH
 else
   printf "Platform not supported, please ensure that the following values are set in your config.toml:\n"
   printf "###         Consensus Configuration Options         ###\n"


### PR DESCRIPTION
## Describe your changes and provide context
This fixes incorrect dependency issues when we have a contract reference. Because the gas discount now expands the wasm dependencies of applicable contract references, we need to cover those as well as the original contract in the Accesscontrol READ access op. However, to prevent excessing iteration to identify the exact contracts, we can just declare a blanket `*` READ dependency since READs aren't blocking for other READs. This performance degrades a little if theres a tx registering a wasm dependency at the same time as executing a wasm TXs, but we expect dependency regsitration to be fairly infrequent in volume compared to the READs incurred by wasm contract execution.

## Testing performed to validate your change
Verified on localsei with wasm contract execution without invalid concurrent deps
