### PR TITLE
modify wasm gas multiplier to make wasm executes more in line with compute cost

### DIFF
--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -255,8 +255,8 @@ func newApp(
 	wasmGasRegisterConfig := wasmkeeper.DefaultGasRegisterConfig()
 	// This varies from the default value of 140_000_000 because we would like to appropriately represent the
 	// compute time required as a proportion of block gas used for a wasm contract that performs a lot of compute
-	// This makes it such that the wasm VM gas converts to sdk gas at a 20x rate vs that of the previous multiplier
-	wasmGasRegisterConfig.GasMultiplier = 7_000_000
+	// This makes it such that the wasm VM gas converts to sdk gas at a 6.66x rate vs that of the previous multiplier
+	wasmGasRegisterConfig.GasMultiplier = 21_000_000
 
 	return app.New(
 		logger,

--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/config"
@@ -251,6 +252,9 @@ func newApp(
 		panic(err)
 	}
 
+	wasmGasRegisterConfig := wasmkeeper.DefaultGasRegisterConfig()
+	wasmGasRegisterConfig.GasMultiplier = 8750000
+
 	return app.New(
 		logger,
 		db,
@@ -263,7 +267,13 @@ func newApp(
 		app.MakeEncodingConfig(),
 		wasm.EnableAllProposals,
 		appOpts,
-		[]wasm.Option{},
+		[]wasm.Option{
+			wasmkeeper.WithGasRegister(
+				wasmkeeper.NewWasmGasRegister(
+					wasmGasRegisterConfig,
+				),
+			),
+		},
 		[]aclkeeper.Option{},
 		baseapp.SetPruning(pruningOpts),
 		baseapp.SetMinGasPrices(cast.ToString(appOpts.Get(server.FlagMinGasPrices))),

--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -253,7 +253,10 @@ func newApp(
 	}
 
 	wasmGasRegisterConfig := wasmkeeper.DefaultGasRegisterConfig()
-	wasmGasRegisterConfig.GasMultiplier = 8750000
+	// This varies from the default value of 140_000_000 because we would like to appropriately represent the
+	// compute time required as a proportion of block gas used for a wasm contract that performs a lot of compute
+	// This makes it such that the wasm VM gas converts to sdk gas at a 20x rate vs that of the previous multiplier
+	wasmGasRegisterConfig.GasMultiplier = 7_000_000
 
 	return app.New(
 		logger,


### PR DESCRIPTION
## Describe your changes and provide context
This increases the gas used by wasm vm to better represent compute time used

## Testing performed to validate your change
Tested on loadtest clusters, verified that contract upload is not affected as well
