### PR TITLE
Use base denom for asset meta data instead

### DIFF
--- a/x/dex/keeper/asset_list.go
+++ b/x/dex/keeper/asset_list.go
@@ -11,7 +11,7 @@ func (k Keeper) SetAssetMetadata(ctx sdk.Context, assetMetadata types.AssetMetad
 	// Even if asset exists already, overwrite the store with new metadata
 	b := k.Cdc.MustMarshal(&assetMetadata)
 
-	store.Set(types.AssetListPrefix(assetMetadata.Metadata.Display), b)
+	store.Set(types.AssetListPrefix(assetMetadata.Metadata.Base), b)
 }
 
 func (k Keeper) GetAssetMetadataByDenom(ctx sdk.Context, assetDenom string) (val types.AssetMetadata, found bool) {


### PR DESCRIPTION
## Describe your changes and provide context
The bank keeper utilizes the base denom as the unique ID to store the denom metadata in the sei-cosmos.

sei-cosmos/x/bank/keeper/keeper.go

```go
func (k BaseKeeper) SetDenomMetaData(ctx sdk.Context, denomMetaData types.Metadata) {
	store := ctx.KVStore(k.storeKey)
	denomMetaDataStore := prefix.NewStore(store, types.DenomMetadataKey(denomMetaData.Base))

	m := k.cdc.MustMarshal(&denomMetaData)
	denomMetaDataStore.Set([]byte(denomMetaData.Base), m)
}
```

However, the asset metadata uses the display denom as the key for storage.

sei-chain/x/dex/keeper/asset_list.go

```go
func (k Keeper) SetAssetMetadata(ctx sdk.Context, assetMetadata types.AssetMetadata) {
	store := ctx.KVStore(k.storeKey)
	// We only allow one asset per base denom for now
	// Even if asset exists already, overwrite the store with new metadata
	b := k.Cdc.MustMarshal(&assetMetadata)

	store.Set(types.AssetListPrefix(assetMetadata.Metadata.Display), b)
}
```

According to the comment, it is supposed to use the base denom as the key because the display may not be the unique identifier for different denom metadata.

## Testing performed to validate your change

