### PR TITLE
Fix genesis import for oracle module

### DIFF
--- a/x/oracle/genesis.go
+++ b/x/oracle/genesis.go
@@ -12,6 +12,7 @@ import (
 // InitGenesis initialize default parameters
 // and the keeper's address to pubkey map
 func InitGenesis(ctx sdk.Context, keeper keeper.Keeper, data *types.GenesisState) {
+	keeper.SetParams(ctx, data.Params)
 	for _, d := range data.FeederDelegations {
 		voter, err := sdk.ValAddressFromBech32(d.ValidatorAddress)
 		if err != nil {
@@ -52,7 +53,6 @@ func InitGenesis(ctx sdk.Context, keeper keeper.Keeper, data *types.GenesisState
 		keeper.AddPriceSnapshot(ctx, priceSnapshot)
 	}
 
-	keeper.SetParams(ctx, data.Params)
 
 	// check if the module account exists
 	moduleAcc := keeper.GetOracleAccount(ctx)


### PR DESCRIPTION
## Describe your changes and provide context
Fixes genesis import logic such that oracle params are set before other oracle state.

## Testing performed to validate your change
Tested exporting & importing, verified it work

