### PR TITLE
Have local chain accept connections from any origin

### DIFF
--- a/scripts/initialize_local_chain.sh
+++ b/scripts/initialize_local_chain.sh
@@ -82,6 +82,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   sed -i 's/timeout_precommit =.*/timeout_precommit = "2000ms"/g' $CONFIG_PATH
   sed -i 's/timeout_commit =.*/timeout_commit = "2000ms"/g' $CONFIG_PATH
   sed -i 's/skip_timeout_commit =.*/skip_timeout_commit = false/g' $CONFIG_PATH
+  sed -i 's/cors-allowed-origins =.*/cors-allowed-origins = ["\*"]/g' $CONFIG_PATH
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   sed -i '' 's/mode = "full"/mode = "validator"/g' $CONFIG_PATH
   sed -i '' 's/indexer = \["null"\]/indexer = \["kv"\]/g' $CONFIG_PATH
@@ -90,6 +91,7 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
   sed -i '' 's/unsafe-vote-timeout-override =.*/unsafe-vote-timeout-override = "2s"/g' $CONFIG_PATH
   sed -i '' 's/unsafe-vote-timeout-delta-override =.*/unsafe-vote-timeout-delta-override = "2s"/g' $CONFIG_PATH
   sed -i '' 's/unsafe-commit-timeout-override =.*/unsafe-commit-timeout-override = "2s"/g' $CONFIG_PATH
+  sed -i '' 's/cors-allowed-origins =.*/cors-allowed-origins = ["\*"]/g' $CONFIG_PATH
 else
   printf "Platform not supported, please ensure that the following values are set in your config.toml:\n"
   printf "###         Consensus Configuration Options         ###\n"


### PR DESCRIPTION
## Describe your changes and provide context
This sets `cors-allowed-origins` of the auto-generated config file to `["*"]`, allowing for the RPC node to be used during front-end testing.

## Testing performed to validate your change
- [x] Script ran on Linux, header present when doing a cross-origin call.
- [ ] Untested on MacOS