### PR TITLE
make chain-id optional for seid start

### DIFF
--- a/cmd/seid/cmd/init.go
+++ b/cmd/seid/cmd/init.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/cosmos/go-bip39"
 	"github.com/pkg/errors"
@@ -16,6 +17,7 @@ import (
 	"github.com/tendermint/tendermint/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
+	clientconfig "github.com/cosmos/cosmos-sdk/client/config"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/input"
 	"github.com/cosmos/cosmos-sdk/server"
@@ -80,6 +82,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			params.SetTendermintConfigs(config)
 
 			config.SetRoot(clientCtx.HomeDir)
+			configPath := filepath.Join(config.RootDir, "config")
 
 			chainID, _ := cmd.Flags().GetString(flags.FlagChainID)
 			if chainID == "" {
@@ -137,6 +140,12 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			if err = genutil.ExportGenesisFile(genDoc, genFile); err != nil {
 				return errors.Wrap(err, "Failed to export genesis file")
 			}
+
+			clientConfig, err := clientconfig.GetClientConfig(configPath, clientCtx.Viper)
+			if err != nil {
+				return err
+			}
+			clientconfig.SetClientConfig(flags.FlagChainID, chainID, configPath, clientConfig)
 
 			toPrint := newPrintInfo(config.Moniker, chainID, nodeID, "", appState)
 

--- a/cmd/seid/cmd/init.go
+++ b/cmd/seid/cmd/init.go
@@ -145,7 +145,9 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			clientconfig.SetClientConfig(flags.FlagChainID, chainID, configPath, clientConfig)
+			if err = clientconfig.SetClientConfig(flags.FlagChainID, chainID, configPath, clientConfig); err != nil {
+				return err
+			}
 
 			toPrint := newPrintInfo(config.Moniker, chainID, nodeID, "", appState)
 

--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -88,7 +88,6 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 			if err != nil {
 				return err
 			}
-
 			if err := client.SetCmdClientContextHandler(initClientCtx, cmd); err != nil {
 				return err
 			}

--- a/go.mod
+++ b/go.mod
@@ -269,7 +269,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.422
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.1.426
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.0.2
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4

--- a/go.sum
+++ b/go.sum
@@ -1066,8 +1066,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.1.422 h1:uBe8bj8V3cIumKNEbwCLbDpf5ckqHa2Z/kjPpCLKP5g=
-github.com/sei-protocol/sei-cosmos v0.1.422/go.mod h1:KE4GvxxiBYtz3z6fKg0cXh5bfdoziI495UDjwAc2aDY=
+github.com/sei-protocol/sei-cosmos v0.1.426 h1:qk3QVUuEEVYjWVf7oo1Cwm58zxsR2hGAYqDlRMHb9AQ=
+github.com/sei-protocol/sei-cosmos v0.1.426/go.mod h1:luUxbQqdQ/xHQi2iSHQjsGV22644e0omq1kFlxwnEoc=
 github.com/sei-protocol/sei-iavl v0.0.2 h1:83CizhXdebrwQEcUMKL0jk21NMvakkKii+RvcoPCoFI=
 github.com/sei-protocol/sei-iavl v0.0.2/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-tendermint v0.1.171 h1:G3ZRnQgiLQ06/3iKrj5UicpHfRWJWruaJFxVYHFOcjA=

--- a/scripts/old_initialize_local.sh
+++ b/scripts/old_initialize_local.sh
@@ -73,7 +73,6 @@ else
   exit 1
 fi
 
-~/go/bin/seid config chain-id sei-chain
 ~/go/bin/seid config keyring-backend test
 
 # start the chain with log tracing


### PR DESCRIPTION
## Describe your changes and provide context
On init, save chain-id to client.toml (used to other commands to run seid commands to bypass requirement for --chain-id already) 

Then on startup, just read from client.toml's value if chainId isn't passed

## Testing performed to validate your change
Ran the new `./scripts/old_initialize_local.sh` 

![image](https://user-images.githubusercontent.com/18161326/218583570-34dcdc07-d8a1-40f7-b49c-ba7fad3f2e81.png)

Then restarted chain with `seid start`


Also validates
![image](https://user-images.githubusercontent.com/18161326/218583641-d5cd619b-6e52-4dfd-9df8-b6b1cb5175a5.png)
