### PR TITLE
Defer store read/write from iterator loop

### DIFF
--- a/x/dex/cache/cache_test.go
+++ b/x/dex/cache/cache_test.go
@@ -74,6 +74,17 @@ func TestDeepFilterAccounts(t *testing.T) {
 	require.Equal(t, 1, len(stateOne.GetDepositInfo(ctx, utils.ContractAddress(TEST_CONTRACT)).Get()))
 }
 
+func TestDeepDelete(t *testing.T) {
+	keeper, ctx := keepertest.DexKeeper(t)
+	stateOne := dex.NewMemState(keeper.GetStoreKey())
+	stateOne.GetBlockOrders(ctx, utils.ContractAddress(TEST_CONTRACT), utils.PairString(TEST_PAIR)).Add(&types.Order{
+		Id:           1,
+		Account:      "test",
+		ContractAddr: TEST_CONTRACT,
+	})
+	dex.DeepDelete(ctx.KVStore(keeper.GetStoreKey()), types.KeyPrefix(types.MemOrderKey), func(_ []byte) bool { return true })
+}
+
 func TestClear(t *testing.T) {
 	keeper, ctx := keepertest.DexKeeper(t)
 	stateOne := dex.NewMemState(keeper.GetStoreKey())

--- a/x/dex/keeper/common.go
+++ b/x/dex/keeper/common.go
@@ -1,12 +1,22 @@
 package keeper
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
 
 func (k Keeper) removeAllForPrefix(ctx sdk.Context, prefix []byte) {
 	store := ctx.KVStore(k.storeKey)
+	for _, key := range k.getAllKeysForPrefix(store, prefix) {
+		store.Delete(key)
+	}
+}
+
+func (k Keeper) getAllKeysForPrefix(store sdk.KVStore, prefix []byte) [][]byte {
+	keys := [][]byte{}
 	iter := sdk.KVStorePrefixIterator(store, prefix)
 	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {
-		store.Delete(iter.Key())
+		keys = append(keys, iter.Key())
 	}
+	return keys
 }

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -317,11 +317,19 @@ func (k Keeper) IterateVoteTargets(ctx sdk.Context, handler func(denom string, d
 
 func (k Keeper) ClearVoteTargets(ctx sdk.Context) {
 	store := ctx.KVStore(k.storeKey)
-	iter := sdk.KVStorePrefixIterator(store, types.VoteTargetKey)
+	for _, key := range k.getAllKeysForPrefix(store, types.VoteTargetKey) {
+		store.Delete(key)
+	}
+}
+
+func (k Keeper) getAllKeysForPrefix(store sdk.KVStore, prefix []byte) [][]byte {
+	keys := [][]byte{}
+	iter := sdk.KVStorePrefixIterator(store, prefix)
 	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {
-		store.Delete(iter.Key())
+		keys = append(keys, iter.Key())
 	}
+	return keys
 }
 
 // ValidateFeeder return the given feeder is allowed to feed the message or not


### PR DESCRIPTION
## Describe your changes and provide context
Performing store access before an iterator is closed may cause deadlocks (see https://github.com/sei-protocol/sei-chain/pull/567 for context).
This PR refactors existing logic to move store access that were previously within iterator's scope to be after iterator closure.

Note that there are still cases for this in oracle keeper, but all the methods there are only called in oracle's Mid/EndBlock, which are not parallelized in any way and thus not subject to the deadlock issue

## Testing performed to validate your change
unit tests + existing tests

