### PR TITLE
Remove TODO for time filter

### DIFF
--- a/x/dex/keeper/query/grpc_query_get_historical_prices.go
+++ b/x/dex/keeper/query/grpc_query_get_historical_prices.go
@@ -19,7 +19,6 @@ func (k KeeperWrapper) GetHistoricalPrices(goCtx context.Context, req *types.Que
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	// TODO: optimize by introducing a getter that takes a time filter
 	prices := k.GetAllPrices(ctx, req.ContractAddr, types.Pair{PriceDenom: req.PriceDenom, AssetDenom: req.AssetDenom})
 	currentTimeStamp := uint64(ctx.BlockTime().Unix())
 	beginTimestamp := currentTimeStamp - req.NumOfPeriods*req.PeriodLengthInSeconds


### PR DESCRIPTION
## Describe your changes and provide context
It's already based on price and asset denom prefix - it's just missing the date in the prefix iterator, in that case it's essentially still iterating on all the prices. 

As of now the logic just gets all the prices and sorts 

## Testing performed to validate your change

