### PR TITLE
remove base denom from oracle

### DIFF
--- a/scripts/initialize_local_chain.sh
+++ b/scripts/initialize_local_chain.sh
@@ -51,6 +51,7 @@ cat ~/.sei/config/genesis.json | jq --arg start_date "$(date +"%Y-%m-%d")" --arg
 cat ~/.sei/config/genesis.json | jq --arg start_date "$(date -v+3d +"%Y-%m-%d")" --arg end_date "$(date -v+5d +"%Y-%m-%d")" '.app_state["mint"]["params"]["token_release_schedule"] += [{"start_date": $start_date, "end_date": $end_date, "token_release_amount": "999999999999"}]' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 cat ~/.sei/config/genesis.json | jq '.app_state["gov"]["voting_params"]["expedited_voting_period"]="10s"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 cat ~/.sei/config/genesis.json | jq '.app_state["oracle"]["params"]["vote_period"]="1"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
+cat ~/.sei/config/genesis.json | jq '.app_state["oracle"]["params"]["whitelist"]=[{"name": "ueth"},{"name": "ubtc"},{"name": "uusdc"},{"name": "uusdt"}]' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 cat ~/.sei/config/genesis.json | jq '.app_state["distribution"]["params"]["community_tax"]="0.000000000000000000"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 
 # set block time to 2s

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -16,7 +16,6 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	"github.com/sei-protocol/sei-chain/x/oracle/types"
-	"github.com/sei-protocol/sei-chain/x/oracle/utils"
 )
 
 // Keeper of the oracle store
@@ -70,15 +69,6 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 // ExchangeRate logic
 
 func (k Keeper) GetBaseExchangeRate(ctx sdk.Context, denom string) (sdk.Dec, sdk.Int, error) {
-	if denom == utils.MicroBaseDenom {
-		votePeriod := k.GetParams(ctx).VotePeriod
-		lastVotingBlockHeight := ((ctx.BlockHeight() / int64(votePeriod)) * int64(votePeriod)) - 1
-		if lastVotingBlockHeight < 0 {
-			lastVotingBlockHeight = 0
-		}
-		return sdk.OneDec(), sdk.NewInt(lastVotingBlockHeight), nil
-	}
-
 	store := ctx.KVStore(k.storeKey)
 	b := store.Get(types.GetExchangeRateKey(denom))
 	if b == nil {

--- a/x/oracle/keeper/keeper_test.go
+++ b/x/oracle/keeper/keeper_test.go
@@ -22,7 +22,6 @@ func TestExchangeRate(t *testing.T) {
 	cnyExchangeRate := sdk.NewDecWithPrec(839, int64(OracleDecPrecision)).MulInt64(utils.MicroUnit)
 	gbpExchangeRate := sdk.NewDecWithPrec(4995, int64(OracleDecPrecision)).MulInt64(utils.MicroUnit)
 	krwExchangeRate := sdk.NewDecWithPrec(2838, int64(OracleDecPrecision)).MulInt64(utils.MicroUnit)
-	seiExchangeRate := sdk.NewDecWithPrec(3282384, int64(OracleDecPrecision)).MulInt64(utils.MicroUnit)
 
 	// Set & get rates
 	input.OracleKeeper.SetBaseExchangeRate(input.Ctx, utils.MicroSeiDenom, cnyExchangeRate)
@@ -33,8 +32,6 @@ func TestExchangeRate(t *testing.T) {
 
 	input.Ctx = input.Ctx.WithBlockHeight(3)
 
-	rate, lastUpdate, _ = input.OracleKeeper.GetBaseExchangeRate(input.Ctx, utils.MicroBaseDenom)
-	require.Equal(t, sdk.OneDec(), rate)
 	// Vote period of 1, so last update should be 2 with a block height of 3
 	require.Equal(t, int64(2), lastUpdate.Int64())
 
@@ -52,9 +49,6 @@ func TestExchangeRate(t *testing.T) {
 	require.Equal(t, krwExchangeRate, rate)
 	require.Equal(t, sdk.NewInt(15), lastUpdate)
 
-	input.OracleKeeper.SetBaseExchangeRate(input.Ctx, utils.MicroBaseDenom, seiExchangeRate)
-	rate, lastUpdate, _ = input.OracleKeeper.GetBaseExchangeRate(input.Ctx, utils.MicroBaseDenom)
-	require.Equal(t, sdk.OneDec(), rate)
 	// Vote period of 1, so last update should be 14 with a block height of 15
 	require.Equal(t, int64(14), lastUpdate.Int64())
 
@@ -78,13 +72,11 @@ func TestIterateSeiExchangeRates(t *testing.T) {
 	cnyExchangeRate := sdk.NewDecWithPrec(839, int64(OracleDecPrecision)).MulInt64(utils.MicroUnit)
 	gbpExchangeRate := sdk.NewDecWithPrec(4995, int64(OracleDecPrecision)).MulInt64(utils.MicroUnit)
 	krwExchangeRate := sdk.NewDecWithPrec(2838, int64(OracleDecPrecision)).MulInt64(utils.MicroUnit)
-	seiExchangeRate := sdk.NewDecWithPrec(3282384, int64(OracleDecPrecision)).MulInt64(utils.MicroUnit)
 
 	// Set & get rates
 	input.OracleKeeper.SetBaseExchangeRate(input.Ctx, utils.MicroSeiDenom, cnyExchangeRate)
 	input.OracleKeeper.SetBaseExchangeRate(input.Ctx, utils.MicroEthDenom, gbpExchangeRate)
 	input.OracleKeeper.SetBaseExchangeRate(input.Ctx, utils.MicroAtomDenom, krwExchangeRate)
-	input.OracleKeeper.SetBaseExchangeRate(input.Ctx, utils.MicroBaseDenom, seiExchangeRate)
 
 	input.OracleKeeper.IterateBaseExchangeRates(input.Ctx, func(denom string, rate types.OracleExchangeRate) (stop bool) {
 		switch denom {
@@ -94,8 +86,6 @@ func TestIterateSeiExchangeRates(t *testing.T) {
 			require.Equal(t, gbpExchangeRate, rate.ExchangeRate)
 		case utils.MicroAtomDenom:
 			require.Equal(t, krwExchangeRate, rate.ExchangeRate)
-		case utils.MicroBaseDenom:
-			require.Equal(t, seiExchangeRate, rate.ExchangeRate)
 		}
 		return false
 	})

--- a/x/oracle/keeper/keeper_test.go
+++ b/x/oracle/keeper/keeper_test.go
@@ -32,9 +32,6 @@ func TestExchangeRate(t *testing.T) {
 
 	input.Ctx = input.Ctx.WithBlockHeight(3)
 
-	// Vote period of 1, so last update should be 2 with a block height of 3
-	require.Equal(t, int64(2), lastUpdate.Int64())
-
 	input.OracleKeeper.SetBaseExchangeRate(input.Ctx, utils.MicroEthDenom, gbpExchangeRate)
 	rate, lastUpdate, err = input.OracleKeeper.GetBaseExchangeRate(input.Ctx, utils.MicroEthDenom)
 	require.NoError(t, err)
@@ -49,9 +46,6 @@ func TestExchangeRate(t *testing.T) {
 	require.Equal(t, krwExchangeRate, rate)
 	require.Equal(t, sdk.NewInt(15), lastUpdate)
 
-	// Vote period of 1, so last update should be 14 with a block height of 15
-	require.Equal(t, int64(14), lastUpdate.Int64())
-
 	input.OracleKeeper.DeleteBaseExchangeRate(input.Ctx, utils.MicroAtomDenom)
 	_, _, err = input.OracleKeeper.GetBaseExchangeRate(input.Ctx, utils.MicroAtomDenom)
 	require.Error(t, err)
@@ -63,7 +57,7 @@ func TestExchangeRate(t *testing.T) {
 	}
 	input.OracleKeeper.IterateBaseExchangeRates(input.Ctx, handler)
 
-	require.True(t, numExchangeRates == 3)
+	require.Equal(t, 2, numExchangeRates)
 }
 
 func TestIterateSeiExchangeRates(t *testing.T) {

--- a/x/oracle/keeper/querier.go
+++ b/x/oracle/keeper/querier.go
@@ -9,7 +9,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/sei-protocol/sei-chain/x/oracle/types"
-	"github.com/sei-protocol/sei-chain/x/oracle/utils"
 )
 
 // querier is used as Keeper will have duplicate methods if used directly, and gRPC names take precedence over q
@@ -59,17 +58,6 @@ func (q querier) ExchangeRates(c context.Context, req *types.QueryExchangeRatesR
 
 	exchangeRates := []types.DenomOracleExchangeRatePair{}
 	q.IterateBaseExchangeRates(ctx, func(denom string, rate types.OracleExchangeRate) (stop bool) {
-		if denom == utils.MicroBaseDenom {
-			votePeriod := q.Keeper.GetParams(ctx).VotePeriod
-			lastVotingBlockHeight := ((ctx.BlockHeight() / int64(votePeriod)) * int64(votePeriod)) - 1
-			if lastVotingBlockHeight < 0 {
-				lastVotingBlockHeight = 0
-			}
-			baseDenomRate := types.OracleExchangeRate{ExchangeRate: sdk.OneDec(), LastUpdate: sdk.NewInt(lastVotingBlockHeight)}
-			exchangeRates = append(exchangeRates, types.DenomOracleExchangeRatePair{Denom: denom, OracleExchangeRate: baseDenomRate})
-			return false
-		}
-
 		exchangeRates = append(exchangeRates, types.DenomOracleExchangeRatePair{Denom: denom, OracleExchangeRate: rate})
 		return false
 	})

--- a/x/oracle/utils/assets.go
+++ b/x/oracle/utils/assets.go
@@ -6,7 +6,5 @@ const (
 	MicroAtomDenom = "uatom"
 	MicroEthDenom  = "ueth"
 
-	MicroBaseDenom = MicroUsdcDenom // use usdc until sei's market stablizes
-
 	MicroUnit = int64(1e6)
 )


### PR DESCRIPTION
## Describe your changes and provide context
This updates oracle to remove the base denom since all assets are priced relative to USD. This will also allow for pricing USDC relative to USD.

## Testing performed to validate your change
unit tests and local sei testing
