### PR TITLE
Add tolerance to nil response for error log

### DIFF
--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -721,17 +721,17 @@ func (o *Oracle) tick(
 }
 
 func (o *Oracle) logResponseError(err error, resp *sdk.TxResponse, startTime time.Time, blockHeight int64) {
-	var responseCode uint32
+	responseCode := -1 // success is 0
 	var txHash string
 
 	if resp != nil {
-		responseCode = resp.Code
+		responseCode = int(resp.Code)
 		txHash = resp.TxHash
 	}
 
 	o.logger.Error().Err(err).
 		Str("status", "failure").
-		Uint32("response_code", responseCode).
+		Int("response_code", responseCode).
 		Str("tx_hash", txHash).
 		Int64("tick_duration", time.Since(startTime).Milliseconds()).
 		Msg(fmt.Sprintf("broadcasted for height %d", blockHeight))

--- a/oracle/price-feeder/oracle/oracle.go
+++ b/oracle/price-feeder/oracle/oracle.go
@@ -702,6 +702,7 @@ func (o *Oracle) tick(
 	resp, err := o.oracleClient.BroadcastTx(clientCtx, voteMsg)
 	if err != nil {
 		o.logResponseError(err, resp, startTime, blockHeight)
+		telemetry.IncrCounter(1, "failure", "broadcast")
 		return err
 	}
 
@@ -734,8 +735,6 @@ func (o *Oracle) logResponseError(err error, resp *sdk.TxResponse, startTime tim
 		Str("tx_hash", txHash).
 		Int64("tick_duration", time.Since(startTime).Milliseconds()).
 		Msg(fmt.Sprintf("broadcasted for height %d", blockHeight))
-
-	telemetry.IncrCounter(1, "failure", "broadcast")
 }
 
 func (o *Oracle) healthchecksPing() {


### PR DESCRIPTION
## Describe your changes and provide context
- If the broadcast request returns as nil response, the log statement would panic
- This makes the log statement tolerant to a nil response, causing a restart

## Testing performed to validate your change
- Reproduced and added unit test

