### PR TITLE
Automatically unregister failed contracts in Dex EndBlock

### DIFF
--- a/x/dex/keeper/contract.go
+++ b/x/dex/keeper/contract.go
@@ -115,11 +115,7 @@ func (k Keeper) GetRentsForContracts(ctx sdk.Context, contractAddrs []string) ma
 	return res
 }
 
-func (k Keeper) unregisterContract(ctx sdk.Context, contract types.ContractInfoV2) error {
-	creatorAddr, _ := sdk.AccAddressFromBech32(contract.Creator)
-	if err := k.BankKeeper.SendCoins(ctx, k.AccountKeeper.GetModuleAddress(types.ModuleName), creatorAddr, sdk.NewCoins(sdk.NewCoin(appparams.BaseCoinUnit, sdk.NewInt(int64(contract.RentBalance))))); err != nil {
-		return err
-	}
+func (k Keeper) DoUnregisterContract(ctx sdk.Context, contract types.ContractInfoV2) error {
 	k.DeleteContract(ctx, contract.ContractAddr)
 	k.RemoveAllLongBooksForContract(ctx, contract.ContractAddr)
 	k.RemoveAllShortBooksForContract(ctx, contract.ContractAddr)
@@ -128,5 +124,9 @@ func (k Keeper) unregisterContract(ctx sdk.Context, contract types.ContractInfoV
 	k.DeleteNextOrderID(ctx, contract.ContractAddr)
 	k.DeleteAllRegisteredPairsForContract(ctx, contract.ContractAddr)
 	k.RemoveAllTriggeredOrders(ctx, contract.ContractAddr)
+	creatorAddr, _ := sdk.AccAddressFromBech32(contract.Creator)
+	if err := k.BankKeeper.SendCoins(ctx, k.AccountKeeper.GetModuleAddress(types.ModuleName), creatorAddr, sdk.NewCoins(sdk.NewCoin(appparams.BaseCoinUnit, sdk.NewInt(int64(contract.RentBalance))))); err != nil {
+		return err
+	}
 	return nil
 }

--- a/x/dex/keeper/contract.go
+++ b/x/dex/keeper/contract.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	appparams "github.com/sei-protocol/sei-chain/app/params"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 )
 
@@ -112,4 +113,20 @@ func (k Keeper) GetRentsForContracts(ctx sdk.Context, contractAddrs []string) ma
 		}
 	}
 	return res
+}
+
+func (k Keeper) unregisterContract(ctx sdk.Context, contract types.ContractInfoV2) error {
+	creatorAddr, _ := sdk.AccAddressFromBech32(contract.Creator)
+	if err := k.BankKeeper.SendCoins(ctx, k.AccountKeeper.GetModuleAddress(types.ModuleName), creatorAddr, sdk.NewCoins(sdk.NewCoin(appparams.BaseCoinUnit, sdk.NewInt(int64(contract.RentBalance))))); err != nil {
+		return err
+	}
+	k.DeleteContract(ctx, contract.ContractAddr)
+	k.RemoveAllLongBooksForContract(ctx, contract.ContractAddr)
+	k.RemoveAllShortBooksForContract(ctx, contract.ContractAddr)
+	k.RemoveAllPricesForContract(ctx, contract.ContractAddr)
+	k.DeleteMatchResultState(ctx, contract.ContractAddr)
+	k.DeleteNextOrderID(ctx, contract.ContractAddr)
+	k.DeleteAllRegisteredPairsForContract(ctx, contract.ContractAddr)
+	k.RemoveAllTriggeredOrders(ctx, contract.ContractAddr)
+	return nil
 }

--- a/x/dex/keeper/msgserver/msg_server_unregister_contract.go
+++ b/x/dex/keeper/msgserver/msg_server_unregister_contract.go
@@ -24,7 +24,7 @@ func (k msgServer) UnregisterContract(goCtx context.Context, msg *types.MsgUnreg
 	if contract.Creator != msg.Creator {
 		return nil, sdkerrors.ErrUnauthorized
 	}
-	if err := k.DoUnregisterContract(ctx, contract); err != nil {
+	if err := k.DoUnregisterContractWithRefund(ctx, contract); err != nil {
 		return nil, err
 	}
 

--- a/x/dex/keeper/msgserver/msg_server_unregister_contract.go
+++ b/x/dex/keeper/msgserver/msg_server_unregister_contract.go
@@ -6,7 +6,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	appparams "github.com/sei-protocol/sei-chain/app/params"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 )
 
@@ -25,19 +24,9 @@ func (k msgServer) UnregisterContract(goCtx context.Context, msg *types.MsgUnreg
 	if contract.Creator != msg.Creator {
 		return nil, sdkerrors.ErrUnauthorized
 	}
-	// refund remaining rent to the creator
-	creatorAddr, _ := sdk.AccAddressFromBech32(contract.Creator)
-	if err := k.BankKeeper.SendCoins(ctx, k.AccountKeeper.GetModuleAddress(types.ModuleName), creatorAddr, sdk.NewCoins(sdk.NewCoin(appparams.BaseCoinUnit, sdk.NewInt(int64(contract.RentBalance))))); err != nil {
+	if err := k.DoUnregisterContract(ctx, contract); err != nil {
 		return nil, err
 	}
-	k.DeleteContract(ctx, msg.ContractAddr)
-	k.RemoveAllLongBooksForContract(ctx, msg.ContractAddr)
-	k.RemoveAllShortBooksForContract(ctx, msg.ContractAddr)
-	k.RemoveAllPricesForContract(ctx, msg.ContractAddr)
-	k.DeleteMatchResultState(ctx, msg.ContractAddr)
-	k.DeleteNextOrderID(ctx, msg.ContractAddr)
-	k.DeleteAllRegisteredPairsForContract(ctx, msg.ContractAddr)
-	k.RemoveAllTriggeredOrders(ctx, msg.ContractAddr)
 
 	ctx.EventManager().EmitEvent(sdk.NewEvent(
 		types.EventTypeUnregisterContract,

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -301,10 +301,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) (ret []abc
 	}
 	for _, c := range validContractsInfoAtBeginning {
 		if _, ok := validContractAddrs[c.ContractAddr]; !ok {
-			// unregister here also refunds rents, which might be a behavior we want to revisit if spamming becomes bad
-			if err := am.keeper.DoUnregisterContract(ctx, c); err != nil {
-				ctx.Logger().Error("unregister %s encountered error %s", c.ContractAddr, err)
-			}
+			am.keeper.DoUnregisterContract(ctx, c)
 		}
 	}
 

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -302,7 +302,9 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) (ret []abc
 	for _, c := range validContractsInfoAtBeginning {
 		if _, ok := validContractAddrs[c.ContractAddr]; !ok {
 			// unregister here also refunds rents, which might be a behavior we want to revisit if spamming becomes bad
-			am.keeper.DoUnregisterContract(ctx, c)
+			if err := am.keeper.DoUnregisterContract(ctx, c); err != nil {
+				ctx.Logger().Error("unregister %s encountered error %s", c.ContractAddr, err)
+			}
 		}
 	}
 

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -273,6 +273,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) (ret []abc
 	defer dexutils.GetMemState(ctx.Context()).Clear(ctx)
 
 	validContractsInfo := am.getAllContractInfo(ctx)
+	validContractsInfoAtBeginning := validContractsInfo
 	// Each iteration is atomic. If an iteration finishes without any error, it will return,
 	// otherwise it will rollback any state change, filter out contracts that cause the error,
 	// and proceed to the next iteration. The loop is guaranteed to finish since
@@ -292,6 +293,16 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) (ret []abc
 		if iterCounter == 0 {
 			ctx.Logger().Error("All contracts failed in dex EndBlock. Doing nothing.")
 			break
+		}
+	}
+	validContractAddrs := map[string]struct{}{}
+	for _, c := range validContractsInfo {
+		validContractAddrs[c.ContractAddr] = struct{}{}
+	}
+	for _, c := range validContractsInfoAtBeginning {
+		if _, ok := validContractAddrs[c.ContractAddr]; !ok {
+			// unregister here also refunds rents, which might be a behavior we want to revisit if spamming becomes bad
+			am.keeper.DoUnregisterContract(ctx, c)
 		}
 	}
 

--- a/x/dex/module_test.go
+++ b/x/dex/module_test.go
@@ -458,6 +458,9 @@ func TestEndBlockPartialRollback(t *testing.T) {
 	// No state change should've been persisted for bad contract
 	matchResult, _ := dexkeeper.GetMatchResultState(ctx, keepertest.TestContract)
 	require.Equal(t, &types.MatchResult{}, matchResult)
+	// bad contract should be unregistered
+	_, err = dexkeeper.GetContract(ctx, keepertest.TestContract)
+	require.Equal(t, types.ErrContractNotExists, err)
 	// state change should've been persisted for good contract
 	matchResult, _ = dexkeeper.GetMatchResultState(ctx, contractAddr.String())
 	require.Equal(t, 1, len(matchResult.Orders))


### PR DESCRIPTION
## Describe your changes and provide context
If a contract fails execution in dex EndBlock, we want to automatically unregister it so that it doesn't slow down the chain for an indefinite amount of time

## Testing performed to validate your change
unit test
