### PR TITLE
Add mint and dex module parsers

### DIFF
--- a/cmd/seid/cmd/debug.go
+++ b/cmd/seid/cmd/debug.go
@@ -221,6 +221,9 @@ func ReadTree(db dbm.DB, version int, prefix []byte) (*iavl.MutableTree, error) 
 
 func PrintKeys(tree *iavl.MutableTree, moduleParser ModuleParser) []byte {
 	fmt.Println("Printing all keys with hashed values (to detect diff)")
+	if moduleParser != nil {
+		fmt.Println("Parsing module with human readable keys")
+	}
 	lines := []byte{}
 	tree.Iterate(func(key []byte, value []byte) bool { //nolint:errcheck
 		printKey := parseWeaveKey(key)

--- a/cmd/seid/cmd/iavl_parser.go
+++ b/cmd/seid/cmd/iavl_parser.go
@@ -6,6 +6,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	dexkeeper "github.com/sei-protocol/sei-chain/x/dex/keeper"
 	dextypes "github.com/sei-protocol/sei-chain/x/dex/types"
 	minttypes "github.com/sei-protocol/sei-chain/x/mint/types"
 )
@@ -71,6 +72,8 @@ func DexParser(key []byte) ([]string, error) {
 		return keyItems, nil
 	}
 	switch {
+	case bytes.HasPrefix(key, []byte(dexkeeper.EpochKey)):
+		// do nothing since the key is a string and no other data to be parsed
 	default:
 		keyItems = append(keyItems, "Unrecognized prefix")
 	}
@@ -96,6 +99,7 @@ func MatchAndExtractDexAddressPrefixKeys(key []byte) (bool, []string, []byte, er
 		dextypes.MemOrderKey,
 		dextypes.MemCancelKey,
 		dextypes.MemDepositKey,
+		dexkeeper.ContractPrefixKey,
 	}
 
 	for _, prefix := range keysToMatch {

--- a/cmd/seid/cmd/iavl_parser.go
+++ b/cmd/seid/cmd/iavl_parser.go
@@ -6,22 +6,33 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	dextypes "github.com/sei-protocol/sei-chain/x/dex/types"
+	minttypes "github.com/sei-protocol/sei-chain/x/mint/types"
 )
 
 type ModuleParser func([]byte) ([]string, error)
 
 var ModuleParserMap = map[string]ModuleParser{
 	"bank": BankParser,
+	"mint": MintParser,
+	"dex":  DexParser,
+}
+
+func MintParser(key []byte) ([]string, error) {
+	keyItems := []string{}
+	switch {
+	case bytes.HasPrefix(key, minttypes.MinterKey):
+		keyItems = append(keyItems, "MinterKey")
+	case bytes.HasPrefix(key, minttypes.LastTokenReleaseDate):
+		keyItems = append(keyItems, "LastTokenReleaseDate")
+	default:
+		keyItems = append(keyItems, "Unrecognized prefix")
+	}
+	return keyItems, nil
 }
 
 func BankParser(key []byte) ([]string, error) {
 	keyItems := []string{}
-	// split the stuff before any colons for JUST prefix
-	// key, err := hex.DecodeString(hexKey)
-	// if err != nil {
-	// 	return keyItems, err
-	// }
-	// iterate through, attempt to match against the Bank key prefixes
 	switch {
 	case bytes.HasPrefix(key, banktypes.SupplyKey):
 		keyItems = append(keyItems, "Supply")
@@ -37,19 +48,90 @@ func BankParser(key []byte) ([]string, error) {
 		keyItems = append(keyItems, "Balances")
 		// remaining is length prefixed addr + denom
 		remaining := bytes.TrimPrefix(key, banktypes.BalancesPrefix)
-		lengthPrefix, remaining := int(remaining[0]), remaining[1:]
-		keyItems = append(keyItems, fmt.Sprintf("AddrLength: %d", lengthPrefix))
-		accountAddr := remaining[0:lengthPrefix]
-		denom := remaining[lengthPrefix:]
-		bech32Addr, err := sdk.Bech32ifyAddressBytes("sei", accountAddr)
+		items, denom, err := parseLengthPrefixedAddress(remaining)
 		if err != nil {
 			return keyItems, err
 		}
-		keyItems = append(keyItems, fmt.Sprintf("AddrBech32: %s", bech32Addr))
+		keyItems = append(keyItems, items...)
 		keyItems = append(keyItems, fmt.Sprintf("Denom: %s", string(denom)))
 	default:
 		keyItems = append(keyItems, "Unrecognized prefix")
 	}
 
 	return keyItems, nil
+}
+
+func DexParser(key []byte) ([]string, error) {
+	keyItems := []string{}
+	switch {
+	case bytes.HasPrefix(key, dextypes.KeyPrefix(dextypes.LongBookKey)):
+		keyItems = append(keyItems, "LongBook")
+		remaining := bytes.TrimPrefix(key, dextypes.KeyPrefix(dextypes.LongBookKey))
+		items, remaining, err := parseLengthPrefixedAddress(remaining)
+		if err != nil {
+			return keyItems, err
+		}
+		keyItems = append(keyItems, items...)
+		// TODO: make this better
+		keyItems = append(keyItems, fmt.Sprintf("RemainingString: %s", string(remaining)))
+	case bytes.HasPrefix(key, dextypes.KeyPrefix(dextypes.ShortBookKey)):
+		keyItems = append(keyItems, "ShortBook")
+		remaining := bytes.TrimPrefix(key, dextypes.KeyPrefix(dextypes.ShortBookKey))
+		items, remaining, err := parseLengthPrefixedAddress(remaining)
+		if err != nil {
+			return keyItems, err
+		}
+		keyItems = append(keyItems, items...)
+		// TODO: make this better
+		keyItems = append(keyItems, fmt.Sprintf("RemainingString: %s", string(remaining)))
+	case bytes.HasPrefix(key, dextypes.KeyPrefix(dextypes.TriggerBookKey)):
+		keyItems = append(keyItems, "TriggerBook")
+		remaining := bytes.TrimPrefix(key, dextypes.KeyPrefix(dextypes.TriggerBookKey))
+		items, remaining, err := parseLengthPrefixedAddress(remaining)
+		if err != nil {
+			return keyItems, err
+		}
+		keyItems = append(keyItems, items...)
+		// TODO: make this better
+		keyItems = append(keyItems, fmt.Sprintf("RemainingString: %s", string(remaining)))
+	case bytes.HasPrefix(key, dextypes.KeyPrefix(dextypes.TwapKey)):
+		keyItems = append(keyItems, "TWAP")
+		remaining := bytes.TrimPrefix(key, dextypes.KeyPrefix(dextypes.TwapKey))
+		items, remaining, err := parseLengthPrefixedAddress(remaining)
+		if err != nil {
+			return keyItems, err
+		}
+		keyItems = append(keyItems, items...)
+		if len(remaining) > 0 {
+			keyItems = append(keyItems, fmt.Sprintf("RemainingString: %s", string(remaining)))
+		}
+	case bytes.HasPrefix(key, dextypes.KeyPrefix(dextypes.PriceKey)):
+		keyItems = append(keyItems, "Price")
+		remaining := bytes.TrimPrefix(key, dextypes.KeyPrefix(dextypes.PriceKey))
+		items, remaining, err := parseLengthPrefixedAddress(remaining)
+		if err != nil {
+			return keyItems, err
+		}
+		keyItems = append(keyItems, items...)
+		if len(remaining) > 0 {
+			keyItems = append(keyItems, fmt.Sprintf("RemainingString: %s", string(remaining)))
+		}
+	default:
+		keyItems = append(keyItems, "Unrecognized prefix")
+	}
+	return keyItems, nil
+}
+
+func parseLengthPrefixedAddress(remainingKey []byte) ([]string, []byte, error) {
+	keyItems := []string{}
+	lengthPrefix, remaining := int(remainingKey[0]), remainingKey[1:]
+	keyItems = append(keyItems, fmt.Sprintf("AddrLength: %d", lengthPrefix))
+	accountAddr := remaining[0:lengthPrefix]
+	remaining = remaining[lengthPrefix:]
+	bech32Addr, err := sdk.Bech32ifyAddressBytes("sei", accountAddr)
+	if err != nil {
+		return keyItems, remaining, err
+	}
+	keyItems = append(keyItems, fmt.Sprintf("AddrBech32: %s", bech32Addr))
+	return keyItems, remaining, nil
 }

--- a/cmd/seid/cmd/iavl_parser.go
+++ b/cmd/seid/cmd/iavl_parser.go
@@ -83,6 +83,7 @@ func DexParser(key []byte) ([]string, error) {
 func MatchAndExtractDexAddressPrefixKeys(key []byte) (bool, []string, []byte, error) {
 	keyItems := []string{}
 	keysToMatch := []string{
+		// Source of truth: github.com/sei-protocol/sei-chain/x/dex/types/keys.go - contains key constants represented here
 		dextypes.LongBookKey,
 		dextypes.ShortBookKey,
 		dextypes.TriggerBookKey,


### PR DESCRIPTION
## Describe your changes and provide context
This change adds mint and dex module parsers for the iavl-dump script.

## Testing performed to validate your change
Tested on cluster with dex activity, example parsed line:
```
  4C6F6E67426F6F6B2D76616C75652D2048B7A40898C7CF2635910035709590D13FD1F323642BB7EB1EB3E6B14D49:zSEI|ATOM45000000000000 | LongBook-value- | AddrBech32: sei1fzm6gzyccl8jvdv3qq6hp9vs6ylaruervs4m06c7k0ntzn2f8faq8un0p6 | RemainingString: SEI|ATOM45000000000000
  ```