### PR TITLE
Add logging if operation takes too long

### DIFF
--- a/utils/logging/time.go
+++ b/utils/logging/time.go
@@ -1,0 +1,32 @@
+package logging
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+func LogIfNotDoneAfter[R any](logger log.Logger, task func() (R, error), after time.Duration, label string) (R, error) {
+	resultChan := make(chan R, 1)
+	errChan := make(chan error, 1)
+	go func() {
+		res, err := task()
+		if err != nil {
+			errChan <- err
+		} else {
+			resultChan <- res
+		}
+	}()
+	for {
+		select {
+		case res := <-resultChan:
+			return res, nil
+		case err := <-errChan:
+			var res R
+			return res, err
+		case <-time.After(after):
+			logger.Error(fmt.Sprintf("%s still not finished after %s", label, after))
+		}
+	}
+}

--- a/utils/logging/time_test.go
+++ b/utils/logging/time_test.go
@@ -1,0 +1,72 @@
+package logging
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+type mockLogger struct {
+	lastError string
+}
+
+func (l *mockLogger) Debug(msg string, keyVals ...interface{}) {}
+func (l *mockLogger) Info(msg string, keyVals ...interface{})  {}
+func (l *mockLogger) Error(msg string, keyVals ...interface{}) {
+	l.lastError = msg
+}
+func (l *mockLogger) With(keyVals ...interface{}) log.Logger { return l }
+
+func TestFastReturn(t *testing.T) {
+	logger := mockLogger{}
+	task := func() (bool, error) {
+		return true, nil
+	}
+	after := 3 * time.Second
+	res, err := LogIfNotDoneAfter(&logger, task, after, "test")
+	require.Nil(t, err)
+	require.True(t, res)
+	require.Empty(t, logger.lastError)
+}
+
+func TestFastError(t *testing.T) {
+	logger := mockLogger{}
+	task := func() (bool, error) {
+		return true, errors.New("test")
+	}
+	after := 3 * time.Second
+	res, err := LogIfNotDoneAfter(&logger, task, after, "test")
+	require.NotNil(t, err)
+	require.Empty(t, res)
+	require.Empty(t, logger.lastError)
+}
+
+func TestSlowReturn(t *testing.T) {
+	logger := mockLogger{}
+	task := func() (bool, error) {
+		time.Sleep(2 * time.Second)
+		return true, nil
+	}
+	after := 1 * time.Second
+	res, err := LogIfNotDoneAfter(&logger, task, after, "test")
+	require.Nil(t, err)
+	require.True(t, res)
+	require.Equal(t, fmt.Sprintf("test still not finished after %s", after), logger.lastError)
+}
+
+func TestSlowError(t *testing.T) {
+	logger := mockLogger{}
+	task := func() (bool, error) {
+		time.Sleep(2 * time.Second)
+		return true, errors.New("test")
+	}
+	after := 1 * time.Second
+	res, err := LogIfNotDoneAfter(&logger, task, after, "test")
+	require.NotNil(t, err)
+	require.Empty(t, res)
+	require.Equal(t, fmt.Sprintf("test still not finished after %s", after), logger.lastError)
+}

--- a/x/dex/contract/runner.go
+++ b/x/dex/contract/runner.go
@@ -3,12 +3,16 @@ package contract
 import (
 	"fmt"
 	"sync/atomic"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/sei-protocol/sei-chain/utils/datastructures"
+	"github.com/sei-protocol/sei-chain/utils/logging"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 	"github.com/sei-protocol/sei-chain/x/dex/types/utils"
 )
+
+const LogAfter = 10 * time.Second
 
 type ParallelRunner struct {
 	runnable func(contract types.ContractInfoV2)
@@ -111,7 +115,10 @@ func (r *ParallelRunner) Run() {
 		})
 		// This corresponds to the "wait for any existing run (could be
 		// from previous iteration) to finish" part in the pseudocode above.
-		<-r.someContractFinished
+		logging.LogIfNotDoneAfter(r.sdkCtx.Logger(), func() (struct{}, error) {
+			<-r.someContractFinished
+			return struct{}{}, nil
+		}, LogAfter, "runner wait for some contract to finish")
 	}
 }
 

--- a/x/dex/contract/runner.go
+++ b/x/dex/contract/runner.go
@@ -115,10 +115,14 @@ func (r *ParallelRunner) Run() {
 		})
 		// This corresponds to the "wait for any existing run (could be
 		// from previous iteration) to finish" part in the pseudocode above.
-		logging.LogIfNotDoneAfter(r.sdkCtx.Logger(), func() (struct{}, error) {
+		_, err := logging.LogIfNotDoneAfter(r.sdkCtx.Logger(), func() (struct{}, error) {
 			<-r.someContractFinished
 			return struct{}{}, nil
 		}, LogAfter, "runner wait for some contract to finish")
+		if err != nil {
+			// this should never happen
+			panic(err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
We want to get insight if some operations are hanging, but we don't want the logs to get noisy. This PR added a utility to only log if an operation takes an unexpectedly long time.

## Testing performed to validate your change
unit tests

