### PR TITLE
Periodically collect and distribute tokens to test accounts 

### DIFF
--- a/loadtest/config.json
+++ b/loadtest/config.json
@@ -17,6 +17,20 @@
         "max": "21",
         "number_of_distinct_values": 20
     },
+    "message_configs": {
+      "default": {
+        "gas": "3000000",
+        "fees": "50000"
+      },
+      "collect_rewards": {
+        "gas": "10000000",
+        "fees": "1000000"
+      },
+      "distribute_rewards": {
+        "gas": "10000000",
+        "fees": "1000000"
+      }
+    },
     "message_type_distribution": {
         "dex": {
             "limit_order_percentage": "0.2",

--- a/loadtest/config.json
+++ b/loadtest/config.json
@@ -19,16 +19,16 @@
     },
     "message_configs": {
       "default": {
-        "gas": "3000000",
-        "fees": "50000"
+        "gas": 3000000,
+        "fees": 50000
       },
       "collect_rewards": {
-        "gas": "10000000",
-        "fees": "1000000"
+        "gas": 10000000,
+        "fees": 1000000
       },
       "distribute_rewards": {
-        "gas": "10000000",
-        "fees": "1000000"
+        "gas": 10000000,
+        "fees": 1000000
       }
     },
     "message_type_distribution": {

--- a/loadtest/config.json
+++ b/loadtest/config.json
@@ -30,7 +30,7 @@
     },
     "constant": true,
     "loadtest_interval": 600,
-    "message_type": "bank,dex,tokenfactory,staking,failure_dex_malformed,failure_dex_invalid",
+    "message_type": "bank,dex,tokenfactory,staking,failure_dex_malformed,failure_dex_invalid,collect_rewards,distribute_rewards",
     "run_oracle": false,
     "metrics_port": 9695,
     "wasm_msg_types": {

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -133,7 +133,9 @@ func (c *LoadTestClient) BuildTxs() (workgroups []*sync.WaitGroup, sendersList [
 		workgroups = append(workgroups, wg)
 
 		for j, account := range activeAccounts {
-			key := c.SignerClient.GetKey(uint64(account))
+			accountIdentifier := string(account)
+			accountKeyPath := c.SignerClient.GetTestAccountKeyPath(accountIdentifier)
+			key := c.SignerClient.GetKey(accountIdentifier, "test", accountKeyPath)
 
 			msg, failureExpected := c.generateMessage(config, key, config.MsgsPerTx)
 			txBuilder := TestConfig.TxConfig.NewTxBuilder()

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -34,12 +34,16 @@ type LoadTestClient struct {
 	TxHashListMutex    *sync.Mutex
 	GrpcConn           *grpc.ClientConn
 	StakingQueryClient stakingtypes.QueryClient
-	//// Staking specific variables
+	// Staking specific variables
 	Validators []stakingtypes.Validator
 	// DelegationMap is a map of delegator -> validator -> delegated amount
 	DelegationMap map[string]map[string]int
-	//// Tokenfactory specific variables
+	// Tokenfactory specific variables
 	TokenFactoryDenomOwner map[string]string
+	// Only one admin message can go in per block
+	generatedAdminMessageForBlock bool
+	// Messages that has to be sent from the admin account
+	isAdminMessageMapping map[string]bool
 }
 
 func NewLoadTestClient(config Config) *LoadTestClient {
@@ -64,19 +68,21 @@ func NewLoadTestClient(config Config) *LoadTestClient {
 	_ = os.Remove(filename)
 	outputFile, _ := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	return &LoadTestClient{
-		LoadTestConfig:         config,
-		TestConfig:             TestConfig,
-		TxClient:               TxClient,
-		TxHashFile:             outputFile,
-		SignerClient:           NewSignerClient(config.NodeURI),
-		ChainID:                config.ChainID,
-		TxHashList:             []string{},
-		TxResponseChan:         make(chan *string),
-		TxHashListMutex:        &sync.Mutex{},
-		GrpcConn:               grpcConn,
-		StakingQueryClient:     stakingtypes.NewQueryClient(grpcConn),
-		DelegationMap:          map[string]map[string]int{},
-		TokenFactoryDenomOwner: map[string]string{},
+		LoadTestConfig:                config,
+		TestConfig:                    TestConfig,
+		TxClient:                      TxClient,
+		TxHashFile:                    outputFile,
+		SignerClient:                  NewSignerClient(config.NodeURI),
+		ChainID:                       config.ChainID,
+		TxHashList:                    []string{},
+		TxResponseChan:                make(chan *string),
+		TxHashListMutex:               &sync.Mutex{},
+		GrpcConn:                      grpcConn,
+		StakingQueryClient:            stakingtypes.NewQueryClient(grpcConn),
+		DelegationMap:                 map[string]map[string]int{},
+		TokenFactoryDenomOwner:        map[string]string{},
+		generatedAdminMessageForBlock: false,
+		isAdminMessageMapping:         map[string]bool{CollectRewards: true, DistributeRewards: true},
 	}
 }
 
@@ -131,13 +137,13 @@ func (c *LoadTestClient) BuildTxs() (workgroups []*sync.WaitGroup, sendersList [
 		wg := &sync.WaitGroup{}
 		var senders []func()
 		workgroups = append(workgroups, wg)
-
+		c.generatedAdminMessageForBlock = false
 		for j, account := range activeAccounts {
-			accountIdentifier := string(account)
-			accountKeyPath := c.SignerClient.GetTestAccountKeyPath(accountIdentifier)
+			accountIdentifier := fmt.Sprint(account)
+			accountKeyPath := c.SignerClient.GetTestAccountKeyPath(uint64(account))
 			key := c.SignerClient.GetKey(accountIdentifier, "test", accountKeyPath)
 
-			msg, failureExpected := c.generateMessage(config, key, config.MsgsPerTx)
+			msg, failureExpected, signer, gas, fee := c.generateMessage(config, key, config.MsgsPerTx)
 			txBuilder := TestConfig.TxConfig.NewTxBuilder()
 			_ = txBuilder.SetMsgs(msg)
 			seqDelta := uint64(i / 2)
@@ -149,7 +155,7 @@ func (c *LoadTestClient) BuildTxs() (workgroups []*sync.WaitGroup, sendersList [
 			// in which a later seqno is delievered before an earlier seqno
 			// In practice, we haven't run into this issue so we'll leave this
 			// as is.
-			sender := SendTx(key, &txBuilder, mode, seqDelta, failureExpected, *c)
+			sender := SendTx(signer, &txBuilder, mode, seqDelta, failureExpected, *c, gas, fee)
 			wg.Add(1)
 			senders = append(senders, func() {
 				defer wg.Done()
@@ -176,7 +182,7 @@ func (c *LoadTestClient) GenerateOracleSenders(i int, config Config, valKeys []c
 			_ = txBuilder.SetMsgs(msg)
 			seqDelta := uint64(i / 2)
 			mode := typestx.BroadcastMode_BROADCAST_MODE_SYNC
-			sender := SendTx(valKey, &txBuilder, mode, seqDelta, false, *c)
+			sender := SendTx(valKey, &txBuilder, mode, seqDelta, false, *c, 30000, 100000)
 			waitGroup.Add(1)
 			senders = append(senders, func() {
 				defer waitGroup.Done()

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -311,9 +311,9 @@ func (c *LoadTestClient) generateMessage(config Config, key cryptotypes.PrivKey,
 	}
 
 	if strings.Contains(config.MessageType, "failure") {
-		return msg, true, signer, uint64(gas), int64(fee)
+		return msg, true, signer, gas, int64(fee)
 	}
-	return msg, false, signer, uint64(gas), int64(fee)
+	return msg, false, signer, gas, int64(fee)
 }
 
 func sampleDexOrderType(config Config) (orderType dextypes.OrderType) {

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -17,13 +17,13 @@ import (
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/cosmos/cosmos-sdk/std"
 
-	"github.com/cosmos/cosmos-sdk/x/auth/tx"
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/tx"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/sei-protocol/sei-chain/app"
 	dextypes "github.com/sei-protocol/sei-chain/x/dex/types"
 	oracletypes "github.com/sei-protocol/sei-chain/x/oracle/types"
@@ -135,6 +135,27 @@ func (c *LoadTestClient) generateMessage(config Config, key cryptotypes.PrivKey,
 				Amount: sdk.NewInt(1),
 			}),
 		}
+	case DistributeRewards:
+		adminKey := c.SignerClient.GetAdminKey()
+		msg = &banktypes.MsgSend{
+			FromAddress: sdk.AccAddress(adminKey.PubKey().Address()).String(),
+			ToAddress:   sdk.AccAddress(key.PubKey().Address()).String(),
+			Amount: sdk.NewCoins(sdk.Coin{
+				Denom:  "usei",
+				Amount: sdk.NewInt(rand.Int63n(10000000)),
+			}),
+		}
+	case CollectRewards:
+		adminKey := c.SignerClient.GetAdminKey()
+		delegatorAddr := sdk.AccAddress(adminKey.PubKey().Address())
+		randomValidatorAddr, err := sdk.ValAddressFromBech32(c.Validators[rand.Intn(len(c.Validators))].OperatorAddress)
+		if err != nil {
+			panic(err.Error())
+		}
+		msg = distributiontypes.NewMsgWithdrawDelegatorReward(
+			delegatorAddr,
+			randomValidatorAddr,
+		)
 	case Dex:
 		price := config.PriceDistr.Sample()
 		quantity := config.QuantityDistr.Sample()
@@ -151,7 +172,6 @@ func (c *LoadTestClient) generateMessage(config Config, key cryptotypes.PrivKey,
 			Funds:        amount,
 		}
 	case Staking:
-
 		delegatorAddr := sdk.AccAddress(key.PubKey().Address()).String()
 		chosenValidator := c.Validators[rand.Intn(len(c.Validators))].OperatorAddress
 		// Randomly pick someone to redelegate / unbond from

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -124,8 +124,17 @@ func (c *LoadTestClient) generateMessage(config Config, key cryptotypes.PrivKey,
 	defer IncrTxMessageType(messageType)
 
 	signer := key
-	gas := 3000000
-	fee := 50000
+
+	defaultMessageTypeConfig := c.LoadTestConfig.PerMessageConfigs["default"]
+	gas := defaultMessageTypeConfig.Gas
+	fee := defaultMessageTypeConfig.Fee
+
+	messageTypeConfig, ok := c.LoadTestConfig.PerMessageConfigs[messageType]
+	if ok {
+		gas = messageTypeConfig.Gas
+		fee = messageTypeConfig.Fee
+	}
+
 	switch messageType {
 	case WasmMintNft:
 		contract := config.WasmMsgTypes.MintNftType.ContractAddr

--- a/loadtest/scripts/run_tests.py
+++ b/loadtest/scripts/run_tests.py
@@ -36,7 +36,7 @@ def create_burst_loadtest_config(base_config_json):
     new_config["constant"] = True
     new_config["metrics_port"] = 9697
     new_config["txs_per_block"] = 600
-    new_config["msgs_per_tx"] = 20
+    new_config["msgs_per_tx"] = 40
     # Run every 20 mins
     new_config["loadtest_interval"] = 1200
     return new_config
@@ -46,10 +46,10 @@ def create_steady_loadtest_config(base_config_json):
     new_config = base_config_json.copy()
     new_config["constant"] = True
     new_config["metrics_port"] = 9696
-    new_config["txs_per_block"] = 300
-    new_config["msgs_per_tx"] = 10
+    new_config["txs_per_block"] = 500
+    new_config["msgs_per_tx"] = 30
     # Run every min
-    new_config["loadtest_interval"] = 60
+    new_config["loadtest_interval"] = 30
     return new_config
 
 def create_continuous_loadtest_config(base_config_json):

--- a/loadtest/scripts/run_tests.py
+++ b/loadtest/scripts/run_tests.py
@@ -38,7 +38,7 @@ def create_burst_loadtest_config(base_config_json):
     new_config["txs_per_block"] = 600
     new_config["msgs_per_tx"] = 40
     # Run every 20 mins
-    new_config["loadtest_interval"] = 1200
+    new_config["loadtest_interval"] = 60
     return new_config
 
 
@@ -49,7 +49,7 @@ def create_steady_loadtest_config(base_config_json):
     new_config["txs_per_block"] = 500
     new_config["msgs_per_tx"] = 30
     # Run every min
-    new_config["loadtest_interval"] = 30
+    new_config["loadtest_interval"] = 10
     return new_config
 
 def create_continuous_loadtest_config(base_config_json):

--- a/loadtest/sign.go
+++ b/loadtest/sign.go
@@ -62,14 +62,14 @@ func NewSignerClient(nodeURI string) *SignerClient {
 	}
 }
 
-func (sc *SignerClient) GetTestAccountKeyPath(accountID string) string {
+func (sc *SignerClient) GetTestAccountKeyPath(accountID uint64) string {
 	userHomeDir, _ := os.UserHomeDir()
-	return filepath.Join(userHomeDir, "test_accounts", fmt.Sprintf("ta%s.json", accountID))
+	return filepath.Join(userHomeDir, "test_accounts", fmt.Sprintf("ta%d.json", accountID))
 }
 
 func (sc *SignerClient) GetAdminAccountKeyPath() string {
 	userHomeDir, _ := os.UserHomeDir()
-	return filepath.Join(userHomeDir, "admin_key.json")
+	return filepath.Join(userHomeDir, ".sei", "config", "admin_key.json")
 }
 
 func (sc *SignerClient) GetAdminKey() cryptotypes.PrivKey {

--- a/loadtest/sign.go
+++ b/loadtest/sign.go
@@ -62,13 +62,26 @@ func NewSignerClient(nodeURI string) *SignerClient {
 	}
 }
 
-func (sc *SignerClient) GetKey(accountIdx uint64) cryptotypes.PrivKey {
-	if val, ok := sc.CachedAccountKey.Load(accountIdx); ok {
+func (sc *SignerClient) GetTestAccountKeyPath(accountID string) string {
+	userHomeDir, _ := os.UserHomeDir()
+	return filepath.Join(userHomeDir, "test_accounts", fmt.Sprintf("ta%s.json", accountID))
+}
+
+func (sc *SignerClient) GetAdminAccountKeyPath() string {
+	userHomeDir, _ := os.UserHomeDir()
+	return filepath.Join(userHomeDir, "admin_key.json")
+}
+
+func (sc *SignerClient) GetAdminKey() cryptotypes.PrivKey {
+	return sc.GetKey("admin", "os", sc.GetAdminAccountKeyPath())
+}
+
+func (sc *SignerClient) GetKey(accountID, backend, accountKeyFilePath string) cryptotypes.PrivKey {
+	if val, ok := sc.CachedAccountKey.Load(accountID); ok {
 		privKey := val.(cryptotypes.PrivKey)
 		return privKey
 	}
 	userHomeDir, _ := os.UserHomeDir()
-	accountKeyFilePath := filepath.Join(userHomeDir, "test_accounts", fmt.Sprintf("ta%d.json", accountIdx))
 	jsonFile, err := os.Open(accountKeyFilePath)
 	if err != nil {
 		panic(err)
@@ -91,7 +104,7 @@ func (sc *SignerClient) GetKey(accountIdx uint64) cryptotypes.PrivKey {
 	privKey := algo.Generate()(derivedPriv)
 
 	// Cache this so we don't need to regenerate it
-	sc.CachedAccountKey.Store(accountIdx, privKey)
+	sc.CachedAccountKey.Store(accountID, privKey)
 	return privKey
 }
 

--- a/loadtest/sign.go
+++ b/loadtest/sign.go
@@ -95,7 +95,7 @@ func (sc *SignerClient) GetKey(accountID, backend, accountKeyFilePath string) cr
 	if err := json.Unmarshal(byteVal, &accountInfo); err != nil {
 		panic(err)
 	}
-	kr, _ := keyring.New(sdk.KeyringServiceName(), "test", filepath.Join(userHomeDir, ".sei"), os.Stdin)
+	kr, _ := keyring.New(sdk.KeyringServiceName(), backend, filepath.Join(userHomeDir, ".sei"), os.Stdin)
 	keyringAlgos, _ := kr.SupportedAlgorithms()
 	algoStr := string(hd.Sr25519Type)
 	algo, _ := keyring.NewSigningAlgoFromString(algoStr, keyringAlgos)

--- a/loadtest/types.go
+++ b/loadtest/types.go
@@ -42,6 +42,7 @@ type Config struct {
 	MsgTypeDistr       MsgTypeDistribution   `json:"message_type_distribution"`
 	WasmMsgTypes       WasmMessageTypes      `json:"wasm_msg_types"`
 	ContractDistr      ContractDistributions `json:"contract_distribution"`
+	PerMessageConfigs   MessageConfigs		   `json:"message_configs"`
 	MetricsPort        uint64                `json:"metrics_port"`
 	Constant           bool                  `json:"constant"`
 	LoadInterval       int64                 `json:"loadtest_interval"`
@@ -55,6 +56,15 @@ type EncodingConfig struct {
 	TxConfig  client.TxConfig
 	Amino     *codec.LegacyAmino
 }
+
+// MessageConfig is the configuration for a message
+// Specify the gas and fee for the message type
+type MessageTypeConfig struct {
+	Gas uint64
+	Fee uint64
+}
+
+type MessageConfigs map[string]MessageTypeConfig
 
 type NumericDistribution struct {
 	Min         sdk.Dec `json:"min"`

--- a/loadtest/types.go
+++ b/loadtest/types.go
@@ -42,7 +42,7 @@ type Config struct {
 	MsgTypeDistr       MsgTypeDistribution   `json:"message_type_distribution"`
 	WasmMsgTypes       WasmMessageTypes      `json:"wasm_msg_types"`
 	ContractDistr      ContractDistributions `json:"contract_distribution"`
-	PerMessageConfigs   MessageConfigs		   `json:"message_configs"`
+	PerMessageConfigs  MessageConfigs        `json:"message_configs"`
 	MetricsPort        uint64                `json:"metrics_port"`
 	Constant           bool                  `json:"constant"`
 	LoadInterval       int64                 `json:"loadtest_interval"`

--- a/loadtest/types.go
+++ b/loadtest/types.go
@@ -13,8 +13,8 @@ import (
 
 const (
 	Bank                 string = "bank"
-	CollectRewards		 string = "collect_rewards"
-	DistributeRewards	 string = "distribute_rewards"
+	CollectRewards       string = "collect_rewards"
+	DistributeRewards    string = "distribute_rewards"
 	FailureBankMalformed string = "failure_bank_malformed"
 	FailureBankInvalid   string = "failure_bank_invalid"
 	FailureDexMalformed  string = "failure_dex_malformed"

--- a/loadtest/types.go
+++ b/loadtest/types.go
@@ -13,6 +13,8 @@ import (
 
 const (
 	Bank                 string = "bank"
+	CollectRewards		 string = "collect_rewards"
+	DistributeRewards	 string = "distribute_rewards"
 	FailureBankMalformed string = "failure_bank_malformed"
 	FailureBankInvalid   string = "failure_bank_invalid"
 	FailureDexMalformed  string = "failure_dex_malformed"

--- a/x/oracle/simulation/operations.go
+++ b/x/oracle/simulation/operations.go
@@ -65,7 +65,7 @@ func WeightedOperations(
 }
 
 // SimulateMsgAggregateExchangeRateVote generates a MsgAggregateExchangeRateVote with random values.
-//nolint: funlen
+// nolint: funlen
 func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
@@ -122,7 +122,7 @@ func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankK
 }
 
 // SimulateMsgDelegateFeedConsent generates a MsgDelegateFeedConsent with random values.
-//nolint: funlen
+// nolint: funlen
 func SimulateMsgDelegateFeedConsent(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,

--- a/x/oracle/simulation/operations.go
+++ b/x/oracle/simulation/operations.go
@@ -65,7 +65,7 @@ func WeightedOperations(
 }
 
 // SimulateMsgAggregateExchangeRateVote generates a MsgAggregateExchangeRateVote with random values.
-// nolint: funlen
+//nolint: funlen
 func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
@@ -122,7 +122,7 @@ func SimulateMsgAggregateExchangeRateVote(ak types.AccountKeeper, bk types.BankK
 }
 
 // SimulateMsgDelegateFeedConsent generates a MsgDelegateFeedConsent with random values.
-// nolint: funlen
+//nolint: funlen
 func SimulateMsgDelegateFeedConsent(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,


### PR DESCRIPTION
## Describe your changes and provide context
Change to periodically collect rewards and also distribute them to test accounts 

## Testing performed to validate your change

Left is node-0, and right is node-1 we see that node-0 (where the LT client is running) has a lot less rewards as it was collected. For sei-internal we'll need to update distribution to collect rewards from the other validators 
![image](https://user-images.githubusercontent.com/18161326/229541859-3faa2687-fe7e-4da9-a466-519ccdca0e82.png)


Saw that the balance for the admin account was dropping 
![image](https://user-images.githubusercontent.com/18161326/229160121-9dacf67d-47e6-4999-a619-757e49dfabb7.png)

Need to refactor the sei-infra script to test the reward collecting properly (too many acc seq issues caused by oracle not using its own acc)  