### PR TITLE
Add add-wasm-genesis-message to seid

### DIFF
--- a/cmd/seid/cmd/genwasm.go
+++ b/cmd/seid/cmd/genwasm.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/spf13/cobra"
+
+	wasmcli "github.com/CosmWasm/wasmd/x/wasm/client/cli"
+)
+
+func AddGenesisWasmMsgCmd(defaultNodeHome string) *cobra.Command {
+	txCmd := &cobra.Command{
+		Use:                        "add-wasm-genesis-message",
+		Short:                      "Wasm genesis subcommands",
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+	genesisIO := wasmcli.NewDefaultGenesisIO()
+	txCmd.AddCommand(
+		wasmcli.GenesisStoreCodeCmd(defaultNodeHome, genesisIO),
+		wasmcli.GenesisInstantiateContractCmd(defaultNodeHome, genesisIO),
+		wasmcli.GenesisExecuteContractCmd(defaultNodeHome, genesisIO),
+		wasmcli.GenesisListContractsCmd(defaultNodeHome, genesisIO),
+		wasmcli.GenesisListCodesCmd(defaultNodeHome, genesisIO),
+	)
+	return txCmd
+}

--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -128,6 +128,7 @@ func initRootCmd(
 		),
 		genutilcli.ValidateGenesisCmd(app.ModuleBasics),
 		AddGenesisAccountCmd(app.DefaultNodeHome),
+		AddGenesisWasmMsgCmd(app.DefaultNodeHome),
 		tmcli.NewCompletionCmd(rootCmd, true),
 		debugCmd,
 		config.Cmd(),


### PR DESCRIPTION
## Describe your changes and provide context
This adds `add-wasm-genesis-message` to seid so that wasm projects can be added during genesis. This already exists in our fork https://github.com/sei-protocol/sei-wasmd/blob/main/cmd/wasmd/genwasm.go#L10 but we cannot import the cmd directly b/c the package is main (so it is a program, not a lib). Recreates the file and adds it to seid
## Testing performed to validate your change
```
 ~/sei-chain | add-wasm-genesis *5 !1  seid add-wasm-genesis-message                                                                                                         ok | 01:39:42 PM
Wasm genesis subcommands

Usage:
  seid add-wasm-genesis-message [flags]
  seid add-wasm-genesis-message [command]

Available Commands:
  execute              Execute a command on a wasm contract
  instantiate-contract Instantiate a wasm contract
  list-codes           Lists all codes from genesis code dump and queued messages
  list-contracts       Lists all contracts from genesis contract dump and queued messages
  store                Upload a wasm binary

Flags:
  -h, --help   help for add-wasm-genesis-message

Global Flags:
      --home string         directory for config and data (default "/Users/philipsu/.sei")
      --log_format string   The logging format (json|plain) (default "plain")
      --log_level string    The logging level (trace|debug|info|warn|error|fatal|panic) (default "info")
      --trace               print out full stack trace on errors

Use "seid add-wasm-genesis-message [command] --help" for more information about a command.
```
