### PR TITLE
[debug] Add smart parse to bank iavl

### DIFF
--- a/cmd/seid/cmd/iavl_parser.go
+++ b/cmd/seid/cmd/iavl_parser.go
@@ -10,7 +10,7 @@ import (
 
 type ModuleParser func([]byte) ([]string, error)
 
-var ModuleParserMap map[string]ModuleParser = map[string]ModuleParser{
+var ModuleParserMap = map[string]ModuleParser{
 	"bank": BankParser,
 }
 
@@ -22,17 +22,18 @@ func BankParser(key []byte) ([]string, error) {
 	// 	return keyItems, err
 	// }
 	// iterate through, attempt to match against the Bank key prefixes
-	if bytes.HasPrefix(key, banktypes.SupplyKey) {
+	switch {
+	case bytes.HasPrefix(key, banktypes.SupplyKey):
 		keyItems = append(keyItems, "Supply")
 		// rest of the key is the denom
 		remaining := bytes.TrimPrefix(key, banktypes.SupplyKey)
 		keyItems = append(keyItems, fmt.Sprintf("Denom: %s", string(remaining)))
-	} else if bytes.HasPrefix(key, banktypes.DenomMetadataPrefix) {
+	case bytes.HasPrefix(key, banktypes.DenomMetadataPrefix):
 		keyItems = append(keyItems, "DenomMetadata")
 		// rest of the key is the denom
 		remaining := bytes.TrimPrefix(key, banktypes.DenomMetadataPrefix)
 		keyItems = append(keyItems, fmt.Sprintf("Denom: %s", string(remaining)))
-	} else if bytes.HasPrefix(key, banktypes.BalancesPrefix) {
+	case bytes.HasPrefix(key, banktypes.BalancesPrefix):
 		keyItems = append(keyItems, "Balances")
 		// remaining is length prefixed addr + denom
 		remaining := bytes.TrimPrefix(key, banktypes.BalancesPrefix)
@@ -46,8 +47,9 @@ func BankParser(key []byte) ([]string, error) {
 		}
 		keyItems = append(keyItems, fmt.Sprintf("AddrBech32: %s", bech32Addr))
 		keyItems = append(keyItems, fmt.Sprintf("Denom: %s", string(denom)))
-	} else {
+	default:
 		keyItems = append(keyItems, "Unrecognized prefix")
 	}
+
 	return keyItems, nil
 }

--- a/cmd/seid/cmd/iavl_parser.go
+++ b/cmd/seid/cmd/iavl_parser.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+)
+
+type ModuleParser func([]byte) ([]string, error)
+
+var ModuleParserMap map[string]ModuleParser = map[string]ModuleParser{
+	"bank": BankParser,
+}
+
+func BankParser(key []byte) ([]string, error) {
+	keyItems := []string{}
+	// split the stuff before any colons for JUST prefix
+	// key, err := hex.DecodeString(hexKey)
+	// if err != nil {
+	// 	return keyItems, err
+	// }
+	// iterate through, attempt to match against the Bank key prefixes
+	if bytes.HasPrefix(key, banktypes.SupplyKey) {
+		keyItems = append(keyItems, "Supply")
+		// rest of the key is the denom
+		remaining := bytes.TrimPrefix(key, banktypes.SupplyKey)
+		keyItems = append(keyItems, fmt.Sprintf("Denom: %s", string(remaining)))
+	} else if bytes.HasPrefix(key, banktypes.DenomMetadataPrefix) {
+		keyItems = append(keyItems, "DenomMetadata")
+		// rest of the key is the denom
+		remaining := bytes.TrimPrefix(key, banktypes.DenomMetadataPrefix)
+		keyItems = append(keyItems, fmt.Sprintf("Denom: %s", string(remaining)))
+	} else if bytes.HasPrefix(key, banktypes.BalancesPrefix) {
+		keyItems = append(keyItems, "Balances")
+		// remaining is length prefixed addr + denom
+		remaining := bytes.TrimPrefix(key, banktypes.BalancesPrefix)
+		lengthPrefix, remaining := int(remaining[0]), remaining[1:]
+		keyItems = append(keyItems, fmt.Sprintf("AddrLength: %d", lengthPrefix))
+		accountAddr := remaining[0:lengthPrefix]
+		denom := remaining[lengthPrefix:]
+		bech32Addr, err := sdk.Bech32ifyAddressBytes("sei", accountAddr)
+		if err != nil {
+			return keyItems, err
+		}
+		keyItems = append(keyItems, fmt.Sprintf("AddrBech32: %s", bech32Addr))
+		keyItems = append(keyItems, fmt.Sprintf("Denom: %s", string(denom)))
+	} else {
+		keyItems = append(keyItems, "Unrecognized prefix")
+	}
+	return keyItems, nil
+}


### PR DESCRIPTION
## Describe your changes and provide context
This adds "shape" output and also adds the smart bank module parser

## Testing performed to validate your change

Example output for `bank.data`

```
  007561746F6D | Supply | Denom: uatom
    C344E9487BFBD5C4E03C9FB90D62A5DDE5E00B54D55C46E9F4A803AEA162B80C
  0075736569 | Supply | Denom: usei
    17FAD2629E760FEE1DB1DEA01C46C6C28ACB4D3F12EC0F434ACDBFF57A913001
  007575736463 | Supply | Denom: uusdc
    C344E9487BFBD5C4E03C9FB90D62A5DDE5E00B54D55C46E9F4A803AEA162B80C
  017561746F6D7561746F6D | DenomMetadata | Denom: uatomuatom
    60736A1A9F3CEC52945D12B4450EF05A0E1A9D87EEBE18F5D1E59B2C87ED2050
  0214E42BCEAB96202850A7021B999A7FF77526D52F2375736569 | Balances | AddrLength: 20 | AddrBech32: sei1us4ua2ukyq59pfczrwve5llhw5nd2terrw9mwx | Denom: usei
    DB3FCA8FAC2245BC9A63C94E8036E3C299A4177E828B79D5EB3FB1650A516FB5
  0214E43D40D05524B57392F3BC610524DD8C8175A12C75736569 | Balances | AddrLength: 20 | AddrBech32: sei1us75p5z4yj6h8yhnh3ss2fxa3jqhtgfvytwfky | Denom: usei
    DB3FCA8FAC2245BC9A63C94E8036E3C299A4177E828B79D5EB3FB1650A516FB5
  0214E95967C60216885E1D436D1A263F4139E3B4F0FE75736569 | Balances | AddrLength: 20 | AddrBech32: sei1a9vk03szz6y9u82rd5dzv06p883mfu87wa5444 | Denom: usei
    DB3FCA8FAC2245BC9A63C94E8036E3C299A4177E828B79D5EB3FB1650A516FB5
  0214F375E83F4F6113BAFFF34B40807C5F51A17F:!usei | Balances | AddrLength: 20 | AddrBech32: sei17d67s060vyfm4llnfdqgqlzl2xsh7w3p00cw04 | Denom: usei
    DB3FCA8FAC2245BC9A63C94E8036E3C299A4177E828B79D5EB3FB1650A516FB5
  0214FC265705B7CF6929F8B0EDD99D44B036A21AC23175736569 | Balances | AddrLength: 20 | AddrBech32: sei1lsn9wpdhea5jn79sahve639sx63p4s339s57kq | Denom: usei
    DB3FCA8FAC2245BC9A63C94E8036E3C299A4177E828B79D5EB3FB1650A516FB5
  0214FD7B53E3BFA67EE2FFD12759ED16C324142C108075736569 | Balances | AddrLength: 20 | AddrBech32: sei1l4a48cal5elw9l73yav769krys2zcyyqdrlq46 | Denom: usei
    DB3FCA8FAC2245BC9A63C94E8036E3C299A4177E828B79D5EB3FB1650A516FB5
  0214FE177601EB22DA2A906DC89E6F188BE28D588CF275736569 | Balances | AddrLength: 20 | AddrBech32: sei1lcthvq0tytdz4yrdez0x7xytu2x43r8jwjp28h | Denom: usei
    DB3FCA8FAC2245BC9A63C94E8036E3C299A4177E828B79D5EB3FB1650A516FB5
  02209E28BEAFA966B2407BFFB0D48651E94972A56E69F3C0897D9E8FACBDAEB9838675736569 | Balances | AddrLength: 32 | AddrBech32: sei1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrqms7u8a | Denom: usei
    2889D65F2368FD9AA17223E226B494F7847575FA3EF7CE4E8905F6DA60C13EBF
  0220ADE4A5F580:439835C636395A8D648DEE57B2FC90D98DC17FA887159B69638B75736569 | Balances | AddrLength: 32 | AddrBech32: sei14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sh9m79m | Denom: usei
    942CF402D484B7AD81C353C40843CF906AFCC5F483053B143A96024455B30E94
  0220F04A31:7349B120C55C99788F12F712176BB3E5926D012D0EA72FA2BBB8505175736569 | Balances | AddrLength: 32 | AddrBech32: sei17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgsrtqewe | Denom: usei
    295CEC5B8A537057E2972B4714488404CCB901A4042E39EC12615E7AE022CD65
Hash: 69822EF4A4101138BBF71294A4326E7D24C2BA5738410D23E0D3D49B9117417A
Size: 41

```