### PR TITLE
Avoid re-initializing providers that fail initially

### DIFF
--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -528,6 +528,7 @@ func (o *Oracle) getOrSetProvider(ctx context.Context, providerName string) (pro
 		ok            bool
 	)
 
+	//TODO: replace with a exponential backoff mechanism
 	if err, ok := o.failedProviders[providerName]; ok {
 		return nil, errors.Wrap(err, "failed at first init (skipping provider)")
 	}

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -13,6 +13,7 @@ import (
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
@@ -37,6 +38,7 @@ type Oracle struct {
 	chainDenomMapping  map[string]string
 	previousVotePeriod float64
 	priceProviders     map[string]provider.Provider
+	failedProviders    map[string]error
 	oracleClient       client.OracleClient
 	deviations         map[string]sdk.Dec
 	endpoints          map[string]config.ProviderEndpoint
@@ -107,6 +109,7 @@ func New(
 		deviations:        deviations,
 		paramCache:        ParamCache{},
 		jailCache:         JailCache{},
+		failedProviders:   make(map[string]error),
 		endpoints:         endpoints,
 		healthchecks:      healthchecks,
 	}
@@ -231,6 +234,10 @@ func (o *Oracle) SetPrices(ctx context.Context) error {
 
 		priceProvider, err := o.getOrSetProvider(ctx, providerName)
 		if err != nil {
+			sendProviderFailureMetric([]string{"failure", "provider"}, 1, []metrics.Label{
+				{Name: "reason", Value: "init"},
+				{Name: "provider", Value: providerName},
+			})
 			o.logger.Debug().AnErr("err", err).Msgf("Failed to get or set provider %s", providerName)
 			continue // don't block everything on one provider having an issue
 		}
@@ -521,6 +528,10 @@ func (o *Oracle) getOrSetProvider(ctx context.Context, providerName string) (pro
 		ok            bool
 	)
 
+	if err, ok := o.failedProviders[providerName]; ok {
+		return nil, errors.Wrap(err, "failed at first init (skipping provider)")
+	}
+
 	priceProvider, ok = o.priceProviders[providerName]
 	if !ok {
 		newProvider, err := NewProvider(
@@ -531,6 +542,7 @@ func (o *Oracle) getOrSetProvider(ctx context.Context, providerName string) (pro
 			o.providerPairs[providerName]...,
 		)
 		if err != nil {
+			o.failedProviders[providerName] = err
 			return nil, err
 		}
 		priceProvider = newProvider
@@ -612,6 +624,8 @@ func (o *Oracle) tick(
 	clientCtx sdkclient.Context,
 	blockHeight int64) error {
 
+	startTime := time.Now().UTC()
+
 	o.logger.Debug().Msg(fmt.Sprintf("executing oracle tick for height %d", blockHeight))
 
 	if blockHeight < 1 {
@@ -649,6 +663,7 @@ func (o *Oracle) tick(
 			Int64("vote_period", oracleVotePeriod).
 			Float64("previous", o.previousVotePeriod).
 			Float64("current", currentVotePeriod).
+			Int64("tick_duration", time.Since(startTime).Milliseconds()).
 			Msg("skipping until next voting period")
 		return nil
 	}
@@ -680,17 +695,26 @@ func (o *Oracle) tick(
 		Str("validator", voteMsg.Validator).
 		Str("feeder", voteMsg.Feeder).
 		Float64("vote_period", currentVotePeriod).
+		Int64("tick_duration", time.Since(startTime).Milliseconds()).
 		Msg("Going to broadcast vote")
 
 	resp, err := o.oracleClient.BroadcastTx(clientCtx, voteMsg)
 	if err != nil {
+		o.logger.Error().Err(err).
+			Str("status", "failure").
+			Uint32("response_code", resp.Code).
+			Str("tx_hash", resp.TxHash).
+			Int64("tick_duration", time.Since(startTime).Milliseconds()).
+			Msg(fmt.Sprintf("broadcasted for height %d", blockHeight))
 		telemetry.IncrCounter(1, "failure", "broadcast")
 		return err
 	}
 	o.logger.Info().
+		Str("status", "success").
 		Uint32("response_code", resp.Code).
 		Str("tx_hash", resp.TxHash).
-		Msg(fmt.Sprintf("Successfully broadcasted for height %d", blockHeight))
+		Int64("tick_duration", time.Since(startTime).Milliseconds()).
+		Msg(fmt.Sprintf("broadcasted for height %d", blockHeight))
 	telemetry.IncrCounter(1, "success", "broadcast")
 
 	o.previousVotePeriod = currentVotePeriod

--- a/oracle/price-feeder/oracle/oracle_test.go
+++ b/oracle/price-feeder/oracle/oracle_test.go
@@ -489,7 +489,7 @@ func (ots *OracleTestSuite) TestPrices() {
 		config.ProviderKraken: mockProvider{
 			prices: map[string]provider.TickerPrice{
 				"UMEEUSDC": {
-					Price:  sdk.MustNewDecFromStr("3.70"),
+					Price:  sdk.MustNewDecFromStr("3.71"),
 					Volume: sdk.MustNewDecFromStr("1994674.34000000"),
 				},
 			},
@@ -521,7 +521,7 @@ func (ots *OracleTestSuite) TestPrices() {
 
 	prices = ots.oracle.GetPrices()
 	ots.Require().Len(prices, 3)
-	ots.Require().Equal(sdk.MustNewDecFromStr("3.70"), prices.AmountOf("uumee"))
+	ots.Require().Equal(sdk.MustNewDecFromStr("3.71"), prices.AmountOf("uumee"))
 	ots.Require().Equal(sdk.MustNewDecFromStr("1"), prices.AmountOf("uusdc"))
 	ots.Require().Equal(sdk.MustNewDecFromStr("1"), prices.AmountOf("uusdt"))
 }


### PR DESCRIPTION
## Describe your changes and provide context
- In US regions, binance clients never initialize
- Initializing takes ~500ms, which impacts price broadcasting cadence
- This quickfix avoids re-initializing binance repeatedly if it fails at startup

## Testing performed to validate your change
- unit test
- local testing
