### PR TITLE
Remove unused cobra arg

### DIFF
--- a/x/dex/client/cli/query/query_match_result.go
+++ b/x/dex/client/cli/query/query_match_result.go
@@ -11,7 +11,7 @@ func CmdGetMatchResult() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get-match-result [contract-address]",
 		Short: "Query get match result by contract",
-		Args:  cobra.ExactArgs(2),
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			contractAddr := args[0]
 			if err != nil {


### PR DESCRIPTION
## Describe your changes and provide context
- Removed the `height` arg in the `get-match-result` cli command, but the cobra args number was not decremented


## Testing performed to validate your change
- Tested fully
