### PR TITLE
Only whitelisted price feeds should be required

### DIFF
--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -40,7 +40,6 @@ type Oracle struct {
 	oracleClient       client.OracleClient
 	deviations         map[string]sdk.Dec
 	endpoints          map[string]config.ProviderEndpoint
-	params             oracletypes.Params
 
 	mtx             sync.RWMutex
 	lastPriceSyncTS time.Time

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -189,7 +189,7 @@ func (o *Oracle) GetPrices() sdk.DecCoins {
 // to determine prices. If candles are not available, uses the most recent prices
 // with VWAP. Warns the user of any missing prices, and filters out any faulty
 // providers which do not report prices or candles within 2𝜎 of the others.
-func (o *Oracle) SetPrices(ctx context.Context) error {
+func (o *Oracle) SetPrices(ctx context.Context, whitelist oracletypes.DenomList) error {
 	if o.mockSetPrices != nil {
 		return o.mockSetPrices(ctx)
 	}
@@ -210,7 +210,9 @@ func (o *Oracle) SetPrices(ctx context.Context) error {
 
 		for _, pair := range currencyPairs {
 			if _, ok := requiredRates[pair.Base]; !ok {
-				requiredRates[pair.Base] = struct{}{}
+				if whitelist.Contains(o.chainDenomMapping[pair.Base]) {
+					requiredRates[pair.Base] = struct{}{}
+				}
 			}
 		}
 
@@ -277,10 +279,6 @@ func (o *Oracle) SetPrices(ctx context.Context) error {
 		return err
 	}
 
-	// TODO: make this more lenient to allow assigning prices even when unable to retrieve all
-	if len(computedPrices) != len(requiredRates) {
-		return fmt.Errorf("unable to get prices for all exchange candles")
-	}
 	for base := range requiredRates {
 		if _, ok := computedPrices[base]; !ok {
 			return fmt.Errorf("reported prices were not equal to required rates, missed: %s", base)
@@ -569,7 +567,7 @@ func (o *Oracle) tick(
 		return err
 	}
 
-	if err = o.SetPrices(ctx); err != nil {
+	if err = o.SetPrices(ctx, oracleParams.Whitelist); err != nil {
 		return err
 	}
 	o.lastPriceSyncTS = time.Now()

--- a/oracle/price-feeder/oracle/oracle_test.go
+++ b/oracle/price-feeder/oracle/oracle_test.go
@@ -79,6 +79,7 @@ type OracleTestSuite struct {
 // SetupSuite executes once before the suite's tests are executed.
 func (ots *OracleTestSuite) SetupSuite() {
 	ots.oracle = New(
+		// set to debug to hit the debug-only code paths
 		zerolog.Nop().Level(zerolog.DebugLevel),
 		client.OracleClient{},
 		[]config.CurrencyPair{
@@ -154,7 +155,11 @@ func (ots *OracleTestSuite) TestPrices() {
 			denoms = append(denoms, v)
 		}
 	}
-	whitelist := denomList(denoms...)
+	ots.oracle.paramCache = ParamCache{
+		params: &oracletypes.Params{
+			Whitelist: denomList(denoms...),
+		},
+	}
 
 	// Use a mock provider with exchange rates that are not specified in
 	// configuration.
@@ -177,7 +182,7 @@ func (ots *OracleTestSuite) TestPrices() {
 		},
 	}
 
-	ots.Require().Error(ots.oracle.SetPrices(context.TODO(), whitelist))
+	ots.Require().Error(ots.oracle.SetPrices(context.TODO()))
 	ots.Require().Empty(ots.oracle.GetPrices())
 
 	// use a mock provider without a conversion rate for these stablecoins
@@ -200,7 +205,7 @@ func (ots *OracleTestSuite) TestPrices() {
 		},
 	}
 
-	ots.Require().Error(ots.oracle.SetPrices(context.TODO(), whitelist))
+	ots.Require().Error(ots.oracle.SetPrices(context.TODO()))
 
 	prices := ots.oracle.GetPrices()
 	ots.Require().Len(prices, 0)
@@ -249,7 +254,7 @@ func (ots *OracleTestSuite) TestPrices() {
 		},
 	}
 
-	ots.Require().NoError(ots.oracle.SetPrices(context.TODO(), whitelist))
+	ots.Require().NoError(ots.oracle.SetPrices(context.TODO()))
 
 	prices = ots.oracle.GetPrices()
 	ots.Require().Len(prices, 4)
@@ -302,7 +307,7 @@ func (ots *OracleTestSuite) TestPrices() {
 		},
 	}
 
-	ots.Require().NoError(ots.oracle.SetPrices(context.TODO(), whitelist))
+	ots.Require().NoError(ots.oracle.SetPrices(context.TODO()))
 	prices = ots.oracle.GetPrices()
 	ots.Require().Len(prices, 4)
 	ots.Require().Equal(sdk.MustNewDecFromStr("3.70"), prices.AmountOf("uumee"))
@@ -354,7 +359,7 @@ func (ots *OracleTestSuite) TestPrices() {
 		},
 	}
 
-	ots.Require().NoError(ots.oracle.SetPrices(context.TODO(), whitelist))
+	ots.Require().NoError(ots.oracle.SetPrices(context.TODO()))
 	prices = ots.oracle.GetPrices()
 	ots.Require().Len(prices, 4)
 	ots.Require().Equal(sdk.MustNewDecFromStr("3.71"), prices.AmountOf("uumee"))
@@ -399,7 +404,7 @@ func (ots *OracleTestSuite) TestPrices() {
 		config.ProviderOkx: failingProvider{},
 	}
 
-	ots.Require().NoError(ots.oracle.SetPrices(context.TODO(), whitelist))
+	ots.Require().NoError(ots.oracle.SetPrices(context.TODO()))
 	prices = ots.oracle.GetPrices()
 	ots.Require().Len(prices, 3)
 	ots.Require().Equal(sdk.MustNewDecFromStr("3.71"), prices.AmountOf("uumee"))

--- a/oracle/price-feeder/oracle/oracle_test.go
+++ b/oracle/price-feeder/oracle/oracle_test.go
@@ -79,7 +79,7 @@ type OracleTestSuite struct {
 // SetupSuite executes once before the suite's tests are executed.
 func (ots *OracleTestSuite) SetupSuite() {
 	ots.oracle = New(
-		zerolog.Nop(),
+		zerolog.Nop().Level(zerolog.DebugLevel),
 		client.OracleClient{},
 		[]config.CurrencyPair{
 			{
@@ -143,6 +143,7 @@ func (ots *OracleTestSuite) TestGetLastPriceSyncTimestamp() {
 }
 
 func (ots *OracleTestSuite) TestPrices() {
+
 	// initial prices should be empty (not set)
 	ots.Require().Empty(ots.oracle.GetPrices())
 

--- a/x/oracle/types/denom.go
+++ b/x/oracle/types/denom.go
@@ -20,6 +20,15 @@ func (d Denom) Equal(d1 *Denom) bool {
 // DenomList is array of Denom
 type DenomList []Denom
 
+func (dl DenomList) Contains(denom string) bool {
+	for _, d := range dl {
+		if d.Name == denom {
+			return true
+		}
+	}
+	return false
+}
+
 // String implements fmt.Stringer interface
 func (dl DenomList) String() (out string) {
 	for _, d := range dl {

--- a/x/oracle/types/denom_test.go
+++ b/x/oracle/types/denom_test.go
@@ -1,0 +1,47 @@
+package types
+
+import "testing"
+
+func TestDenomListContains(t *testing.T) {
+	tests := []struct {
+		name      string
+		denomList DenomList
+		denom     string
+		want      bool
+	}{
+		{
+			name: "denomination present",
+			denomList: DenomList{
+				{Name: "USD"},
+				{Name: "EUR"},
+				{Name: "INR"},
+			},
+			denom: "EUR",
+			want:  true,
+		},
+		{
+			name: "denomination absent",
+			denomList: DenomList{
+				{Name: "USD"},
+				{Name: "EUR"},
+				{Name: "INR"},
+			},
+			denom: "JPY",
+			want:  false,
+		},
+		{
+			name:      "empty list",
+			denomList: DenomList{},
+			denom:     "USD",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.denomList.Contains(tt.denom); got != tt.want {
+				t.Errorf("DenomList.Contains() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Describe your changes and provide context
**Background**
- The `SetPrices()` method enforces that all price feeds are present rather than only whitelisted entries
- If a non-whitelisted entry fails, it means that it would abstain the vote, which is undesirable
  
**Change Summary**
- This change only requires whitelisted entries, and all others will populate if successful
- It also removes a length check to allow for more entries (it already checks that every required value is present)

## Testing performed to validate your change
- Unit Tests (mocking "bad providers")
  - The existing tests now confirm a non-whitelisted entry continues to be set
  - A new test confirms a failing non-whitelisted entry doesn't prevent the setting of prices
- Local Chain Testing 