### PR TITLE
Reset block gas meter if concurrent processing fails

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1188,6 +1188,10 @@ func (app *App) ProcessTxs(
 	// CacheMultiStore where it writes the data to the parent store (DeliverState) in sorted Key order to maintain
 	// deterministic ordering between validators in the case of concurrent deliverTXs
 	processBlockCtx, processBlockCache := app.CacheContext(ctx)
+	blockGasMeterConsumed := uint64(0)
+	if processBlockCtx.BlockGasMeter() != nil {
+		blockGasMeterConsumed = processBlockCtx.BlockGasMeter().GasConsumed()
+	}
 	concurrentResults, ok := processBlockConcurrentFunction(
 		processBlockCtx,
 		txs,
@@ -1214,6 +1218,10 @@ func (app *App) ProcessTxs(
 	dexMemState := dexutils.GetMemState(ctx.Context())
 	dexMemState.Clear(ctx)
 	dexMemState.ClearContractToDependencies()
+
+	if ctx.BlockGasMeter() != nil {
+		ctx.BlockGasMeter().RefundGas(ctx.BlockGasMeter().GasConsumed()-blockGasMeterConsumed, "concurrent failure rollback")
+	}
 
 	txResults := app.ProcessBlockSynchronous(ctx, txs)
 	processBlockCache.Write()

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -15,6 +15,7 @@ import (
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	"github.com/cosmos/cosmos-sdk/x/staking/teststaking"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	dexutils "github.com/sei-protocol/sei-chain/x/dex/utils"
 	minttypes "github.com/sei-protocol/sei-chain/x/mint/types"
 	"github.com/stretchr/testify/suite"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -50,9 +51,11 @@ type TestWrapper struct {
 
 func NewTestWrapper(t *testing.T, tm time.Time, valPub crptotypes.PubKey) *TestWrapper {
 	appPtr := Setup(false)
+	ctx := appPtr.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "sei-test", Time: tm})
+	ctx = ctx.WithContext(context.WithValue(ctx.Context(), dexutils.DexMemStateContextKey, appPtr.MemState))
 	wrapper := &TestWrapper{
 		App: appPtr,
-		Ctx: appPtr.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "sei-test", Time: tm}),
+		Ctx: ctx,
 	}
 	wrapper.SetT(t)
 	wrapper.setupValidator(stakingtypes.Bonded, valPub)


### PR DESCRIPTION
## Describe your changes and provide context
Refund any used gas during concurrent processing before sequential fallback processing

## Testing performed to validate your change

