### PR TITLE
[EVM] add subscription utility

### DIFF
--- a/evmrpc/subscribe_test.go
+++ b/evmrpc/subscribe_test.go
@@ -1,0 +1,42 @@
+package evmrpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryBuilder(t *testing.T) {
+	q := mockQueryBuilder()
+	expectedQuery := "tm.event = 'Tx' AND evm_log.contract_address = 'test contract' AND evm_log.block_hash = 'block hash' AND evm_log.block_number = '1' AND evm_log.tx_hash = 'tx hash' AND evm_log.tx_idx = '2' AND evm_log.idx = '3' AND evm_log.topics CONTAINS 'topic a' AND evm_log.topics CONTAINS 'topic b'"
+	require.Equal(t, expectedQuery, q.Build())
+}
+
+func TestSubscribe(t *testing.T) {
+	manager := NewSubscriptionManager(&MockClient{})
+	res, err := manager.Subscribe(context.Background(), mockQueryBuilder(), 10)
+	require.Nil(t, err)
+	require.Equal(t, 1, int(res))
+
+	res, err = manager.Subscribe(context.Background(), mockQueryBuilder(), 10)
+	require.Nil(t, err)
+	require.Equal(t, 2, int(res))
+
+	badManager := NewSubscriptionManager(&MockBadClient{})
+	_, err = badManager.Subscribe(context.Background(), mockQueryBuilder(), 10)
+	require.NotNil(t, err)
+}
+
+func mockQueryBuilder() *QueryBuilder {
+	q := NewQueryBuilder()
+	q.FilterContractAddress("test contract")
+	q.FilterBlockHash("block hash")
+	q.FilterBlockNumber(1)
+	q.FilterTxHash("tx hash")
+	q.FilterTxIndex(2)
+	q.FilterIndex(3)
+	q.FilterTopic("topic a")
+	q.FilterTopic("topic b")
+	return q
+}

--- a/evmrpc/testutils.go
+++ b/evmrpc/testutils.go
@@ -134,6 +134,10 @@ func (c *MockClient) BlockResults(context.Context, *int64) (*coretypes.ResultBlo
 	}, nil
 }
 
+func (c *MockClient) Subscribe(context.Context, string, string, ...int) (<-chan coretypes.ResultEvent, error) {
+	return make(chan coretypes.ResultEvent, 1), nil
+}
+
 type MockBadClient struct {
 	MockClient
 }
@@ -148,6 +152,10 @@ func (m *MockBadClient) BlockByHash(context.Context, bytes.HexBytes) (*coretypes
 
 func (m *MockBadClient) Genesis(context.Context) (*coretypes.ResultGenesis, error) {
 	return nil, errors.New("error genesis")
+}
+
+func (m *MockBadClient) Subscribe(context.Context, string, string, ...int) (<-chan coretypes.ResultEvent, error) {
+	return nil, errors.New("bad subscribe")
 }
 
 var EVMKeeper *keeper.Keeper


### PR DESCRIPTION
## Describe your changes and provide context
Add a helper class `SubscriptionManager` to facilitate subscription to tendermint events (docs: https://docs.tendermint.com/v0.34/rpc/#/Websocket/subscribe). Filters can be created via the new `QueryBuilder` struct and passed to `SubscriptionManager`.

Note that we make use of `Subscribe` method which is marked as deprecated, but not really deprecated in the new tendermint version.

## Testing performed to validate your change
unit tests
