### PR TITLE
[cmd] Add dump-iavl to debug command

### DIFF
--- a/cmd/seid/cmd/debug.go
+++ b/cmd/seid/cmd/debug.go
@@ -1,0 +1,242 @@
+package cmd
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/version"
+	"github.com/cosmos/iavl"
+	"github.com/spf13/cobra"
+	dbm "github.com/tendermint/tm-db"
+)
+
+const (
+	DefaultCacheSize  int    = 10000
+	FlagDBPath        string = "db-path"
+	FlagOutputDir     string = "output-dir"
+	FlagModuleName    string = "module"
+	FlagHumanReadable string = "human"
+)
+
+var modules = []string{
+	"dex", "wasm", "accesscontrol", "oracle", "epoch", "mint", "acc", "bank", "crisis", "feegrant", "staking", "distribution", "slashing", "gov", "params", "ibc", "upgrade", "evidence", "transfer", "tokenfactory",
+}
+
+func DumpIavlCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dump-iavl [height]",
+		Short: "Dump iavl data for a specific height",
+		Long: fmt.Sprintf(`Dump iavl data for a specific height
+
+Example:
+$ %s debug dump-iavl 12345
+			`, version.AppName),
+		Args: cobra.ExactArgs(1),
+		RunE: dumpIavlCmdHandler,
+	}
+
+	cmd.Flags().String(FlagOutputDir, "", "The output directory for the iavl dump, if none specified, the home directory will be used")
+	cmd.Flags().StringP(FlagDBPath, "d", "", "The path to the db, default is $HOME/.sei/data/application.db")
+	cmd.Flags().StringP(FlagModuleName, "m", "", "The specific module to dump IAVL for, if none specified, all modules will be dumped")
+	cmd.Flags().Bool(FlagHumanReadable, false, "Whether to parse the iavl data into human readable format. Default is false")
+
+	return cmd
+}
+
+func dumpIavlCmdHandler(cmd *cobra.Command, args []string) error {
+	var err error
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	dbPath, err := cmd.Flags().GetString(FlagDBPath)
+	if err != nil {
+		return err
+	}
+	if dbPath == "" {
+		dbPath = fmt.Sprintf("%s/.sei/data/application.db", home)
+	}
+
+	fmt.Printf("db path: %s\n", dbPath)
+
+	version := 0
+	version, err = strconv.Atoi(args[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Invalid version number: %s\n", err)
+		os.Exit(1)
+	}
+	// create output directory OR take in arg
+	outputDir, err := cmd.Flags().GetString(FlagOutputDir)
+	if err != nil {
+		return err
+	}
+	if outputDir == "" {
+		outputDir = fmt.Sprintf("%s/state_%s/", home, args[0])
+	}
+	err = os.Mkdir(outputDir, os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	moduleName, err := cmd.Flags().GetString(FlagModuleName)
+	if err != nil {
+		return err
+	}
+
+	humanFmt, err := cmd.Flags().GetBool(FlagHumanReadable)
+	if err != nil {
+		return err
+	}
+	if humanFmt {
+		return fmt.Errorf("human readable not supported yet")
+	}
+
+	if moduleName != "" {
+		// if module name passed in, override `modules`
+		modules = []string{moduleName}
+	}
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		return err
+	}
+	for _, module := range modules {
+		fmt.Printf("Processing Module: %s\n", module)
+		tree, err := ReadTree(db, version, []byte(BuildPrefix(module)))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading data: %s\n", err)
+			continue
+			// os.Exit(1)
+		}
+		lines := PrintKeys(tree)
+		hash, err := tree.Hash()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error hashing tree: %s\n", err)
+			os.Exit(1)
+		}
+		lines = append(lines, []byte(fmt.Sprintf("Hash: %X\n", hash))...)
+		lines = append(lines, []byte(fmt.Sprintf("Size: %X\n", tree.Size()))...)
+		// write lines to file
+		err = os.WriteFile(fmt.Sprintf("%s/%s.data", outputDir, module), lines, os.ModePerm)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func BuildPrefix(moduleName string) string {
+	return fmt.Sprintf("s/k:%s/", moduleName)
+}
+
+func OpenDB(dir string) (dbm.DB, error) {
+	switch {
+	case strings.HasSuffix(dir, ".db"):
+		dir = dir[:len(dir)-3]
+	case strings.HasSuffix(dir, ".db/"):
+		dir = dir[:len(dir)-4]
+	default:
+		return nil, fmt.Errorf("database directory must end with .db")
+	}
+
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: doesn't work on windows!
+	cut := strings.LastIndex(dir, "/")
+	if cut == -1 {
+		return nil, fmt.Errorf("cannot cut paths on %s", dir)
+	}
+	name := dir[cut+1:]
+	db, err := dbm.NewGoLevelDB(name, dir[:cut])
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+// ReadTree loads an iavl tree from the directory
+// If version is 0, load latest, otherwise, load named version
+// The prefix represents which iavl tree you want to read. The iaviwer will always set a prefix.
+func ReadTree(db dbm.DB, version int, prefix []byte) (*iavl.MutableTree, error) {
+	if len(prefix) != 0 {
+		fmt.Printf("Loading prefix: %s", prefix)
+		db = dbm.NewPrefixDB(db, prefix)
+	}
+
+	tree, err := iavl.NewMutableTree(db, DefaultCacheSize, false)
+	if err != nil {
+		return nil, err
+	}
+	ver, err := tree.LoadVersion(int64(version))
+	fmt.Printf("Got version: %d\n", ver)
+	return tree, err
+}
+
+func PrintKeys(tree *iavl.MutableTree) []byte {
+	fmt.Println("Printing all keys with hashed values (to detect diff)")
+	lines := []byte{}
+	tree.Iterate(func(key []byte, value []byte) bool { //nolint:errcheck
+		printKey := parseWeaveKey(key)
+		digest := sha256.Sum256(value)
+		lines = append(lines, []byte(fmt.Sprintf("  %s\n    %X\n", printKey, digest))...)
+		return false
+	})
+	return lines
+}
+
+// parseWeaveKey assumes a separating : where all in front should be ascii,
+// and all afterwards may be ascii or binary
+func parseWeaveKey(key []byte) string {
+	cut := bytes.IndexRune(key, ':')
+	if cut == -1 {
+		return encodeID(key)
+	}
+	prefix := key[:cut]
+	id := key[cut+1:]
+	return fmt.Sprintf("%s:%s", encodeID(prefix), encodeID(id))
+}
+
+// casts to a string if it is printable ascii, hex-encodes otherwise
+func encodeID(id []byte) string {
+	for _, b := range id {
+		if b < 0x20 || b >= 0x80 {
+			return strings.ToUpper(hex.EncodeToString(id))
+		}
+	}
+	return string(id)
+}
+
+func PrintShape(tree *iavl.MutableTree) {
+	// shape := tree.RenderShape("  ", nil)
+	// TODO: handle this error
+	shape, _ := tree.RenderShape("  ", nodeEncoder)
+	fmt.Println(strings.Join(shape, "\n"))
+}
+
+func nodeEncoder(id []byte, depth int, isLeaf bool) string {
+	prefix := fmt.Sprintf("-%d ", depth)
+	if isLeaf {
+		prefix = fmt.Sprintf("*%d ", depth)
+	}
+	if len(id) == 0 {
+		return fmt.Sprintf("%s<nil>", prefix)
+	}
+	return fmt.Sprintf("%s%s", prefix, parseWeaveKey(id))
+}
+
+func PrintVersions(tree *iavl.MutableTree) {
+	versions := tree.AvailableVersions()
+	fmt.Println("Available versions:")
+	for _, v := range versions {
+		fmt.Printf("  %d\n", v)
+	}
+}

--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -113,6 +113,10 @@ func initRootCmd(
 	cfg := sdk.GetConfig()
 	cfg.Seal()
 
+	// extend debug command
+	debugCmd := debug.Cmd()
+	debugCmd.AddCommand(DumpIavlCmd())
+
 	rootCmd.AddCommand(
 		InitCmd(app.ModuleBasics, app.DefaultNodeHome),
 		genutilcli.CollectGenTxsCmd(banktypes.GenesisBalancesIterator{}, app.DefaultNodeHome),
@@ -126,7 +130,7 @@ func initRootCmd(
 		genutilcli.ValidateGenesisCmd(app.ModuleBasics),
 		AddGenesisAccountCmd(app.DefaultNodeHome),
 		tmcli.NewCompletionCmd(rootCmd, true),
-		debug.Cmd(),
+		debugCmd,
 		config.Cmd(),
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/armon/go-metrics v0.3.10
 	github.com/cosmos/cosmos-sdk v0.45.4
 	github.com/cosmos/go-bip39 v1.0.0
+	github.com/cosmos/iavl v0.19.4
 	github.com/cosmos/ibc-go/v3 v3.0.0
 	github.com/go-playground/validator/v10 v10.4.1
 	github.com/gogo/protobuf v1.3.3
@@ -72,7 +73,6 @@ require (
 	github.com/confio/ics23/go v0.7.0 // indirect
 	github.com/cosmos/btcutil v1.0.4 // indirect
 	github.com/cosmos/gorocksdb v1.2.0 // indirect
-	github.com/cosmos/iavl v0.19.4 // indirect
 	github.com/cosmos/ledger-cosmos-go v0.11.1 // indirect
 	github.com/cosmos/ledger-go v0.9.2 // indirect
 	github.com/creachadair/taskgroup v0.3.2 // indirect


### PR DESCRIPTION
## Describe your changes and provide context
This adds the dump-iavl script as a debug command instead, using this, we can further extend logic to make certain iavl dumped data more human readable
## Testing performed to validate your change
Tested command locally

Example Output:
```
seid debug dump-iavl 90
db path: <REDACTED>
Processing Module: dex
Got version: 90
Printing all keys with hashed values (to detect diff)
Processing Module: wasm
Got version: 90
Printing all keys with hashed values (to detect diff)
Processing Module: accesscontrol
Got version: 0
Error reading data: no versions found while trying to load 90
Processing Module: oracle
Got version: 90
Printing all keys with hashed values (to detect diff)
Processing Module: epoch
Got version: 90
Printing all keys with hashed values (to detect diff)
Processing Module: mint
Got version: 90
Printing all keys with hashed values (to detect diff)
Processing Module: acc
Got version: 90
Printing all keys with hashed values (to detect diff)
Processing Module: bank
Got version: 90
Printing all keys with hashed values (to detect diff)
Processing Module: crisis
Got version: 0
Error reading data: no versions found while trying to load 90
Processing Module: feegrant
Got version: 90
Printing all keys with hashed values (to detect diff)
Processing Module: staking
Got version: 90
Printing all keys with hashed values (to detect diff)
Processing Module: distribution
Got version: 90
Printing all keys with hashed values (to detect diff)
Processing Module: slashing
Got version: 90
Printing all keys with hashed values (to detect diff)
Processing Module: gov
Got version: 90
Printing all keys with hashed values (to detect diff)
Processing Module: params
Got version: 90
Printing all keys with hashed values (to detect diff)
Processing Module: ibc
Got version: 90
Printing all keys with hashed values (to detect diff)
Processing Module: upgrade
Got version: 90
Printing all keys with hashed values (to detect diff)
Processing Module: evidence
Got version: 90
Printing all keys with hashed values (to detect diff)
Processing Module: transfer
Got version: 90
Printing all keys with hashed values (to detect diff)
Processing Module: tokenfactory
Got version: 90
Printing all keys with hashed values (to detect diff)


ls ~/state_90/
acc.data		distribution.data	feegrant.data		mint.data		slashing.data		transfer.data
bank.data		epoch.data		gov.data		oracle.data		staking.data		upgrade.data
dex.data		evidence.data		ibc.data		params.data		tokenfactory.data	wasm.data

ls ~ | grep state
state_90
state_90.zip
```