### PR TITLE
Modified minimum-gas-prices to 0.0001usei

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ mv $HOME/go/bin/seid /usr/bin/
 
 * Download the Genesis file: `https://github.com/sei-protocol/testnet/raw/main/sei-testnet-1/genesis.json -P $HOME/.sei/config/`
  
-* Edit the minimum-gas-prices in ${HOME}/.sei/config/app.toml: `sed -i 's/minimum-gas-prices = ""/minimum-gas-prices = "0.01usei"/g' $HOME/.sei/config/app.toml`
+* Edit the minimum-gas-prices in ${HOME}/.sei/config/app.toml: `sed -i 's/minimum-gas-prices = ""/minimum-gas-prices = "0.0001usei"/g' $HOME/.sei/config/app.toml`
 
 * Start seid by creating a systemd service to run the node in the background
 `nano /etc/systemd/system/seid.service`


### PR DESCRIPTION
## Describe your changes and provide context
In README.md, corrected the value of `minimum-gas-prices` from `0.01usei` to `0.0001usei` before the current recommended setting.
## Testing performed to validate your change

