### PR TITLE
Add CLI/wasmbinding to set tokenfactory metadata

### DIFF
--- a/wasmbinding/bindings/msg.go
+++ b/wasmbinding/bindings/msg.go
@@ -2,6 +2,7 @@ package bindings
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/sei-protocol/sei-chain/x/dex/types"
 )
 
@@ -20,6 +21,10 @@ type CreateDenom struct {
 type ChangeAdmin struct {
 	Denom           string `json:"denom"`
 	NewAdminAddress string `json:"new_admin_address"`
+}
+
+type SetMetadata struct {
+	Metadata banktypes.Metadata `json:"metadata"`
 }
 
 type MintTokens struct {

--- a/wasmbinding/encoder.go
+++ b/wasmbinding/encoder.go
@@ -17,6 +17,7 @@ type SeiWasmMessage struct {
 	MintTokens   json.RawMessage `json:"mint_tokens,omitempty"`
 	BurnTokens   json.RawMessage `json:"burn_tokens,omitempty"`
 	ChangeAdmin  json.RawMessage `json:"change_admin,omitempty"`
+	SetMetadata  json.RawMessage `json:"set_metadata,omitempty"`
 }
 
 func CustomEncoder(sender sdk.AccAddress, msg json.RawMessage) ([]sdk.Msg, error) {
@@ -37,6 +38,8 @@ func CustomEncoder(sender sdk.AccAddress, msg json.RawMessage) ([]sdk.Msg, error
 		return tokenfactorywasm.EncodeTokenFactoryBurn(parsedMessage.BurnTokens, sender)
 	case parsedMessage.ChangeAdmin != nil:
 		return tokenfactorywasm.EncodeTokenFactoryChangeAdmin(parsedMessage.ChangeAdmin, sender)
+	case parsedMessage.SetMetadata != nil:
+		return tokenfactorywasm.EncodeTokenFactorySetMetadata(parsedMessage.SetMetadata, sender)
 	default:
 		return []sdk.Msg{}, wasmvmtypes.UnsupportedRequest{Kind: "Unknown Sei Wasm Message"}
 	}

--- a/x/tokenfactory/client/cli/tx.go
+++ b/x/tokenfactory/client/cli/tx.go
@@ -2,13 +2,17 @@ package cli
 
 import (
 	"fmt"
+	"io/ioutil"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	"github.com/sei-protocol/sei-chain/x/tokenfactory/types"
 )
@@ -151,4 +155,87 @@ func NewChangeAdminCmd() *cobra.Command {
 
 	flags.AddTxFlagsToCmd(cmd)
 	return cmd
+}
+
+func NewSetDenomMetadataCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set-denom-metadata [metadata-file] [flags]",
+		Short: "Set metadata for a factory-created denom. Must have admin authority to do so.",
+		Long: strings.TrimSpace(
+			`Submit a parameter proposal along with an initial deposit.
+The proposal details must be supplied via a JSON file. For values that contains
+objects, only non-empty fields will be updated.
+
+IMPORTANT: Currently parameter changes are evaluated but not validated, so it is
+very important that any "value" change is valid (ie. correct type and within bounds)
+for its respective parameter, eg. "MaxValidators" should be an integer and not a decimal.
+
+Proper vetting of a parameter change proposal should prevent this from happening
+(no deposits should occur during the governance process), but it should be noted
+regardless.
+
+Example:
+$ seid tx tokenfactory set-denom-metadata <path/to/metadata.json> --from=<key_or_address>
+
+Where metadata.json contains:
+
+{
+  "description": "Update token metadata",
+  "denom_units": [
+	{
+		"denom": "doge1",
+		"exponent": 6,
+		"aliases": ["d", "o", "g"]
+	},
+	{
+		"denom": "doge2",
+		"exponent": 3,
+		"aliases": ["d", "o", "g"]
+	}
+  ],
+  "base": "doge",
+  "display": "DOGE",
+  "name": "dogecoin",
+  "symbol": "DOGE"
+}`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			txf := tx.NewFactoryCLI(clientCtx, cmd.Flags()).WithTxConfig(clientCtx.TxConfig).WithAccountRetriever(clientCtx.AccountRetriever)
+
+			metadata, err := ParseMetadataJSON(clientCtx.LegacyAmino, args[0])
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgSetDenomMetadata(
+				clientCtx.GetFromAddress().String(),
+				metadata,
+			)
+
+			return tx.GenerateOrBroadcastTxWithFactory(clientCtx, txf, msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}
+
+func ParseMetadataJSON(cdc *codec.LegacyAmino, metadataFile string) (banktypes.Metadata, error) {
+	proposal := banktypes.Metadata{}
+
+	contents, err := ioutil.ReadFile(metadataFile)
+	if err != nil {
+		return proposal, err
+	}
+
+	if err := cdc.UnmarshalJSON(contents, &proposal); err != nil {
+		return proposal, err
+	}
+
+	return proposal, nil
 }

--- a/x/tokenfactory/client/cli/tx.go
+++ b/x/tokenfactory/client/cli/tx.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -228,7 +228,7 @@ Where metadata.json contains:
 func ParseMetadataJSON(cdc *codec.LegacyAmino, metadataFile string) (banktypes.Metadata, error) {
 	proposal := banktypes.Metadata{}
 
-	contents, err := ioutil.ReadFile(metadataFile)
+	contents, err := os.ReadFile(metadataFile)
 	if err != nil {
 		return proposal, err
 	}

--- a/x/tokenfactory/client/cli/tx.go
+++ b/x/tokenfactory/client/cli/tx.go
@@ -162,18 +162,7 @@ func NewSetDenomMetadataCmd() *cobra.Command {
 		Use:   "set-denom-metadata [metadata-file] [flags]",
 		Short: "Set metadata for a factory-created denom. Must have admin authority to do so.",
 		Long: strings.TrimSpace(
-			`Submit a parameter proposal along with an initial deposit.
-The proposal details must be supplied via a JSON file. For values that contains
-objects, only non-empty fields will be updated.
-
-IMPORTANT: Currently parameter changes are evaluated but not validated, so it is
-very important that any "value" change is valid (ie. correct type and within bounds)
-for its respective parameter, eg. "MaxValidators" should be an integer and not a decimal.
-
-Proper vetting of a parameter change proposal should prevent this from happening
-(no deposits should occur during the governance process), but it should be noted
-regardless.
-
+			`
 Example:
 $ seid tx tokenfactory set-denom-metadata <path/to/metadata.json> --from=<key_or_address>
 

--- a/x/tokenfactory/client/cli/tx_test.go
+++ b/x/tokenfactory/client/cli/tx_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMetadata(t *testing.T) {
+	cdc := codec.NewLegacyAmino()
+	okJSON := testutil.WriteToNewTempFile(t, `
+{
+	"description": "Update token metadata",
+	"denom_units": [
+		{
+			"denom": "doge1",
+			"exponent": 6,
+			"aliases": ["d", "o", "g"]
+		},
+		{
+			"denom": "doge2",
+			"exponent": 3,
+			"aliases": ["d", "o", "g"]
+		}
+	],
+	"base": "doge",
+	"display": "DOGE",
+	"name": "dogecoin",
+	"symbol": "DOGE"
+}
+`)
+	metadata, err := ParseMetadataJSON(cdc, okJSON.Name())
+	require.NoError(t, err)
+
+	require.Equal(t, banktypes.Metadata{
+		Description: "Update token metadata",
+		DenomUnits: []*banktypes.DenomUnit{{
+			Denom:    "doge1",
+			Exponent: 6,
+			Aliases:  []string{"d", "o", "g"},
+		}, {
+			Denom:    "doge2",
+			Exponent: 3,
+			Aliases:  []string{"d", "o", "g"},
+		}},
+		Base:    "doge",
+		Display: "DOGE",
+		Name:    "dogecoin",
+		Symbol:  "DOGE",
+	}, metadata)
+}

--- a/x/tokenfactory/client/wasm/encoder.go
+++ b/x/tokenfactory/client/wasm/encoder.go
@@ -56,3 +56,15 @@ func EncodeTokenFactoryChangeAdmin(rawMsg json.RawMessage, sender sdk.AccAddress
 	}
 	return []sdk.Msg{&changeAdminMsg}, nil
 }
+
+func EncodeTokenFactorySetMetadata(rawMsg json.RawMessage, sender sdk.AccAddress) ([]sdk.Msg, error) {
+	encodedSetMetadataMsg := bindings.SetMetadata{}
+	if err := json.Unmarshal(rawMsg, &encodedSetMetadataMsg); err != nil {
+		return []sdk.Msg{}, types.ErrEncodeTokenFactorySetMetadata
+	}
+	setMetadataMsg := types.MsgSetDenomMetadata{
+		Sender:   sender.String(),
+		Metadata: encodedSetMetadataMsg.Metadata,
+	}
+	return []sdk.Msg{&setMetadataMsg}, nil
+}

--- a/x/tokenfactory/types/errors.go
+++ b/x/tokenfactory/types/errors.go
@@ -25,5 +25,6 @@ var (
 	ErrEncodeTokenFactoryChangeAdmin = sdkerrors.Register(ModuleName, 14, "Error while encoding tokenfactory change admin msg in wasmd")
 	ErrParsingSeiTokenFactoryQuery   = sdkerrors.Register(ModuleName, 15, "Error parsing SeiTokenFactoryQuery")
 	ErrAdminAlreadyExists            = sdkerrors.Register(ModuleName, 16, "attempting to create a new admin that already exists for the denom")
+	ErrEncodeTokenFactorySetMetadata = sdkerrors.Register(ModuleName, 17, "Error while encoding tokenfactory set metadata msg in wasmd")
 	ErrUnknownSeiTokenFactoryQuery   = sdkerrors.Register(ModuleName, 23, "Error unknown sei token factory query")
 )


### PR DESCRIPTION
## Describe your changes and provide context
The CLI allow passing in a JSON file, and the wasmbinding takes in a json blob with the same format

## Testing performed to validate your change
local sei
