### PR TITLE
[oak] Use map[T]struct{}{} instead of map[T]bool for performance reason

### DIFF
--- a/x/dex/types/genesis.go
+++ b/x/dex/types/genesis.go
@@ -36,20 +36,20 @@ func (cs ContractState) Validate() error {
 		return fmt.Errorf("empty contract addr")
 	}
 	// Check for duplicated ID in shortBook
-	longBookIDMap := make(map[uint64]bool)
+	longBookIDMap := make(map[uint64]struct{})
 	for _, elem := range cs.LongBookList {
 		if _, ok := longBookIDMap[elem.Price.BigInt().Uint64()]; ok {
 			return fmt.Errorf("duplicated price for longBook")
 		}
-		longBookIDMap[elem.Price.BigInt().Uint64()] = true
+		longBookIDMap[elem.Price.BigInt().Uint64()] = struct{}{}
 	}
 	// Check for duplicated ID in shortBook
-	shortBookIDMap := make(map[uint64]bool)
+	shortBookIDMap := make(map[uint64]struct{})
 	for _, elem := range cs.ShortBookList {
 		if _, ok := shortBookIDMap[elem.Price.BigInt().Uint64()]; ok {
 			return fmt.Errorf("duplicated price for shortBook")
 		}
-		shortBookIDMap[elem.Price.BigInt().Uint64()] = true
+		shortBookIDMap[elem.Price.BigInt().Uint64()] = struct{}{}
 	}
 	return nil
 }

--- a/x/dex/types/wasm/block_hooks.go
+++ b/x/dex/types/wasm/block_hooks.go
@@ -55,9 +55,9 @@ func NewContractOrderResult(contractAddr string) ContractOrderResult {
 
 func PopulateOrderPlacementResults(contractAddr string, orders []*types.Order, cancellations []*types.Cancellation, resultMap map[string]ContractOrderResult) {
 	// get cancelled order ids
-	cancels := make(map[uint64]bool)
+	cancels := make(map[uint64]struct{})
 	for _, cancel := range cancellations {
-		cancels[cancel.Id] = true
+		cancels[cancel.Id] = struct{}{}
 	}
 
 	for _, order := range orders {


### PR DESCRIPTION
## Describe your changes and provide context
The alternative representation can be faster and more efficient in terms of memory.

This PR changes this representation of the hash map to a map[T]struct{}{} based on the results from https://itnext.io/set-in-go-map-bool-and-map-struct-performance-comparison-5315b4b107b.

## Testing performed to validate your change
Existing unit test covers it 

