### PR TITLE
promote dex rent log level

### DIFF
--- a/x/dex/contract/abci.go
+++ b/x/dex/contract/abci.go
@@ -198,7 +198,7 @@ func orderMatchingRunnable(ctx context.Context, sdkContext sdk.Context, env *env
 	}
 	parentSdkContext := sdkContext
 	sdkContext = decorateContextForContract(sdkContext, contractInfo, keeper.GetParams(sdkContext).EndBlockGasLimit)
-	sdkContext.Logger().Info(fmt.Sprintf("End block for %s with balance of %d", contractInfo.ContractAddr, contractInfo.RentBalance))
+	sdkContext.Logger().Debug(fmt.Sprintf("End block for %s with balance of %d", contractInfo.ContractAddr, contractInfo.RentBalance))
 	pairs, pairFound := env.registeredPairs.Load(contractInfo.ContractAddr)
 	orderBooks, found := env.orderBooks.Load(contractInfo.ContractAddr)
 

--- a/x/dex/contract/abci.go
+++ b/x/dex/contract/abci.go
@@ -198,7 +198,7 @@ func orderMatchingRunnable(ctx context.Context, sdkContext sdk.Context, env *env
 	}
 	parentSdkContext := sdkContext
 	sdkContext = decorateContextForContract(sdkContext, contractInfo, keeper.GetParams(sdkContext).EndBlockGasLimit)
-	sdkContext.Logger().Debug(fmt.Sprintf("End block for %s with balance of %d", contractInfo.ContractAddr, contractInfo.RentBalance))
+	sdkContext.Logger().Info(fmt.Sprintf("End block for %s with balance of %d", contractInfo.ContractAddr, contractInfo.RentBalance))
 	pairs, pairFound := env.registeredPairs.Load(contractInfo.ContractAddr)
 	orderBooks, found := env.orderBooks.Load(contractInfo.ContractAddr)
 

--- a/x/dex/keeper/utils/wasm.go
+++ b/x/dex/keeper/utils/wasm.go
@@ -57,6 +57,7 @@ func sudo(sdkCtx sdk.Context, k *keeper.Keeper, contractAddress sdk.AccAddress, 
 			sdk.NewAttribute("consumed", fmt.Sprintf("%d", gasConsumed)),
 			sdk.NewAttribute("type", msgType),
 			sdk.NewAttribute("contract", contractAddress.String()),
+			sdk.NewAttribute("height", fmt.Sprintf("%d", sdkCtx.BlockHeight())),
 		),
 	)
 	if gasConsumed > 0 {

--- a/x/dex/keeper/utils/wasm.go
+++ b/x/dex/keeper/utils/wasm.go
@@ -50,7 +50,7 @@ func sudo(sdkCtx sdk.Context, k *keeper.Keeper, contractAddress sdk.AccAddress, 
 	tmpCtx := sdkCtx.WithGasMeter(sdk.NewGasMeter(gasLimit))
 	data, err := sudoWithoutOutOfGasPanic(tmpCtx, k, contractAddress, wasmMsg, msgType)
 	gasConsumed := tmpCtx.GasMeter().GasConsumed()
-	sdkCtx.Logger().Debug(fmt.Sprintf("%s %s consumed %d gas", contractAddress.String(), msgType, gasConsumed))
+	sdkCtx.Logger().Info(fmt.Sprintf("%s %s consumed %d gas", contractAddress.String(), msgType, gasConsumed))
 	if gasConsumed > 0 {
 		sdkCtx.GasMeter().ConsumeGas(gasConsumed, "sudo")
 	}


### PR DESCRIPTION
## Describe your changes and provide context
Since we are seeing non-determinism with rent consumption, we need more visible log for rent gas consumed for future clusters.

## Testing performed to validate your change
n/a
