### PR TITLE
Add more metrics for dex module

### DIFF
--- a/x/dex/contract/abci.go
+++ b/x/dex/contract/abci.go
@@ -72,7 +72,7 @@ func EndBlockerAtomic(ctx sdk.Context, keeper *keeper.Keeper, validContractsInfo
 	handleSettlements(spanCtx, cachedCtx, env, keeper, tracer)
 	handleUnfulfilledMarketOrders(spanCtx, cachedCtx, env, keeper, tracer)
 
-	telemetry.SetGauge(float32(env.failedContractAddresses.Size()), "dex", "failed_contracts_count")
+	telemetry.SetGauge(float32(env.failedContractAddresses.Size()), "dex", "num_of_failed_contracts")
 	// No error is thrown for any contract. This should happen most of the time.
 	if env.failedContractAddresses.Size() == 0 {
 		postRunRents := keeper.GetRentsForContracts(cachedCtx, seiutils.Map(validContractsInfo, func(c types.ContractInfoV2) string { return c.ContractAddr }))

--- a/x/dex/contract/abci.go
+++ b/x/dex/contract/abci.go
@@ -72,7 +72,7 @@ func EndBlockerAtomic(ctx sdk.Context, keeper *keeper.Keeper, validContractsInfo
 	handleSettlements(spanCtx, cachedCtx, env, keeper, tracer)
 	handleUnfulfilledMarketOrders(spanCtx, cachedCtx, env, keeper, tracer)
 
-	telemetry.SetGauge(float32(env.failedContractAddresses.Size()), "dex", "num_of_failed_contracts")
+	telemetry.IncrCounter(float32(env.failedContractAddresses.Size()), "dex", "total_failed_contracts")
 	// No error is thrown for any contract. This should happen most of the time.
 	if env.failedContractAddresses.Size() == 0 {
 		postRunRents := keeper.GetRentsForContracts(cachedCtx, seiutils.Map(validContractsInfo, func(c types.ContractInfoV2) string { return c.ContractAddr }))

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -228,8 +228,8 @@ func (am AppModule) getAllContractInfo(ctx sdk.Context) []types.ContractInfoV2 {
 	defer telemetry.MeasureSince(time.Now(), am.Name(), "get_all_contract_info")
 	allRegisteredContracts := am.keeper.GetAllContractInfo(ctx)
 	validContracts := utils.Filter(allRegisteredContracts, func(c types.ContractInfoV2) bool { return c.RentBalance > 0 })
-	telemetry.SetGauge(float32(len(allRegisteredContracts)), am.Name(), "registered_contracts_count")
-	telemetry.SetGauge(float32(len(validContracts)), am.Name(), "valid_contracts_count")
+	telemetry.SetGauge(float32(len(allRegisteredContracts)), am.Name(), "num_of_registered_contracts")
+	telemetry.SetGauge(float32(len(validContracts)), am.Name(), "num_of_valid_contracts_count")
 	return validContracts
 }
 

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -230,7 +230,7 @@ func (am AppModule) getAllContractInfo(ctx sdk.Context) []types.ContractInfoV2 {
 	validContracts := utils.Filter(allRegisteredContracts, func(c types.ContractInfoV2) bool { return c.RentBalance > 0 })
 	telemetry.SetGauge(float32(len(allRegisteredContracts)), am.Name(), "num_of_registered_contracts")
 	telemetry.SetGauge(float32(len(validContracts)), am.Name(), "num_of_valid_contracts")
-	telemetry.SetGauge(float32(len(allRegisteredContracts)-len(validContracts)), am.Name(), "num_of_invalid_contracts")
+	telemetry.SetGauge(float32(len(allRegisteredContracts)-len(validContracts)), am.Name(), "num_of_zero_balance_contracts")
 	return validContracts
 }
 
@@ -313,6 +313,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) (ret []abc
 		if _, ok := validContractAddrs[c.ContractAddr]; !ok {
 			ctx.Logger().Error(fmt.Sprintf("Unregistering invalid contract %s", c.ContractAddr))
 			am.keeper.DoUnregisterContract(ctx, c)
+			telemetry.IncrCounter(float32(1), am.Name(), "total_unregistered_contracts")
 		}
 	}
 

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -229,7 +229,8 @@ func (am AppModule) getAllContractInfo(ctx sdk.Context) []types.ContractInfoV2 {
 	allRegisteredContracts := am.keeper.GetAllContractInfo(ctx)
 	validContracts := utils.Filter(allRegisteredContracts, func(c types.ContractInfoV2) bool { return c.RentBalance > 0 })
 	telemetry.SetGauge(float32(len(allRegisteredContracts)), am.Name(), "num_of_registered_contracts")
-	telemetry.SetGauge(float32(len(validContracts)), am.Name(), "num_of_valid_contracts_count")
+	telemetry.SetGauge(float32(len(validContracts)), am.Name(), "num_of_valid_contracts")
+	telemetry.SetGauge(float32(len(allRegisteredContracts)-len(validContracts)), am.Name(), "num_of_invalid_contracts")
 	return validContracts
 }
 

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -304,7 +304,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) (ret []abc
 			break
 		}
 	}
-	telemetry.MeasureSince(endBlockerStartTime, am.Name(), am.Name(), "total_end_blocker_atomic")
+	telemetry.MeasureSince(endBlockerStartTime, am.Name(), "total_end_blocker_atomic")
 	validContractAddrs := map[string]struct{}{}
 	for _, c := range validContractsInfo {
 		validContractAddrs[c.ContractAddr] = struct{}{}


### PR DESCRIPTION
## Describe your changes and provide context

Added following metrics:
**Latency:**
- get_all_contract_info
- end_blocker_atomic
- total_end_blocker_atomic
- handle_deposits
- order_matching_runnable
- handle_settlements
- handle_unfulfilled_market_orders

**Gauge:**
- num_of_registered_contracts
- num_of_valid_contracts
- num_of_zero_balance_contracts (rent =0)

**Counter:**
- total_failed_contracts
- total_unregistered_contracts

## Testing performed to validate your change
Tested in rpc nodes
