### PR TITLE
Record and emit transaction, metrics and order counter 

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1015,6 +1015,8 @@ func (app *App) RecordAndEmitMetrics(ctx sdk.Context) {
 	for metricName, value := range *(app.metricCounter) {
 		metrics.IncrementThroughputMetrics(metricName, float32(value))
 	}
+
+	ctx.ContextMemCache().Clear()
 }
 
 func (app *App) DeliverTxWithResult(ctx sdk.Context, tx []byte) *abci.ExecTxResult {

--- a/app/app.go
+++ b/app/app.go
@@ -1015,7 +1015,7 @@ func (app *App) RecordAndEmitMetrics(ctx sdk.Context) {
 
 	for metricName, value := range *(app.metricCounter) {
 		app.Logger().Info("debug metrics", "emit metricName", metricName, "value", value, "height", height)
-		metrics.IncrementThroughputMetrics(metricName, value)
+		metrics.SetThroughputMetric(metricName, value)
 	}
 
 	ctx.ContextMemCache().Clear()

--- a/app/app.go
+++ b/app/app.go
@@ -403,8 +403,8 @@ func New(
 		tracingInfo: &tracing.Info{
 			Tracer: &tr,
 		},
-		txDecoder:   encodingConfig.TxConfig.TxDecoder(),
-		versionInfo: version.NewInfo(),
+		txDecoder:     encodingConfig.TxConfig.TxDecoder(),
+		versionInfo:   version.NewInfo(),
 		metricCounter: &map[string]float32{},
 	}
 	app.tracingInfo.SetContext(context.Background())

--- a/app/app.go
+++ b/app/app.go
@@ -1023,6 +1023,10 @@ func (app *App) DeliverTxWithResult(ctx sdk.Context, tx []byte) *abci.ExecTxResu
 	deliverTxResp := app.DeliverTx(ctx, abci.RequestDeliverTx{
 		Tx: tx,
 	})
+
+	ctx.ContextMemCache().IncrMetricCounter(uint32(deliverTxResp.GasWanted), "gas_wanted")
+	ctx.ContextMemCache().IncrMetricCounter(uint32(deliverTxResp.GasUsed), "gas_used")
+
 	return &abci.ExecTxResult{
 		Code:      deliverTxResp.Code,
 		Data:      deliverTxResp.Data,

--- a/app/app.go
+++ b/app/app.go
@@ -964,6 +964,7 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 				optimisticProcessingInfo.TxRes = txResults
 				optimisticProcessingInfo.EndBlockResp = endBlockResp
 				optimisticProcessingInfo.Completion <- struct{}{}
+				app.RecordAndEmitMetrics(ctx)
 			}()
 		}
 	} else if !bytes.Equal(app.optimisticProcessingInfo.Hash, req.Hash) {
@@ -975,8 +976,6 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 }
 
 func (app *App) FinalizeBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock) (*abci.ResponseFinalizeBlock, error) {
-	defer app.RecordAndEmitMetrics(ctx)
-
 	startTime := time.Now()
 	defer func() {
 		app.optimisticProcessingInfo = nil
@@ -995,6 +994,7 @@ func (app *App) FinalizeBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock)
 	}
 	ctx.Logger().Info("optimistic processing ineligible")
 	events, txResults, endBlockResp, _ := app.ProcessBlock(ctx, req.Txs, req, req.DecidedLastCommit)
+	app.RecordAndEmitMetrics(ctx)
 
 	app.SetDeliverStateToCommit()
 	appHash := app.WriteStateToCommitAndGetWorkingHash()
@@ -1003,7 +1003,7 @@ func (app *App) FinalizeBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock)
 }
 
 func (app *App) RecordAndEmitMetrics(ctx sdk.Context) {
-	app.Logger().Info("Recording and emitting metrics")
+	app.Logger().Info("Recording and emitting metrics", "size", len(*ctx.ContextMemCache().GetMetricCounters()))
 	for metricName, value := range *ctx.ContextMemCache().GetMetricCounters() {
 		(*app.metricCounter)[metricName] += value
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -341,6 +341,9 @@ type App struct {
 	txDecoder sdk.TxDecoder
 
 	versionInfo version.Info
+
+	// Stores mapping counter name to counter value
+	metricCounter *map[string]uint64
 }
 
 // New returns a reference to an initialized blockchain app

--- a/app/app.go
+++ b/app/app.go
@@ -405,6 +405,7 @@ func New(
 		},
 		txDecoder:   encodingConfig.TxConfig.TxDecoder(),
 		versionInfo: version.NewInfo(),
+		metricCounter: &map[string]uint64{},
 	}
 	app.tracingInfo.SetContext(context.Background())
 
@@ -1001,6 +1002,7 @@ func (app *App) FinalizeBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock)
 }
 
 func (app *App) RecordAndEmitMetrics(ctx sdk.Context) {
+	app.Logger().Info("Recording and emitting metrics")
 	for metricName, value := range *ctx.ContextMemCache().GetMetricCounters() {
 		(*app.metricCounter)[metricName] += value
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -1008,13 +1008,11 @@ func (app *App) RecordAndEmitMetrics(ctx sdk.Context) {
 	}
 
 	for metricName, value := range *ctx.ContextMemCache().GetMetricCounters() {
-		app.Logger().Info("debug metrics", "metricName", metricName, "value", value, "height", height)
 		(*app.metricCounter)[metricName] += float32(value)
 	}
 	(*app.metricCounter)["last_updated_height"] = height
 
 	for metricName, value := range *(app.metricCounter) {
-		app.Logger().Info("debug metrics", "emit metricName", metricName, "value", value, "height", height)
 		metrics.SetThroughputMetric(metricName, value)
 	}
 

--- a/app/app.go
+++ b/app/app.go
@@ -1220,10 +1220,10 @@ func (app *App) BuildDependenciesAndRunTxs(ctx sdk.Context, txs [][]byte) ([]*ab
 
 	dependencyDag, err := app.AccessControlKeeper.BuildDependencyDag(ctx, app.txDecoder, app.GetAnteDepGenerator(), txs)
 
+	// Start with a fresh state for the MemCache
+	ctx = ctx.WithContextMemCache(sdk.NewContextMemCache())
 	switch err {
 	case nil:
-		// Start with a fresh state for the MemCache
-		ctx = ctx.WithContextMemCache(sdk.NewContextMemCache())
 		txResults, ctx = app.ProcessTxs(ctx, txs, dependencyDag, app.ProcessBlockConcurrent)
 	case acltypes.ErrGovMsgInBlock:
 		ctx.Logger().Info(fmt.Sprintf("Gov msg found while building DAG, processing synchronously: %s", err))

--- a/app/app.go
+++ b/app/app.go
@@ -405,7 +405,7 @@ func New(
 		},
 		txDecoder:   encodingConfig.TxConfig.TxDecoder(),
 		versionInfo: version.NewInfo(),
-		metricCounter: &map[string]uint64{},
+		metricCounter: &map[string]float32{},
 	}
 	app.tracingInfo.SetContext(context.Background())
 

--- a/app/app.go
+++ b/app/app.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
-	"github.com/cosmos/iavl/internal/logger"
 
 	"github.com/sei-protocol/sei-chain/aclmapping"
 	aclutils "github.com/sei-protocol/sei-chain/aclmapping/utils"
@@ -1003,7 +1002,7 @@ func (app *App) FinalizeBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock)
 
 func (app *App) RecordAndEmitMetrics(ctx sdk.Context) {
 	if (*app.metricCounter)["last_updated_height"] == uint64(ctx.BlockHeight()) {
-		logger.Debug("Metrics already recorded for this block", "height", ctx.BlockHeight())
+		app.Logger().Debug("Metrics already recorded for this block", "height", ctx.BlockHeight())
 		return
 	}
 

--- a/app/app.go
+++ b/app/app.go
@@ -975,6 +975,8 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 }
 
 func (app *App) FinalizeBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock) (*abci.ResponseFinalizeBlock, error) {
+	defer app.RecordAndEmitMetrics(ctx)
+
 	startTime := time.Now()
 	defer func() {
 		app.optimisticProcessingInfo = nil
@@ -994,7 +996,6 @@ func (app *App) FinalizeBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock)
 	ctx.Logger().Info("optimistic processing ineligible")
 	events, txResults, endBlockResp, _ := app.ProcessBlock(ctx, req.Txs, req, req.DecidedLastCommit)
 
-	app.RecordAndEmitMetrics(ctx)
 	app.SetDeliverStateToCommit()
 	appHash := app.WriteStateToCommitAndGetWorkingHash()
 	resp := app.getFinalizeBlockResponse(appHash, events, txResults, endBlockResp)

--- a/app/app.go
+++ b/app/app.go
@@ -1008,6 +1008,7 @@ func (app *App) RecordAndEmitMetrics(ctx sdk.Context) {
 
 	app.Logger().Info("Recording and emitting metrics", "size", len(*ctx.ContextMemCache().GetMetricCounters()))
 	for metricName, value := range *ctx.ContextMemCache().GetMetricCounters() {
+		app.Logger().Info("debug metrics", "metricName", metricName, "value", value, "height", ctx.BlockHeight())
 		(*app.metricCounter)[metricName] += value
 	}
 	(*app.metricCounter)["last_updated_height"] = uint64(ctx.BlockHeight())

--- a/app/app.go
+++ b/app/app.go
@@ -964,7 +964,6 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 				optimisticProcessingInfo.TxRes = txResults
 				optimisticProcessingInfo.EndBlockResp = endBlockResp
 				optimisticProcessingInfo.Completion <- struct{}{}
-				app.RecordAndEmitMetrics(ctx)
 			}()
 		}
 	} else if !bytes.Equal(app.optimisticProcessingInfo.Hash, req.Hash) {
@@ -994,7 +993,6 @@ func (app *App) FinalizeBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock)
 	}
 	ctx.Logger().Info("optimistic processing ineligible")
 	events, txResults, endBlockResp, _ := app.ProcessBlock(ctx, req.Txs, req, req.DecidedLastCommit)
-	app.RecordAndEmitMetrics(ctx)
 
 	app.SetDeliverStateToCommit()
 	appHash := app.WriteStateToCommitAndGetWorkingHash()
@@ -1309,7 +1307,7 @@ func (app *App) ProcessBlock(ctx sdk.Context, txs [][]byte, req BlockProcessRequ
 	})
 
 	events = append(events, endBlockResp.Events...)
-
+	app.RecordAndEmitMetrics(ctx)
 	return events, txResults, endBlockResp, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -269,7 +269,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317214326-51fc406c0711
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317225428-53bb8f419543
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.3
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4

--- a/go.mod
+++ b/go.mod
@@ -269,7 +269,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.5-0.20230318010240-8584b787f3e5
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.5
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.3
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4

--- a/go.mod
+++ b/go.mod
@@ -269,7 +269,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317210849-d0376cf2593a
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317211153-9b7bd6a99381
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.3
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4

--- a/go.mod
+++ b/go.mod
@@ -269,7 +269,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317195457-cb9b7a97815a
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317210849-d0376cf2593a
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.3
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4

--- a/go.mod
+++ b/go.mod
@@ -269,7 +269,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317232516-b23668f8dc0f
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.5-0.20230318010240-8584b787f3e5
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.3
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4

--- a/go.mod
+++ b/go.mod
@@ -269,7 +269,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.4
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317195457-cb9b7a97815a
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.3
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4

--- a/go.mod
+++ b/go.mod
@@ -269,7 +269,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317225428-53bb8f419543
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317232516-b23668f8dc0f
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.3
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4

--- a/go.mod
+++ b/go.mod
@@ -269,7 +269,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317211153-9b7bd6a99381
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317214326-51fc406c0711
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.3
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4

--- a/go.sum
+++ b/go.sum
@@ -1067,8 +1067,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317214326-51fc406c0711 h1:KD5KLqLK4LRU42Xa1F/UBP7lmZ7OFiqeCuIbJGfzMYA=
-github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317214326-51fc406c0711/go.mod h1:LUhhplOtRXliV1x17gbOptKPy90xSK0Sxv8zmgsMvTY=
+github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317225428-53bb8f419543 h1:Iwl8M2nJrGC37V2Haik+BzJ657XxpaE6sE1XvWoo1FM=
+github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317225428-53bb8f419543/go.mod h1:LUhhplOtRXliV1x17gbOptKPy90xSK0Sxv8zmgsMvTY=
 github.com/sei-protocol/sei-iavl v0.1.3 h1:0hvW1NtmBlZ7ZkerQcM/n+2tFKg0vUlYWK8q/OeuCgw=
 github.com/sei-protocol/sei-iavl v0.1.3/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-tendermint v0.1.179 h1:ihHiqMIeiOE85rgy8YsQXu/BgdTYOCVdqGSLGq0jA2Q=

--- a/go.sum
+++ b/go.sum
@@ -1067,8 +1067,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.2.4 h1:t4lQYtoUcLWjoisQtwuppYgL1xKV7TLTnnNmoTvj5Ac=
-github.com/sei-protocol/sei-cosmos v0.2.4/go.mod h1:LUhhplOtRXliV1x17gbOptKPy90xSK0Sxv8zmgsMvTY=
+github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317195457-cb9b7a97815a h1:afzTZ7kUfhU7z0b5vNkVlsliW+cNvnDD7nOmZspxsHM=
+github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317195457-cb9b7a97815a/go.mod h1:LUhhplOtRXliV1x17gbOptKPy90xSK0Sxv8zmgsMvTY=
 github.com/sei-protocol/sei-iavl v0.1.3 h1:0hvW1NtmBlZ7ZkerQcM/n+2tFKg0vUlYWK8q/OeuCgw=
 github.com/sei-protocol/sei-iavl v0.1.3/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-tendermint v0.1.179 h1:ihHiqMIeiOE85rgy8YsQXu/BgdTYOCVdqGSLGq0jA2Q=

--- a/go.sum
+++ b/go.sum
@@ -1067,8 +1067,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317210849-d0376cf2593a h1:XJmc8dY1mKR1Y46kx5c2aik/5G+1EnkZvmZPyi/7XgQ=
-github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317210849-d0376cf2593a/go.mod h1:LUhhplOtRXliV1x17gbOptKPy90xSK0Sxv8zmgsMvTY=
+github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317211153-9b7bd6a99381 h1:DbPIVUv9kbko5VJvVYD17ZRYy0Rz7cP5j8TB5YDexj0=
+github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317211153-9b7bd6a99381/go.mod h1:LUhhplOtRXliV1x17gbOptKPy90xSK0Sxv8zmgsMvTY=
 github.com/sei-protocol/sei-iavl v0.1.3 h1:0hvW1NtmBlZ7ZkerQcM/n+2tFKg0vUlYWK8q/OeuCgw=
 github.com/sei-protocol/sei-iavl v0.1.3/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-tendermint v0.1.179 h1:ihHiqMIeiOE85rgy8YsQXu/BgdTYOCVdqGSLGq0jA2Q=

--- a/go.sum
+++ b/go.sum
@@ -1067,8 +1067,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317195457-cb9b7a97815a h1:afzTZ7kUfhU7z0b5vNkVlsliW+cNvnDD7nOmZspxsHM=
-github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317195457-cb9b7a97815a/go.mod h1:LUhhplOtRXliV1x17gbOptKPy90xSK0Sxv8zmgsMvTY=
+github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317210849-d0376cf2593a h1:XJmc8dY1mKR1Y46kx5c2aik/5G+1EnkZvmZPyi/7XgQ=
+github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317210849-d0376cf2593a/go.mod h1:LUhhplOtRXliV1x17gbOptKPy90xSK0Sxv8zmgsMvTY=
 github.com/sei-protocol/sei-iavl v0.1.3 h1:0hvW1NtmBlZ7ZkerQcM/n+2tFKg0vUlYWK8q/OeuCgw=
 github.com/sei-protocol/sei-iavl v0.1.3/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-tendermint v0.1.179 h1:ihHiqMIeiOE85rgy8YsQXu/BgdTYOCVdqGSLGq0jA2Q=

--- a/go.sum
+++ b/go.sum
@@ -1067,8 +1067,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.2.5-0.20230318010240-8584b787f3e5 h1:eA/b9roIzs9lNHB/yqfS0qndiZ+amSolyeAWi7U8kx0=
-github.com/sei-protocol/sei-cosmos v0.2.5-0.20230318010240-8584b787f3e5/go.mod h1:LUhhplOtRXliV1x17gbOptKPy90xSK0Sxv8zmgsMvTY=
+github.com/sei-protocol/sei-cosmos v0.2.5 h1:VR50G39LSlBklxFdAP41ZGVnxj3tyPcYjbCJW0+NQeE=
+github.com/sei-protocol/sei-cosmos v0.2.5/go.mod h1:LUhhplOtRXliV1x17gbOptKPy90xSK0Sxv8zmgsMvTY=
 github.com/sei-protocol/sei-iavl v0.1.3 h1:0hvW1NtmBlZ7ZkerQcM/n+2tFKg0vUlYWK8q/OeuCgw=
 github.com/sei-protocol/sei-iavl v0.1.3/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-tendermint v0.1.179 h1:ihHiqMIeiOE85rgy8YsQXu/BgdTYOCVdqGSLGq0jA2Q=

--- a/go.sum
+++ b/go.sum
@@ -1067,8 +1067,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317211153-9b7bd6a99381 h1:DbPIVUv9kbko5VJvVYD17ZRYy0Rz7cP5j8TB5YDexj0=
-github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317211153-9b7bd6a99381/go.mod h1:LUhhplOtRXliV1x17gbOptKPy90xSK0Sxv8zmgsMvTY=
+github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317214326-51fc406c0711 h1:KD5KLqLK4LRU42Xa1F/UBP7lmZ7OFiqeCuIbJGfzMYA=
+github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317214326-51fc406c0711/go.mod h1:LUhhplOtRXliV1x17gbOptKPy90xSK0Sxv8zmgsMvTY=
 github.com/sei-protocol/sei-iavl v0.1.3 h1:0hvW1NtmBlZ7ZkerQcM/n+2tFKg0vUlYWK8q/OeuCgw=
 github.com/sei-protocol/sei-iavl v0.1.3/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-tendermint v0.1.179 h1:ihHiqMIeiOE85rgy8YsQXu/BgdTYOCVdqGSLGq0jA2Q=

--- a/go.sum
+++ b/go.sum
@@ -1067,8 +1067,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317232516-b23668f8dc0f h1:70V4n7ZXt62yKPI25b/u5Ap6G4sM5094GGymnV4OP24=
-github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317232516-b23668f8dc0f/go.mod h1:LUhhplOtRXliV1x17gbOptKPy90xSK0Sxv8zmgsMvTY=
+github.com/sei-protocol/sei-cosmos v0.2.5-0.20230318010240-8584b787f3e5 h1:eA/b9roIzs9lNHB/yqfS0qndiZ+amSolyeAWi7U8kx0=
+github.com/sei-protocol/sei-cosmos v0.2.5-0.20230318010240-8584b787f3e5/go.mod h1:LUhhplOtRXliV1x17gbOptKPy90xSK0Sxv8zmgsMvTY=
 github.com/sei-protocol/sei-iavl v0.1.3 h1:0hvW1NtmBlZ7ZkerQcM/n+2tFKg0vUlYWK8q/OeuCgw=
 github.com/sei-protocol/sei-iavl v0.1.3/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-tendermint v0.1.179 h1:ihHiqMIeiOE85rgy8YsQXu/BgdTYOCVdqGSLGq0jA2Q=

--- a/go.sum
+++ b/go.sum
@@ -1067,8 +1067,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317225428-53bb8f419543 h1:Iwl8M2nJrGC37V2Haik+BzJ657XxpaE6sE1XvWoo1FM=
-github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317225428-53bb8f419543/go.mod h1:LUhhplOtRXliV1x17gbOptKPy90xSK0Sxv8zmgsMvTY=
+github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317232516-b23668f8dc0f h1:70V4n7ZXt62yKPI25b/u5Ap6G4sM5094GGymnV4OP24=
+github.com/sei-protocol/sei-cosmos v0.2.5-0.20230317232516-b23668f8dc0f/go.mod h1:LUhhplOtRXliV1x17gbOptKPy90xSK0Sxv8zmgsMvTY=
 github.com/sei-protocol/sei-iavl v0.1.3 h1:0hvW1NtmBlZ7ZkerQcM/n+2tFKg0vUlYWK8q/OeuCgw=
 github.com/sei-protocol/sei-iavl v0.1.3/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-tendermint v0.1.179 h1:ihHiqMIeiOE85rgy8YsQXu/BgdTYOCVdqGSLGq0jA2Q=

--- a/utils/metrics/metrics_util.go
+++ b/utils/metrics/metrics_util.go
@@ -138,3 +138,14 @@ func SetEpochNew(epochNum uint64) {
 		float32(epochNum),
 	)
 }
+
+// Measures throughput
+// Metric Name:
+//
+//	sei_throughput_<metric_name>
+func IncrementThroughputMetrics(metricName string, value float32) {
+	telemetry.IncrCounter(
+		value,
+		"sei", "throughput", metricName,
+	)
+}

--- a/utils/metrics/metrics_util.go
+++ b/utils/metrics/metrics_util.go
@@ -143,8 +143,8 @@ func SetEpochNew(epochNum uint64) {
 // Metric Name:
 //
 //	sei_throughput_<metric_name>
-func IncrementThroughputMetrics(metricName string, value float32) {
-	telemetry.IncrCounter(
+func SetThroughputMetric(metricName string, value float32) {
+	telemetry.SetGauge(
 		value,
 		"sei", "throughput", metricName,
 	)

--- a/x/dex/keeper/msgserver/msg_server_place_orders.go
+++ b/x/dex/keeper/msgserver/msg_server_place_orders.go
@@ -47,6 +47,7 @@ func (k msgServer) PlaceOrders(goCtx context.Context, msg *types.MsgPlaceOrders)
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	defer ctx.ContextMemCache().IncrMetricCounter(uint64(len(msg.Orders)), sdk.ORDER_COUNT)
+	ctx.Logger().Info(fmt.Sprintf("received request to place orders: %s", msg.String()))
 
 	if err := msg.ValidateBasic(); err != nil {
 		ctx.Logger().Error(fmt.Sprintf("request invalid: %s", err))

--- a/x/dex/keeper/msgserver/msg_server_place_orders.go
+++ b/x/dex/keeper/msgserver/msg_server_place_orders.go
@@ -47,7 +47,7 @@ func (k msgServer) PlaceOrders(goCtx context.Context, msg *types.MsgPlaceOrders)
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	defer ctx.ContextMemCache().IncrMetricCounter(uint64(len(msg.Orders)), sdk.ORDER_COUNT)
-	ctx.Logger().Info(fmt.Sprintf("received request to place orders: %s", msg.String()), "height", ctx.BlockHeight())
+	ctx.Logger().Info("received request to place orders", "num_orders", len(msg.Orders), "height", ctx.BlockHeight())
 
 	if err := msg.ValidateBasic(); err != nil {
 		ctx.Logger().Error(fmt.Sprintf("request invalid: %s", err))

--- a/x/dex/keeper/msgserver/msg_server_place_orders.go
+++ b/x/dex/keeper/msgserver/msg_server_place_orders.go
@@ -46,7 +46,7 @@ func (k msgServer) transferFunds(goCtx context.Context, msg *types.MsgPlaceOrder
 func (k msgServer) PlaceOrders(goCtx context.Context, msg *types.MsgPlaceOrders) (*types.MsgPlaceOrdersResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	defer ctx.ContextMemCache().IncrMetricCounter(uint64(len(msg.Orders)), sdk.ORDER_COUNT)
+	defer ctx.ContextMemCache().IncrMetricCounter(uint32(len(msg.Orders)), sdk.ORDER_COUNT)
 	ctx.Logger().Info("received request to place orders", "num_orders", len(msg.Orders), "height", ctx.BlockHeight())
 
 	if err := msg.ValidateBasic(); err != nil {

--- a/x/dex/keeper/msgserver/msg_server_place_orders.go
+++ b/x/dex/keeper/msgserver/msg_server_place_orders.go
@@ -46,6 +46,8 @@ func (k msgServer) transferFunds(goCtx context.Context, msg *types.MsgPlaceOrder
 func (k msgServer) PlaceOrders(goCtx context.Context, msg *types.MsgPlaceOrders) (*types.MsgPlaceOrdersResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
+	defer ctx.ContextMemCache().IncrMetricCounter(uint64(len(msg.Orders)), sdk.ORDER_COUNT)
+
 	if err := msg.ValidateBasic(); err != nil {
 		ctx.Logger().Error(fmt.Sprintf("request invalid: %s", err))
 		return nil, err

--- a/x/dex/keeper/msgserver/msg_server_place_orders.go
+++ b/x/dex/keeper/msgserver/msg_server_place_orders.go
@@ -47,7 +47,6 @@ func (k msgServer) PlaceOrders(goCtx context.Context, msg *types.MsgPlaceOrders)
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	defer ctx.ContextMemCache().IncrMetricCounter(uint32(len(msg.Orders)), sdk.ORDER_COUNT)
-	ctx.Logger().Info("received request to place orders", "num_orders", len(msg.Orders), "height", ctx.BlockHeight())
 
 	if err := msg.ValidateBasic(); err != nil {
 		ctx.Logger().Error(fmt.Sprintf("request invalid: %s", err))

--- a/x/dex/keeper/msgserver/msg_server_place_orders.go
+++ b/x/dex/keeper/msgserver/msg_server_place_orders.go
@@ -47,7 +47,7 @@ func (k msgServer) PlaceOrders(goCtx context.Context, msg *types.MsgPlaceOrders)
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	defer ctx.ContextMemCache().IncrMetricCounter(uint64(len(msg.Orders)), sdk.ORDER_COUNT)
-	ctx.Logger().Info(fmt.Sprintf("received request to place orders: %s", msg.String()))
+	ctx.Logger().Info(fmt.Sprintf("received request to place orders: %s", msg.String()), "height", ctx.BlockHeight())
 
 	if err := msg.ValidateBasic(); err != nil {
 		ctx.Logger().Error(fmt.Sprintf("request invalid: %s", err))

--- a/x/oracle/simulation/operations.go
+++ b/x/oracle/simulation/operations.go
@@ -65,7 +65,7 @@ func WeightedOperations(
 }
 
 // SimulateMsgAggregateExchangeRateVote generates a MsgAggregateExchangeRateVote with random values.
-//nolint: funlen
+// nolint: funlen
 func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
@@ -122,7 +122,7 @@ func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankK
 }
 
 // SimulateMsgDelegateFeedConsent generates a MsgDelegateFeedConsent with random values.
-//nolint: funlen
+// nolint: funlen
 func SimulateMsgDelegateFeedConsent(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,


### PR DESCRIPTION
## Describe your changes and provide context
Emit metrics for chain level performance. 

We need to store it in the baseapp as a counter we only scrape every 30seconds and our block times are < 1s most of the time, so if it's emitted per block it's not entirely accurate. (As seen in my testing, it was severally underreporting) 

The reason why we add the final counter at the end of the ProcessBlock is also due to the lifecycle of the contextMemcache object, and that's when we're sure that the counters are the ones being committed to the block. 


## Testing performed to validate your change
See this PR:
https://github.com/sei-protocol/sei-cosmos/pull/200
