### PR TITLE
Not charge gas for contract dependency loading

### DIFF
--- a/x/dex/ante.go
+++ b/x/dex/ante.go
@@ -126,20 +126,13 @@ func (d CheckDexGasDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 	} else {
 		memState = utils.GetMemState(ctx.Context())
 	}
-	contractLoader := func(addr string) *types.ContractInfoV2 {
-		contract, err := d.dexKeeper.GetContract(ctx, addr)
-		if err != nil {
-			return nil
-		}
-		return &contract
-	}
 	for _, msg := range tx.GetMsgs() {
 		switch m := msg.(type) {
 		case *types.MsgPlaceOrders:
-			numDependencies := len(memState.GetContractToDependencies(m.ContractAddr, contractLoader))
+			numDependencies := len(memState.GetContractToDependencies(ctx, m.ContractAddr, d.dexKeeper.GetContractWithoutGasCharge))
 			dexGasRequired += params.DefaultGasPerOrder * uint64(len(m.Orders)*numDependencies)
 		case *types.MsgCancelOrders:
-			numDependencies := len(memState.GetContractToDependencies(m.ContractAddr, contractLoader))
+			numDependencies := len(memState.GetContractToDependencies(ctx, m.ContractAddr, d.dexKeeper.GetContractWithoutGasCharge))
 			dexGasRequired += params.DefaultGasPerCancel * uint64(len(m.Cancellations)*numDependencies)
 		}
 	}

--- a/x/dex/cache/cache_test.go
+++ b/x/dex/cache/cache_test.go
@@ -222,11 +222,5 @@ func TestGetAllDownstreamContracts(t *testing.T) {
 		"sei1ery8l6jquynn9a4cz2pff6khg8c68f7urt33l5n9dng2cwzz4c4q4hncrd",
 		"sei1wl59k23zngj34l7d42y9yltask7rjlnxgccawc7ltrknp6n52fpsj6ctln",
 		"sei1stwdtk6ja0705v8qmtukcp4vd422p5vy4jr5wdc4qk44c57k955qcannhd",
-	}, dex.GetAllDownstreamContracts("sei1ery8l6jquynn9a4cz2pff6khg8c68f7urt33l5n9dng2cwzz4c4q4hncrd", func(addr string) *types.ContractInfoV2 {
-		c, err := keeper.GetContract(ctx, addr)
-		if err != nil {
-			return nil
-		}
-		return &c
-	}))
+	}, dex.GetAllDownstreamContracts(ctx, "sei1ery8l6jquynn9a4cz2pff6khg8c68f7urt33l5n9dng2cwzz4c4q4hncrd", keeper.GetContractWithoutGasCharge))
 }

--- a/x/dex/keeper/contract.go
+++ b/x/dex/keeper/contract.go
@@ -50,6 +50,10 @@ func (k Keeper) GetContract(ctx sdk.Context, contractAddr string) (types.Contrac
 	return res, nil
 }
 
+func (k Keeper) GetContractWithoutGasCharge(ctx sdk.Context, contractAddr string) (types.ContractInfoV2, error) {
+	return k.GetContract(ctx.WithGasMeter(sdk.NewInfiniteGasMeter()), contractAddr)
+}
+
 func (k Keeper) GetContractGasLimit(ctx sdk.Context, contractAddr sdk.AccAddress) (uint64, error) {
 	bech32ContractAddr := contractAddr.String()
 	contract, err := k.GetContract(ctx, bech32ContractAddr)

--- a/x/dex/keeper/msgserver/msg_server_cancel_orders.go
+++ b/x/dex/keeper/msgserver/msg_server_cancel_orders.go
@@ -56,12 +56,6 @@ func (k msgServer) CancelOrders(goCtx context.Context, msg *types.MsgCancelOrder
 		}
 	}
 	ctx.EventManager().EmitEvents(events)
-	utils.GetMemState(ctx.Context()).SetDownstreamsToProcess(msg.ContractAddr, func(addr string) *types.ContractInfoV2 {
-		contract, err := k.GetContract(ctx, addr)
-		if err != nil {
-			return nil
-		}
-		return &contract
-	})
+	utils.GetMemState(ctx.Context()).SetDownstreamsToProcess(ctx, msg.ContractAddr, k.GetContractWithoutGasCharge)
 	return &types.MsgCancelOrdersResponse{}, nil
 }

--- a/x/dex/keeper/msgserver/msg_server_place_orders.go
+++ b/x/dex/keeper/msgserver/msg_server_place_orders.go
@@ -87,13 +87,7 @@ func (k msgServer) PlaceOrders(goCtx context.Context, msg *types.MsgPlaceOrders)
 	k.SetNextOrderID(ctx, msg.ContractAddr, nextID)
 	ctx.EventManager().EmitEvents(events)
 
-	utils.GetMemState(ctx.Context()).SetDownstreamsToProcess(msg.ContractAddr, func(addr string) *types.ContractInfoV2 {
-		contract, err := k.GetContract(ctx, addr)
-		if err != nil {
-			return nil
-		}
-		return &contract
-	})
+	utils.GetMemState(ctx.Context()).SetDownstreamsToProcess(ctx, msg.ContractAddr, k.GetContractWithoutGasCharge)
 	return &types.MsgPlaceOrdersResponse{
 		OrderIds: idsInResp,
 	}, nil

--- a/x/dex/module_test.go
+++ b/x/dex/module_test.go
@@ -118,13 +118,7 @@ func TestEndBlockMarketOrder(t *testing.T) {
 			Amount:  sdk.MustNewDecFromStr("2000000"),
 		},
 	)
-	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(contractAddr.String(), func(addr string) *types.ContractInfoV2 {
-		c, err := dexkeeper.GetContract(ctx, addr)
-		if err != nil {
-			return nil
-		}
-		return &c
-	})
+	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(ctx, contractAddr.String(), dexkeeper.GetContractWithoutGasCharge)
 
 	ctx = ctx.WithBlockHeight(1)
 	testApp.EndBlocker(ctx, abci.RequestEndBlock{})
@@ -147,13 +141,7 @@ func TestEndBlockMarketOrder(t *testing.T) {
 			Data:              "{\"position_effect\":\"Open\",\"leverage\":\"1\"}",
 		},
 	)
-	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(contractAddr.String(), func(addr string) *types.ContractInfoV2 {
-		c, err := dexkeeper.GetContract(ctx, addr)
-		if err != nil {
-			return nil
-		}
-		return &c
-	})
+	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(ctx, contractAddr.String(), dexkeeper.GetContractWithoutGasCharge)
 
 	ctx = ctx.WithBlockHeight(2)
 	testApp.EndBlocker(ctx, abci.RequestEndBlock{})
@@ -185,13 +173,7 @@ func TestEndBlockMarketOrder(t *testing.T) {
 			Data:              "{\"position_effect\":\"Open\",\"leverage\":\"1\"}",
 		},
 	)
-	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(contractAddr.String(), func(addr string) *types.ContractInfoV2 {
-		c, err := dexkeeper.GetContract(ctx, addr)
-		if err != nil {
-			return nil
-		}
-		return &c
-	})
+	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(ctx, contractAddr.String(), dexkeeper.GetContractWithoutGasCharge)
 
 	ctx = ctx.WithBlockHeight(3)
 	testApp.EndBlocker(ctx, abci.RequestEndBlock{})
@@ -283,13 +265,7 @@ func TestEndBlockLimitOrder(t *testing.T) {
 			Amount:  sdk.MustNewDecFromStr("2000000"),
 		},
 	)
-	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(contractAddr.String(), func(addr string) *types.ContractInfoV2 {
-		c, err := dexkeeper.GetContract(ctx, addr)
-		if err != nil {
-			return nil
-		}
-		return &c
-	})
+	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(ctx, contractAddr.String(), dexkeeper.GetContractWithoutGasCharge)
 
 	ctx = ctx.WithBlockHeight(1)
 	testApp.EndBlocker(ctx, abci.RequestEndBlock{})
@@ -329,13 +305,7 @@ func TestEndBlockLimitOrder(t *testing.T) {
 			Data:              "{\"position_effect\":\"Open\",\"leverage\":\"1\"}",
 		},
 	)
-	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(contractAddr.String(), func(addr string) *types.ContractInfoV2 {
-		c, err := dexkeeper.GetContract(ctx, addr)
-		if err != nil {
-			return nil
-		}
-		return &c
-	})
+	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(ctx, contractAddr.String(), dexkeeper.GetContractWithoutGasCharge)
 
 	ctx = ctx.WithBlockHeight(2)
 	testApp.EndBlocker(ctx, abci.RequestEndBlock{})
@@ -368,13 +338,7 @@ func TestEndBlockLimitOrder(t *testing.T) {
 			Data:              "{\"position_effect\":\"Open\",\"leverage\":\"1\"}",
 		},
 	)
-	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(contractAddr.String(), func(addr string) *types.ContractInfoV2 {
-		c, err := dexkeeper.GetContract(ctx, addr)
-		if err != nil {
-			return nil
-		}
-		return &c
-	})
+	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(ctx, contractAddr.String(), dexkeeper.GetContractWithoutGasCharge)
 
 	ctx = ctx.WithBlockHeight(3)
 	testApp.EndBlocker(ctx, abci.RequestEndBlock{})
@@ -414,13 +378,7 @@ func TestEndBlockRollback(t *testing.T) {
 			PositionDirection: types.PositionDirection_LONG,
 		},
 	)
-	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(keepertest.TestContract, func(addr string) *types.ContractInfoV2 {
-		c, err := dexkeeper.GetContract(ctx, addr)
-		if err != nil {
-			return nil
-		}
-		return &c
-	})
+	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(ctx, keepertest.TestContract, dexkeeper.GetContractWithoutGasCharge)
 	ctx = ctx.WithBlockHeight(1)
 	testApp.EndBlocker(ctx, abci.RequestEndBlock{})
 	// No state change should've been persisted
@@ -456,13 +414,7 @@ func TestEndBlockPartialRollback(t *testing.T) {
 			PositionDirection: types.PositionDirection_LONG,
 		},
 	)
-	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(keepertest.TestContract, func(addr string) *types.ContractInfoV2 {
-		c, err := dexkeeper.GetContract(ctx, addr)
-		if err != nil {
-			return nil
-		}
-		return &c
-	})
+	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(ctx, keepertest.TestContract, dexkeeper.GetContractWithoutGasCharge)
 	// GOOD CONTRACT
 	testAccount, _ := sdk.AccAddressFromBech32("sei1yezq49upxhunjjhudql2fnj5dgvcwjj87pn2wx")
 	amounts := sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(1000000)), sdk.NewCoin("uusdc", sdk.NewInt(1000000)))
@@ -511,13 +463,7 @@ func TestEndBlockPartialRollback(t *testing.T) {
 			Amount:  sdk.MustNewDecFromStr("10000"),
 		},
 	)
-	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(contractAddr.String(), func(addr string) *types.ContractInfoV2 {
-		c, err := dexkeeper.GetContract(ctx, addr)
-		if err != nil {
-			return nil
-		}
-		return &c
-	})
+	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(ctx, contractAddr.String(), dexkeeper.GetContractWithoutGasCharge)
 
 	ctx = ctx.WithBlockHeight(1)
 	testApp.EndBlocker(ctx, abci.RequestEndBlock{})
@@ -683,13 +629,7 @@ func TestEndBlockRollbackWithRentCharge(t *testing.T) {
 			Amount:  sdk.MustNewDecFromStr("10000"),
 		},
 	)
-	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(contractAddr.String(), func(addr string) *types.ContractInfoV2 {
-		c, err := dexkeeper.GetContract(ctx, addr)
-		if err != nil {
-			return nil
-		}
-		return &c
-	})
+	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(ctx, contractAddr.String(), dexkeeper.GetContractWithoutGasCharge)
 	// overwrite params for testing
 	params := dexkeeper.GetParams(ctx)
 	params.MinProcessableRent = 0
@@ -846,13 +786,7 @@ func TestOrderCountUpdate(t *testing.T) {
 			Amount:  sdk.MustNewDecFromStr("2000000"),
 		},
 	)
-	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(contractAddr.String(), func(addr string) *types.ContractInfoV2 {
-		c, err := dexkeeper.GetContract(ctx, addr)
-		if err != nil {
-			return nil
-		}
-		return &c
-	})
+	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(ctx, contractAddr.String(), dexkeeper.GetContractWithoutGasCharge)
 
 	ctx = ctx.WithBlockHeight(1)
 	testApp.EndBlocker(ctx, abci.RequestEndBlock{})
@@ -889,13 +823,7 @@ func TestOrderCountUpdate(t *testing.T) {
 			PositionDirection: types.PositionDirection_LONG,
 		},
 	)
-	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(contractAddr.String(), func(addr string) *types.ContractInfoV2 {
-		c, err := dexkeeper.GetContract(ctx, addr)
-		if err != nil {
-			return nil
-		}
-		return &c
-	})
+	dexutils.GetMemState(ctx.Context()).SetDownstreamsToProcess(ctx, contractAddr.String(), dexkeeper.GetContractWithoutGasCharge)
 	ctx = ctx.WithBlockHeight(2)
 	testApp.EndBlocker(ctx, abci.RequestEndBlock{})
 	require.Equal(t, uint64(2), dexkeeper.GetOrderCountState(ctx, contractAddr.String(), pair.PriceDenom, pair.AssetDenom, types.PositionDirection_LONG, sdk.NewDec(1)))


### PR DESCRIPTION
## Describe your changes and provide context
Since the number of times and timing of contract dependency loading can be different across nodes due to issues like process restart, transaction parallelization, etc., we decide to not charge gas for times when the dependencies need to be loaded from the store, so that the difference wouldn't cause non-determinism.

Using an infinite gas meter instead of the original gas meter + refund because we don't want this now "free" operation to cause panics (e.g. when the original meter is just about to run out of gas)

## Testing performed to validate your change
unit tests + load test

