### PR TITLE
Re enable tx concurrency for non-oracle/prio txs

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1311,11 +1311,7 @@ func (app *App) ProcessBlock(ctx sdk.Context, txs [][]byte, req BlockProcessRequ
 	midBlockEvents := app.MidBlock(ctx, req.GetHeight())
 	events = append(events, midBlockEvents...)
 
-	// run other txs - this will run them synchronously without building a dag or executing concurrently
-	// TODO: re-enable this tx concurrency once dependencies have been declared properly and any potential
-	// nondeterminism with remediation flow has been fully investigated / resolved
-	// otherResults, ctx := app.BuildDependenciesAndRunTxs(ctx, txs)
-	otherResults := app.ProcessBlockSynchronous(ctx, txs)
+	otherResults, ctx := app.BuildDependenciesAndRunTxs(ctx, txs)
 	txResults = append(txResults, otherResults...)
 
 	// Finalize all Bank Module Transfers here so that events are included


### PR DESCRIPTION
## Describe your changes and provide context
This re-enables tx concurrency

## Testing performed to validate your change
Tested along with the fixes for feegrant to verify that we no longer had concurrency violations for that execution path.
