### PR TITLE
[oak] Remove redundant PlaceOrder checks for nil or negative transfer fund amount

### DIFF
--- a/x/dex/keeper/msgserver/msg_server_place_orders.go
+++ b/x/dex/keeper/msgserver/msg_server_place_orders.go
@@ -22,11 +22,6 @@ func (k msgServer) transferFunds(goCtx context.Context, msg *types.MsgPlaceOrder
 	if err != nil {
 		return err
 	}
-	for _, fund := range msg.Funds {
-		if fund.Amount.IsNil() {
-			return errors.New("deposit amount cannot be nil")
-		}
-	}
 	if err := k.BankKeeper.IsSendEnabledCoins(ctx, msg.Funds...); err != nil {
 		return err
 	}

--- a/x/dex/keeper/msgserver/msg_server_place_orders_test.go
+++ b/x/dex/keeper/msgserver/msg_server_place_orders_test.go
@@ -196,6 +196,57 @@ func TestPlaceInvalidOrder(t *testing.T) {
 	server = msgserver.NewMsgServerImpl(*keeper)
 	_, err = server.PlaceOrders(wctx, msg)
 	require.NotNil(t, err)
+
+	// Nil Fund Amount
+	msg = &types.MsgPlaceOrders{
+		Creator:      TestCreator,
+		ContractAddr: TestContract,
+		Orders: []*types.Order{
+			{
+				Price:             sdk.MustNewDecFromStr("10"),
+				Quantity:          sdk.MustNewDecFromStr("10"),
+				Data:              "",
+				PositionDirection: types.PositionDirection_LONG,
+				OrderType:         types.OrderType_LIMIT,
+				PriceDenom:        keepertest.TestPriceDenom,
+				AssetDenom:        keepertest.TestAssetDenom,
+			},
+		},
+		Funds: sdk.Coins{
+			sdk.Coin{
+				Denom: "TEST",
+			},
+		},
+	}
+	server = msgserver.NewMsgServerImpl(*keeper)
+	_, err = server.PlaceOrders(wctx, msg)
+	require.NotNil(t, err)
+
+	// Negative Fund Amount
+	msg = &types.MsgPlaceOrders{
+		Creator:      TestCreator,
+		ContractAddr: TestContract,
+		Orders: []*types.Order{
+			{
+				Price:             sdk.MustNewDecFromStr("10"),
+				Quantity:          sdk.MustNewDecFromStr("10"),
+				Data:              "",
+				PositionDirection: types.PositionDirection_LONG,
+				OrderType:         types.OrderType_LIMIT,
+				PriceDenom:        keepertest.TestPriceDenom,
+				AssetDenom:        keepertest.TestAssetDenom,
+			},
+		},
+		Funds: sdk.Coins{
+			sdk.Coin{
+				Denom:  "TEST",
+				Amount: sdk.NewInt(-10),
+			},
+		},
+	}
+	server = msgserver.NewMsgServerImpl(*keeper)
+	_, err = server.PlaceOrders(wctx, msg)
+	require.NotNil(t, err)
 }
 
 func TestPlaceNoOrder(t *testing.T) {


### PR DESCRIPTION
## Describe your changes and provide context
- Removes redundant checks for nil fund amount during place order
- Adds unit tests for nil fund amount + negative fund amount during place order

## Testing performed to validate your change
- Added in unit tests
- Tested e2e with place order
