### PR TITLE
Update Names to Get Tokenfactory Queries

### DIFF
--- a/wasmbinding/queries.go
+++ b/wasmbinding/queries.go
@@ -162,8 +162,8 @@ func (qp QueryPlugin) HandleTokenFactoryQuery(ctx sdk.Context, queryData json.Ra
 		return nil, tokenfactorytypes.ErrParsingSeiTokenFactoryQuery
 	}
 	switch {
-	case parsedQuery.DenomAuthorityMetadata != nil:
-		res, err := qp.tokenfactoryHandler.GetDenomAuthorityMetadata(ctx, parsedQuery.DenomAuthorityMetadata)
+	case parsedQuery.GetDenomAuthorityMetadata != nil:
+		res, err := qp.tokenfactoryHandler.GetDenomAuthorityMetadata(ctx, parsedQuery.GetDenomAuthorityMetadata)
 		if err != nil {
 			return nil, err
 		}
@@ -173,8 +173,8 @@ func (qp QueryPlugin) HandleTokenFactoryQuery(ctx sdk.Context, queryData json.Ra
 		}
 
 		return bz, nil
-	case parsedQuery.DenomsFromCreator != nil:
-		res, err := qp.tokenfactoryHandler.GetDenomsFromCreator(ctx, parsedQuery.DenomsFromCreator)
+	case parsedQuery.GetDenomsFromCreator != nil:
+		res, err := qp.tokenfactoryHandler.GetDenomsFromCreator(ctx, parsedQuery.GetDenomsFromCreator)
 		if err != nil {
 			return nil, err
 		}

--- a/x/tokenfactory/client/wasm/bindings/queries.go
+++ b/x/tokenfactory/client/wasm/bindings/queries.go
@@ -4,7 +4,7 @@ import "github.com/sei-protocol/sei-chain/x/tokenfactory/types"
 
 type SeiTokenFactoryQuery struct {
 	// queries the tokenfactory authority metadata
-	DenomAuthorityMetadata *types.QueryDenomAuthorityMetadataRequest `json:"denom_authority_metadata,omitempty"`
+	GetDenomAuthorityMetadata *types.QueryDenomAuthorityMetadataRequest `json:"get_denom_authority_metadata,omitempty"`
 	// queries the tokenfactory denoms from a creator
-	DenomsFromCreator *types.QueryDenomsFromCreatorRequest `json:"denoms_from_creator,omitempty"`
+	GetDenomsFromCreator *types.QueryDenomsFromCreatorRequest `json:"get_denoms_from_creator,omitempty"`
 }


### PR DESCRIPTION
## Describe your changes and provide context
- Update tokenfactory wasm queries to use the same name as keeper fn => GetDenomAuthorityMetadata vs DenomAuthorityMetadata and GetDenomsFromCreator vs DenomsFromCreator

## Testing performed to validate your change
