### PR TITLE
Gas discount calc

### DIFF
--- a/app/antedecorators/gas.go
+++ b/app/antedecorators/gas.go
@@ -22,9 +22,11 @@ func GetGasMeterSetter(aclkeeper aclkeeper.Keeper) func(bool, sdk.Context, uint6
 		}
 
 		denominator := uint64(1)
+		updatedGasDenominator := false
 		for _, msg := range tx.GetMsgs() {
 			candidateDenominator := getMessageMultiplierDenominator(ctx, msg, aclkeeper)
-			if candidateDenominator > denominator {
+			if !updatedGasDenominator || candidateDenominator < denominator {
+				updatedGasDenominator = true
 				denominator = candidateDenominator
 			}
 		}

--- a/app/antedecorators/gas_test.go
+++ b/app/antedecorators/gas_test.go
@@ -17,6 +17,8 @@ func TestMultiplierGasSetter(t *testing.T) {
 	testApp := app.Setup(false)
 	contractAddr, err := sdk.AccAddressFromBech32("sei1y3pxq5dp900czh0mkudhjdqjq5m8cpmmps8yjw")
 	require.NoError(t, err)
+	otherContractAddr, err := sdk.AccAddressFromBech32("sei14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sh9m79m")
+	require.NoError(t, err)
 	ctx := testApp.NewContext(false, types.Header{}).WithBlockHeight(2)
 	testMsg := wasmtypes.MsgExecuteContract{
 		Contract: "sei1y3pxq5dp900czh0mkudhjdqjq5m8cpmmps8yjw",
@@ -39,10 +41,38 @@ func TestMultiplierGasSetter(t *testing.T) {
 			},
 		},
 	})
+	// other contract not discounted
+	testApp.AccessControlKeeper.SetWasmDependencyMapping(ctx, accesscontrol.WasmDependencyMapping{
+		ContractAddress: otherContractAddr.String(),
+		BaseAccessOps: []*accesscontrol.WasmAccessOperation{
+			{
+				Operation: &accesscontrol.AccessOperation{
+					AccessType:         accesscontrol.AccessType_READ,
+					ResourceType:       accesscontrol.ResourceType_KV,
+					IdentifierTemplate: "*",
+				},
+			},
+			{
+				Operation: acltypes.CommitAccessOp(),
+			},
+		},
+	})
+
 	gasMeterSetter := antedecorators.GetGasMeterSetter(testApp.AccessControlKeeper)
 	ctxWithGasMeter := gasMeterSetter(false, ctx, 1000, testTx)
 	ctxWithGasMeter.GasMeter().ConsumeGas(2, "")
 	require.Equal(t, uint64(1), ctxWithGasMeter.GasMeter().GasConsumed())
+
+	otherTestMsg := wasmtypes.MsgExecuteContract{
+		Contract: "sei14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sh9m79m",
+		Msg:      []byte("{\"xyz\":{}}"),
+	}
+	testTx2 := app.NewTestTx([]sdk.Msg{&testMsg, &otherTestMsg})
+	ctxWithGasMeter = gasMeterSetter(false, ctx, 1000, testTx2)
+	ctxWithGasMeter.GasMeter().ConsumeGas(2, "")
+	// should still not give discount because of other contract being non-discounted
+	require.Equal(t, uint64(2), ctxWithGasMeter.GasMeter().GasConsumed())
+
 	// not discounted mapping
 	testApp.AccessControlKeeper.SetWasmDependencyMapping(ctx, accesscontrol.WasmDependencyMapping{
 		ContractAddress: contractAddr.String(),


### PR DESCRIPTION
## Describe your changes and provide context
Modifies the gas denominator calculation to use the most conservative denominator for the TX so that users can't game the system by including a message with discount to get a discount on the whole Tx.

## Testing performed to validate your change
Updated unit test
