### PR TITLE
[Certik Audit] Set default blocks per min to a more realistic value

### DIFF
--- a/x/oracle/keeper/querier_test.go
+++ b/x/oracle/keeper/querier_test.go
@@ -92,7 +92,7 @@ func TestQuerySlashingWindow(t *testing.T) {
 	res, err := querier.SlashWindow(ctx, &types.QuerySlashWindowRequest{})
 	require.NoError(t, err)
 	// Based on voting period
-	require.Equal(t, 12502, int(res.WindowProgress))
+	require.Equal(t, 300501, int(res.WindowProgress))
 
 	input.Ctx = input.Ctx.WithBlockHeight(300501)
 	ctx = sdk.WrapSDKContext(input.Ctx)

--- a/x/oracle/keeper/querier_test.go
+++ b/x/oracle/keeper/querier_test.go
@@ -92,13 +92,13 @@ func TestQuerySlashingWindow(t *testing.T) {
 	res, err := querier.SlashWindow(ctx, &types.QuerySlashWindowRequest{})
 	require.NoError(t, err)
 	// Based on voting period
-	require.Equal(t, 300501, int(res.WindowProgress))
+	require.Equal(t, 12502, int(res.WindowProgress))
 
 	input.Ctx = input.Ctx.WithBlockHeight(300501)
 	ctx = sdk.WrapSDKContext(input.Ctx)
 	res, err = querier.SlashWindow(ctx, &types.QuerySlashWindowRequest{})
 	require.NoError(t, err)
-	require.Equal(t, 98901, int(res.WindowProgress))
+	require.Equal(t, 300501, int(res.WindowProgress))
 }
 
 func TestQueryVoteTargets(t *testing.T) {

--- a/x/oracle/utils/period.go
+++ b/x/oracle/utils/period.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	BlocksPerMinute = uint64(20)
+	BlocksPerMinute = uint64(75)
 	BlocksPerHour   = BlocksPerMinute * 60
 	BlocksPerDay    = BlocksPerHour * 24
 	BlocksPerWeek   = BlocksPerDay * 7


### PR DESCRIPTION
## Describe your changes and provide context
Derive this value based on oracle slash window of 108000

## Testing performed to validate your change

