### PR TITLE
Add metrics for message type throughput and runTx latency

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -386,17 +386,18 @@ func New(
 	memKeys := sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey, dexmoduletypes.MemStoreKey)
 
 	app := &App{
-		BaseApp:           bApp,
-		cdc:               cdc,
-		appCodec:          appCodec,
-		interfaceRegistry: interfaceRegistry,
-		invCheckPeriod:    invCheckPeriod,
-		keys:              keys,
-		tkeys:             tkeys,
-		memKeys:           memKeys,
-		txDecoder:         encodingConfig.TxConfig.TxDecoder(),
-		versionInfo:       version.NewInfo(),
-		metricCounter:     &map[string]float32{},
+		BaseApp:                bApp,
+		cdc:                    cdc,
+		appCodec:               appCodec,
+		interfaceRegistry:      interfaceRegistry,
+		invCheckPeriod:         invCheckPeriod,
+		keys:                   keys,
+		tkeys:                  tkeys,
+		memKeys:                memKeys,
+		txDecoder:              encodingConfig.TxConfig.TxDecoder(),
+		versionInfo:            version.NewInfo(),
+		metricCounter:          &map[string]float32{},
+		metricCounterWithLabel: &map[string]map[string]uint32{},
 	}
 	app.ParamsKeeper = initParamsKeeper(appCodec, cdc, keys[paramstypes.StoreKey], tkeys[paramstypes.TStoreKey])
 

--- a/go.mod
+++ b/go.mod
@@ -269,7 +269,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.31
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.32
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.3
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4

--- a/go.sum
+++ b/go.sum
@@ -1067,8 +1067,6 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.2.31 h1:nvNEf17SQSv/kk7ianRO7+LTpasYmgkYx7g/cfD8Xy0=
-github.com/sei-protocol/sei-cosmos v0.2.31/go.mod h1:KEwpc1S0Byvf0KtMPPC/xTH2hVomjGyllxgUUHfOQJo=
 github.com/sei-protocol/sei-iavl v0.1.3 h1:0hvW1NtmBlZ7ZkerQcM/n+2tFKg0vUlYWK8q/OeuCgw=
 github.com/sei-protocol/sei-iavl v0.1.3/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-tendermint v0.2.17 h1:TwOVyF8F+Of2G8UEt0ShHDFQcFNmbGy4/c5Uui5UHqg=

--- a/go.sum
+++ b/go.sum
@@ -1067,6 +1067,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
+github.com/sei-protocol/sei-cosmos v0.2.32 h1:a1NMxSo7tk1WKPEMq0by7wEyyEQiwhYdsdQJRWdIbS4=
+github.com/sei-protocol/sei-cosmos v0.2.32/go.mod h1:KEwpc1S0Byvf0KtMPPC/xTH2hVomjGyllxgUUHfOQJo=
 github.com/sei-protocol/sei-iavl v0.1.3 h1:0hvW1NtmBlZ7ZkerQcM/n+2tFKg0vUlYWK8q/OeuCgw=
 github.com/sei-protocol/sei-iavl v0.1.3/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-tendermint v0.2.17 h1:TwOVyF8F+Of2G8UEt0ShHDFQcFNmbGy4/c5Uui5UHqg=

--- a/utils/metrics/metrics_util.go
+++ b/utils/metrics/metrics_util.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/telemetry"
 )
 
-// Measures the time taken to execute a sudo msg
+// MeasureSudoExecutionDuration Measures the time taken to execute a sudo msg
 // Metric Names:
 //
 //	sei_sudo_duration_miliseconds
@@ -21,7 +21,7 @@ func MeasureSudoExecutionDuration(start time.Time, msgType string) {
 	)
 }
 
-// Measures failed sudo execution count
+// IncrementSudoFailCount Measures failed sudo execution count
 // Metric Name:
 //
 //	sei_sudo_error_count
@@ -33,7 +33,7 @@ func IncrementSudoFailCount(msgType string) {
 	)
 }
 
-// Gauge metric with seid version and git commit as labels
+// GaugeSeidVersionAndCommit Gauge metric with seid version and git commit as labels
 // Metric Name:
 //
 //	seid_version_and_commit
@@ -45,7 +45,7 @@ func GaugeSeidVersionAndCommit(version string, commit string) {
 	)
 }
 
-// sei_tx_process_type_count
+// IncrTxProcessTypeCounter sei_tx_process_type_count
 func IncrTxProcessTypeCounter(processType string) {
 	metrics.IncrCounterWithLabels(
 		[]string{"sei", "tx", "process", "type"},
@@ -54,7 +54,7 @@ func IncrTxProcessTypeCounter(processType string) {
 	)
 }
 
-// Measures the time taken to process a block by the process type
+// BlockProcessLatency Measures the time taken to process a block by the process type
 // Metric Names:
 //
 //	sei_process_block_miliseconds
@@ -68,7 +68,7 @@ func BlockProcessLatency(start time.Time, processType string) {
 	)
 }
 
-// Measures the time taken to execute a sudo msg
+// IncrDagBuildErrorCounter Measures the time taken to execute a sudo msg
 // Metric Names:
 //
 //	sei_tx_process_type_count
@@ -80,7 +80,7 @@ func IncrDagBuildErrorCounter(reason string) {
 	)
 }
 
-// Counts the number of concurrent transactions that failed
+// IncrFailedConcurrentDeliverTxCounter Counts the number of concurrent transactions that failed
 // Metric Names:
 //
 //	sei_tx_concurrent_delivertx_error
@@ -92,7 +92,7 @@ func IncrFailedConcurrentDeliverTxCounter() {
 	)
 }
 
-// Counts the number of operations that failed due to operation timeout
+// IncrLogIfNotDoneAfter Counts the number of operations that failed due to operation timeout
 // Metric Names:
 //
 //	sei_log_not_done_after_counter
@@ -106,7 +106,7 @@ func IncrLogIfNotDoneAfter(label string) {
 	)
 }
 
-// Measures the time taken to execute a sudo msg
+// MeasureDeliverTxDuration Measures the time taken to execute a sudo msg
 // Metric Names:
 //
 //	sei_deliver_tx_duration_miliseconds
@@ -119,7 +119,33 @@ func MeasureDeliverTxDuration(start time.Time) {
 	)
 }
 
-// sei_oracle_vote_penalty_count
+// MeasureRunPrioritizedTxDuration Measures the time taken to run prioritized txs
+// Metric Names:
+//
+//	sei_run_prioritized_txs_duration_miliseconds
+//	sei_run_prioritized_txs_duration_miliseconds_count
+//	sei_run_prioritized_txs_duration_miliseconds_sum
+func MeasureRunPrioritizedTxDuration(start time.Time) {
+	metrics.MeasureSince(
+		[]string{"sei", "run", "prioritized_txs", "milliseconds"},
+		start.UTC(),
+	)
+}
+
+// MeasureRunTxDuration Measures the time taken to run prioritized txs
+// Metric Names:
+//
+//	sei_run_txs_duration_miliseconds
+//	sei_run_txs_duration_miliseconds_count
+//	sei_run_txs_duration_miliseconds_sum
+func MeasureRunTxDuration(start time.Time) {
+	metrics.MeasureSince(
+		[]string{"sei", "run", "txs", "milliseconds"},
+		start.UTC(),
+	)
+}
+
+// SetOracleVotePenaltyCount sei_oracle_vote_penalty_count
 func SetOracleVotePenaltyCount(count uint64, valAddr string, penaltyType string) {
 	metrics.SetGaugeWithLabels(
 		[]string{"sei", "oracle", "vote", "penalty", "count"},
@@ -131,7 +157,7 @@ func SetOracleVotePenaltyCount(count uint64, valAddr string, penaltyType string)
 	)
 }
 
-// sei_epoch_new
+// SetEpochNew sei_epoch_new
 func SetEpochNew(epochNum uint64) {
 	metrics.SetGauge(
 		[]string{"sei", "epoch", "new"},
@@ -139,7 +165,7 @@ func SetEpochNew(epochNum uint64) {
 	)
 }
 
-// Measures throughput
+// SetThroughputMetric Measures throughput
 // Metric Name:
 //
 //	sei_throughput_<metric_name>
@@ -150,7 +176,19 @@ func SetThroughputMetric(metricName string, value float32) {
 	)
 }
 
-// Measures number of times a denom's price is updated
+// SetThroughputMetricWithLabel Measures throughput with label
+// Metric Name:
+//
+//	sei_throughput_<metric_name>{label_name=label_key}
+func SetThroughputMetricWithLabel(metricName string, value float32, labelName string, labelValue string) {
+	telemetry.SetGaugeWithLabels(
+		[]string{"sei", "throughput", metricName},
+		value,
+		[]metrics.Label{{Name: labelName, Value: labelValue}},
+	)
+}
+
+// IncrPriceUpdateDenom Measures number of times a denom's price is updated
 // Metric Name:
 //
 //	sei_oracle_price_update_count
@@ -162,7 +200,7 @@ func IncrPriceUpdateDenom(denom string) {
 	)
 }
 
-// Measures the number of times the total block gas wanted in the proposal exceeds the max
+// IncrFailedTotalGasWantedCheck Measures the number of times the total block gas wanted in the proposal exceeds the max
 // Metric Name:
 //
 //	sei_failed_total_gas_wanted_check
@@ -174,7 +212,7 @@ func IncrFailedTotalGasWantedCheck(proposer string) {
 	)
 }
 
-// Measures the number of times the total block gas wanted in the proposal exceeds the max
+// IncrValidatorSlashed Measures the number of times the total block gas wanted in the proposal exceeds the max
 // Metric Name:
 //
 //	sei_failed_total_gas_wanted_check
@@ -186,7 +224,7 @@ func IncrValidatorSlashed(proposer string) {
 	)
 }
 
-// Measures number of times a denom's price is updated
+// SetCoinsMinted Measures number of times a denom's price is updated
 // Metric Name:
 //
 //	sei_oracle_price_update_count


### PR DESCRIPTION
## Describe your changes and provide context
Related change: https://github.com/sei-protocol/sei-cosmos/pull/246
Changes:
1. Add helper function to support labeled counter metrics 
2. Add runTx latency metrics for prioritized txs and non prioritized txs, this will help catch the Levana latency regression we saw this time.

## Testing performed to validate your change
Testing in RPC node

