### PR TITLE
Fix optimistic processing deadlock in upgrade issue

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -945,7 +945,7 @@ func (app *App) ClearOptimisticProcessingInfo() {
 
 func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcessProposal) (*abci.ResponseProcessProposal, error) {
 	if app.optimisticProcessingInfo == nil {
-		completionSignal := make(chan struct{}, 1)
+		completionSignal := make(chan bool, 1)
 		optimisticProcessingInfo := &OptimisticProcessingInfo{
 			Height:     req.Height,
 			Hash:       req.Hash,
@@ -956,18 +956,18 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 		plan, found := app.UpgradeKeeper.GetUpgradePlan(ctx)
 		if found && plan.ShouldExecute(ctx) {
 			app.Logger().Info(fmt.Sprintf("Potential upgrade planned for height=%d skipping optimistic processing", plan.Height))
-			app.optimisticProcessingInfo.Aborted = true
+			optimisticProcessingInfo.Completion <- false
 		} else {
 			go func() {
 				events, txResults, endBlockResp, _ := app.ProcessBlock(ctx, req.Txs, req, req.ProposedLastCommit)
 				optimisticProcessingInfo.Events = events
 				optimisticProcessingInfo.TxRes = txResults
 				optimisticProcessingInfo.EndBlockResp = endBlockResp
-				optimisticProcessingInfo.Completion <- struct{}{}
+				optimisticProcessingInfo.Completion <- true
 			}()
 		}
 	} else if !bytes.Equal(app.optimisticProcessingInfo.Hash, req.Hash) {
-		app.optimisticProcessingInfo.Aborted = true
+		app.optimisticProcessingInfo.Completion <- false
 	}
 	return &abci.ResponseProcessProposal{
 		Status: abci.ResponseProcessProposal_ACCEPT,
@@ -983,8 +983,8 @@ func (app *App) FinalizeBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock)
 	}()
 
 	if app.optimisticProcessingInfo != nil {
-		<-app.optimisticProcessingInfo.Completion
-		if !app.optimisticProcessingInfo.Aborted && bytes.Equal(app.optimisticProcessingInfo.Hash, req.Hash) {
+		completion := <- app.optimisticProcessingInfo.Completion
+		if completion && bytes.Equal(app.optimisticProcessingInfo.Hash, req.Hash) {
 			app.SetProcessProposalStateToCommit()
 			appHash := app.WriteStateToCommitAndGetWorkingHash()
 			resp := app.getFinalizeBlockResponse(appHash, app.optimisticProcessingInfo.Events, app.optimisticProcessingInfo.TxRes, app.optimisticProcessingInfo.EndBlockResp)

--- a/app/app.go
+++ b/app/app.go
@@ -983,7 +983,7 @@ func (app *App) FinalizeBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock)
 	}()
 
 	if app.optimisticProcessingInfo != nil {
-		completion := <- app.optimisticProcessingInfo.Completion
+		completion := <-app.optimisticProcessingInfo.Completion
 		if completion && bytes.Equal(app.optimisticProcessingInfo.Hash, req.Hash) {
 			app.SetProcessProposalStateToCommit()
 			appHash := app.WriteStateToCommitAndGetWorkingHash()

--- a/app/upgrade_test.go
+++ b/app/upgrade_test.go
@@ -45,7 +45,7 @@ func TestSkipOptimisticProcessingOnUpgrade(t *testing.T) {
 		Height: 1,
 	})
 	require.Equal(t, res.Status, abci.ResponseProcessProposal_ACCEPT)
-	require.True(t, testWrapper.App.GetOptimisticProcessingInfo().Aborted)
+	require.False(t, <-testWrapper.App.GetOptimisticProcessingInfo().Completion)
 
 	testWrapper.App.ClearOptimisticProcessingInfo()
 	testWrapper.App.UpgradeKeeper.ScheduleUpgrade(testWrapper.Ctx, types.Plan{
@@ -57,5 +57,5 @@ func TestSkipOptimisticProcessingOnUpgrade(t *testing.T) {
 	})
 
 	require.Equal(t, res.Status, abci.ResponseProcessProposal_ACCEPT)
-	require.False(t, testWrapper.App.GetOptimisticProcessingInfo().Aborted)
+	require.True(t, <-testWrapper.App.GetOptimisticProcessingInfo().Completion)
 }

--- a/app/utils.go
+++ b/app/utils.go
@@ -9,8 +9,7 @@ import (
 type OptimisticProcessingInfo struct {
 	Height     int64
 	Hash       []byte
-	Aborted    bool
-	Completion chan struct{}
+	Completion chan bool
 	// result fields
 	Events       []abci.Event
 	TxRes        []*abci.ExecTxResult

--- a/scripts/initialize_local_test_node.sh
+++ b/scripts/initialize_local_test_node.sh
@@ -8,10 +8,10 @@ read release
 echo
 
 echo "Building..."
-# git fetch --tags -f
-# git checkout $release
-# make install
-# git checkout master
+git fetch --tags -f
+git checkout $release
+make install
+git checkout master
 sudo -S rm -r ~/.sei/
 sudo -S rm -r ~/test_accounts/
 ~/go/bin/seid tendermint unsafe-reset-all

--- a/scripts/initialize_local_test_node.sh
+++ b/scripts/initialize_local_test_node.sh
@@ -8,10 +8,10 @@ read release
 echo
 
 echo "Building..."
-git fetch --tags -f
-git checkout $release
-make install
-git checkout master
+# git fetch --tags -f
+# git checkout $release
+# make install
+# git checkout master
 sudo -S rm -r ~/.sei/
 sudo -S rm -r ~/test_accounts/
 ~/go/bin/seid tendermint unsafe-reset-all


### PR DESCRIPTION
## Describe your changes and provide context
This fixes the deadlock issue of the optimistic processing (when it is disabled by an upgrade). When the optimistic processing is aborted: https://github.com/sei-protocol/sei-chain/blob/master/app/app.go#L959, the FinalizeBlocker is stuck by the op.Completion channel here https://github.com/sei-protocol/sei-chain/blob/master/app/app.go#L986

This PR replaces the `Abort` with a buffered boolean channel (size 1) `Completion` to signal whether an OP succeeds or gets aborted

## Testing performed to validate your change
- e2e test locally
- unit test
