### PR TITLE
Fix metric for candle error

### DIFF
--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -267,7 +267,7 @@ func (o *Oracle) SetPrices(ctx context.Context) error {
 				if err != nil {
 					o.logger.Debug().Err(err).Msg("failed to get candle prices from provider")
 				}
-				reportPriceErrMetrics(providerName, "candle", prices, currencyPairs)
+				reportPriceErrMetrics(providerName, "candle", candles, currencyPairs)
 			}()
 
 			select {


### PR DESCRIPTION
## Describe your changes and provide context
- This was processing the set of ticker prices rather than candle prices
- This caused a lack of an error metric if ticker was fine, and candle was missing

## Testing performed to validate your change
- Unit test to capture this scenario (good tickers, bad candle)
