### PR TITLE
Decrease consensus timeout backoff values

### DIFF
--- a/app/params/config.go
+++ b/app/params/config.go
@@ -95,10 +95,10 @@ func SetTendermintConfigs(config *tmcfg.Config) {
 	config.Mempool.TTLNumBlocks = 100
 	// Consensus Configs
 	config.Consensus.GossipTransactionKeyOnly = true
-	config.Consensus.UnsafeProposeTimeoutOverride = 1 * time.Second
-	config.Consensus.UnsafeProposeTimeoutDeltaOverride = 500 * time.Millisecond
+	config.Consensus.UnsafeProposeTimeoutOverride = 300 * time.Millisecond
+	config.Consensus.UnsafeProposeTimeoutDeltaOverride = 50 * time.Millisecond
 	config.Consensus.UnsafeVoteTimeoutOverride = 50 * time.Millisecond
-	config.Consensus.UnsafeVoteTimeoutDeltaOverride = 500 * time.Millisecond
+	config.Consensus.UnsafeVoteTimeoutDeltaOverride = 50 * time.Millisecond
 	config.Consensus.UnsafeCommitTimeoutOverride = 100 * time.Millisecond
 	config.Consensus.UnsafeBypassCommitTimeoutOverride = &UnsafeBypassCommitTimeoutOverride
 	// Metrics


### PR DESCRIPTION
## Describe your changes and provide context
Tunes consensus configs so that we don't have high p95 block times on a slow validator:
- UnsafeProposeTimeoutOverride: let's validators vote "nil" if a proposal doesn't come in in time: 1s -> 300ms, shoudl be enough time for 1 network rtt
- UnsafeProposeTimeoutDeltaOverride: How much time to increase the propose timeout every time we enter a new round
- UnsafeVoteTimeoutDelta: How much time to incrase the vote timeout every time we enter a new round

## Testing performed to validate your change
Launched a cluster and slowed a node down.
Before:
<img width="484" alt="image" src="https://github.com/sei-protocol/sei-chain/assets/3821073/5ab6f938-b725-4512-b68d-3ab540ad58b7">
<img width="1855" alt="image" src="https://github.com/sei-protocol/sei-chain/assets/3821073/51763aeb-e30c-4777-847b-22374fc32b59">

After:
<img width="513" alt="image" src="https://github.com/sei-protocol/sei-chain/assets/3821073/ccb63f41-d248-4e51-b13f-815c8fa9988b">
<img width="1894" alt="image" src="https://github.com/sei-protocol/sei-chain/assets/3821073/04459515-fbac-4ea6-877f-f3e98807d911">


