### PR TITLE
[oak] Fix inefficient implementation of UpdateQuantityTickSize and UpdatePriceTickSize

### DIFF
--- a/x/dex/keeper/msgserver/msg_server_register_pairs.go
+++ b/x/dex/keeper/msgserver/msg_server_register_pairs.go
@@ -26,14 +26,11 @@ func (k msgServer) RegisterPairs(goCtx context.Context, msg *types.MsgRegisterPa
 		if msg.Creator != contractInfo.Creator {
 			return nil, sdkerrors.ErrUnauthorized
 		}
-	}
 
-	// Loop through each batch contract pair an individual contract pair, token pair
-	// tuple and register them individually
-	for _, batchContractPair := range msg.Batchcontractpair {
-		contractAddress := batchContractPair.ContractAddr
-		for _, pair := range batchContractPair.Pairs {
-			k.AddRegisteredPair(ctx, contractAddress, *pair)
+		// Loop through each batch contract pair an individual contract pair, token pair
+		// tuple and register them individually
+		for _, pair := range batchPair.Pairs {
+			k.AddRegisteredPair(ctx, contractAddr, *pair)
 		}
 	}
 

--- a/x/dex/keeper/msgserver/msg_server_update_price_tick_size.go
+++ b/x/dex/keeper/msgserver/msg_server_update_price_tick_size.go
@@ -26,10 +26,8 @@ func (k msgServer) UpdatePriceTickSize(goCtx context.Context, msg *types.MsgUpda
 		if msg.Creator != contractInfo.Creator {
 			return nil, sdkerrors.ErrUnauthorized
 		}
-	}
 
-	for _, tickSize := range msg.TickSizeList {
-		err := k.SetPriceTickSizeForPair(ctx, tickSize.ContractAddr, *tickSize.Pair, tickSize.Ticksize)
+		err = k.SetPriceTickSizeForPair(ctx, tickSize.ContractAddr, *tickSize.Pair, tickSize.Ticksize)
 		if err != nil {
 			return nil, err
 		}

--- a/x/dex/keeper/msgserver/msg_server_update_quantity_tick_size.go
+++ b/x/dex/keeper/msgserver/msg_server_update_quantity_tick_size.go
@@ -26,10 +26,8 @@ func (k msgServer) UpdateQuantityTickSize(goCtx context.Context, msg *types.MsgU
 		if msg.Creator != contractInfo.Creator {
 			return nil, sdkerrors.ErrUnauthorized
 		}
-	}
 
-	for _, tickSize := range msg.TickSizeList {
-		err := k.SetQuantityTickSizeForPair(ctx, tickSize.ContractAddr, *tickSize.Pair, tickSize.Ticksize)
+		err = k.SetQuantityTickSizeForPair(ctx, tickSize.ContractAddr, *tickSize.Pair, tickSize.Ticksize)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Describe your changes and provide context
**Problem**:
Validate and update are using two separate loops

**Action Items**: 
Combine validate & update in 1 loop
## Testing performed to validate your change

