### PR TITLE
Add validation for dex contract rent balance

### DIFF
--- a/loadtest/contracts/deploy_ten_contracts.sh
+++ b/loadtest/contracts/deploy_ten_contracts.sh
@@ -66,16 +66,16 @@ marsaddr4=$(python3 parser.py contract_address $marsinsres4)
 # register
 echo "Registering..."
 
-printf "12345678\n" | $seidbin tx dex register-contract $marsaddr $marsid false true 10000000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
-printf "12345678\n" | $seidbin tx dex register-contract $saturnaddr $saturnid false true 10000000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
-printf "12345678\n" | $seidbin tx dex register-contract $venusaddr $venusid false true 10000000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
-printf "12345678\n" | $seidbin tx dex register-contract $marsaddr2 $marsid false true 100000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
-printf "12345678\n" | $seidbin tx dex register-contract $saturnaddr2 $saturnid false true 10000000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
-printf "12345678\n" | $seidbin tx dex register-contract $venusaddr2 $venusid false true 10000000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
-printf "12345678\n" | $seidbin tx dex register-contract $marsaddr3 $marsid false true 10000000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
-printf "12345678\n" | $seidbin tx dex register-contract $saturnaddr3 $saturnid false true 10000000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
-printf "12345678\n" | $seidbin tx dex register-contract $venusaddr3 $venusid false true 10000000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
-printf "12345678\n" | $seidbin tx dex register-contract $marsaddr4 $marsid false true 10000000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
+printf "12345678\n" | $seidbin tx dex register-contract $marsaddr $marsid false true 100000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
+printf "12345678\n" | $seidbin tx dex register-contract $saturnaddr $saturnid false true 100000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
+printf "12345678\n" | $seidbin tx dex register-contract $venusaddr $venusid false true 100000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
+printf "12345678\n" | $seidbin tx dex register-contract $marsaddr2 $marsid false true 1000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
+printf "12345678\n" | $seidbin tx dex register-contract $saturnaddr2 $saturnid false true 100000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
+printf "12345678\n" | $seidbin tx dex register-contract $venusaddr2 $venusid false true 100000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
+printf "12345678\n" | $seidbin tx dex register-contract $marsaddr3 $marsid false true 100000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
+printf "12345678\n" | $seidbin tx dex register-contract $saturnaddr3 $saturnid false true 100000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
+printf "12345678\n" | $seidbin tx dex register-contract $venusaddr3 $venusid false true 100000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
+printf "12345678\n" | $seidbin tx dex register-contract $marsaddr4 $marsid false true 100000000000 -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block
 
 echo '{"batch_contract_pair":[{"contract_addr":"'$marsaddr'","pairs":[{"price_denom":"SEI","asset_denom":"ATOM","price_tick_size":"0.0000001", "quantity_tick_size":"0.0000001"}]}]}' > mars.json
 marspair=$(printf "12345678\n" | $seidbin tx dex register-pairs mars.json -y --from=$keyname --chain-id=$chainid --fees=10000000usei --gas=500000 --broadcast-mode=block --output=json)

--- a/x/dex/keeper/msgserver/msg_server_register_contract.go
+++ b/x/dex/keeper/msgserver/msg_server_register_contract.go
@@ -31,6 +31,10 @@ func (k msgServer) RegisterContract(goCtx context.Context, msg *types.MsgRegiste
 		return nil, sdkerrors.ErrUnauthorized
 	}
 
+	if err := k.ValidateRentBalance(msg.GetContract().GetRentBalance()); err != nil {
+		ctx.Logger().Error("invalid rent balance")
+		return &types.MsgRegisterContractResponse{}, err
+	}
 	if err := k.ValidateUniqueDependencies(msg); err != nil {
 		ctx.Logger().Error(fmt.Sprintf("dependencies of contract %s are not unique", msg.Contract.ContractAddr))
 		return &types.MsgRegisterContractResponse{}, err

--- a/x/dex/keeper/msgserver/validations.go
+++ b/x/dex/keeper/msgserver/validations.go
@@ -1,0 +1,23 @@
+package msgserver
+
+import (
+	"fmt"
+	"math"
+
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+)
+
+// Since cosmwasm would amplify gas limit by a multiplier for its internal gas metering,
+// we want to make sure the amplified result doesn't exceed uint64 limit.
+func (k msgServer) ValidateRentBalance(rentBalance uint64) error {
+	maxAllowedRent := k.maxAllowedRentBalance()
+	if rentBalance > maxAllowedRent {
+		return fmt.Errorf("maximum allowed rent balance is %d", maxAllowedRent)
+	}
+	return nil
+}
+
+func (k msgServer) maxAllowedRentBalance() uint64 {
+	// TODO: replace with a wasm keeper query once its gas registry is made public
+	return uint64(math.MaxUint64) / wasmkeeper.DefaultGasMultiplier
+}


### PR DESCRIPTION
## Describe your changes and provide context
Wasm would multiply gas limit by a factor of 140000000, so we need to make sure the rent deposited (which would be used as the gas limit for dex wasm sudo calls) would not overflow after being multiplied.

## Testing performed to validate your change
unit tests

