### PR TITLE
Improve oracle unit test coverage

### DIFF
--- a/x/oracle/ante.go
+++ b/x/oracle/ante.go
@@ -108,7 +108,6 @@ func (spd SpammingPreventionDecorator) CheckOracleSpamming(ctx sdk.Context, msgs
 			if err != nil {
 				return err
 			}
-
 			if lastSubmittedHeight, ok := spd.oracleVoteMap[msg.Validator]; ok && lastSubmittedHeight == curHeight {
 				return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, fmt.Sprintf("the validator has already submitted a vote at the current height=%d", curHeight))
 			}

--- a/x/oracle/ante_test.go
+++ b/x/oracle/ante_test.go
@@ -4,10 +4,15 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	aclutils "github.com/sei-protocol/sei-chain/aclmapping/utils"
 	"github.com/sei-protocol/sei-chain/app"
 	"github.com/sei-protocol/sei-chain/x/oracle"
+	"github.com/sei-protocol/sei-chain/x/oracle/keeper"
+	"github.com/sei-protocol/sei-chain/x/oracle/types"
 	oracletypes "github.com/sei-protocol/sei-chain/x/oracle/types"
+	"github.com/sei-protocol/sei-chain/x/oracle/utils"
 	"github.com/stretchr/testify/require"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
@@ -19,8 +24,7 @@ func TestOracleVoteAloneAnteHandler(t *testing.T) {
 	testNonOracleMsg2 := banktypes.MsgSend{}
 
 	decorator := oracle.NewOracleVoteAloneDecorator()
-	anteHandler, _ := sdk.ChainAnteDecorators(decorator)
-
+	anteHandler, depGen := sdk.ChainAnteDecorators(decorator)
 	testCases := []struct {
 		name   string
 		expErr bool
@@ -39,6 +43,82 @@ func TestOracleVoteAloneAnteHandler(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+			_, err = depGen([]sdkacltypes.AccessOperation{}, tc.tx)
+			require.NoError(t, err)
 		})
 	}
+}
+
+func TestSpammingPreventionAnteHandler(t *testing.T) {
+	input, _ := setup(t)
+
+	exchangeRateStr := randomExchangeRate.String() + utils.MicroAtomDenom
+
+	voteMsg := types.NewMsgAggregateExchangeRateVote(exchangeRateStr, keeper.Addrs[0], keeper.ValAddrs[0])
+	invalidVoteMsg := types.NewMsgAggregateExchangeRateVote(exchangeRateStr, keeper.Addrs[3], keeper.ValAddrs[2])
+
+	spd := oracle.NewSpammingPreventionDecorator(input.OracleKeeper)
+	anteHandler, _ := sdk.ChainAnteDecorators(spd)
+
+	recheckCtx := input.Ctx.WithIsReCheckTx(true)
+	_, err := anteHandler(recheckCtx, app.NewTestTx([]sdk.Msg{voteMsg}), false) // should skip the SPD
+	require.NoError(t, err)
+
+	ctx := input.Ctx.WithIsCheckTx(true)
+	_, err = anteHandler(ctx, app.NewTestTx([]sdk.Msg{voteMsg}), false)
+	require.NoError(t, err)
+
+	// invalid because bad feeder val combo
+	_, err = anteHandler(ctx, app.NewTestTx([]sdk.Msg{invalidVoteMsg}), false)
+	require.Error(t, err)
+
+	// malform feeder
+	malformedVote := voteMsg
+	malformedVote.Feeder = "seifoobar"
+	_, err = anteHandler(ctx, app.NewTestTx([]sdk.Msg{malformedVote}), false)
+	require.Error(t, err)
+
+	// malform val
+	malformedVote = voteMsg
+	malformedVote.Validator = "seivaloperfoobar"
+	_, err = anteHandler(ctx, app.NewTestTx([]sdk.Msg{malformedVote}), false)
+	require.Error(t, err)
+
+	// set aggregate vote for val 0
+	input.OracleKeeper.SetAggregateExchangeRateVote(ctx, keeper.ValAddrs[0], types.NewAggregateExchangeRateVote(types.ExchangeRateTuples{}, keeper.ValAddrs[0]))
+	// now should fail
+	_, err = anteHandler(ctx, app.NewTestTx([]sdk.Msg{voteMsg}), false)
+	require.Error(t, err)
+}
+
+func TestSpammingPreventionAnteDeps(t *testing.T) {
+	input, _ := setup(t)
+
+	exchangeRateStr := randomExchangeRate.String() + utils.MicroAtomDenom
+
+	voteMsg := types.NewMsgAggregateExchangeRateVote(exchangeRateStr, keeper.Addrs[0], keeper.ValAddrs[0])
+
+	spd := oracle.NewSpammingPreventionDecorator(input.OracleKeeper)
+	anteHandler, depGen := sdk.ChainAnteDecorators(spd)
+
+	ctx := input.Ctx.WithIsCheckTx(true)
+
+	// test anteDeps
+	msgValidator := sdkacltypes.NewMsgValidator(aclutils.StoreKeyToResourceTypePrefixMap)
+	ctx = ctx.WithMsgValidator(msgValidator)
+	ms := ctx.MultiStore()
+	msCache := ms.CacheMultiStore()
+	ctx = ctx.WithMultiStore(msCache)
+	tx := app.NewTestTx([]sdk.Msg{voteMsg})
+
+	_, err := anteHandler(ctx, tx, false)
+	require.NoError(t, err)
+
+	newDeps, err := depGen([]sdkacltypes.AccessOperation{}, tx)
+	require.NoError(t, err)
+
+	storeAccessOpEvents := msCache.GetEvents()
+
+	missingAccessOps := ctx.MsgValidator().ValidateAccessOperations(newDeps, storeAccessOpEvents)
+	require.Equal(t, 0, len(missingAccessOps))
 }

--- a/x/oracle/keeper/keeper_test.go
+++ b/x/oracle/keeper/keeper_test.go
@@ -240,6 +240,7 @@ func TestVotePenaltyCounter(t *testing.T) {
 	require.Equal(t, uint64(1), counter.SuccessCount)
 	require.Equal(t, uint64(2), input.OracleKeeper.GetMissCount(input.Ctx, ValAddrs[0]))
 	require.Equal(t, uint64(3), input.OracleKeeper.GetAbstainCount(input.Ctx, ValAddrs[0]))
+	require.Equal(t, uint64(1), input.OracleKeeper.GetSuccessCount(input.Ctx, ValAddrs[0]))
 }
 
 func TestIterateMissCounters(t *testing.T) {


### PR DESCRIPTION
## Describe your changes and provide context
Improved oracle unit test coverage for keeper and other material logic

## Testing performed to validate your change
unit testing and coverage report
```
github.com/sei-protocol/sei-chain/x/oracle/abci.go:16:				MidBlocker					100.0%
github.com/sei-protocol/sei-chain/x/oracle/abci.go:157:				EndBlocker					100.0%
github.com/sei-protocol/sei-chain/x/oracle/ante.go:26:				NewSpammingPreventionDecorator			100.0%
github.com/sei-protocol/sei-chain/x/oracle/ante.go:35:				AnteHandle					100.0%
github.com/sei-protocol/sei-chain/x/oracle/ante.go:52:				AnteDeps					85.7%
github.com/sei-protocol/sei-chain/x/oracle/ante.go:89:				CheckOracleSpamming				85.0%
github.com/sei-protocol/sei-chain/x/oracle/ante.go:127:				NewOracleVoteAloneDecorator			100.0%
github.com/sei-protocol/sei-chain/x/oracle/ante.go:132:				AnteHandle					100.0%
github.com/sei-protocol/sei-chain/x/oracle/ante.go:152:				AnteDeps					100.0%

github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:36:			NewKeeper					80.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:64:			Logger						0.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:71:			GetBaseExchangeRate				100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:83:			SetBaseExchangeRate				100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:91:			SetBaseExchangeRateWithEvent			100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:101:		DeleteBaseExchangeRate				100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:106:		IterateBaseExchangeRates			88.9%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:124:		GetFeederDelegation				100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:136:		SetFeederDelegation				100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:142:		IterateFeederDelegations			87.5%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:162:		GetVotePenaltyCounter				100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:176:		SetVotePenaltyCounter				100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:186:		IncrementMissCount				100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:191:		IncrementAbstainCount				100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:196:		IncrementSuccessCount				100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:201:		GetMissCount					100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:206:		GetAbstainCount					100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:211:		GetSuccessCount					100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:217:		DeleteVotePenaltyCounter			100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:227:		IterateVotePenaltyCounters			88.9%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:249:		GetAggregateExchangeRateVote			100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:261:		SetAggregateExchangeRateVote			100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:268:		DeleteAggregateExchangeRateVote			100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:274:		IterateAggregateExchangeRateVotes		88.9%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:289:		GetVoteTarget					100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:303:		SetVoteTarget					100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:309:		IterateVoteTargets				88.9%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:324:		ClearVoteTargets				100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:331:		getAllKeysForPrefix				100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:342:		ValidateFeeder					100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:358:		GetPriceSnapshot				85.7%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:370:		SetPriceSnapshot				100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:377:		AddPriceSnapshot				93.8%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:410:		IteratePriceSnapshots				100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:424:		IteratePriceSnapshotsReverse			100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:438:		DeletePriceSnapshot				100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:443:		CalculateTwaps					100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/keeper.go:528:		ValidateLookbackSeconds				100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/migrations.go:16:		NewMigrator					100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/migrations.go:21:		Migrate2to3					100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/migrations.go:40:		Migrate3to4					100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/migrations.go:61:		Migrate4to5					100.0%
github.com/sei-protocol/sei-chain/x/oracle/keeper/migrations.go:74:		Migrate5To6					100.0%

github.com/sei-protocol/sei-chain/x/oracle/keeper/slash.go:12:			SlashAndResetCounters				95.2%
```
