### PR TITLE
[EVM] add endpoint to return fee history

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/compatiblity_check.yml
+++ b/.github/workflows/compatiblity_check.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.21'
 
       - name: Check Latest Dependencies
         run: |

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.20'
+        go-version: '1.21'
 
     - name: Fuzz Place Order Msg
       run: go test github.com/sei-protocol/sei-chain/x/dex/keeper/msgserver -fuzz FuzzPlaceOrders -fuzztime 30s

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version': '1.20'
+          go-version: '1.21.3'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.21'
 
       - name: Start 4 node docker cluster
         run: make clean && INVARIANT_CHECK_INTERVAL=10 make docker-cluster-start &

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.21'
 
       # Download all coverage reports from the 'tests' job
       - name: Download coverage reports

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # docker build . -t sei-protocol/sei:latest
 # docker run --rm -it sei-protocol/sei:latest /bin/sh
-FROM golang:1.20-alpine AS go-builder
+FROM golang:1.21-alpine AS go-builder
 
 # this comes from standard alpine nightly file
 #  https://github.com/rust-lang/docker-rust-nightly/blob/master/alpine3.12/Dockerfile

--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -19,11 +19,11 @@ import (
 type BlockAPI struct {
 	tmClient    rpcclient.Client
 	keeper      *keeper.Keeper
-	ctxProvider func() sdk.Context
+	ctxProvider func(int64) sdk.Context
 	txDecoder   sdk.TxDecoder
 }
 
-func NewBlockAPI(tmClient rpcclient.Client, k *keeper.Keeper, ctxProvider func() sdk.Context, txDecoder sdk.TxDecoder) *BlockAPI {
+func NewBlockAPI(tmClient rpcclient.Client, k *keeper.Keeper, ctxProvider func(int64) sdk.Context, txDecoder sdk.TxDecoder) *BlockAPI {
 	return &BlockAPI{tmClient: tmClient, keeper: k, ctxProvider: ctxProvider, txDecoder: txDecoder}
 }
 
@@ -58,7 +58,7 @@ func (a *BlockAPI) GetBlockByHash(ctx context.Context, blockHash common.Hash, fu
 	if err != nil {
 		return nil, err
 	}
-	return encodeTmBlock(a.ctxProvider(), block, blockRes, a.keeper, a.txDecoder, fullTx)
+	return encodeTmBlock(a.ctxProvider(LatestCtxHeight), block, blockRes, a.keeper, a.txDecoder, fullTx)
 }
 
 func (a *BlockAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (map[string]interface{}, error) {
@@ -74,7 +74,7 @@ func (a *BlockAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber,
 	if err != nil {
 		return nil, err
 	}
-	return encodeTmBlock(a.ctxProvider(), block, blockRes, a.keeper, a.txDecoder, fullTx)
+	return encodeTmBlock(a.ctxProvider(LatestCtxHeight), block, blockRes, a.keeper, a.txDecoder, fullTx)
 }
 
 func getBlockNumber(ctx context.Context, tmClient rpcclient.Client, number rpc.BlockNumber) (*int64, error) {

--- a/evmrpc/info.go
+++ b/evmrpc/info.go
@@ -1,0 +1,143 @@
+package evmrpc
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"slices"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/sei-protocol/sei-chain/x/evm/keeper"
+	rpcclient "github.com/tendermint/tendermint/rpc/client"
+	"github.com/tendermint/tendermint/rpc/coretypes"
+)
+
+type InfoAPI struct {
+	tmClient    rpcclient.Client
+	keeper      *keeper.Keeper
+	ctxProvider func(int64) sdk.Context
+	txDecoder   sdk.TxDecoder
+}
+
+func NewInfoAPI(tmClient rpcclient.Client, k *keeper.Keeper, ctxProvider func(int64) sdk.Context, txDecoder sdk.TxDecoder) *InfoAPI {
+	return &InfoAPI{tmClient: tmClient, keeper: k, ctxProvider: ctxProvider, txDecoder: txDecoder}
+}
+
+type FeeHistoryResult struct {
+	OldestBlock  *hexutil.Big     `json:"oldestBlock"`
+	Reward       [][]*hexutil.Big `json:"reward,omitempty"`
+	BaseFee      []*hexutil.Big   `json:"baseFeePerGas,omitempty"`
+	GasUsedRatio []float64        `json:"gasUsedRatio"`
+}
+
+// lastBlock is inclusive
+func (i *InfoAPI) FeeHistory(ctx context.Context, blockCount math.HexOrDecimal64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*FeeHistoryResult, error) {
+	result := FeeHistoryResult{}
+
+	// validate reward percentiles
+	for i, p := range rewardPercentiles {
+		if p < 0 || p > 100 || (i > 0 && p < rewardPercentiles[i-1]) {
+			return nil, errors.New("invalid reward percentiles: must be ascending and between 0 and 100")
+		}
+	}
+
+	lastBlockNumber := lastBlock.Int64()
+	genesis, err := i.tmClient.Genesis(ctx)
+	if err != nil {
+		return nil, err
+	}
+	genesisHeight := genesis.Genesis.InitialHeight
+	currentHeight := i.ctxProvider(LatestCtxHeight).BlockHeight()
+	switch lastBlock {
+	case rpc.SafeBlockNumber, rpc.FinalizedBlockNumber, rpc.LatestBlockNumber, rpc.PendingBlockNumber:
+		lastBlockNumber = currentHeight
+	case rpc.EarliestBlockNumber:
+		lastBlockNumber = genesisHeight
+	default:
+		if lastBlockNumber > currentHeight {
+			lastBlockNumber = currentHeight
+		}
+	}
+
+	if lastBlockNumber < genesisHeight {
+		return nil, errors.New("requested last block is before genesis height")
+	}
+
+	if uint64(lastBlockNumber-genesisHeight) < uint64(blockCount) {
+		result.OldestBlock = (*hexutil.Big)(big.NewInt(genesisHeight))
+	} else {
+		result.OldestBlock = (*hexutil.Big)(big.NewInt(lastBlockNumber - int64(blockCount) + 1))
+	}
+
+	// Potentially parallelize the following logic
+	for blockNum := result.OldestBlock.ToInt().Int64(); blockNum <= lastBlockNumber; blockNum++ {
+		result.GasUsedRatio = append(result.GasUsedRatio, GasUsedRatio)
+		sdkCtx := i.ctxProvider(blockNum)
+		baseFee := i.keeper.GetBaseFeePerGas(sdkCtx).BigInt()
+		result.BaseFee = append(result.BaseFee, (*hexutil.Big)(baseFee))
+		height := blockNum
+		block, err := i.tmClient.Block(ctx, &height)
+		if err != nil {
+			return nil, err
+		}
+		rewards, err := i.getRewards(block, baseFee, rewardPercentiles)
+		if err != nil {
+			return nil, err
+		}
+		result.Reward = append(result.Reward, rewards)
+	}
+	return &result, nil
+}
+
+type gasAndReward struct {
+	gasUsed uint64
+	reward  uint64
+}
+
+func (i *InfoAPI) getRewards(block *coretypes.ResultBlock, baseFee *big.Int, rewardPercentiles []float64) ([]*hexutil.Big, error) {
+	gasAndRewards := []gasAndReward{}
+	totalEVMGasUsed := uint64(0)
+	for _, txbz := range block.Block.Txs {
+		ethtx := getEthTxForTxBz(txbz, i.txDecoder)
+		if ethtx == nil {
+			// not evm tx
+			continue
+		}
+		// okay to get from latest since receipt is immutable
+		receipt, err := i.keeper.GetReceipt(i.ctxProvider(LatestCtxHeight), ethtx.Hash())
+		if err != nil {
+			return nil, err
+		}
+		gasAndRewards = append(gasAndRewards, gasAndReward{gasUsed: receipt.GasUsed, reward: receipt.EffectiveGasPrice - baseFee.Uint64()})
+		totalEVMGasUsed += receipt.GasUsed
+	}
+	return calculatePercentiles(rewardPercentiles, gasAndRewards, totalEVMGasUsed), nil
+}
+
+// Following go-ethereum implementation
+// Specifically, the reward value at a percentile of p% will be the reward value of the
+// lowest-rewarded transaction such that the sum of its gasUsed value and gasUsed values
+// of all lower-rewarded transactions is no less than (total gasUsed * p%).
+func calculatePercentiles(rewardPercentiles []float64, gasAndRewards []gasAndReward, totalEVMGasUsed uint64) []*hexutil.Big {
+	slices.SortStableFunc(gasAndRewards, func(a, b gasAndReward) int {
+		return int(a.reward) - int(b.reward)
+	})
+	res := []*hexutil.Big{}
+	if len(gasAndRewards) == 0 {
+		return res
+	}
+	var txIndex int
+	sumGasUsed := gasAndRewards[0].gasUsed
+	for _, p := range rewardPercentiles {
+		thresholdGasUsed := uint64(float64(totalEVMGasUsed) * p / 100)
+		for sumGasUsed < thresholdGasUsed && txIndex < len(gasAndRewards)-1 {
+			txIndex++
+			sumGasUsed += gasAndRewards[txIndex].gasUsed
+		}
+		res = append(res, (*hexutil.Big)(big.NewInt(int64(gasAndRewards[txIndex].reward))))
+	}
+	return res
+}

--- a/evmrpc/info_test.go
+++ b/evmrpc/info_test.go
@@ -1,0 +1,103 @@
+package evmrpc
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFeeHistory(t *testing.T) {
+	bodyByNumber := "{\"jsonrpc\": \"2.0\",\"method\": \"eth_feeHistory\",\"params\":[\"0x1\",\"0x8\",[0.5]],\"id\":\"test\"}"
+	bodyByLatest := "{\"jsonrpc\": \"2.0\",\"method\": \"eth_feeHistory\",\"params\":[\"0x1\",\"latest\",[0.5]],\"id\":\"test\"}"
+	bodyByEarliest := "{\"jsonrpc\": \"2.0\",\"method\": \"eth_feeHistory\",\"params\":[\"0x1\",\"earliest\",[0.5]],\"id\":\"test\"}"
+	bodyOld := "{\"jsonrpc\": \"2.0\",\"method\": \"eth_feeHistory\",\"params\":[\"0x1\",\"0x1\",[0.5]],\"id\":\"test\"}"
+	bodyFuture := "{\"jsonrpc\": \"2.0\",\"method\": \"eth_feeHistory\",\"params\":[\"0x1\",\"0x9\",[0.5]],\"id\":\"test\"}"
+	for body, expectedOldest := range map[string]string{
+		bodyByNumber: "0x8", bodyByLatest: "0x8", bodyByEarliest: "0x1", bodyOld: "0x1", bodyFuture: "0x8",
+	} {
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s:%d", TestAddr, TestPort), strings.NewReader(body))
+		require.Nil(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		res, err := http.DefaultClient.Do(req)
+		require.Nil(t, err)
+		resBody, err := io.ReadAll(res.Body)
+		require.Nil(t, err)
+		resObj := map[string]interface{}{}
+		require.Nil(t, json.Unmarshal(resBody, &resObj))
+		resObj = resObj["result"].(map[string]interface{})
+		require.Equal(t, expectedOldest, resObj["oldestBlock"].(string))
+		rewards := resObj["reward"].([]interface{})
+		require.Equal(t, 1, len(rewards))
+		reward := rewards[0].([]interface{})
+		require.Equal(t, 1, len(reward))
+		require.Equal(t, "0xa", reward[0].(string))
+		baseFeePerGas := resObj["baseFeePerGas"].([]interface{})
+		require.Equal(t, 1, len(baseFeePerGas))
+		require.Equal(t, "0x0", baseFeePerGas[0].(string))
+		gasUsedRatio := resObj["gasUsedRatio"].([]interface{})
+		require.Equal(t, 1, len(gasUsedRatio))
+		require.Equal(t, 0.5, gasUsedRatio[0].(float64))
+	}
+
+	// bad percentile
+	outOfRangeBody1 := "{\"jsonrpc\": \"2.0\",\"method\": \"eth_feeHistory\",\"params\":[\"0x1\",\"0x8\",[-1]],\"id\":\"test\"}"
+	outOfRangeBody2 := "{\"jsonrpc\": \"2.0\",\"method\": \"eth_feeHistory\",\"params\":[\"0x1\",\"0x8\",[101]],\"id\":\"test\"}"
+	outOfOrderBody := "{\"jsonrpc\": \"2.0\",\"method\": \"eth_feeHistory\",\"params\":[\"0x1\",\"0x8\",[99, 1]],\"id\":\"test\"}"
+	for _, body := range []string{outOfRangeBody1, outOfRangeBody2, outOfOrderBody} {
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s:%d", TestAddr, TestPort), strings.NewReader(body))
+		require.Nil(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		res, err := http.DefaultClient.Do(req)
+		require.Nil(t, err)
+		resBody, err := io.ReadAll(res.Body)
+		require.Nil(t, err)
+		resObj := map[string]interface{}{}
+		require.Nil(t, json.Unmarshal(resBody, &resObj))
+		errMap := resObj["error"].(map[string]interface{})
+		require.Equal(t, "invalid reward percentiles: must be ascending and between 0 and 100", errMap["message"].(string))
+	}
+}
+
+func TestCalculatePercentiles(t *testing.T) {
+	// all empty
+	result := calculatePercentiles([]float64{}, []gasAndReward{}, 0)
+	require.Equal(t, 0, len(result))
+
+	// empty gasAndRewards
+	result = calculatePercentiles([]float64{1}, []gasAndReward{}, 0)
+	require.Equal(t, 0, len(result))
+
+	// empty percentiles
+	result = calculatePercentiles([]float64{}, []gasAndReward{{reward: 10, gasUsed: 1}}, 1)
+	require.Equal(t, 0, len(result))
+
+	// 0 percentile
+	result = calculatePercentiles([]float64{0}, []gasAndReward{{reward: 10, gasUsed: 1}}, 1)
+	require.Equal(t, 1, len(result))
+	// see comments above calculatePercentiles to understand why it should return 10 here
+	require.Equal(t, big.NewInt(10), result[0].ToInt())
+
+	// 100 percentile
+	result = calculatePercentiles([]float64{100}, []gasAndReward{{reward: 10, gasUsed: 1}}, 1)
+	require.Equal(t, 1, len(result))
+	require.Equal(t, big.NewInt(10), result[0].ToInt())
+
+	// 0 percentile and 100 percentile with just one transaction
+	result = calculatePercentiles([]float64{0, 100}, []gasAndReward{{reward: 10, gasUsed: 1}}, 1)
+	require.Equal(t, 2, len(result))
+	require.Equal(t, big.NewInt(10), result[0].ToInt())
+	require.Equal(t, big.NewInt(10), result[1].ToInt())
+
+	// more transactions than percentiles
+	result = calculatePercentiles([]float64{0, 50, 100}, []gasAndReward{{reward: 10, gasUsed: 1}, {reward: 5, gasUsed: 2}, {reward: 3, gasUsed: 3}}, 6)
+	require.Equal(t, 3, len(result))
+	require.Equal(t, big.NewInt(3), result[0].ToInt())
+	require.Equal(t, big.NewInt(3), result[1].ToInt())
+	require.Equal(t, big.NewInt(10), result[2].ToInt())
+}

--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -19,7 +19,7 @@ func NewEVMHTTPServer(
 	timeouts rpc.HTTPTimeouts,
 	tmClient rpcclient.Client,
 	k *keeper.Keeper,
-	ctxProvider func() sdk.Context,
+	ctxProvider func(int64) sdk.Context,
 	txDecoder sdk.TxDecoder,
 ) (EVMServer, error) {
 	httpServer := newHTTPServer(logger, timeouts)
@@ -38,6 +38,10 @@ func NewEVMHTTPServer(
 		{
 			Namespace: "eth",
 			Service:   NewTransactionAPI(tmClient, k, ctxProvider, txDecoder),
+		},
+		{
+			Namespace: "eth",
+			Service:   NewInfoAPI(tmClient, k, ctxProvider, txDecoder),
 		},
 	}
 	if err := httpServer.enableRPC(apis, httpConfig{

--- a/evmrpc/testutils.go
+++ b/evmrpc/testutils.go
@@ -148,14 +148,14 @@ var Ctx sdk.Context
 func init() {
 	types.RegisterInterfaces(EncodingConfig.InterfaceRegistry)
 	EVMKeeper, _, Ctx = keeper.MockEVMKeeper()
-	httpServer, err := NewEVMHTTPServer(log.NewNopLogger(), TestAddr, TestPort, rpc.DefaultHTTPTimeouts, &MockClient{}, EVMKeeper, func() sdk.Context { return Ctx }, Decoder)
+	httpServer, err := NewEVMHTTPServer(log.NewNopLogger(), TestAddr, TestPort, rpc.DefaultHTTPTimeouts, &MockClient{}, EVMKeeper, func(int64) sdk.Context { return Ctx }, Decoder)
 	if err != nil {
 		panic(err)
 	}
 	if err := httpServer.Start(); err != nil {
 		panic(err)
 	}
-	badHTTPServer, err := NewEVMHTTPServer(log.NewNopLogger(), TestAddr, TestBadPort, rpc.DefaultHTTPTimeouts, &MockBadClient{}, EVMKeeper, func() sdk.Context { return Ctx }, Decoder)
+	badHTTPServer, err := NewEVMHTTPServer(log.NewNopLogger(), TestAddr, TestBadPort, rpc.DefaultHTTPTimeouts, &MockBadClient{}, EVMKeeper, func(int64) sdk.Context { return Ctx }, Decoder)
 	if err != nil {
 		panic(err)
 	}

--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -24,16 +24,16 @@ import (
 type TransactionAPI struct {
 	tmClient    rpcclient.Client
 	keeper      *keeper.Keeper
-	ctxProvider func() sdk.Context
+	ctxProvider func(int64) sdk.Context
 	txDecoder   sdk.TxDecoder
 }
 
-func NewTransactionAPI(tmClient rpcclient.Client, k *keeper.Keeper, ctxProvider func() sdk.Context, txDecoder sdk.TxDecoder) *TransactionAPI {
+func NewTransactionAPI(tmClient rpcclient.Client, k *keeper.Keeper, ctxProvider func(int64) sdk.Context, txDecoder sdk.TxDecoder) *TransactionAPI {
 	return &TransactionAPI{tmClient: tmClient, keeper: k, ctxProvider: ctxProvider, txDecoder: txDecoder}
 }
 
 func (t *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
-	receipt, err := t.keeper.GetReceipt(t.ctxProvider(), hash)
+	receipt, err := t.keeper.GetReceipt(t.ctxProvider(LatestCtxHeight), hash)
 	if err != nil {
 		// When the transaction doesn't exist, the RPC method should return JSON null
 		// as per specification.
@@ -76,7 +76,7 @@ func (t *TransactionAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, 
 }
 
 func (t *TransactionAPI) GetTransactionByHash(ctx context.Context, hash common.Hash) (*RPCTransaction, error) {
-	receipt, err := t.keeper.GetReceipt(t.ctxProvider(), hash)
+	receipt, err := t.keeper.GetReceipt(t.ctxProvider(LatestCtxHeight), hash)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (t *TransactionAPI) GetTransactionCount(ctx context.Context, address common
 	result := hexutil.Uint64(0)
 	for _, tx := range block.Block.Txs {
 		if ethtx := getEthTxForTxBz(tx, t.txDecoder); ethtx != nil {
-			receipt, err := t.keeper.GetReceipt(t.ctxProvider(), ethtx.Hash())
+			receipt, err := t.keeper.GetReceipt(t.ctxProvider(LatestCtxHeight), ethtx.Hash())
 			if err != nil {
 				continue
 			}
@@ -121,7 +121,7 @@ func (t *TransactionAPI) getTransactionWithBlock(block *coretypes.ResultBlock, i
 	if ethtx == nil {
 		return nil
 	}
-	receipt, err := t.keeper.GetReceipt(t.ctxProvider(), ethtx.Hash())
+	receipt, err := t.keeper.GetReceipt(t.ctxProvider(LatestCtxHeight), ethtx.Hash())
 	if err != nil {
 		return nil
 	}

--- a/evmrpc/utils.go
+++ b/evmrpc/utils.go
@@ -9,6 +9,13 @@ import (
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
 
+const LatestCtxHeight int64 = -1
+
+// Since we use a static base fee, we want GasUsedRatio returned in RPC queries
+// to reflect the fact that base fee would never change, which is only true if
+// the block is exactly half-utilized.
+const GasUsedRatio float64 = 0.5
+
 type RPCTransaction struct {
 	BlockHash           *common.Hash         `json:"blockHash"`
 	BlockNumber         *hexutil.Big         `json:"blockNumber"`

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sei-protocol/sei-chain
 
-go 1.20
+go 1.21
 
 require (
 	github.com/BurntSushi/toml v1.3.2

--- a/x/evm/keeper/testutils.go
+++ b/x/evm/keeper/testutils.go
@@ -58,7 +58,7 @@ func MockEVMKeeper() (*Keeper, *paramskeeper.Keeper, sdk.Context) {
 	bankKeeper := bankkeeper.NewBaseKeeper(cdc, bankStoreKey, accountKeeper, paramsKeeper.Subspace(banktypes.ModuleName), map[string]bool{})
 	stakingKeeper := stakingkeeper.NewKeeper(cdc, stakingStoreKey, accountKeeper, bankKeeper, paramsKeeper.Subspace(stakingtypes.ModuleName))
 
-	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())
+	ctx := sdk.NewContext(stateStore, tmproto.Header{Height: 8}, false, log.NewNopLogger())
 	k := NewKeeper(evmStoreKey, paramsKeeper.Subspace(types.ModuleName), big.NewInt(1), bankKeeper, &accountKeeper, &stakingKeeper)
 	k.InitGenesis(ctx)
 	return k, &paramsKeeper, ctx


### PR DESCRIPTION
## Describe your changes and provide context
Add `feeHistory` endpoints that returns base fee and rewards percentile (weighted by gas used) for the requested block range. More details on the percentile calculation can be found in comments.

## Testing performed to validate your change
unit tests

