### PR TITLE
Continously emit version metrics

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -339,6 +339,8 @@ type App struct {
 
 	// batchVerifier *ante.SR25519BatchVerifier
 	txDecoder sdk.TxDecoder
+
+	versionInfo version.Info
 }
 
 // New returns a reference to an initialized blockchain app
@@ -399,7 +401,8 @@ func New(
 			Tracer:        &tr,
 			TracerContext: context.Background(),
 		},
-		txDecoder: encodingConfig.TxConfig.TxDecoder(),
+		txDecoder:   encodingConfig.TxConfig.TxDecoder(),
+		versionInfo: version.NewInfo(),
 	}
 
 	app.ParamsKeeper = initParamsKeeper(appCodec, cdc, keys[paramstypes.StoreKey], tkeys[paramstypes.TStoreKey])
@@ -895,15 +898,7 @@ func (app App) GetBaseApp() *baseapp.BaseApp { return app.BaseApp }
 
 // BeginBlocker application updates every begin block
 func (app *App) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
-	// newCtx := ctx.WithContext(
-	// 	context.WithValue(ctx.Context(), dexcache.GOCTX_KEY, dexcache.NewOrders()),
-	// )
-	// app.Logger().Info(fmt.Sprintf("BeginBlocker context %s", newCtx.Context().Value(dexcache.GOCTX_KEY).(dexcache.Orders)))
-	if !EmittedSeidVersionMetric {
-		verInfo := version.NewInfo()
-		metrics.GaugeSeidVersionAndCommit(verInfo.Version, verInfo.GitCommit)
-		EmittedSeidVersionMetric = true
-	}
+	metrics.GaugeSeidVersionAndCommit(app.versionInfo.Version, app.versionInfo.GitCommit)
 	return app.mm.BeginBlock(ctx, req)
 }
 

--- a/x/oracle/keeper/test_utils.go
+++ b/x/oracle/keeper/test_utils.go
@@ -1,4 +1,4 @@
-// nolint
+//nolint
 package keeper
 
 import (

--- a/x/oracle/simulation/operations.go
+++ b/x/oracle/simulation/operations.go
@@ -65,7 +65,7 @@ func WeightedOperations(
 }
 
 // SimulateMsgAggregateExchangeRateVote generates a MsgAggregateExchangeRateVote with random values.
-// nolint: funlen
+//nolint: funlen
 func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
@@ -122,7 +122,7 @@ func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankK
 }
 
 // SimulateMsgDelegateFeedConsent generates a MsgDelegateFeedConsent with random values.
-// nolint: funlen
+//nolint: funlen
 func SimulateMsgDelegateFeedConsent(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,


### PR DESCRIPTION
## Describe your changes and provide context
This is so that it's easier to track what versions our nodes are running between loadtest clusters and our testnet/devnet clusters 

## Testing performed to validate your change
Ran locally 
