### PR TITLE
reduce genesis values to not overflow int64

### DIFF
--- a/scripts/initialize_local_chain.sh
+++ b/scripts/initialize_local_chain.sh
@@ -38,11 +38,11 @@ make install
 # add the key as a genesis account with massive balances of several different tokens
 ~/go/bin/seid add-genesis-account $(~/go/bin/seid keys show $keyname -a --keyring-backend test) 100000000000000000000usei,100000000000000000000uusdc,100000000000000000000uatom
 # gentx for account
-~/go/bin/seid gentx $keyname 70000000000000000000usei --chain-id sei-chain --keyring-backend test
+~/go/bin/seid gentx $keyname 7000000000000000usei --chain-id sei-chain --keyring-backend test
 # add validator information to genesis file
 KEY=$(jq '.pub_key' ~/.sei/config/priv_validator_key.json -c)
 jq '.validators = [{}]' ~/.sei/config/genesis.json > ~/.sei/config/tmp_genesis.json
-jq '.validators[0] += {"power":"70000000000000"}' ~/.sei/config/tmp_genesis.json > ~/.sei/config/tmp_genesis_2.json
+jq '.validators[0] += {"power":"7000000000"}' ~/.sei/config/tmp_genesis.json > ~/.sei/config/tmp_genesis_2.json
 jq '.validators[0] += {"pub_key":'$KEY'}' ~/.sei/config/tmp_genesis_2.json > ~/.sei/config/tmp_genesis_3.json
 mv ~/.sei/config/tmp_genesis_3.json ~/.sei/config/genesis.json && rm ~/.sei/config/tmp_genesis.json && rm ~/.sei/config/tmp_genesis_2.json
 


### PR DESCRIPTION
## Describe your changes and provide context
The previous value for genesis tokens and voting power caused issues when paired with sei-cosmos-exporter, since querying the `general` metrics (which returns staking pool balances) would fail due to int64 overflow. This isn't an issue on chain because the chain uses bigInt for accounting, and ~~I'll need to make an appropriate fix in sei-cosmos exporter, but for the meantime, this will make sure that sei-cosmos-exporter doesn't break when used against local chain~~ never mind, float64 is the limit for a prometheus gauge, so we want the values to remain within int64 bounds

## Testing performed to validate your change
verified that sei-cosmos-exporter works properly on local chain
