### PR TITLE
Add display,name,symbol to tokenfactory denom creation

### DIFF
--- a/integration_test/dex_module/place_order_test.yaml
+++ b/integration_test/dex_module/place_order_test.yaml
@@ -1,6 +1,6 @@
 - name: Test placing a new order and query the placed order
   inputs:
-    # Get contract address, this requires contrat already deployed
+    # Get contract address, this requires contract already deployed
     - cmd: tail -1 integration_test/contracts/mars-addr.txt
       env: CONTRACT_ADDR
     # Prepare parameter

--- a/integration_test/tokenfactory_module/create_tokenfactory_test.yaml
+++ b/integration_test/tokenfactory_module/create_tokenfactory_test.yaml
@@ -1,0 +1,24 @@
+- name: Test creating a denom
+  inputs:
+    # Get admin
+    - cmd: seid keys list --output json | jq '.[] | select (.name=="admin")' | jq -r .address
+      env: ADMIN_ADDR
+    # Create denom
+    - cmd: seid tx tokenfactory create-denom test --from admin --fees 2000usei
+      env: PARAMS
+    # Mint the denom
+    - cmd: printf "12345678\n" | seid tx dex place-orders $CONTRACT_ADDR $PARAMS --amount=1000000000usei -y --from=admin --chain-id=sei --fees=1000000usei --gas=50000000 --broadcast-mode=block --output json|jq -M -r ".logs[].events[].attributes[] | select(.key == \"order_id\").value"
+      env: ORDER_ID
+    # Query various fields about denom
+    - cmd: seid q bank denom-metadata --output json | jq .metadatas | jq ".[] | select (.base==\"factory/${ADMIN_ADDR}/test\")" | jq -r .base
+      env: BASE
+    - cmd: seid q bank denom-metadata --output json | jq .metadatas | jq ".[] | select (.base==\"factory/${ADMIN_ADDR}/test\")" | jq -r .name
+      env: NAME
+    - cmd: seid q bank denom-metadata --output json | jq .metadatas | jq ".[] | select (.base==\"factory/${ADMIN_ADDR}/test\")" | jq -r .symbol
+      env: SYMBOL
+    - cmd: seid q bank denom-metadata --output json | jq .metadatas | jq ".[] | select (.base==\"factory/${ADMIN_ADDR}/test\")" | jq -r .display
+      env: DISPLAY
+  verifiers:
+    # All fields should be populated and match the base name
+    - type: eval
+      expr: NAME == BASE && SYMBOL == BASE && DISPLAY == BASE

--- a/integration_test/tokenfactory_module/create_tokenfactory_test.yaml
+++ b/integration_test/tokenfactory_module/create_tokenfactory_test.yaml
@@ -1,14 +1,11 @@
 - name: Test creating a denom
   inputs:
     # Get admin
-    - cmd: seid keys list --output json | jq '.[] | select (.name=="admin")' | jq -r .address
+    - cmd: printf "12345678\n" | seid keys list --output json | jq ".[] | select (.name==\"admin\")" | jq -r .address
       env: ADMIN_ADDR
     # Create denom
-    - cmd: seid tx tokenfactory create-denom test --from admin --fees 2000usei
+    - cmd: printf "12345678\n" | seid tx tokenfactory create-denom test --from admin --fees 2000usei -y
       env: PARAMS
-    # Mint the denom
-    - cmd: printf "12345678\n" | seid tx dex place-orders $CONTRACT_ADDR $PARAMS --amount=1000000000usei -y --from=admin --chain-id=sei --fees=1000000usei --gas=50000000 --broadcast-mode=block --output json|jq -M -r ".logs[].events[].attributes[] | select(.key == \"order_id\").value"
-      env: ORDER_ID
     # Query various fields about denom
     - cmd: seid q bank denom-metadata --output json | jq .metadatas | jq ".[] | select (.base==\"factory/${ADMIN_ADDR}/test\")" | jq -r .base
       env: BASE
@@ -21,4 +18,4 @@
   verifiers:
     # All fields should be populated and match the base name
     - type: eval
-      expr: NAME == BASE && SYMBOL == BASE && DISPLAY == BASE
+      expr: NAME == BASE

--- a/integration_test/tokenfactory_module/create_tokenfactory_test.yaml
+++ b/integration_test/tokenfactory_module/create_tokenfactory_test.yaml
@@ -17,4 +17,4 @@
   verifiers:
     # All fields should be populated and match the base name
     - type: eval
-      expr: NAME == BASE
+      expr: NAME == BASE and SYMBOL == BASE and DISPLAY == BASE

--- a/integration_test/tokenfactory_module/create_tokenfactory_test.yaml
+++ b/integration_test/tokenfactory_module/create_tokenfactory_test.yaml
@@ -5,7 +5,6 @@
       env: ADMIN_ADDR
     # Create denom
     - cmd: printf "12345678\n" | seid tx tokenfactory create-denom test --from admin --fees 2000usei -y
-      env: PARAMS
     # Query various fields about denom
     - cmd: seid q bank denom-metadata --output json | jq .metadatas | jq ".[] | select (.base==\"factory/${ADMIN_ADDR}/test\")" | jq -r .base
       env: BASE

--- a/x/tokenfactory/keeper/createdenom.go
+++ b/x/tokenfactory/keeper/createdenom.go
@@ -29,6 +29,10 @@ func (k Keeper) createDenomAfterValidation(ctx sdk.Context, creatorAddr string, 
 			Exponent: 0,
 		}},
 		Base: denom,
+		// The following is necessary for x/bank denom validation
+		Display: denom,
+		Name:    denom,
+		Symbol:  denom,
 	}
 
 	k.bankKeeper.SetDenomMetaData(ctx, denomMetaData)

--- a/x/tokenfactory/keeper/createdenom_test.go
+++ b/x/tokenfactory/keeper/createdenom_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"fmt"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -96,7 +97,13 @@ func (suite *KeeperTestSuite) TestCreateDenom() {
 
 				suite.Require().NoError(err)
 				suite.Require().Equal(suite.TestAccs[0].String(), queryRes.AuthorityMetadata.Admin)
+				// Make sure that the denom is valid from the perspective of x/bank
+				bankQueryRes, err := suite.bankQueryClient.DenomMetadata(suite.Ctx.Context(), &banktypes.QueryDenomMetadataRequest{
+					Denom: res.GetNewTokenDenom(),
+				})
 
+				suite.Require().NoError(err)
+				suite.Require().NoError(bankQueryRes.Metadata.Validate())
 			} else {
 				suite.Require().Error(err)
 			}

--- a/x/tokenfactory/keeper/keeper_test.go
+++ b/x/tokenfactory/keeper/keeper_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -15,8 +16,9 @@ import (
 type KeeperTestSuite struct {
 	apptesting.KeeperTestHelper
 
-	queryClient types.QueryClient
-	msgServer   types.MsgServer
+	queryClient     types.QueryClient
+	bankQueryClient banktypes.QueryClient
+	msgServer       types.MsgServer
 	// defaultDenom is on the suite, as it depends on the creator test address.
 	defaultDenom string
 }
@@ -31,6 +33,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 	suite.SetupTokenFactory()
 
 	suite.queryClient = types.NewQueryClient(suite.QueryHelper)
+	suite.bankQueryClient = banktypes.NewQueryClient(suite.QueryHelper)
 	suite.msgServer = keeper.NewMsgServerImpl(suite.App.TokenFactoryKeeper)
 }
 

--- a/x/tokenfactory/keeper/migrations.go
+++ b/x/tokenfactory/keeper/migrations.go
@@ -2,8 +2,9 @@ package keeper
 
 import (
 	"fmt"
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"strings"
+
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/sei-protocol/sei-chain/x/tokenfactory/types"
@@ -57,7 +58,7 @@ func (m Migrator) Migrate3to4(ctx sdk.Context) error {
 
 func (m Migrator) SetMetadata(denomMetadata *banktypes.Metadata) {
 	if len(denomMetadata.Base) == 0 {
-		panic(fmt.Errorf("No base exists for denom %v\n", denomMetadata))
+		panic(fmt.Errorf("no base exists for denom %v", denomMetadata))
 	}
 	if len(denomMetadata.Display) == 0 {
 		denomMetadata.Display = denomMetadata.Base

--- a/x/tokenfactory/keeper/migrations.go
+++ b/x/tokenfactory/keeper/migrations.go
@@ -44,7 +44,7 @@ func (m Migrator) Migrate3to4(ctx sdk.Context) error {
 	// Set denom metadata for all denoms
 	m.keeper.bankKeeper.IterateTotalSupply(ctx, func(coin sdk.Coin) bool {
 		fmt.Printf("Denom: %s\n", coin.Denom)
-		if denomMetadata, err := m.keeper.bankKeeper.GetDenomMetaData(ctx, coin.Denom); err {
+		if denomMetadata, err := m.keeper.bankKeeper.GetDenomMetaData(ctx, coin.Denom); !err {
 			panic(fmt.Errorf("denom %s does not exist", coin.Denom))
 		} else {
 			m.SetMetadata(&denomMetadata)

--- a/x/tokenfactory/keeper/migrations.go
+++ b/x/tokenfactory/keeper/migrations.go
@@ -44,7 +44,7 @@ func (m Migrator) Migrate2to3(ctx sdk.Context) error {
 func (m Migrator) Migrate3to4(ctx sdk.Context) error {
 	// Set denom metadata for all denoms
 	m.keeper.bankKeeper.IterateTotalSupply(ctx, func(coin sdk.Coin) bool {
-		fmt.Printf("Denom: %s\n", coin.Denom)
+		fmt.Printf("Migration denom: %s\n", coin.Denom)
 		if denomMetadata, err := m.keeper.bankKeeper.GetDenomMetaData(ctx, coin.Denom); !err {
 			panic(fmt.Errorf("denom %s does not exist", coin.Denom))
 		} else {

--- a/x/tokenfactory/keeper/migrations_test.go
+++ b/x/tokenfactory/keeper/migrations_test.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"strings"
 	"testing"
 
@@ -65,4 +66,22 @@ func TestMigrate2to3(t *testing.T) {
 	params := types.Params{}
 	paramsSubspace.GetParamSet(ctx, &params)
 	require.Equal(t, types.Params{}, params)
+}
+
+func TestMigrate3To4(t *testing.T) {
+	// Test migration with all metadata denom
+	metadata := banktypes.Metadata{Description: sdk.DefaultBondDenom, Base: sdk.DefaultBondDenom, Display: sdk.DefaultBondDenom, Name: sdk.DefaultBondDenom, Symbol: sdk.DefaultBondDenom}
+	keeper := NewKeeper(nil, nil, typesparams.Subspace{}, nil, nil, nil)
+	m := NewMigrator(keeper)
+	m.SetMetadata(&metadata)
+	require.Equal(t, sdk.DefaultBondDenom, metadata.Display)
+	require.Equal(t, sdk.DefaultBondDenom, metadata.Name)
+	require.Equal(t, sdk.DefaultBondDenom, metadata.Symbol)
+	// Test migration with missing fields
+	testDenom := "test_denom"
+	metadata = banktypes.Metadata{Base: testDenom}
+	m.SetMetadata(&metadata)
+	require.Equal(t, testDenom, metadata.Display)
+	require.Equal(t, testDenom, metadata.Name)
+	require.Equal(t, testDenom, metadata.Symbol)
 }

--- a/x/tokenfactory/module.go
+++ b/x/tokenfactory/module.go
@@ -148,6 +148,7 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	m := keeper.NewMigrator(am.keeper)
 	_ = cfg.RegisterMigration(types.ModuleName, 1, func(ctx sdk.Context) error { return nil })
 	_ = cfg.RegisterMigration(types.ModuleName, 2, m.Migrate2to3)
+	_ = cfg.RegisterMigration(types.ModuleName, 3, m.Migrate3to4)
 }
 
 // RegisterInvariants registers the x/tokenfactory module's invariants.
@@ -172,7 +173,7 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 }
 
 // ConsensusVersion implements ConsensusVersion.
-func (AppModule) ConsensusVersion() uint64 { return 1 }
+func (AppModule) ConsensusVersion() uint64 { return 4 }
 
 // BeginBlock executes all ABCI BeginBlock logic respective to the tokenfactory module.
 func (am AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}

--- a/x/tokenfactory/types/expected_keepers.go
+++ b/x/tokenfactory/types/expected_keepers.go
@@ -12,6 +12,7 @@ type BankKeeper interface {
 	SetDenomMetaData(ctx sdk.Context, denomMetaData banktypes.Metadata)
 
 	HasSupply(ctx sdk.Context, denom string) bool
+	IterateTotalSupply(ctx sdk.Context, cb func(sdk.Coin) bool)
 
 	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error


### PR DESCRIPTION
## Describe your changes and provide context
x/bank requires that display, name and symbol for all denoms are valid. However, when exporting genesis we found that this is not the case.
This is an initial PoC. We need to backport (migrate all existing denoms) if this looks good.
## Testing performed to validate your change
- Unit test 
- Created denom locally, ran validate-genesis, ensure it passes
- Created denom on 3.0.3, ran upgrade, ensure new genesis is valid

```
      "denom_metadata": [
        {
          "base": "factory/sei1099gwedy7ds2ysc8xjegfl9720qmczgfwdzdk7/test",
          "denom_units": [
            {
              "aliases": [],
              "denom": "factory/sei1099gwedy7ds2ysc8xjegfl9720qmczgfwdzdk7/test",
              "exponent": 0
            }
          ],
          "description": "",
          "display": "factory/sei1099gwedy7ds2ysc8xjegfl9720qmczgfwdzdk7/test",
          "name": "factory/sei1099gwedy7ds2ysc8xjegfl9720qmczgfwdzdk7/test",
          "symbol": "factory/sei1099gwedy7ds2ysc8xjegfl9720qmczgfwdzdk7/test"
        },
```