### PR TITLE
[OraclePriceFeeder] Improve feeder performance by making tx broadcast async

### DIFF
--- a/oracle/price-feeder/oracle/client/chain_height.go
+++ b/oracle/price-feeder/oracle/client/chain_height.go
@@ -47,7 +47,7 @@ func (heightUpdater HeightUpdater) subscribe(
 ) {
 	for {
 		eventData, err := tmrpcclient.WaitForOneEvent(ctx, eventsClient, queryEventNewBlockHeader.String())
-		fmt.Println("Received a new event ")
+
 		if err != nil {
 			logger.Err(err).Msg("Failed to query EventNewBlockHeader")
 		}
@@ -60,6 +60,8 @@ func (heightUpdater HeightUpdater) subscribe(
 				heightUpdater.ChBlockHeight <- eventHeight
 				heightUpdater.LastHeight = eventHeight
 				logger.Debug().Msg(fmt.Sprintf("Received new Chain Height: %d", eventDataNewBlockHeader.Header.Height))
+			} else {
+				fmt.Printf("Received a new event with same height: %d\n", eventHeight)
 			}
 		}
 	}

--- a/oracle/price-feeder/oracle/client/chain_height.go
+++ b/oracle/price-feeder/oracle/client/chain_height.go
@@ -6,11 +6,13 @@ import (
 	"github.com/rs/zerolog"
 	tmrpcclient "github.com/tendermint/tendermint/rpc/client"
 	tmtypes "github.com/tendermint/tendermint/types"
+	"time"
 )
 
 var (
 	started                  = false
 	queryEventNewBlockHeader = tmtypes.QueryForEvent(tmtypes.EventNewBlockHeaderValue)
+	queryInterval            = 20 * time.Millisecond
 )
 
 // HeightUpdater is used to provide the updates of the latest chain
@@ -61,7 +63,7 @@ func (heightUpdater HeightUpdater) subscribe(
 				heightUpdater.LastHeight = eventHeight
 				logger.Debug().Msg(fmt.Sprintf("Received new Chain Height: %d", eventDataNewBlockHeader.Header.Height))
 			} else {
-				fmt.Printf("Received a new event with same height: %d\n", eventHeight)
+				time.Sleep(queryInterval)
 			}
 		}
 	}

--- a/oracle/price-feeder/oracle/client/chain_height.go
+++ b/oracle/price-feeder/oracle/client/chain_height.go
@@ -60,7 +60,7 @@ func (heightUpdater HeightUpdater) subscribe(
 			if eventHeight > heightUpdater.LastHeight {
 				heightUpdater.ChBlockHeight <- eventHeight
 				heightUpdater.LastHeight = eventHeight
-				logger.Debug().Msg(fmt.Sprintf("Received new Chain Height: %d", eventDataNewBlockHeader.Header.Height))
+				logger.Info().Msg(fmt.Sprintf("Received new Chain Height: %d", eventDataNewBlockHeader.Header.Height))
 			} else {
 				time.Sleep(queryInterval)
 			}

--- a/oracle/price-feeder/oracle/client/chain_height.go
+++ b/oracle/price-feeder/oracle/client/chain_height.go
@@ -2,100 +2,65 @@ package client
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"sync"
-	"time"
-
 	"github.com/rs/zerolog"
 	tmrpcclient "github.com/tendermint/tendermint/rpc/client"
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
 var (
-	errParseEventDataNewBlockHeader = errors.New("error parsing EventDataNewBlockHeader")
-	queryEventNewBlockHeader        = tmtypes.QueryForEvent(tmtypes.EventNewBlockHeaderValue)
+	started                  = false
+	queryEventNewBlockHeader = tmtypes.QueryForEvent(tmtypes.EventNewBlockHeaderValue)
 )
 
-// ChainHeight is used to cache the chain height of the
-// current node which is being updated each time the
-// node sends an event of EventNewBlockHeader.
-// It starts a goroutine to subscribe to blockchain new block event and update the cached height.
-type ChainHeight struct {
-	Logger zerolog.Logger
-
-	mtx               sync.RWMutex
-	errGetChainHeight error
-	lastChainHeight   int64
+// HeightUpdater is used to provide the updates of the latest chain
+// It starts a goroutine to subscribe to new block event and send the latest block height to the channel
+type HeightUpdater struct {
+	Logger        zerolog.Logger
+	LastHeight    int64
+	ChBlockHeight chan int64
 }
 
-// NewChainHeight returns a new ChainHeight struct that
-// starts a new goroutine subscribed to EventNewBlockHeader.
-func NewChainHeight(
+// Start will start a new goroutine subscribed to EventNewBlockHeader.
+func (heightUpdater HeightUpdater) Start(
 	ctx context.Context,
 	rpcClient tmrpcclient.Client,
 	logger zerolog.Logger,
-	initialHeight int64,
-) (*ChainHeight, error) {
-	if initialHeight < 1 {
-		return nil, fmt.Errorf("expected positive initial block height")
+) error {
+	if !started {
+		if err := rpcClient.Start(ctx); err != nil {
+			return err
+		}
+		go heightUpdater.subscribe(ctx, rpcClient, logger)
+		started = true
 	}
 
-	if err := rpcClient.Start(ctx); err != nil {
-		return nil, err
-	}
-
-	chainHeight := &ChainHeight{
-		Logger:            logger.With().Str("oracle_client", "chain_height").Logger(),
-		errGetChainHeight: nil,
-		lastChainHeight:   initialHeight,
-	}
-
-	go chainHeight.subscribe(ctx, rpcClient)
-
-	return chainHeight, nil
-}
-
-// updateChainHeight receives the data to be updated thread safe.
-func (chainHeight *ChainHeight) updateChainHeight(blockHeight int64, err error) {
-	chainHeight.mtx.Lock()
-	defer chainHeight.mtx.Unlock()
-
-	chainHeight.lastChainHeight = blockHeight
-	chainHeight.errGetChainHeight = err
+	return nil
 }
 
 // subscribe listens to new blocks being made
 // and updates the chain height.
-func (chainHeight *ChainHeight) subscribe(
+func (heightUpdater HeightUpdater) subscribe(
 	ctx context.Context,
 	eventsClient tmrpcclient.EventsClient,
+	logger zerolog.Logger,
 ) {
 	for {
 		eventData, err := tmrpcclient.WaitForOneEvent(ctx, eventsClient, queryEventNewBlockHeader.String())
+		fmt.Println("Received a new event ")
 		if err != nil {
-			chainHeight.Logger.Err(err)
-			chainHeight.updateChainHeight(chainHeight.lastChainHeight, err)
+			logger.Err(err).Msg("Failed to query EventNewBlockHeader")
 		}
 		eventDataNewBlockHeader, ok := eventData.(tmtypes.EventDataNewBlockHeader)
 		if !ok {
-			chainHeight.Logger.Err(errParseEventDataNewBlockHeader)
-			chainHeight.updateChainHeight(chainHeight.lastChainHeight, errParseEventDataNewBlockHeader)
-			continue
+			logger.Err(err).Msg("Failed to parse event from eventDataNewBlockHeader")
+		} else {
+			eventHeight := eventDataNewBlockHeader.Header.Height
+			if eventHeight > heightUpdater.LastHeight {
+				heightUpdater.ChBlockHeight <- eventHeight
+				heightUpdater.LastHeight = eventHeight
+				logger.Debug().Msg(fmt.Sprintf("Received new Chain Height: %d", eventDataNewBlockHeader.Header.Height))
+			}
 		}
-		if eventDataNewBlockHeader.Header.Height != chainHeight.lastChainHeight {
-			chainHeight.updateChainHeight(eventDataNewBlockHeader.Header.Height, nil)
-			chainHeight.Logger.Debug().Msg(fmt.Sprintf("New Chain Height: %d", eventDataNewBlockHeader.Header.Height))
-		}
-		// sleep 20 ms before checking for new block
-		time.Sleep(20 * time.Millisecond)
 	}
-}
-
-// GetChainHeight returns the last chain height available.
-func (chainHeight *ChainHeight) GetChainHeight() (int64, error) {
-	chainHeight.mtx.RLock()
-	defer chainHeight.mtx.RUnlock()
-
-	return chainHeight.lastChainHeight, chainHeight.errGetChainHeight
 }

--- a/oracle/price-feeder/oracle/client/chain_height.go
+++ b/oracle/price-feeder/oracle/client/chain_height.go
@@ -36,7 +36,6 @@ func (heightUpdater HeightUpdater) Start(
 		go heightUpdater.subscribe(ctx, rpcClient, logger)
 		started = true
 	}
-
 	return nil
 }
 

--- a/oracle/price-feeder/oracle/client/chain_height.go
+++ b/oracle/price-feeder/oracle/client/chain_height.go
@@ -3,10 +3,11 @@ package client
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/rs/zerolog"
 	tmrpcclient "github.com/tendermint/tendermint/rpc/client"
 	tmtypes "github.com/tendermint/tendermint/types"
-	"time"
 )
 
 var (

--- a/oracle/price-feeder/oracle/client/client.go
+++ b/oracle/price-feeder/oracle/client/client.go
@@ -112,8 +112,7 @@ func NewOracleClient(
 		ChBlockHeight: oracleClient.BlockHeightEvents,
 	}
 
-	chainHeightUpdater.Start(ctx, clientCtx.Client, oracleClient.Logger)
-
+	err = chainHeightUpdater.Start(ctx, clientCtx.Client, oracleClient.Logger)
 	if err != nil {
 		return OracleClient{}, err
 	}

--- a/oracle/price-feeder/oracle/client/client.go
+++ b/oracle/price-feeder/oracle/client/client.go
@@ -139,8 +139,8 @@ func (r *passReader) Read(p []byte) (n int, err error) {
 	return n, err
 }
 
-// BroadcastTx attempts to broadcast a signed transaction. If it fails, a few re-attempts
-// will be made until the transaction succeeds or ultimately times out or fails.
+// BroadcastTx attempts to broadcast a signed transaction in best effort mode.
+// Retry is not needed since we are doing this for every new block.
 // Ref: https://github.com/terra-money/oracle-feeder/blob/baef2a4a02f57a2ffeaa207932b2e03d7fb0fb25/feeder/src/vote.ts#L230
 func (oc OracleClient) BroadcastTx(
 	blockHeight int64,

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -3,27 +3,24 @@ package oracle
 import (
 	"context"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/client/tx"
 	"math"
 	"net/http"
 	"sync"
 	"time"
 
 	cosmosclient "github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
-	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc"
-
 	"github.com/sei-protocol/sei-chain/oracle/price-feeder/config"
 	"github.com/sei-protocol/sei-chain/oracle/price-feeder/oracle/client"
 	"github.com/sei-protocol/sei-chain/oracle/price-feeder/oracle/provider"
 	"github.com/sei-protocol/sei-chain/oracle/price-feeder/oracle/types"
 	pfsync "github.com/sei-protocol/sei-chain/oracle/price-feeder/pkg/sync"
-
 	oracletypes "github.com/sei-protocol/sei-chain/x/oracle/types"
-
-	"github.com/cosmos/cosmos-sdk/telemetry"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
 )
 
 // Oracle implements the core component responsible for fetching exchange rates

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -134,7 +134,7 @@ func (o *Oracle) Start(ctx context.Context) error {
 				}
 
 				// Catch any missing blocks (should never happen)
-				if currBlockHeight > lastProcessedBlock-1 && lastProcessedBlock > 0 {
+				if currBlockHeight > (lastProcessedBlock+1) && lastProcessedBlock > 0 {
 					missedBlocks := currBlockHeight - (lastProcessedBlock + 1)
 					telemetry.IncrCounter(float32(missedBlocks), "num_missed_blocks", "tick")
 				}

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -500,7 +500,7 @@ func (o *Oracle) tick(
 	clientContext cosmosclient.Context,
 	txFactory tx.Factory,
 	blockHeight int64) error {
-	
+
 	o.logger.Info().Msg(fmt.Sprintf("executing oracle tick at height %d", blockHeight))
 
 	if blockHeight < 1 {

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -500,7 +500,8 @@ func (o *Oracle) tick(
 	clientContext cosmosclient.Context,
 	txFactory tx.Factory,
 	blockHeight int64) error {
-	o.logger.Debug().Msg("executing oracle tick")
+	
+	o.logger.Info().Msg(fmt.Sprintf("executing oracle tick at height %d", blockHeight))
 
 	if blockHeight < 1 {
 		return fmt.Errorf("expected positive block height")

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -501,7 +501,7 @@ func (o *Oracle) tick(
 	txFactory tx.Factory,
 	blockHeight int64) error {
 
-	o.logger.Info().Msg(fmt.Sprintf("executing oracle tick at height %d", blockHeight))
+	o.logger.Debug().Msg(fmt.Sprintf("executing oracle tick for height %d", blockHeight))
 
 	if blockHeight < 1 {
 		return fmt.Errorf("expected positive block height")


### PR DESCRIPTION
## Describe your changes and provide context
**Problem:**
Currently, the oracle price feeder is not able to keep up with the block chain speed, it is only able to broadcast the transactions for every a few blocks. Ideally, we want the transaction to be broadcasted for every block, not to skippping any blocks.

**Solution:**
This PR propose the change to make the tick asynchronous and best effort. 

The previous behavior is that, we have a separate thread keep updating the height, and on block height changes, we will send a new tx broadcast. Whenever each time if there are some broadcast failures, we will retry the same tx for the next few blocks up till some max retry blocks  and will sleep for 1 second between each retry. This 1 second sleep takes too much time and doesn't make lot of sense any more. 

The new behavior will use a blockHeight channel to get new block updates, and for each new block, it will spin up a new goroutine to call tick() asynchronously. Within each ticket, we will get the latest prices and send the tx broadcast request without doing any retry. Retry is not needed here because as long as we are doing broadcast for every height, the future requests will succeed anyway.

## Testing performed to validate your change
Tested on sei-devenet-2
