### PR TITLE
feat: crypto.com provider

### DIFF
--- a/oracle/price-feeder/config.example.toml
+++ b/oracle/price-feeder/config.example.toml
@@ -35,7 +35,8 @@ quote = "USD"
 
 [[currency_pairs]]
 base = "SOL"
-chain_denom = "usol"
+# this is because we need some dummy price feed that moves for usei
+chain_denom = "usei"
 providers = [
   "huobi",
   "kraken",

--- a/oracle/price-feeder/config.example.toml
+++ b/oracle/price-feeder/config.example.toml
@@ -35,11 +35,12 @@ quote = "USD"
 
 [[currency_pairs]]
 base = "SOL"
-chain_denom = "usei"
+chain_denom = "usol"
 providers = [
   "huobi",
   "kraken",
   "coinbase",
+  "crypto",
 ]
 quote = "USD"
 
@@ -50,6 +51,7 @@ providers = [
   "huobi",
   "kraken",
   "coinbase",
+  "crypto",
 ]
 quote = "USD"
 

--- a/oracle/price-feeder/config/config.go
+++ b/oracle/price-feeder/config/config.go
@@ -22,6 +22,7 @@ const (
 
 	ProviderKraken   = "kraken"
 	ProviderBinance  = "binance"
+	ProviderCrypto   = "crypto"
 	ProviderMexc     = "mexc"
 	ProviderHuobi    = "huobi"
 	ProviderOkx      = "okx"

--- a/oracle/price-feeder/oracle/provider/crypto.go
+++ b/oracle/price-feeder/oracle/provider/crypto.go
@@ -20,7 +20,6 @@ import (
 const (
 	cryptoWSHost             = "stream.crypto.com"
 	cryptoWSPath             = "/v2/market"
-	cryptoReconnectTime      = time.Second * 30
 	cryptoRestHost           = "https://api.crypto.com"
 	cryptoRestPath           = "/v2/public/get-ticker"
 	cryptoTickerChannel      = "ticker"

--- a/oracle/price-feeder/oracle/provider/crypto.go
+++ b/oracle/price-feeder/oracle/provider/crypto.go
@@ -2,10 +2,15 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
+	"strings"
 	"sync"
+	"time"
 
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
 	"github.com/sei-protocol/sei-chain/oracle/price-feeder/config"
@@ -13,70 +18,88 @@ import (
 )
 
 const (
-	cryptoRestHost = "https://api.crypto.com"
-	cryptoRestPath = "/exchange/v1"
-	cryptoWsHost   = "wss://stream.crypto.com"
-	cryptoWsPath   = "/exchange/v1/market"
+	cryptoWSHost             = "stream.crypto.com"
+	cryptoWSPath             = "/v2/market"
+	cryptoReconnectTime      = time.Second * 30
+	cryptoRestHost           = "https://api.crypto.com"
+	cryptoRestPath           = "/v2/public/get-ticker"
+	cryptoTickerChannel      = "ticker"
+	cryptoCandleChannel      = "candlestick"
+	cryptoHeartbeatMethod    = "public/heartbeat"
+	cryptoHeartbeatReqMethod = "public/respond-heartbeat"
+	cryptoTickerMsgPrefix    = "ticker."
+	cryptoCandleMsgPrefix    = "candlestick.5m."
 )
 
-var _ Provider = (*Provider)(nil)
+var _ Provider = (*CryptoProvider)(nil)
 
 type (
-	// CryptoProvider defines an oracle provider implemented by the crypto.com
-	// public API.
+	// CryptoProvider defines an Oracle provider implemented by the Crypto.com public
+	// API.
 	//
-	// REF: https://exchange-docs.crypto.com/exchange/v1/rest-ws/index.html
+	// REF: https://exchange-docs.crypto.com/spot/index.html#introduction
 	CryptoProvider struct {
-		ctx      context.Context
-		logger   zerolog.Logger
-		endpoint config.ProviderEndpoint
-		wsURL    url.URL
-		wsClient *websocket.Conn
-
+		wsc             *WebsocketController
+		logger          zerolog.Logger
 		mtx             sync.RWMutex
-		tickers         map[string]CryptoTicker
-		candles         map[string][]CryptoCandle
+		endpoint        config.ProviderEndpoint
+		tickers         map[string]TickerPrice        // Symbol => TickerPrice
+		candles         map[string][]CandlePrice      // Symbol => CandlePrice
 		subscribedPairs map[string]types.CurrencyPair // Symbol => types.CurrencyPair
 	}
 
-	CryptoTickersResponse struct {
-		Code   int64                     `json:"code"`
-		Result CryptoTickersResponseData `json:"result"`
+	CryptoTickerResponse struct {
+		Result CryptoTickerResult `json:"result"`
 	}
-
-	CryptoTickersResponseData struct {
-		Data []CryptoTicker `json:"data"`
+	CryptoTickerResult struct {
+		InstrumentName string         `json:"instrument_name"` // ex.: ATOM_USDT
+		Channel        string         `json:"channel"`         // ex.: ticker
+		Data           []CryptoTicker `json:"data"`            // ticker data
 	}
-
 	CryptoTicker struct {
-		Symbol string `json:"i"` // Symbol ex.: BTC_USDT
-		Price  string `json:"a"` // Last price ex.: 0.0025
-		Volume string `json:"v"` // Total traded base asset volume ex.: 1000
-		Time   int64  `json:"t"` // Timestamp ex.: 1675246930699
+		InstrumentName string `json:"i"` // Instrument Name, e.g. BTC_USDT, ETH_CRO, etc.
+		Volume         string `json:"v"` // The total 24h traded volume
+		LatestTrade    string `json:"a"` // The price of the latest trade, null if there weren't any trades
 	}
 
 	CryptoCandleResponse struct {
-		Code   int64                    `json:"code"`
-		Result CryptoCandleResponseData `json:"result"`
+		Result CryptoCandleResult `json:"result"`
 	}
-
-	CryptoCandleResponseData struct {
-		Data           []CryptoCandle `json:"data"`
-		InstrumentName string         `json:"instrument_name"`
+	CryptoCandleResult struct {
+		InstrumentName string         `json:"instrument_name"` // ex.: ATOM_USDT
+		Channel        string         `json:"channel"`         // ex.: candlestick
+		Data           []CryptoCandle `json:"data"`            // candlestick data
 	}
-
 	CryptoCandle struct {
-		Open   string `json:"o"` // Open price
-		High   string `json:"h"` // High price
-		Low    string `json:"l"` // Low price
-		Close  string `json:"c"` // Close price
-		Volume string `json:"v"` // Volume
-		Start  int64  `json:"t"` // Start time
+		Close     string `json:"c"` // Price at close
+		Volume    string `json:"v"` // Volume during interval
+		Timestamp int64  `json:"t"` // End time of candlestick (Unix timestamp)
 	}
 
 	CryptoSubscriptionMsg struct {
-		Method   string   `json:"method"`   // subscribe/unsubscribe
-		Channels []string `json:"channels"` // Channels to be subscribed
+		ID     int64                    `json:"id"`
+		Method string                   `json:"method"` // subscribe, unsubscribe
+		Params CryptoSubscriptionParams `json:"params"`
+		Nonce  int64                    `json:"nonce"` // Current timestamp (milliseconds since the Unix epoch)
+	}
+	CryptoSubscriptionParams struct {
+		Channels []string `json:"channels"` // Channels to be subscribed ex. ticker.ATOM_USDT
+	}
+
+	CryptoPairsSummary struct {
+		Result CryptoInstruments `json:"result"`
+	}
+	CryptoInstruments struct {
+		Data []CryptoTicker `json:"data"`
+	}
+
+	CryptoHeartbeatResponse struct {
+		ID     int64  `json:"id"`
+		Method string `json:"method"` // public/heartbeat
+	}
+	CryptoHeartbeatRequest struct {
+		ID     int64  `json:"id"`
+		Method string `json:"method"` // public/respond-heartbeat
 	}
 )
 
@@ -90,120 +113,320 @@ func NewCryptoProvider(
 		endpoint = config.ProviderEndpoint{
 			Name:      config.ProviderCrypto,
 			Rest:      cryptoRestHost,
-			Websocket: cryptoWsHost,
+			Websocket: cryptoWSHost,
 		}
 	}
 
 	wsURL := url.URL{
 		Scheme: "wss",
 		Host:   endpoint.Websocket,
-		Path:   cryptoWsPath,
-	}
-
-	wsConn, response, err := websocket.DefaultDialer.Dial(wsURL.String(), nil)
-	defer func() {
-		if response != nil {
-			response.Body.Close()
-		}
-	}()
-	if err != nil {
-		return nil, fmt.Errorf("error connecting to crypto.com websocket: %w", err)
+		Path:   cryptoWSPath,
 	}
 
 	provider := &CryptoProvider{
-		wsURL:           wsURL,
-		wsClient:        wsConn,
-		logger:          logger.With().Str("provider", "okx").Logger(),
+		logger:          logger.With().Str("provider", "crypto").Logger(),
 		endpoint:        endpoint,
-		tickers:         map[string]CryptoTicker{},
-		candles:         map[string][]CryptoCandle{},
+		tickers:         map[string]TickerPrice{},
+		candles:         map[string][]CandlePrice{},
 		subscribedPairs: map[string]types.CurrencyPair{},
 	}
 
-	if err := provider.SubscribeCurrencyPairs(pairs...); err != nil {
-		return nil, err
-	}
+	provider.setSubscribedPairs(pairs...)
 
-	// go provider.handleWebSocketMsgs(ctx)
+	provider.wsc = NewWebsocketController(
+		ctx,
+		ProviderCrypto,
+		wsURL,
+		provider.getSubscriptionMsgs(pairs...),
+		provider.messageReceived,
+		disabledPingDuration,
+		websocket.PingMessage,
+		cryptoLogger,
+	)
+	go provider.wsc.Start()
 
 	return provider, nil
 }
 
+func (p *CryptoProvider) getSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {
+	subscriptionMsgs := make([]interface{}, 0, len(cps)*2)
+	for _, cp := range cps {
+		cryptoPair := currencyPairToCryptoPair(cp)
+		channel := cryptoTickerMsgPrefix + cryptoPair
+		msg := newCryptoSubscriptionMsg([]string{channel})
+		subscriptionMsgs = append(subscriptionMsgs, msg)
+
+		cryptoPair = currencyPairToCryptoPair(cp)
+		channel = cryptoCandleMsgPrefix + cryptoPair
+		msg = newCryptoSubscriptionMsg([]string{channel})
+		subscriptionMsgs = append(subscriptionMsgs, msg)
+	}
+	return subscriptionMsgs
+}
+
+// SubscribeCurrencyPairs sends the new subscription messages to the websocket
+// and adds them to the providers subscribedPairs array
 func (p *CryptoProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
-	if len(cps) == 0 {
-		return fmt.Errorf("currency pairs is empty")
-	}
-
-	if err := p.subscribeChannels(cps...); err != nil {
-		return err
-	}
-
-	p.setSubscribedPairs(cps...)
-	return nil
-}
-
-func (p *CryptoProvider) subscribeChannels(cps ...types.CurrencyPair) error {
-	if err := p.subscribeTickers(cps...); err != nil {
-		return err
-	}
-
-	return p.subscribeCandles(cps...)
-}
-
-func (p *CryptoProvider) subscribeTickers(cps ...types.CurrencyPair) error {
-	pairs := make([]string, len(cps))
-
-	for i, cp := range cps {
-		pairs[i] = fmt.Sprintf("ticker.%s_%s", cp.Base, cp.Quote)
-	}
-
-	return p.subscribePairs(pairs...)
-}
-
-func (p *CryptoProvider) subscribeCandles(cps ...types.CurrencyPair) error {
-	pairs := make([]string, len(cps))
-
-	for i, cp := range cps {
-		pairs[i] = fmt.Sprintf("candlestick.1m.%s_%s", cp.Base, cp.Quote)
-	}
-
-	return p.subscribePairs(pairs...)
-}
-
-func (p *CryptoProvider) subscribePairs(channels ...string) error {
-	subsMsg := CryptoSubscriptionMsg{
-		Method:   "subscribe",
-		Channels: channels,
-	}
-
-	return p.wsClient.WriteJSON(subsMsg)
-}
-
-func (p *CryptoProvider) setSubscribedPairs(cps ...types.CurrencyPair) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 
+	newPairs := []types.CurrencyPair{}
+	for _, cp := range cps {
+		if _, ok := p.subscribedPairs[cp.String()]; !ok {
+			newPairs = append(newPairs, cp)
+		}
+	}
+
+	newSubscriptionMsgs := p.getSubscriptionMsgs(newPairs...)
+	if err := p.wsc.AddSubscriptionMsgs(newSubscriptionMsgs); err != nil {
+		return err
+	}
+
+	p.setSubscribedPairs(newPairs...)
+	return nil
+}
+
+// GetTickerPrices returns the tickerPrices based on the saved map.
+func (p *CryptoProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]TickerPrice, error) {
+	tickerPrices := make(map[string]TickerPrice, len(pairs))
+
+	for _, cp := range pairs {
+		key := currencyPairToCryptoPair(cp)
+		price, err := p.getTickerPrice(key)
+		if err != nil {
+			return nil, err
+		}
+		tickerPrices[cp.String()] = price
+	}
+
+	return tickerPrices, nil
+}
+
+// GetCandlePrices returns the candlePrices based on the saved map
+func (p *CryptoProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]CandlePrice, error) {
+	candlePrices := make(map[string][]CandlePrice, len(pairs))
+
+	for _, cp := range pairs {
+		key := currencyPairToCryptoPair(cp)
+		prices, err := p.getCandlePrices(key)
+		if err != nil {
+			return nil, err
+		}
+		candlePrices[cp.String()] = prices
+	}
+
+	return candlePrices, nil
+}
+
+func (p *CryptoProvider) getTickerPrice(key string) (TickerPrice, error) {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	ticker, ok := p.tickers[key]
+	if !ok {
+		return TickerPrice{}, fmt.Errorf("%s ticker not found for %s", config.ProviderCrypto, key)
+	}
+
+	return ticker, nil
+}
+
+func (p *CryptoProvider) getCandlePrices(key string) ([]CandlePrice, error) {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	candles, ok := p.candles[key]
+	if !ok {
+		return []CandlePrice{}, fmt.Errorf("%s candle not found for %s", config.ProviderCrypto, key)
+	}
+
+	candleList := []CandlePrice{}
+	candleList = append(candleList, candles...)
+
+	return candleList, nil
+}
+
+func (p *CryptoProvider) messageReceived(messageType int, bz []byte) {
+	if messageType != websocket.TextMessage {
+		return
+	}
+
+	var (
+		heartbeatResp CryptoHeartbeatResponse
+		heartbeatErr  error
+
+		tickerResp CryptoTickerResponse
+		tickerErr  error
+
+		candleResp CryptoCandleResponse
+		candleErr  error
+	)
+
+	// sometimes the message received is not a ticker or a candle response.
+	heartbeatErr = json.Unmarshal(bz, &heartbeatResp)
+	if heartbeatResp.Method == cryptoHeartbeatMethod {
+		p.pong(heartbeatResp)
+		return
+	}
+
+	tickerErr = json.Unmarshal(bz, &tickerResp)
+	if tickerResp.Result.Channel == cryptoTickerChannel {
+		for _, tickerPair := range tickerResp.Result.Data {
+			p.setTickerPair(tickerResp.Result.InstrumentName, tickerPair)
+			telemetry.IncrCounter(
+				1,
+				"websocket",
+				"message",
+				"type",
+				"ticker",
+				"provider",
+				config.ProviderCrypto,
+			)
+		}
+		return
+	}
+
+	candleErr = json.Unmarshal(bz, &candleResp)
+	if candleResp.Result.Channel == cryptoCandleChannel {
+		for _, candlePair := range candleResp.Result.Data {
+			p.setCandlePair(candleResp.Result.InstrumentName, candlePair)
+			telemetry.IncrCounter(
+				1,
+				"websocket",
+				"message",
+				"type",
+				"candle",
+				"provider",
+				config.ProviderCrypto,
+			)
+		}
+		return
+	}
+
+	p.logger.Error().
+		Int("length", len(bz)).
+		AnErr("heartbeat", heartbeatErr).
+		AnErr("ticker", tickerErr).
+		AnErr("candle", candleErr).
+		Msg("Error on receive message")
+}
+
+// pong return a heartbeat message when a "ping" is received and reset the
+// reconnect ticker because the connection is alive. After connected to crypto.com's
+// Websocket server, the server will send heartbeat periodically (30s interval).
+// When client receives an heartbeat message, it must respond back with the
+// public/respond-heartbeat method, using the same matching id,
+// within 5 seconds, or the connection will break.
+func (p *CryptoProvider) pong(heartbeatResp CryptoHeartbeatResponse) {
+	heartbeatReq := CryptoHeartbeatRequest{
+		ID:     heartbeatResp.ID,
+		Method: cryptoHeartbeatReqMethod,
+	}
+
+	if err := p.wsc.SendJSON(heartbeatReq); err != nil {
+		p.logger.Err(err).Msg("could not send pong message back")
+	}
+}
+
+func (p *CryptoProvider) setTickerPair(symbol string, tickerPair CryptoTicker) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	tickerPrice, err := newTickerPrice(
+		config.ProviderCrypto,
+		symbol,
+		tickerPair.LatestTrade,
+		tickerPair.Volume,
+	)
+	if err != nil {
+		p.logger.Warn().Err(err).Msg("crypto: failed to parse ticker")
+		return
+	}
+
+	p.tickers[symbol] = tickerPrice
+}
+
+func (p *CryptoProvider) setCandlePair(symbol string, candlePair CryptoCandle) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	candle, err := newCandlePrice(
+		config.ProviderCrypto,
+		symbol,
+		candlePair.Close,
+		candlePair.Volume,
+		candlePair.Timestamp,
+	)
+	if err != nil {
+		p.logger.Warn().Err(err).Msg("crypto: failed to parse candle")
+		return
+	}
+
+	staleTime := PastUnixTime(providerCandlePeriod)
+	candleList := []CandlePrice{}
+	candleList = append(candleList, candle)
+
+	for _, c := range p.candles[symbol] {
+		if staleTime < c.TimeStamp {
+			candleList = append(candleList, c)
+		}
+	}
+
+	p.candles[symbol] = candleList
+}
+
+// setSubscribedPairs sets N currency pairs to the map of subscribed pairs.
+func (p *CryptoProvider) setSubscribedPairs(cps ...types.CurrencyPair) {
 	for _, cp := range cps {
 		p.subscribedPairs[cp.String()] = cp
 	}
 }
 
-// func (p *BinanceProvider) GetAvailablePairs() (map[string]struct{}, error) {
-// 	resp, err := http.Get(p.endpoints.Rest + binanceRestPath)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	defer resp.Body.Close()
+// GetAvailablePairs returns all pairs to which the provider can subscribe.
+// ex.: map["ATOMUSDT" => {}, "UMEEUSDC" => {}].
+func (p *CryptoProvider) GetAvailablePairs() (map[string]struct{}, error) {
+	resp, err := http.Get(p.endpoint.Rest + cryptoRestPath)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
 
-// 	var pairsSummary []BinancePairSummary
-// 	if err := json.NewDecoder(resp.Body).Decode(&pairsSummary); err != nil {
-// 		return nil, err
-// 	}
+	var pairsSummary CryptoPairsSummary
+	if err := json.NewDecoder(resp.Body).Decode(&pairsSummary); err != nil {
+		return nil, err
+	}
 
-// 	availablePairs := make(map[string]struct{}, len(pairsSummary))
-// 	for _, pairName := range pairsSummary {
-// 		availablePairs[strings.ToUpper(pairName.Symbol)] = struct{}{}
-// 	}
+	availablePairs := make(map[string]struct{}, len(pairsSummary.Result.Data))
+	for _, pair := range pairsSummary.Result.Data {
+		splitInstName := strings.Split(pair.InstrumentName, "_")
+		if len(splitInstName) != 2 {
+			continue
+		}
 
-// 	return availablePairs, nil
-// }
+		cp := types.CurrencyPair{
+			Base:  strings.ToUpper(splitInstName[0]),
+			Quote: strings.ToUpper(splitInstName[1]),
+		}
+
+		availablePairs[cp.String()] = struct{}{}
+	}
+
+	return availablePairs, nil
+}
+
+// currencyPairToCryptoPair receives a currency pair and return crypto
+// ticker symbol atomusdt@ticker.
+func currencyPairToCryptoPair(cp types.CurrencyPair) string {
+	return strings.ToUpper(cp.Base + "_" + cp.Quote)
+}
+
+// newCryptoSubscriptionMsg returns a new subscription Msg.
+func newCryptoSubscriptionMsg(channels []string) CryptoSubscriptionMsg {
+	return CryptoSubscriptionMsg{
+		ID:     1,
+		Method: "subscribe",
+		Params: CryptoSubscriptionParams{
+			Channels: channels,
+		},
+		Nonce: time.Now().UnixMilli(),
+	}
+}

--- a/oracle/price-feeder/oracle/provider/crypto.go
+++ b/oracle/price-feeder/oracle/provider/crypto.go
@@ -135,14 +135,15 @@ func NewCryptoProvider(
 
 	provider.wsc = NewWebsocketController(
 		ctx,
-		ProviderCrypto,
+		config.ProviderCrypto,
 		wsURL,
 		provider.getSubscriptionMsgs(pairs...),
 		provider.messageReceived,
 		disabledPingDuration,
 		websocket.PingMessage,
-		cryptoLogger,
+		provider.logger,
 	)
+
 	go provider.wsc.Start()
 
 	return provider, nil

--- a/oracle/price-feeder/oracle/provider/crypto.go
+++ b/oracle/price-feeder/oracle/provider/crypto.go
@@ -1,0 +1,36 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/sei-protocol/sei-chain/oracle/price-feeder/config"
+)
+
+var _ Provider = (*Provider)(nil)
+
+type (
+	// CryptoProvider defines an oracle provider implemented by the crypto.com
+	// public API.
+	//
+	// REF: https://exchange-docs.crypto.com/spot/index.html
+	CryptoProvider struct {
+		ctx       context.Context
+		endpoints config.ProviderEndpoint
+	}
+
+	CryptoTickersResponse struct {
+		Code   int64                     `json:"code"`
+		Result CryptoTickersResponseData `json:"result"`
+	}
+
+	CryptoTickersResponseData struct {
+		Data []CryptoTicker `json:"data"`
+	}
+
+	CryptoTicker struct {
+		Symbol string `json:"i"` // Symbol ex.: BTC_USDT
+		Price  string `json:"a"` // Last price ex.: 0.0025
+		Volume string `json:"v"` // Total traded base asset volume ex.: 1000
+		Time   int64  `json:"t"` // Timestamp ex.: 1675246930699
+	}
+)

--- a/oracle/price-feeder/oracle/provider/crypto_test.go
+++ b/oracle/price-feeder/oracle/provider/crypto_test.go
@@ -1,0 +1,1 @@
+package provider

--- a/oracle/price-feeder/oracle/provider/crypto_test.go
+++ b/oracle/price-feeder/oracle/provider/crypto_test.go
@@ -2,28 +2,121 @@ package provider
 
 import (
 	"context"
-	"os"
 	"testing"
-	"time"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/sei-protocol/sei-chain/oracle/price-feeder/config"
 	"github.com/sei-protocol/sei-chain/oracle/price-feeder/oracle/types"
 	"github.com/stretchr/testify/require"
 )
 
-func TestCryptoProvider(t *testing.T) {
-	_, err := NewCryptoProvider(
+func TestCryptoProvider_GetTickerPrices(t *testing.T) {
+	p, err := NewCryptoProvider(
 		context.TODO(),
-		zerolog.New(os.Stdout).With().Timestamp().Logger(),
-		config.ProviderEndpoint{
-			Name:      config.ProviderCrypto,
-			Rest:      cryptoRestHost,
-			Websocket: "wss://uat-stream.3ona.com",
-		},
-		types.CurrencyPair{},
+		zerolog.Nop(),
+		config.ProviderEndpoint{},
+		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
 	)
 	require.NoError(t, err)
 
-	time.Sleep(1 * time.Minute)
+	t.Run("valid_request_single_ticker", func(t *testing.T) {
+		lastPrice := sdk.MustNewDecFromStr("34.69000000")
+		volume := sdk.MustNewDecFromStr("2396974.02000000")
+
+		tickerMap := map[string]TickerPrice{}
+		tickerMap["ATOM_USDT"] = TickerPrice{
+			Price:  lastPrice,
+			Volume: volume,
+		}
+
+		p.tickers = tickerMap
+
+		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+		require.NoError(t, err)
+		require.Len(t, prices, 1)
+		require.Equal(t, lastPrice, prices["ATOMUSDT"].Price)
+		require.Equal(t, volume, prices["ATOMUSDT"].Volume)
+	})
+
+	t.Run("valid_request_multi_ticker", func(t *testing.T) {
+		lastPriceAtom := sdk.MustNewDecFromStr("34.69000000")
+		lastPriceLuna := sdk.MustNewDecFromStr("41.35000000")
+		volume := sdk.MustNewDecFromStr("2396974.02000000")
+
+		tickerMap := map[string]TickerPrice{}
+		tickerMap["ATOM_USDT"] = TickerPrice{
+			Price:  lastPriceAtom,
+			Volume: volume,
+		}
+
+		tickerMap["LUNA_USDT"] = TickerPrice{
+			Price:  lastPriceLuna,
+			Volume: volume,
+		}
+
+		p.tickers = tickerMap
+		prices, err := p.GetTickerPrices(
+			types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
+			types.CurrencyPair{Base: "LUNA", Quote: "USDT"},
+		)
+		require.NoError(t, err)
+		require.Len(t, prices, 2)
+		require.Equal(t, lastPriceAtom, prices["ATOMUSDT"].Price)
+		require.Equal(t, volume, prices["ATOMUSDT"].Volume)
+		require.Equal(t, lastPriceLuna, prices["LUNAUSDT"].Price)
+		require.Equal(t, volume, prices["LUNAUSDT"].Volume)
+	})
+
+	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {
+		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "FOO", Quote: "BAR"})
+		require.Error(t, err)
+		require.Nil(t, prices)
+	})
+}
+
+func TestCryptoProvider_GetCandlePrices(t *testing.T) {
+	p, err := NewCryptoProvider(
+		context.TODO(),
+		zerolog.Nop(),
+		config.ProviderEndpoint{},
+		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
+	)
+	require.NoError(t, err)
+
+	t.Run("valid_request_single_candle", func(t *testing.T) {
+		price := "34.689998626708984000"
+		volume := "2396974.000000000000000000"
+		timeStamp := int64(1000000)
+
+		candle := CryptoCandle{
+			Volume:    volume,
+			Close:     price,
+			Timestamp: timeStamp,
+		}
+
+		p.setCandlePair("ATOM_USDT", candle)
+
+		prices, err := p.GetCandlePrices(types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+		require.NoError(t, err)
+		require.Len(t, prices, 1)
+		priceDec, _ := sdk.NewDecFromStr(price)
+		volumeDec, _ := sdk.NewDecFromStr(volume)
+
+		require.Equal(t, priceDec, prices["ATOMUSDT"][0].Price)
+		require.Equal(t, volumeDec, prices["ATOMUSDT"][0].Volume)
+		require.Equal(t, timeStamp, prices["ATOMUSDT"][0].TimeStamp)
+	})
+
+	t.Run("invalid_request_invalid_candle", func(t *testing.T) {
+		prices, err := p.GetCandlePrices(types.CurrencyPair{Base: "FOO", Quote: "BAR"})
+		require.Error(t, err)
+		require.Nil(t, prices)
+	})
+}
+
+func TestCryptoCurrencyPairToCryptoPair(t *testing.T) {
+	cp := types.CurrencyPair{Base: "ATOM", Quote: "USDT"}
+	cryptoSymbol := currencyPairToCryptoPair(cp)
+	require.Equal(t, cryptoSymbol, "ATOM_USDT")
 }

--- a/oracle/price-feeder/oracle/provider/crypto_test.go
+++ b/oracle/price-feeder/oracle/provider/crypto_test.go
@@ -1,1 +1,29 @@
 package provider
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/sei-protocol/sei-chain/oracle/price-feeder/config"
+	"github.com/sei-protocol/sei-chain/oracle/price-feeder/oracle/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCryptoProvider(t *testing.T) {
+	_, err := NewCryptoProvider(
+		context.TODO(),
+		zerolog.New(os.Stdout).With().Timestamp().Logger(),
+		config.ProviderEndpoint{
+			Name:      config.ProviderCrypto,
+			Rest:      cryptoRestHost,
+			Websocket: "wss://uat-stream.3ona.com",
+		},
+		types.CurrencyPair{},
+	)
+	require.NoError(t, err)
+
+	time.Sleep(1 * time.Minute)
+}

--- a/oracle/price-feeder/oracle/provider/provider.go
+++ b/oracle/price-feeder/oracle/provider/provider.go
@@ -18,6 +18,17 @@ const (
 	defaultReconnectTime     = time.Minute * 20
 	maxReconnectionTries     = 3
 	providerCandlePeriod     = 10 * time.Minute
+
+	// Provider names
+	ProviderBinance  = "binance"
+	ProviderCoinbase = "coinbase"
+	ProviderCrypto   = "crypto"
+	ProviderHuobi    = "huobi"
+	ProviderKraken   = "kraken"
+	ProviderMexc     = "mexc"
+	ProviderMock     = "mock"
+	ProviderOkx      = "okx"
+	ProviderGate     = "gate"
 )
 
 var ping = []byte("ping")

--- a/oracle/price-feeder/oracle/provider/provider.go
+++ b/oracle/price-feeder/oracle/provider/provider.go
@@ -12,12 +12,10 @@ import (
 )
 
 const (
-	defaultTimeout           = 10 * time.Second
-	defaultReadNewWSMessage  = 50 * time.Millisecond
-	defaultMaxConnectionTime = time.Hour * 23 // should be < 24h
-	defaultReconnectTime     = time.Minute * 20
-	maxReconnectionTries     = 3
-	providerCandlePeriod     = 10 * time.Minute
+	defaultTimeout       = 10 * time.Second
+	defaultReconnectTime = time.Minute * 20
+	maxReconnectionTries = 3
+	providerCandlePeriod = 10 * time.Minute
 )
 
 var ping = []byte("ping")

--- a/oracle/price-feeder/oracle/provider/provider.go
+++ b/oracle/price-feeder/oracle/provider/provider.go
@@ -18,17 +18,6 @@ const (
 	defaultReconnectTime     = time.Minute * 20
 	maxReconnectionTries     = 3
 	providerCandlePeriod     = 10 * time.Minute
-
-	// Provider names
-	ProviderBinance  = "binance"
-	ProviderCoinbase = "coinbase"
-	ProviderCrypto   = "crypto"
-	ProviderHuobi    = "huobi"
-	ProviderKraken   = "kraken"
-	ProviderMexc     = "mexc"
-	ProviderMock     = "mock"
-	ProviderOkx      = "okx"
-	ProviderGate     = "gate"
 )
 
 var ping = []byte("ping")

--- a/oracle/price-feeder/oracle/provider/ws_controller.go
+++ b/oracle/price-feeder/oracle/provider/ws_controller.go
@@ -1,0 +1,288 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/rs/zerolog"
+)
+
+const (
+	defaultReadNewWSMessage   = 50 * time.Millisecond
+	defaultMaxConnectionTime  = time.Hour * 23 // should be < 24h
+	defaultPingDuration       = 15 * time.Second
+	disabledPingDuration      = time.Duration(0)
+	startingReconnectDuration = 5 * time.Second
+	maxRetryMultiplier        = 25 // max retry duration: 52m5s
+)
+
+type (
+	MessageHandler func(int, []byte)
+
+	// WebsocketController defines a provider agnostic websocket handler
+	// that manages reconnecting, subscribing, and receiving messages
+	WebsocketController struct {
+		parentCtx           context.Context
+		websocketCtx        context.Context
+		websocketCancelFunc context.CancelFunc
+		providerName        string
+		websocketURL        url.URL
+		subscriptionMsgs    []interface{}
+		messageHandler      MessageHandler
+		pingDuration        time.Duration
+		pingMessageType     uint
+		logger              zerolog.Logger
+
+		mtx              sync.Mutex
+		client           *websocket.Conn
+		reconnectCounter uint
+	}
+)
+
+// NewWebsocketController does nothing except initialize a new WebsocketController
+// and provider a reminder for what fields need to be passed in.
+func NewWebsocketController(
+	ctx context.Context,
+	providerName string,
+	websocketURL url.URL,
+	subscriptionMsgs []interface{},
+	messageHandler MessageHandler,
+	pingDuration time.Duration,
+	pingMessageType uint,
+	logger zerolog.Logger,
+) *WebsocketController {
+	return &WebsocketController{
+		parentCtx:        ctx,
+		providerName:     providerName,
+		websocketURL:     websocketURL,
+		subscriptionMsgs: subscriptionMsgs,
+		messageHandler:   messageHandler,
+		pingDuration:     pingDuration,
+		pingMessageType:  pingMessageType,
+		logger:           logger,
+	}
+}
+
+// Start will continuously loop and attempt connecting to the websocket
+// until a successful connection is made. It then starts the ping
+// service and read listener in new go routines and sends subscription
+// messages  using the passed in subscription messages
+func (wsc *WebsocketController) Start() {
+	connectTicker := time.NewTicker(time.Millisecond)
+	defer connectTicker.Stop()
+
+	for {
+		if err := wsc.connect(); err != nil {
+			wsc.logger.Err(err).Send()
+			select {
+			case <-wsc.parentCtx.Done():
+				return
+			case <-connectTicker.C:
+				connectTicker.Reset(wsc.iterateRetryCounter())
+				continue
+			}
+		}
+
+		go wsc.readWebSocket()
+		go wsc.pingLoop()
+
+		if err := wsc.subscribe(wsc.subscriptionMsgs); err != nil {
+			wsc.logger.Err(err).Send()
+			wsc.close()
+			continue
+		}
+		return
+	}
+}
+
+// connect dials the websocket and sets the client to the established connection
+func (wsc *WebsocketController) connect() error {
+	wsc.mtx.Lock()
+	defer wsc.mtx.Unlock()
+
+	wsc.logger.Debug().Msg("connecting to websocket")
+	conn, resp, err := websocket.DefaultDialer.Dial(wsc.websocketURL.String(), nil)
+	if err != nil {
+		return fmt.Errorf("failed to dial WS for %s: %w", wsc.providerName, err)
+	}
+
+	defer resp.Body.Close()
+
+	wsc.client = conn
+	wsc.websocketCtx, wsc.websocketCancelFunc = context.WithCancel(wsc.parentCtx)
+	wsc.client.SetPingHandler(wsc.pingHandler)
+	wsc.reconnectCounter = 0
+
+	return nil
+}
+
+func (wsc *WebsocketController) iterateRetryCounter() time.Duration {
+	if wsc.reconnectCounter < 25 {
+		wsc.reconnectCounter++
+	}
+	multiplier := math.Pow(float64(wsc.reconnectCounter), 2)
+	return startingReconnectDuration * time.Duration(multiplier)
+}
+
+// subscribe sends the WebsocketControllers subscription messages to the websocket
+func (wsc *WebsocketController) subscribe(msgs []interface{}) error {
+	for _, jsonMessage := range msgs {
+		if err := wsc.SendJSON(jsonMessage); err != nil {
+			return fmt.Errorf("failed to send WS message for %s: %w", wsc.providerName, err)
+		}
+	}
+	return nil
+}
+
+// AddSubscriptionMsgs immediately sends the new subscription messages and
+// adds them to the subscriptionMsgs array if successful
+func (wsc *WebsocketController) AddSubscriptionMsgs(msgs []interface{}) error {
+	err := wsc.subscribe(msgs)
+	if err != nil {
+		return err
+	}
+	wsc.subscriptionMsgs = append(wsc.subscriptionMsgs, msgs...)
+	return nil
+}
+
+// SendJSON sends a json message to the websocket connection using the Websocket
+// Controller mutex to ensure multiple writes do not happen at once
+func (wsc *WebsocketController) SendJSON(msg interface{}) error {
+	wsc.mtx.Lock()
+	defer wsc.mtx.Unlock()
+
+	if wsc.client == nil {
+		return fmt.Errorf("unable to send JSON on a closed connection")
+	}
+
+	wsc.logger.Debug().Interface("msg", msg).Msg("sending websocket message")
+
+	if err := wsc.client.WriteJSON(msg); err != nil {
+		return fmt.Errorf("failed to send WS message for %s: %w", wsc.providerName, err)
+	}
+
+	return nil
+}
+
+// ping sends a ping to the server every defaultPingDuration
+func (wsc *WebsocketController) pingLoop() {
+	if wsc.pingDuration == disabledPingDuration {
+		return // disable ping loop if disabledPingDuration
+	}
+
+	pingTicker := time.NewTicker(wsc.pingDuration)
+	defer pingTicker.Stop()
+
+	for {
+		err := wsc.ping()
+		if err != nil {
+			return
+		}
+
+		select {
+		case <-wsc.websocketCtx.Done():
+			return
+
+		case <-pingTicker.C:
+			continue
+		}
+	}
+}
+
+func (wsc *WebsocketController) ping() error {
+	wsc.mtx.Lock()
+	defer wsc.mtx.Unlock()
+
+	if wsc.client == nil {
+		return fmt.Errorf("unable to ping closed connection")
+	}
+
+	err := wsc.client.WriteMessage(int(wsc.pingMessageType), ping)
+	if err != nil {
+		wsc.logger.Err(fmt.Errorf("failed to send WS message for %s: %w", wsc.providerName, err)).Send()
+	}
+
+	return err
+}
+
+// readWebSocket continuously reads from the websocket and relays messages
+// to the passed in messageHandler. On websocket error this function
+// terminates and starts the reconnect process.
+// Some providers (Binance) will only allow a valid connection for 24 hours
+// so we manually disconnect and reconnect every 23 hours (defaultMaxConnectionTime)
+func (wsc *WebsocketController) readWebSocket() {
+	reconnectTicker := time.NewTicker(defaultMaxConnectionTime)
+	defer reconnectTicker.Stop()
+
+	for {
+		select {
+		case <-wsc.websocketCtx.Done():
+			wsc.close()
+			return
+
+		case <-time.After(defaultReadNewWSMessage):
+			messageType, bz, err := wsc.client.ReadMessage()
+			if err != nil {
+				wsc.logger.Err(fmt.Errorf("failed to read WS message for %s: %w", wsc.providerName, err)).Send()
+				wsc.reconnect()
+
+				return
+			}
+
+			wsc.readSuccess(messageType, bz)
+
+		case <-reconnectTicker.C:
+			wsc.reconnect()
+			return
+		}
+	}
+}
+
+func (wsc *WebsocketController) readSuccess(messageType int, bz []byte) {
+	if len(bz) == 0 {
+		return
+	}
+
+	// mexc and bitget do not send a valid pong response code so check for it here
+	if string(bz) == "pong" {
+		return
+	}
+
+	wsc.messageHandler(messageType, bz)
+}
+
+// close sends a close message to the websocket and sets the client to nil
+func (wsc *WebsocketController) close() {
+	wsc.mtx.Lock()
+	defer wsc.mtx.Unlock()
+
+	wsc.logger.Debug().Msg("closing websocket")
+	wsc.websocketCancelFunc()
+
+	if err := wsc.client.Close(); err != nil {
+		wsc.logger.Err(fmt.Errorf("failed to close WS connection for %s: %w", wsc.providerName, err)).Send()
+	}
+
+	wsc.client = nil
+}
+
+// reconnect closes the current websocket and starts a new connection process
+func (wsc *WebsocketController) reconnect() {
+	wsc.close()
+	go wsc.Start()
+}
+
+// pingHandler is called by the websocket library whenever a ping message is received
+// and responds with a pong message to the server
+func (wsc *WebsocketController) pingHandler(appData string) error {
+	if err := wsc.client.WriteMessage(websocket.PongMessage, []byte("pong")); err != nil {
+		wsc.logger.Error().Err(err).Msg("error sending pong")
+	}
+
+	return nil
+}

--- a/oracle/price-feeder/oracle/provider/ws_controller.go
+++ b/oracle/price-feeder/oracle/provider/ws_controller.go
@@ -41,6 +41,7 @@ type (
 		mtx              sync.Mutex
 		client           *websocket.Conn
 		reconnectCounter uint
+		dialer           *websocket.Dialer
 	}
 )
 
@@ -65,6 +66,7 @@ func NewWebsocketController(
 		pingDuration:     pingDuration,
 		pingMessageType:  pingMessageType,
 		logger:           logger,
+		dialer:           websocket.DefaultDialer,
 	}
 }
 
@@ -106,7 +108,7 @@ func (wsc *WebsocketController) connect() error {
 	defer wsc.mtx.Unlock()
 
 	wsc.logger.Debug().Msg("connecting to websocket")
-	conn, resp, err := websocket.DefaultDialer.Dial(wsc.websocketURL.String(), nil)
+	conn, resp, err := wsc.dialer.Dial(wsc.websocketURL.String(), nil)
 	if err != nil {
 		return fmt.Errorf("failed to dial WS for %s: %w", wsc.providerName, err)
 	}

--- a/oracle/price-feeder/oracle/provider/ws_controller.go
+++ b/oracle/price-feeder/oracle/provider/ws_controller.go
@@ -15,7 +15,6 @@ import (
 const (
 	defaultReadNewWSMessage   = 50 * time.Millisecond
 	defaultMaxConnectionTime  = time.Hour * 23 // should be < 24h
-	defaultPingDuration       = 15 * time.Second
 	disabledPingDuration      = time.Duration(0)
 	startingReconnectDuration = 5 * time.Second
 	maxRetryMultiplier        = 25 // max retry duration: 52m5s
@@ -124,7 +123,7 @@ func (wsc *WebsocketController) connect() error {
 }
 
 func (wsc *WebsocketController) iterateRetryCounter() time.Duration {
-	if wsc.reconnectCounter < 25 {
+	if wsc.reconnectCounter < maxRetryMultiplier {
 		wsc.reconnectCounter++
 	}
 	multiplier := math.Pow(float64(wsc.reconnectCounter), 2)

--- a/oracle/price-feeder/oracle/provider/ws_controller_test.go
+++ b/oracle/price-feeder/oracle/provider/ws_controller_test.go
@@ -1,0 +1,60 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/sei-protocol/sei-chain/oracle/price-feeder/config"
+	"github.com/stretchr/testify/require"
+)
+
+type TestProvider struct {
+	handlerCalled bool
+}
+
+func (mp *TestProvider) messageHandler(messageType int, bz []byte) {
+	mp.handlerCalled = true
+}
+
+func TestWebsocketController_readSuccess(t *testing.T) {
+	testCases := []struct {
+		name                     string
+		messageType              int
+		bz                       []byte
+		shouldCallMessageHandler bool
+	}{
+		{
+			"message length is zero",
+			1,
+			[]byte{},
+			false,
+		},
+		{
+			"message is a pong",
+			1,
+			[]byte("pong"),
+			false,
+		},
+		{
+			"is a valid message for the messageHandler",
+			1,
+			[]byte("asdf"),
+			true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			provider := TestProvider{}
+			mockClient := new(websocket.Conn)
+			c := &WebsocketController{
+				providerName:   config.ProviderMock,
+				messageHandler: provider.messageHandler,
+				client:         mockClient,
+			}
+
+			c.readSuccess(testCase.messageType, testCase.bz)
+			require.Equal(t, provider.handlerCalled, testCase.shouldCallMessageHandler)
+		})
+	}
+}


### PR DESCRIPTION
## Changelog

* Implement crypto.com provider
* Import and use `WebsocketController` which is used by the `CryptoProvider`

Note, this was lifted from Umee's version of the price-feeder @ v3.x. When we have sufficient capacity, we may want to explore the generalized improvements both the Kujira and Umee versions have made, such as generalizing the provider implementation. 