### PR TITLE
[price-feeder] gracefully handle nil response for new provider

### DIFF
--- a/oracle/price-feeder/oracle/provider/binance.go
+++ b/oracle/price-feeder/oracle/provider/binance.go
@@ -104,7 +104,11 @@ func NewBinanceProvider(
 	}
 
 	wsConn, response, err := websocket.DefaultDialer.Dial(wsURL.String(), nil)
-	defer response.Body.Close()
+	defer func() {
+		if response != nil {
+			response.Body.Close()
+		}
+	}()
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to Binance websocket: %w", err)
 	}
@@ -366,7 +370,11 @@ func (p *BinanceProvider) reconnect() error {
 
 	p.logger.Debug().Msg("reconnecting websocket")
 	wsConn, response, err := websocket.DefaultDialer.Dial(p.wsURL.String(), nil)
-	defer response.Body.Close()
+	defer func() {
+		if response != nil {
+			response.Body.Close()
+		}
+	}()
 	if err != nil {
 		return fmt.Errorf("error reconnect to binance websocket: %w", err)
 	}

--- a/oracle/price-feeder/oracle/provider/coinbase.go
+++ b/oracle/price-feeder/oracle/provider/coinbase.go
@@ -113,7 +113,11 @@ func NewCoinbaseProvider(
 	}
 
 	wsConn, response, err := websocket.DefaultDialer.Dial(wsURL.String(), nil)
-	defer response.Body.Close()
+	defer func() {
+		if response != nil {
+			response.Body.Close()
+		}
+	}()
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to Coinbase websocket: %w", err)
 	}
@@ -486,7 +490,11 @@ func (p *CoinbaseProvider) reconnect() error {
 
 	p.logger.Debug().Msg("reconnecting websocket")
 	wsConn, response, err := websocket.DefaultDialer.Dial(p.wsURL.String(), nil)
-	defer response.Body.Close()
+	defer func() {
+		if response != nil {
+			response.Body.Close()
+		}
+	}()
 	if err != nil {
 		return fmt.Errorf("error reconnecting to Coinbase websocket: %w", err)
 	}

--- a/oracle/price-feeder/oracle/provider/gate.go
+++ b/oracle/price-feeder/oracle/provider/gate.go
@@ -126,7 +126,11 @@ func NewGateProvider(
 	}
 
 	wsConn, response, err := websocket.DefaultDialer.Dial(wsURL.String(), nil)
-	defer response.Body.Close()
+	defer func() {
+		if response != nil {
+			response.Body.Close()
+		}
+	}()
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to Gate websocket: %w", err)
 	}
@@ -551,7 +555,11 @@ func (p *GateProvider) reconnect() error {
 
 	p.logger.Debug().Msg("reconnecting websocket")
 	wsConn, response, err := websocket.DefaultDialer.Dial(p.wsURL.String(), nil)
-	defer response.Body.Close()
+	defer func() {
+		if response != nil {
+			response.Body.Close()
+		}
+	}()
 	if err != nil {
 		return fmt.Errorf("error reconnecting to Gate websocket: %w", err)
 	}

--- a/oracle/price-feeder/oracle/provider/huobi.go
+++ b/oracle/price-feeder/oracle/provider/huobi.go
@@ -116,7 +116,11 @@ func NewHuobiProvider(
 	}
 
 	wsConn, response, err := websocket.DefaultDialer.Dial(wsURL.String(), nil)
-	defer response.Body.Close()
+	defer func() {
+		if response != nil {
+			response.Body.Close()
+		}
+	}()
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to Huobi websocket: %w", err)
 	}
@@ -388,7 +392,11 @@ func (p *HuobiProvider) reconnect() error {
 
 	p.logger.Debug().Msg("reconnecting websocket")
 	wsConn, response, err := websocket.DefaultDialer.Dial(p.wsURL.String(), nil)
-	defer response.Body.Close()
+	defer func() {
+		if response != nil {
+			response.Body.Close()
+		}
+	}()
 	if err != nil {
 		return fmt.Errorf("error reconnecting to Huobi websocket: %w", err)
 	}

--- a/oracle/price-feeder/oracle/provider/kraken.go
+++ b/oracle/price-feeder/oracle/provider/kraken.go
@@ -122,7 +122,11 @@ func NewKrakenProvider(
 	}
 
 	wsConn, response, err := websocket.DefaultDialer.Dial(wsURL.String(), nil)
-	defer response.Body.Close()
+	defer func() {
+		if response != nil {
+			response.Body.Close()
+		}
+	}()
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to websocket: %w", err)
 	}
@@ -492,7 +496,11 @@ func (p *KrakenProvider) reconnect() error {
 	p.logger.Debug().Msg("trying to reconnect")
 
 	wsConn, response, err := websocket.DefaultDialer.Dial(p.wsURL.String(), nil)
-	defer response.Body.Close()
+	defer func() {
+		if response != nil {
+			response.Body.Close()
+		}
+	}()
 	if err != nil {
 		return fmt.Errorf("error connecting to Kraken websocket: %w", err)
 	}

--- a/oracle/price-feeder/oracle/provider/mexc.go
+++ b/oracle/price-feeder/oracle/provider/mexc.go
@@ -123,7 +123,11 @@ func NewMexcProvider(
 	}
 
 	wsConn, response, err := websocket.DefaultDialer.Dial(wsURL.String(), nil)
-	defer response.Body.Close()
+	defer func() {
+		if response != nil {
+			response.Body.Close()
+		}
+	}()
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to mexc websocket: %w", err)
 	}
@@ -396,7 +400,11 @@ func (p *MexcProvider) reconnect() error {
 
 	p.logger.Debug().Msg("mexc: reconnecting websocket")
 	wsConn, response, err := websocket.DefaultDialer.Dial(p.wsURL.String(), nil)
-	defer response.Body.Close()
+	defer func() {
+		if response != nil {
+			response.Body.Close()
+		}
+	}()
 	if err != nil {
 		return fmt.Errorf("mexc: error reconnect to mexc websocket: %w", err)
 	}

--- a/oracle/price-feeder/oracle/provider/okx.go
+++ b/oracle/price-feeder/oracle/provider/okx.go
@@ -124,7 +124,11 @@ func NewOkxProvider(
 	}
 
 	wsConn, response, err := websocket.DefaultDialer.Dial(wsURL.String(), nil)
-	defer response.Body.Close()
+	defer func() {
+		if response != nil {
+			response.Body.Close()
+		}
+	}()
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to Okx websocket: %w", err)
 	}
@@ -430,7 +434,11 @@ func (p *OkxProvider) reconnect() error {
 
 	p.logger.Debug().Msg("reconnecting websocket")
 	wsConn, response, err := websocket.DefaultDialer.Dial(p.wsURL.String(), nil)
-	defer response.Body.Close()
+	defer func() {
+		if response != nil {
+			response.Body.Close()
+		}
+	}()
 	if err != nil {
 		return fmt.Errorf("error reconnecting to Okx websocket: %w", err)
 	}


### PR DESCRIPTION
## Describe your changes and provide context
The response from `Dial` can sometimes be nil if there are specific errors. However, the defer assumes that there will never be a nil response, so attempting to get the `Body` from response causes a nil pointer panic. The true correct assumption is that body is non-nil IFF response is non-nil, so we want to have a check for non-nil response prior to `Close`ing the body.

## Testing performed to validate your change

