### PR TITLE
[Oak Audit] Add check for non-existent transaction

### DIFF
--- a/x/nitro/keeper/msg_server.go
+++ b/x/nitro/keeper/msg_server.go
@@ -76,7 +76,11 @@ func (server msgServer) SubmitFraudChallenge(goCtx context.Context, msg *types.M
 	txsBz := [][]byte{}
 	slot := msg.StartSlot
 	for slot <= msg.EndSlot {
-		bz, _ := server.GetTransactionData(ctx, slot)
+		bz, err := server.GetTransactionData(ctx, slot)
+		if err != nil {
+			return nil, types.ErrFindingTransctionData
+		}
+
 		txsBz = append(txsBz, bz...)
 		slot++
 	}

--- a/x/nitro/keeper/msg_server_test.go
+++ b/x/nitro/keeper/msg_server_test.go
@@ -79,11 +79,34 @@ func TestSubmitFraudChallenge(t *testing.T) {
 		Txs:       []string{"5678"},
 	})
 	require.Nil(t, err)
+	_, err = server.RecordTransactionData(sdk.WrapSDKContext(ctx), &types.MsgRecordTransactionData{
+		Sender:    "sei14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sh9m79m",
+		Slot:      2,
+		StateRoot: hex.EncodeToString(stateRoot),
+		Txs:       []string{"091011"},
+	})
+	require.Nil(t, err)
+	_, err = server.RecordTransactionData(sdk.WrapSDKContext(ctx), &types.MsgRecordTransactionData{
+		Sender:    "sei14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sh9m79m",
+		Slot:      4,
+		StateRoot: hex.EncodeToString(stateRoot),
+		Txs:       []string{"121314"},
+	})
+	require.Nil(t, err)
+
+	// err getting non-existent transaction data
+	_, err = server.SubmitFraudChallenge(sdk.WrapSDKContext(ctx), &types.MsgSubmitFraudChallenge{
+		StartSlot:        0,
+		EndSlot:          4,
+		FraudStatePubKey: "123",
+		MerkleProof:      proof,
+	})
+	require.Equal(t, err, types.ErrFindingTransctionData)
 
 	// end slot doesn't exist
 	_, err = server.SubmitFraudChallenge(sdk.WrapSDKContext(ctx), &types.MsgSubmitFraudChallenge{
 		StartSlot:        0,
-		EndSlot:          2,
+		EndSlot:          5,
 		FraudStatePubKey: "123",
 		MerkleProof:      proof,
 	})

--- a/x/nitro/types/errors.go
+++ b/x/nitro/types/errors.go
@@ -13,4 +13,5 @@ var (
 	ErrInvalidAccountState     = sdkerrors.Register(ModuleName, 4, "Error invalid provided account state")
 	ErrInvalidFraudStatePubkey = sdkerrors.Register(ModuleName, 6, "Error invalid provided fraud state public key")
 	ErrFraudChallengeDisabled  = sdkerrors.Register(ModuleName, 7, "Error fraud challenge is not enabled yet")
+	ErrFindingTransctionData   = sdkerrors.Register(ModuleName, 8, "Error getting transaction data for the given slots")
 )


### PR DESCRIPTION
## Describe your changes and provide context
Unchecked error on SubmitFraudChallenge might cause adding an empty transaction. n x/nitro/keeper/msg_server.go:76 there is no check for an error on server.GetTransactionData. In case there was an error, it will mean that the transaction was not found but still added into the slice of transactions. This will be caught later on in the replay function. However, it is unnecessary to perform extra computations on input that is known to fail.

This PR adds a check for non-existent transaction data.

## Testing performed to validate your change
- unit test
