### PR TITLE
Split Unit tests into multiple git PR jobs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,16 +24,13 @@ jobs:
       with:
         go-version: 1.18
 
-    - name: Test
-      run: python3 runtests.py
-
     - run: go install github.com/axw/gocov/gocov@latest
     - run: go install github.com/AlekSi/gocov-xml@latest
 
     - name: Test coverage report
       run: go test ./...  -coverprofile=cover.out
     - run: gocov convert cover.out | gocov-xml > coverage.xml
-      
+
     - name: Code Coverage Summary Report
       uses: irongut/CodeCoverageSummary@v1.3.0
       with:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,35 @@
+name: Test
+on:
+  pull_request:
+  push:
+    paths:
+      - "**.go"
+    branches:
+      - main
+      - release/**
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        part: ["00", "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"]
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.19"
+      - uses: actions/checkout@v3
+      - uses: technote-space/get-diff-action@v6
+        with:
+          PATTERNS: |
+            **/**.go
+            "!test/"
+            go.mod
+            go.sum
+            Makefile
+      - name: Run Go Tests
+        run: |
+          NUM_SPLIT=20
+          make test-group-${{matrix.part}} NUM_SPLIT=20
+        if: env.GIT_DIFF


### PR DESCRIPTION
## Describe your changes and provide context
Runtests.py runs it concurrently on a single machine, it works well locally but this is better when running against git workflows as we can split it up to reduce the time to build for PR jobs

The test coverage report also takes a while to run too so its good to split it out from the Go workflow
## Testing performed to validate your change

PR jobs 