### PR TITLE
Send deposit funds in message server instead of EndBlock

### DIFF
--- a/aclmapping/dex/mappings.go
+++ b/aclmapping/dex/mappings.go
@@ -51,7 +51,6 @@ func DexPlaceOrdersDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context,
 	}
 
 	senderBankAddrIdentifier := hex.EncodeToString(banktypes.CreateAccountBalancesPrefixFromBech32(placeOrdersMsg.Creator))
-	contractBankAddrIdentifier := hex.EncodeToString(banktypes.CreateAccountBalancesPrefixFromBech32(placeOrdersMsg.ContractAddr))
 	contractAddr := placeOrdersMsg.ContractAddr
 
 	aclOps := []sdkacltypes.AccessOperation{
@@ -109,30 +108,6 @@ func DexPlaceOrdersDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context,
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_BANK_BALANCES,
 			IdentifierTemplate: senderBankAddrIdentifier,
-		},
-
-		// Checks balance for receiver
-		{
-			AccessType:         sdkacltypes.AccessType_READ,
-			ResourceType:       sdkacltypes.ResourceType_KV_BANK_BALANCES,
-			IdentifierTemplate: contractBankAddrIdentifier,
-		},
-		{
-			AccessType:         sdkacltypes.AccessType_WRITE,
-			ResourceType:       sdkacltypes.ResourceType_KV_BANK_BALANCES,
-			IdentifierTemplate: contractBankAddrIdentifier,
-		},
-
-		// Tries to create the reciever's account if it doesn't exist
-		{
-			AccessType:         sdkacltypes.AccessType_READ,
-			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
-			IdentifierTemplate: hex.EncodeToString(authtypes.CreateAddressStoreKeyFromBech32(placeOrdersMsg.ContractAddr)),
-		},
-		{
-			AccessType:         sdkacltypes.AccessType_WRITE,
-			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
-			IdentifierTemplate: hex.EncodeToString(authtypes.CreateAddressStoreKeyFromBech32(placeOrdersMsg.ContractAddr)),
 		},
 
 		// Gets Account Info for the sender

--- a/aclmapping/dex/mappings.go
+++ b/aclmapping/dex/mappings.go
@@ -10,7 +10,6 @@ import (
 	acltypes "github.com/cosmos/cosmos-sdk/x/accesscontrol/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	"github.com/sei-protocol/sei-chain/aclmapping/utils"
 	dextypes "github.com/sei-protocol/sei-chain/x/dex/types"
 )
 
@@ -116,30 +115,6 @@ func DexPlaceOrdersDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context,
 			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
 			IdentifierTemplate: hex.EncodeToString(authtypes.CreateAddressStoreKeyFromBech32(placeOrdersMsg.Creator)),
 		},
-
-		{
-			AccessType:         sdkacltypes.AccessType_READ,
-			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_GLOBAL_ACCOUNT_NUMBER,
-			IdentifierTemplate: hex.EncodeToString(authtypes.GlobalAccountNumberKey),
-		},
-	}
-
-	toAddr, err := sdk.AccAddressFromBech32(placeOrdersMsg.ContractAddr)
-	if err != nil {
-		// let msg server handle it
-		aclOps = append(aclOps, sdkacltypes.AccessOperation{
-			ResourceType:       sdkacltypes.ResourceType_ANY,
-			AccessType:         sdkacltypes.AccessType_COMMIT,
-			IdentifierTemplate: utils.DefaultIDTemplate,
-		})
-		return aclOps, nil
-	}
-	if !keeper.AccountKeeper.HasAccount(ctx, toAddr) {
-		aclOps = append(aclOps, sdkacltypes.AccessOperation{
-			AccessType:         sdkacltypes.AccessType_WRITE,
-			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_GLOBAL_ACCOUNT_NUMBER,
-			IdentifierTemplate: hex.EncodeToString(authtypes.GlobalAccountNumberKey),
-		})
 	}
 
 	// Last Operation should always be a commit

--- a/x/dex/keeper/abci/end_block_deposit.go
+++ b/x/dex/keeper/abci/end_block_deposit.go
@@ -45,7 +45,7 @@ func (w KeeperWrapper) GetDepositSudoMsg(ctx sdk.Context, typedContractAddr type
 	if err != nil {
 		panic(err)
 	}
-	if err := w.BankKeeper.SendCoins(ctx, w.AccountKeeper.GetModuleAccount(ctx, types.ModuleName).GetAddress(), contractAddr, escrowed); err != nil {
+	if err := w.BankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, contractAddr, escrowed); err != nil {
 		panic(err)
 	}
 	return wasm.SudoOrderPlacementMsg{

--- a/x/dex/keeper/abci/end_block_place_orders_test.go
+++ b/x/dex/keeper/abci/end_block_place_orders_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 	typesutils "github.com/sei-protocol/sei-chain/x/dex/types/utils"
 	dexutils "github.com/sei-protocol/sei-chain/x/dex/utils"
-	minttypes "github.com/sei-protocol/sei-chain/x/mint/types"
 	"github.com/stretchr/testify/require"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
@@ -40,11 +39,8 @@ func TestGetDepositSudoMsg(t *testing.T) {
 	testApp := keepertest.TestApp()
 	ctx := testApp.BaseApp.NewContext(false, tmproto.Header{})
 	ctx = ctx.WithContext(context.WithValue(ctx.Context(), dexutils.DexMemStateContextKey, dexcache.NewMemState(testApp.GetKey(types.StoreKey))))
-	bankkeeper := testApp.BankKeeper
 	testAccount, _ := sdk.AccAddressFromBech32("sei1yezq49upxhunjjhudql2fnj5dgvcwjj87pn2wx")
 	amounts := sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(1000000)))
-	bankkeeper.MintCoins(ctx, minttypes.ModuleName, amounts)
-	bankkeeper.SendCoinsFromModuleToAccount(ctx, minttypes.ModuleName, testAccount, amounts)
 	keeper := testApp.DexKeeper
 	dexutils.GetMemState(ctx.Context()).GetDepositInfo(ctx, keepertest.TestContract).Add(
 		&types.DepositInfoEntry{

--- a/x/dex/keeper/msgserver/msg_server_place_orders.go
+++ b/x/dex/keeper/msgserver/msg_server_place_orders.go
@@ -37,8 +37,7 @@ func (k msgServer) transferFunds(goCtx context.Context, msg *types.MsgPlaceOrder
 			Amount:  sdk.NewDec(fund.Amount.Int64()),
 		})
 	}
-	escrow := k.AccountKeeper.GetModuleAccount(ctx, types.ModuleName).GetAddress()
-	if err := k.BankKeeper.SendCoins(ctx, sender, escrow, msg.Funds); err != nil {
+	if err := k.BankKeeper.DeferredSendCoinsFromAccountToModule(ctx, sender, types.ModuleName, msg.Funds); err != nil {
 		return fmt.Errorf("error sending coins to contract: %s", err)
 	}
 	return nil

--- a/x/dex/keeper/msgserver/msg_server_place_orders_test.go
+++ b/x/dex/keeper/msgserver/msg_server_place_orders_test.go
@@ -124,8 +124,6 @@ func TestPlaceOrderWithDeposit(t *testing.T) {
 	require.NotNil(t, err)
 	senderBalance = bankkeeper.GetBalance(ctx, testAccount, "usei")
 	require.Equal(t, sdk.ZeroInt(), senderBalance.Amount)
-	escrowBalance = bankkeeper.GetBalance(ctx, keeper.AccountKeeper.GetModuleAddress("dex"), "usei")
-	require.Equal(t, sdk.NewInt(10), escrowBalance.Amount)
 }
 
 func TestPlaceInvalidOrder(t *testing.T) {

--- a/x/dex/keeper/msgserver/msg_server_place_orders_test.go
+++ b/x/dex/keeper/msgserver/msg_server_place_orders_test.go
@@ -116,8 +116,6 @@ func TestPlaceOrderWithDeposit(t *testing.T) {
 	require.Equal(t, uint64(0), res.OrderIds[0])
 	senderBalance := bankkeeper.GetBalance(ctx, testAccount, "usei")
 	require.Equal(t, sdk.ZeroInt(), senderBalance.Amount)
-	escrowBalance := bankkeeper.GetBalance(ctx, keeper.AccountKeeper.GetModuleAddress("dex"), "usei")
-	require.Equal(t, sdk.NewInt(10), escrowBalance.Amount)
 
 	// insufficient fund
 	res, err = server.PlaceOrders(wctx, msg)


### PR DESCRIPTION
## Describe your changes and provide context
We originally placed coin sending logic in EndBlock to improve performance with batch operation (e.g. if an account placed a lot of micro deposits in the same currency, it will only be sent once in EndBlock). However this opened up an attack vector as described in https://linear.app/seilabs/issue/SEI-2678/[sei-chain]-msgplaceorders-should-hold-funds-in-escrow So we are moving the logic into transaction processing stage.

## Testing performed to validate your change
unit tests

