### PR TITLE
Tolerate candles within same second as now

### DIFF
--- a/oracle/price-feeder/oracle/util.go
+++ b/oracle/price-feeder/oracle/util.go
@@ -111,7 +111,7 @@ func ComputeTVWAP(prices provider.AggregatedProviderCandles) (map[string]sdk.Dec
 			if !period.Equal(sdk.ZeroDec()) {
 				weightUnit = weightUnit.Sub(minimumTimeWeight).Quo(period)
 			}
-			
+
 			// get weighted prices, and sum of volumes
 			for _, candle := range cp {
 				// we only want candles within the last timePeriod

--- a/oracle/price-feeder/oracle/util.go
+++ b/oracle/price-feeder/oracle/util.go
@@ -1,7 +1,6 @@
 package oracle
 
 import (
-	"fmt"
 	"sort"
 	"time"
 
@@ -111,10 +110,8 @@ func ComputeTVWAP(prices provider.AggregatedProviderCandles) (map[string]sdk.Dec
 			// if zero, it would divide by zero
 			if !period.Equal(sdk.ZeroDec()) {
 				weightUnit = weightUnit.Sub(minimumTimeWeight).Quo(period)
-			} else {
-				fmt.Println("HERE")
 			}
-
+			
 			// get weighted prices, and sum of volumes
 			for _, candle := range cp {
 				// we only want candles within the last timePeriod

--- a/oracle/price-feeder/oracle/util.go
+++ b/oracle/price-feeder/oracle/util.go
@@ -105,11 +105,11 @@ func ComputeTVWAP(prices provider.AggregatedProviderCandles) (map[string]sdk.Dec
 			period := sdk.NewDec(now - cp[0].TimeStamp)
 
 			// weight unit is one, then decreased proportionately by candle age
-			weightUnit := sdk.OneDec()
+			weightUnit := sdk.OneDec().Sub(minimumTimeWeight)
 
 			// if zero, it would divide by zero
 			if !period.Equal(sdk.ZeroDec()) {
-				weightUnit = weightUnit.Sub(minimumTimeWeight).Quo(period)
+				weightUnit = weightUnit.Quo(period)
 			}
 
 			// get weighted prices, and sum of volumes


### PR DESCRIPTION
## Describe your changes and provide context
- TVWAP calculation decreases a weight by time passed
- Before this change, it would return a divide-by-zero error
- Now it correctly starts the value as 1 if it's the same second
- This was occurring every few hours in arctic-1

## Testing performed to validate your change
- unit testing
- local chain testing (though we need to watch it over time in envs)
