### PR TITLE
[config] Update default UnsafeCommitTimeoutOverride to 100ms

### DIFF
--- a/app/params/config.go
+++ b/app/params/config.go
@@ -97,7 +97,7 @@ func SetTendermintConfigs(config *tmcfg.Config) {
 	config.Consensus.UnsafeProposeTimeoutDeltaOverride = 500 * time.Millisecond
 	config.Consensus.UnsafeVoteTimeoutOverride = 50 * time.Millisecond
 	config.Consensus.UnsafeVoteTimeoutDeltaOverride = 500 * time.Millisecond
-	config.Consensus.UnsafeCommitTimeoutOverride = 50 * time.Millisecond
+	config.Consensus.UnsafeCommitTimeoutOverride = 100 * time.Millisecond
 	config.Consensus.UnsafeBypassCommitTimeoutOverride = &UnsafeBypassCommitTimeoutOverride
 	// Metrics
 	config.Instrumentation.Prometheus = true


### PR DESCRIPTION
## Describe your changes and provide context
50ms is too fast if we want a truly decentralized chain as that will put a strong preference on validators staying close together and alienate any validators that are further 
## Testing performed to validate your change

