### PR TITLE
Reorder tx results into absolute order

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1337,8 +1337,6 @@ func (app *App) ProcessBlock(ctx sdk.Context, txs [][]byte, req BlockProcessRequ
 	events = append(events, beginBlockResp.Events...)
 
 	txResults := make([]*abci.ExecTxResult, len(txs))
-
-	// TODO: need to recombine txresults based on ORIGINAL ordering
 	prioritizedTxs, otherTxs, prioritizedIndices, otherIndices := app.PartitionPrioritizedTxs(ctx, txs)
 
 	// run the prioritized txs


### PR DESCRIPTION
## Describe your changes and provide context
This reorders the TXResults such that the true order of tx indices is preserves as opposed to ordering parititoned and then other TXs which was occurring previously
## Testing performed to validate your change
unit tests + will test patch on chain