### PR TITLE
remove deferred send usages from dex and tk

### DIFF
--- a/aclmapping/dex/mappings.go
+++ b/aclmapping/dex/mappings.go
@@ -50,6 +50,8 @@ func DexPlaceOrdersDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context,
 		return []sdkacltypes.AccessOperation{}, ErrPlaceOrdersGenerator
 	}
 
+	moduleAdr := keeper.AccountKeeper.GetModuleAddress(dextypes.ModuleName)
+
 	senderBankAddrIdentifier := hex.EncodeToString(banktypes.CreateAccountBalancesPrefixFromBech32(placeOrdersMsg.Creator))
 	contractAddr := placeOrdersMsg.ContractAddr
 
@@ -108,6 +110,23 @@ func DexPlaceOrdersDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Context,
 			AccessType:         sdkacltypes.AccessType_WRITE,
 			ResourceType:       sdkacltypes.ResourceType_KV_BANK_BALANCES,
 			IdentifierTemplate: senderBankAddrIdentifier,
+		},
+
+		// update the amounts for dex module balance
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
+			IdentifierTemplate: hex.EncodeToString(authtypes.AddressStoreKey(moduleAdr)),
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV_BANK_BALANCES,
+			IdentifierTemplate: hex.EncodeToString(banktypes.CreateAccountBalancesPrefix(moduleAdr)),
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_WRITE,
+			ResourceType:       sdkacltypes.ResourceType_KV_BANK_BALANCES,
+			IdentifierTemplate: hex.EncodeToString(banktypes.CreateAccountBalancesPrefix(moduleAdr)),
 		},
 
 		// Gets Account Info for the sender

--- a/aclmapping/tokenfactory/mappings.go
+++ b/aclmapping/tokenfactory/mappings.go
@@ -158,6 +158,16 @@ func TokenFactoryBurnDependencyGenerator(keeper aclkeeper.Keeper, ctx sdk.Contex
 			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
 			IdentifierTemplate: hex.EncodeToString(authtypes.AddressStoreKey(moduleAdr)),
 		},
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV_BANK_BALANCES,
+			IdentifierTemplate: hex.EncodeToString(banktypes.CreateAccountBalancesPrefix(moduleAdr)),
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_WRITE,
+			ResourceType:       sdkacltypes.ResourceType_KV_BANK_BALANCES,
+			IdentifierTemplate: hex.EncodeToString(banktypes.CreateAccountBalancesPrefix(moduleAdr)),
+		},
 
 		// Checks balance for receiver
 		{

--- a/app/app.go
+++ b/app/app.go
@@ -1308,6 +1308,10 @@ func (app *App) ProcessBlock(ctx sdk.Context, txs [][]byte, req BlockProcessRequ
 	prioritizedResults, ctx := app.BuildDependenciesAndRunTxs(ctx, prioritizedTxs)
 	txResults = append(txResults, prioritizedResults...)
 
+	// Finalize all Bank Module Transfers here so that events are included for prioritiezd txs
+	deferredWriteEvents := app.BankKeeper.WriteDeferredOperations(ctx)
+	events = append(events, deferredWriteEvents...)
+
 	midBlockEvents := app.MidBlock(ctx, req.GetHeight())
 	events = append(events, midBlockEvents...)
 

--- a/x/dex/keeper/msgserver/msg_server_place_orders.go
+++ b/x/dex/keeper/msgserver/msg_server_place_orders.go
@@ -36,7 +36,7 @@ func (k msgServer) transferFunds(goCtx context.Context, msg *types.MsgPlaceOrder
 			Amount:  sdk.NewDec(fund.Amount.Int64()),
 		})
 	}
-	if err := k.BankKeeper.DeferredSendCoinsFromAccountToModule(ctx, sender, types.ModuleName, msg.Funds); err != nil {
+	if err := k.BankKeeper.SendCoinsFromAccountToModule(ctx, sender, types.ModuleName, msg.Funds); err != nil {
 		return fmt.Errorf("error sending coins to contract: %s", err)
 	}
 	return nil

--- a/x/tokenfactory/keeper/bankactions.go
+++ b/x/tokenfactory/keeper/bankactions.go
@@ -45,7 +45,7 @@ func (k Keeper) burnFrom(ctx sdk.Context, amount sdk.Coin, burnFrom string) erro
 	}
 
 	ctx.Logger().Info(fmt.Sprintf("Sending amount=%s to module=%s from account=%s", amount.String(), types.ModuleName, addr.String()))
-	err = k.bankKeeper.DeferredSendCoinsFromAccountToModule(ctx,
+	err = k.bankKeeper.SendCoinsFromAccountToModule(ctx,
 		addr,
 		types.ModuleName,
 		sdk.NewCoins(amount))


### PR DESCRIPTION
## Describe your changes and provide context
This removes deferred send usages from tokenfactory and dex. This increases overall safety because now only feecollector uses deferred balances.

## Testing performed to validate your change
tested on localsei
