### PR TITLE
Fix init chain script for Linux

### DIFF
--- a/scripts/initialize_local_chain.sh
+++ b/scripts/initialize_local_chain.sh
@@ -39,9 +39,7 @@ make install
 ~/go/bin/seid add-genesis-account $(~/go/bin/seid keys show $keyname -a --keyring-backend test) 100000000000000000000usei,100000000000000000000uusdc,100000000000000000000uatom
 # gentx for account
 ~/go/bin/seid gentx $keyname 70000000000000000000usei --chain-id sei-chain --keyring-backend test
-# update config to run as a validator, add validator information to genesis file
-sed -i '' 's/mode = "full"/mode = "validator"/g' $HOME/.sei/config/config.toml
-sed -i '' 's/indexer = \["null"\]/indexer = \["kv"\]/g' $HOME/.sei/config/config.toml
+# add validator information to genesis file
 KEY=$(jq '.pub_key' ~/.sei/config/priv_validator_key.json -c)
 jq '.validators = [{}]' ~/.sei/config/genesis.json > ~/.sei/config/tmp_genesis.json
 jq '.validators[0] += {"power":"70000000000000"}' ~/.sei/config/tmp_genesis.json > ~/.sei/config/tmp_genesis_2.json
@@ -78,11 +76,15 @@ else
 fi
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  sed -i 's/mode = "full"/mode = "validator"/g' $CONFIG_PATH
+  sed -i 's/indexer = \["null"\]/indexer = \["kv"\]/g' $CONFIG_PATH
   sed -i 's/timeout_prevote =.*/timeout_prevote = "2000ms"/g' $CONFIG_PATH
   sed -i 's/timeout_precommit =.*/timeout_precommit = "2000ms"/g' $CONFIG_PATH
   sed -i 's/timeout_commit =.*/timeout_commit = "2000ms"/g' $CONFIG_PATH
   sed -i 's/skip_timeout_commit =.*/skip_timeout_commit = false/g' $CONFIG_PATH
 elif [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' 's/mode = "full"/mode = "validator"/g' $CONFIG_PATH
+  sed -i '' 's/indexer = \["null"\]/indexer = \["kv"\]/g' $CONFIG_PATH
   sed -i '' 's/unsafe-propose-timeout-override =.*/unsafe-propose-timeout-override = "2s"/g' $CONFIG_PATH
   sed -i '' 's/unsafe-propose-timeout-delta-override =.*/unsafe-propose-timeout-delta-override = "2s"/g' $CONFIG_PATH
   sed -i '' 's/unsafe-vote-timeout-override =.*/unsafe-vote-timeout-override = "2s"/g' $CONFIG_PATH


### PR DESCRIPTION
## Describe your changes and provide context
- Mac uses a BSD variety of `sed` whereas Linux is on GNU version
- On Mac, `sed` requires `sed -i ''` whereas on linux it requires `sed -i` (no `''`)
- This change checks `$OSTYPE` before running `sed` to replace config entries for mode & indexer

## Testing performed to validate your change
- Local testing of initializing the local chain 
