### PR TITLE
[go.mod] bump for auto restart if behind

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -269,10 +269,10 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.16
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.17
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.3
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
-	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.2.4
+	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.2.7
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1067,12 +1067,12 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.2.16 h1:C7jIWo74vKpbdqtar7kuAzbwmBi24cC8E7dfW5pOVgg=
-github.com/sei-protocol/sei-cosmos v0.2.16/go.mod h1:CYMdG9mBiQ9Dfw3Wd+JCF+ph7NpySllMAnMA3qNG5ro=
+github.com/sei-protocol/sei-cosmos v0.2.17 h1:ZOCQ1BF2D5UeIfjYwNWvI/pJNpw1e1hP6GGv0uE1l1E=
+github.com/sei-protocol/sei-cosmos v0.2.17/go.mod h1:ZG0A5JQzj4f7Lk3AR5zLaZMCfYA/UpGE0YiKHfApd+w=
 github.com/sei-protocol/sei-iavl v0.1.3 h1:0hvW1NtmBlZ7ZkerQcM/n+2tFKg0vUlYWK8q/OeuCgw=
 github.com/sei-protocol/sei-iavl v0.1.3/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
-github.com/sei-protocol/sei-tendermint v0.2.4 h1:bdeO1QyQpV0p18Y4uRiU13f0FD4qlRJ8L1lQMjTUkY8=
-github.com/sei-protocol/sei-tendermint v0.2.4/go.mod h1:+BtDvAwTkE64BlxzpH9ZP7S6vUYT9wRXiZa/WW8/o4g=
+github.com/sei-protocol/sei-tendermint v0.2.7 h1:uVweGrk1pa3Dla/i6fv/mJY0rGd18tgK+q4dxT6LxzM=
+github.com/sei-protocol/sei-tendermint v0.2.7/go.mod h1:+BtDvAwTkE64BlxzpH9ZP7S6vUYT9wRXiZa/WW8/o4g=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
 github.com/sei-protocol/sei-wasmd v0.0.1 h1:dRvdapc1sqWxhIB2+DKS5LfilFjOsaFwWkGkSWwQIow=


### PR DESCRIPTION
## Describe your changes and provide context
Bumping cosmos and tendermint versions to include feature to auto restart if the node is behind a threshold 
```
#######################################################
###       SelfRemediation Configuration Options     ###
#######################################################
[self-remediation]

# If the node has no p2p peers available then trigger a restart
# Set to 0 to disable
p2p-no-peers-available-window-seconds = 60

# If node has no peers for statesync after a period of time then restart
# Set to 0 to disable
statesync-no-peers-available-window-seconds = 60

# Threshold for how far back the node can be behind the current block height before triggering a restart
# Set to 0 to disable
blocks-behind-threshold = 1000

# How often to check if node is behind
blocks-behind-check-interval = 30

# Cooldown between each restart
restart-cooldown-seconds = 1800
```

## Testing performed to validate your change
This node is running with 200ms delay on all egress requests

The first break is when I restarted the node with the self-remediation turned on, and after that we see that there's no breaks between restarts and going into block sync mode and node is able to catch up

![image](https://user-images.githubusercontent.com/18161326/233407549-9635b56d-8edb-427b-b132-ab3333720e25.png)

