### PR TITLE
Fix Zero Price Order

### DIFF
--- a/x/dex/ante.go
+++ b/x/dex/ante.go
@@ -57,7 +57,7 @@ func (tsmd TickSizeMultipleDecorator) CheckTickSizeMultiple(ctx sdk.Context, msg
 				if !IsDecimalMultipleOf(order.Price, priceTickSize) {
 					// Allow Market Orders with Price 0
 					if !IsMarketOrder(order) || !order.Price.IsZero() {
-						return sdkerrors.Wrapf(errors.New("ErrPriceNotMultipleOfTickSize"), "price needs to be multiple of price tick size")
+						return sdkerrors.Wrapf(errors.New("ErrPriceNotMultipleOfTickSize"), "price needs to be non-zero and multiple of price tick size")
 					}
 				}
 				quantityTickSize, found := tsmd.dexKeeper.GetQuantityTickSizeForPair(ctx, contractAddr,
@@ -69,7 +69,7 @@ func (tsmd TickSizeMultipleDecorator) CheckTickSizeMultiple(ctx sdk.Context, msg
 					return sdkerrors.Wrapf(sdkerrors.ErrKeyNotFound, "the pair {price:%s,asset:%s} has no quantity ticksize configured", order.PriceDenom, order.AssetDenom)
 				}
 				if !IsDecimalMultipleOf(order.Quantity, quantityTickSize) {
-					return sdkerrors.Wrapf(errors.New("ErrQuantityNotMultipleOfTickSize"), "quantity needs to be multiple of quantity tick size")
+					return sdkerrors.Wrapf(errors.New("ErrQuantityNotMultipleOfTickSize"), "quantity needs to be non-zero and multiple of quantity tick size")
 				}
 			}
 			continue

--- a/x/dex/ante.go
+++ b/x/dex/ante.go
@@ -79,8 +79,11 @@ func (tsmd TickSizeMultipleDecorator) CheckTickSizeMultiple(ctx sdk.Context, msg
 	return nil
 }
 
-// Check whether decimal a is multiple of decimal b
+// Check whether decimal a is multiple of decimal b or a is zero
 func IsDecimalMultipleOf(a, b sdk.Dec) bool {
+	if a.IsZero() {
+		return true
+	}
 	if a.LT(b) {
 		return false
 	}

--- a/x/dex/ante.go
+++ b/x/dex/ante.go
@@ -56,7 +56,7 @@ func (tsmd TickSizeMultipleDecorator) CheckTickSizeMultiple(ctx sdk.Context, msg
 				}
 				if !IsDecimalMultipleOf(order.Price, priceTickSize) {
 					// Allow Market Orders with Price 0
-					if !IsMarketOrder(order) || !order.Price.IsZero() {
+					if !(IsMarketOrder(order) && order.Price.IsZero()) {
 						return sdkerrors.Wrapf(errors.New("ErrPriceNotMultipleOfTickSize"), "price needs to be non-zero and multiple of price tick size")
 					}
 				}

--- a/x/dex/ante.go
+++ b/x/dex/ante.go
@@ -65,8 +65,11 @@ func (tsmd TickSizeMultipleDecorator) CheckTickSizeMultiple(ctx sdk.Context, msg
 				if !found {
 					return sdkerrors.Wrapf(sdkerrors.ErrKeyNotFound, "the pair {price:%s,asset:%s} has no quantity ticksize configured", order.PriceDenom, order.AssetDenom)
 				}
+				if order.Quantity.IsZero() {
+					return sdkerrors.Wrapf(errors.New("ErrQuantityZero"), "quantity can not be zero")
+				}
 				if !IsDecimalMultipleOf(order.Quantity, quantityTickSize) {
-					return sdkerrors.Wrapf(errors.New("ErrPriceNotMultipleOfTickSize"), "price needs to be multiple of quantity tick size")
+					return sdkerrors.Wrapf(errors.New("ErrQuantityNotMultipleOfTickSize"), "quantity needs to be multiple of quantity tick size")
 				}
 			}
 			continue

--- a/x/dex/ante_test.go
+++ b/x/dex/ante_test.go
@@ -49,7 +49,6 @@ func TestIsDecimalMultipleOf(t *testing.T) {
 	v8, _ := sdk.NewDecFromStr("3")
 	v9, _ := sdk.NewDecFromStr("5.4")
 	v10, _ := sdk.NewDecFromStr("0.3")
-	v11 := sdk.ZeroDec()
 
 	assert.True(t, dex.IsDecimalMultipleOf(v1, v2))
 	assert.True(t, !dex.IsDecimalMultipleOf(v2, v1))

--- a/x/dex/ante_test.go
+++ b/x/dex/ante_test.go
@@ -62,19 +62,6 @@ func TestIsDecimalMultipleOf(t *testing.T) {
 	assert.True(t, !dex.IsDecimalMultipleOf(v7, v3))
 	assert.True(t, dex.IsDecimalMultipleOf(v8, v6))
 	assert.True(t, dex.IsDecimalMultipleOf(v9, v10))
-
-	// Zero is multiple of all
-	assert.True(t, dex.IsDecimalMultipleOf(v11, v1))
-	assert.True(t, dex.IsDecimalMultipleOf(v11, v2))
-	assert.True(t, dex.IsDecimalMultipleOf(v11, v3))
-	assert.True(t, dex.IsDecimalMultipleOf(v11, v4))
-	assert.True(t, dex.IsDecimalMultipleOf(v11, v5))
-	assert.True(t, dex.IsDecimalMultipleOf(v11, v6))
-	assert.True(t, dex.IsDecimalMultipleOf(v11, v7))
-	assert.True(t, dex.IsDecimalMultipleOf(v11, v8))
-	assert.True(t, dex.IsDecimalMultipleOf(v11, v9))
-	assert.True(t, dex.IsDecimalMultipleOf(v11, v10))
-	assert.True(t, dex.IsDecimalMultipleOf(v11, v11))
 }
 
 func TestCheckDexGasDecorator(t *testing.T) {

--- a/x/dex/ante_test.go
+++ b/x/dex/ante_test.go
@@ -49,6 +49,7 @@ func TestIsDecimalMultipleOf(t *testing.T) {
 	v8, _ := sdk.NewDecFromStr("3")
 	v9, _ := sdk.NewDecFromStr("5.4")
 	v10, _ := sdk.NewDecFromStr("0.3")
+	v11 := sdk.ZeroDec()
 
 	assert.True(t, dex.IsDecimalMultipleOf(v1, v2))
 	assert.True(t, !dex.IsDecimalMultipleOf(v2, v1))
@@ -61,6 +62,19 @@ func TestIsDecimalMultipleOf(t *testing.T) {
 	assert.True(t, !dex.IsDecimalMultipleOf(v7, v3))
 	assert.True(t, dex.IsDecimalMultipleOf(v8, v6))
 	assert.True(t, dex.IsDecimalMultipleOf(v9, v10))
+
+	// Zero is multiple of all
+	assert.True(t, dex.IsDecimalMultipleOf(v11, v1))
+	assert.True(t, dex.IsDecimalMultipleOf(v11, v2))
+	assert.True(t, dex.IsDecimalMultipleOf(v11, v3))
+	assert.True(t, dex.IsDecimalMultipleOf(v11, v4))
+	assert.True(t, dex.IsDecimalMultipleOf(v11, v5))
+	assert.True(t, dex.IsDecimalMultipleOf(v11, v6))
+	assert.True(t, dex.IsDecimalMultipleOf(v11, v7))
+	assert.True(t, dex.IsDecimalMultipleOf(v11, v8))
+	assert.True(t, dex.IsDecimalMultipleOf(v11, v9))
+	assert.True(t, dex.IsDecimalMultipleOf(v11, v10))
+	assert.True(t, dex.IsDecimalMultipleOf(v11, v11))
 }
 
 func TestCheckDexGasDecorator(t *testing.T) {

--- a/x/dex/exchange/market_order.go
+++ b/x/dex/exchange/market_order.go
@@ -1,7 +1,6 @@
 package exchange
 
 import (
-	"fmt"
 	"math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -16,7 +15,6 @@ func MatchMarketOrders(
 	direction types.PositionDirection,
 	blockOrders *cache.BlockOrders,
 ) ExecutionOutcome {
-	ctx.Logger().Info(fmt.Sprintf("MatchMarketOrders orders beginning %+v\n", marketOrders))
 	totalExecuted, totalPrice := sdk.ZeroDec(), sdk.ZeroDec()
 	minPrice, maxPrice := sdk.NewDecFromInt(sdk.NewIntFromUint64(math.MaxInt64)), sdk.OneDec().Neg()
 	settlements := []*types.SettlementEntry{}
@@ -35,20 +33,14 @@ func MatchMarketOrders(
 		}
 	}
 
-	ctx.Logger().Info(fmt.Sprintf("MatchMarketOrders total Executed %+v\n", totalExecuted))
-	ctx.Logger().Info(fmt.Sprintf("MatchMarketOrders total Price %+v\n", totalPrice))
-
 	if totalExecuted.IsPositive() {
-		ctx.Logger().Info(fmt.Sprintf("MatchMarketOrders total first \n"))
 		clearingPrice := totalPrice.Quo(totalExecuted)
-		ctx.Logger().Info(fmt.Sprintf("MatchMarketOrders total second \n"))
 		for _, settlement := range allTakerSettlements {
 			settlement.ExecutionCostOrProceed = clearingPrice
 		}
 		minPrice, maxPrice = clearingPrice, clearingPrice
 		settlements = append(settlements, allTakerSettlements...)
 	}
-	ctx.Logger().Info(fmt.Sprintf("MatchMarketOrders end \n"))
 	return ExecutionOutcome{
 		TotalNotional: totalPrice,
 		TotalQuantity: totalExecuted,
@@ -71,7 +63,6 @@ func MatchMarketOrder(
 	allTakerSettlements []*types.SettlementEntry,
 	blockOrders *cache.BlockOrders,
 ) ([]*types.SettlementEntry, []*types.SettlementEntry) {
-	ctx.Logger().Info(fmt.Sprintf("MatchMarketOrders order inner %+v\n", marketOrder))
 	remainingQuantity := marketOrder.Quantity
 	for i := range orderBookEntries.Entries {
 		var existingOrder types.OrderBookEntry


### PR DESCRIPTION
## Describe your changes and provide context

- Allows Market Price of Zero
- Fixes issue with Orders where zero price (which is allowed) was giving error because it previously wasn't a multiple of tick size

## Testing performed to validate your change
- Tested e2e local chain placing orders + market orders with price 0
