### PR TITLE
Fix dex contract runner goroutine leak

### DIFF
--- a/x/dex/contract/runner.go
+++ b/x/dex/contract/runner.go
@@ -98,6 +98,9 @@ func NewParallelRunner(runnable func(contract types.ContractInfoV2), contracts [
 //
 // The following `Run` method implements the pseudocode above.
 func (r *ParallelRunner) Run() {
+	if atomic.LoadInt64(&r.inProgressCnt) == 0 && atomic.LoadInt64(&r.readyCnt) == 0 {
+		return
+	}
 	// The ordering of the two conditions below matters, since readyCnt
 	// is updated before inProgressCnt.
 	for atomic.LoadInt64(&r.inProgressCnt) > 0 || atomic.LoadInt64(&r.readyCnt) > 0 {


### PR DESCRIPTION
## Describe your changes and provide context
The runner would spawn one goroutine per contract, and each of those goroutines will send to a common unbuffered channel (which means the send operation is blocking). The main goroutine has a loop that keeps iterating until all contract runnables are confirmed finished, and the main goroutine is responsible for receiving from the common buffer. If the runnable for each contract is fast enough, the receiving operation of that common channel may happen fewer times than the number of goroutines trying to send to it. This would not block the main goroutine because only senders, which are spawned off goroutines, would have no counterpart receiver and block, and this would not cause contract runnable to malfunction because the send operation happens at the very end of the spawned off goroutines. However, this does cause those spawned off goroutines to never finish, and therefore cannot be GC'ed. This PR fixes this issue by explicitly exiting the spawned off goroutines if the main goroutine function returns.

## Testing performed to validate your change
existing unit test should still work (no good way to tell how many goroutines are present during unit tests)

