### PR TITLE
Modify loadtest metric script to output best block

### DIFF
--- a/loadtest/scripts/metrics.py
+++ b/loadtest/scripts/metrics.py
@@ -1,9 +1,10 @@
 import json
 import requests
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 
-def get_block_height_and_timestamp(tx_hash_str):
+DATE_TIME_FMT = "%Y-%m-%dT%H:%M:%S.%f"
+def get_block_height(tx_hash_str):
     res = requests.get(f"http://0.0.0.0:1317/txs/{tx_hash_str}")
     body = res.json()
     if "height" not in body:
@@ -18,7 +19,7 @@ def get_all_heights():
     with open(filename, "r") as f:
         curr = f.readline()[:-1]
         while curr:
-            height = get_block_height_and_timestamp(curr)
+            height = get_block_height(curr)
             curr = f.readline()[:-1]
             if height is not None:
                 seen_heights.add(height)
@@ -26,11 +27,37 @@ def get_all_heights():
 
 def get_block_info(height):
     res = requests.get(f"http://localhost:26657/block?height={height}")
+    #timestamp: "2023-02-27T23:00:44.214Z"
     block = res.json()["block"]
     return {
-        "timestamp": datetime.strptime(block["header"]["time"][:26], "%Y-%m-%dT%H:%M:%S.%f"),
+        "height": height,
+        "timestamp": datetime.strptime(block["header"]["time"][:26], DATE_TIME_FMT),
         "number_of_txs": len(block["data"]["txs"])
     }
+
+def get_block_time(height):
+    return get_block_info(height)["timestamp"]
+
+def get_transaction_breakdown(height):
+    res = requests.get(f"http://localhost:26657/tx_search?query=tx.height%3D{height}&prove=false&page=1&per_page=100000")
+    output = res.json()["txs"]
+    tx_mapping = {}
+    for tx in output:
+        module = None
+        # Ignore failed txs
+        if "code" in tx["tx_result"] and tx["tx_result"]["code"] != 0:
+            continue
+        if "events" in tx["tx_result"]:
+            events = tx["tx_result"]["events"]
+            for event in events:
+                for attr in event["attributes"]:
+                    if attr["key"] == "module":
+                        module = attr["value"]
+        if module not in tx_mapping:
+            tx_mapping[module] = 1
+        else:
+            tx_mapping[module] += 1
+    return tx_mapping
 
 def get_metrics():
     all_heights = get_all_heights()
@@ -48,6 +75,16 @@ def get_metrics():
     total_txs_num = sum([block["number_of_txs"] for block in skip_edge_blocks])
     average_txs_num = total_txs_num / len(skip_edge_blocks)
 
+    # Best block stats:
+    max_tx, max_tx_height, max_tx_height_block_time = -1, -1, -1
+    for block in block_info_list:
+        if block["number_of_txs"] > max_tx:
+            max_tx, max_tx_height, max_tx_height_block_time = block["number_of_txs"], block["height"], block["timestamp"]
+
+  # Block times are set at proposal, so the best estimate is to compare block n with n+1 for block time
+    tx_mapping = get_transaction_breakdown(max_tx_height)
+    max_tx_height_block_time = (get_block_time(max_tx_height + 1) - max_tx_height_block_time) // timedelta(milliseconds=1)
+
     return {
         "Summary (excl. edge block)": {
             "average_block_time": average_block_time,
@@ -60,6 +97,12 @@ def get_metrics():
         "Detail (incl. edge blocks)": {
             "blocks": all_heights,
             "txs_per_block": [block["number_of_txs"] for block in block_info_list]
+        },
+        "Best block": {
+            "height": max_tx_height,
+            "num_txs": max_tx,
+            "tx_mapping": tx_mapping,
+            "block_time_ms": max_tx_height_block_time
         }
     }
 


### PR DESCRIPTION
## Describe your changes and provide context
Adds "Best Block" output:
```
    "Best block": {
        "height": 56602,
        "num_txs": 87,
        "tx_mapping": {
            "bank": 30,
            "oracle": 28
        },
        "block_time_ms": 506
```
It simply picks the best block based on most number of txs and shows you the tx breakdown. Note that sum(tx_mapping) < num_txs b/c the block contains txs that failed checks as well (i.e. code != 0).
## Testing performed to validate your change
Ran and tested
