### PR TITLE
Remove redundant validate basic in tx place order

### DIFF
--- a/x/dex/client/cli/tx/tx_place_orders.go
+++ b/x/dex/client/cli/tx/tx_place_orders.go
@@ -97,9 +97,6 @@ func CmdPlaceOrders() *cobra.Command {
 				argContractAddr,
 				amount,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}


### PR DESCRIPTION
## Describe your changes and provide context
- Removes redundant call to validate basic (ValidateBasic is already called in `GenerateOrBroadcastTxCLI`)

## Testing performed to validate your change
- Tested with place order from cli  and verified validate basic throws error 
