### PR TITLE
[EVM] add endpoint to send transaction

### DIFF
--- a/evmrpc/send.go
+++ b/evmrpc/send.go
@@ -1,0 +1,51 @@
+package evmrpc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/sei-protocol/sei-chain/x/evm/types"
+	"github.com/sei-protocol/sei-chain/x/evm/types/ethtx"
+	rpcclient "github.com/tendermint/tendermint/rpc/client"
+)
+
+type SendAPI struct {
+	tmClient rpcclient.Client
+	txConfig client.TxConfig
+}
+
+func NewSendAPI(tmClient rpcclient.Client, txConfig client.TxConfig) *SendAPI {
+	return &SendAPI{tmClient: tmClient, txConfig: txConfig}
+}
+
+func (s *SendAPI) SendRawTransaction(ctx context.Context, input hexutil.Bytes) (common.Hash, error) {
+	tx := new(ethtypes.Transaction)
+	if err := tx.UnmarshalBinary(input); err != nil {
+		return common.Hash{}, err
+	}
+	txdata, err := ethtx.NewTxDataFromTx(tx)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	msg, err := types.NewMsgEVMTransaction(txdata)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	txBuilder := s.txConfig.NewTxBuilder()
+	if err := txBuilder.SetMsgs(msg); err != nil {
+		return common.Hash{}, err
+	}
+	txbz, err := s.txConfig.TxEncoder()(txBuilder.GetTx())
+	if err != nil {
+		return common.Hash{}, err
+	}
+	res, err := s.tmClient.BroadcastTx(ctx, txbz)
+	if err != nil || res.Code != 0 {
+		return common.Hash{}, fmt.Errorf("error code: %d under %s, log: %s, error: %s", res.Code, res.Codespace, res.Log, err)
+	}
+	return tx.Hash(), nil
+}

--- a/evmrpc/send_test.go
+++ b/evmrpc/send_test.go
@@ -1,0 +1,55 @@
+package evmrpc
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendRawTransaction(t *testing.T) {
+	// build tx
+	to := common.HexToAddress("010203")
+	txData := ethtypes.DynamicFeeTx{
+		Nonce:     1,
+		GasFeeCap: big.NewInt(10),
+		Gas:       1000,
+		To:        &to,
+		Value:     big.NewInt(1000),
+		Data:      []byte("abc"),
+		ChainID:   big.NewInt(1),
+	}
+	mnemonic := "fish mention unlock february marble dove vintage sand hub ordinary fade found inject room embark supply fabric improve spike stem give current similar glimpse"
+	derivedPriv, _ := hd.Secp256k1.Derive()(mnemonic, "", "")
+	privKey := hd.Secp256k1.Generate()(derivedPriv)
+	testPrivHex := hex.EncodeToString(privKey.Bytes())
+	key, _ := crypto.HexToECDSA(testPrivHex)
+	evmParams := EVMKeeper.GetParams(Ctx)
+	ethCfg := evmParams.GetChainConfig().EthereumConfig(big.NewInt(1))
+	signer := ethtypes.MakeSigner(ethCfg, big.NewInt(Ctx.BlockHeight()), uint64(Ctx.BlockTime().Unix()))
+	tx := ethtypes.NewTx(&txData)
+	tx, err := ethtypes.SignTx(tx, signer, key)
+	require.Nil(t, err)
+	bz, err := tx.MarshalBinary()
+	require.Nil(t, err)
+	payload := "0x" + hex.EncodeToString(bz)
+
+	resObj := sendRequestGood(t, "sendRawTransaction", payload)
+	result := resObj["result"].(string)
+	require.Equal(t, tx.Hash().Hex(), result)
+
+	// bad payload
+	resObj = sendRequestGood(t, "sendRawTransaction", "0x1234")
+	errMap := resObj["error"].(map[string]interface{})
+	require.Equal(t, "transaction type not supported", errMap["message"].(string))
+
+	// bad server
+	resObj = sendRequestBad(t, "sendRawTransaction", payload)
+	errMap = resObj["error"].(map[string]interface{})
+	require.Equal(t, "error code: 1 under test, log: log, error: %!s(<nil>)", errMap["message"].(string))
+}

--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -1,6 +1,7 @@
 package evmrpc
 
 import (
+	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/sei-protocol/sei-chain/x/evm/keeper"
@@ -20,7 +21,7 @@ func NewEVMHTTPServer(
 	tmClient rpcclient.Client,
 	k *keeper.Keeper,
 	ctxProvider func(int64) sdk.Context,
-	txDecoder sdk.TxDecoder,
+	txConfig client.TxConfig,
 ) (EVMServer, error) {
 	httpServer := newHTTPServer(logger, timeouts)
 	if err := httpServer.setListenAddr(addr, port); err != nil {
@@ -33,11 +34,11 @@ func NewEVMHTTPServer(
 		},
 		{
 			Namespace: "eth",
-			Service:   NewBlockAPI(tmClient, k, ctxProvider, txDecoder),
+			Service:   NewBlockAPI(tmClient, k, ctxProvider, txConfig.TxDecoder()),
 		},
 		{
 			Namespace: "eth",
-			Service:   NewTransactionAPI(tmClient, k, ctxProvider, txDecoder),
+			Service:   NewTransactionAPI(tmClient, k, ctxProvider, txConfig.TxDecoder()),
 		},
 		{
 			Namespace: "eth",
@@ -45,7 +46,11 @@ func NewEVMHTTPServer(
 		},
 		{
 			Namespace: "eth",
-			Service:   NewInfoAPI(tmClient, k, ctxProvider, txDecoder),
+			Service:   NewInfoAPI(tmClient, k, ctxProvider, txConfig.TxDecoder()),
+		},
+		{
+			Namespace: "eth",
+			Service:   NewSendAPI(tmClient, txConfig),
 		},
 	}
 	if err := httpServer.enableRPC(apis, httpConfig{

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -88,11 +88,11 @@ func NewLoadTestClient(config Config) *LoadTestClient {
 
 func (c *LoadTestClient) SetValidators() {
 	if strings.Contains(c.LoadTestConfig.MessageType, "staking") {
-		if resp, err := c.StakingQueryClient.Validators(context.Background(), &stakingtypes.QueryValidatorsRequest{}); err != nil {
+		resp, err := c.StakingQueryClient.Validators(context.Background(), &stakingtypes.QueryValidatorsRequest{})
+		if err != nil {
 			panic(err)
-		} else {
-			c.Validators = resp.Validators
 		}
+		c.Validators = resp.Validators
 	}
 }
 

--- a/x/dex/cache/cancel.go
+++ b/x/dex/cache/cancel.go
@@ -57,9 +57,9 @@ func (o *BlockCancellations) GetIdsToCancel() (list []uint64) {
 func (o *BlockCancellations) Add(newItem *types.Cancellation) {
 	keybz := make([]byte, 8)
 	binary.BigEndian.PutUint64(keybz, newItem.Id)
-	if valbz, err := newItem.Marshal(); err != nil {
+	valbz, err := newItem.Marshal()
+	if err != nil {
 		panic(err)
-	} else {
-		o.cancelStore.Set(keybz, valbz)
 	}
+	o.cancelStore.Set(keybz, valbz)
 }

--- a/x/dex/cache/deposit.go
+++ b/x/dex/cache/deposit.go
@@ -42,10 +42,10 @@ func (d *DepositInfo) Add(newItem *types.DepositInfoEntry) {
 			panic(err)
 		}
 		newItem.Amount = newItem.Amount.Add(existingItem.Amount)
-		if newVal, err := newItem.Marshal(); err != nil {
+		newVal, err := newItem.Marshal()
+		if err != nil {
 			panic(err)
-		} else {
-			d.store.Set(key, newVal)
 		}
+		d.store.Set(key, newVal)
 	}
 }

--- a/x/dex/cache/order.go
+++ b/x/dex/cache/order.go
@@ -20,11 +20,11 @@ func NewOrders(orderStore prefix.Store) *BlockOrders {
 func (o *BlockOrders) Add(newItem *types.Order) {
 	keybz := make([]byte, 8)
 	binary.BigEndian.PutUint64(keybz, newItem.Id)
-	if valbz, err := newItem.Marshal(); err != nil {
+	valbz, err := newItem.Marshal()
+	if err != nil {
 		panic(err)
-	} else {
-		o.orderStore.Set(keybz, valbz)
 	}
+	o.orderStore.Set(keybz, valbz)
 }
 
 func (o *BlockOrders) GetByID(id uint64) *types.Order {
@@ -81,12 +81,12 @@ func (o *BlockOrders) getKVsToSet(failedOrdersMap map[uint64]types.UnsuccessfulO
 			val.Status = types.OrderStatus_FAILED_TO_PLACE
 			val.StatusDescription = failedOrder.Reason
 		}
-		if bz, err := val.Marshal(); err != nil {
+		bz, err := val.Marshal()
+		if err != nil {
 			panic(err)
-		} else {
-			keys = append(keys, iterator.Key())
-			vals = append(vals, bz)
 		}
+		keys = append(keys, iterator.Key())
+		vals = append(vals, bz)
 	}
 	return keys, vals
 }

--- a/x/dex/keeper/utils/wasm.go
+++ b/x/dex/keeper/utils/wasm.go
@@ -73,9 +73,8 @@ func sudoWithoutOutOfGasPanic(ctx sdk.Context, k *keeper.Keeper, contractAddress
 			// only propagate panic if the error is NOT out of gas
 			if _, ok := err.(sdk.ErrorOutOfGas); !ok {
 				panic(err)
-			} else {
-				ctx.Logger().Error(fmt.Sprintf("%s %s is out of gas", sdk.AccAddress(contractAddress).String(), logName))
 			}
+			ctx.Logger().Error(fmt.Sprintf("%s %s is out of gas", sdk.AccAddress(contractAddress).String(), logName))
 		}
 	}()
 	return logging.LogIfNotDoneAfter(ctx.Logger(), func() ([]byte, error) {

--- a/x/evm/types/ethtx/txdata.go
+++ b/x/evm/types/ethtx/txdata.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	proto "github.com/gogo/protobuf/proto"
 )
 
 var (
@@ -17,6 +18,7 @@ var (
 // Unfortunately `TxData` interface in go-ethereum/core/types defines its functions
 // as private, so we have to define our own here.
 type TxData interface {
+	proto.Message
 	TxType() byte
 	Copy() TxData
 	GetChainID() *big.Int

--- a/x/tokenfactory/keeper/migrations.go
+++ b/x/tokenfactory/keeper/migrations.go
@@ -47,14 +47,13 @@ func (m Migrator) Migrate3to4(ctx sdk.Context) error {
 	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {
 		denom := string(iter.Value())
-		if denomMetadata, err := m.keeper.bankKeeper.GetDenomMetaData(ctx, denom); !err {
+		denomMetadata, err := m.keeper.bankKeeper.GetDenomMetaData(ctx, denom)
+		if !err {
 			panic(fmt.Errorf("denom %s does not exist", denom))
-		} else {
-			fmt.Printf("Migrating denom: %s\n", denom)
-			m.SetMetadata(&denomMetadata)
-			m.keeper.bankKeeper.SetDenomMetaData(ctx, denomMetadata)
 		}
-
+		fmt.Printf("Migrating denom: %s\n", denom)
+		m.SetMetadata(&denomMetadata)
+		m.keeper.bankKeeper.SetDenomMetaData(ctx, denomMetadata)
 	}
 	return nil
 }

--- a/x/tokenfactory/types/events.go
+++ b/x/tokenfactory/types/events.go
@@ -3,9 +3,10 @@ package types
 
 // event types
 const (
-	AttributeAmount              = "amount"
-	AttributeCreator             = "creator"
-	AttributeSubdenom            = "subdenom"
+	AttributeAmount   = "amount"
+	AttributeCreator  = "creator"
+	AttributeSubdenom = "subdenom"
+	//nolint:gosec
 	AttributeNewTokenDenom       = "new_token_denom"
 	AttributeMintToAddress       = "mint_to_address"
 	AttributeBurnFromAddress     = "burn_from_address"


### PR DESCRIPTION
## Describe your changes and provide context
Implement `SendRawTransaction`. Note that for now Sei nodes will not custody users' private keys so it will not offer endpoints that provide signing capability (e.g. SendTransaction, Sign, SignTransaction)

## Testing performed to validate your change
unit tests

