### PR TITLE
fix: handle panics in epoch hooks

### DIFF
--- a/utils/panic.go
+++ b/utils/panic.go
@@ -23,6 +23,8 @@ func PanicHandler(recoverCallback func(any)) func() {
 	}
 }
 
+// LogPanicCallback returns a callback function, given a context and a recovered
+// error value, that logs the error and a stack trace.
 func LogPanicCallback(ctx sdk.Context, r any) func(any) {
 	return func(a any) {
 		stackTrace := string(debug.Stack())

--- a/utils/panic.go
+++ b/utils/panic.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"runtime/debug"
 	"strings"
 
 	"github.com/armon/go-metrics"
@@ -19,6 +20,13 @@ func PanicHandler(recoverCallback func(any)) func() {
 			}
 			recoverCallback(err)
 		}
+	}
+}
+
+func LogPanicCallback(ctx sdk.Context, r any) func(any) {
+	return func(a any) {
+		stackTrace := string(debug.Stack())
+		ctx.Logger().Error("recovered panic", "recover_err", r, "recover_type", fmt.Sprintf("%T", r), "stack_trace", stackTrace)
 	}
 }
 

--- a/x/epoch/module.go
+++ b/x/epoch/module.go
@@ -168,8 +168,10 @@ func (AppModule) ConsensusVersion() uint64 { return 2 }
 func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
 	lastEpoch := am.keeper.GetEpoch(ctx)
 	ctx.Logger().Info(fmt.Sprintf("Current block time %s, last %s; duration %d", ctx.BlockTime().String(), lastEpoch.CurrentEpochStartTime.String(), lastEpoch.EpochDuration))
+
 	if ctx.BlockTime().Sub(lastEpoch.CurrentEpochStartTime) > lastEpoch.EpochDuration {
 		am.keeper.AfterEpochEnd(ctx, lastEpoch)
+
 		newEpoch := types.Epoch{
 			GenesisTime:           lastEpoch.GenesisTime,
 			EpochDuration:         lastEpoch.EpochDuration,
@@ -179,6 +181,7 @@ func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
 		}
 		am.keeper.SetEpoch(ctx, newEpoch)
 		am.keeper.BeforeEpochStart(ctx, newEpoch)
+
 		ctx.EventManager().EmitEvent(
 			sdk.NewEvent(types.EventTypeNewEpoch,
 				sdk.NewAttribute(types.AttributeEpochNumber, fmt.Sprint(newEpoch.CurrentEpoch)),
@@ -186,6 +189,7 @@ func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
 				sdk.NewAttribute(types.AttributeEpochHeight, fmt.Sprint(newEpoch.CurrentEpochHeight)),
 			),
 		)
+
 		metrics.SetEpochNew(newEpoch.CurrentEpoch)
 	}
 }

--- a/x/epoch/types/hooks.go
+++ b/x/epoch/types/hooks.go
@@ -37,11 +37,7 @@ func (h MultiEpochHooks) BeforeEpochStart(ctx sdk.Context, epoch Epoch) {
 	}
 }
 
-func panicCatchingEpochHook(
-	ctx sdk.Context,
-	hookFn func(ctx sdk.Context, epoch Epoch),
-	epoch Epoch,
-) {
+func panicCatchingEpochHook(ctx sdk.Context, hookFn func(ctx sdk.Context, epoch Epoch), epoch Epoch) {
 	defer func() {
 		if r := recover(); r != nil {
 			utils.PanicHandler(utils.LogPanicCallback(ctx, r))

--- a/x/epoch/types/hooks.go
+++ b/x/epoch/types/hooks.go
@@ -2,12 +2,14 @@ package types
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/utils"
 )
 
 type EpochHooks interface {
-	// the first block whose timestamp is after the duration is counted as the end of the epoch
+	// AfterEpochEnd defines the first block whose timestamp is after the duration
+	// is counted as the end of the epoch.
 	AfterEpochEnd(ctx sdk.Context, epoch Epoch)
-	// new epoch is next block of epoch end block
+	// BeforeEpochStart defines the new epoch is next block of epoch EndBlock.
 	BeforeEpochStart(ctx sdk.Context, epoch Epoch)
 }
 
@@ -19,16 +21,35 @@ func NewMultiEpochHooks(hooks ...EpochHooks) MultiEpochHooks {
 	return hooks
 }
 
-// AfterEpochEnd is called when epoch is going to be ended, epochNumber is the number of epoch that is ending.
+// AfterEpochEnd is called when epoch is going to be ended, epochNumber is the
+// number of epoch that is ending.
 func (h MultiEpochHooks) AfterEpochEnd(ctx sdk.Context, epoch Epoch) {
 	for i := range h {
-		h[i].AfterEpochEnd(ctx, epoch)
+		panicCatchingEpochHook(ctx, h[i].AfterEpochEnd, epoch)
 	}
 }
 
-// BeforeEpochStart is called when epoch is going to be started, epochNumber is the number of epoch that is starting.
+// BeforeEpochStart is called when epoch is going to be started, epochNumber is
+// the number of epoch that is starting.
 func (h MultiEpochHooks) BeforeEpochStart(ctx sdk.Context, epoch Epoch) {
 	for i := range h {
-		h[i].BeforeEpochStart(ctx, epoch)
+		panicCatchingEpochHook(ctx, h[i].BeforeEpochStart, epoch)
 	}
+}
+
+func panicCatchingEpochHook(
+	ctx sdk.Context,
+	hookFn func(ctx sdk.Context, epoch Epoch),
+	epoch Epoch,
+) {
+	defer func() {
+		if r := recover(); r != nil {
+			utils.PanicHandler(utils.LogPanicCallback(ctx, r))
+		}
+	}()
+
+	// cache the context and only write if no panic (which is caught above)
+	cacheCtx, write := ctx.CacheContext()
+	hookFn(cacheCtx, epoch)
+	write()
 }

--- a/x/epoch/types/hooks.go
+++ b/x/epoch/types/hooks.go
@@ -38,11 +38,9 @@ func (h MultiEpochHooks) BeforeEpochStart(ctx sdk.Context, epoch Epoch) {
 }
 
 func panicCatchingEpochHook(ctx sdk.Context, hookFn func(sdk.Context, Epoch), epoch Epoch) {
-	defer func() {
-		if r := recover(); r != nil {
-			utils.PanicHandler(utils.LogPanicCallback(ctx, r))
-		}
-	}()
+	defer utils.PanicHandler(func(r any) {
+		utils.PanicHandler(utils.LogPanicCallback(ctx, r))
+	})()
 
 	// cache the context and only write if no panic (which is caught above)
 	cacheCtx, write := ctx.CacheContext()

--- a/x/epoch/types/hooks.go
+++ b/x/epoch/types/hooks.go
@@ -39,7 +39,7 @@ func (h MultiEpochHooks) BeforeEpochStart(ctx sdk.Context, epoch Epoch) {
 
 func panicCatchingEpochHook(ctx sdk.Context, hookFn func(sdk.Context, Epoch), epoch Epoch) {
 	defer utils.PanicHandler(func(r any) {
-		utils.PanicHandler(utils.LogPanicCallback(ctx, r))
+		utils.LogPanicCallback(ctx, r)
 	})()
 
 	// cache the context and only write if no panic (which is caught above)

--- a/x/epoch/types/hooks.go
+++ b/x/epoch/types/hooks.go
@@ -37,7 +37,7 @@ func (h MultiEpochHooks) BeforeEpochStart(ctx sdk.Context, epoch Epoch) {
 	}
 }
 
-func panicCatchingEpochHook(ctx sdk.Context, hookFn func(ctx sdk.Context, epoch Epoch), epoch Epoch) {
+func panicCatchingEpochHook(ctx sdk.Context, hookFn func(sdk.Context, Epoch), epoch Epoch) {
 	defer func() {
 		if r := recover(); r != nil {
 			utils.PanicHandler(utils.LogPanicCallback(ctx, r))

--- a/x/epoch/types/hooks_test.go
+++ b/x/epoch/types/hooks_test.go
@@ -3,10 +3,13 @@ package types_test
 import (
 	"testing"
 
+	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/sei-protocol/sei-chain/x/epoch/keeper"
 	"github.com/sei-protocol/sei-chain/x/epoch/types"
 	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	tmdb "github.com/tendermint/tm-db"
 )
 
 type mockEpochHooks struct {
@@ -45,8 +48,10 @@ func TestMultiHooks(t *testing.T) {
 		hooks,
 	}
 
-	ctx := sdk.Context{}   // setup context as required
-	epoch := types.Epoch{} // setup epoch as required
+	db := tmdb.NewMemDB()
+	ms := store.NewCommitMultiStore(db)
+	ctx := sdk.NewContext(ms, tmproto.Header{}, false, nil)
+	epoch := types.Epoch{}
 
 	multiHooks.AfterEpochEnd(ctx, epoch)
 	require.True(t, hooks.afterEpochEndCalled)


### PR DESCRIPTION
Gracefully recover any x/epoch hook, both before and after, and log the recovered error.

ref: sei-4591