### PR TITLE
Add state-related function implementations in EVM state interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/CosmWasm/wasmd v0.27.0
 	github.com/CosmWasm/wasmvm v1.0.1
 	github.com/armon/go-metrics v0.4.0
+	github.com/btcsuite/btcd v0.22.1
 	github.com/cosmos/cosmos-sdk v0.45.10
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/iavl v0.19.4
@@ -19,6 +20,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
+	github.com/holiman/uint256 v1.2.3
 	github.com/justinas/alice v1.2.0
 	github.com/k0kubun/pp/v3 v3.2.0
 	github.com/mitchellh/mapstructure v1.5.0
@@ -66,7 +68,6 @@ require (
 	github.com/bombsimon/wsl/v3 v3.3.0 // indirect
 	github.com/breml/bidichk v0.2.3 // indirect
 	github.com/breml/errchkjson v0.3.0 // indirect
-	github.com/btcsuite/btcd v0.22.1 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.2.0 // indirect
 	github.com/butuzov/ireturn v0.1.1 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
@@ -103,7 +104,6 @@ require (
 	github.com/firefart/nonamedreturns v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/fzipp/gocyclo v0.5.1 // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-critic/go-critic v0.6.3 // indirect
 	github.com/go-kit/kit v0.12.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
@@ -151,7 +151,6 @@ require (
 	github.com/gostaticanalysis/nilerr v0.1.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
@@ -162,7 +161,6 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hdevalence/ed25519consensus v0.0.0-20210204194344-59a8610d2b87 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
-	github.com/holiman/uint256 v1.2.3 // indirect
 	github.com/improbable-eng/grpc-web v0.14.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/jgautheron/goconst v1.5.1 // indirect
@@ -288,7 +286,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.61
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.61-evm-2
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.7
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.2.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.mod
+++ b/go.mod
@@ -286,7 +286,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.61-evm-2
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.61
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.7
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.2.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.sum
+++ b/go.sum
@@ -1115,8 +1115,8 @@ github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+f
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.2.61-evm-2 h1:BJsJtckh1+bxfFxWh/O1RfN6JVmohqMj3u7d+RI9oRY=
-github.com/sei-protocol/sei-cosmos v0.2.61-evm-2/go.mod h1:IdRmfhjeuY+S3HLd+pSwsYdDt/j+egIk0KHyHMmXSgM=
+github.com/sei-protocol/sei-cosmos v0.2.61 h1:2BmRscI5ZPfTqRbBQpwrBMZ0vJeGRBBUoDwDUwPnlGA=
+github.com/sei-protocol/sei-cosmos v0.2.61/go.mod h1:IdRmfhjeuY+S3HLd+pSwsYdDt/j+egIk0KHyHMmXSgM=
 github.com/sei-protocol/sei-iavl v0.1.7 h1:cUdHDBkxs0FF/kOt1qCVLm0K+Bqaw92/dbZSgn4kxiA=
 github.com/sei-protocol/sei-iavl v0.1.7/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-ibc-go/v3 v3.2.0 h1:T8V75OEWKvYDraPZZKilprl7ZkahZYGo40crxNL4unc=

--- a/go.sum
+++ b/go.sum
@@ -369,7 +369,6 @@ github.com/fullstorydev/grpcurl v1.6.0/go.mod h1:ZQ+ayqbKMJNhzLmbpCiurTVlaK2M/3n
 github.com/fzipp/gocyclo v0.5.1 h1:L66amyuYogbxl0j2U+vGqJXusPF2IkduvXLnYD5TFgw=
 github.com/fzipp/gocyclo v0.5.1/go.mod h1:rXPyn8fnlpa0R2csP/31uerbiVBugk5whMdlyaLkLoA=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
@@ -632,8 +631,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.12.1/go.mod h1:8XEsbTttt/W+VvjtQhLACqCisSPWTxCZ7sBRjU6iH9c=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0 h1:RtRsiaGvWxcwd8y3BiRZxsylPT8hLWZ5SPcfI+3IDNk=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0/go.mod h1:TzP6duP4Py2pHLVPPQp42aoYI92+PCrVotyR5e8Vqlk=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
@@ -1118,8 +1115,8 @@ github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+f
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.2.61 h1:2BmRscI5ZPfTqRbBQpwrBMZ0vJeGRBBUoDwDUwPnlGA=
-github.com/sei-protocol/sei-cosmos v0.2.61/go.mod h1:IdRmfhjeuY+S3HLd+pSwsYdDt/j+egIk0KHyHMmXSgM=
+github.com/sei-protocol/sei-cosmos v0.2.61-evm-2 h1:BJsJtckh1+bxfFxWh/O1RfN6JVmohqMj3u7d+RI9oRY=
+github.com/sei-protocol/sei-cosmos v0.2.61-evm-2/go.mod h1:IdRmfhjeuY+S3HLd+pSwsYdDt/j+egIk0KHyHMmXSgM=
 github.com/sei-protocol/sei-iavl v0.1.7 h1:cUdHDBkxs0FF/kOt1qCVLm0K+Bqaw92/dbZSgn4kxiA=
 github.com/sei-protocol/sei-iavl v0.1.7/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-ibc-go/v3 v3.2.0 h1:T8V75OEWKvYDraPZZKilprl7ZkahZYGo40crxNL4unc=

--- a/x/evm/keeper/address.go
+++ b/x/evm/keeper/address.go
@@ -12,6 +12,12 @@ func (k *Keeper) SetAddressMapping(ctx sdk.Context, seiAddress sdk.AccAddress, e
 	store.Set(types.SeiAddressToEVMAddressKey(seiAddress), evmAddress[:])
 }
 
+func (k *Keeper) DeleteAddressMapping(ctx sdk.Context, seiAddress sdk.AccAddress, evmAddress common.Address) {
+	store := ctx.KVStore(k.storeKey)
+	store.Delete(types.EVMAddressToSeiAddressKey(evmAddress))
+	store.Delete(types.SeiAddressToEVMAddressKey(seiAddress))
+}
+
 func (k *Keeper) GetEVMAddress(ctx sdk.Context, seiAddress sdk.AccAddress) (common.Address, bool) {
 	store := ctx.KVStore(k.storeKey)
 	bz := store.Get(types.SeiAddressToEVMAddressKey(seiAddress))

--- a/x/evm/keeper/address_test.go
+++ b/x/evm/keeper/address_test.go
@@ -21,3 +21,20 @@ func TestSetGetAddressMapping(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, seiAddr, foundSei)
 }
+
+func TestDeleteAddressMapping(t *testing.T) {
+	k, _, ctx := MockEVMKeeper()
+	seiAddr, evmAddr := MockAddressPair()
+	k.SetAddressMapping(ctx, seiAddr, evmAddr)
+	foundEVM, ok := k.GetEVMAddress(ctx, seiAddr)
+	require.True(t, ok)
+	require.Equal(t, evmAddr, foundEVM)
+	foundSei, ok := k.GetSeiAddress(ctx, evmAddr)
+	require.True(t, ok)
+	require.Equal(t, seiAddr, foundSei)
+	k.DeleteAddressMapping(ctx, seiAddr, evmAddr)
+	foundEVM, ok = k.GetEVMAddress(ctx, seiAddr)
+	require.False(t, ok)
+	foundSei, ok = k.GetSeiAddress(ctx, evmAddr)
+	require.False(t, ok)
+}

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"math/big"
 
+	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
@@ -53,4 +54,22 @@ func (k *Keeper) GetModuleBalance(ctx sdk.Context) *big.Int {
 
 func (k *Keeper) GetStoreKey() sdk.StoreKey {
 	return k.storeKey
+}
+
+func (k *Keeper) PrefixStore(ctx sdk.Context, pref []byte) sdk.KVStore {
+	store := ctx.KVStore(k.GetStoreKey())
+	return prefix.NewStore(store, pref)
+}
+
+func (k *Keeper) PurgePrefix(ctx sdk.Context, pref []byte) {
+	store := k.PrefixStore(ctx, pref)
+	iter := store.Iterator(nil, nil)
+	keys := [][]byte{}
+	for ; iter.Valid(); iter.Next() {
+		keys = append(keys, iter.Key())
+	}
+	iter.Close()
+	for _, key := range keys {
+		store.Delete(key)
+	}
 }

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -50,3 +50,7 @@ func (k *Keeper) BankKeeper() bankkeeper.Keeper {
 func (k *Keeper) GetModuleBalance(ctx sdk.Context) *big.Int {
 	return k.BankKeeper().GetBalance(ctx, k.AccountKeeper().GetModuleAddress(types.ModuleName), k.GetBaseDenom(ctx)).Amount.BigInt()
 }
+
+func (k *Keeper) GetStoreKey() sdk.StoreKey {
+	return k.storeKey
+}

--- a/x/evm/state/balance.go
+++ b/x/evm/state/balance.go
@@ -11,12 +11,6 @@ import (
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
 
-func (s *StateDBImpl) CreateAccount(common.Address) {
-	// noop
-	// EVM account creation is handled in ante handlers.
-	// State initialization is handled in Get/SetState
-}
-
 func (s *StateDBImpl) SubBalance(evmAddr common.Address, amt *big.Int) {
 	if amt.Sign() == 0 {
 		return

--- a/x/evm/state/balance.go
+++ b/x/evm/state/balance.go
@@ -11,6 +11,16 @@ import (
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
 
+var (
+	// changes to EVM module balance because of balance movements. If this value
+	// does not equal to the change in EVM module account balance minus the minted
+	// amount at the end of the execution, the transaction should fail.
+	DeficitKey = []byte{0x01}
+	// the number of base tokens minted to temporarily facilitate balance movements.
+	// At the end of execution, `minted` number of base tokens will be burnt.
+	MintedKey = []byte{0x02}
+)
+
 func (s *StateDBImpl) SubBalance(evmAddr common.Address, amt *big.Int) {
 	if amt.Sign() == 0 {
 		return
@@ -20,7 +30,7 @@ func (s *StateDBImpl) SubBalance(evmAddr common.Address, amt *big.Int) {
 		return
 	}
 	defer func() {
-		s.deficit = new(big.Int).Sub(s.deficit, amt)
+		s.AddBigIntTransientModuleState(new(big.Int).Neg(amt), DeficitKey)
 	}()
 
 	if seiAddr, ok := s.k.GetSeiAddress(s.ctx, evmAddr); ok {
@@ -48,7 +58,7 @@ func (s *StateDBImpl) AddBalance(evmAddr common.Address, amt *big.Int) {
 		return
 	}
 	defer func() {
-		s.deficit = new(big.Int).Add(s.deficit, amt)
+		s.AddBigIntTransientModuleState(amt, DeficitKey)
 	}()
 
 	if seiAddr, ok := s.k.GetSeiAddress(s.ctx, evmAddr); ok {
@@ -61,7 +71,7 @@ func (s *StateDBImpl) AddBalance(evmAddr common.Address, amt *big.Int) {
 			if s.err != nil {
 				return
 			}
-			s.minted = new(big.Int).Add(s.minted, amt)
+			s.AddBigIntTransientModuleState(amt, MintedKey)
 		}
 		s.err = s.k.BankKeeper().SendCoinsFromModuleToAccount(s.ctx, types.ModuleName, seiAddr, coins)
 		return
@@ -88,14 +98,41 @@ func (s *StateDBImpl) CheckBalance() error {
 		return errors.New("should not call CheckBalance if there is already an error during execution")
 	}
 	currentModuleBalance := s.k.GetModuleBalance(s.ctx)
-	effectiveCurrentModuleBalance := new(big.Int).Sub(currentModuleBalance, s.minted)
-	expectedCurrentModuleBalance := new(big.Int).Sub(s.initialModuleBalance, s.deficit)
+	minted := s.GetBigIntTransientModuleState(MintedKey)
+	deficit := s.GetBigIntTransientModuleState(DeficitKey)
+	initialBalance := s.k.GetModuleBalance(s.snapshottedCtxs[0])
+	effectiveCurrentModuleBalance := new(big.Int).Sub(currentModuleBalance, minted)
+	expectedCurrentModuleBalance := new(big.Int).Sub(initialBalance, deficit)
 	if effectiveCurrentModuleBalance.Cmp(expectedCurrentModuleBalance) != 0 {
-		return fmt.Errorf("balance check failed. Initial balance: %s, current balance: %s, minted: %s, deficit: %s", s.initialModuleBalance, currentModuleBalance, s.minted, s.deficit)
+		return fmt.Errorf("balance check failed. Initial balance: %s, current balance: %s, minted: %s, deficit: %s", initialBalance, currentModuleBalance, minted, deficit)
 	}
 	// burn any minted token. If the function errors before, the state would be rolled back anyway
-	if err := s.k.BankKeeper().BurnCoins(s.ctx, types.ModuleName, sdk.NewCoins(sdk.NewCoin(s.k.GetBaseDenom(s.ctx), sdk.NewIntFromBigInt(s.minted)))); err != nil {
+	if err := s.k.BankKeeper().BurnCoins(s.ctx, types.ModuleName, sdk.NewCoins(sdk.NewCoin(s.k.GetBaseDenom(s.ctx), sdk.NewIntFromBigInt(minted)))); err != nil {
 		return err
 	}
 	return nil
+}
+
+func (s *StateDBImpl) AddBigIntTransientModuleState(delta *big.Int, key []byte) {
+	store := s.k.PrefixStore(s.ctx, types.TransientModuleStateKeyPrefix)
+	old := s.GetBigIntTransientModuleState(key)
+	new := new(big.Int).Add(old, delta)
+	sign := []byte{0}
+	if new.Sign() < 0 {
+		sign = []byte{1}
+	}
+	store.Set(key, append(sign, new.Bytes()...))
+}
+
+func (s *StateDBImpl) GetBigIntTransientModuleState(key []byte) *big.Int {
+	store := s.k.PrefixStore(s.ctx, types.TransientModuleStateKeyPrefix)
+	bz := store.Get(key)
+	if bz == nil {
+		return big.NewInt(0)
+	}
+	res := new(big.Int).SetBytes(bz[1:])
+	if bz[0] != 0 {
+		res = new(big.Int).Neg(res)
+	}
+	return res
 }

--- a/x/evm/state/state.go
+++ b/x/evm/state/state.go
@@ -1,0 +1,127 @@
+package state
+
+import (
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/sei-protocol/sei-chain/x/evm/types"
+)
+
+func (s *StateDBImpl) CreateAccount(acc common.Address) {
+	// clear any existing state but keep balance untouched
+	s.clearAccountState(acc)
+
+	s.created[acc.String()] = struct{}{}
+	delete(s.selfDestructedAccs, acc.String())
+}
+
+func (s *StateDBImpl) GetCommittedState(addr common.Address, hash common.Hash) common.Hash {
+	return s.getState(addr, hash, func(kv sdk.KVStore, h common.Hash) []byte { return kv.GetCommitted(h[:]) })
+}
+
+func (s *StateDBImpl) GetState(addr common.Address, hash common.Hash) common.Hash {
+	return s.getState(addr, hash, func(kv sdk.KVStore, h common.Hash) []byte { return kv.Get(h[:]) })
+}
+
+func (s *StateDBImpl) getState(addr common.Address, hash common.Hash, getter func(sdk.KVStore, common.Hash) []byte) common.Hash {
+	val := getter(s.prefixStore(addr), hash)
+	if val == nil {
+		return common.Hash{}
+	}
+	return common.BytesToHash(val)
+}
+
+func (s *StateDBImpl) SetState(addr common.Address, key common.Hash, val common.Hash) {
+	s.prefixStore(addr).Set(key[:], val[:])
+}
+
+func (s *StateDBImpl) GetTransientState(addr common.Address, key common.Hash) common.Hash {
+	if addrState, ok := s.transientStorage[addr.String()]; !ok {
+		return common.Hash{}
+	} else if val, ok := addrState[key.String()]; !ok {
+		return common.Hash{}
+	} else {
+		return common.BytesToHash(val)
+	}
+}
+
+func (s *StateDBImpl) SetTransientState(addr common.Address, key, value common.Hash) {
+	addrKey := addr.String()
+	if addrState, ok := s.transientStorage[addrKey]; !ok {
+		s.transientStorage[addrKey] = map[string][]byte{key.String(): value[:]}
+	} else {
+		addrState[key.String()] = value[:]
+	}
+}
+
+// burns account's balance
+// clear account's state except the transient state (in Ethereum transient states are
+// still available even after self destruction in the same tx)
+func (s *StateDBImpl) SelfDestruct(acc common.Address) {
+	var balance sdk.Coin
+	if seiAddr, ok := s.k.GetSeiAddress(s.ctx, acc); ok {
+		// send all useis from seiAddr to the EVM module
+		balance = s.k.BankKeeper().GetBalance(s.ctx, seiAddr, s.k.GetBaseDenom(s.ctx))
+		if balance.Amount.Int64() != 0 {
+			if err := s.k.BankKeeper().SendCoinsFromAccountToModule(s.ctx, seiAddr, types.ModuleName, sdk.NewCoins(balance)); err != nil {
+				s.err = err
+				return
+			}
+		}
+		// remove the association
+		s.k.DeleteAddressMapping(s.ctx, seiAddr, acc)
+	} else {
+		// get old EVM balance
+		balance = sdk.NewCoin(s.k.GetBaseDenom(s.ctx), sdk.NewIntFromUint64(s.k.GetBalance(s.ctx, acc)))
+		// set EVM balance to 0
+		s.k.SetOrDeleteBalance(s.ctx, acc, 0)
+	}
+
+	// burn all useis from the destructed account
+	if balance.Amount.Int64() != 0 {
+		if err := s.k.BankKeeper().BurnCoins(s.ctx, types.ModuleName, sdk.NewCoins(balance)); err != nil {
+			s.err = err
+			return
+		}
+	}
+
+	// clear account state
+	s.clearAccountState(acc)
+
+	// mark account as self-destructed
+	s.selfDestructedAccs[acc.String()] = struct{}{}
+	delete(s.created, acc.String())
+}
+
+func (s *StateDBImpl) SelfDestruct6780(acc common.Address) {
+	// only self-destruct if acc is newly created in the same block
+	if _, ok := s.created[acc.String()]; ok {
+		s.SelfDestruct(acc)
+	}
+}
+
+// the Ethereum semantics of HasSelfDestructed checks if the account is self destructed in the
+// **CURRENT** block
+func (s *StateDBImpl) HasSelfDestructed(acc common.Address) bool {
+	_, ok := s.selfDestructedAccs[acc.String()]
+	return ok
+}
+
+func (s *StateDBImpl) prefixStore(addr common.Address) sdk.KVStore {
+	store := s.ctx.KVStore(s.k.GetStoreKey())
+	pref := types.StateKey(addr)
+	return prefix.NewStore(store, pref)
+}
+
+func (s *StateDBImpl) clearAccountState(acc common.Address) {
+	store := s.prefixStore(acc)
+	iter := store.Iterator(nil, nil)
+	keys := [][]byte{}
+	for ; iter.Valid(); iter.Next() {
+		keys = append(keys, iter.Key())
+	}
+	iter.Close()
+	for _, key := range keys {
+		store.Delete(key)
+	}
+}

--- a/x/evm/state/state_test.go
+++ b/x/evm/state/state_test.go
@@ -1,0 +1,110 @@
+package state
+
+import (
+	"math/big"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/sei-protocol/sei-chain/x/evm/keeper"
+	"github.com/sei-protocol/sei-chain/x/evm/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestState(t *testing.T) {
+	k, _, ctx := keeper.MockEVMKeeper()
+	_, evmAddr := keeper.MockAddressPair()
+	statedb := NewStateDBImpl(ctx, k)
+	statedb.CreateAccount(evmAddr)
+	require.Contains(t, statedb.created, evmAddr.String())
+	require.NotContains(t, statedb.selfDestructedAccs, evmAddr.String())
+	statedb.AddBalance(evmAddr, big.NewInt(10))
+	k.BankKeeper().MintCoins(ctx, types.ModuleName, sdk.NewCoins(sdk.NewCoin(k.GetBaseDenom(ctx), sdk.NewInt(10))))
+	// set state to the committed store first
+	key := common.BytesToHash([]byte("abc"))
+	val := common.BytesToHash([]byte("def"))
+	statedb.SetState(evmAddr, key, val)
+	require.Equal(t, val, statedb.GetState(evmAddr, key))
+	require.Equal(t, val, statedb.GetCommittedState(evmAddr, key))
+	// fork the store and overwrite the key
+	statedb.ctx = ctx.WithMultiStore(ctx.MultiStore().CacheMultiStore())
+	newVal := common.BytesToHash([]byte("ghi"))
+	statedb.SetState(evmAddr, key, newVal)
+	require.Equal(t, newVal, statedb.GetState(evmAddr, key))
+	require.Equal(t, val, statedb.GetCommittedState(evmAddr, key))
+	tkey := common.BytesToHash([]byte("jkl"))
+	tval := common.BytesToHash([]byte("mno"))
+	statedb.SetTransientState(evmAddr, tkey, tval)
+	require.Equal(t, tval, statedb.GetTransientState(evmAddr, tkey))
+	// destruct should clear balance and state, but keep transient state. Committed state should also be accessible
+	statedb.SelfDestruct(evmAddr)
+	require.Equal(t, tval, statedb.GetTransientState(evmAddr, tkey))
+	require.Equal(t, common.Hash{}, statedb.GetState(evmAddr, key))
+	require.Equal(t, val, statedb.GetCommittedState(evmAddr, key))
+	require.Equal(t, big.NewInt(0), statedb.GetBalance(evmAddr))
+}
+
+func TestCreate(t *testing.T) {
+	k, _, ctx := keeper.MockEVMKeeper()
+	_, evmAddr := keeper.MockAddressPair()
+	statedb := NewStateDBImpl(ctx, k)
+	statedb.CreateAccount(evmAddr)
+	key := common.BytesToHash([]byte("abc"))
+	val := common.BytesToHash([]byte("def"))
+	tkey := common.BytesToHash([]byte("jkl"))
+	tval := common.BytesToHash([]byte("mno"))
+	statedb.SetState(evmAddr, key, val)
+	statedb.SetTransientState(evmAddr, tkey, tval)
+	statedb.AddBalance(evmAddr, big.NewInt(10))
+	k.BankKeeper().MintCoins(ctx, types.ModuleName, sdk.NewCoins(sdk.NewCoin(k.GetBaseDenom(ctx), sdk.NewInt(10))))
+	// recreate an account should clear its state, but keep its balance and transient state
+	statedb.CreateAccount(evmAddr)
+	require.Equal(t, tval, statedb.GetTransientState(evmAddr, tkey))
+	require.Equal(t, common.Hash{}, statedb.GetState(evmAddr, key))
+	require.Equal(t, big.NewInt(10), statedb.GetBalance(evmAddr))
+	require.Contains(t, statedb.created, evmAddr.String())
+	require.NotContains(t, statedb.selfDestructedAccs, evmAddr.String())
+	// recreate a destructed (in the same tx) account should clear its selfDestructed flag
+	statedb.SelfDestruct(evmAddr)
+	require.Equal(t, big.NewInt(0), statedb.GetBalance(evmAddr))
+	statedb.CreateAccount(evmAddr)
+	require.Equal(t, tval, statedb.GetTransientState(evmAddr, tkey))
+	require.Equal(t, common.Hash{}, statedb.GetState(evmAddr, key))
+	require.Equal(t, big.NewInt(0), statedb.GetBalance(evmAddr)) // cleared during SelfDestruct
+	require.Contains(t, statedb.created, evmAddr.String())
+	require.NotContains(t, statedb.selfDestructedAccs, evmAddr.String())
+}
+
+func TestSelfDestructAssociated(t *testing.T) {
+	k, _, ctx := keeper.MockEVMKeeper()
+	seiAddr, evmAddr := keeper.MockAddressPair()
+	k.SetAddressMapping(ctx, seiAddr, evmAddr)
+	statedb := NewStateDBImpl(ctx, k)
+	statedb.CreateAccount(evmAddr)
+	key := common.BytesToHash([]byte("abc"))
+	val := common.BytesToHash([]byte("def"))
+	tkey := common.BytesToHash([]byte("jkl"))
+	tval := common.BytesToHash([]byte("mno"))
+	statedb.SetState(evmAddr, key, val)
+	statedb.SetTransientState(evmAddr, tkey, tval)
+	amt := sdk.NewCoins(sdk.NewCoin(k.GetBaseDenom(ctx), sdk.NewInt(10)))
+	k.BankKeeper().MintCoins(ctx, types.ModuleName, amt)
+	k.BankKeeper().SendCoinsFromModuleToAccount(ctx, types.ModuleName, seiAddr, amt)
+
+	// SelfDestruct6780 should only act if the account is created in the same block
+	tmp := statedb.created
+	statedb.created = map[string]struct{}{}
+	statedb.SelfDestruct6780(evmAddr)
+	require.Equal(t, val, statedb.GetState(evmAddr, key))
+	statedb.created = tmp
+
+	// SelfDestruct6780 is equivalent to SelfDestruct if account is created in the same block
+	statedb.SelfDestruct6780(evmAddr)
+	require.Equal(t, tval, statedb.GetTransientState(evmAddr, tkey))
+	require.Equal(t, common.Hash{}, statedb.GetState(evmAddr, key))
+	require.Equal(t, big.NewInt(0), statedb.GetBalance(evmAddr))
+	require.Equal(t, big.NewInt(0), k.BankKeeper().GetBalance(ctx, seiAddr, k.GetBaseDenom(ctx)).Amount.BigInt())
+	// association should also be removed
+	_, ok := k.GetSeiAddress(ctx, evmAddr)
+	require.False(t, ok)
+}

--- a/x/evm/state/state_test.go
+++ b/x/evm/state/state_test.go
@@ -16,22 +16,21 @@ func TestState(t *testing.T) {
 	_, evmAddr := keeper.MockAddressPair()
 	statedb := NewStateDBImpl(ctx, k)
 	statedb.CreateAccount(evmAddr)
-	require.Contains(t, statedb.created, evmAddr.String())
-	require.NotContains(t, statedb.selfDestructedAccs, evmAddr.String())
+	require.True(t, statedb.created(evmAddr))
+	require.False(t, statedb.HasSelfDestructed(evmAddr))
 	statedb.AddBalance(evmAddr, big.NewInt(10))
-	k.BankKeeper().MintCoins(ctx, types.ModuleName, sdk.NewCoins(sdk.NewCoin(k.GetBaseDenom(ctx), sdk.NewInt(10))))
-	// set state to the committed store first
+	k.BankKeeper().MintCoins(statedb.ctx, types.ModuleName, sdk.NewCoins(sdk.NewCoin(k.GetBaseDenom(ctx), sdk.NewInt(10))))
 	key := common.BytesToHash([]byte("abc"))
 	val := common.BytesToHash([]byte("def"))
 	statedb.SetState(evmAddr, key, val)
 	require.Equal(t, val, statedb.GetState(evmAddr, key))
-	require.Equal(t, val, statedb.GetCommittedState(evmAddr, key))
+	require.Equal(t, common.Hash{}, statedb.GetCommittedState(evmAddr, key))
 	// fork the store and overwrite the key
-	statedb.ctx = ctx.WithMultiStore(ctx.MultiStore().CacheMultiStore())
+	statedb.Snapshot()
 	newVal := common.BytesToHash([]byte("ghi"))
 	statedb.SetState(evmAddr, key, newVal)
 	require.Equal(t, newVal, statedb.GetState(evmAddr, key))
-	require.Equal(t, val, statedb.GetCommittedState(evmAddr, key))
+	require.Equal(t, common.Hash{}, statedb.GetCommittedState(evmAddr, key))
 	tkey := common.BytesToHash([]byte("jkl"))
 	tval := common.BytesToHash([]byte("mno"))
 	statedb.SetTransientState(evmAddr, tkey, tval)
@@ -40,8 +39,9 @@ func TestState(t *testing.T) {
 	statedb.SelfDestruct(evmAddr)
 	require.Equal(t, tval, statedb.GetTransientState(evmAddr, tkey))
 	require.Equal(t, common.Hash{}, statedb.GetState(evmAddr, key))
-	require.Equal(t, val, statedb.GetCommittedState(evmAddr, key))
+	require.Equal(t, common.Hash{}, statedb.GetCommittedState(evmAddr, key))
 	require.Equal(t, big.NewInt(0), statedb.GetBalance(evmAddr))
+	require.True(t, statedb.HasSelfDestructed(evmAddr))
 }
 
 func TestCreate(t *testing.T) {
@@ -49,6 +49,7 @@ func TestCreate(t *testing.T) {
 	_, evmAddr := keeper.MockAddressPair()
 	statedb := NewStateDBImpl(ctx, k)
 	statedb.CreateAccount(evmAddr)
+	require.False(t, statedb.HasSelfDestructed(evmAddr))
 	key := common.BytesToHash([]byte("abc"))
 	val := common.BytesToHash([]byte("def"))
 	tkey := common.BytesToHash([]byte("jkl"))
@@ -62,17 +63,18 @@ func TestCreate(t *testing.T) {
 	require.Equal(t, tval, statedb.GetTransientState(evmAddr, tkey))
 	require.Equal(t, common.Hash{}, statedb.GetState(evmAddr, key))
 	require.Equal(t, big.NewInt(10), statedb.GetBalance(evmAddr))
-	require.Contains(t, statedb.created, evmAddr.String())
-	require.NotContains(t, statedb.selfDestructedAccs, evmAddr.String())
+	require.True(t, statedb.created(evmAddr))
+	require.False(t, statedb.HasSelfDestructed(evmAddr))
 	// recreate a destructed (in the same tx) account should clear its selfDestructed flag
 	statedb.SelfDestruct(evmAddr)
+	require.True(t, statedb.HasSelfDestructed(evmAddr))
 	require.Equal(t, big.NewInt(0), statedb.GetBalance(evmAddr))
 	statedb.CreateAccount(evmAddr)
 	require.Equal(t, tval, statedb.GetTransientState(evmAddr, tkey))
 	require.Equal(t, common.Hash{}, statedb.GetState(evmAddr, key))
 	require.Equal(t, big.NewInt(0), statedb.GetBalance(evmAddr)) // cleared during SelfDestruct
-	require.Contains(t, statedb.created, evmAddr.String())
-	require.NotContains(t, statedb.selfDestructedAccs, evmAddr.String())
+	require.True(t, statedb.created(evmAddr))
+	require.False(t, statedb.HasSelfDestructed(evmAddr))
 }
 
 func TestSelfDestructAssociated(t *testing.T) {
@@ -88,15 +90,15 @@ func TestSelfDestructAssociated(t *testing.T) {
 	statedb.SetState(evmAddr, key, val)
 	statedb.SetTransientState(evmAddr, tkey, tval)
 	amt := sdk.NewCoins(sdk.NewCoin(k.GetBaseDenom(ctx), sdk.NewInt(10)))
-	k.BankKeeper().MintCoins(ctx, types.ModuleName, amt)
-	k.BankKeeper().SendCoinsFromModuleToAccount(ctx, types.ModuleName, seiAddr, amt)
+	k.BankKeeper().MintCoins(statedb.ctx, types.ModuleName, amt)
+	k.BankKeeper().SendCoinsFromModuleToAccount(statedb.ctx, types.ModuleName, seiAddr, amt)
 
 	// SelfDestruct6780 should only act if the account is created in the same block
-	tmp := statedb.created
-	statedb.created = map[string]struct{}{}
+	statedb.markAccount(evmAddr, nil)
 	statedb.SelfDestruct6780(evmAddr)
 	require.Equal(t, val, statedb.GetState(evmAddr, key))
-	statedb.created = tmp
+	statedb.markAccount(evmAddr, AccountCreated)
+	require.False(t, statedb.HasSelfDestructed(evmAddr))
 
 	// SelfDestruct6780 is equivalent to SelfDestruct if account is created in the same block
 	statedb.SelfDestruct6780(evmAddr)
@@ -104,7 +106,46 @@ func TestSelfDestructAssociated(t *testing.T) {
 	require.Equal(t, common.Hash{}, statedb.GetState(evmAddr, key))
 	require.Equal(t, big.NewInt(0), statedb.GetBalance(evmAddr))
 	require.Equal(t, big.NewInt(0), k.BankKeeper().GetBalance(ctx, seiAddr, k.GetBaseDenom(ctx)).Amount.BigInt())
+	require.True(t, statedb.HasSelfDestructed(evmAddr))
+	require.False(t, statedb.created(evmAddr))
 	// association should also be removed
-	_, ok := k.GetSeiAddress(ctx, evmAddr)
+	_, ok := k.GetSeiAddress(statedb.ctx, evmAddr)
 	require.False(t, ok)
+}
+
+func TestSnapshot(t *testing.T) {
+	k, _, ctx := keeper.MockEVMKeeper()
+	seiAddr, evmAddr := keeper.MockAddressPair()
+	k.SetAddressMapping(ctx, seiAddr, evmAddr)
+	statedb := NewStateDBImpl(ctx, k)
+	statedb.CreateAccount(evmAddr)
+	key := common.BytesToHash([]byte("abc"))
+	val := common.BytesToHash([]byte("def"))
+	tkey := common.BytesToHash([]byte("jkl"))
+	tval := common.BytesToHash([]byte("mno"))
+	statedb.SetState(evmAddr, key, val)
+	statedb.SetTransientState(evmAddr, tkey, tval)
+
+	rev := statedb.Snapshot()
+
+	newVal := common.BytesToHash([]byte("x"))
+	newTVal := common.BytesToHash([]byte("y"))
+	statedb.SetState(evmAddr, key, newVal)
+	statedb.SetTransientState(evmAddr, tkey, newTVal)
+
+	statedb.RevertToSnapshot(rev)
+
+	require.Equal(t, tval, statedb.GetTransientState(evmAddr, tkey))
+	require.Equal(t, val, statedb.GetState(evmAddr, key))
+
+	newStateDB := NewStateDBImpl(ctx, k)
+	// prev state DB not committed yet
+	require.Equal(t, common.Hash{}, newStateDB.GetTransientState(evmAddr, tkey))
+	require.Equal(t, common.Hash{}, newStateDB.GetState(evmAddr, key))
+
+	require.Nil(t, statedb.Finalize())
+	newStateDB = NewStateDBImpl(ctx, k)
+	// prev state DB committed except for transient states
+	require.Equal(t, common.Hash{}, newStateDB.GetTransientState(evmAddr, tkey))
+	require.Equal(t, val, newStateDB.GetState(evmAddr, key))
 }

--- a/x/evm/state/statedb.go
+++ b/x/evm/state/statedb.go
@@ -1,45 +1,50 @@
 package state
 
 import (
-	"math/big"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/sei-protocol/sei-chain/x/evm/keeper"
+	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
 
 // Initialized for each transaction individually
 type StateDBImpl struct {
-	ctx sdk.Context
+	ctx             sdk.Context
+	snapshottedCtxs []sdk.Context
 	// If err is not nil at the end of the execution, the transaction will be rolled
 	// back.
 	err error
 
-	// changes to EVM module balance because of balance movements. If this value
-	// does not equal to the change in EVM module account balance minus the minted
-	// amount at the end of the execution, the transaction should fail.
-	deficit *big.Int
-	// the number of base tokens minted to temporarily facilitate balance movements.
-	// At the end of execution, `minted` number of base tokens will be burnt.
-	minted *big.Int
-
-	initialModuleBalance *big.Int
-
 	k *keeper.Keeper
-
-	transientStorage   map[string]map[string][]byte
-	created            map[string]struct{}
-	selfDestructedAccs map[string]struct{}
 }
 
 func NewStateDBImpl(ctx sdk.Context, k *keeper.Keeper) *StateDBImpl {
-	return &StateDBImpl{
-		ctx:                  ctx,
-		k:                    k,
-		deficit:              big.NewInt(0),
-		minted:               big.NewInt(0),
-		initialModuleBalance: k.GetModuleBalance(ctx),
-		transientStorage:     map[string]map[string][]byte{},
-		created:              map[string]struct{}{},
-		selfDestructedAccs:   map[string]struct{}{},
+	s := &StateDBImpl{
+		ctx:             ctx,
+		k:               k,
+		snapshottedCtxs: []sdk.Context{},
 	}
+	s.Snapshot() // take an initial snapshot for GetCommitted
+	return s
+}
+
+func (s *StateDBImpl) Finalize() error {
+	if s.err != nil {
+		return s.err
+	}
+	if err := s.CheckBalance(); err != nil {
+		return err
+	}
+	// remove transient states
+	s.k.PurgePrefix(s.ctx, types.TransientStateKeyPrefix)
+	s.k.PurgePrefix(s.ctx, types.AccountTransientStateKeyPrefix)
+	s.k.PurgePrefix(s.ctx, types.TransientModuleStateKeyPrefix)
+
+	// write cache to underlying
+	s.ctx.MultiStore().(sdk.CacheMultiStore).Write()
+	// write all snapshotted caches in reverse order, except the very first one
+	for i := len(s.snapshottedCtxs) - 1; i > 0; i-- {
+		s.snapshottedCtxs[i].MultiStore().(sdk.CacheMultiStore).Write()
+	}
+
+	return nil
 }

--- a/x/evm/state/statedb.go
+++ b/x/evm/state/statedb.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sei-protocol/sei-chain/x/evm/keeper"
 )
 
+// Initialized for each transaction individually
 type StateDBImpl struct {
 	ctx sdk.Context
 	// If err is not nil at the end of the execution, the transaction will be rolled
@@ -24,6 +25,10 @@ type StateDBImpl struct {
 	initialModuleBalance *big.Int
 
 	k *keeper.Keeper
+
+	transientStorage   map[string]map[string][]byte
+	created            map[string]struct{}
+	selfDestructedAccs map[string]struct{}
 }
 
 func NewStateDBImpl(ctx sdk.Context, k *keeper.Keeper) *StateDBImpl {
@@ -33,5 +38,8 @@ func NewStateDBImpl(ctx sdk.Context, k *keeper.Keeper) *StateDBImpl {
 		deficit:              big.NewInt(0),
 		minted:               big.NewInt(0),
 		initialModuleBalance: k.GetModuleBalance(ctx),
+		transientStorage:     map[string]map[string][]byte{},
+		created:              map[string]struct{}{},
+		selfDestructedAccs:   map[string]struct{}{},
 	}
 }

--- a/x/evm/types/keys.go
+++ b/x/evm/types/keys.go
@@ -21,7 +21,8 @@ const (
 var (
 	BalanceKeyPrefix                = []byte{0x01}
 	EVMAddressToSeiAddressKeyPrefix = []byte{0x02}
-	SeiAddressToEVMAddressKeyPrefix = []byte{0x02}
+	SeiAddressToEVMAddressKeyPrefix = []byte{0x03}
+	StateKeyPrefix                  = []byte{0x04}
 )
 
 func BalanceKey(addr common.Address) []byte {
@@ -34,4 +35,8 @@ func EVMAddressToSeiAddressKey(evmAddress common.Address) []byte {
 
 func SeiAddressToEVMAddressKey(seiAddress sdk.AccAddress) []byte {
 	return append(SeiAddressToEVMAddressKeyPrefix, seiAddress...)
+}
+
+func StateKey(evmAddress common.Address) []byte {
+	return append(StateKeyPrefix, evmAddress[:]...)
 }

--- a/x/evm/types/keys.go
+++ b/x/evm/types/keys.go
@@ -23,6 +23,9 @@ var (
 	EVMAddressToSeiAddressKeyPrefix = []byte{0x02}
 	SeiAddressToEVMAddressKeyPrefix = []byte{0x03}
 	StateKeyPrefix                  = []byte{0x04}
+	TransientStateKeyPrefix         = []byte{0x05}
+	AccountTransientStateKeyPrefix  = []byte{0x06}
+	TransientModuleStateKeyPrefix   = []byte{0x07}
 )
 
 func BalanceKey(addr common.Address) []byte {
@@ -39,4 +42,8 @@ func SeiAddressToEVMAddressKey(seiAddress sdk.AccAddress) []byte {
 
 func StateKey(evmAddress common.Address) []byte {
 	return append(StateKeyPrefix, evmAddress[:]...)
+}
+
+func TransientStateKey(evmAddress common.Address) []byte {
+	return append(TransientStateKeyPrefix, evmAddress[:]...)
 }


### PR DESCRIPTION
## Describe your changes and provide context
Implement functions to initialize/get/set/destruct state in EVM state interface. Specifically,
- Get/SetState sets a KV entry under a specified account prefix
- GetCommittedState is similar to GetState but reads from the state as if at the beginning of the transaction (i.e. skip the cache layer and go directly to the parent. See corresponding sei-cosmos extension here: https://github.com/sei-protocol/sei-cosmos/pull/319)
- Get/SetTransientState writes to a in-memory map under a specified account prefix, and is not committed to KV store.
- SelfDestruct would burn account's balance and clear its state, but leave transient state untouched (as per go-ethereum behavior)
- SelfDestruct6780 is equivalent to SelfDestruct iff the account is newly created in the same block
- CreateAccount marks an account as created in the current block (a transient marker). If the account already exists, it wipes its state, but leaves the transient state and balance untouched (as per go-ethereum behavior)

## Testing performed to validate your change
unit tests

