### PR TITLE
[price-feeder] Change tick failure log to warning

### DIFF
--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -122,7 +122,7 @@ func (o *Oracle) Start(ctx context.Context) error {
 			err = o.tick(ctx, clientCtx, currBlockHeight)
 			if err != nil {
 				telemetry.IncrCounter(1, "failure", "tick")
-				o.logger.Err(err).Msg(fmt.Sprintf("Oracle tick failed for height %d", currBlockHeight))
+				o.logger.Warn().Msg(fmt.Sprintf("Oracle tick failed for height %d, err: %s", currBlockHeight, err.Error()))
 			} else {
 				telemetry.IncrCounter(1, "success", "tick")
 			}


### PR DESCRIPTION
## Describe your changes and provide context
Because tick failures are tolerated infrequently, it seems appropriate to downgrade the log message for failed ticks to a warning, which represents the incorrect behavior of that oracle's tick, but shouldn't affect future tick operation so it won't cause price feeder failure.

## Testing performed to validate your change
patched and tested on a node running price feeder
