### PR TITLE
Remove unit-test-coverage on master merge

### DIFF
--- a/.github/workflows/unit-test-coverage.yml
+++ b/.github/workflows/unit-test-coverage.yml
@@ -2,8 +2,6 @@ name: Go
 
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
## Describe your changes and provide context
This workflow requires a github.event.number that likely doesn't exist when merging a PR, which causes it to fail with:
`  Error: fatal: invalid refspec '+refs/pull//merge:refs/remotes/pull//merge'`
This only needs to be run on PR updates anyways.
## Testing performed to validate your change
Will validate once merged
