### PR TITLE
[oak] Fix boolean parse for CLI

### DIFF
--- a/x/dex/client/cli/tx/tx_register_contract.go
+++ b/x/dex/client/cli/tx/tx_register_contract.go
@@ -24,13 +24,19 @@ func CmdRegisterContract() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			argNeedHook := args[2] == "true"
-			argNeedMatching := args[3] == "true"
+			argNeedHook, err := strconv.ParseBool(args[2])
+			if err != nil {
+				return err
+			}
+			argNeedMatching, err := strconv.ParseBool(args[3])
+			if err != nil {
+				return err
+			}
 			argDeposit, err := cast.ToUint64E(args[4])
 			if err != nil {
 				return err
 			}
-			dependencies := []*types.ContractDependencyInfo{}
+			var dependencies []*types.ContractDependencyInfo
 			for _, dependency := range args[5:] {
 				dependencies = append(dependencies, &types.ContractDependencyInfo{Dependency: dependency})
 			}


### PR DESCRIPTION
## Describe your changes and provide context
**Problem**:
In x/dex/client/cli/tx/tx_register_contract.go, arguments [need hook] and [need order matching], only check against the string true. For example, if a user capitalizes the word, the flag is going to be set as false. Use strconv.ParseBool

## Testing performed to validate your change
Tested manually with cli after building sei chain
