### PR TITLE
Send consumed rent to fee collector

### DIFF
--- a/x/dex/contract/abci.go
+++ b/x/dex/contract/abci.go
@@ -6,10 +6,13 @@ import (
 	"sync"
 	"time"
 
+	seiutils "github.com/sei-protocol/sei-chain/utils"
 	"github.com/sei-protocol/sei-chain/utils/logging"
 	"github.com/sei-protocol/sei-chain/utils/tracing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	"github.com/sei-protocol/sei-chain/store/whitelist/multi"
 	seisync "github.com/sei-protocol/sei-chain/sync"
 	"github.com/sei-protocol/sei-chain/utils/datastructures"
@@ -46,6 +49,8 @@ func EndBlockerAtomic(ctx sdk.Context, keeper *keeper.Keeper, validContractsInfo
 	env := newEnv(ctx, validContractsInfo, keeper)
 	cachedCtx, msCached := cacheContext(ctx, env)
 	memStateCopy := dexutils.GetMemState(cachedCtx.Context()).DeepCopy()
+	preRunRents := keeper.GetRentsForContracts(ctx, seiutils.Map(validContractsInfo, func(c types.ContractInfoV2) string { return c.ContractAddr }))
+
 	handleDeposits(spanCtx, cachedCtx, env, keeper, tracer)
 
 	runner := NewParallelRunner(func(contract types.ContractInfoV2) {
@@ -66,6 +71,8 @@ func EndBlockerAtomic(ctx sdk.Context, keeper *keeper.Keeper, validContractsInfo
 
 	// No error is thrown for any contract. This should happen most of the time.
 	if env.failedContractAddresses.Size() == 0 {
+		postRunRents := keeper.GetRentsForContracts(ctx, seiutils.Map(validContractsInfo, func(c types.ContractInfoV2) string { return c.ContractAddr }))
+		TransferRentFromDexToCollector(ctx, keeper.BankKeeper, preRunRents, postRunRents)
 		msCached.Write()
 		return env.validContractsInfo, ctx, true
 	}
@@ -240,4 +247,18 @@ func filterNewValidContracts(ctx sdk.Context, env *environment) []types.Contract
 		dexutils.GetMemState(ctx.Context()).DeepFilterAccount(ctx, failedContractAddress)
 	}
 	return newValidContracts
+}
+
+func TransferRentFromDexToCollector(ctx sdk.Context, bankKeeper bankkeeper.Keeper, preRents map[string]uint64, postRents map[string]uint64) {
+	total := uint64(0)
+	for addr, preRent := range preRents {
+		if postRent, ok := postRents[addr]; ok {
+			total += preRent - postRent
+		} else {
+			total += preRent
+		}
+	}
+	if err := bankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, authtypes.FeeCollectorName, sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(int64(total))))); err != nil {
+		ctx.Logger().Error("sending coints from dex to fee collector failed due to %s", err)
+	}
 }

--- a/x/dex/contract/abci_test.go
+++ b/x/dex/contract/abci_test.go
@@ -1,0 +1,34 @@
+package contract_test
+
+import (
+	"testing"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/x/dex/contract"
+	"github.com/sei-protocol/sei-chain/x/dex/types"
+	minttypes "github.com/sei-protocol/sei-chain/x/mint/types"
+	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+)
+
+func TestTransferRentFromDexToCollector(t *testing.T) {
+	preRents := map[string]uint64{"abc": 100, "def": 50}
+	postRents := map[string]uint64{"abc": 70}
+
+	// expected total is (100 - 70) + 50 = 80
+	testApp := keepertest.TestApp()
+	ctx := testApp.BaseApp.NewContext(false, tmproto.Header{Time: time.Now()})
+	bankkeeper := testApp.BankKeeper
+	err := bankkeeper.MintCoins(ctx, minttypes.ModuleName, sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(100))))
+	require.Nil(t, err)
+	err = bankkeeper.SendCoinsFromModuleToModule(ctx, minttypes.ModuleName, types.ModuleName, sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(100))))
+	require.Nil(t, err)
+	contract.TransferRentFromDexToCollector(ctx, bankkeeper, preRents, postRents)
+	dexBalance := bankkeeper.GetBalance(ctx, testApp.AccountKeeper.GetModuleAddress(types.ModuleName), "usei")
+	require.Equal(t, int64(20), dexBalance.Amount.Int64())
+	collectorBalance := bankkeeper.GetBalance(ctx, testApp.AccountKeeper.GetModuleAddress(authtypes.FeeCollectorName), "usei")
+	require.Equal(t, int64(80), collectorBalance.Amount.Int64())
+}

--- a/x/dex/keeper/contract.go
+++ b/x/dex/keeper/contract.go
@@ -103,3 +103,13 @@ func (k Keeper) ChargeRentForGas(ctx sdk.Context, contractAddr string, gasUsed u
 	contract.RentBalance -= uint64(gasPrice)
 	return k.SetContract(ctx, &contract)
 }
+
+func (k Keeper) GetRentsForContracts(ctx sdk.Context, contractAddrs []string) map[string]uint64 {
+	res := map[string]uint64{}
+	for _, contractAddr := range contractAddrs {
+		if contract, err := k.GetContract(ctx, contractAddr); err == nil {
+			res[contractAddr] = contract.RentBalance
+		}
+	}
+	return res
+}

--- a/x/dex/keeper/contract_test.go
+++ b/x/dex/keeper/contract_test.go
@@ -1,8 +1,9 @@
 package keeper_test
 
 import (
-	"github.com/cosmos/cosmos-sdk/store/prefix"
 	"testing"
+
+	"github.com/cosmos/cosmos-sdk/store/prefix"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
@@ -125,4 +126,18 @@ func TestGetContractGasLimit(t *testing.T) {
 	gasLimit, err := keeper.GetContractGasLimit(ctx, contractAddr)
 	require.Nil(t, err)
 	require.Equal(t, uint64(10000000), gasLimit)
+}
+
+func TestGetRentsForContracts(t *testing.T) {
+	keeper, ctx := keepertest.DexKeeper(t)
+	addr := "sei1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrsgshtdj"
+	require.Equal(t, 0, len(keeper.GetRentsForContracts(ctx, []string{addr})))
+
+	keeper.SetContract(ctx, &types.ContractInfoV2{
+		Creator:      keepertest.TestAccount,
+		ContractAddr: addr,
+		CodeId:       1,
+		RentBalance:  100,
+	})
+	require.Equal(t, map[string]uint64{addr: uint64(100)}, keeper.GetRentsForContracts(ctx, []string{addr}))
 }


### PR DESCRIPTION
## Describe your changes and provide context
We want to automatically send rent consumed in each EndBlock to FeeCollector.

Specifically we will take an in-mem snapshot of eligible contracts' rent before EndBlock execution starts, and take another only if all contracts execute successfully. Then we will send the difference between the snapshots from `dex` module to `fee_collector` module (note that all rents are already stored in `dex` module's bank account: https://github.com/sei-protocol/sei-chain/blob/master/x/dex/keeper/msgserver/msg_server_contract_deposit_rent.go#L41)

## Testing performed to validate your change
unit tests

