### PR TITLE
Clear unregistered contracts from other contracts dependency list

### DIFF
--- a/proto/dex/contract.proto
+++ b/proto/dex/contract.proto
@@ -23,6 +23,9 @@ message ContractInfoV2 {
   uint64 rentBalance = 8;
 }
 
+// suppose A is first registered and depends on X, then B is added and depends on X,
+// and then C is added and depends on X, then A is the elder sibling to B and B is 
+// the younger sibling to A, and B is the elder sibling to C and C is the younger to B
 message ContractDependencyInfo {
   string dependency = 1;
   string immediateElderSibling = 2;

--- a/utils/datastructures/set.go
+++ b/utils/datastructures/set.go
@@ -30,6 +30,12 @@ func (s *SyncSet[T]) Add(val T) {
 	s.dict[val] = true
 }
 
+func (s *SyncSet[T]) AddAll(vals []T) {
+	for _, val := range vals {
+		s.Add(val)
+	}
+}
+
 func (s *SyncSet[T]) Remove(val T) {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
## Describe your changes and provide context
When a contract X is unregistered, we should update other registered contracts' dependency list to remove that unregistered contracts, which includes:
- for contracts that depend on X, remove X from their list
- for contracts that X depend on, decrement `NumIncomingDependencies`
- for contracts that depend on the same contract which X depend on (i.e. sibling contracts), update the immediate sibling pointer so that X's immediate elder and younger sibling become immediate siblings with each other

If dependencies are not updated properly, `dex` EndBlock may hang due to dependency requirements that's never fulfillable.

## Testing performed to validate your change
unit test & local sei
