### PR TITLE
Do not make Sudo call if parameters are empty

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -952,6 +952,7 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 		if found && plan.ShouldExecute(ctx) {
 			app.Logger().Info(fmt.Sprintf("Potential upgrade planned for height=%d skipping optimistic processing", plan.Height))
 			app.optimisticProcessingInfo.Aborted = true
+			app.optimisticProcessingInfo.Completion <- struct{}{}
 		} else {
 			go func() {
 				events, txResults, endBlockResp, _ := app.ProcessBlock(ctx, req.Txs, req, req.ProposedLastCommit)

--- a/x/dex/contract/abci.go
+++ b/x/dex/contract/abci.go
@@ -209,6 +209,9 @@ func handleFinalizedBlocks(ctx context.Context, sdkCtx sdk.Context, env *environ
 		if !contractsNeedHook.Contains(contractAddr) {
 			return true
 		}
+		if len(finalizeBlockMsg.FinalizeBlock.Results) == 0 {
+			return true
+		}
 		if _, err := dexkeeperutils.CallContractSudo(sdkCtx, keeper, contractAddr, finalizeBlockMsg, dexutils.ZeroUserProvidedGas); err != nil {
 			sdkCtx.Logger().Error(fmt.Sprintf("Error calling FinalizeBlock of %s", contractAddr))
 			env.failedContractAddresses.Add(contractAddr)

--- a/x/dex/contract/execution.go
+++ b/x/dex/contract/execution.go
@@ -239,7 +239,7 @@ func HandleExecutionForContract(
 	tracer *otrace.Tracer,
 ) (map[string]dextypeswasm.ContractOrderResult, []*types.SettlementEntry, error) {
 	executionStart := time.Now()
-	defer telemetry.ModuleSetGauge(types.ModuleName, float32(time.Since(executionStart).Milliseconds()), "handle_execution_for_contract_ms")
+	defer telemetry.ModuleMeasureSince(types.ModuleName, float32(time.Since(executionStart).Milliseconds()), "handle_execution_for_contract_ms")
 	contractAddr := contract.ContractAddr
 	typedContractAddr := dextypesutils.ContractAddress(contractAddr)
 	orderResults := map[string]dextypeswasm.ContractOrderResult{}

--- a/x/dex/contract/execution.go
+++ b/x/dex/contract/execution.go
@@ -239,7 +239,7 @@ func HandleExecutionForContract(
 	tracer *otrace.Tracer,
 ) (map[string]dextypeswasm.ContractOrderResult, []*types.SettlementEntry, error) {
 	executionStart := time.Now()
-	defer telemetry.ModuleMeasureSince(types.ModuleName, float32(time.Since(executionStart).Milliseconds()), "handle_execution_for_contract_ms")
+	defer telemetry.ModuleMeasureSince(types.ModuleName, executionStart, "handle_execution_for_contract_ms")
 	contractAddr := contract.ContractAddr
 	typedContractAddr := dextypesutils.ContractAddress(contractAddr)
 	orderResults := map[string]dextypeswasm.ContractOrderResult{}

--- a/x/dex/contract/settlement.go
+++ b/x/dex/contract/settlement.go
@@ -24,6 +24,9 @@ func callSettlementHook(
 	dexkeeper *keeper.Keeper,
 	settlementEntries []*types.SettlementEntry,
 ) error {
+	if len(settlementEntries) == 0 {
+		return nil
+	}
 	_, currentEpoch := dexkeeper.IsNewEpoch(ctx)
 	nativeSettlementMsg := dextypeswasm.SudoSettlementMsg{
 		Settlement: types.Settlements{

--- a/x/dex/keeper/abci/end_block_cancel_orders.go
+++ b/x/dex/keeper/abci/end_block_cancel_orders.go
@@ -20,6 +20,9 @@ func (w KeeperWrapper) HandleEBCancelOrders(ctx context.Context, sdkCtx sdk.Cont
 
 	typedContractAddr := typesutils.ContractAddress(contractAddr)
 	msg := w.getCancelSudoMsg(sdkCtx, typedContractAddr, registeredPairs)
+	if len(msg.OrderCancellations.IdsToCancel) == 0 {
+		return nil
+	}
 	userProvidedGas := w.GetParams(sdkCtx).DefaultGasPerCancel * uint64(len(msg.OrderCancellations.IdsToCancel))
 	if _, err := utils.CallContractSudo(sdkCtx, w.Keeper, contractAddr, msg, userProvidedGas); err != nil {
 		sdkCtx.Logger().Error(fmt.Sprintf("Error during cancellation: %s", err.Error()))

--- a/x/dex/keeper/abci/end_block_deposit.go
+++ b/x/dex/keeper/abci/end_block_deposit.go
@@ -22,6 +22,9 @@ func (w KeeperWrapper) HandleEBDeposit(ctx context.Context, sdkCtx sdk.Context, 
 
 	typedContractAddr := typesutils.ContractAddress(contractAddr)
 	msg := w.GetDepositSudoMsg(sdkCtx, typedContractAddr)
+	if msg.IsEmpty() {
+		return nil
+	}
 	_, err := utils.CallContractSudo(sdkCtx, w.Keeper, contractAddr, msg, dexutils.ZeroUserProvidedGas) // deposit
 	if err != nil {
 		sdkCtx.Logger().Error(fmt.Sprintf("Error during deposit: %s", err.Error()))

--- a/x/dex/keeper/abci/end_block_place_orders.go
+++ b/x/dex/keeper/abci/end_block_place_orders.go
@@ -30,6 +30,9 @@ func (w KeeperWrapper) HandleEBPlaceOrders(ctx context.Context, sdkCtx sdk.Conte
 	responses := []wasm.SudoOrderPlacementResponse{}
 
 	for _, msg := range msgs {
+		if msg.IsEmpty() {
+			continue
+		}
 		userProvidedGas := w.GetParams(sdkCtx).DefaultGasPerOrder * uint64(len(msg.OrderPlacements.Orders))
 		data, err := utils.CallContractSudo(sdkCtx, w.Keeper, contractAddr, msg, userProvidedGas)
 		if err != nil {

--- a/x/dex/types/wasm/order_placement.go
+++ b/x/dex/types/wasm/order_placement.go
@@ -15,6 +15,10 @@ type OrderPlacementMsgDetails struct {
 	Deposits []types.ContractDepositInfo `json:"deposits"`
 }
 
+func (m *SudoOrderPlacementMsg) IsEmpty() bool {
+	return len(m.OrderPlacements.Deposits) == 0 && len(m.OrderPlacements.Orders) == 0
+}
+
 type SudoOrderPlacementResponse struct {
 	UnsuccessfulOrders []UnsuccessfulOrder `json:"unsuccessful_orders"`
 }


### PR DESCRIPTION
## Describe your changes and provide context
To reduce overheads we will skip sudo calls if the arguments are empty (e.g. no order in order placement call, no settlement in settlement call, etc.)

## Testing performed to validate your change
WIP
