### PR TITLE
Filter oracle price broadcast by whitelist values

### DIFF
--- a/oracle/price-feeder/oracle/client/client.go
+++ b/oracle/price-feeder/oracle/client/client.go
@@ -45,6 +45,9 @@ type (
 		GRPCEndpoint        string
 		KeyringPassphrase   string
 		BlockHeightEvents   chan int64
+
+		// MockBroadcastTx allows for a basic mock without refactoring this to an interface
+		MockBroadcastTx func(clientCtx client.Context, msgs ...sdk.Msg) (*sdk.TxResponse, error)
 	}
 
 	passReader struct {
@@ -149,6 +152,11 @@ func (r *passReader) Read(p []byte) (n int, err error) {
 func (oc OracleClient) BroadcastTx(
 	clientCtx client.Context,
 	msgs ...sdk.Msg) (*sdk.TxResponse, error) {
+
+	// this allows for basic mocking without refactoring this to an interface (much larger change)
+	if oc.MockBroadcastTx != nil {
+		return oc.MockBroadcastTx(clientCtx, msgs...)
+	}
 
 	startTime := time.Now()
 	defer telemetry.MeasureSince(startTime, "latency", "broadcast")

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -51,7 +51,7 @@ type Oracle struct {
 }
 
 // createMappingsFromPairs is a helper function to initialize maps from currencyPairs
-// this is used to by test cases to initialize the oracle lcient
+// this is used to by test cases to initialize the oracle client
 func createMappingsFromPairs(currencyPairs []config.CurrencyPair) (
 	map[string]string,
 	map[string][]types.CurrencyPair) {

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -14,14 +14,15 @@ import (
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+
 	"github.com/sei-protocol/sei-chain/oracle/price-feeder/config"
 	"github.com/sei-protocol/sei-chain/oracle/price-feeder/oracle/client"
 	"github.com/sei-protocol/sei-chain/oracle/price-feeder/oracle/provider"
 	"github.com/sei-protocol/sei-chain/oracle/price-feeder/oracle/types"
 	pfsync "github.com/sei-protocol/sei-chain/oracle/price-feeder/pkg/sync"
 	oracletypes "github.com/sei-protocol/sei-chain/x/oracle/types"
-	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc"
 )
 
 // Oracle implements the core component responsible for fetching exchange rates
@@ -49,7 +50,11 @@ type Oracle struct {
 	mockSetPrices   func(ctx context.Context) error
 }
 
-func createMappingsFromPairs(currencyPairs []config.CurrencyPair) (map[string]string, map[string][]types.CurrencyPair) {
+// createMappingsFromPairs is a helper function to initialize maps from currencyPairs
+// this is used to by test cases to initialize the oracle lcient
+func createMappingsFromPairs(currencyPairs []config.CurrencyPair) (
+	map[string]string,
+	map[string][]types.CurrencyPair) {
 	chainDenomMapping := make(map[string]string)
 	providerPairs := make(map[string][]types.CurrencyPair)
 

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -533,10 +533,10 @@ func (o *Oracle) checkWhitelist(params oracletypes.Params) {
 
 // filterPricesByDenomList takes a list of DecCoins and filters out any
 // coins that are not in the provided DenomList.
-func filterPricesByDenomList(dc sdk.DecCoins, dl oracletypes.DenomList) sdk.DecCoins {
+func filterPricesByDenomList(coinPrices sdk.DecCoins, denomList oracletypes.DenomList) sdk.DecCoins {
 	result := sdk.NewDecCoins()
-	for _, c := range dc {
-		for _, d := range dl {
+	for _, c := range coinPrices {
+		for _, d := range denomList {
 			if d.Name == c.Denom {
 				result = result.Add(c)
 			}

--- a/oracle/price-feeder/oracle/oracle_test.go
+++ b/oracle/price-feeder/oracle/oracle_test.go
@@ -447,7 +447,7 @@ func TestTick_Scenarios(t *testing.T) {
 			var setPriceCount int
 			var broadcastCount int
 			// Create the oracle instance
-			oracleInstance := &Oracle{
+			oracle := &Oracle{
 				jailCache: JailCache{
 					isJailed: test.isJailed,
 				},
@@ -485,7 +485,7 @@ func TestTick_Scenarios(t *testing.T) {
 			}
 
 			// execute the tick function
-			err := oracleInstance.tick(ctx, sdkclient.Context{}, test.blockHeight)
+			err := oracle.tick(ctx, sdkclient.Context{}, test.blockHeight)
 
 			if test.expectedErr != nil {
 				require.Equal(t, test.expectedErr, err)

--- a/oracle/price-feeder/oracle/oracle_test.go
+++ b/oracle/price-feeder/oracle/oracle_test.go
@@ -3,12 +3,11 @@ package oracle
 import (
 	"context"
 	"fmt"
-	sdkclient "github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
-	oracletypes "github.com/sei-protocol/sei-chain/x/oracle/types"
 	"testing"
 	"time"
 
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
@@ -18,6 +17,7 @@ import (
 	"github.com/sei-protocol/sei-chain/oracle/price-feeder/oracle/client"
 	"github.com/sei-protocol/sei-chain/oracle/price-feeder/oracle/provider"
 	"github.com/sei-protocol/sei-chain/oracle/price-feeder/oracle/types"
+	oracletypes "github.com/sei-protocol/sei-chain/x/oracle/types"
 )
 
 type mockProvider struct {
@@ -387,7 +387,7 @@ func TestTick_Scenarios(t *testing.T) {
 		blockHeight     int64
 		expectedErr     error
 	}{
-		"Filtered prices, should broadcst all entries": {
+		"Filtered prices, should broadcast all entries, none filtered": {
 			isJailed:    false,
 			blockHeight: 1,
 			pairs: []config.CurrencyPair{
@@ -484,6 +484,7 @@ func TestTick_Scenarios(t *testing.T) {
 				},
 			}
 
+			// execute the tick function
 			err := oracleInstance.tick(ctx, sdkclient.Context{}, test.blockHeight)
 
 			if test.expectedErr != nil {


### PR DESCRIPTION
## Describe your changes and provide context
- Filters all prices to only whitelisted entries so that configuring extra prices do not cause a penalty
- This allows us to safely add new oracle prices to the network (add first, then adjust requirement)
- Added a test for tick(), which relies on OracleClient.  
- Instead of refactoring all of OracleClient to be an interface, I used a mock function.  I prefer interfaces, but this was a safer blast radius on the codebase.

## Testing performed to validate your change
- Unit Tests for Filtering logic
- Unit Tests for tick() logic
- local price-feeder verification

## Local testing output (via price-feeder)
There is now a new DEBUG line including pre-filtered values (see uextra)
```
DBG pre-filtered prices exchange_rates=27136.481901959936667054ubtc,1699.246734346635898342ueth,0.999870004013299023uextra,1.000000000000000000uusdc module=oracle
```
This is followed by the INFO line for the broadcast
```
INF Going to broadcast vote exchange_rates=27136.481901285386982230ubtc,1699.248149670818160415ueth,1.000000000000000000uusdc feeder=sei1spcyd7ausz5z79wjplhlwmeccu9rtsn549y3e4 module=oracle validator=seivaloper1spcyd7ausz5z79wjplhlwmeccu9rtsn5t24lc9 vote_period=427
```
Note that the broadcast does not include uextra (because it was filtered out)
