### PR TITLE
Fix race condition when optimisticProcessingInfo is not nil

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -269,7 +269,7 @@ func TestProcessOracleAndOtherTxsSuccess(t *testing.T) {
 	require.Equal(t, 2, len(txResults))
 }
 
-// we want to test all possible deadlock paths in this test, i.e. we will test every scenario followed a different one 
+// we want to test all possible deadlock paths in this test, i.e. we will test every scenario followed a different one
 func TestOptimisticProcessingDeadlocks(t *testing.T) {
 	tm := time.Now().UTC()
 	valPub := secp256k1.GenPrivKey().PubKey()
@@ -293,7 +293,7 @@ func TestOptimisticProcessingDeadlocks(t *testing.T) {
 		Height: 1,
 	})
 	testWrapper.App.ProcessProposalHandler(testCtx.WithBlockHeight(4), &abci.RequestProcessProposal{
-		Hash: []byte("test_hash"),
+		Hash:   []byte("test_hash"),
 		Height: 1,
 	})
 	testWrapper.App.FinalizeBlocker(testWrapper.Ctx, &abci.RequestFinalizeBlock{
@@ -332,7 +332,7 @@ func TestOptimisticProcessingDeadlocks(t *testing.T) {
 		Height: 1,
 	})
 	testWrapper.App.ProcessProposalHandler(testCtx.WithBlockHeight(4), &abci.RequestProcessProposal{
-		Hash: []byte("test_hash"),
+		Hash:   []byte("test_hash"),
 		Height: 1,
 	})
 	testWrapper.App.FinalizeBlocker(testWrapper.Ctx, &abci.RequestFinalizeBlock{
@@ -350,4 +350,3 @@ func TestOptimisticProcessingDeadlocks(t *testing.T) {
 		Height: 1,
 	})
 }
-

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -59,6 +59,20 @@ func NewTestWrapper(t *testing.T, tm time.Time, valPub crptotypes.PubKey) *TestW
 	return wrapper
 }
 
+func (s *TestWrapper) PopulateOptimisticProcessingInfo(ctx sdk.Context, req *abci.RequestProcessProposal) {
+	optimisticProcessingInfo := OptimisticProcessingInfo{
+		Height:     req.Height,
+		Hash:       req.Hash,
+	}
+
+	events, txResults, endBlockResp, _ := s.App.ProcessBlock(ctx, req.Txs, req, req.ProposedLastCommit)
+	optimisticProcessingInfo.Events = events
+	optimisticProcessingInfo.TxRes = txResults
+	optimisticProcessingInfo.EndBlockResp = endBlockResp
+
+	s.App.optimisticProcessingInfo = &optimisticProcessingInfo
+}
+
 func (s *TestWrapper) FundAcc(acc sdk.AccAddress, amounts sdk.Coins) {
 	err := s.App.BankKeeper.MintCoins(s.Ctx, minttypes.ModuleName, amounts)
 	s.Require().NoError(err)

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -61,8 +61,8 @@ func NewTestWrapper(t *testing.T, tm time.Time, valPub crptotypes.PubKey) *TestW
 
 func (s *TestWrapper) PopulateOptimisticProcessingInfo(ctx sdk.Context, req *abci.RequestProcessProposal) {
 	optimisticProcessingInfo := OptimisticProcessingInfo{
-		Height:     req.Height,
-		Hash:       req.Hash,
+		Height: req.Height,
+		Hash:   req.Hash,
 	}
 
 	events, txResults, endBlockResp, _ := s.App.ProcessBlock(ctx, req.Txs, req, req.ProposedLastCommit)


### PR DESCRIPTION
## Describe your changes and provide context
This PR adds a fix for race condition in which `optimisticProcessingInfo` is not nil and previous channel was not reset.

## Testing performed to validate your change
- e2e with `optimisticProcessingInfo` is nil scenario
- unit tests
