### PR TITLE
Cut v3.0.9 for version release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 -->
 
 # Changelog
+## v3.0.9
+* [#154](https://github.com/sei-protocol/sei-tendermint/pull/154) Fix empty prevote latency metrics
+
 ## 3.0.8
 sei-chain:
 * [#1018](https://github.com/sei-protocol/sei-chain/pull/1018) Reorder tx results into absolute order

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -58,6 +58,7 @@ var upgradesList = []string{
 	"3.0.6",
 	"3.0.7",
 	"3.0.8",
+	"v3.0.9",
 }
 
 func (app App) RegisterUpgradeHandlers() {

--- a/go.mod
+++ b/go.mod
@@ -278,7 +278,7 @@ replace (
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.1.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
-	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.2.25
+	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.2.27
 	github.com/tendermint/tm-db => github.com/sei-protocol/tm-db v0.0.4
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1080,8 +1080,8 @@ github.com/sei-protocol/sei-iavl v0.1.7 h1:cUdHDBkxs0FF/kOt1qCVLm0K+Bqaw92/dbZSg
 github.com/sei-protocol/sei-iavl v0.1.7/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-ibc-go/v3 v3.1.0 h1:rFHk2R/3vbG9iNr7cYtVclW/UyEDSRFjNVPz60zZswU=
 github.com/sei-protocol/sei-ibc-go/v3 v3.1.0/go.mod h1:Mb+1NXiPOLd+CPFlOC6BKeAUaxXlhuWenMmRiUiSmwY=
-github.com/sei-protocol/sei-tendermint v0.2.25 h1:zxISpSYd4DPVMPpxhcHc+HYw0qlT8smzMwsV/2UvhhQ=
-github.com/sei-protocol/sei-tendermint v0.2.25/go.mod h1:+BtDvAwTkE64BlxzpH9ZP7S6vUYT9wRXiZa/WW8/o4g=
+github.com/sei-protocol/sei-tendermint v0.2.27 h1:KNf+kzkj11VRONT7IW8AmbhQGt0Cw6jYnXyNal3uPfA=
+github.com/sei-protocol/sei-tendermint v0.2.27/go.mod h1:+BtDvAwTkE64BlxzpH9ZP7S6vUYT9wRXiZa/WW8/o4g=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
 github.com/sei-protocol/sei-wasmd v0.0.2 h1:I0FVTMSWWVVssBQtDgwcDAyDF+ZT2+RqT20ItTBYih8=


### PR DESCRIPTION
## Describe your changes and provide context
Changes for 3.0.9 upgrade:
1. Bump tendermint version to include the patch
2. Fix the version naming convention
3. Add upgrade handler for v3.0.9

## Testing performed to validate your change

