### PR TITLE
Fix deadlock when optimistic processing is skipped for the 1st proposal

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -952,6 +952,7 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 		if found && plan.ShouldExecute(ctx) {
 			app.Logger().Info(fmt.Sprintf("Potential upgrade planned for height=%d skipping optimistic processing", plan.Height))
 			app.optimisticProcessingInfo.Aborted = true
+			app.optimisticProcessingInfo.Completion <- struct{}{}
 		} else {
 			go func() {
 				events, txResults, endBlockResp, _ := app.ProcessBlock(ctx, req.Txs, req, req.ProposedLastCommit)


### PR DESCRIPTION
## Describe your changes and provide context
Optimistic processing may be skipped even for the first proposal of a height for reasons like upgrade. In those cases we want to mark completion immediately so that FinalizeBlocker won't be blocked.

The original fix was reverted due to concerns of regression on the non-determinism problem. 

## Testing performed to validate your change

