### PR TITLE
Parse txs rather than events for loadtest metrics script

### DIFF
--- a/loadtest/scripts/metrics.py
+++ b/loadtest/scripts/metrics.py
@@ -122,6 +122,7 @@ def get_metrics():
         },
         "Best block": {
             "height": max_block_height,
+            "tps": max_throughput * 1000,
             "tx_mapping": tx_mapping,
             "block_time_ms": max_block_time
         }

--- a/loadtest/scripts/metrics.py
+++ b/loadtest/scripts/metrics.py
@@ -122,7 +122,6 @@ def get_metrics():
         },
         "Best block": {
             "height": max_block_height,
-            "tps": max_throughput * 1000,
             "tx_mapping": tx_mapping,
             "block_time_ms": max_block_time
         }


### PR DESCRIPTION
## Describe your changes and provide context
Previously we were using events for which not all txs were reported (we neeed to emit events for custom modules).
This instead parses the txs and looks for matching words. This is a short term solution before we actually use some sort of cosmos-sdk / sei-chain python client
## Testing performed to validate your change
Ran and verified different txs showed up:
```
    "Best block": {
        "height": 17773,
        "tps": 212.5984251968504,
        "tx_mapping": {
            "oracle": 53,
            "bank": 1
        },
        "block_time_ms": 254
    }
```