### PR TITLE
Bump max wasm file size to 2MB

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1580,6 +1580,6 @@ func (app *App) decorateContextWithDexMemState(base context.Context) context.Con
 }
 
 func init() {
-	// override max wasm size to 1MB
-	wasmtypes.MaxWasmSize = 1280 * 1024
+	// override max wasm size to 2MB
+	wasmtypes.MaxWasmSize = 2 * 1024 * 1024
 }

--- a/app/app.go
+++ b/app/app.go
@@ -1581,5 +1581,5 @@ func (app *App) decorateContextWithDexMemState(base context.Context) context.Con
 
 func init() {
 	// override max wasm size to 1MB
-	wasmtypes.MaxWasmSize = 1024 * 1024
+	wasmtypes.MaxWasmSize = 1280 * 1024
 }


### PR DESCRIPTION
## Describe your changes and provide context
This change bumps the maximal uploadable wasm file size from 1024 * 1024 to 1280 * 1024.

## Testing performed to validate your change
- unit test
- e2e contract deployment test
