### PR TITLE
Disable tx concurrency

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1330,6 +1330,8 @@ func (app *App) ProcessBlock(ctx sdk.Context, txs [][]byte, req BlockProcessRequ
 	events = append(events, midBlockEvents...)
 
 	// run other txs - this will run them synchronously without building a dag or executing concurrently
+	// TODO: re-enable this tx concurrency once dependencies have been declared properly and any potential
+	// nondeterminism with remediation flow has been fully investigated / resolved
 	// otherResults, ctx := app.BuildDependenciesAndRunTxs(ctx, txs)
 	otherResults := app.ProcessBlockSynchronous(ctx, txs)
 	txResults = append(txResults, otherResults...)

--- a/app/app.go
+++ b/app/app.go
@@ -1329,8 +1329,9 @@ func (app *App) ProcessBlock(ctx sdk.Context, txs [][]byte, req BlockProcessRequ
 	midBlockEvents := app.MidBlock(ctx, req.GetHeight())
 	events = append(events, midBlockEvents...)
 
-	// run other txs
-	otherResults, ctx := app.BuildDependenciesAndRunTxs(ctx, txs)
+	// run other txs - this will run them synchronously without building a dag or executing concurrently
+	// otherResults, ctx := app.BuildDependenciesAndRunTxs(ctx, txs)
+	otherResults := app.ProcessBlockSynchronous(ctx, txs)
 	txResults = append(txResults, otherResults...)
 
 	// Finalize all Bank Module Transfers here so that events are included


### PR DESCRIPTION
## Describe your changes and provide context
This disables tx execution concurrency on non prioritized (non-oracle, dexregister msgs) txs

## Testing performed to validate your change
Will test on a loadtest cluster
