### PR TITLE
Refactor deferred usages

### DIFF
--- a/aclmapping/tokenfactory/mappings_test.go
+++ b/aclmapping/tokenfactory/mappings_test.go
@@ -60,7 +60,6 @@ func (suite *KeeperTestSuite) PrepareTest() {
 		sdk.WrapSDKContext(suite.Ctx),
 		types.NewMsgCreateDenom(suite.TestAccs[0].String(), suite.testDenom),
 	)
-	suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 
 	if err != nil {
 		panic(err)
@@ -74,7 +73,6 @@ func (suite *KeeperTestSuite) PrepareTest() {
 	if err != nil {
 		panic(err)
 	}
-	suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 
 	msgValidator := sdkacltypes.NewMsgValidator(aclutils.StoreKeyToResourceTypePrefixMap)
 	suite.Ctx = suite.Ctx.WithMsgValidator(msgValidator)
@@ -117,7 +115,6 @@ func (suite *KeeperTestSuite) TestMsgBurnDependencies() {
 				sdk.WrapSDKContext(handlerCtx),
 				tc.msg,
 			)
-			suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 
 			depdenencies, _ := tkfactory.TokenFactoryBurnDependencyGenerator(
 				suite.App.AccessControlKeeper,
@@ -172,7 +169,6 @@ func (suite *KeeperTestSuite) TestMsgMintDependencies() {
 				sdk.WrapSDKContext(handlerCtx),
 				tc.msg,
 			)
-			suite.App.BankKeeper.WriteDeferredOperations(handlerCtx)
 
 			depdenencies, _ := tkfactory.TokenFactoryMintDependencyGenerator(
 				suite.App.AccessControlKeeper,

--- a/aclmapping/utils/resource_type.go
+++ b/aclmapping/utils/resource_type.go
@@ -66,6 +66,10 @@ var StoreKeyToResourceTypePrefixMap = aclsdktypes.StoreKeyToResourceTypePrefixMa
 		aclsdktypes.ResourceType_KV_BANK_SUPPLY:   banktypes.SupplyKey,
 		aclsdktypes.ResourceType_KV_BANK_DENOM:    banktypes.DenomMetadataPrefix,
 	},
+	banktypes.DeferredCacheStoreKey: {
+		aclsdktypes.ResourceType_KV_BANK_DEFERRED:                 aclsdktypes.EmptyPrefix,
+		aclsdktypes.ResourceType_KV_BANK_DEFERRED_MODULE_TX_INDEX: banktypes.DeferredCachePrefix,
+	},
 	authtypes.StoreKey: {
 		aclsdktypes.ResourceType_KV_AUTH:                       aclsdktypes.EmptyPrefix,
 		aclsdktypes.ResourceType_KV_AUTH_ADDRESS_STORE:         authtypes.AddressStoreKeyPrefix,

--- a/app/ante_test.go
+++ b/app/ante_test.go
@@ -184,7 +184,7 @@ func (suite *AnteTestSuite) TestValidateDepedencies() {
 	validTx, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.Ctx.ChainID())
 
 	suite.Require().NoError(err)
-	depdenencies, _ := suite.anteDepGenerator([]sdkacltypes.AccessOperation{}, validTx)
+	depdenencies, _ := suite.anteDepGenerator([]sdkacltypes.AccessOperation{}, validTx, 1)
 	_, err = suite.anteHandler(handlerCtx, validTx, false)
 	suite.Require().Nil(err, "ValidateBasicDecorator returned error on valid tx. err: %v", err)
 	err = suite.AnteHandlerValidateAccessOp(depdenencies)
@@ -199,7 +199,7 @@ func (suite *AnteTestSuite) TestValidateDepedencies() {
 
 	// decorator should skip processing invalidTx on recheck and thus return nil-error
 	handlerCtx, cms = aclutils.CacheTxContext(suite.Ctx)
-	depdenencies, _ = suite.anteDepGenerator([]sdkacltypes.AccessOperation{}, invalidTx)
+	depdenencies, _ = suite.anteDepGenerator([]sdkacltypes.AccessOperation{}, invalidTx, 1)
 	_, err = suite.anteHandler(handlerCtx, invalidTx, false)
 	missing = handlerCtx.MsgValidator().ValidateAccessOperations(depdenencies, cms.GetEvents())
 

--- a/app/ante_test.go
+++ b/app/ante_test.go
@@ -184,7 +184,7 @@ func (suite *AnteTestSuite) TestValidateDepedencies() {
 	validTx, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.Ctx.ChainID())
 
 	suite.Require().NoError(err)
-	depdenencies, _ := suite.anteDepGenerator([]sdkacltypes.AccessOperation{}, validTx, 1)
+	depdenencies, _ := suite.anteDepGenerator([]sdkacltypes.AccessOperation{}, validTx, 0)
 	_, err = suite.anteHandler(handlerCtx, validTx, false)
 	suite.Require().Nil(err, "ValidateBasicDecorator returned error on valid tx. err: %v", err)
 	err = suite.AnteHandlerValidateAccessOp(depdenencies)
@@ -199,7 +199,7 @@ func (suite *AnteTestSuite) TestValidateDepedencies() {
 
 	// decorator should skip processing invalidTx on recheck and thus return nil-error
 	handlerCtx, cms = aclutils.CacheTxContext(suite.Ctx)
-	depdenencies, _ = suite.anteDepGenerator([]sdkacltypes.AccessOperation{}, invalidTx, 1)
+	depdenencies, _ = suite.anteDepGenerator([]sdkacltypes.AccessOperation{}, invalidTx, 0)
 	_, err = suite.anteHandler(handlerCtx, invalidTx, false)
 	missing = handlerCtx.MsgValidator().ValidateAccessOperations(depdenencies, cms.GetEvents())
 

--- a/app/antedecorators/accesscontrol_wasm_dependency.go
+++ b/app/antedecorators/accesscontrol_wasm_dependency.go
@@ -54,7 +54,7 @@ func (ad ACLWasmDependencyDecorator) SenderMatchesContractAdmin(ctx sdk.Context,
 	return contractInfo.Admin == msg.FromAddress, nil
 }
 
-func (ad ACLWasmDependencyDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
+func (ad ACLWasmDependencyDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, txIndex int, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
 	deps := []sdkacltypes.AccessOperation{}
 
 	for _, msg := range tx.GetMsgs() {
@@ -78,5 +78,5 @@ func (ad ACLWasmDependencyDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperati
 		}
 	}
 
-	return next(append(txDeps, deps...), tx)
+	return next(append(txDeps, deps...), tx, txIndex)
 }

--- a/app/antedecorators/depdecorators/gas.go
+++ b/app/antedecorators/depdecorators/gas.go
@@ -9,7 +9,7 @@ import (
 type GasMeterSetterDecorator struct {
 }
 
-func (d GasMeterSetterDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
+func (d GasMeterSetterDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, txIndex int, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
 	for _, msg := range tx.GetMsgs() {
 		if _, ok := msg.(*wasmtypes.MsgExecuteContract); ok {
 			// if we have a wasm execute message, we need to declare the dependency to read accesscontrol for giving gas discount
@@ -20,5 +20,5 @@ func (d GasMeterSetterDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, 
 			})
 		}
 	}
-	return next(txDeps, tx)
+	return next(txDeps, tx, txIndex)
 }

--- a/app/antedecorators/depdecorators/signers.go
+++ b/app/antedecorators/depdecorators/signers.go
@@ -14,7 +14,7 @@ type SignerDepDecorator struct {
 	ReadOnly bool
 }
 
-func (d SignerDepDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
+func (d SignerDepDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, txIndex int, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
 	sigTx, ok := tx.(authsigning.SigVerifiableTx)
 	if !ok {
 		return txDeps, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid tx type")
@@ -32,5 +32,5 @@ func (d SignerDepDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sd
 			IdentifierTemplate: hex.EncodeToString(authtypes.AddressStoreKey(signer)),
 		})
 	}
-	return next(txDeps, tx)
+	return next(txDeps, tx, txIndex)
 }

--- a/app/antedecorators/gasless.go
+++ b/app/antedecorators/gasless.go
@@ -58,13 +58,13 @@ func (gd GaslessDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool,
 	return next(ctx, tx, simulate)
 }
 
-func (gd GaslessDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
+func (gd GaslessDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, txIndex int, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
 	deps := []sdkacltypes.AccessOperation{}
-	terminatorDeps := func(txDeps []sdkacltypes.AccessOperation, _ sdk.Tx) ([]sdkacltypes.AccessOperation, error) {
+	terminatorDeps := func(txDeps []sdkacltypes.AccessOperation, _ sdk.Tx, _ int) ([]sdkacltypes.AccessOperation, error) {
 		return txDeps, nil
 	}
 	for _, depGen := range gd.wrapped {
-		deps, _ = depGen.AnteDeps(deps, tx, terminatorDeps)
+		deps, _ = depGen.AnteDeps(deps, tx, txIndex, terminatorDeps)
 	}
 	for _, msg := range tx.GetMsgs() {
 		// Error checking will be handled in AnteHandler
@@ -97,7 +97,7 @@ func (gd GaslessDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk
 		}
 	}
 
-	return next(append(txDeps, deps...), tx)
+	return next(append(txDeps, deps...), tx, txIndex)
 }
 
 func isTxGasless(tx sdk.Tx, ctx sdk.Context, oracleKeeper oraclekeeper.Keeper) (bool, error) {

--- a/app/antedecorators/gasless_test.go
+++ b/app/antedecorators/gasless_test.go
@@ -30,9 +30,9 @@ func (ad FakeAnteDecoratorOne) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 	return next(ctx, tx, simulate)
 }
 
-func (ad FakeAnteDecoratorOne) AnteDeps(txDeps []accesscontrol.AccessOperation, tx sdk.Tx, next sdk.AnteDepGenerator) (newTxDeps []accesscontrol.AccessOperation, err error) {
+func (ad FakeAnteDecoratorOne) AnteDeps(txDeps []accesscontrol.AccessOperation, tx sdk.Tx, txIndex int, next sdk.AnteDepGenerator) (newTxDeps []accesscontrol.AccessOperation, err error) {
 	outputDeps = fmt.Sprintf("%sone", outputDeps)
-	return next(txDeps, tx)
+	return next(txDeps, tx, txIndex)
 }
 
 type FakeAnteDecoratorTwo struct{}
@@ -42,9 +42,9 @@ func (ad FakeAnteDecoratorTwo) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 	return next(ctx, tx, simulate)
 }
 
-func (ad FakeAnteDecoratorTwo) AnteDeps(txDeps []accesscontrol.AccessOperation, tx sdk.Tx, next sdk.AnteDepGenerator) (newTxDeps []accesscontrol.AccessOperation, err error) {
+func (ad FakeAnteDecoratorTwo) AnteDeps(txDeps []accesscontrol.AccessOperation, tx sdk.Tx, txIndex int, next sdk.AnteDepGenerator) (newTxDeps []accesscontrol.AccessOperation, err error) {
 	outputDeps = fmt.Sprintf("%stwo", outputDeps)
-	return next(txDeps, tx)
+	return next(txDeps, tx, txIndex)
 }
 
 type FakeAnteDecoratorThree struct{}
@@ -54,9 +54,9 @@ func (ad FakeAnteDecoratorThree) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate
 	return next(ctx, tx, simulate)
 }
 
-func (ad FakeAnteDecoratorThree) AnteDeps(txDeps []accesscontrol.AccessOperation, tx sdk.Tx, next sdk.AnteDepGenerator) (newTxDeps []accesscontrol.AccessOperation, err error) {
+func (ad FakeAnteDecoratorThree) AnteDeps(txDeps []accesscontrol.AccessOperation, tx sdk.Tx, txIndex int, next sdk.AnteDepGenerator) (newTxDeps []accesscontrol.AccessOperation, err error) {
 	outputDeps = fmt.Sprintf("%sthree", outputDeps)
-	return next(txDeps, tx)
+	return next(txDeps, tx, txIndex)
 }
 
 type FakeAnteDecoratorGasReqd struct{}
@@ -107,7 +107,7 @@ func CallGaslessDecoratorWithMsg(ctx sdk.Context, msg sdk.Msg, oracleKeeper orac
 	if err != nil {
 		return err
 	}
-	_, err = depGen([]accesscontrol.AccessOperation{}, fakeTx)
+	_, err = depGen([]accesscontrol.AccessOperation{}, fakeTx, 1)
 	return err
 }
 
@@ -127,7 +127,7 @@ func TestGaslessDecorator(t *testing.T) {
 	_, err := chainedHandler(ctx, FakeTx{}, false)
 	require.NoError(t, err)
 	require.Equal(t, "onetwothree", output)
-	_, err = depGen([]accesscontrol.AccessOperation{}, FakeTx{})
+	_, err = depGen([]accesscontrol.AccessOperation{}, FakeTx{}, 1)
 	require.NoError(t, err)
 	require.Equal(t, "onetwothree", outputDeps)
 }

--- a/app/app.go
+++ b/app/app.go
@@ -1191,8 +1191,6 @@ func (app *App) ProcessTxs(
 	// we need to add the wasm dependencies before we process synchronous otherwise it never gets included
 	ctx = app.addBadWasmDependenciesToContext(ctx, concurrentResults)
 	ctx.Logger().Error("Concurrent Execution failed, retrying with Synchronous")
-	// Clear the memcache context from the previous state as it failed, we no longer need to commit the data
-	ctx.ContextMemCache().Clear()
 
 	oldDexMemStateCtx := context.WithValue(ctx.Context(), dexutils.DexMemStateContextKey, oldDexMemState)
 	ctx = ctx.WithContext(oldDexMemStateCtx)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -103,53 +103,6 @@ func MockProcessBlockConcurrentFunctionSuccess(
 	return []*abci.ExecTxResult{}, true
 }
 
-func TestProcessTxsSuccess(t *testing.T) {
-	tm := time.Now().UTC()
-	valPub := secp256k1.GenPrivKey().PubKey()
-
-	testWrapper := app.NewTestWrapper(t, tm, valPub)
-	dag := acltypes.NewDag()
-
-	// Set some test context mem cache values
-	testWrapper.Ctx.ContextMemCache().UpsertDeferredSends("Some Account", sdk.NewCoins(sdk.Coin{
-		Denom:  "test",
-		Amount: sdk.NewInt(1),
-	}))
-	require.Equal(t, 1, len(testWrapper.Ctx.ContextMemCache().GetDeferredSends().GetSortedKeys()))
-	testWrapper.App.ProcessTxs(
-		testWrapper.Ctx,
-		[][]byte{},
-		&dag,
-		MockProcessBlockConcurrentFunctionSuccess,
-	)
-
-	// It should be reset if it fails to prevent any values from being written
-	require.Equal(t, 1, len(testWrapper.Ctx.ContextMemCache().GetDeferredSends().GetSortedKeys()))
-}
-
-func TestProcessTxsClearCacheOnFail(t *testing.T) {
-	tm := time.Now().UTC()
-	valPub := secp256k1.GenPrivKey().PubKey()
-
-	testWrapper := app.NewTestWrapper(t, tm, valPub)
-	dag := acltypes.NewDag()
-
-	// Set some test context mem cache values
-	testWrapper.Ctx.ContextMemCache().UpsertDeferredSends("Some Account", sdk.NewCoins(sdk.Coin{
-		Denom:  "test",
-		Amount: sdk.NewInt(1),
-	}))
-	testWrapper.App.ProcessTxs(
-		testWrapper.Ctx,
-		[][]byte{},
-		&dag,
-		MockProcessBlockConcurrentFunctionFail,
-	)
-
-	// It should be reset if it fails to prevent any values from being written
-	require.Equal(t, 0, len(testWrapper.Ctx.ContextMemCache().GetDeferredSends().GetSortedKeys()))
-}
-
 func TestPartitionPrioritizedTxs(t *testing.T) {
 	tm := time.Now().UTC()
 	valPub := secp256k1.GenPrivKey().PubKey()

--- a/go.mod
+++ b/go.mod
@@ -274,7 +274,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.43
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.44-0.20230614025934-38cd768a9307
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.4
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.1.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.mod
+++ b/go.mod
@@ -272,7 +272,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.44-0.20230614034322-0627520a9b46
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.44-0.20230614154814-85b0d5f9be0e
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.4
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.1.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.mod
+++ b/go.mod
@@ -274,7 +274,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.44-0.20230614025934-38cd768a9307
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.44-0.20230614033727-938f3c0fbe49
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.4
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.1.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,6 @@ require (
 	github.com/firefart/nonamedreturns v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/fzipp/gocyclo v0.5.1 // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-critic/go-critic v0.6.3 // indirect
 	github.com/go-kit/kit v0.12.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
@@ -141,7 +140,6 @@ require (
 	github.com/gostaticanalysis/nilerr v0.1.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
@@ -274,7 +272,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.44-0.20230614033727-938f3c0fbe49
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.44-0.20230614034322-0627520a9b46
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.4
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.1.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.sum
+++ b/go.sum
@@ -341,7 +341,6 @@ github.com/fullstorydev/grpcurl v1.6.0/go.mod h1:ZQ+ayqbKMJNhzLmbpCiurTVlaK2M/3n
 github.com/fzipp/gocyclo v0.5.1 h1:L66amyuYogbxl0j2U+vGqJXusPF2IkduvXLnYD5TFgw=
 github.com/fzipp/gocyclo v0.5.1/go.mod h1:rXPyn8fnlpa0R2csP/31uerbiVBugk5whMdlyaLkLoA=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
@@ -599,8 +598,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.12.1/go.mod h1:8XEsbTttt/W+VvjtQhLACqCisSPWTxCZ7sBRjU6iH9c=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
@@ -1075,8 +1072,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.2.44-0.20230614033727-938f3c0fbe49 h1:zDgI8/RYL4q7vHBkXwUsVfyjEAeyNmoF0B4jv4wELPs=
-github.com/sei-protocol/sei-cosmos v0.2.44-0.20230614033727-938f3c0fbe49/go.mod h1:LSR2ut3T6Sv24d8TkXSh9hQ8fskdpI6PNUjY3NQ3pcA=
+github.com/sei-protocol/sei-cosmos v0.2.44-0.20230614034322-0627520a9b46 h1:2EGg8zxq9wEoif6keOgyQByc4NoJuOut5iAAzw7n51w=
+github.com/sei-protocol/sei-cosmos v0.2.44-0.20230614034322-0627520a9b46/go.mod h1:LSR2ut3T6Sv24d8TkXSh9hQ8fskdpI6PNUjY3NQ3pcA=
 github.com/sei-protocol/sei-iavl v0.1.4 h1:lT5doPDTBq/UlbofQbM5iS01FbTSJttmA22+d0PJj5o=
 github.com/sei-protocol/sei-iavl v0.1.4/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-ibc-go/v3 v3.1.0 h1:rFHk2R/3vbG9iNr7cYtVclW/UyEDSRFjNVPz60zZswU=

--- a/go.sum
+++ b/go.sum
@@ -1072,8 +1072,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.2.44-0.20230614034322-0627520a9b46 h1:2EGg8zxq9wEoif6keOgyQByc4NoJuOut5iAAzw7n51w=
-github.com/sei-protocol/sei-cosmos v0.2.44-0.20230614034322-0627520a9b46/go.mod h1:LSR2ut3T6Sv24d8TkXSh9hQ8fskdpI6PNUjY3NQ3pcA=
+github.com/sei-protocol/sei-cosmos v0.2.44-0.20230614154814-85b0d5f9be0e h1:E85RQhxwJ5IV3YWPRGTbMbOiErzJFRaIdw4wBCqRz7E=
+github.com/sei-protocol/sei-cosmos v0.2.44-0.20230614154814-85b0d5f9be0e/go.mod h1:LSR2ut3T6Sv24d8TkXSh9hQ8fskdpI6PNUjY3NQ3pcA=
 github.com/sei-protocol/sei-iavl v0.1.4 h1:lT5doPDTBq/UlbofQbM5iS01FbTSJttmA22+d0PJj5o=
 github.com/sei-protocol/sei-iavl v0.1.4/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-ibc-go/v3 v3.1.0 h1:rFHk2R/3vbG9iNr7cYtVclW/UyEDSRFjNVPz60zZswU=

--- a/go.sum
+++ b/go.sum
@@ -1075,8 +1075,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.2.43 h1:WZJJZrzPScXzbNdCYwFfca09fLV1jAEIzEcQuaIhKEY=
-github.com/sei-protocol/sei-cosmos v0.2.43/go.mod h1:LSR2ut3T6Sv24d8TkXSh9hQ8fskdpI6PNUjY3NQ3pcA=
+github.com/sei-protocol/sei-cosmos v0.2.44-0.20230614025934-38cd768a9307 h1:roF387QogJ53aUzza0xHAi9euXuTmfCosLZLmxqoB6g=
+github.com/sei-protocol/sei-cosmos v0.2.44-0.20230614025934-38cd768a9307/go.mod h1:LSR2ut3T6Sv24d8TkXSh9hQ8fskdpI6PNUjY3NQ3pcA=
 github.com/sei-protocol/sei-iavl v0.1.4 h1:lT5doPDTBq/UlbofQbM5iS01FbTSJttmA22+d0PJj5o=
 github.com/sei-protocol/sei-iavl v0.1.4/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-ibc-go/v3 v3.1.0 h1:rFHk2R/3vbG9iNr7cYtVclW/UyEDSRFjNVPz60zZswU=

--- a/go.sum
+++ b/go.sum
@@ -1075,8 +1075,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.2.44-0.20230614025934-38cd768a9307 h1:roF387QogJ53aUzza0xHAi9euXuTmfCosLZLmxqoB6g=
-github.com/sei-protocol/sei-cosmos v0.2.44-0.20230614025934-38cd768a9307/go.mod h1:LSR2ut3T6Sv24d8TkXSh9hQ8fskdpI6PNUjY3NQ3pcA=
+github.com/sei-protocol/sei-cosmos v0.2.44-0.20230614033727-938f3c0fbe49 h1:zDgI8/RYL4q7vHBkXwUsVfyjEAeyNmoF0B4jv4wELPs=
+github.com/sei-protocol/sei-cosmos v0.2.44-0.20230614033727-938f3c0fbe49/go.mod h1:LSR2ut3T6Sv24d8TkXSh9hQ8fskdpI6PNUjY3NQ3pcA=
 github.com/sei-protocol/sei-iavl v0.1.4 h1:lT5doPDTBq/UlbofQbM5iS01FbTSJttmA22+d0PJj5o=
 github.com/sei-protocol/sei-iavl v0.1.4/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-ibc-go/v3 v3.1.0 h1:rFHk2R/3vbG9iNr7cYtVclW/UyEDSRFjNVPz60zZswU=

--- a/tests/dex_test.go
+++ b/tests/dex_test.go
@@ -98,3 +98,22 @@ func TestPlaceOrders(t *testing.T) {
 		testCase.run(t, app)
 	}
 }
+
+func TestPlaceImposterOrders(t *testing.T) {
+	app := processblock.NewTestApp()
+	p := processblock.DexPreset(app, 3, 2)
+	p.DoRegisterMarkets(app)
+
+	for _, testCase := range []TestCase{
+		{
+			description: "send an order for someone else",
+			input: []signing.Tx{
+				app.Sign(p.SignableAccounts[0], 10000, p.AllDexMarkets[0].LongMarketOrder(p.SignableAccounts[1], "11", "2")),
+			},
+			verifier:      []verify.Verifier{},
+			expectedCodes: []uint32{8},
+		},
+	} {
+		testCase.run(t, app)
+	}
+}

--- a/x/dex/ante.go
+++ b/x/dex/ante.go
@@ -155,7 +155,7 @@ func (d CheckDexGasDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 	return ctx, sdkerrors.ErrInsufficientFee
 }
 
-func (d CheckDexGasDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
+func (d CheckDexGasDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, txIndex int, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
 	deps := []sdkacltypes.AccessOperation{}
 	for _, msg := range tx.GetMsgs() {
 		// Error checking will be handled in AnteHandler
@@ -173,5 +173,5 @@ func (d CheckDexGasDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx 
 			continue
 		}
 	}
-	return next(append(txDeps, deps...), tx)
+	return next(append(txDeps, deps...), tx, txIndex)
 }

--- a/x/oracle/ante.go
+++ b/x/oracle/ante.go
@@ -49,7 +49,7 @@ func (spd SpammingPreventionDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, si
 	return next(ctx, tx, simulate)
 }
 
-func (spd SpammingPreventionDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
+func (spd SpammingPreventionDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, txIndex int, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
 	deps := []sdkacltypes.AccessOperation{}
 	for _, msg := range tx.GetMsgs() {
 		// Error checking will be handled in AnteHandler
@@ -82,7 +82,7 @@ func (spd SpammingPreventionDecorator) AnteDeps(txDeps []sdkacltypes.AccessOpera
 		}
 	}
 
-	return next(append(txDeps, deps...), tx)
+	return next(append(txDeps, deps...), tx, txIndex)
 }
 
 // CheckOracleSpamming check whether the msgs are spamming purpose or not
@@ -149,7 +149,7 @@ func (VoteAloneDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, 
 	return next(ctx, tx, simulate)
 }
 
-func (VoteAloneDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
+func (VoteAloneDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, txIndex int, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
 	// requires no dependencies
-	return next(txDeps, tx)
+	return next(txDeps, tx, txIndex)
 }

--- a/x/oracle/ante_test.go
+++ b/x/oracle/ante_test.go
@@ -43,7 +43,7 @@ func TestOracleVoteAloneAnteHandler(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-			_, err = depGen([]sdkacltypes.AccessOperation{}, tc.tx)
+			_, err = depGen([]sdkacltypes.AccessOperation{}, tc.tx, 1)
 			require.NoError(t, err)
 		})
 	}
@@ -114,7 +114,7 @@ func TestSpammingPreventionAnteDeps(t *testing.T) {
 	_, err := anteHandler(ctx, tx, false)
 	require.NoError(t, err)
 
-	newDeps, err := depGen([]sdkacltypes.AccessOperation{}, tx)
+	newDeps, err := depGen([]sdkacltypes.AccessOperation{}, tx, 1)
 	require.NoError(t, err)
 
 	storeAccessOpEvents := msCache.GetEvents()

--- a/x/tokenfactory/keeper/admins_test.go
+++ b/x/tokenfactory/keeper/admins_test.go
@@ -17,13 +17,11 @@ func (suite *KeeperTestSuite) TestAdminMsgs() {
 	queryRes, err := suite.queryClient.DenomAuthorityMetadata(suite.Ctx.Context(), &types.QueryDenomAuthorityMetadataRequest{
 		Denom: suite.defaultDenom,
 	})
-	suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 	suite.Require().NoError(err)
 	suite.Require().Equal(suite.TestAccs[0].String(), queryRes.AuthorityMetadata.Admin)
 
 	// Test minting to admins own account
 	_, err = suite.msgServer.Mint(sdk.WrapSDKContext(suite.Ctx), types.NewMsgMint(suite.TestAccs[0].String(), sdk.NewInt64Coin(suite.defaultDenom, 10)))
-	suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 
 	addr0bal += 10
 	suite.Require().NoError(err)
@@ -31,7 +29,6 @@ func (suite *KeeperTestSuite) TestAdminMsgs() {
 
 	// Test burning from own account
 	_, err = suite.msgServer.Burn(sdk.WrapSDKContext(suite.Ctx), types.NewMsgBurn(suite.TestAccs[0].String(), sdk.NewInt64Coin(suite.defaultDenom, 5)))
-	suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 
 	addr0bal -= 5
 	suite.Require().NoError(err)
@@ -39,7 +36,6 @@ func (suite *KeeperTestSuite) TestAdminMsgs() {
 
 	// Test Change Admin
 	_, err = suite.msgServer.ChangeAdmin(sdk.WrapSDKContext(suite.Ctx), types.NewMsgChangeAdmin(suite.TestAccs[0].String(), suite.defaultDenom, suite.TestAccs[1].String()))
-	suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 
 	queryRes, err = suite.queryClient.DenomAuthorityMetadata(suite.Ctx.Context(), &types.QueryDenomAuthorityMetadataRequest{
 		Denom: suite.defaultDenom,
@@ -49,13 +45,11 @@ func (suite *KeeperTestSuite) TestAdminMsgs() {
 
 	// Make sure old admin can no longer do actions
 	_, err = suite.msgServer.Burn(sdk.WrapSDKContext(suite.Ctx), types.NewMsgBurn(suite.TestAccs[0].String(), sdk.NewInt64Coin(suite.defaultDenom, 5)))
-	suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 
 	suite.Require().Error(err)
 
 	// Make sure the new admin works
 	_, err = suite.msgServer.Mint(sdk.WrapSDKContext(suite.Ctx), types.NewMsgMint(suite.TestAccs[1].String(), sdk.NewInt64Coin(suite.defaultDenom, 5)))
-	suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 
 	addr1bal += 5
 	suite.Require().NoError(err)
@@ -63,7 +57,6 @@ func (suite *KeeperTestSuite) TestAdminMsgs() {
 
 	// Try setting admin to empty
 	_, err = suite.msgServer.ChangeAdmin(sdk.WrapSDKContext(suite.Ctx), types.NewMsgChangeAdmin(suite.TestAccs[1].String(), suite.defaultDenom, ""))
-	suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 
 	suite.Require().NoError(err)
 	queryRes, err = suite.queryClient.DenomAuthorityMetadata(suite.Ctx.Context(), &types.QueryDenomAuthorityMetadataRequest{
@@ -129,18 +122,15 @@ func (suite *KeeperTestSuite) TestChangeAdminDenom() {
 
 			// Create a denom and mint
 			res, err := suite.msgServer.CreateDenom(sdk.WrapSDKContext(suite.Ctx), types.NewMsgCreateDenom(suite.TestAccs[0].String(), "bitcoin"))
-			suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 			suite.Require().NoError(err)
 
 			testDenom := res.GetNewTokenDenom()
 
 			_, err = suite.msgServer.Mint(sdk.WrapSDKContext(suite.Ctx), types.NewMsgMint(suite.TestAccs[0].String(), sdk.NewInt64Coin(testDenom, 10)))
-			suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 
 			suite.Require().NoError(err)
 
 			_, err = suite.msgServer.ChangeAdmin(sdk.WrapSDKContext(suite.Ctx), tc.msgChangeAdmin(testDenom))
-			suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 
 			if tc.expectedChangeAdminPass {
 				suite.Require().NoError(err)
@@ -164,7 +154,6 @@ func (suite *KeeperTestSuite) TestChangeAdminDenom() {
 			// we test mint to test if admin authority is performed properly after admin change.
 			if tc.msgMint != nil {
 				_, err := suite.msgServer.Mint(sdk.WrapSDKContext(suite.Ctx), tc.msgMint(testDenom))
-				suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 
 				if tc.expectedMintPass {
 					suite.Require().NoError(err)

--- a/x/tokenfactory/keeper/bankactions_test.go
+++ b/x/tokenfactory/keeper/bankactions_test.go
@@ -14,7 +14,6 @@ func (suite *KeeperTestSuite) TestMultipleMintsPriorToDeferredSettlement() {
 	queryRes, err := suite.queryClient.DenomAuthorityMetadata(suite.Ctx.Context(), &types.QueryDenomAuthorityMetadataRequest{
 		Denom: suite.defaultDenom,
 	})
-	suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 	suite.Require().NoError(err)
 	suite.Require().Equal(suite.TestAccs[0].String(), queryRes.AuthorityMetadata.Admin)
 
@@ -24,8 +23,6 @@ func (suite *KeeperTestSuite) TestMultipleMintsPriorToDeferredSettlement() {
 
 	_, err = suite.msgServer.Mint(sdk.WrapSDKContext(suite.Ctx), types.NewMsgMint(suite.TestAccs[0].String(), sdk.NewInt64Coin(suite.defaultDenom, 5)))
 	suite.Require().NoError(err)
-
-	suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 
 	addr0Bal := suite.App.BankKeeper.GetBalance(suite.Ctx, suite.TestAccs[0], suite.defaultDenom).Amount.Int64()
 	suite.Require().Equal(int64(55), addr0Bal, addr0Bal)
@@ -40,15 +37,12 @@ func (suite *KeeperTestSuite) TestMultipleInterleavedMintsBurns() {
 	queryRes, err := suite.queryClient.DenomAuthorityMetadata(suite.Ctx.Context(), &types.QueryDenomAuthorityMetadataRequest{
 		Denom: suite.defaultDenom,
 	})
-	suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 	suite.Require().NoError(err)
 	suite.Require().Equal(suite.TestAccs[0].String(), queryRes.AuthorityMetadata.Admin)
 
 	// Test minting to admins own account
 	_, err = suite.msgServer.Mint(sdk.WrapSDKContext(suite.Ctx), types.NewMsgMint(suite.TestAccs[0].String(), sdk.NewInt64Coin(suite.defaultDenom, 50)))
 	suite.Require().NoError(err)
-
-	suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 
 	addr0Bal := suite.App.BankKeeper.GetBalance(suite.Ctx, suite.TestAccs[0], suite.defaultDenom).Amount.Int64()
 	suite.Require().Equal(int64(50), addr0Bal, addr0Bal)
@@ -62,8 +56,6 @@ func (suite *KeeperTestSuite) TestMultipleInterleavedMintsBurns() {
 
 	_, err = suite.msgServer.Burn(sdk.WrapSDKContext(suite.Ctx), types.NewMsgBurn(suite.TestAccs[0].String(), sdk.NewInt64Coin(suite.defaultDenom, 15)))
 	suite.Require().NoError(err)
-
-	suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 
 	// Try burning more than what's left
 	_, err = suite.msgServer.Burn(sdk.WrapSDKContext(suite.Ctx), types.NewMsgBurn(suite.TestAccs[0].String(), sdk.NewInt64Coin(suite.defaultDenom, 100)))
@@ -90,8 +82,6 @@ func (suite *KeeperTestSuite) TestMultipleInterleavedMintsBurns() {
 
 	_, err = suite.msgServer.Burn(sdk.WrapSDKContext(suite.Ctx), types.NewMsgBurn(suite.TestAccs[0].String(), sdk.NewInt64Coin(suite.defaultDenom, 5)))
 	suite.Require().NoError(err)
-
-	suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 
 	// Check final balances
 	addr0Bal = suite.App.BankKeeper.GetBalance(suite.Ctx, suite.TestAccs[0], suite.defaultDenom).Amount.Int64()
@@ -143,7 +133,6 @@ func (suite *KeeperTestSuite) TestMintDenom() {
 		suite.Run(fmt.Sprintf("Case %s", tc.desc), func() {
 			// Test minting to admins own account
 			_, err := suite.msgServer.Mint(sdk.WrapSDKContext(suite.Ctx), types.NewMsgMint(tc.admin, sdk.NewInt64Coin(tc.mintDenom, 10)))
-			suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 
 			if tc.valid {
 				addr0bal += 10
@@ -164,7 +153,6 @@ func (suite *KeeperTestSuite) TestBurnDenom() {
 
 	// mint 10 default token for testAcc[0]
 	suite.msgServer.Mint(sdk.WrapSDKContext(suite.Ctx), types.NewMsgMint(suite.TestAccs[0].String(), sdk.NewInt64Coin(suite.defaultDenom, 10)))
-	suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 
 	addr0bal += 10
 
@@ -207,7 +195,6 @@ func (suite *KeeperTestSuite) TestBurnDenom() {
 		suite.Run(fmt.Sprintf("Case %s", tc.desc), func() {
 			// Test minting to admins own account
 			_, err := suite.msgServer.Burn(sdk.WrapSDKContext(suite.Ctx), types.NewMsgBurn(tc.admin, sdk.NewInt64Coin(tc.burnDenom, 10)))
-			suite.App.BankKeeper.WriteDeferredOperations(suite.Ctx)
 
 			if tc.valid {
 				addr0bal -= 10


### PR DESCRIPTION
## Describe your changes and provide context
This PR does the following:
- refactors ante dependency decorators to follow the new pattern of passing txIndex through
- Adds the new deferredcache resource type to the tree
- removes the ContextCache (because of incoming deprecation) setup performed in BuildDependenciesAndRunTxs
- updates instantiation of seid app to use the new BankKeeper with DeferredCache memstore created

## Testing performed to validate your change
local sei testing (and needs more tests added via test harness)

