### PR TITLE
Fix Set Metadata Command

### DIFF
--- a/x/tokenfactory/client/cli/tx.go
+++ b/x/tokenfactory/client/cli/tx.go
@@ -33,6 +33,7 @@ func GetTxCmd() *cobra.Command {
 		NewBurnCmd(),
 		// NewForceTransferCmd(),
 		NewChangeAdminCmd(),
+		NewSetDenomMetadataCmd(),
 	)
 
 	return cmd


### PR DESCRIPTION
## Describe your changes and provide context
- Registers the Set Metadata Command To Tokenfactory
- Was not showing up previously

## Testing performed to validate your change
- Tested e2e

```
seid q bank denom-metadata --denom factory/sei1y098n8yfpyt8hzhhckncf3d6p70j7mna33g6kx/randomDenom
metadata:
  base: factory/sei1y098n8yfpyt8hzhhckncf3d6p70j7mna33g6kx/randomDenom
  denom_units:
  - aliases:
    - randomDenom
    denom: factory/sei1y098n8yfpyt8hzhhckncf3d6p70j7mna33g6kx/randomDenom
    exponent: 0
  - aliases:
    - aliasRandomDenom
    denom: moreRandomDenom
    exponent: 6
  description: Update token metadata
  display: factory/sei1y098n8yfpyt8hzhhckncf3d6p70j7mna33g6kx/randomDenom
  name: randomDenom
  symbol: RAND```

```cat set_metadata.json 
{
	"description": "Update token metadata",
	"denom_units": [
		{
			"denom": "factory/sei1y098n8yfpyt8hzhhckncf3d6p70j7mna33g6kx/randomDenom",
			"exponent": 0,
			"aliases": ["randomDenom"]
		},
		{
			"denom": "moreRandomDenom",
			"exponent": 6,
			"aliases": ["aliasRandomDenom"]
		}
	],
	"base": "factory/sei1y098n8yfpyt8hzhhckncf3d6p70j7mna33g6kx/randomDenom",
	"display": "factory/sei1y098n8yfpyt8hzhhckncf3d6p70j7mna33g6kx/randomDenom",
	"name": "randomDenom",
	"symbol": "RAND"
}```
  
  
