### PR TITLE
Fix documentation for default inflation rate

### DIFF
--- a/x/mint/types/minter.go
+++ b/x/mint/types/minter.go
@@ -30,7 +30,7 @@ func InitialMinter() Minter {
 }
 
 // DefaultInitialMinter returns a default initial Minter object for a new chain
-// which uses an inflation rate of 13%.
+// which uses an inflation rate of 0%.
 func DefaultInitialMinter() Minter {
 	return InitialMinter()
 }


### PR DESCRIPTION
## Describe your changes and provide context
**Problem**:
Update inflation documentation In x/mint/types/minter.go:26 is stated that the intended default initial inflation rate should be 13%. However, in L21 the initial inflation rate is set to sdk.NewDec(0). If this is not intended behavior, this error may cause severe errors on the initial token distribution of the Sei token.

## Testing performed to validate your change

