### PR TITLE
Cut v3.1.0 for version release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 -->
 
 # Changelog
+## v3.1.0
+sei-ibc-go:
+* [#34](https://github.com/sei-protocol/sei-ibc-go/pull/34) Upgrade to Ibc v3.2.0
+
 ## v3.0.9
 * [#154](https://github.com/sei-protocol/sei-tendermint/pull/154) Fix empty prevote latency metrics
 

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -59,6 +59,7 @@ var upgradesList = []string{
 	"3.0.7",
 	"3.0.8",
 	"v3.0.9",
+	"v3.1.0",
 }
 
 func (app App) RegisterUpgradeHandlers() {


### PR DESCRIPTION
Changes for 3.1.0 upgrade:
- Add upgrade handler for v3.1.0
- sei-ibc-go version has already been bumped

