### PR TITLE
[oracle] Sorts map keys prior to tallying for consistent ordering

### DIFF
--- a/oracle/price-feeder/config.example.toml
+++ b/oracle/price-feeder/config.example.toml
@@ -55,7 +55,7 @@ enable_service_label = true
 enabled = true
 global_labels = [["chain-id", "sei-chain"]]
 service_name = "price-feeder"
-type = "prometheus"
+prometheus_retention = 60
 
 [[provider_endpoints]]
 name = "binance"

--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -28,8 +28,13 @@ func MidBlocker(ctx sdk.Context, k keeper.Keeper) {
 		powerReduction := k.StakingKeeper.PowerReduction(ctx)
 
 		i := 0
+		powerOrderedValAddrs := []sdk.ValAddress{}
 		for ; iterator.Valid() && i < int(maxValidators); iterator.Next() {
-			validator := k.StakingKeeper.Validator(ctx, iterator.Value())
+			powerOrderedValAddrs = append(powerOrderedValAddrs, iterator.Value())
+		}
+
+		for _, valAddr := range powerOrderedValAddrs {
+			validator := k.StakingKeeper.Validator(ctx, valAddr)
 
 			// Exclude not bonded validator
 			if validator.IsBonded() {

--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -1,6 +1,7 @@
 package oracle
 
 import (
+	"sort"
 	"time"
 
 	"github.com/sei-protocol/sei-chain/x/oracle/keeper"
@@ -61,8 +62,15 @@ func MidBlocker(ctx sdk.Context, k keeper.Keeper) {
 			exchangeRateRD := ballotRD.WeightedMedianWithAssertion()
 
 			// Iterate through ballots and update exchange rates; drop if not enough votes have been achieved.
-			for denom, ballot := range voteMap {
-
+			keys := make([]string, len(voteMap))
+			j := 0
+			for denom := range voteMap {
+				keys[j] = denom
+				j++
+			}
+			sort.Strings(keys)
+			for _, denom := range keys {
+				ballot := voteMap[denom]
 				// Convert ballot to cross exchange rates
 				if denom != referenceDenom {
 					ballot = ballot.ToCrossRateWithSort(voteMapRD)
@@ -79,17 +87,20 @@ func MidBlocker(ctx sdk.Context, k keeper.Keeper) {
 				// Set the exchange rate, emit ABCI event
 				k.SetBaseExchangeRateWithEvent(ctx, denom, exchangeRate)
 			}
+		}
 
-			for _, ballot := range belowThresholdVoteMap {
-				// perform tally for below threshold assets to calculate total win count
-				Tally(ctx, ballot, params.RewardBand, validatorClaimMap)
-			}
-		} else {
-			// in this case, all assets would be in the belowThresholdVoteMap
-			for _, ballot := range belowThresholdVoteMap {
-				// perform tally for below threshold assets to calculate total win count
-				Tally(ctx, ballot, params.RewardBand, validatorClaimMap)
-			}
+		belowThresholdKeys := make([]string, len(belowThresholdVoteMap))
+		n := 0
+		for denom := range belowThresholdVoteMap {
+			belowThresholdKeys[n] = denom
+			n++
+		}
+		sort.Strings(belowThresholdKeys)
+		// in this case, all assets would be in the belowThresholdVoteMap
+		for _, denom := range belowThresholdKeys {
+			ballot := belowThresholdVoteMap[denom]
+			// perform tally for below threshold assets to calculate total win count
+			Tally(ctx, ballot, params.RewardBand, validatorClaimMap)
 		}
 
 		//---------------------------


### PR DESCRIPTION
## Describe your changes and provide context
This fixes map iteration to happen in sorted order for consistent event order, and also removes store READs within a store iterator


## Testing performed to validate your change
Existing tests
