### PR TITLE
Populate empty orderbook when no pair registered

### DIFF
--- a/x/dex/keeper/utils/order_book.go
+++ b/x/dex/keeper/utils/order_book.go
@@ -41,6 +41,7 @@ func PopulateAllOrderbooks(
 	var orderBooks = datastructures.NewTypedNestedSyncMap[string, dextypesutils.PairString, *types.OrderBook]()
 	wg := sync.WaitGroup{}
 	for contractAddr, pairs := range contractsAndPairs {
+		orderBooks.Store(contractAddr, datastructures.NewTypedSyncMap[dextypesutils.PairString, *types.OrderBook]())
 		for _, pair := range pairs {
 			wg.Add(1)
 			go func(contractAddr string, pair types.Pair) {


### PR DESCRIPTION
## Describe your changes and provide context
When no pair is registered for a contract, the old logic would not populate orderbook for the contract which would cause this check to fail https://github.com/sei-protocol/sei-chain/blob/master/x/dex/contract/abci.go#L225 and thus cause the contract to be considered a failed contract. This does not cause correctness issue because a no-pair contract should no-op anyway but does cause performance issue because each EndBlock now needs to be processed twice. This PR populates empty orderbook for such contract so that they will properly noop.

## Testing performed to validate your change
unit test which fails before the change and passes after the change

