### PR TITLE
[Oak Audit] Register legacy amino for x/dex

### DIFF
--- a/x/dex/types/codec.go
+++ b/x/dex/types/codec.go
@@ -3,6 +3,7 @@ package types
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
@@ -58,3 +59,9 @@ var (
 	Amino     = codec.NewLegacyAmino()
 	ModuleCdc = codec.NewProtoCodec(cdctypes.NewInterfaceRegistry())
 )
+
+func init() {
+	RegisterCodec(Amino)
+	cryptocodec.RegisterCrypto(Amino)
+	Amino.Seal()
+}


### PR DESCRIPTION
## Describe your changes and provide context
Similar to https://github.com/cosmos/cosmos-sdk/blob/v0.45.4/x/staking/types/codec.go#L51-L55, registers legacy amino
## Testing performed to validate your change
- Unit tests
- Ran chain locally

