### PR TITLE
Bump max packet msg payload

### DIFF
--- a/app/params/config.go
+++ b/app/params/config.go
@@ -85,7 +85,7 @@ func SetTendermintConfigs(config *tmcfg.Config) {
 	config.P2P.MaxConnections = 200
 	config.P2P.SendRate = 20480000
 	config.P2P.RecvRate = 20480000
-	config.P2P.MaxPacketMsgPayloadSize = 10240
+	config.P2P.MaxPacketMsgPayloadSize = 1000000 // 1MB
 	config.P2P.FlushThrottleTimeout = 10 * time.Millisecond
 	// Mempool configs
 	config.Mempool.Size = 5000

--- a/loadtest/contracts/deploy_ten_contracts.sh
+++ b/loadtest/contracts/deploy_ten_contracts.sh
@@ -66,8 +66,6 @@ marsaddr4=$(python3 parser.py contract_address $marsinsres4)
 # register
 echo "Registering..."
 
-valaddr=$(printf "12345678\n" | $seidbin keys show $(printf "12345678\n" | $seidbin keys show node_admin --output json | jq -r .address) --bech=val --output json | jq -r '.address')
-
 printf "12345678\n" | $seidbin tx dex register-contract $marsaddr $marsid false true 10000000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
 printf "12345678\n" | $seidbin tx dex register-contract $saturnaddr $saturnid false true 10000000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
 printf "12345678\n" | $seidbin tx dex register-contract $venusaddr $venusid false true 10000000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block

--- a/loadtest/contracts/deploy_ten_contracts.sh
+++ b/loadtest/contracts/deploy_ten_contracts.sh
@@ -67,7 +67,6 @@ marsaddr4=$(python3 parser.py contract_address $marsinsres4)
 echo "Registering..."
 
 valaddr=$(printf "12345678\n" | $seidbin keys show $(printf "12345678\n" | $seidbin keys show node_admin --output json | jq -r .address) --bech=val --output json | jq -r '.address')
-printf "12345678\n" | $seidbin tx staking delegate $valaddr 1000000000usei --from=$keyname --chain-id=$chainid -b block -y --fees 2000usei
 
 printf "12345678\n" | $seidbin tx dex register-contract $marsaddr $marsid false true 10000000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
 printf "12345678\n" | $seidbin tx dex register-contract $saturnaddr $saturnid false true 10000000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block


### PR DESCRIPTION
## Describe your changes and provide context
based on sei-tendermint, max packet mesg should just be used in the channel when reading msgs and errors out if the packet size is too long so this should be fine to bump up 

https://github.com/sei-protocol/sei-tendermint/blob/46d0a598a7f5c67cbdefea37c8da18df2c25d184/internal/p2p/conn/connection_test.go#L503-L544 

![image](https://user-images.githubusercontent.com/18161326/216145117-5751f09f-b7ac-44c3-bf52-3656d2f5d2be.png)


## Testing performed to validate your change

