### PR TITLE
Reject proposal if max block gas is exceeded

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -277,7 +277,7 @@ func TestInvalidProposalWithExcessiveGasWanted(t *testing.T) {
 	ap := testWrapper.App
 	ctx := testWrapper.Ctx.WithConsensusParams(&types.ConsensusParams{
 		Block: &types.BlockParams{MaxGas: 10},
-	})
+	}).WithBlockHeight(1)
 	emptyTxBuilder := app.MakeEncodingConfig().TxConfig.NewTxBuilder()
 	txEncoder := app.MakeEncodingConfig().TxConfig.TxEncoder()
 	emptyTxBuilder.SetGasLimit(10)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -277,22 +277,17 @@ func TestInvalidProposalWithExcessiveGasWanted(t *testing.T) {
 	ap := testWrapper.App
 	ctx := testWrapper.Ctx.WithConsensusParams(&types.ConsensusParams{
 		Block: &types.BlockParams{MaxGas: 10},
-	}).WithBlockHeight(1)
+	})
 	emptyTxBuilder := app.MakeEncodingConfig().TxConfig.NewTxBuilder()
 	txEncoder := app.MakeEncodingConfig().TxConfig.TxEncoder()
 	emptyTxBuilder.SetGasLimit(10)
 	emptyTx, _ := txEncoder(emptyTxBuilder.GetTx())
-	goodProposal := abci.RequestProcessProposal{
-		Txs: [][]byte{emptyTx},
-	}
-	res, err := ap.ProcessProposalHandler(ctx, &goodProposal)
-	require.Nil(t, err)
-	require.Equal(t, abci.ResponseProcessProposal_ACCEPT, res.Status)
 
 	badProposal := abci.RequestProcessProposal{
-		Txs: [][]byte{emptyTx, emptyTx},
+		Txs:    [][]byte{emptyTx, emptyTx},
+		Height: 1,
 	}
-	res, err = ap.ProcessProposalHandler(ctx, &badProposal)
+	res, err := ap.ProcessProposalHandler(ctx, &badProposal)
 	require.Nil(t, err)
 	require.Equal(t, abci.ResponseProcessProposal_REJECT, res.Status)
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -15,6 +15,7 @@ import (
 	oracletypes "github.com/sei-protocol/sei-chain/x/oracle/types"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
 func TestEmptyBlockIdempotency(t *testing.T) {
@@ -266,4 +267,32 @@ func TestProcessOracleAndOtherTxsSuccess(t *testing.T) {
 	)
 
 	require.Equal(t, 2, len(txResults))
+}
+
+func TestInvalidProposalWithExcessiveGasWanted(t *testing.T) {
+	tm := time.Now().UTC()
+	valPub := secp256k1.GenPrivKey().PubKey()
+
+	testWrapper := app.NewTestWrapper(t, tm, valPub)
+	ap := testWrapper.App
+	ctx := testWrapper.Ctx.WithConsensusParams(&types.ConsensusParams{
+		Block: &types.BlockParams{MaxGas: 10},
+	})
+	emptyTxBuilder := app.MakeEncodingConfig().TxConfig.NewTxBuilder()
+	txEncoder := app.MakeEncodingConfig().TxConfig.TxEncoder()
+	emptyTxBuilder.SetGasLimit(10)
+	emptyTx, _ := txEncoder(emptyTxBuilder.GetTx())
+	goodProposal := abci.RequestProcessProposal{
+		Txs: [][]byte{emptyTx},
+	}
+	res, err := ap.ProcessProposalHandler(ctx, &goodProposal)
+	require.Nil(t, err)
+	require.Equal(t, abci.ResponseProcessProposal_ACCEPT, res.Status)
+
+	badProposal := abci.RequestProcessProposal{
+		Txs: [][]byte{emptyTx, emptyTx},
+	}
+	res, err = ap.ProcessProposalHandler(ctx, &badProposal)
+	require.Nil(t, err)
+	require.Equal(t, abci.ResponseProcessProposal_REJECT, res.Status)
 }


### PR DESCRIPTION
## Describe your changes and provide context
Implementation for https://github.com/sei-protocol/sei-chain/pull/new/tony-chen-max-block-gas-check

We want honest validators (i.e. validators who do not use a maliciously modified binary) to reject block proposals whose transactions' GasWanted add up to something greater than max block gas. Since transactions in block proposals are sent as raw bytes, the only place to decode them would be on application-level during ProcessProposal. For context, ProcessProposal is called during `prevote` phase by validators, and if it returns a status of `REJECT`, validators will vote nil.

## Testing performed to validate your change
unit test
integration test in a loadtest cluster with a modified node to verify such proposal will indeed be rejected
