### PR TITLE
Improve pf providers

### DIFF
--- a/oracle/price-feeder/config/config.go
+++ b/oracle/price-feeder/config/config.go
@@ -286,16 +286,6 @@ func ParseConfig(configPath string) (Config, error) {
 		}
 	}
 
-	gatePairs := []string{}
-	for base, providers := range pairs {
-		if _, ok := providers["gate"]; ok {
-			gatePairs = append(gatePairs, base)
-		}
-	}
-	if len(gatePairs) > 1 {
-		return cfg, fmt.Errorf("gate provider does not support multiple pairs: %v", gatePairs)
-	}
-
 	for _, deviation := range cfg.Deviations {
 		threshold, err := sdk.NewDecFromStr(deviation.Threshold)
 		if err != nil {

--- a/oracle/price-feeder/config/config.go
+++ b/oracle/price-feeder/config/config.go
@@ -281,8 +281,8 @@ func ParseConfig(configPath string) (Config, error) {
 	}
 
 	for base, providers := range pairs {
-		if _, ok := pairs[base]["mock"]; !ok && len(providers) < 2 {
-			return cfg, fmt.Errorf("must have at least two providers for %s", base)
+		if _, ok := pairs[base]["mock"]; !ok && len(providers) < 3 {
+			return cfg, fmt.Errorf("must have at least three providers for %s", base)
 		}
 	}
 

--- a/oracle/price-feeder/config/config.go
+++ b/oracle/price-feeder/config/config.go
@@ -281,8 +281,8 @@ func ParseConfig(configPath string) (Config, error) {
 	}
 
 	for base, providers := range pairs {
-		if _, ok := pairs[base]["mock"]; !ok && len(providers) < 3 {
-			return cfg, fmt.Errorf("must have at least three providers for %s", base)
+		if _, ok := pairs[base]["mock"]; !ok && len(providers) < 2 {
+			return cfg, fmt.Errorf("must have at least two providers for %s", base)
 		}
 	}
 

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -318,9 +318,6 @@ func GetComputedPrices(
 		assetProviderMap := make(map[string][]string)
 		for provider, val := range providerPrices {
 			for asset := range val {
-				if _, ok := assetProviderMap[asset]; !ok {
-					assetProviderMap[asset] = []string{}
-				}
 				assetProviderMap[asset] = append(assetProviderMap[asset], provider)
 			}
 		}
@@ -333,9 +330,6 @@ func GetComputedPrices(
 		candleProviderMap := make(map[string][]string)
 		for provider, val := range providerCandles {
 			for asset := range val {
-				if _, ok := candleProviderMap[asset]; !ok {
-					candleProviderMap[asset] = []string{}
-				}
 				candleProviderMap[asset] = append(candleProviderMap[asset], provider)
 			}
 		}
@@ -367,19 +361,19 @@ func GetComputedPrices(
 	}
 
 	// attempt to use candles for TVWAP calculations
-	tvwapPrices, err := ComputeTVWAP(filteredCandles)
+	computedPrices, err := ComputeTVWAP(filteredCandles)
 	if err != nil {
 		return nil, err
 	}
 
 	candleAssets := []string{}
 	tickerAssets := []string{}
-	for base := range tvwapPrices {
+	for base := range computedPrices {
 		candleAssets = append(candleAssets, base)
 	}
 	allRequiredAssetsPresent := true
 	for asset := range requiredRates {
-		if _, ok := tvwapPrices[asset]; !ok {
+		if _, ok := computedPrices[asset]; !ok {
 			allRequiredAssetsPresent = false
 		}
 	}
@@ -412,14 +406,14 @@ func GetComputedPrices(
 		}
 
 		for asset, price := range vwapPrices {
-			if _, ok := tvwapPrices[asset]; !ok {
+			if _, ok := computedPrices[asset]; !ok {
 				tickerAssets = append(tickerAssets, asset)
-				tvwapPrices[asset] = price
+				computedPrices[asset] = price
 			}
 		}
 	}
 	logger.Debug().Msg(fmt.Sprint("Assets using Candle TVWAP: ", candleAssets, " Assets using Ticker VWAP: ", tickerAssets))
-	return tvwapPrices, nil
+	return computedPrices, nil
 }
 
 // SetProviderTickerPricesAndCandles flattens and collects prices for

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -322,11 +322,26 @@ func GetComputedPrices(
 				assetProviderMap[asset] = append(assetProviderMap[asset], provider)
 			}
 		}
-		assetProviderJSON, err := json.MarshalIndent(assetProviderMap, "", "  ")
+		assetProviderJSON, err := json.Marshal(assetProviderMap)
 		if err != nil {
 			return nil, err
 		}
 		logger.Debug().Msg(fmt.Sprintf("Asset Provider Coverage Map: %s", string(assetProviderJSON)))
+
+		candleProviderMap := make(map[string][]string)
+		for provider, val := range providerCandles {
+			for asset := range val {
+				if _, ok := candleProviderMap[asset]; !ok {
+					candleProviderMap[asset] = []string{}
+				}
+				candleProviderMap[asset] = append(candleProviderMap[asset], provider)
+			}
+		}
+		candleProviderJSON, err := json.Marshal(candleProviderMap)
+		if err != nil {
+			return nil, err
+		}
+		logger.Debug().Msg(fmt.Sprintf("Candle Provider Coverage Map: %s", string(candleProviderJSON)))
 	}
 	// convert any non-USD denominated candles into USD
 	convertedCandles, err := convertCandlesToUSD(

--- a/oracle/price-feeder/oracle/oracle_test.go
+++ b/oracle/price-feeder/oracle/oracle_test.go
@@ -770,6 +770,9 @@ func TestSuccessGetComputedPricesCandles(t *testing.T) {
 		make(provider.AggregatedProviderPrices, 1),
 		providerPair,
 		make(map[string]sdk.Dec),
+		map[string]struct{}{
+			"ATOM": {},
+		},
 	)
 
 	require.NoError(t, err, "It should successfully get computed candle prices")
@@ -803,6 +806,9 @@ func TestSuccessGetComputedPricesTickers(t *testing.T) {
 		providerPrices,
 		providerPair,
 		make(map[string]sdk.Dec),
+		map[string]struct{}{
+			"ATOM": {},
+		},
 	)
 
 	require.NoError(t, err, "It should successfully get computed ticker prices")
@@ -899,6 +905,9 @@ func TestGetComputedPricesCandlesConversion(t *testing.T) {
 		make(provider.AggregatedProviderPrices, 1),
 		providerPair,
 		make(map[string]sdk.Dec),
+		map[string]struct{}{
+			"BTC": {},
+		},
 	)
 
 	require.NoError(t, err,
@@ -983,6 +992,9 @@ func TestGetComputedPricesTickersConversion(t *testing.T) {
 		providerPrices,
 		providerPair,
 		make(map[string]sdk.Dec),
+		map[string]struct{}{
+			"BTC": {},
+		},
 	)
 
 	require.NoError(t, err,

--- a/oracle/price-feeder/oracle/provider/binance.go
+++ b/oracle/price-feeder/oracle/provider/binance.go
@@ -140,7 +140,7 @@ func (p *BinanceProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[stri
 		key := cp.String()
 		price, err := p.getTickerPrice(key)
 		if err != nil {
-			p.logger.Warn().Msg(fmt.Sprint("failed to fetch tickers for pair ", cp, " due to the following error ", err.Error()))
+			p.logger.Debug().AnErr("err", err).Msg(fmt.Sprint("failed to fetch tickers for pair ", cp))
 			continue
 		}
 		tickerPrices[key] = price
@@ -157,7 +157,7 @@ func (p *BinanceProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[stri
 		key := cp.String()
 		prices, err := p.getCandlePrices(key)
 		if err != nil {
-			p.logger.Warn().Msg(fmt.Sprint("failed to fetch candles for pair ", cp, " due to the following error ", err.Error()))
+			p.logger.Debug().AnErr("err", err).Msg(fmt.Sprint("failed to fetch candles for pair ", cp))
 			continue
 		}
 		candlePrices[key] = prices

--- a/oracle/price-feeder/oracle/provider/binance.go
+++ b/oracle/price-feeder/oracle/provider/binance.go
@@ -110,7 +110,7 @@ func NewBinanceProvider(
 		}
 	}()
 	if err != nil {
-		return nil, fmt.Errorf("error connecting to Binance websocket: %w", err)
+		return nil, fmt.Errorf("error connecting to Binance websocket: %w, %v", err, response)
 	}
 
 	provider := &BinanceProvider{
@@ -140,7 +140,8 @@ func (p *BinanceProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[stri
 		key := cp.String()
 		price, err := p.getTickerPrice(key)
 		if err != nil {
-			return nil, err
+			p.logger.Warn().Msg(fmt.Sprint("failed to fetch tickers for pair ", cp, " due to the following error ", err.Error()))
+			continue
 		}
 		tickerPrices[key] = price
 	}
@@ -156,7 +157,8 @@ func (p *BinanceProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[stri
 		key := cp.String()
 		prices, err := p.getCandlePrices(key)
 		if err != nil {
-			return nil, err
+			p.logger.Warn().Msg(fmt.Sprint("failed to fetch candles for pair ", cp, " due to the following error ", err.Error()))
+			continue
 		}
 		candlePrices[key] = prices
 	}

--- a/oracle/price-feeder/oracle/provider/binance_test.go
+++ b/oracle/price-feeder/oracle/provider/binance_test.go
@@ -82,21 +82,24 @@ func TestBinanceProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {
 		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "FOO", Quote: "BAR"})
-		require.Error(t, err)
-		require.Equal(t, "binance provider failed to get ticker price for FOOBAR", err.Error())
-		require.Nil(t, prices)
+		require.NoError(t, err)
+		require.Zero(t, len(prices))
 	})
 }
 
 func TestBinanceProvider_SubscribeCurrencyPairs(t *testing.T) {
-	// server := NewMockProviderServer()
-	// server.Start()
-	// defer server.Close()
+	server := NewMockProviderServer()
+	server.Start()
+	defer server.Close()
 
 	p, err := NewBinanceProvider(
 		context.TODO(),
 		zerolog.Nop(),
-		config.ProviderEndpoint{},
+		config.ProviderEndpoint{
+			Name:      config.ProviderBinance,
+			Rest:      "",
+			Websocket: server.GetBaseURL(),
+		},
 		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
 	)
 	require.NoError(t, err)

--- a/oracle/price-feeder/oracle/provider/binance_test.go
+++ b/oracle/price-feeder/oracle/provider/binance_test.go
@@ -89,18 +89,14 @@ func TestBinanceProvider_GetTickerPrices(t *testing.T) {
 }
 
 func TestBinanceProvider_SubscribeCurrencyPairs(t *testing.T) {
-	server := NewMockProviderServer()
-	server.Start()
-	defer server.Close()
+	// server := NewMockProviderServer()
+	// server.Start()
+	// defer server.Close()
 
 	p, err := NewBinanceProvider(
 		context.TODO(),
 		zerolog.Nop(),
-		config.ProviderEndpoint{
-			Name:      config.ProviderBinance,
-			Rest:      "",
-			Websocket: server.GetBaseURL(),
-		},
+		config.ProviderEndpoint{},
 		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
 	)
 	require.NoError(t, err)

--- a/oracle/price-feeder/oracle/provider/coinbase.go
+++ b/oracle/price-feeder/oracle/provider/coinbase.go
@@ -150,7 +150,7 @@ func (p *CoinbaseProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[str
 	for _, currencyPair := range pairs {
 		price, err := p.getTickerPrice(currencyPair)
 		if err != nil {
-			p.logger.Warn().Msg(fmt.Sprint("failed to fetch tickers for pair ", currencyPair, " due to the following error ", err.Error()))
+			p.logger.Debug().AnErr("err", err).Msg(fmt.Sprint("failed to fetch tickers for pair ", currencyPair))
 			continue
 		}
 
@@ -169,7 +169,7 @@ func (p *CoinbaseProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[str
 		key := currencyPairToCoinbasePair(cp)
 		tradeSet, err := p.getTradePrices(key)
 		if err != nil {
-			p.logger.Warn().Msg(fmt.Sprint("failed to fetch candles for pair ", cp, " due to the following error ", err.Error()))
+			p.logger.Debug().AnErr("err", err).Msg(fmt.Sprint("failed to fetch candles for pair ", cp))
 			continue
 		}
 		tradeMap[key] = tradeSet

--- a/oracle/price-feeder/oracle/provider/coinbase.go
+++ b/oracle/price-feeder/oracle/provider/coinbase.go
@@ -150,7 +150,8 @@ func (p *CoinbaseProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[str
 	for _, currencyPair := range pairs {
 		price, err := p.getTickerPrice(currencyPair)
 		if err != nil {
-			return nil, err
+			p.logger.Warn().Msg(fmt.Sprint("failed to fetch tickers for pair ", currencyPair, " due to the following error ", err.Error()))
+			continue
 		}
 
 		tickerPrices[currencyPair.String()] = price
@@ -168,7 +169,8 @@ func (p *CoinbaseProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[str
 		key := currencyPairToCoinbasePair(cp)
 		tradeSet, err := p.getTradePrices(key)
 		if err != nil {
-			return nil, err
+			p.logger.Warn().Msg(fmt.Sprint("failed to fetch candles for pair ", cp, " due to the following error ", err.Error()))
+			continue
 		}
 		tradeMap[key] = tradeSet
 	}

--- a/oracle/price-feeder/oracle/provider/coinbase_test.go
+++ b/oracle/price-feeder/oracle/provider/coinbase_test.go
@@ -71,9 +71,8 @@ func TestCoinbaseProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {
 		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "FOO", Quote: "BAR"})
-		require.Error(t, err)
-		require.Equal(t, "failed to get ticker price for FOO-BAR", err.Error())
-		require.Nil(t, prices)
+		require.NoError(t, err)
+		require.Zero(t, len(prices))
 	})
 }
 

--- a/oracle/price-feeder/oracle/provider/crypto.go
+++ b/oracle/price-feeder/oracle/provider/crypto.go
@@ -194,7 +194,8 @@ func (p *CryptoProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[strin
 		key := currencyPairToCryptoPair(cp)
 		price, err := p.getTickerPrice(key)
 		if err != nil {
-			return nil, err
+			p.logger.Warn().Msg(fmt.Sprint("failed to fetch tickers for pair ", cp, " due to the following error ", err.Error()))
+			continue
 		}
 		tickerPrices[cp.String()] = price
 	}
@@ -210,7 +211,8 @@ func (p *CryptoProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[strin
 		key := currencyPairToCryptoPair(cp)
 		prices, err := p.getCandlePrices(key)
 		if err != nil {
-			return nil, err
+			p.logger.Warn().Msg(fmt.Sprint("failed to fetch candles for pair ", cp, " due to the following error ", err.Error()))
+			continue
 		}
 		candlePrices[cp.String()] = prices
 	}

--- a/oracle/price-feeder/oracle/provider/crypto.go
+++ b/oracle/price-feeder/oracle/provider/crypto.go
@@ -194,7 +194,7 @@ func (p *CryptoProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[strin
 		key := currencyPairToCryptoPair(cp)
 		price, err := p.getTickerPrice(key)
 		if err != nil {
-			p.logger.Warn().Msg(fmt.Sprint("failed to fetch tickers for pair ", cp, " due to the following error ", err.Error()))
+			p.logger.Debug().AnErr("err", err).Msg(fmt.Sprint("failed to fetch tickers for pair ", cp))
 			continue
 		}
 		tickerPrices[cp.String()] = price
@@ -211,7 +211,7 @@ func (p *CryptoProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[strin
 		key := currencyPairToCryptoPair(cp)
 		prices, err := p.getCandlePrices(key)
 		if err != nil {
-			p.logger.Warn().Msg(fmt.Sprint("failed to fetch candles for pair ", cp, " due to the following error ", err.Error()))
+			p.logger.Debug().AnErr("err", err).Msg(fmt.Sprint("failed to fetch candles for pair ", cp))
 			continue
 		}
 		candlePrices[cp.String()] = prices

--- a/oracle/price-feeder/oracle/provider/crypto_test.go
+++ b/oracle/price-feeder/oracle/provider/crypto_test.go
@@ -70,8 +70,8 @@ func TestCryptoProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {
 		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "FOO", Quote: "BAR"})
-		require.Error(t, err)
-		require.Nil(t, prices)
+		require.NoError(t, err)
+		require.Zero(t, len(prices))
 	})
 }
 

--- a/oracle/price-feeder/oracle/provider/crypto_test.go
+++ b/oracle/price-feeder/oracle/provider/crypto_test.go
@@ -110,8 +110,8 @@ func TestCryptoProvider_GetCandlePrices(t *testing.T) {
 
 	t.Run("invalid_request_invalid_candle", func(t *testing.T) {
 		prices, err := p.GetCandlePrices(types.CurrencyPair{Base: "FOO", Quote: "BAR"})
-		require.Error(t, err)
-		require.Nil(t, prices)
+		require.NoError(t, err)
+		require.Zero(t, len(prices))
 	})
 }
 

--- a/oracle/price-feeder/oracle/provider/gate.go
+++ b/oracle/price-feeder/oracle/provider/gate.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -19,8 +20,8 @@ import (
 )
 
 const (
-	gateWSHost    = "ws.gate.io"
-	gateWSPath    = "/v3"
+	gateWSHost    = "api.gateio.ws"
+	gateWSPath    = "/ws/v4/"
 	gatePingCheck = time.Second * 28 // should be < 30
 	gateRestHost  = "https://api.gateio.ws"
 	gateRestPath  = "/api/v4/spot/currency_pairs"
@@ -60,22 +61,45 @@ type (
 
 	// GateTickerSubscriptionMsg Msg to subscribe all the tickers channels.
 	GateTickerSubscriptionMsg struct {
-		Method string   `json:"method"` // ticker.subscribe
-		Params []string `json:"params"` // streams to subscribe ex.: BOT_USDT
-		ID     uint16   `json:"id"`     // identify messages going back and forth
+		Time int64 `json:"time"`
+		// Method string   `json:"method"` // ticker.subscribe
+		Channel string `json:"channel"` // spot.tickers
+		Event   string `json:"event"`   // subscribe
+		// Params  []string `json:"params"`  // streams to subscribe ex.: BOT_USDT
+		Payload []string `json:"payload"` // streams to subscribe ex.: BOT_USDT
+		ID      uint16   `json:"id"`      // identify messages going back and forth
 	}
 
 	// GateCandleSubscriptionMsg Msg to subscribe to a candle channel.
 	GateCandleSubscriptionMsg struct {
-		Method string        `json:"method"` // ticker.subscribe
-		Params []interface{} `json:"params"` // streams to subscribe ex.: ["BOT_USDT": 1800]
-		ID     uint16        `json:"id"`     // identify messages going back and forth
+		Time    int64  `json:"time"`
+		Channel string `json:"channel"` // spot.candlesticks
+		Event   string `json:"event"`   // subscribe
+		// Params  []string `json:"params"`  // streams to subscribe ex.: BOT_USDT
+		Payload []string `json:"payload"` // streams to subscribe ex.: BOT_USDT
+		ID      uint16   `json:"id"`      // identify messages going back and forth
 	}
 
 	// GateTickerResponse defines the response body for gate tickers.
 	GateTickerResponse struct {
-		Method string        `json:"method"`
-		Params []interface{} `json:"params"`
+		Time    int64            `json:"time"`
+		TimeMS  int64            `json:"time_ms"`
+		Channel string           `json:"channel"`
+		Event   string           `json:"event"`
+		Result  GateTickerResult `json:"result"`
+	}
+
+	// GateTickerResult defines the response body for gate tickers result data.
+	GateTickerResult struct {
+		CurrencyPair     string `json:"currency_pair"`
+		Last             string `json:"last"`
+		LowestAsk        string `json:"lowest_ask"`
+		HighestBid       string `json:"highest_bid"`
+		ChangePercentage string `json:"change_percentage"`
+		BaseVolume       string `json:"base_volume"`
+		QuoteVolume      string `json:"quote_volume"`
+		High24h          string `json:"high_24h"`
+		Low24h           string `json:"low_24h"`
 	}
 
 	// GateTickerResponse defines the response body for gate tickers.
@@ -83,8 +107,23 @@ type (
 	//
 	// REF: https://www.gate.io/docs/websocket/index.html
 	GateCandleResponse struct {
-		Method string          `json:"method"`
-		Params [][]interface{} `json:"params"`
+		Time    int64            `json:"time"`
+		TimeMS  int64            `json:"time_ms"`
+		Channel string           `json:"channel"`
+		Event   string           `json:"event"`
+		Result  GateCandleResult `json:"result"`
+	}
+
+	// GateCandleResult defines the response body for gate candle result data.
+	GateCandleResult struct {
+		Timestamp         string `json:"t"`
+		Volume            string `json:"v"`
+		ClosePrice        string `json:"c"`
+		HighestPrice      string `json:"h"`
+		LowestPrice       string `json:"l"`
+		OpenPrice         string `json:"o"`
+		SubscriptionName  string `json:"n"`
+		BaseTradingAmount string `json:"a"`
 	}
 
 	// GateEvent defines the response body for gate subscription statuses.
@@ -159,11 +198,11 @@ func NewGateProvider(
 // GetTickerPrices returns the tickerPrices based on the saved map.
 func (p *GateProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]TickerPrice, error) {
 	tickerPrices := make(map[string]TickerPrice, len(pairs))
-
 	for _, currencyPair := range pairs {
 		price, err := p.getTickerPrice(currencyPair)
 		if err != nil {
-			return nil, err
+			p.logger.Warn().Msg(fmt.Sprint("failed to fetch tickers for pair ", currencyPair, " due to the following error ", err.Error()))
+			continue
 		}
 
 		tickerPrices[currencyPair.String()] = price
@@ -175,12 +214,12 @@ func (p *GateProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]
 // GetCandlePrices returns the candlePrices based on the saved map
 func (p *GateProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]CandlePrice, error) {
 	candlePrices := make(map[string][]CandlePrice, len(pairs))
-
 	for _, currencyPair := range pairs {
 		gp := currencyPairToGatePair(currencyPair)
 		price, err := p.getCandlePrices(gp)
 		if err != nil {
-			return nil, err
+			p.logger.Warn().Msg(fmt.Sprint("failed to fetch candles for pair ", currencyPair, " due to the following error ", err.Error()))
+			continue
 		}
 
 		candlePrices[currencyPair.String()] = price
@@ -335,7 +374,7 @@ func (p *GateProvider) messageReceived(messageType int, bz []byte) {
 		tickerErr error
 		candleErr error
 	)
-
+	// fmt.Println("gate response", string(bz))
 	gateErr = json.Unmarshal(bz, &gateEvent)
 	if gateErr == nil {
 		switch gateEvent.Result.Status {
@@ -384,27 +423,15 @@ func (p *GateProvider) messageReceivedTickerPrice(bz []byte) error {
 		return err
 	}
 
-	if tickerMessage.Method != "ticker.update" {
+	if tickerMessage.Channel != "spot.tickers" || tickerMessage.Event != "update" {
 		return fmt.Errorf("message is not a ticker update")
 	}
 
-	tickerBz, err := json.Marshal(tickerMessage.Params[1])
-	if err != nil {
-		p.logger.Err(err).Msg("could not marshal ticker message")
-		return err
+	gateTicker := GateTicker{
+		Last:   tickerMessage.Result.Last,
+		Vol:    tickerMessage.Result.BaseVolume,
+		Symbol: tickerMessage.Result.CurrencyPair,
 	}
-
-	var gateTicker GateTicker
-	if err := json.Unmarshal(tickerBz, &gateTicker); err != nil {
-		p.logger.Err(err).Msg("could not unmarshal ticker message")
-		return err
-	}
-
-	symbol, ok := tickerMessage.Params[0].(string)
-	if !ok {
-		return fmt.Errorf("symbol should be a string")
-	}
-	gateTicker.Symbol = symbol
 
 	p.setTickerPair(gateTicker)
 	telemetry.IncrCounter(
@@ -470,14 +497,22 @@ func (p *GateProvider) messageReceivedCandle(bz []byte) error {
 	if err := json.Unmarshal(bz, &candleMessage); err != nil {
 		return err
 	}
-
-	if candleMessage.Method != "kline.update" {
-		return fmt.Errorf("message is not a kline update")
+	if candleMessage.Channel != "spot.candlesticks" || candleMessage.Event != "update" {
+		return fmt.Errorf("message is not a candle update")
 	}
 
-	var gateCandle GateCandle
-	if err := gateCandle.UnmarshalParams(candleMessage.Params); err != nil {
+	timeStamp, err := strconv.ParseInt(candleMessage.Result.Timestamp, 10, 64)
+	if err != nil {
 		return err
+	}
+
+	symbolArr := strings.SplitN(candleMessage.Result.SubscriptionName, "_", 2)
+
+	gateCandle := GateCandle{
+		Close:     candleMessage.Result.ClosePrice,
+		TimeStamp: timeStamp,
+		Volume:    candleMessage.Result.BaseTradingAmount,
+		Symbol:    symbolArr[1],
 	}
 
 	p.setCandlePair(gateCandle)
@@ -635,22 +670,25 @@ func currencyPairToGatePair(pair types.CurrencyPair) string {
 
 // newGateTickerSubscription returns a new subscription topic for tickers.
 func newGateTickerSubscription(cp ...string) GateTickerSubscriptionMsg {
+	time_secs := time.Now().Unix()
 	return GateTickerSubscriptionMsg{
-		Method: "ticker.subscribe",
-		Params: cp,
-		ID:     1,
+		Time:    time_secs,
+		Channel: "spot.tickers",
+		Event:   "subscribe",
+		Payload: cp,
+		ID:      1,
 	}
 }
 
 // newGateCandleSubscription returns a new subscription topic for candles.
 func newGateCandleSubscription(gatePair string) GateCandleSubscriptionMsg {
-	params := []interface{}{
-		gatePair, // currency pair ex. "ATOM_USDT"
-		60,       // time interval in seconds
-	}
+	pair := []string{"1m", gatePair}
+	time_secs := time.Now().Unix()
 	return GateCandleSubscriptionMsg{
-		Method: "kline.subscribe",
-		Params: params,
-		ID:     2,
+		Time:    time_secs,
+		Channel: "spot.candlesticks",
+		Event:   "subscribe",
+		Payload: pair,
+		ID:      2,
 	}
 }

--- a/oracle/price-feeder/oracle/provider/gate.go
+++ b/oracle/price-feeder/oracle/provider/gate.go
@@ -670,9 +670,9 @@ func currencyPairToGatePair(pair types.CurrencyPair) string {
 
 // newGateTickerSubscription returns a new subscription topic for tickers.
 func newGateTickerSubscription(cp ...string) GateTickerSubscriptionMsg {
-	time_secs := time.Now().Unix()
+	timeSecs := time.Now().Unix()
 	return GateTickerSubscriptionMsg{
-		Time:    time_secs,
+		Time:    timeSecs,
 		Channel: "spot.tickers",
 		Event:   "subscribe",
 		Payload: cp,
@@ -683,9 +683,9 @@ func newGateTickerSubscription(cp ...string) GateTickerSubscriptionMsg {
 // newGateCandleSubscription returns a new subscription topic for candles.
 func newGateCandleSubscription(gatePair string) GateCandleSubscriptionMsg {
 	pair := []string{"1m", gatePair}
-	time_secs := time.Now().Unix()
+	timeSecs := time.Now().Unix()
 	return GateCandleSubscriptionMsg{
-		Time:    time_secs,
+		Time:    timeSecs,
 		Channel: "spot.candlesticks",
 		Event:   "subscribe",
 		Payload: pair,

--- a/oracle/price-feeder/oracle/provider/gate.go
+++ b/oracle/price-feeder/oracle/provider/gate.go
@@ -201,7 +201,7 @@ func (p *GateProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]
 	for _, currencyPair := range pairs {
 		price, err := p.getTickerPrice(currencyPair)
 		if err != nil {
-			p.logger.Warn().Msg(fmt.Sprint("failed to fetch tickers for pair ", currencyPair, " due to the following error ", err.Error()))
+			p.logger.Debug().AnErr("err", err).Msg(fmt.Sprint("failed to fetch tickers for pair ", currencyPair))
 			continue
 		}
 
@@ -218,7 +218,7 @@ func (p *GateProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string]
 		gp := currencyPairToGatePair(currencyPair)
 		price, err := p.getCandlePrices(gp)
 		if err != nil {
-			p.logger.Warn().Msg(fmt.Sprint("failed to fetch candles for pair ", currencyPair, " due to the following error ", err.Error()))
+			p.logger.Debug().AnErr("err", err).Msg(fmt.Sprint("failed to fetch candles for pair ", currencyPair))
 			continue
 		}
 
@@ -374,7 +374,7 @@ func (p *GateProvider) messageReceived(messageType int, bz []byte) {
 		tickerErr error
 		candleErr error
 	)
-	// fmt.Println("gate response", string(bz))
+
 	gateErr = json.Unmarshal(bz, &gateEvent)
 	if gateErr == nil {
 		switch gateEvent.Result.Status {

--- a/oracle/price-feeder/oracle/provider/gate_test.go
+++ b/oracle/price-feeder/oracle/provider/gate_test.go
@@ -75,9 +75,8 @@ func TestGateProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {
 		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "FOO", Quote: "BAR"})
-		require.Error(t, err)
-		require.Equal(t, "gate provider failed to get ticker price for FOO_BAR", err.Error())
-		require.Nil(t, prices)
+		require.NoError(t, err)
+		require.Zero(t, len(prices))
 	})
 }
 

--- a/oracle/price-feeder/oracle/provider/gate_test.go
+++ b/oracle/price-feeder/oracle/provider/gate_test.go
@@ -13,19 +13,11 @@ import (
 )
 
 func TestGateProvider_GetTickerPrices(t *testing.T) {
-	// use mock provider server
-	server := NewMockProviderServer()
-	server.Start()
-	defer server.Close()
 
 	p, err := NewGateProvider(
 		context.TODO(),
 		zerolog.Nop(),
-		config.ProviderEndpoint{
-			Name:      config.ProviderGate,
-			Rest:      "",
-			Websocket: server.GetBaseURL(),
-		},
+		config.ProviderEndpoint{},
 		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
 	)
 	require.NoError(t, err)
@@ -90,19 +82,10 @@ func TestGateProvider_GetTickerPrices(t *testing.T) {
 }
 
 func TestGateProvider_SubscribeCurrencyPairs(t *testing.T) {
-	// // use mock provider server
-	server := NewMockProviderServer()
-	server.Start()
-	defer server.Close()
-
 	p, err := NewGateProvider(
 		context.TODO(),
 		zerolog.Nop(),
-		config.ProviderEndpoint{
-			Name:      config.ProviderGate,
-			Rest:      "",
-			Websocket: server.GetBaseURL(),
-		},
+		config.ProviderEndpoint{},
 		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
 	)
 	require.NoError(t, err)

--- a/oracle/price-feeder/oracle/provider/huobi.go
+++ b/oracle/price-feeder/oracle/provider/huobi.go
@@ -151,7 +151,8 @@ func (p *HuobiProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string
 	for _, cp := range pairs {
 		price, err := p.getTickerPrice(cp)
 		if err != nil {
-			return nil, err
+			p.logger.Warn().Msg(fmt.Sprint("failed to fetch tickers for pair ", cp, " due to the following error ", err.Error()))
+			continue
 		}
 		tickerPrices[cp.String()] = price
 	}
@@ -166,7 +167,8 @@ func (p *HuobiProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string
 	for _, cp := range pairs {
 		price, err := p.getCandlePrices(cp)
 		if err != nil {
-			return nil, err
+			p.logger.Warn().Msg(fmt.Sprint("failed to fetch candles for pair ", cp, " due to the following error ", err.Error()))
+			continue
 		}
 		candlePrices[cp.String()] = price
 	}

--- a/oracle/price-feeder/oracle/provider/huobi.go
+++ b/oracle/price-feeder/oracle/provider/huobi.go
@@ -151,7 +151,7 @@ func (p *HuobiProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string
 	for _, cp := range pairs {
 		price, err := p.getTickerPrice(cp)
 		if err != nil {
-			p.logger.Warn().Msg(fmt.Sprint("failed to fetch tickers for pair ", cp, " due to the following error ", err.Error()))
+			p.logger.Debug().AnErr("err", err).Msg(fmt.Sprint("failed to fetch tickers for pair ", cp))
 			continue
 		}
 		tickerPrices[cp.String()] = price
@@ -167,7 +167,7 @@ func (p *HuobiProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string
 	for _, cp := range pairs {
 		price, err := p.getCandlePrices(cp)
 		if err != nil {
-			p.logger.Warn().Msg(fmt.Sprint("failed to fetch candles for pair ", cp, " due to the following error ", err.Error()))
+			p.logger.Debug().AnErr("err", err).Msg(fmt.Sprint("failed to fetch candles for pair ", cp))
 			continue
 		}
 		candlePrices[cp.String()] = price

--- a/oracle/price-feeder/oracle/provider/huobi_test.go
+++ b/oracle/price-feeder/oracle/provider/huobi_test.go
@@ -81,9 +81,8 @@ func TestHuobiProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {
 		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "FOO", Quote: "BAR"})
-		require.Error(t, err)
-		require.Equal(t, "failed to get ticker price for FOOBAR", err.Error())
-		require.Nil(t, prices)
+		require.NoError(t, err)
+		require.Zero(t, len(prices))
 	})
 }
 

--- a/oracle/price-feeder/oracle/provider/kraken.go
+++ b/oracle/price-feeder/oracle/provider/kraken.go
@@ -162,7 +162,7 @@ func (p *KrakenProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[strin
 		tickerPrice, ok := p.tickers[key]
 		if !ok {
 			err := fmt.Errorf("failed to get ticker price for %s", key)
-			p.logger.Warn().Msg(fmt.Sprint("failed to fetch tickers for pair ", cp, " due to the following error ", err.Error()))
+			p.logger.Debug().AnErr("err", err).Msg(fmt.Sprint("failed to fetch tickers for pair ", cp))
 			continue
 		}
 		tickerPrices[key] = tickerPrice
@@ -179,7 +179,7 @@ func (p *KrakenProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[strin
 		key := cp.String()
 		candlePrice, err := p.getCandlePrices(key)
 		if err != nil {
-			p.logger.Warn().Msg(fmt.Sprint("failed to fetch candles for pair ", cp, " due to the following error ", err.Error()))
+			p.logger.Debug().AnErr("err", err).Msg(fmt.Sprint("failed to fetch candles for pair ", cp))
 			continue
 		}
 		candlePrices[key] = candlePrice

--- a/oracle/price-feeder/oracle/provider/kraken.go
+++ b/oracle/price-feeder/oracle/provider/kraken.go
@@ -161,7 +161,9 @@ func (p *KrakenProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[strin
 		key := cp.String()
 		tickerPrice, ok := p.tickers[key]
 		if !ok {
-			return nil, fmt.Errorf("failed to get ticker price for %s", key)
+			err := fmt.Errorf("failed to get ticker price for %s", key)
+			p.logger.Warn().Msg(fmt.Sprint("failed to fetch tickers for pair ", cp, " due to the following error ", err.Error()))
+			continue
 		}
 		tickerPrices[key] = tickerPrice
 	}
@@ -177,7 +179,8 @@ func (p *KrakenProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[strin
 		key := cp.String()
 		candlePrice, err := p.getCandlePrices(key)
 		if err != nil {
-			return nil, err
+			p.logger.Warn().Msg(fmt.Sprint("failed to fetch candles for pair ", cp, " due to the following error ", err.Error()))
+			continue
 		}
 		candlePrices[key] = candlePrice
 	}

--- a/oracle/price-feeder/oracle/provider/kraken_test.go
+++ b/oracle/price-feeder/oracle/provider/kraken_test.go
@@ -71,9 +71,8 @@ func TestKrakenProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {
 		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "FOO", Quote: "BAR"})
-		require.Error(t, err)
-		require.Equal(t, "failed to get ticker price for FOOBAR", err.Error())
-		require.Nil(t, prices)
+		require.NoError(t, err)
+		require.Zero(t, len(prices))
 	})
 }
 

--- a/oracle/price-feeder/oracle/provider/mexc.go
+++ b/oracle/price-feeder/oracle/provider/mexc.go
@@ -159,7 +159,8 @@ func (p *MexcProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]
 		key := cp.String()
 		price, err := p.getTickerPrice(key)
 		if err != nil {
-			return nil, err
+			p.logger.Warn().Msg(fmt.Sprint("failed to fetch tickers for pair ", cp, " due to the following error ", err.Error()))
+			continue
 		}
 		tickerPrices[key] = price
 	}
@@ -175,7 +176,8 @@ func (p *MexcProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string]
 		key := cp.String()
 		prices, err := p.getCandlePrices(key)
 		if err != nil {
-			return nil, err
+			p.logger.Warn().Msg(fmt.Sprint("failed to fetch candles for pair ", cp, " due to the following error ", err.Error()))
+			continue
 		}
 		candlePrices[key] = prices
 	}

--- a/oracle/price-feeder/oracle/provider/mexc.go
+++ b/oracle/price-feeder/oracle/provider/mexc.go
@@ -159,7 +159,7 @@ func (p *MexcProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]
 		key := cp.String()
 		price, err := p.getTickerPrice(key)
 		if err != nil {
-			p.logger.Warn().Msg(fmt.Sprint("failed to fetch tickers for pair ", cp, " due to the following error ", err.Error()))
+			p.logger.Debug().AnErr("err", err).Msg(fmt.Sprint("failed to fetch tickers for pair ", cp))
 			continue
 		}
 		tickerPrices[key] = price
@@ -176,7 +176,7 @@ func (p *MexcProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string]
 		key := cp.String()
 		prices, err := p.getCandlePrices(key)
 		if err != nil {
-			p.logger.Warn().Msg(fmt.Sprint("failed to fetch candles for pair ", cp, " due to the following error ", err.Error()))
+			p.logger.Debug().AnErr("err", err).Msg(fmt.Sprint("failed to fetch candles for pair ", cp))
 			continue
 		}
 		candlePrices[key] = prices

--- a/oracle/price-feeder/oracle/provider/mexc_test.go
+++ b/oracle/price-feeder/oracle/provider/mexc_test.go
@@ -74,9 +74,8 @@ func TestMexcProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {
 		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "FOO", Quote: "BAR"})
-		require.Error(t, err)
-		require.Equal(t, "mexc provider failed to get ticker price for FOOBAR", err.Error())
-		require.Nil(t, prices)
+		require.NoError(t, err)
+		require.Zero(t, len(prices))
 	})
 }
 

--- a/oracle/price-feeder/oracle/provider/okx.go
+++ b/oracle/price-feeder/oracle/provider/okx.go
@@ -234,16 +234,17 @@ func (p *OkxProvider) subscribeTickers(cps ...types.CurrencyPair) error {
 	return p.subscribePairs(topics...)
 }
 
-// subscribeCandles subscribe all currency pairs into candle channel.
-func (p *OkxProvider) subscribeCandles(cps ...types.CurrencyPair) error {
-	topics := make([]OkxSubscriptionTopic, len(cps))
+// CONTEXT: commented out because okx candles are currently unused
+// // subscribeCandles subscribe all currency pairs into candle channel.
+// func (p *OkxProvider) subscribeCandles(cps ...types.CurrencyPair) error {
+// 	topics := make([]OkxSubscriptionTopic, len(cps))
 
-	for i, cp := range cps {
-		topics[i] = newOkxCandleSubscriptionTopic(currencyPairToOkxPair(cp))
-	}
+// 	for i, cp := range cps {
+// 		topics[i] = newOkxCandleSubscriptionTopic(currencyPairToOkxPair(cp))
+// 	}
 
-	return p.subscribePairs(topics...)
-}
+// 	return p.subscribePairs(topics...)
+// }
 
 // subscribedPairsToSlice returns the map of subscribed pairs as slice
 func (p *OkxProvider) subscribedPairsToSlice() []types.CurrencyPair {
@@ -528,13 +529,14 @@ func newOkxTickerSubscriptionTopic(instID string) OkxSubscriptionTopic {
 	}
 }
 
-// newOkxSubscriptionTopic returns a new subscription topic.
-func newOkxCandleSubscriptionTopic(instID string) OkxSubscriptionTopic {
-	return OkxSubscriptionTopic{
-		Channel: "candle1m",
-		InstID:  instID,
-	}
-}
+// CONTEXT: commented out because okx candles are unused
+// // newOkxSubscriptionTopic returns a new subscription topic.
+// func newOkxCandleSubscriptionTopic(instID string) OkxSubscriptionTopic {
+// 	return OkxSubscriptionTopic{
+// 		Channel: "candle1m",
+// 		InstID:  instID,
+// 	}
+// }
 
 // newOkxSubscriptionMsg returns a new subscription Msg for Okx.
 func newOkxSubscriptionMsg(args ...OkxSubscriptionTopic) OkxSubscriptionMsg {

--- a/oracle/price-feeder/oracle/provider/okx.go
+++ b/oracle/price-feeder/oracle/provider/okx.go
@@ -161,7 +161,7 @@ func (p *OkxProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]T
 	for _, currencyPair := range pairs {
 		price, err := p.getTickerPrice(currencyPair)
 		if err != nil {
-			p.logger.Warn().Msg(fmt.Sprint("failed to fetch tickers for pair ", currencyPair, " due to the following error ", err.Error()))
+			p.logger.Debug().AnErr("err", err).Msg(fmt.Sprint("failed to fetch tickers for pair ", currencyPair))
 			continue
 		}
 

--- a/oracle/price-feeder/oracle/provider/okx_test.go
+++ b/oracle/price-feeder/oracle/provider/okx_test.go
@@ -80,9 +80,8 @@ func TestOkxProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {
 		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "FOO", Quote: "BAR"})
-		require.Error(t, err)
-		require.Equal(t, "okx provider failed to get ticker price for FOO-BAR", err.Error())
-		require.Nil(t, prices)
+		require.NoError(t, err)
+		require.Zero(t, len(prices))
 	})
 }
 

--- a/scripts/initialize_local_chain.sh
+++ b/scripts/initialize_local_chain.sh
@@ -56,7 +56,7 @@ cat ~/.sei/config/genesis.json | jq '.app_state["gov"]["deposit_params"]["max_de
 cat ~/.sei/config/genesis.json | jq '.app_state["gov"]["voting_params"]["voting_period"]="30s"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 cat ~/.sei/config/genesis.json | jq '.app_state["gov"]["voting_params"]["expedited_voting_period"]="10s"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 cat ~/.sei/config/genesis.json | jq '.app_state["oracle"]["params"]["vote_period"]="2"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
-cat ~/.sei/config/genesis.json | jq '.app_state["oracle"]["params"]["whitelist"]=[{"name": "ueth"},{"name": "ubtc"},{"name": "uusdc"},{"name": "uusdt"}]' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
+cat ~/.sei/config/genesis.json | jq '.app_state["oracle"]["params"]["whitelist"]=[{"name": "ueth"},{"name": "ubtc"},{"name": "uusdc"},{"name": "uusdt"},{"name": "uosmo"},{"name": "uatom"},{"name": "usei"}]' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 cat ~/.sei/config/genesis.json | jq '.app_state["distribution"]["params"]["community_tax"]="0.000000000000000000"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 cat ~/.sei/config/genesis.json | jq '.consensus_params["block"]["max_gas"]="35000000"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
 


### PR DESCRIPTION
## Describe your changes and provide context
This does the following:
- adds some additional debug and warning logging
- Refactors the gate provider to use the new API that allows for subscribing to more than one currency pair
- removes the all or nothing behavior that prevents providers from returning prices unless ALL of their configured asset prices are available


## Testing performed to validate your change
Tested with oracle price feeder with local chain, need to test longer running on a loadtest cluster with steven's monitoring additions
