### PR TITLE
Bump sei-cosmos and sei-tednermint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -269,10 +269,10 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.3
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.4
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.3
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
-	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.178
+	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.179
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1067,12 +1067,12 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.2.3 h1:Jt3UD1nm7o//IV+L4SmhtAGjBGJIjgYqEh8HL7t058g=
-github.com/sei-protocol/sei-cosmos v0.2.3/go.mod h1:LUhhplOtRXliV1x17gbOptKPy90xSK0Sxv8zmgsMvTY=
+github.com/sei-protocol/sei-cosmos v0.2.4 h1:t4lQYtoUcLWjoisQtwuppYgL1xKV7TLTnnNmoTvj5Ac=
+github.com/sei-protocol/sei-cosmos v0.2.4/go.mod h1:LUhhplOtRXliV1x17gbOptKPy90xSK0Sxv8zmgsMvTY=
 github.com/sei-protocol/sei-iavl v0.1.3 h1:0hvW1NtmBlZ7ZkerQcM/n+2tFKg0vUlYWK8q/OeuCgw=
 github.com/sei-protocol/sei-iavl v0.1.3/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
-github.com/sei-protocol/sei-tendermint v0.1.178 h1:7ozXwpCvNrkU7UaaKcbHhtB/nRT0jQC3sC9VZJnK+Ak=
-github.com/sei-protocol/sei-tendermint v0.1.178/go.mod h1:+BtDvAwTkE64BlxzpH9ZP7S6vUYT9wRXiZa/WW8/o4g=
+github.com/sei-protocol/sei-tendermint v0.1.179 h1:ihHiqMIeiOE85rgy8YsQXu/BgdTYOCVdqGSLGq0jA2Q=
+github.com/sei-protocol/sei-tendermint v0.1.179/go.mod h1:+BtDvAwTkE64BlxzpH9ZP7S6vUYT9wRXiZa/WW8/o4g=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
 github.com/sei-protocol/sei-wasmd v0.0.1 h1:dRvdapc1sqWxhIB2+DKS5LfilFjOsaFwWkGkSWwQIow=


### PR DESCRIPTION
## Describe your changes and provide context

Thought we should bump up sei-cosmos and sei-tendermint and let some chains run with the new cosmos and tendermint changes if we're planning to do an upgrade soon

Had a chain run over night and no issues so far
![image](https://user-images.githubusercontent.com/18161326/225925457-2b86fb18-f7b4-4dfe-9f21-8e2dcc69f7d2.png)

## Testing performed to validate your change

