### PR TITLE
Exclude gasless tx in ProposalProposal block gas check

### DIFF
--- a/app/antedecorators/gasless.go
+++ b/app/antedecorators/gasless.go
@@ -25,10 +25,10 @@ func NewGaslessDecorator(wrapped []sdk.AnteFullDecorator, oracleKeeper oraclekee
 
 func (gd GaslessDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
 	originalGasMeter := ctx.GasMeter()
-	// eagerly set infinite gas meter so that queries performed by isTxGasless will not incur gas cost
+	// eagerly set infinite gas meter so that queries performed by IsTxGasless will not incur gas cost
 	ctx = ctx.WithGasMeter(storetypes.NewNoConsumptionInfiniteGasMeter())
 
-	isGasless, err := isTxGasless(tx, ctx, gd.oracleKeeper)
+	isGasless, err := IsTxGasless(tx, ctx, gd.oracleKeeper)
 	if err != nil {
 		return ctx, err
 	}
@@ -108,7 +108,7 @@ func (gd GaslessDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk
 	return next(append(txDeps, deps...), tx, txIndex)
 }
 
-func isTxGasless(tx sdk.Tx, ctx sdk.Context, oracleKeeper oraclekeeper.Keeper) (bool, error) {
+func IsTxGasless(tx sdk.Tx, ctx sdk.Context, oracleKeeper oraclekeeper.Keeper) (bool, error) {
 	if len(tx.GetMsgs()) == 0 {
 		// empty TX shouldn't be gasless
 		return false, nil

--- a/app/app.go
+++ b/app/app.go
@@ -1524,7 +1524,7 @@ func (app *App) checkTotalBlockGasWanted(ctx sdk.Context, txs [][]byte) bool {
 		}
 		if isGasless {
 			// gasless tx's gas should not be included in total block gas wanted
-			// continue
+			continue
 		}
 		totalGasWanted += feeTx.GetGas()
 		if totalGasWanted > uint64(ctx.ConsensusParams().Block.MaxGas) {

--- a/app/app.go
+++ b/app/app.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/sei-protocol/sei-chain/aclmapping"
 	aclutils "github.com/sei-protocol/sei-chain/aclmapping/utils"
+	"github.com/sei-protocol/sei-chain/app/antedecorators"
 	appparams "github.com/sei-protocol/sei-chain/app/params"
 	"github.com/sei-protocol/sei-chain/utils"
 	"github.com/sei-protocol/sei-chain/wasmbinding"
@@ -1515,6 +1516,15 @@ func (app *App) checkTotalBlockGasWanted(ctx sdk.Context, txs [][]byte) bool {
 		if !ok {
 			// such tx will not be processed and thus won't consume gas. Skipping
 			continue
+		}
+		isGasless, err := antedecorators.IsTxGasless(decoded, ctx, app.OracleKeeper)
+		if err != nil {
+			ctx.Logger().Error("error checking if tx is gasless", "error", err)
+			continue
+		}
+		if isGasless {
+			// gasless tx's gas should not be included in total block gas wanted
+			// continue
 		}
 		totalGasWanted += feeTx.GetGas()
 		if totalGasWanted > uint64(ctx.ConsensusParams().Block.MaxGas) {

--- a/integration_test/dex_module/place_order_test.yaml
+++ b/integration_test/dex_module/place_order_test.yaml
@@ -6,14 +6,8 @@
     # Prepare parameter
     - cmd: echo "LONG?1.01?5?SEI?ATOM?LIMIT?{\"leverage\":\"1\",\"position_effect\":\"Open\"}"
       env: PARAMS
-    # Fill up mempool quickly so that the following order placement is likely to be in a multi-tx block (WARNING possible flaky test)
-    - cmd: printf "12345678\n" | seid tx bank send admin $CONTRACT_ADDR 10usei -y --chain-id=sei --fees=1000000usei --gas=500000 --broadcast-mode=async --output json
-    - cmd: printf "12345678\n" | seid tx bank send admin $CONTRACT_ADDR 10usei -y --chain-id=sei --fees=1000000usei --gas=500000 --broadcast-mode=async --output json
-    - cmd: printf "12345678\n" | seid tx bank send admin $CONTRACT_ADDR 10usei -y --chain-id=sei --fees=1000000usei --gas=500000 --broadcast-mode=async --output json
-    - cmd: printf "12345678\n" | seid tx bank send admin $CONTRACT_ADDR 10usei -y --chain-id=sei --fees=1000000usei --gas=500000 --broadcast-mode=async --output json
-    - cmd: printf "12345678\n" | seid tx bank send admin $CONTRACT_ADDR 10usei -y --chain-id=sei --fees=1000000usei --gas=500000 --broadcast-mode=async --output json
     # Verify that placing a dex order with gas > max block gas is okay since gas will be ignored
-    - cmd: printf "12345678\n" | seid tx dex place-orders $CONTRACT_ADDR $PARAMS --amount=1000000000usei -y --from=admin --chain-id=sei --fees=1000000usei --gas=5000000000 --broadcast-mode=block --output json|jq -M -r ".logs[].events[].attributes[] | select(.key == \"order_id\").value"
+    - cmd: printf "12345678\n" | seid tx dex place-orders $CONTRACT_ADDR $PARAMS --amount=1000000000usei -y --from=admin --chain-id=sei --fees=1000000usei --gas=6000000000 --broadcast-mode=block --output json|jq -M -r ".logs[].events[].attributes[] | select(.key == \"order_id\").value"
     # Place an order and set ORDER_ID
     - cmd: printf "12345678\n" | seid tx dex place-orders $CONTRACT_ADDR $PARAMS --amount=1000000000usei -y --from=admin --chain-id=sei --fees=1000000usei --gas=50000000 --broadcast-mode=block --output json|jq -M -r ".logs[].events[].attributes[] | select(.key == \"order_id\").value"
       env: ORDER_ID

--- a/integration_test/dex_module/place_order_test.yaml
+++ b/integration_test/dex_module/place_order_test.yaml
@@ -6,6 +6,12 @@
     # Prepare parameter
     - cmd: echo "LONG?1.01?5?SEI?ATOM?LIMIT?{\"leverage\":\"1\",\"position_effect\":\"Open\"}"
       env: PARAMS
+    # Fill up mempool quickly so that the following order placement is likely to be in a multi-tx block (WARNING possible flaky test)
+    - cmd: printf "12345678\n" | seid tx bank send admin $CONTRACT_ADDR 10usei -y --chain-id=sei --fees=1000000usei --gas=500000 --broadcast-mode=async --output json
+    - cmd: printf "12345678\n" | seid tx bank send admin $CONTRACT_ADDR 10usei -y --chain-id=sei --fees=1000000usei --gas=500000 --broadcast-mode=async --output json
+    - cmd: printf "12345678\n" | seid tx bank send admin $CONTRACT_ADDR 10usei -y --chain-id=sei --fees=1000000usei --gas=500000 --broadcast-mode=async --output json
+    - cmd: printf "12345678\n" | seid tx bank send admin $CONTRACT_ADDR 10usei -y --chain-id=sei --fees=1000000usei --gas=500000 --broadcast-mode=async --output json
+    - cmd: printf "12345678\n" | seid tx bank send admin $CONTRACT_ADDR 10usei -y --chain-id=sei --fees=1000000usei --gas=500000 --broadcast-mode=async --output json
     # Verify that placing a dex order with gas > max block gas is okay since gas will be ignored
     - cmd: printf "12345678\n" | seid tx dex place-orders $CONTRACT_ADDR $PARAMS --amount=1000000000usei -y --from=admin --chain-id=sei --fees=1000000usei --gas=500000000 --broadcast-mode=block --output json|jq -M -r ".logs[].events[].attributes[] | select(.key == \"order_id\").value"
     # Place an order and set ORDER_ID

--- a/integration_test/dex_module/place_order_test.yaml
+++ b/integration_test/dex_module/place_order_test.yaml
@@ -13,7 +13,7 @@
     - cmd: printf "12345678\n" | seid tx bank send admin $CONTRACT_ADDR 10usei -y --chain-id=sei --fees=1000000usei --gas=500000 --broadcast-mode=async --output json
     - cmd: printf "12345678\n" | seid tx bank send admin $CONTRACT_ADDR 10usei -y --chain-id=sei --fees=1000000usei --gas=500000 --broadcast-mode=async --output json
     # Verify that placing a dex order with gas > max block gas is okay since gas will be ignored
-    - cmd: printf "12345678\n" | seid tx dex place-orders $CONTRACT_ADDR $PARAMS --amount=1000000000usei -y --from=admin --chain-id=sei --fees=1000000usei --gas=500000000 --broadcast-mode=block --output json|jq -M -r ".logs[].events[].attributes[] | select(.key == \"order_id\").value"
+    - cmd: printf "12345678\n" | seid tx dex place-orders $CONTRACT_ADDR $PARAMS --amount=1000000000usei -y --from=admin --chain-id=sei --fees=1000000usei --gas=5000000000 --broadcast-mode=block --output json|jq -M -r ".logs[].events[].attributes[] | select(.key == \"order_id\").value"
     # Place an order and set ORDER_ID
     - cmd: printf "12345678\n" | seid tx dex place-orders $CONTRACT_ADDR $PARAMS --amount=1000000000usei -y --from=admin --chain-id=sei --fees=1000000usei --gas=50000000 --broadcast-mode=block --output json|jq -M -r ".logs[].events[].attributes[] | select(.key == \"order_id\").value"
       env: ORDER_ID


### PR DESCRIPTION
## Describe your changes and provide context
TM mempool will not count gasless TX's GasWanted when proposing a block because from mempool's perspective, GasWanted is the value returned by CheckTx which will be zero for gasless TXs. However in ProcessProposal we check if GasWanted of txs are greater than max block gas using the original specified GasWanted of the txs, which may cause rejection. The fix is to always ignore gasless TX's GasWanted.

## Testing performed to validate your change
integration test

