### PR TITLE
Fix oracle account sequence number increment logic

### DIFF
--- a/oracle/price-feeder/oracle/client/client.go
+++ b/oracle/price-feeder/oracle/client/client.go
@@ -184,7 +184,7 @@ func (oc OracleClient) BroadcastTx(
 		Uint32("tx_code", resp.Code).
 		Str("tx_hash", resp.TxHash).
 		Int64("tx_height", resp.Height).
-		Msg(fmt.Sprintf("successfully broadcasted tx at height %d", blockHeight))
+		Msg(fmt.Sprintf("Successfully broadcasted tx at height %d", blockHeight))
 	return nil
 }
 

--- a/oracle/price-feeder/oracle/client/tx.go
+++ b/oracle/price-feeder/oracle/client/tx.go
@@ -51,7 +51,9 @@ func BroadcastTx(clientCtx client.Context, txf tx.Factory, logger zerolog.Logger
 		// When error happen, it could be that the sequence number are mismatching
 		// We need to reset sequence number to query the latest value from the chain
 		_ = resetAccountSequence(clientCtx, txf)
-
+	} else {
+		// Only increment sequence number if we successfully broadcast the previous transaction
+		oracleAccountInfo.AccountSequence++
 	}
 
 	return res, err
@@ -66,8 +68,6 @@ func prepareFactory(ctx client.Context, txf tx.Factory) (tx.Factory, error) {
 		if err != nil {
 			return txf, err
 		}
-	} else {
-		oracleAccountInfo.AccountSequence++
 	}
 	txf = txf.WithAccountNumber(oracleAccountInfo.AccountNumber)
 	txf = txf.WithSequence(oracleAccountInfo.AccountSequence)

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -542,7 +542,7 @@ func (o *Oracle) tick(
 		Str("validator", voteMsg.Validator).
 		Str("feeder", voteMsg.Feeder).
 		Float64("vote_period", currentVotePeriod).
-		Msg("broadcasting vote")
+		Msg("Going to broadcast vote")
 
 	if err := o.oracleClient.BroadcastTx(blockHeight, voteMsg); err != nil {
 		return err


### PR DESCRIPTION
## Describe your changes and provide context
When broadcastTx hit an error, we should not increment the sequence number, we should refresh the current sequence number and use that for the next transaction request.


## Testing performed to validate your change

