### PR TITLE
Change go job to Pull request target 

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,8 @@ name: Go
 on:
   push:
     branches: [ master ]
-  pull_request:
+  # Allows non-contributors to run PR jobs
+  pull_request_target:
     branches: [ master ]
 
 defaults:


### PR DESCRIPTION
## Describe your changes and provide context
Context: https://github.com/actions/first-interaction/issues/10#issuecomment-670968624

This should fix non-contributors not being able to run PR jobs 
## Testing performed to validate your change
Can't test on my side but I can update the branch for one of the external PRs to test after merging 
