### PR TITLE
[cleanup] Remove Terra and Luna references

### DIFF
--- a/oracle/.env
+++ b/oracle/.env
@@ -4,8 +4,8 @@ CHAIN_ID="sei-chain"
 # Cron tab for how frequently prices will be posted (ex: 10 seconds)
 CRONTAB="*/10 * * * * *"
 
-# List of markets the oracle will post prices for, against ust 
-MARKET_IDS="btc,luna,btc,eth,sol,osmo"
+# List of markets the oracle will post prices for, against ust
+MARKET_IDS="btc,btc,eth,sol,osmo"
 
 # RPC of tendermint node
 CHAIN_RPC="http://localhost:26657"

--- a/oracle/oracle.js
+++ b/oracle/oracle.js
@@ -8,7 +8,6 @@ const utils = require('./utils').utils;
 // TODO(psu): Insert actual addresses
 const TOKEN_ADDR_MAP = {
   btc: 'cosmos14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s4hmalr',
-  luna: 'cosmos14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s4hmalr',
   eth: 'cosmos14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s4hmalr',
   sol: 'cosmos14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s4hmalr',
   osmo: 'cosmos14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s4hmalr',
@@ -71,7 +70,7 @@ class PriceOracle {
       return fetchedPrice.price;
     });
   }
-  
+
 
   /**
    * Fetches price for a market ID

--- a/oracle/price-feeder/README.md
+++ b/oracle/price-feeder/README.md
@@ -1,10 +1,10 @@
 # Oracle Price Feeder
 
-This is a standalone version of [Umee's fantastic work](https://github.com/umee-network/umee/tree/main/price-feeder) migrating [Terra's oracle-feeder](https://github.com/terra-money/oracle-feeder) app to Go, and integrating it more closely with the Cosmos SDK.
+This is a standalone version of [Umee's fantastic work](https://github.com/umee-network/umee/tree/main/price-feeder) and integrating it more closely with the Cosmos SDK.
 
 ## Changes
 
-- `exchange_rates` when broadcasting votes has been reverted to the Cosmos SDK denom string, as is used in Terra's Oracle module
+- `exchange_rates` when broadcasting votes has been reverted to the Cosmos SDK denom string, as is used in Se's Oracle module
 - `config.toml` supports an `account.prefix` property, to provide compatibility across multiple networks
 
 ---

--- a/oracle/price-feeder/oracle/client/client.go
+++ b/oracle/price-feeder/oracle/client/client.go
@@ -140,7 +140,6 @@ func (r *passReader) Read(p []byte) (n int, err error) {
 
 // BroadcastTx attempts to broadcast a signed transaction in best effort mode.
 // Retry is not needed since we are doing this for every new block.
-// Ref: https://github.com/terra-money/oracle-feeder/blob/baef2a4a02f57a2ffeaa207932b2e03d7fb0fb25/feeder/src/vote.ts#L230
 func (oc OracleClient) BroadcastTx(
 	blockHeight int64,
 	msgs ...sdk.Msg) error {

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -97,7 +97,7 @@ func New(
 
 // Start starts the oracle process in a blocking fashion.
 func (o *Oracle) Start(ctx context.Context) error {
-	var lastProcessedBlock int64 = 0
+	var lastProcessedBlock int64
 
 	for {
 		select {

--- a/oracle/price-feeder/oracle/provider/binance_test.go
+++ b/oracle/price-feeder/oracle/provider/binance_test.go
@@ -51,7 +51,7 @@ func TestBinanceProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("valid_request_multi_ticker", func(t *testing.T) {
 		lastPriceAtom := "34.69000000"
-		lastPriceLuna := "41.35000000"
+		lastPriceSei := "41.35000000"
 		volume := "2396974.02000000"
 
 		tickerMap := map[string]BinanceTicker{}
@@ -61,23 +61,23 @@ func TestBinanceProvider_GetTickerPrices(t *testing.T) {
 			Volume:    volume,
 		}
 
-		tickerMap["LUNAUSDT"] = BinanceTicker{
-			Symbol:    "LUNAUSDT",
-			LastPrice: lastPriceLuna,
+		tickerMap["SEIUSDT"] = BinanceTicker{
+			Symbol:    "SEIUSDT",
+			LastPrice: lastPriceSei,
 			Volume:    volume,
 		}
 
 		p.tickers = tickerMap
 		prices, err := p.GetTickerPrices(
 			types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
-			types.CurrencyPair{Base: "LUNA", Quote: "USDT"},
+			types.CurrencyPair{Base: "SEI", Quote: "USDT"},
 		)
 		require.NoError(t, err)
 		require.Len(t, prices, 2)
 		require.Equal(t, sdk.MustNewDecFromStr(lastPriceAtom), prices["ATOMUSDT"].Price)
 		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["ATOMUSDT"].Volume)
-		require.Equal(t, sdk.MustNewDecFromStr(lastPriceLuna), prices["LUNAUSDT"].Price)
-		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["LUNAUSDT"].Volume)
+		require.Equal(t, sdk.MustNewDecFromStr(lastPriceSei), prices["SEIUSDT"].Price)
+		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["SEIUSDT"].Volume)
 	})
 
 	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {

--- a/oracle/price-feeder/oracle/provider/huobi_test.go
+++ b/oracle/price-feeder/oracle/provider/huobi_test.go
@@ -46,7 +46,7 @@ func TestHuobiProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("valid_request_multi_ticker", func(t *testing.T) {
 		lastPriceAtom := 34.69000000
-		lastPriceLuna := 41.35000000
+		lastPriceSei := 41.35000000
 		volume := 2396974.02000000
 
 		tickerMap := map[string]HuobiTicker{}
@@ -58,10 +58,10 @@ func TestHuobiProvider_GetTickerPrices(t *testing.T) {
 			},
 		}
 
-		tickerMap["market.lunausdt.ticker"] = HuobiTicker{
-			CH: "market.lunausdt.ticker",
+		tickerMap["market.seiusdt.ticker"] = HuobiTicker{
+			CH: "market.seiusdt.ticker",
 			Tick: HuobiTick{
-				LastPrice: lastPriceLuna,
+				LastPrice: lastPriceSei,
 				Vol:       volume,
 			},
 		}
@@ -69,14 +69,14 @@ func TestHuobiProvider_GetTickerPrices(t *testing.T) {
 		p.tickers = tickerMap
 		prices, err := p.GetTickerPrices(
 			types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
-			types.CurrencyPair{Base: "LUNA", Quote: "USDT"},
+			types.CurrencyPair{Base: "SEI", Quote: "USDT"},
 		)
 		require.NoError(t, err)
 		require.Len(t, prices, 2)
 		require.Equal(t, sdk.MustNewDecFromStr(strconv.FormatFloat(lastPriceAtom, 'f', -1, 64)), prices["ATOMUSDT"].Price)
 		require.Equal(t, sdk.MustNewDecFromStr(strconv.FormatFloat(volume, 'f', -1, 64)), prices["ATOMUSDT"].Volume)
-		require.Equal(t, sdk.MustNewDecFromStr(strconv.FormatFloat(lastPriceLuna, 'f', -1, 64)), prices["LUNAUSDT"].Price)
-		require.Equal(t, sdk.MustNewDecFromStr(strconv.FormatFloat(volume, 'f', -1, 64)), prices["LUNAUSDT"].Volume)
+		require.Equal(t, sdk.MustNewDecFromStr(strconv.FormatFloat(lastPriceSei, 'f', -1, 64)), prices["SEIUSDT"].Price)
+		require.Equal(t, sdk.MustNewDecFromStr(strconv.FormatFloat(volume, 'f', -1, 64)), prices["SEIUSDT"].Volume)
 	})
 
 	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {

--- a/oracle/price-feeder/oracle/provider/kraken_test.go
+++ b/oracle/price-feeder/oracle/provider/kraken_test.go
@@ -42,7 +42,7 @@ func TestKrakenProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("valid_request_multi_ticker", func(t *testing.T) {
 		lastPriceAtom := sdk.MustNewDecFromStr("34.69000000")
-		lastPriceLuna := sdk.MustNewDecFromStr("41.35000000")
+		lastPriceSei := sdk.MustNewDecFromStr("41.35000000")
 		volume := sdk.MustNewDecFromStr("2396974.02000000")
 
 		tickerMap := map[string]TickerPrice{}
@@ -51,22 +51,22 @@ func TestKrakenProvider_GetTickerPrices(t *testing.T) {
 			Volume: volume,
 		}
 
-		tickerMap["LUNAUSDT"] = TickerPrice{
-			Price:  lastPriceLuna,
+		tickerMap["SEIUSDT"] = TickerPrice{
+			Price:  lastPriceSei,
 			Volume: volume,
 		}
 
 		p.tickers = tickerMap
 		prices, err := p.GetTickerPrices(
 			types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
-			types.CurrencyPair{Base: "LUNA", Quote: "USDT"},
+			types.CurrencyPair{Base: "SEI", Quote: "USDT"},
 		)
 		require.NoError(t, err)
 		require.Len(t, prices, 2)
 		require.Equal(t, lastPriceAtom, prices["ATOMUSDT"].Price)
 		require.Equal(t, volume, prices["ATOMUSDT"].Volume)
-		require.Equal(t, lastPriceLuna, prices["LUNAUSDT"].Price)
-		require.Equal(t, volume, prices["LUNAUSDT"].Volume)
+		require.Equal(t, lastPriceSei, prices["SEIUSDT"].Price)
+		require.Equal(t, volume, prices["SEIUSDT"].Volume)
 	})
 
 	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {

--- a/oracle/price-feeder/oracle/provider/mexc_test.go
+++ b/oracle/price-feeder/oracle/provider/mexc_test.go
@@ -43,7 +43,7 @@ func TestMexcProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("valid_request_multi_ticker", func(t *testing.T) {
 		lastPriceAtom := "34.69000000"
-		lastPriceLuna := "41.35000000"
+		lastPriceSei := "41.35000000"
 		volume := "2396974.02000000"
 
 		tickerMap := map[string]MexcTicker{}
@@ -53,23 +53,23 @@ func TestMexcProvider_GetTickerPrices(t *testing.T) {
 			Volume:    volume,
 		}
 
-		tickerMap["LUNAUSDT"] = MexcTicker{
-			Symbol:    "LUNAUSDT",
-			LastPrice: lastPriceLuna,
+		tickerMap["SEIUSDT"] = MexcTicker{
+			Symbol:    "SEIUSDT",
+			LastPrice: lastPriceSei,
 			Volume:    volume,
 		}
 
 		p.tickers = tickerMap
 		prices, err := p.GetTickerPrices(
 			types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
-			types.CurrencyPair{Base: "LUNA", Quote: "USDT"},
+			types.CurrencyPair{Base: "SEI", Quote: "USDT"},
 		)
 		require.NoError(t, err)
 		require.Len(t, prices, 2)
 		require.Equal(t, sdk.MustNewDecFromStr(lastPriceAtom), prices["ATOMUSDT"].Price)
 		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["ATOMUSDT"].Volume)
-		require.Equal(t, sdk.MustNewDecFromStr(lastPriceLuna), prices["LUNAUSDT"].Price)
-		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["LUNAUSDT"].Volume)
+		require.Equal(t, sdk.MustNewDecFromStr(lastPriceSei), prices["SEIUSDT"].Price)
+		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["SEIUSDT"].Volume)
 	})
 
 	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {

--- a/oracle/price-feeder/oracle/provider/okx_test.go
+++ b/oracle/price-feeder/oracle/provider/okx_test.go
@@ -45,7 +45,7 @@ func TestOkxProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("valid_request_multi_ticker", func(t *testing.T) {
 		lastPriceAtom := "34.69000000"
-		lastPriceLuna := "41.35000000"
+		lastPriceSei := "41.35000000"
 		volume := "2396974.02000000"
 
 		syncMap := map[string]OkxTickerPair{}
@@ -57,25 +57,25 @@ func TestOkxProvider_GetTickerPrices(t *testing.T) {
 			Vol24h: volume,
 		}
 
-		syncMap["LUNA-USDT"] = OkxTickerPair{
+		syncMap["SEI-USDT"] = OkxTickerPair{
 			OkxInstID: OkxInstID{
-				InstID: "LUNA-USDT",
+				InstID: "SEI-USDT",
 			},
-			Last:   lastPriceLuna,
+			Last:   lastPriceSei,
 			Vol24h: volume,
 		}
 
 		p.tickers = syncMap
 		prices, err := p.GetTickerPrices(
 			types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
-			types.CurrencyPair{Base: "LUNA", Quote: "USDT"},
+			types.CurrencyPair{Base: "SEI", Quote: "USDT"},
 		)
 		require.NoError(t, err)
 		require.Len(t, prices, 2)
 		require.Equal(t, sdk.MustNewDecFromStr(lastPriceAtom), prices["ATOMUSDT"].Price)
 		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["ATOMUSDT"].Volume)
-		require.Equal(t, sdk.MustNewDecFromStr(lastPriceLuna), prices["LUNAUSDT"].Price)
-		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["LUNAUSDT"].Volume)
+		require.Equal(t, sdk.MustNewDecFromStr(lastPriceSei), prices["SEIUSDT"].Price)
+		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["SEIUSDT"].Volume)
 	})
 
 	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {

--- a/oracle/price-feeder/oracle/util_test.go
+++ b/oracle/price-feeder/oracle/util_test.go
@@ -35,7 +35,7 @@ func TestComputeVWAP(t *testing.T) {
 						Price:  sdk.MustNewDecFromStr("1.13000000"),
 						Volume: sdk.MustNewDecFromStr("249102.38000000"),
 					},
-					"LUNA": provider.TickerPrice{
+					"SEI": provider.TickerPrice{
 						Price:  sdk.MustNewDecFromStr("64.87000000"),
 						Volume: sdk.MustNewDecFromStr("7854934.69000000"),
 					},
@@ -45,7 +45,7 @@ func TestComputeVWAP(t *testing.T) {
 						Price:  sdk.MustNewDecFromStr("28.268700"),
 						Volume: sdk.MustNewDecFromStr("178277.53314385"),
 					},
-					"LUNA": provider.TickerPrice{
+					"SEI": provider.TickerPrice{
 						Price:  sdk.MustNewDecFromStr("64.87853000"),
 						Volume: sdk.MustNewDecFromStr("458917.46353577"),
 					},
@@ -60,7 +60,7 @@ func TestComputeVWAP(t *testing.T) {
 			expected: map[string]sdk.Dec{
 				"ATOM": sdk.MustNewDecFromStr("28.185812745610043621"),
 				"UMEE": sdk.MustNewDecFromStr("1.13000000"),
-				"LUNA": sdk.MustNewDecFromStr("64.870470848638112395"),
+				"SEI": sdk.MustNewDecFromStr("64.870470848638112395"),
 			},
 		},
 	}
@@ -102,12 +102,12 @@ func TestStandardDeviation(t *testing.T) {
 				config.ProviderBinance: {
 					"ATOM": sdk.MustNewDecFromStr("28.21000000"),
 					"UMEE": sdk.MustNewDecFromStr("1.13000000"),
-					"LUNA": sdk.MustNewDecFromStr("64.87000000"),
+					"SEI": sdk.MustNewDecFromStr("64.87000000"),
 				},
 				config.ProviderKraken: {
 					"ATOM": sdk.MustNewDecFromStr("28.23000000"),
 					"UMEE": sdk.MustNewDecFromStr("1.13050000"),
-					"LUNA": sdk.MustNewDecFromStr("64.85000000"),
+					"SEI": sdk.MustNewDecFromStr("64.85000000"),
 				},
 			},
 			expected: map[string]deviation{},
@@ -117,7 +117,7 @@ func TestStandardDeviation(t *testing.T) {
 				config.ProviderBinance: {
 					"ATOM": sdk.MustNewDecFromStr("28.21000000"),
 					"UMEE": sdk.MustNewDecFromStr("1.13000000"),
-					"LUNA": sdk.MustNewDecFromStr("64.87000000"),
+					"SEI": sdk.MustNewDecFromStr("64.87000000"),
 				},
 				config.ProviderKraken: {
 					"ATOM": sdk.MustNewDecFromStr("28.23000000"),
@@ -126,7 +126,7 @@ func TestStandardDeviation(t *testing.T) {
 				config.ProviderCoinbase: {
 					"ATOM": sdk.MustNewDecFromStr("28.40000000"),
 					"UMEE": sdk.MustNewDecFromStr("1.14000000"),
-					"LUNA": sdk.MustNewDecFromStr("64.10000000"),
+					"SEI": sdk.MustNewDecFromStr("64.10000000"),
 				},
 			},
 			expected: map[string]deviation{
@@ -147,17 +147,17 @@ func TestStandardDeviation(t *testing.T) {
 					"ATOM": sdk.MustNewDecFromStr("28.21000000"),
 
 					"UMEE": sdk.MustNewDecFromStr("1.13000000"),
-					"LUNA": sdk.MustNewDecFromStr("64.87000000"),
+					"SEI": sdk.MustNewDecFromStr("64.87000000"),
 				},
 				config.ProviderKraken: {
 					"ATOM": sdk.MustNewDecFromStr("28.23000000"),
 					"UMEE": sdk.MustNewDecFromStr("1.13050000"),
-					"LUNA": sdk.MustNewDecFromStr("64.85000000"),
+					"SEI": sdk.MustNewDecFromStr("64.85000000"),
 				},
 				config.ProviderCoinbase: {
 					"ATOM": sdk.MustNewDecFromStr("28.40000000"),
 					"UMEE": sdk.MustNewDecFromStr("1.14000000"),
-					"LUNA": sdk.MustNewDecFromStr("64.10000000"),
+					"SEI": sdk.MustNewDecFromStr("64.10000000"),
 				},
 			},
 			expected: map[string]deviation{
@@ -169,7 +169,7 @@ func TestStandardDeviation(t *testing.T) {
 					mean:      sdk.MustNewDecFromStr("1.1335"),
 					deviation: sdk.MustNewDecFromStr("0.004600724580614015"),
 				},
-				"LUNA": {
+				"SEI": {
 					mean:      sdk.MustNewDecFromStr("64.606666666666666666"),
 					deviation: sdk.MustNewDecFromStr("0.358360464089193609"),
 				},

--- a/oracle/utils.js
+++ b/oracle/utils.js
@@ -2,8 +2,8 @@ const COINGECKO_V3_SIMPLE_PRICE_REQUEST = (ids, currencies) =>
   `https://api.coingecko.com/api/v3/simple/price/?ids=${ids}&vs_currencies=${currencies}`;
 const BINANCE_V3_TICKER_REQUEST = (symbol) =>
   `https://api.binance.com/api/v3/ticker/24hr?symbol=${symbol}`;
-const BINANCE_SUPPORTED_MARKET_IDS = ['ust', 'btc', 'atom', 'luna', 'sol', 'eth'];
-const BINACE_MARKET_IDS_WITH_DIRECT_UST_CONVERSION = ['luna', 'eth'];
+const BINANCE_SUPPORTED_MARKET_IDS = ['ust', 'btc', 'atom', 'sei', 'sol', 'eth'];
+const BINACE_MARKET_IDS_WITH_DIRECT_UST_CONVERSION = ['sei', 'eth'];
 
 // Check https://api.coingecko.com/api/v3/simple/supported_vs_currencies
 // for supported currencies
@@ -15,8 +15,8 @@ const loadCoinGeckoMarket = (marketID) => {
       return 'bitcoin';
     case 'atom':
       return 'cosmos';
-    case 'luna':
-      return 'terra-luna';
+    case 'sei':
+      return 'sei';
     case 'osmo':
       return 'osmosis';
     case 'sol':

--- a/proto/oracle/query.proto
+++ b/proto/oracle/query.proto
@@ -76,7 +76,7 @@ message QueryExchangeRateRequest {
 // QueryExchangeRateResponse is response type for the
 // Query/ExchangeRate RPC method.
 message QueryExchangeRateResponse {
-  // exchange_rate defines the exchange rate of Luna denominated in various Terra
+  // exchange_rate defines the exchange rate of Sei denominated in various Sei
   OracleExchangeRate oracle_exchange_rate = 1 [(gogoproto.nullable) = false];
 }
 

--- a/vue/src/store/generated/sei-protocol/sei-chain/seiprotocol.seichain.oracle/module/types/oracle/query.d.ts
+++ b/vue/src/store/generated/sei-protocol/sei-chain/seiprotocol.seichain.oracle/module/types/oracle/query.d.ts
@@ -11,7 +11,7 @@ export interface QueryExchangeRateRequest {
  * Query/ExchangeRate RPC method.
  */
 export interface QueryExchangeRateResponse {
-    /** exchange_rate defines the exchange rate of Luna denominated in various Terra */
+    /** exchange_rate defines the exchange rate of Sei denominated in various Sei */
     oracleExchangeRate: OracleExchangeRate | undefined;
 }
 /** QueryExchangeRatesRequest is the request type for the Query/ExchangeRates RPC method. */

--- a/vue/src/store/generated/sei-protocol/sei-chain/seiprotocol.seichain.oracle/module/types/oracle/query.ts
+++ b/vue/src/store/generated/sei-protocol/sei-chain/seiprotocol.seichain.oracle/module/types/oracle/query.ts
@@ -24,7 +24,7 @@ export interface QueryExchangeRateRequest {
  * Query/ExchangeRate RPC method.
  */
 export interface QueryExchangeRateResponse {
-  /** exchange_rate defines the exchange rate of Luna denominated in various Terra */
+  /** exchange_rate defines the exchange rate of Sei denominated in various Sei */
   oracle_exchange_rate: OracleExchangeRate | undefined;
 }
 

--- a/x/dex/keeper/price.go
+++ b/x/dex/keeper/price.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"encoding/binary"
+
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/sei-protocol/sei-chain/x/dex/types"

--- a/x/oracle/client/cli/query.go
+++ b/x/oracle/client/cli/query.go
@@ -44,16 +44,16 @@ func GetCmdQueryExchangeRates() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "exchange-rates [denom]",
 		Args:  cobra.RangeArgs(0, 1),
-		Short: "Query the current Luna exchange rate w.r.t an asset",
+		Short: "Query the current Sei exchange rate w.r.t an asset",
 		Long: strings.TrimSpace(`
-Query the current exchange rate of Luna with an asset.
+Query the current exchange rate of Sei with an asset.
 You can find the current list of active denoms by running
 
-$ terrad query oracle exchange-rates
+$ seid query oracle exchange-rates
 
 Or, can filter with denom
 
-$ terrad query oracle exchange-rates ukrw
+$ seid query oracle exchange-rates ukrw
 `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)
@@ -163,11 +163,11 @@ func GetCmdQueryActives() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "actives",
 		Args:  cobra.NoArgs,
-		Short: "Query the active list of Terra assets recognized by the oracle",
+		Short: "Query the active list of Sei assets recognized by the oracle",
 		Long: strings.TrimSpace(`
-Query the active list of Terra assets recognized by the types.
+Query the active list of Sei assets recognized by the types.
 
-$ terrad query oracle actives
+$ seid query oracle actives
 `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)
@@ -224,7 +224,7 @@ func GetCmdQueryFeederDelegation() *cobra.Command {
 		Long: strings.TrimSpace(`
 Query the account the validator's oracle voting right is delegated to.
 
-$ terrad query oracle feeder terravaloper...
+$ seid query oracle feeder terravaloper...
 `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)
@@ -304,11 +304,11 @@ func GetCmdQueryAggregateVote() *cobra.Command {
 		Long: strings.TrimSpace(`
 Query outstanding oracle aggregate vote.
 
-$ terrad query oracle aggregate-votes
+$ seid query oracle aggregate-votes
 
 Or, can filter with voter address
 
-$ terrad query oracle aggregate-votes terravaloper...
+$ seid query oracle aggregate-votes terravaloper...
 `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)

--- a/x/oracle/client/cli/tx.go
+++ b/x/oracle/client/cli/tx.go
@@ -45,7 +45,7 @@ Delegate the permission to submit exchange rate votes for the oracle to an addre
 
 Delegation can keep your validator operator key offline and use a separate replaceable key online.
 
-$ terrad tx oracle set-feeder terra1...
+$ seid tx oracle set-feeder terra1...
 
 where "terra1..." is the address you want to delegate your voting rights to.
 `),
@@ -94,7 +94,7 @@ Submit a aggregate vote for the exchange_rates of the base denom w.r.t the input
 
 $ seid tx oracle aggregate-vote 8888.0ukrw,1.243uusd,0.99usdr
 
-where "ukrw,uusd,usdr" is the denominating currencies, and "8888.0,1.243,0.99" is the exchange rates of micro Luna in micro denoms from the voter's point of view.
+where "ukrw,uusd,usdr" is the denominating currencies, and "8888.0,1.243,0.99" is the exchange rates of micro Sei in micro denoms from the voter's point of view.
 
 If voting from a voting delegate, set "validator" to the address of the validator to vote on behalf of:
 $ seid tx oracle aggregate-vote 1234 8888.0ukrw,1.243uusd,0.99usdr seivaloper1....

--- a/x/oracle/keeper/keeper_test.go
+++ b/x/oracle/keeper/keeper_test.go
@@ -22,7 +22,7 @@ func TestExchangeRate(t *testing.T) {
 	cnyExchangeRate := sdk.NewDecWithPrec(839, int64(OracleDecPrecision)).MulInt64(utils.MicroUnit)
 	gbpExchangeRate := sdk.NewDecWithPrec(4995, int64(OracleDecPrecision)).MulInt64(utils.MicroUnit)
 	krwExchangeRate := sdk.NewDecWithPrec(2838, int64(OracleDecPrecision)).MulInt64(utils.MicroUnit)
-	lunaExchangeRate := sdk.NewDecWithPrec(3282384, int64(OracleDecPrecision)).MulInt64(utils.MicroUnit)
+	seiExchangeRate := sdk.NewDecWithPrec(3282384, int64(OracleDecPrecision)).MulInt64(utils.MicroUnit)
 
 	// Set & get rates
 	input.OracleKeeper.SetBaseExchangeRate(input.Ctx, utils.MicroSeiDenom, cnyExchangeRate)
@@ -52,7 +52,7 @@ func TestExchangeRate(t *testing.T) {
 	require.Equal(t, krwExchangeRate, rate)
 	require.Equal(t, sdk.NewInt(15), lastUpdate)
 
-	input.OracleKeeper.SetBaseExchangeRate(input.Ctx, utils.MicroBaseDenom, lunaExchangeRate)
+	input.OracleKeeper.SetBaseExchangeRate(input.Ctx, utils.MicroBaseDenom, seiExchangeRate)
 	rate, lastUpdate, _ = input.OracleKeeper.GetBaseExchangeRate(input.Ctx, utils.MicroBaseDenom)
 	require.Equal(t, sdk.OneDec(), rate)
 	// with votePeriod == 10 blocks, the last end of vote period is 9
@@ -72,19 +72,19 @@ func TestExchangeRate(t *testing.T) {
 	require.True(t, numExchangeRates == 3)
 }
 
-func TestIterateLunaExchangeRates(t *testing.T) {
+func TestIterateSeiExchangeRates(t *testing.T) {
 	input := CreateTestInput(t)
 
 	cnyExchangeRate := sdk.NewDecWithPrec(839, int64(OracleDecPrecision)).MulInt64(utils.MicroUnit)
 	gbpExchangeRate := sdk.NewDecWithPrec(4995, int64(OracleDecPrecision)).MulInt64(utils.MicroUnit)
 	krwExchangeRate := sdk.NewDecWithPrec(2838, int64(OracleDecPrecision)).MulInt64(utils.MicroUnit)
-	lunaExchangeRate := sdk.NewDecWithPrec(3282384, int64(OracleDecPrecision)).MulInt64(utils.MicroUnit)
+	seiExchangeRate := sdk.NewDecWithPrec(3282384, int64(OracleDecPrecision)).MulInt64(utils.MicroUnit)
 
 	// Set & get rates
 	input.OracleKeeper.SetBaseExchangeRate(input.Ctx, utils.MicroSeiDenom, cnyExchangeRate)
 	input.OracleKeeper.SetBaseExchangeRate(input.Ctx, utils.MicroEthDenom, gbpExchangeRate)
 	input.OracleKeeper.SetBaseExchangeRate(input.Ctx, utils.MicroAtomDenom, krwExchangeRate)
-	input.OracleKeeper.SetBaseExchangeRate(input.Ctx, utils.MicroBaseDenom, lunaExchangeRate)
+	input.OracleKeeper.SetBaseExchangeRate(input.Ctx, utils.MicroBaseDenom, seiExchangeRate)
 
 	input.OracleKeeper.IterateBaseExchangeRates(input.Ctx, func(denom string, rate types.OracleExchangeRate) (stop bool) {
 		switch denom {
@@ -95,7 +95,7 @@ func TestIterateLunaExchangeRates(t *testing.T) {
 		case utils.MicroAtomDenom:
 			require.Equal(t, krwExchangeRate, rate.ExchangeRate)
 		case utils.MicroBaseDenom:
-			require.Equal(t, lunaExchangeRate, rate.ExchangeRate)
+			require.Equal(t, seiExchangeRate, rate.ExchangeRate)
 		}
 		return false
 	})

--- a/x/oracle/simulation/operations.go
+++ b/x/oracle/simulation/operations.go
@@ -65,7 +65,7 @@ func WeightedOperations(
 }
 
 // SimulateMsgAggregateExchangeRateVote generates a MsgAggregateExchangeRateVote with random values.
-//nolint: funlen
+// nolint: funlen
 func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
@@ -122,7 +122,7 @@ func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankK
 }
 
 // SimulateMsgDelegateFeedConsent generates a MsgDelegateFeedConsent with random values.
-//nolint: funlen
+// nolint: funlen
 func SimulateMsgDelegateFeedConsent(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,

--- a/x/oracle/spec/02_state.md
+++ b/x/oracle/spec/02_state.md
@@ -12,7 +12,7 @@ order: 2
 
 ```go
 type ExchangeRateVote struct {
-	ExchangeRate sdk.Dec        // ExchangeRate of Luna in target fiat currency
+	ExchangeRate sdk.Dec        // ExchangeRate of Sei in target fiat currency
 	Denom        string         // Ticker name of target fiat currency
 	Voter        sdk.ValAddress // voter val address of validator
 }
@@ -20,9 +20,9 @@ type ExchangeRateVote struct {
 
 ## ExchangeRate
 
-An `sdk.Dec` that stores the current Luna exchange rate against a given denom, which is used by the [Market](../../market/spec/README.md) module for pricing swaps.
+An `sdk.Dec` that stores the current Sei exchange rate against a given denom, which is used by the [Market](../../market/spec/README.md) module for pricing swaps.
 
-You can get the active list of denoms trading against `Luna` (denominations with votes past `VoteThreshold`) with `k.GetActiveDenoms()`.
+You can get the active list of denoms trading against `Sei` (denominations with votes past `VoteThreshold`) with `k.GetActiveDenoms()`.
 
 - ExchangeRate: `0x03<denom_Bytes> -> amino(sdk.Dec)`
 
@@ -53,7 +53,7 @@ type ExchangeRateTuple struct {
 type ExchangeRateTuples []ExchangeRateTuple
 
 type AggregateExchangeRateVote struct {
-	ExchangeRateTuples ExchangeRateTuples // ExchangeRates of Luna in target fiat currencies
+	ExchangeRateTuples ExchangeRateTuples // ExchangeRates of Sei in target fiat currencies
 	Voter              sdk.ValAddress     // voter val address of validator
 }
 ```

--- a/x/oracle/spec/03_end_block.md
+++ b/x/oracle/spec/03_end_block.md
@@ -8,7 +8,7 @@ order: 3
 
 At the end of every block, the `Oracle` module checks whether it's the last block of the `VotePeriod`. If it is, it runs the [Voting Procedure](./01_concepts.md#Voting_Procedure):
 
-1. All current active Luna exchange rates are purged from the store
+1. All current active Sei exchange rates are purged from the store
 
 2. Received votes are organized into ballots by denomination. Abstained votes, as well as votes by inactive or jailed validators are ignored
 
@@ -21,7 +21,7 @@ At the end of every block, the `Oracle` module checks whether it's the last bloc
 
     - Tally up votes and find the weighted median exchange rate and winners with `tally()`
     - Iterate through winners of the ballot and add their weight to their running total
-    - Set the Luna exchange rate on the blockchain for that Luna<>`denom` with `k.SetLunaExchangeRate()`
+    - Set the Sei exchange rate on the blockchain for that Sei<>`denom` with `k.SetSeiExchangeRate()`
    - Emit a `exchange_rate_update` event
 
 5. Count up the validators who [missed](./01_concepts.md#Slashing) the Oracle vote and increase the appropriate miss counters

--- a/x/oracle/spec/04_messages.md
+++ b/x/oracle/spec/04_messages.md
@@ -10,7 +10,7 @@ order: 4
 
 `Denom` is the denomination of the currency for which the vote is being cast. For example, if the voter wishes to submit a prevote for the usd, then the correct `Denom` is `uusd`.
 
-The exchange rate used in the hash must be the open market exchange rate of Luna, with respect to the denomination matching `Denom`. For example, if `Denom` is `uusd` and the going exchange rate for Luna is 1 USD, then "1" must be used as the exchange rate, as `1 uluna = 1 uusd`.
+The exchange rate used in the hash must be the open market exchange rate of Sei, with respect to the denomination matching `Denom`. For example, if `Denom` is `uusd` and the going exchange rate for Sei is 1 USD, then "1" must be used as the exchange rate, as `1 usei = 1 uusd`.
 
 `Feeder` (`terra-` address) is used if the validator wishes to delegate oracle vote signing to a separate key (who "feeds" the price in lieu of the operator) to de-risk exposing their validator signing key.
 
@@ -36,11 +36,11 @@ The `MsgExchangeRateVote` contains the actual exchange rate vote. The `Salt` par
 
 ```go
 // Deprecated: normal prevote and vote will be deprecated after columbus-4
-// MsgExchangeRateVote - struct for voting on the exchange rate of Luna denominated in various Terra assets.
-// For example, if the validator believes that the effective exchange rate of Luna in USD is 10.39, that's
+// MsgExchangeRateVote - struct for voting on the exchange rate of Sei denominated in various Sei assets.
+// For example, if the validator believes that the effective exchange rate of Sei in USD is 10.39, that's
 // what the exchange rate field would be, and if 1213.34 for KRW, same.
 type MsgExchangeRateVote struct {
-	ExchangeRate sdk.Dec        // the effective rate of Luna in {Denom}
+	ExchangeRate sdk.Dec        // the effective rate of Sei in {Denom}
 	Salt         string
 	Denom        string
 	Feeder       sdk.AccAddress
@@ -52,15 +52,15 @@ type MsgExchangeRateVote struct {
 
 Validators may also elect to delegate voting rights to another key to prevent the block signing key from being kept online. To do so, they must submit a `MsgDelegateFeedConsent`, delegating their oracle voting rights to a `Delegate` that sign `MsgExchangeRatePrevote` and `MsgExchangeRateVote` on behalf of the validator.
 
-> Delegate validators will likely require you to deposit some funds (in Terra or Luna) which they can use to pay fees, sent in a separate MsgSend. This agreement is made off-chain and not enforced by the Terra protocol.
+> Delegate validators will likely require you to deposit some funds (in Sei or Sei) which they can use to pay fees, sent in a separate MsgSend. This agreement is made off-chain and not enforced by the Sei protocol.
 
 The `Operator` field contains the operator address of the validator (prefixed `terravaloper-`). The `Delegate` field is the account address (prefixed `terra-`) of the delegate account that will be submitting exchange rate related votes and prevotes on behalf of the `Operator`.
 
 ```go
 // MsgDelegateFeedConsent - struct for delegating oracle voting rights to another address.
 type MsgDelegateFeedConsent struct {
-	Operator sdk.ValAddress 
-	Delegate sdk.AccAddress 
+	Operator sdk.ValAddress
+	Delegate sdk.AccAddress
 }
 ```
 
@@ -73,9 +73,9 @@ type MsgDelegateFeedConsent struct {
 // The purpose of aggregate prevote is to hide vote exchange rates with hash
 // which is formatted as hex string in SHA256("{salt}:{exchange rate}{denom},...,{exchange rate}{denom}:{voter}")
 type MsgAggregateExchangeRatePrevote struct {
-	Hash      AggregateVoteHash 
-	Feeder    sdk.AccAddress    
-	Validator sdk.ValAddress    
+	Hash      AggregateVoteHash
+	Feeder    sdk.AccAddress
+	Validator sdk.ValAddress
 }
 ```
 
@@ -84,11 +84,11 @@ type MsgAggregateExchangeRatePrevote struct {
 The `MsgAggregateExchangeRateVote` contains the actual exchange rates vote. The `Salt` parameter must match the salt used to create the prevote, otherwise the voter cannot be rewarded.
 
 ```go
-// MsgAggregateExchangeRateVote - struct for voting on the exchange rates of Luna denominated in various Terra assets.
+// MsgAggregateExchangeRateVote - struct for voting on the exchange rates of Sei denominated in various Sei assets.
 type MsgAggregateExchangeRateVote struct {
 	Salt          string
 	ExchangeRates string
-	Feeder        sdk.AccAddress 
-	Validator     sdk.ValAddress 
+	Feeder        sdk.AccAddress
+	Validator     sdk.ValAddress
 }
 ```

--- a/x/oracle/types/ballot.go
+++ b/x/oracle/types/ballot.go
@@ -53,7 +53,7 @@ func (pb ExchangeRateBallot) ToCrossRate(bases map[string]sdk.Dec) (cb ExchangeR
 		if exchangeRateRT, ok := bases[string(vote.Voter)]; ok && vote.ExchangeRate.IsPositive() {
 			vote.ExchangeRate = exchangeRateRT.Quo(vote.ExchangeRate)
 		} else {
-			// If we can't get reference terra exchange rate, we just convert the vote as abstain vote
+			// If we can't get reference seiexchange rate, we just convert the vote as abstain vote
 			vote.ExchangeRate = sdk.ZeroDec()
 			vote.Power = 0
 		}

--- a/x/oracle/types/ballot.go
+++ b/x/oracle/types/ballot.go
@@ -53,7 +53,7 @@ func (pb ExchangeRateBallot) ToCrossRate(bases map[string]sdk.Dec) (cb ExchangeR
 		if exchangeRateRT, ok := bases[string(vote.Voter)]; ok && vote.ExchangeRate.IsPositive() {
 			vote.ExchangeRate = exchangeRateRT.Quo(vote.ExchangeRate)
 		} else {
-			// If we can't get reference seiexchange rate, we just convert the vote as abstain vote
+			// If we can't get reference Sei exchange rate, we just convert the vote as abstain vote
 			vote.ExchangeRate = sdk.ZeroDec()
 			vote.Power = 0
 		}

--- a/x/oracle/types/query.pb.go
+++ b/x/oracle/types/query.pb.go
@@ -71,7 +71,7 @@ var xxx_messageInfo_QueryExchangeRateRequest proto.InternalMessageInfo
 // QueryExchangeRateResponse is response type for the
 // Query/ExchangeRate RPC method.
 type QueryExchangeRateResponse struct {
-	// exchange_rate defines the exchange rate of Luna denominated in various Terra
+	// exchange_rate defines the exchange rate of Sei denominated in various
 	OracleExchangeRate OracleExchangeRate `protobuf:"bytes,1,opt,name=oracle_exchange_rate,json=oracleExchangeRate,proto3" json:"oracle_exchange_rate"`
 }
 

--- a/x/oracle/types/vote_test.go
+++ b/x/oracle/types/vote_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 func TestParseExchangeRateTuples(t *testing.T) {
-	valid := "123.0uluna,123.123ukrw"
+	valid := "123.0usei,123.123ukrw"
 	_, err := ParseExchangeRateTuples(valid)
 	require.NoError(t, err)
 
-	duplicatedDenom := "100.0uluna,123.123ukrw,121233.123ukrw"
+	duplicatedDenom := "100.0usei,123.123ukrw,121233.123ukrw"
 	_, err = ParseExchangeRateTuples(duplicatedDenom)
 	require.Error(t, err)
 
@@ -19,11 +19,11 @@ func TestParseExchangeRateTuples(t *testing.T) {
 	_, err = ParseExchangeRateTuples(invalidCoins)
 	require.Error(t, err)
 
-	invalidCoinsWithValid := "123.0uluna,123.1"
+	invalidCoinsWithValid := "123.0usei,123.1"
 	_, err = ParseExchangeRateTuples(invalidCoinsWithValid)
 	require.Error(t, err)
 
-	abstainCoinsWithValid := "0.0uluna,123.1ukrw"
+	abstainCoinsWithValid := "0.0usei,123.1ukrw"
 	_, err = ParseExchangeRateTuples(abstainCoinsWithValid)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Describe your changes and provide context
Did a mass replace for `Terra,terra,TERRA` and `Luna,luna,LUNA` for `Sei,sei,SEI` respectively 

## Testing performed to validate your change
Unit tests