### PR TITLE
Update GetRentsForContracts to use cachedCtx

### DIFF
--- a/x/dex/contract/abci.go
+++ b/x/dex/contract/abci.go
@@ -49,7 +49,7 @@ func EndBlockerAtomic(ctx sdk.Context, keeper *keeper.Keeper, validContractsInfo
 	env := newEnv(ctx, validContractsInfo, keeper)
 	cachedCtx, msCached := cacheContext(ctx, env)
 	memStateCopy := dexutils.GetMemState(cachedCtx.Context()).DeepCopy()
-	preRunRents := keeper.GetRentsForContracts(ctx, seiutils.Map(validContractsInfo, func(c types.ContractInfoV2) string { return c.ContractAddr }))
+	preRunRents := keeper.GetRentsForContracts(cachedCtx, seiutils.Map(validContractsInfo, func(c types.ContractInfoV2) string { return c.ContractAddr }))
 
 	handleDeposits(spanCtx, cachedCtx, env, keeper, tracer)
 
@@ -71,7 +71,7 @@ func EndBlockerAtomic(ctx sdk.Context, keeper *keeper.Keeper, validContractsInfo
 
 	// No error is thrown for any contract. This should happen most of the time.
 	if env.failedContractAddresses.Size() == 0 {
-		postRunRents := keeper.GetRentsForContracts(ctx, seiutils.Map(validContractsInfo, func(c types.ContractInfoV2) string { return c.ContractAddr }))
+		postRunRents := keeper.GetRentsForContracts(cachedCtx, seiutils.Map(validContractsInfo, func(c types.ContractInfoV2) string { return c.ContractAddr }))
 		TransferRentFromDexToCollector(ctx, keeper.BankKeeper, preRunRents, postRunRents)
 		msCached.Write()
 		return env.validContractsInfo, ctx, true


### PR DESCRIPTION
## Describe your changes and provide context
- Fixes issue with `TransferRentFromDexToCollector` not updating amount deducted for rent in End Block
-  `GetRentsForContracts` to used cached context `cachedCtx`

## Testing performed to validate your change
- Spun up local chain, uploaded contract and verified amount sent from `TransferRentFromDexToCollector` 

```
11:36PM INF TransferRentFromDexToCollector - preRents map[sei14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sh9m79m:100000000]

11:36PM INF TransferRentFromDexToCollector - postRents map[sei14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sh9m79m:99984719]

11:36PM INF TransferRentFromDexToCollector - total 15281```
