### PR TITLE
Add dex order metrics

### DIFF
--- a/x/dex/keeper/msgserver/msg_server_place_orders.go
+++ b/x/dex/keeper/msgserver/msg_server_place_orders.go
@@ -48,12 +48,12 @@ func (k msgServer) PlaceOrders(goCtx context.Context, msg *types.MsgPlaceOrders)
 
 	// We will report the following dex metrics:
 	//   total order count: sei_throughput_order_count
-	//   per order info: sei_throughput_order_count-[ORDER_TYPE]-[POSITION_DIRECTION]-[ORDER_STATUS]
+	//   per order info: sei_throughput_order_count_[ORDER_TYPE]_[POSITION_DIRECTION]_[ORDER_STATUS]
 
 	defer func() {
 		ctx.ContextMemCache().IncrMetricCounter(uint32(len(msg.Orders)), sdk.ORDER_COUNT)
 		for _, order := range msg.Orders {
-			ctx.ContextMemCache().IncrMetricCounter(1, fmt.Sprintf("%s-%s-%s-%s", sdk.ORDER_COUNT, order.OrderType.String(), order.PositionDirection.String(), order.Status.String()))
+			ctx.ContextMemCache().IncrMetricCounter(1, fmt.Sprintf("%s_%s_%s_%s", sdk.ORDER_COUNT, order.OrderType.String(), order.PositionDirection.String(), order.Status.String()))
 		}
 	}()
 

--- a/x/dex/keeper/msgserver/msg_server_place_orders.go
+++ b/x/dex/keeper/msgserver/msg_server_place_orders.go
@@ -53,8 +53,7 @@ func (k msgServer) PlaceOrders(goCtx context.Context, msg *types.MsgPlaceOrders)
 	defer func() {
 		ctx.ContextMemCache().IncrMetricCounter(uint32(len(msg.Orders)), sdk.ORDER_COUNT)
 		for _, order := range msg.Orders {
-			ctx.ContextMemCache().IncrMetricCounter(1, fmt.Sprintf("%s-%s-%s", sdk.ORDER_COUNT, order.OrderType, order.PositionDirection, order.Status))
-
+			ctx.ContextMemCache().IncrMetricCounter(1, fmt.Sprintf("%s-%s-%s", sdk.ORDER_COUNT, order.OrderType.String(), order.PositionDirection.String(), order.Status.String()))
 		}
 	}()
 

--- a/x/dex/keeper/msgserver/msg_server_place_orders.go
+++ b/x/dex/keeper/msgserver/msg_server_place_orders.go
@@ -53,7 +53,7 @@ func (k msgServer) PlaceOrders(goCtx context.Context, msg *types.MsgPlaceOrders)
 	defer func() {
 		ctx.ContextMemCache().IncrMetricCounter(uint32(len(msg.Orders)), sdk.ORDER_COUNT)
 		for _, order := range msg.Orders {
-			ctx.ContextMemCache().IncrMetricCounter(1, fmt.Sprintf("%s-%s-%s", sdk.ORDER_COUNT, order.OrderType.String(), order.PositionDirection.String(), order.Status.String()))
+			ctx.ContextMemCache().IncrMetricCounter(1, fmt.Sprintf("%s-%s-%s-%s", sdk.ORDER_COUNT, order.OrderType.String(), order.PositionDirection.String(), order.Status.String()))
 		}
 	}()
 


### PR DESCRIPTION
## Describe your changes and provide context
Adds more fine-grained dex order metrics for debugging.
## Testing performed to validate your change

Deployed to a cluster and verified:
```
# TYPE sei_throughput_order_count gauge
sei_throughput_order_count 500
# HELP sei_throughput_order_count_LIMIT_LONG_PLACED sei_throughput_order_count_LIMIT_LONG_PLACED
# TYPE sei_throughput_order_count_LIMIT_LONG_PLACED gauge
sei_throughput_order_count_LIMIT_LONG_PLACED 47
# HELP sei_throughput_order_count_LIMIT_SHORT_PLACED sei_throughput_order_count_LIMIT_SHORT_PLACED
# TYPE sei_throughput_order_count_LIMIT_SHORT_PLACED gauge
sei_throughput_order_count_LIMIT_SHORT_PLACED 48
# HELP sei_throughput_order_count_MARKET_LONG_PLACED sei_throughput_order_count_MARKET_LONG_PLACED
# TYPE sei_throughput_order_count_MARKET_LONG_PLACED gauge
sei_throughput_order_count_MARKET_LONG_PLACED 200
# HELP sei_throughput_order_count_MARKET_SHORT_PLACED sei_throughput_order_count_MARKET_SHORT_PLACED
# TYPE sei_throughput_order_count_MARKET_SHORT_PLACED gauge
sei_throughput_order_count_MARKET_SHORT_PLACED 205
```
