### PR TITLE
[Certik Audit] Fix validator address parsing for genesis export

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"encoding/json"
+	"github.com/cosmos/cosmos-sdk/types/kv"
 	"log"
 
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -45,6 +46,12 @@ func (app *App) ExportAppStateAndValidators(
 		Height:          height,
 		ConsensusParams: app.BaseApp.GetConsensusParams(ctx),
 	}, nil
+}
+
+// AddressFromValidatorsKey creates the validator operator address from ValidatorsKey
+func AddressFromValidatorsKey(key []byte) []byte {
+	kv.AssertKeyAtLeastLength(key, 3)
+	return key[2:] // remove prefix bytes and address length
 }
 
 // prepare for fresh start at zero height
@@ -147,7 +154,7 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 	counter := int16(0)
 
 	for ; iter.Valid(); iter.Next() {
-		addr := sdk.ValAddress(iter.Key()[1:])
+		addr := sdk.ValAddress(AddressFromValidatorsKey(iter.Key()))
 		validator, found := app.StakingKeeper.GetValidator(ctx, addr)
 		if !found {
 			panic("expected validator, not found")

--- a/app/export.go
+++ b/app/export.go
@@ -2,8 +2,9 @@ package app
 
 import (
 	"encoding/json"
-	"github.com/cosmos/cosmos-sdk/types/kv"
 	"log"
+
+	"github.com/cosmos/cosmos-sdk/types/kv"
 
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 


### PR DESCRIPTION
## Describe your changes and provide context
Original way of parsing validator key is incorrect.
## Testing performed to validate your change
Verified `seid export --for-zero-height --chain-id=sei-chain` now works

