### PR TITLE
[dex] Add events to msgs

### DIFF
--- a/x/dex/keeper/msgserver/msg_server_cancel_orders.go
+++ b/x/dex/keeper/msgserver/msg_server_cancel_orders.go
@@ -19,6 +19,7 @@ func (k msgServer) CancelOrders(goCtx context.Context, msg *types.MsgCancelOrder
 		return nil, err
 	}
 
+	events := []sdk.Event{}
 	for _, cancellation := range msg.GetCancellations() {
 		var allocation *types.Allocation
 		var found bool
@@ -49,8 +50,12 @@ func (k msgServer) CancelOrders(goCtx context.Context, msg *types.MsgCancelOrder
 				PositionDirection: cancellation.PositionDirection,
 			}
 			pairBlockCancellations.Add(&cancel)
+			events = append(events, sdk.NewEvent(
+				types.EventTypeCancelOrder,
+				sdk.NewAttribute(types.AttributeKeyCancellationID, fmt.Sprint(cancellation.Id)),
+			))
 		}
 	}
-
+	ctx.EventManager().EmitEvents(events)
 	return &types.MsgCancelOrdersResponse{}, nil
 }

--- a/x/dex/keeper/msgserver/msg_server_contract_deposit_rent.go
+++ b/x/dex/keeper/msgserver/msg_server_contract_deposit_rent.go
@@ -47,5 +47,10 @@ func (k msgServer) ContractDepositRent(goCtx context.Context, msg *types.MsgCont
 		return nil, err
 	}
 
+	ctx.EventManager().EmitEvent(sdk.NewEvent(
+		types.EventTypeDepositRent,
+		sdk.NewAttribute(types.AttributeKeyContractAddress, msg.ContractAddr),
+		sdk.NewAttribute(types.AttributeKeyRentBalance, fmt.Sprint(contract.RentBalance)),
+	))
 	return &types.MsgContractDepositRentResponse{}, nil
 }

--- a/x/dex/keeper/msgserver/msg_server_register_contract.go
+++ b/x/dex/keeper/msgserver/msg_server_register_contract.go
@@ -65,6 +65,11 @@ func (k msgServer) RegisterContract(goCtx context.Context, msg *types.MsgRegiste
 		return &types.MsgRegisterContractResponse{}, err
 	}
 
+	ctx.EventManager().EmitEvent(sdk.NewEvent(
+		types.EventTypeRegisterContract,
+		sdk.NewAttribute(types.AttributeKeyContractAddress, msg.Contract.ContractAddr),
+	))
+
 	return &types.MsgRegisterContractResponse{}, nil
 }
 

--- a/x/dex/keeper/msgserver/msg_server_register_pairs.go
+++ b/x/dex/keeper/msgserver/msg_server_register_pairs.go
@@ -15,6 +15,7 @@ func (k msgServer) RegisterPairs(goCtx context.Context, msg *types.MsgRegisterPa
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
+	events := []sdk.Event{}
 	// Validation such that only the user who stored the code can register pairs
 	for _, batchPair := range msg.Batchcontractpair {
 		contractAddr := batchPair.ContractAddr
@@ -31,8 +32,16 @@ func (k msgServer) RegisterPairs(goCtx context.Context, msg *types.MsgRegisterPa
 		// tuple and register them individually
 		for _, pair := range batchPair.Pairs {
 			k.AddRegisteredPair(ctx, contractAddr, *pair)
+			events = append(events, sdk.NewEvent(
+				types.EventTypeRegisterPair,
+				sdk.NewAttribute(types.AttributeKeyContractAddress, contractAddr),
+				sdk.NewAttribute(types.AttributeKeyPriceDenom, pair.PriceDenom),
+				sdk.NewAttribute(types.AttributeKeyContractAddress, pair.AssetDenom),
+			))
 		}
 	}
+
+	ctx.EventManager().EmitEvents(events)
 
 	return &types.MsgRegisterPairsResponse{}, nil
 }

--- a/x/dex/keeper/msgserver/msg_server_unregister_contract.go
+++ b/x/dex/keeper/msgserver/msg_server_unregister_contract.go
@@ -38,5 +38,10 @@ func (k msgServer) UnregisterContract(goCtx context.Context, msg *types.MsgUnreg
 	k.DeleteNextOrderID(ctx, msg.ContractAddr)
 	k.DeleteAllRegisteredPairsForContract(ctx, msg.ContractAddr)
 	k.RemoveAllTriggeredOrders(ctx, msg.ContractAddr)
+
+	ctx.EventManager().EmitEvent(sdk.NewEvent(
+		types.EventTypeUnregisterContract,
+		sdk.NewAttribute(types.AttributeKeyContractAddress, msg.ContractAddr),
+	))
 	return &types.MsgUnregisterContractResponse{}, nil
 }

--- a/x/dex/types/events.go
+++ b/x/dex/types/events.go
@@ -1,0 +1,19 @@
+package types
+
+const (
+	EventTypePlaceOrder         = "place_order"
+	EventTypeCancelOrder        = "cancel_order"
+	EventTypeDepositRent        = "deposit_rent"
+	EventTypeRegisterContract   = "register_contract"
+	EventTypeUnregisterContract = "unregister_contract"
+	EventTypeRegisterPair       = "register_pair"
+
+	AttributeKeyOrderID         = "order_id"
+	AttributeKeyCancellationID  = "cancellation_id"
+	AttributeKeyContractAddress = "contract_address"
+	AttributeKeyRentBalance     = "rent_balance"
+	AttributeKeyPriceDenom      = "price_denom"
+	AttributeKeyAssetDenom      = "asset_denom"
+
+	AttributeValueCategory = ModuleName
+)


### PR DESCRIPTION
## Describe your changes and provide context
This adds events for many of the dex messages for potential downstream consumption

## Testing performed to validate your change
Tested locally, and verified on 20 node cluster that TPS isn't materially affected:
```
{
    "Summary (excl. edge block)": {
        "average_block_time": 1.3750865,
        "average_throughput_per_block": 69.85714285714286,
        "average_throughput_per_sec": 50.80199889762779,
        "number_of_full_blocks": 7,
        "full_blocks": [
            3760,
            3762,
            3764,
            3765,
            3766,
            3782,
            3785
        ],
        "total_txs_num": 489
    },
    "Detail (incl. edge blocks)": {
        "blocks": [
            3757,
            3760,
            3762,
            3764,
            3765,
            3766,
            3782,
            3785,
            3802
        ],
        "txs_per_block": [
            103,
            95,
            39,
            108,
            4,
            111,
            29,
            103,
            17
        ]
    },
    "Best block": {
        "height": 3766,
        "tps": 360.38961038961037,
        "tx_mapping": {
            "oracle": 17,
            "dex": 94
        },
        "block_time_ms": 308
    }
}
```
