### PR TITLE
Handle panics correctly in logging util

### DIFF
--- a/utils/logging/time_test.go
+++ b/utils/logging/time_test.go
@@ -84,5 +84,6 @@ func TestPanic(t *testing.T) {
 		}()
 		LogIfNotDoneAfter(&logger, task, after, "test")
 	}
+	require.Panics(t, func() { LogIfNotDoneAfter(&logger, task, after, "test") })
 	require.NotPanics(t, outer)
 }

--- a/utils/logging/time_test.go
+++ b/utils/logging/time_test.go
@@ -70,3 +70,19 @@ func TestSlowError(t *testing.T) {
 	require.Empty(t, res)
 	require.Equal(t, fmt.Sprintf("test still not finished after %s", after), logger.lastError)
 }
+
+func TestPanic(t *testing.T) {
+	logger := mockLogger{}
+	task := func() (bool, error) {
+		panic("test")
+	}
+	after := 1 * time.Second
+	outer := func() {
+		defer func() {
+			if err := recover(); err != nil {
+			}
+		}()
+		LogIfNotDoneAfter(&logger, task, after, "test")
+	}
+	require.NotPanics(t, outer)
+}


### PR DESCRIPTION
## Describe your changes and provide context
Panics in a separate goroutine will not be recovered by main goroutine's `recover`, so we need to capture any panic and reraise

## Testing performed to validate your change
unit test (failing before the change, passed after the change)
