### PR TITLE
Don't optimistic processing if theres a planned upgrade

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -934,6 +934,14 @@ func (app *App) PrepareProposalHandler(ctx sdk.Context, req *abci.RequestPrepare
 	}, nil
 }
 
+func (app *App) GetOptimisticProcessingInfo() OptimisticProcessingInfo {
+	return *app.optimisticProcessingInfo
+}
+
+func (app *App) ClearOptimisticProcessingInfo() {
+	app.optimisticProcessingInfo = nil
+}
+
 func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcessProposal) (*abci.ResponseProcessProposal, error) {
 	if app.optimisticProcessingInfo == nil {
 		completionSignal := make(chan struct{}, 1)
@@ -943,13 +951,20 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 			Completion: completionSignal,
 		}
 		app.optimisticProcessingInfo = optimisticProcessingInfo
-		go func() {
-			events, txResults, endBlockResp, _ := app.ProcessBlock(ctx, req.Txs, req, req.ProposedLastCommit)
-			optimisticProcessingInfo.Events = events
-			optimisticProcessingInfo.TxRes = txResults
-			optimisticProcessingInfo.EndBlockResp = endBlockResp
-			optimisticProcessingInfo.Completion <- struct{}{}
-		}()
+
+		plan, found := app.UpgradeKeeper.GetUpgradePlan(ctx)
+		if found && plan.ShouldExecute(ctx) {
+			app.Logger().Info(fmt.Sprintf("Potential upgrade planned for height=%d skipping optimistic processing", plan.Height))
+			app.optimisticProcessingInfo.Aborted = true
+		} else {
+			go func() {
+				events, txResults, endBlockResp, _ := app.ProcessBlock(ctx, req.Txs, req, req.ProposedLastCommit)
+				optimisticProcessingInfo.Events = events
+				optimisticProcessingInfo.TxRes = txResults
+				optimisticProcessingInfo.EndBlockResp = endBlockResp
+				optimisticProcessingInfo.Completion <- struct{}{}
+			}()
+		}
 	} else if !bytes.Equal(app.optimisticProcessingInfo.Hash, req.Hash) {
 		app.optimisticProcessingInfo.Aborted = true
 	}

--- a/app/upgrade_test.go
+++ b/app/upgrade_test.go
@@ -6,7 +6,11 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	"github.com/sei-protocol/sei-chain/app"
+	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
 func TestUpgradesListIsSorted(t *testing.T) {
@@ -24,4 +28,31 @@ func TestDistributionCommunityTaxParamMigration(t *testing.T) {
 	testWrapper.App.RegisterUpgradeHandlers()
 	params := testWrapper.App.DistrKeeper.GetParams(testWrapper.Ctx)
 	testWrapper.Require().Equal(params.CommunityTax, sdk.NewDec(0))
+}
+
+func TestSkipOptimisticProcessingOnUpgrade(t *testing.T) {
+	tm := time.Now().UTC()
+	valPub := secp256k1.GenPrivKey().PubKey()
+
+	testWrapper := app.NewTestWrapper(t, tm, valPub)
+
+	testCtx := testWrapper.App.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "sei-test", Time: tm})
+	testWrapper.App.UpgradeKeeper.ScheduleUpgrade(testWrapper.Ctx, types.Plan{
+		Name: "test-plan",
+		Height: 4,
+	})
+	res, _ := testWrapper.App.ProcessProposalHandler(testCtx.WithBlockHeight(4), &abci.RequestProcessProposal{})
+	require.Equal(t, res.Status, abci.ResponseProcessProposal_ACCEPT)
+	require.True(t, testWrapper.App.GetOptimisticProcessingInfo().Aborted)
+
+
+	testWrapper.App.ClearOptimisticProcessingInfo()
+	testWrapper.App.UpgradeKeeper.ScheduleUpgrade(testWrapper.Ctx, types.Plan{
+		Name: "test-plan",
+		Height: 5,
+	})
+	res, _ = testWrapper.App.ProcessProposalHandler(testCtx.WithBlockHeight(4), &abci.RequestProcessProposal{})
+
+	require.Equal(t, res.Status, abci.ResponseProcessProposal_ACCEPT)
+	require.False(t, testWrapper.App.GetOptimisticProcessingInfo().Aborted)
 }

--- a/app/upgrade_test.go
+++ b/app/upgrade_test.go
@@ -31,9 +31,9 @@ func TestDistributionCommunityTaxParamMigration(t *testing.T) {
 }
 
 func TestSkipOptimisticProcessingOnUpgrade(t *testing.T) {
+	println("TestSkipOptimisticProcessingOnUpgrade")
 	tm := time.Now().UTC()
 	valPub := secp256k1.GenPrivKey().PubKey()
-
 	testWrapper := app.NewTestWrapper(t, tm, valPub)
 
 	testCtx := testWrapper.App.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "sei-test", Time: tm})
@@ -41,7 +41,9 @@ func TestSkipOptimisticProcessingOnUpgrade(t *testing.T) {
 		Name: "test-plan",
 		Height: 4,
 	})
-	res, _ := testWrapper.App.ProcessProposalHandler(testCtx.WithBlockHeight(4), &abci.RequestProcessProposal{})
+	res, _ := testWrapper.App.ProcessProposalHandler(testCtx.WithBlockHeight(4), &abci.RequestProcessProposal{
+		Height: 1,
+	})
 	require.Equal(t, res.Status, abci.ResponseProcessProposal_ACCEPT)
 	require.True(t, testWrapper.App.GetOptimisticProcessingInfo().Aborted)
 
@@ -51,7 +53,9 @@ func TestSkipOptimisticProcessingOnUpgrade(t *testing.T) {
 		Name: "test-plan",
 		Height: 5,
 	})
-	res, _ = testWrapper.App.ProcessProposalHandler(testCtx.WithBlockHeight(4), &abci.RequestProcessProposal{})
+	res, _ = testWrapper.App.ProcessProposalHandler(testCtx.WithBlockHeight(4), &abci.RequestProcessProposal{
+		Height: 1,
+	})
 
 	require.Equal(t, res.Status, abci.ResponseProcessProposal_ACCEPT)
 	require.False(t, testWrapper.App.GetOptimisticProcessingInfo().Aborted)

--- a/x/oracle/simulation/operations.go
+++ b/x/oracle/simulation/operations.go
@@ -65,7 +65,7 @@ func WeightedOperations(
 }
 
 // SimulateMsgAggregateExchangeRateVote generates a MsgAggregateExchangeRateVote with random values.
-// nolint: funlen
+//nolint: funlen
 func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
@@ -122,7 +122,7 @@ func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankK
 }
 
 // SimulateMsgDelegateFeedConsent generates a MsgDelegateFeedConsent with random values.
-// nolint: funlen
+//nolint: funlen
 func SimulateMsgDelegateFeedConsent(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,


### PR DESCRIPTION
## Describe your changes and provide context
When there's a planned upgrade then process block will panic, this is an issue when there's a scheduled upgrade as it relies on the priv_val_state and WAL log, but in the optimsitic processing we don't flush before existing. Issue here is that the wal log is deep inside the tendermint state and inaccessible from sei-chain when it does Panic handling

Therefore the suggestion here is to not try to optimistic processing if there's a potential upgrade at this height

## Testing performed to validate your change
Before we would see:
`10:45PM ERR failed signing vote err="error signing vote: conflicting data" height=20 module=consensus round=0 vote={"block_id":{"hash":"","parts":{"hash":"","total":0}},"extension":null,"extension_signature":null,"height":"20","round":0,"signature":null,"timestamp":"2023-02-07T03:45:44.730316Z","type":1,"validator_address":"5AAFC34DFA7481616100C7EEC6DFF1CE494FDAF6","validator_index":0}`

Panicked at height 15 
![image](https://user-images.githubusercontent.com/18161326/217366479-00c4f8c5-81d3-4d1a-9d30-615ce7fdb11a.png)


Restarted with new binary
![image](https://user-images.githubusercontent.com/18161326/217366400-a0255bf9-a52a-4d74-8f8d-8f2efaf2d0e7.png)
