### PR TITLE
Add price feeds to the example config toml

### DIFF
--- a/oracle/price-feeder/config.example.toml
+++ b/oracle/price-feeder/config.example.toml
@@ -10,7 +10,31 @@ verbose_cors = true
 write_timeout = "20s"
 
 [[deviation_thresholds]]
+base = "ETH"
+threshold = "2"
+
+[[deviation_thresholds]]
+base = "BTC"
+threshold = "2"
+
+[[deviation_thresholds]]
+base = "USDC"
+threshold = "2"
+
+[[deviation_thresholds]]
 base = "USDT"
+threshold = "2"
+
+[[deviation_thresholds]]
+base = "OSMO"
+threshold = "2"
+
+[[deviation_thresholds]]
+base = "ATOM"
+threshold = "2"
+
+[[deviation_thresholds]]
+base = "SEI"
 threshold = "2"
 
 [[currency_pairs]]
@@ -18,10 +42,12 @@ base = "ETH"
 chain_denom = "ueth"
 providers = [
   "huobi",
-  "kraken",
+  "crypto",
   "coinbase",
+  "kraken",
+  "okx"
 ]
-quote = "USD"
+quote = "USDT"
 
 [[currency_pairs]]
 base = "BTC"
@@ -29,19 +55,49 @@ chain_denom = "ubtc"
 providers = [
   "huobi",
   "kraken",
+  "crypto",
+  "coinbase",
+  "okx",
+]
+quote = "USDT"
+
+[[currency_pairs]]
+base = "USDC"
+chain_denom = "uusdc"
+providers = [
+  "huobi",
+  "kraken",
+  "okx",
+]
+quote = "USDT"
+
+[[currency_pairs]]
+base = "USDT"
+chain_denom = "uusdt"
+providers = [
+  "kraken",
+  "crypto",
   "coinbase",
 ]
 quote = "USD"
 
 [[currency_pairs]]
-base = "SOL"
-# this is because we need some dummy price feed that moves for usei
+base = "OSMO"
+chain_denom = "uosmo"
+providers = [
+  "okx",
+  "huobi",
+  "gate"
+]
+quote = "USDT"
+
+[[currency_pairs]]
+base = "SEI"
 chain_denom = "usei"
 providers = [
-  "huobi",
-  "kraken",
+  "okx",
   "coinbase",
-  "crypto",
+  "kraken",
 ]
 quote = "USD"
 
@@ -49,20 +105,9 @@ quote = "USD"
 base = "ATOM"
 chain_denom = "uatom"
 providers = [
-  "huobi",
-  "kraken",
+  "okx",
   "coinbase",
-  "crypto",
-]
-quote = "USD"
-
-[[currency_pairs]]
-base = "USDT"
-chain_denom = "factory/sei1jdppe6fnj2q7hjsepty5crxtrryzhuqsjrj95y/uust2"
-providers = [
-  "huobi",
   "kraken",
-  "coinbase",
 ]
 quote = "USD"
 


### PR DESCRIPTION
## Describe your changes and provide context
- The example config toml will be an example for pacific-1 
- It now includes ATOM, SEI, and OSMO
- Only two providers work for each of these.  
  - At this time a 3rd provider (okx) is added to satisfy the 3-provider requirement.

## Testing performed to validate your change
- Tested configuration in local mode (output from log means these providers are loading)
```json
{
  "ATOM": [
    "coinbase", "kraken"
  ],
  "BTC": [
    "coinbase", "kraken", "crypto", "huobi"
  ],
  "ETH": [
    "coinbase", "kraken", "crypto", "huobi"
  ],
  "OSMO": [
    "gate", "huobi"
  ],
  "SEI": [
    "coinbase", "kraken"
  ],
  "USDC": [
    "kraken", "huobi"
  ],
  "USDT": [
    "coinbase", "kraken", "crypto"
  ]
}
DBG pre-filtered prices exchange_rates=6.864999999999998121uatom,25697.497452222193405273ubtc,1632.085678885738215518ueth,0.356640025154169049uosmo,0.125800000000034358usei,0.999875812058908680uusdc,0.999276245064923190uusdt module=oracle
```
- Before releasing these will be added to arctic-1, atlantic-2
