### PR TITLE
[EVM] get simulation endpoints

### DIFF
--- a/.github/workflows/compatiblity_check.yml
+++ b/.github/workflows/compatiblity_check.yml
@@ -20,8 +20,10 @@ jobs:
           git clone https://github.com/sei-protocol/sei-cosmos.git
           git clone https://github.com/sei-protocol/sei-tendermint.git
           git clone https://github.com/sei-protocol/sei-iavl.git
+          git clone https://github.com/sei-protocol/go-ethereum.git
           go mod edit -replace github.com/cosmos/iavl=./sei-iavl
           go mod edit -replace github.com/tendermint/tendermint=./sei-tendermint
           go mod edit -replace github.com/cosmos/cosmos-sdk=./sei-cosmos
+          go mod edit -replace github.com/ethereum/go-ethereum=./go-ethereum
           go mod tidy
           make install

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,7 @@ linters:
     # - structcheck ## author abandoned project
     - stylecheck
     - revive
-    - typecheck
+    # - typecheck
     - unconvert
     # - unused
     # - unparam

--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -22,6 +22,7 @@ func NewEVMHTTPServer(
 	k *keeper.Keeper,
 	ctxProvider func(int64) sdk.Context,
 	txConfig client.TxConfig,
+	simulationConfig *SimulateConfig,
 ) (EVMServer, error) {
 	httpServer := newHTTPServer(logger, timeouts)
 	if err := httpServer.setListenAddr(addr, port); err != nil {
@@ -51,6 +52,10 @@ func NewEVMHTTPServer(
 		{
 			Namespace: "eth",
 			Service:   NewSendAPI(tmClient, txConfig),
+		},
+		{
+			Namespace: "eth",
+			Service:   NewSimulationAPI(ctxProvider, k, tmClient, simulationConfig),
 		},
 	}
 	if err := httpServer.enableRPC(apis, httpConfig{

--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -1,0 +1,148 @@
+package evmrpc
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/eth"
+	"github.com/ethereum/go-ethereum/lib/ethapi"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/sei-protocol/sei-chain/x/evm/keeper"
+	"github.com/sei-protocol/sei-chain/x/evm/state"
+	rpcclient "github.com/tendermint/tendermint/rpc/client"
+	"github.com/tendermint/tendermint/rpc/coretypes"
+)
+
+type SimulationAPI struct {
+	ctxProvider func(int64) sdk.Context
+	keeper      *keeper.Keeper
+	tmClient    rpcclient.Client
+	config      *SimulateConfig
+}
+
+func NewSimulationAPI(
+	ctxProvider func(int64) sdk.Context,
+	keeper *keeper.Keeper,
+	tmClient rpcclient.Client,
+	config *SimulateConfig,
+) *SimulationAPI {
+	return &SimulationAPI{
+		ctxProvider: ctxProvider,
+		keeper:      keeper,
+		tmClient:    tmClient,
+		config:      config,
+	}
+}
+
+type accessListResult struct {
+	Accesslist *ethtypes.AccessList `json:"accessList"`
+	Error      string               `json:"error,omitempty"`
+	GasUsed    hexutil.Uint64       `json:"gasUsed"`
+}
+
+func (s *SimulationAPI) CreateAccessList(ctx context.Context, args ethapi.TransactionArgs, blockNrOrHash *rpc.BlockNumberOrHash) (*accessListResult, error) {
+	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+	if blockNrOrHash != nil {
+		bNrOrHash = *blockNrOrHash
+	}
+	acl, gasUsed, vmerr, err := ethapi.AccessList(ctx, &Backend{
+		ctxProvider: s.ctxProvider,
+		keeper:      s.keeper,
+		tmClient:    s.tmClient,
+		config:      s.config,
+	}, bNrOrHash, args)
+	if err != nil {
+		return nil, err
+	}
+	result := &accessListResult{Accesslist: &acl, GasUsed: hexutil.Uint64(gasUsed)}
+	if vmerr != nil {
+		result.Error = vmerr.Error()
+	}
+	return result, nil
+}
+
+type SimulateConfig struct {
+	GasCap uint64
+}
+
+type Backend struct {
+	*eth.EthAPIBackend
+	ctxProvider func(int64) sdk.Context
+	keeper      *keeper.Keeper
+	tmClient    rpcclient.Client
+	config      *SimulateConfig
+}
+
+func NewBackend(ctxProvider func(int64) sdk.Context, keeper *keeper.Keeper, tmClient rpcclient.Client, config *SimulateConfig) *Backend {
+	return &Backend{ctxProvider: ctxProvider, keeper: keeper, tmClient: tmClient, config: config}
+}
+
+func (b *Backend) StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (vm.StateDB, *ethtypes.Header, error) {
+	var block *coretypes.ResultBlock
+	var err error
+	if blockNr, ok := blockNrOrHash.Number(); ok {
+		blockNumber, blockNumErr := getBlockNumber(ctx, b.tmClient, blockNr)
+		if blockNumErr != nil {
+			return nil, nil, blockNumErr
+		}
+		block, err = b.tmClient.Block(ctx, blockNumber)
+	} else {
+		block, err = b.tmClient.BlockByHash(ctx, blockNrOrHash.BlockHash[:])
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	return state.NewDBImpl(b.ctxProvider(block.Block.Height), b.keeper), b.getHeader(), nil
+}
+
+func (b *Backend) RPCGasCap() uint64 { return b.config.GasCap }
+
+func (b *Backend) ChainConfig() *params.ChainConfig {
+	return b.keeper.GetChainConfig(b.ctxProvider(LatestCtxHeight)).EthereumConfig(b.keeper.ChainID())
+}
+
+func (b *Backend) GetPoolNonce(ctx context.Context, addr common.Address) (uint64, error) {
+	return state.NewDBImpl(b.ctxProvider(LatestCtxHeight), b.keeper).GetNonce(addr), nil
+}
+
+func (b *Backend) Engine() consensus.Engine {
+	return &Engine{ctxProvider: b.ctxProvider, keeper: b.keeper}
+}
+
+func (b *Backend) HeaderByNumber(context.Context, rpc.BlockNumber) (*ethtypes.Header, error) {
+	return b.getHeader(), nil
+}
+
+func (b *Backend) GetEVM(ctx context.Context, msg *core.Message, state vm.StateDB, header *ethtypes.Header, vmConfig *vm.Config, _ *vm.BlockContext) (*vm.EVM, func() error) {
+	if vmConfig == nil {
+		panic("vmConfig should not be nil")
+	}
+	txContext := core.NewEVMTxContext(msg)
+	context, err := b.keeper.GetVMBlockContext(b.ctxProvider(LatestCtxHeight), core.GasPool(b.RPCGasCap()))
+	if err != nil {
+		panic(err)
+	}
+	return vm.NewEVM(*context, txContext, state, b.ChainConfig(), *vmConfig), state.Error
+}
+
+func (b *Backend) getHeader() *ethtypes.Header {
+	return &ethtypes.Header{}
+}
+
+type Engine struct {
+	*ethash.Ethash
+	ctxProvider func(int64) sdk.Context
+	keeper      *keeper.Keeper
+}
+
+func (e *Engine) Author(*ethtypes.Header) (common.Address, error) {
+	return e.keeper.GetFeeCollectorAddress(e.ctxProvider(LatestCtxHeight))
+}

--- a/evmrpc/simulate_test.go
+++ b/evmrpc/simulate_test.go
@@ -30,6 +30,12 @@ func TestEstimateGas(t *testing.T) {
 	resObj := sendRequestGood(t, "estimateGas", txArgs, nil, map[string]interface{}{})
 	result := resObj["result"].(string)
 	require.Equal(t, "0x5208", result) // 21000
+	resObj = sendRequestGood(t, "estimateGas", txArgs, "latest", map[string]interface{}{})
+	result = resObj["result"].(string)
+	require.Equal(t, "0x5208", result) // 21000
+	resObj = sendRequestGood(t, "estimateGas", txArgs, "0x123456", map[string]interface{}{})
+	result = resObj["result"].(string)
+	require.Equal(t, "0x5208", result) // 21000
 
 	// contract call
 	_, contractAddr := keeper.MockAddressPair()
@@ -80,4 +86,8 @@ func TestCreateAccessList(t *testing.T) {
 	resObj := sendRequestGood(t, "createAccessList", txArgs, "latest")
 	result := resObj["result"].(map[string]interface{})
 	require.Equal(t, []interface{}{}, result["accessList"]) // the code uses MSTORE which does not trace access list
+
+	resObj = sendRequestBad(t, "createAccessList", txArgs, "latest")
+	result = resObj["error"].(map[string]interface{})
+	require.Equal(t, "error block", result["message"])
 }

--- a/evmrpc/simulate_test.go
+++ b/evmrpc/simulate_test.go
@@ -1,0 +1,83 @@
+package evmrpc
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"os"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/x/evm/keeper"
+	"github.com/sei-protocol/sei-chain/x/evm/keeper/testdata"
+	"github.com/sei-protocol/sei-chain/x/evm/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEstimateGas(t *testing.T) {
+	// transfer
+	_, from := keeper.MockAddressPair()
+	_, to := keeper.MockAddressPair()
+	txArgs := map[string]interface{}{
+		"from":    from.Hex(),
+		"to":      to.Hex(),
+		"value":   "0x10",
+		"nonce":   "0x1",
+		"chainId": fmt.Sprintf("%#x", EVMKeeper.ChainID()),
+	}
+	EVMKeeper.BankKeeper().MintCoins(Ctx, types.ModuleName, sdk.NewCoins(sdk.NewCoin(EVMKeeper.GetBaseDenom(Ctx), sdk.NewInt(20))))
+	EVMKeeper.SetOrDeleteBalance(Ctx, from, 20)
+	resObj := sendRequestGood(t, "estimateGas", txArgs, nil, map[string]interface{}{})
+	result := resObj["result"].(string)
+	require.Equal(t, "0x5208", result) // 21000
+
+	// contract call
+	_, contractAddr := keeper.MockAddressPair()
+	code, err := os.ReadFile("../x/evm/keeper/testdata/SimpleStorage/SimpleStorage.bin")
+	require.Nil(t, err)
+	bz, err := hex.DecodeString(string(code))
+	require.Nil(t, err)
+	abi, err := testdata.TestdataMetaData.GetAbi()
+	require.Nil(t, err)
+	input, err := abi.Pack("set", big.NewInt(20))
+	require.Nil(t, err)
+	EVMKeeper.SetCode(Ctx, contractAddr, bz)
+	txArgs = map[string]interface{}{
+		"from":    from.Hex(),
+		"to":      contractAddr.Hex(),
+		"value":   "0x0",
+		"nonce":   "0x2",
+		"chainId": fmt.Sprintf("%#x", EVMKeeper.ChainID()),
+		"input":   fmt.Sprintf("%#x", input),
+	}
+	resObj = sendRequestGood(t, "estimateGas", txArgs, nil, map[string]interface{}{})
+	result = resObj["result"].(string)
+	require.Equal(t, "0x534d", result) // 21325
+}
+
+func TestCreateAccessList(t *testing.T) {
+	_, from := keeper.MockAddressPair()
+	_, contractAddr := keeper.MockAddressPair()
+	code, err := os.ReadFile("../x/evm/keeper/testdata/SimpleStorage/SimpleStorage.bin")
+	require.Nil(t, err)
+	bz, err := hex.DecodeString(string(code))
+	require.Nil(t, err)
+	abi, err := testdata.TestdataMetaData.GetAbi()
+	require.Nil(t, err)
+	input, err := abi.Pack("set", big.NewInt(20))
+	require.Nil(t, err)
+	EVMKeeper.SetCode(Ctx, contractAddr, bz)
+	txArgs := map[string]interface{}{
+		"from":    from.Hex(),
+		"to":      contractAddr.Hex(),
+		"value":   "0x0",
+		"nonce":   "0x1",
+		"chainId": fmt.Sprintf("%#x", EVMKeeper.ChainID()),
+		"input":   fmt.Sprintf("%#x", input),
+	}
+	EVMKeeper.BankKeeper().MintCoins(Ctx, types.ModuleName, sdk.NewCoins(sdk.NewCoin(EVMKeeper.GetBaseDenom(Ctx), sdk.NewInt(20))))
+	EVMKeeper.SetOrDeleteBalance(Ctx, from, 20)
+	resObj := sendRequestGood(t, "createAccessList", txArgs, "latest")
+	result := resObj["result"].(map[string]interface{})
+	require.Equal(t, []interface{}{}, result["accessList"]) // the code uses MSTORE which does not trace access list
+}

--- a/evmrpc/state_test.go
+++ b/evmrpc/state_test.go
@@ -74,7 +74,6 @@ func TestGetBalance(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fmt.Println("addr = ", tt.addr)
 			body := fmt.Sprintf("{\"jsonrpc\": \"2.0\",\"method\": \"eth_getBalance\",\"params\":[\"%s\",\"%s\"],\"id\":\"test\"}", tt.addr, tt.blockNr)
 			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s:%d", TestAddr, TestPort), strings.NewReader(body))
 			require.Nil(t, err)

--- a/evmrpc/testutils.go
+++ b/evmrpc/testutils.go
@@ -294,6 +294,9 @@ func sendRequest(t *testing.T, port int, method string, params ...interface{}) m
 }
 
 func formatParam(p interface{}) string {
+	if p == nil {
+		return "null"
+	}
 	switch v := p.(type) {
 	case int:
 		return fmt.Sprintf("%d", v)
@@ -303,6 +306,12 @@ func formatParam(p interface{}) string {
 		return fmt.Sprintf("\"%s\"", v)
 	case []interface{}:
 		return fmt.Sprintf("[%s]", strings.Join(utils.Map(v, formatParam), ","))
+	case map[string]interface{}:
+		kvs := []string{}
+		for k, v := range v {
+			kvs = append(kvs, fmt.Sprintf("\"%s\":%s", k, formatParam(v)))
+		}
+		return fmt.Sprintf("{%s}", strings.Join(kvs, ","))
 	default:
 		return fmt.Sprintf("%s", p)
 	}

--- a/evmrpc/testutils.go
+++ b/evmrpc/testutils.go
@@ -44,6 +44,8 @@ var Encoder = TxConfig.TxEncoder()
 var Decoder = TxConfig.TxDecoder()
 var Tx sdk.Tx
 
+var SConfig = SimulateConfig{GasCap: 10000000}
+
 type MockClient struct {
 	mock.Client
 }
@@ -172,14 +174,14 @@ var Ctx sdk.Context
 func init() {
 	types.RegisterInterfaces(EncodingConfig.InterfaceRegistry)
 	EVMKeeper, _, Ctx = keeper.MockEVMKeeper()
-	httpServer, err := NewEVMHTTPServer(log.NewNopLogger(), TestAddr, TestPort, rpc.DefaultHTTPTimeouts, &MockClient{}, EVMKeeper, func(int64) sdk.Context { return Ctx }, TxConfig)
+	httpServer, err := NewEVMHTTPServer(log.NewNopLogger(), TestAddr, TestPort, rpc.DefaultHTTPTimeouts, &MockClient{}, EVMKeeper, func(int64) sdk.Context { return Ctx }, TxConfig, &SConfig)
 	if err != nil {
 		panic(err)
 	}
 	if err := httpServer.Start(); err != nil {
 		panic(err)
 	}
-	badHTTPServer, err := NewEVMHTTPServer(log.NewNopLogger(), TestAddr, TestBadPort, rpc.DefaultHTTPTimeouts, &MockBadClient{}, EVMKeeper, func(int64) sdk.Context { return Ctx }, TxConfig)
+	badHTTPServer, err := NewEVMHTTPServer(log.NewNopLogger(), TestAddr, TestBadPort, rpc.DefaultHTTPTimeouts, &MockBadClient{}, EVMKeeper, func(int64) sdk.Context { return Ctx }, TxConfig, &SConfig)
 	if err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 	github.com/cosmos/gorocksdb v1.2.0 // indirect
 	github.com/cosmos/ledger-cosmos-go v0.11.1 // indirect
 	github.com/cosmos/ledger-go v0.9.2 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/crate-crypto/go-kzg-4844 v0.3.0 // indirect
 	github.com/creachadair/taskgroup v0.3.2 // indirect
 	github.com/daixiang0/gci v0.3.3 // indirect
@@ -114,9 +115,10 @@ require (
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/firefart/nonamedreturns v1.0.1 // indirect
+	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/fzipp/gocyclo v0.5.1 // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff // indirect
 	github.com/go-critic/go-critic v0.6.3 // indirect
 	github.com/go-kit/kit v0.12.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
@@ -165,9 +167,9 @@ require (
 	github.com/gostaticanalysis/nilerr v0.1.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-bexpr v0.1.10 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
@@ -176,9 +178,12 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hdevalence/ed25519consensus v0.0.0-20210204194344-59a8610d2b87 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
+	github.com/holiman/billy v0.0.0-20230718173358-1c7e68d277a7 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
+	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/improbable-eng/grpc-web v0.14.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jgautheron/goconst v1.5.1 // indirect
 	github.com/jingyugao/rowserrcheck v1.1.1 // indirect
 	github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af // indirect
@@ -210,6 +215,7 @@ require (
 	github.com/mbilski/exhaustivestruct v1.2.0 // indirect
 	github.com/mgechev/revive v1.2.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/pointerstructure v1.2.0 // indirect
 	github.com/mmcloughlin/addchain v0.4.0 // indirect
 	github.com/moricho/tparallel v0.2.1 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
@@ -239,6 +245,7 @@ require (
 	github.com/regen-network/cosmos-proto v0.3.1 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/rs/xid v1.3.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ryancurrah/gomodguard v1.2.3 // indirect
 	github.com/ryanrolds/sqlclosecheck v0.3.0 // indirect
 	github.com/sanposhiho/wastedassign/v2 v2.0.6 // indirect
@@ -258,6 +265,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.13.0 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
+	github.com/status-im/keycard-go v0.2.0 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.1.1 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
@@ -273,9 +281,12 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/tomarrell/wrapcheck/v2 v2.6.1 // indirect
 	github.com/tommy-muehle/go-mnd/v2 v2.5.0 // indirect
+	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	github.com/ultraware/funlen v0.0.3 // indirect
 	github.com/ultraware/whitespace v0.0.5 // indirect
+	github.com/urfave/cli/v2 v2.25.7 // indirect
 	github.com/uudashr/gocognit v1.0.5 // indirect
+	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	github.com/yagipy/maintidx v1.0.0 // indirect
 	github.com/yeya24/promlinter v0.2.0 // indirect
 	github.com/yourbasic/graph v0.0.0-20210606180040-8ecfec1c2869 // indirect
@@ -291,10 +302,12 @@ require (
 	golang.org/x/net v0.15.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/term v0.12.0 // indirect
+	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.13.0 // indirect
 	google.golang.org/genproto v0.0.0-20230803162519-f966b187b2e5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	honnef.co/go/tools v0.3.1 // indirect
 	mvdan.cc/gofumpt v0.3.1 // indirect
 	mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed // indirect
@@ -310,7 +323,7 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.61
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.7
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.2.0
-	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.2-sei
+	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.2-sei-5
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.2.27

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,7 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1/go.mod h1:fBF9PQNqB8scdgpZ3
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.3.0/go.mod h1:tPaiy8S5bQ+S5sOiDlINkp7+Ef339+Nz5L5XO+cnOHo=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
+github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
@@ -107,6 +108,7 @@ github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuN
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
+github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OpenPeeDeeP/depguard v1.1.0 h1:pjK9nLPS1FwQYGGpPxoMYpe7qACHOhAWQMQzV71i49o=
@@ -124,6 +126,7 @@ github.com/Zilliqa/gozilliqa-sdk v1.2.1-0.20201201074141-dd0ecada1be6/go.mod h1:
 github.com/aclements/go-gg v0.0.0-20170118225347-6dbb4e4fefb0/go.mod h1:55qNq4vcpkIuHowELi5C8e+1yUHtoLoOUR9QU5j7Tes=
 github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794/go.mod h1:7e+I0LQFUI9AXWxOfsQROs9xPhoJtbsyWcjJqDd4KPY=
 github.com/adlio/schema v1.3.0 h1:eSVYLxYWbm/6ReZBCkLw4Fz7uqC+ZNoPvA39bOwi52A=
+github.com/adlio/schema v1.3.0/go.mod h1:51QzxkpeFs6lRY11kPye26IaFPOV+HqEj01t5aXXKfs=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
@@ -208,6 +211,7 @@ github.com/btcsuite/btcutil v0.0.0-20190207003914-4c204d697803/go.mod h1:+5NJ2+q
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/btcsuite/btcutil v1.0.2/go.mod h1:j9HUFwoQRsZL3V4n+qG+CUnEGHOarIxfC3Le2Yhbcts=
 github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce h1:YtWJF7RHm2pYCvA5t0RPmAaLUhREsKuKd+SLhxFbFeQ=
+github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce/go.mod h1:0DVlHczLPewLcPGEIeUEzfOJhqGPQ0mJJRDBtD307+o=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
 github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVaaLLH7j4eDXPRvw78tMflu7Ie2bzYOH4Y8rRKBY=
 github.com/btcsuite/goleveldb v1.0.0/go.mod h1:QiK9vBlgftBg6rWQIj6wFzbPfRjiykIEhBH4obrXJ/I=
@@ -273,6 +277,7 @@ github.com/consensys/gnark-crypto v0.10.0 h1:zRh22SR7o4K35SoNqouS9J/TKHTyU2QWaj5
 github.com/consensys/gnark-crypto v0.10.0/go.mod h1:Iq/P3HHl0ElSjsg2E1gsMwhAyxnxoKK5nVyZKd+/KhU=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
 github.com/containerd/continuity v0.2.1 h1:/EeEo2EtN3umhbbgCveyjifoMYg0pS+nMMEemaYw634=
+github.com/containerd/continuity v0.2.1/go.mod h1:wCYX+dRqZdImhGucXOqTQn05AhX6EUDaGEMUzTFFpLg=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
@@ -294,6 +299,7 @@ github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4x
 github.com/cosmos/gorocksdb v1.2.0 h1:d0l3jJG8M4hBouIZq0mDUHZ+zjOx044J3nGRskwTb4Y=
 github.com/cosmos/gorocksdb v1.2.0/go.mod h1:aaKvKItm514hKfNJpUJXnnOWeBnk2GL4+Qw9NHizILw=
 github.com/cosmos/interchain-accounts v0.1.0 h1:QmuwNsf1Hxl3P5GSGt7Z+JeuHPiZw4Z34R/038P5T6s=
+github.com/cosmos/interchain-accounts v0.1.0/go.mod h1:Fv6LXDs+0ng4mIDVWwEJMXbAIMxY4kiq+A7Bw1Fb9AY=
 github.com/cosmos/ledger-cosmos-go v0.11.1 h1:9JIYsGnXP613pb2vPjFeMMjBI5lEDsEaF6oYorTy6J4=
 github.com/cosmos/ledger-cosmos-go v0.11.1/go.mod h1:J8//BsAGTo3OC/vDLjMRFLW6q0WAaXvHnVc7ZmE8iUY=
 github.com/cosmos/ledger-go v0.9.2 h1:Nnao/dLwaVTk1Q5U9THldpUMMXU94BOTWPddSmVB6pI=
@@ -301,6 +307,7 @@ github.com/cosmos/ledger-go v0.9.2/go.mod h1:oZJ2hHAZROdlHiwTg4t7kP+GKIIkBT+o6c9
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/crate-crypto/go-ipa v0.0.0-20230601170251-1830d0757c80/go.mod h1:gzbVz57IDJgQ9rLQwfSk696JGWof8ftznEL9GoAv3NI=
 github.com/crate-crypto/go-kzg-4844 v0.3.0 h1:UBlWE0CgyFqqzTI+IFyCzA7A3Zw4iip6uzRv5NIXG0A=
@@ -354,6 +361,7 @@ github.com/dnaeon/go-vcr v1.1.0/go.mod h1:M7tiix8f0r6mKKJ3Yq/kqU1OYf3MnfmBWVbPx/
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/docker/docker v24.0.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
+github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dop251/goja v0.0.0-20211022113120-dc8c55024d06/go.mod h1:R9ET47fwRVRPZnOGvHxxhuZcbrMCuiqOz3Rlrh4KSnk=
@@ -382,8 +390,11 @@ github.com/ethereum/c-kzg-4844 v0.3.1/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1
 github.com/ettle/strcase v0.1.1 h1:htFueZyVeE1XNnMEfbqp5r67qAN/4r6ya1ysq8Q+Zcw=
 github.com/ettle/strcase v0.1.1/go.mod h1:hzDLsPC7/lwKyBOywSHEP89nt2pDgdy+No1NBA9o9VY=
 github.com/facebookgo/ensure v0.0.0-20200202191622-63f1cf65ac4c h1:8ISkoahWXwZR41ois5lSJBSVw4D0OV19Ht/JSTzvSv0=
+github.com/facebookgo/ensure v0.0.0-20200202191622-63f1cf65ac4c/go.mod h1:Yg+htXGokKKdzcwhuNDwVvN+uBxDGXJ7G/VN1d8fa64=
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojtoVVWjGfOF9635RETekkoH6Cc9SX0A=
+github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqLaRiH3MsBH8va0n7s1pQYcu3uTb8G4tygF4Zg=
 github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 h1:7HZCaLC5+BZpmbhCOZJ293Lz68O7PYrF2EzeiFMwCLk=
+github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
@@ -399,15 +410,18 @@ github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/firefart/nonamedreturns v1.0.1 h1:fSvcq6ZpK/uBAgJEGMvzErlzyM4NELLqqdTofVjVNag=
 github.com/firefart/nonamedreturns v1.0.1/go.mod h1:D3dpIBojGGNh5UfElmwPu73SwDCm+VKhHYqwlNOk2uQ=
 github.com/fjl/gencodec v0.0.0-20230517082657-f9840df7b83e/go.mod h1:AzA8Lj6YtixmJWL+wkKoBGsLWy9gFrAzi4g+5bCKwpY=
+github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 h1:FtmdgXiUlNeRsoNMFlKLDt+S+6hbjVMEW6RGQ7aUf7c=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/flosch/pongo2 v0.0.0-20190707114632-bbf5a6c351f4/go.mod h1:T9YF2M40nIgbVgp3rreNmTged+9HrbNTIQf1PsaIiTA=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
+github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
+github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
@@ -424,7 +438,6 @@ github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x
 github.com/gballet/go-verkle v0.0.0-20230607174250-df487255f46b/go.mod h1:CDncRYVRSDqwakm282WEkjfaAj1hxU/v5RXxk5nXOiI=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghemawat/stream v0.0.0-20171120220530-696b145b53b9/go.mod h1:106OIgooyS7OzLDOpUGgm9fA3bQENb/cFSyyBmMoJDs=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
@@ -432,6 +445,7 @@ github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/gin-gonic/gin v1.7.7 h1:3DoBmSbJbZAWqXJC3SLjAPfutPJJRN1U5pALB7EeTTs=
+github.com/gin-gonic/gin v1.7.7/go.mod h1:axIBovoeJpVj8S3BwE0uPMTeReE4+AfFtqpqaZ1qq1U=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-chi/chi/v5 v5.0.0/go.mod h1:BBug9lr0cqtdAhsu6R4AAdvufI0/XBzAQSsUqJpoZOs=
 github.com/go-critic/go-critic v0.6.3 h1:abibh5XYBTASawfTQ0rA7dVtQT+6KzpGqb/J+DxRDaw=
@@ -711,6 +725,7 @@ github.com/gostaticanalysis/nilerr v0.1.1 h1:ThE+hJP0fEp4zWLkWHWcRyI2Od0p7DlgYG3
 github.com/gostaticanalysis/nilerr v0.1.1/go.mod h1:wZYb6YI5YAxxq0i1+VJbY0s2YONW0HU0GPE3+5PWN4A=
 github.com/gostaticanalysis/testutil v0.3.1-0.20210208050101-bfb5c8eec0e4/go.mod h1:D+FIZ+7OahH3ePw/izIEeH5I06eKs1IKI4Xr64/Am3M=
 github.com/gostaticanalysis/testutil v0.4.0 h1:nhdCmubdmDF6VEatUNjgUZBJKWRqugoISdUv3PPQgHY=
+github.com/gostaticanalysis/testutil v0.4.0/go.mod h1:bLIoPefWXrRi/ssLFWX1dx7Repi5x3CuviD3dgAZaBU=
 github.com/graph-gophers/graphql-go v1.3.0/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -726,8 +741,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.12.1/go.mod h1:8XEsbTttt/W+VvjtQhLACqCisSPWTxCZ7sBRjU6iH9c=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0 h1:RtRsiaGvWxcwd8y3BiRZxsylPT8hLWZ5SPcfI+3IDNk=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0/go.mod h1:TzP6duP4Py2pHLVPPQp42aoYI92+PCrVotyR5e8Vqlk=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/guptarohit/asciigraph v0.5.5/go.mod h1:dYl5wwK4gNsnFf9Zp+l06rFiDZ5YtXM6x7SRWZ3KGag=
@@ -737,6 +750,7 @@ github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyN
 github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-bexpr v0.1.10 h1:9kuI5PFotCboP3dkDYFr/wi0gg0QVbSNz5oFRpxn4uE=
 github.com/hashicorp/go-bexpr v0.1.10/go.mod h1:oxlubA2vC/gFVfX1A6JGp7ls7uCDlfJn732ehYYg+g0=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -785,6 +799,7 @@ github.com/hdevalence/ed25519consensus v0.0.0-20210204194344-59a8610d2b87 h1:uUj
 github.com/hdevalence/ed25519consensus v0.0.0-20210204194344-59a8610d2b87/go.mod h1:XGsKKeXxeRr95aEOgipvluMPlgjr7dGlk9ZTWOjcUcg=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
+github.com/holiman/billy v0.0.0-20230718173358-1c7e68d277a7 h1:3JQNjnMRil1yD0IfZKHF9GxxWKDJGj8I0IqOUol//sw=
 github.com/holiman/billy v0.0.0-20230718173358-1c7e68d277a7/go.mod h1:5GuXa7vkL8u9FkFuWdVvfR5ix8hRB7DbOAaYULamFpc=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
 github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iURXE7ZOP9L9hSkA=
@@ -825,6 +840,7 @@ github.com/jgautheron/goconst v1.5.1 h1:HxVbL1MhydKs8R8n/HE5NPvzfaYmQJA3o879lE4+
 github.com/jgautheron/goconst v1.5.1/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=
 github.com/jhump/protoreflect v1.6.1/go.mod h1:RZQ/lnuN+zqeRVpQigTwO6o0AJUkxbnSnpuG7toUTG4=
 github.com/jhump/protoreflect v1.12.1-0.20220417024638-438db461d753 h1:uFlcJKZPLQd7rmOY/RrvBuUaYmAFnlFHKLivhO6cOy8=
+github.com/jhump/protoreflect v1.12.1-0.20220417024638-438db461d753/go.mod h1:JytZfP5d0r8pVNLZvai7U/MCuTWITgrI4tTg7puQFKI=
 github.com/jingyugao/rowserrcheck v1.1.1 h1:zibz55j/MJtLsjP1OF4bSdgXxwL1b+Vn7Tjzq7gFzUs=
 github.com/jingyugao/rowserrcheck v1.1.1/go.mod h1:4yvlZSDb3IyDTUZJUmpZfm2Hwok+Dtp+nu2qOq+er9c=
 github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af h1:KA9BjwUk7KlCh6S9EAGWBt1oExIUv9WyNCiRz5amv48=
@@ -1012,6 +1028,7 @@ github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/pointerstructure v1.2.0 h1:O+i9nHnXS3l/9Wu7r4NrEdwA2VFTicjUEN1uBnDo34A=
 github.com/mitchellh/pointerstructure v1.2.0/go.mod h1:BRAsLI5zgXmw97Lf6s25bs8ohIXc3tViBH44KcwB2g4=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
@@ -1097,7 +1114,9 @@ github.com/onsi/gomega v1.18.1 h1:M1GfJqGRrBrrGGsbxzV5dqM2U2ApXefZCQpkukxYRLE=
 github.com/onsi/gomega v1.18.1/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
+github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v1.1.5 h1:L44KXEpKmfWDcS02aeGm8QNTFXTo2D+8MYGDIJ/GDEs=
 github.com/opencontainers/runc v1.1.5/go.mod h1:1J5XiS+vdZ3wCyZybsuxXZWGrgSr8fFJHLXuG2PsnNg=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
@@ -1111,6 +1130,7 @@ github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJ
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
+github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/copy v1.6.0 h1:IinKAryFFuPONZ7cm6T6E2QX/vcJwSnlaA5lfoaXIiQ=
 github.com/otiai10/copy v1.6.0/go.mod h1:XWfuS3CrI0R6IE0FbgHsEazaXO8G0LpMp9o8tos0x4E=
@@ -1246,6 +1266,7 @@ github.com/rs/zerolog v1.27.0 h1:1T7qCieN22GVc8S4Q2yuexzBb1EqjbgjSH9RohbMjKs=
 github.com/rs/zerolog v1.27.0/go.mod h1:7frBqO0oezxmnO7GF86FY++uy8I0Tk/If5ni1G9Qc0U=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245/go.mod h1:pQAZKsJ8yyVxGRWYNEm9oFB8ieLgKFnamEyDmSA0BRk=
@@ -1269,8 +1290,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/go-ethereum v1.13.2-sei h1:fbu2Y88WDyPHsdnqZx6Y6BzmTlX3+sbUFXaFMhEdfac=
-github.com/sei-protocol/go-ethereum v1.13.2-sei/go.mod h1:i/Hz2ZHc7yCb+a2t8LsJOfEvT/LT7KBplwTpbceS3q0=
+github.com/sei-protocol/go-ethereum v1.13.2-sei-5 h1:MOX1MuCfaAp0thGqYlmjfXh1XlfGYteErRQ98Qy8s9k=
+github.com/sei-protocol/go-ethereum v1.13.2-sei-5/go.mod h1:i/Hz2ZHc7yCb+a2t8LsJOfEvT/LT7KBplwTpbceS3q0=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-cosmos v0.2.61 h1:2BmRscI5ZPfTqRbBQpwrBMZ0vJeGRBBUoDwDUwPnlGA=
@@ -1434,6 +1455,7 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/urfave/cli/v2 v2.24.1/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
+github.com/urfave/cli/v2 v2.25.7 h1:VAzn5oq403l5pHjc4OhD54+XGO9cdKVL/7lDjF+iKUs=
 github.com/urfave/cli/v2 v2.25.7/go.mod h1:8qnjx1vcq5s2/wpsqoZFndg2CE5tNFyrTvS6SinrnYQ=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/uudashr/gocognit v1.0.5 h1:rrSex7oHr3/pPLQ0xoWq108XMU8s678FJcQ+aSfOHa4=
@@ -1454,6 +1476,7 @@ github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQ
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yagipy/maintidx v1.0.0 h1:h5NvIsCz+nRDapQ0exNv4aJ0yXSI0420omVANTv3GJM=
 github.com/yagipy/maintidx v1.0.0/go.mod h1:0qNf/I/CCZXSMhsRsrEPDZ+DkekpKLXAJfsTACwgXLk=
@@ -1880,6 +1903,7 @@ golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20201208040808-7e3f01d25324/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
 golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -2174,6 +2198,7 @@ gopkg.in/ini.v1 v1.66.4/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
@@ -2196,6 +2221,7 @@ gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
@@ -2217,6 +2243,7 @@ mvdan.cc/unparam v0.0.0-20211214103731-d0ef000c54e5/go.mod h1:b8RRCBm0eeiWR8cfN8
 nhooyr.io/websocket v1.8.6 h1:s+C3xAMLwGmlI31Nyn/eAehUlZPwfYZu2JXM621Q5/k=
 nhooyr.io/websocket v1.8.6/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
 pgregory.net/rapid v0.4.7 h1:MTNRktPuv5FNqOO151TM9mDTa+XHcX6ypYeISDVD14g=
+pgregory.net/rapid v0.4.7/go.mod h1:UYpPVyjFHzYBGHIxLFoupi8vwk6rXNzRY9OMvVxFIOU=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"fmt"
+	"math"
 	"math/big"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
@@ -9,7 +11,11 @@ import (
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
+	tmtypes "github.com/tendermint/tendermint/types"
 )
 
 type Keeper struct {
@@ -75,4 +81,60 @@ func (k *Keeper) PurgePrefix(ctx sdk.Context, pref []byte) {
 	for _, key := range keys {
 		store.Delete(key)
 	}
+}
+
+func (k *Keeper) GetVMBlockContext(ctx sdk.Context, gp core.GasPool) (*vm.BlockContext, error) {
+	coinbase, err := k.GetFeeCollectorAddress(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &vm.BlockContext{
+		CanTransfer: core.CanTransfer,
+		Transfer:    core.Transfer,
+		GetHash:     k.getHashFn(ctx),
+		Coinbase:    coinbase,
+		GasLimit:    gp.Gas(),
+		BlockNumber: big.NewInt(ctx.BlockHeight()),
+		Time:        uint64(ctx.BlockHeader().Time.Unix()),
+		Difficulty:  big.NewInt(0),                               // only needed for PoW
+		BaseFee:     k.GetBaseFeePerGas(ctx).RoundInt().BigInt(), // feemarket not enabled
+		Random:      nil,                                         // not supported
+	}, nil
+}
+
+// returns a function that provides block header hash based on block number
+func (k *Keeper) getHashFn(ctx sdk.Context) vm.GetHashFunc {
+	return func(height uint64) common.Hash {
+		if height > math.MaxInt64 {
+			ctx.Logger().Error("Sei block height is bounded by int64 range")
+			return common.Hash{}
+		}
+		h := int64(height)
+		if ctx.BlockHeight() == h {
+			// current header hash is in the context already
+			return common.BytesToHash(ctx.HeaderHash())
+		}
+		if ctx.BlockHeight() < h {
+			// future block doesn't have a hash yet
+			return common.Hash{}
+		}
+		// fetch historical hash from historical info
+		return k.getHistoricalHash(ctx, h)
+	}
+}
+
+func (k *Keeper) getHistoricalHash(ctx sdk.Context, h int64) common.Hash {
+	histInfo, found := k.stakingKeeper.GetHistoricalInfo(ctx, h)
+	if !found {
+		// too old, already pruned
+		return common.Hash{}
+	}
+	header, err := tmtypes.HeaderFromProto(&histInfo.Header)
+	if err != nil {
+		// parsing issue
+		ctx.Logger().Error(fmt.Sprintf("failed to parse historical info header %s due to %s", histInfo.Header.String(), err))
+		return common.Hash{}
+	}
+
+	return common.BytesToHash(header.Hash())
 }

--- a/x/evm/keeper/keeper_test.go
+++ b/x/evm/keeper/keeper_test.go
@@ -1,12 +1,33 @@
 package keeper
 
 import (
+	"math"
 	"testing"
 
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGetChainID(t *testing.T) {
 	k, _, _ := MockEVMKeeper()
 	require.Equal(t, int64(1), k.ChainID().Int64())
+}
+
+func TestGetVMBlockContext(t *testing.T) {
+	k, _, ctx := MockEVMKeeper()
+	moduleAddr := k.accountKeeper.GetModuleAddress(authtypes.FeeCollectorName)
+	evmAddr, _ := k.GetEVMAddress(ctx, moduleAddr)
+	k.DeleteAddressMapping(ctx, moduleAddr, evmAddr)
+	_, err := k.GetVMBlockContext(ctx, 0)
+	require.NotNil(t, err)
+}
+
+func TestGetHashFn(t *testing.T) {
+	k, _, ctx := MockEVMKeeper()
+	f := k.getHashFn(ctx)
+	require.Equal(t, common.Hash{}, f(math.MaxInt64+1))
+	require.Equal(t, common.BytesToHash(ctx.HeaderHash()), f(uint64(ctx.BlockHeight())))
+	require.Equal(t, common.Hash{}, f(uint64(ctx.BlockHeight())+1))
+	require.Equal(t, common.Hash{}, f(uint64(ctx.BlockHeight())-1))
 }

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -2,19 +2,16 @@ package keeper
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"math/big"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
-	tmtypes "github.com/tendermint/tendermint/types"
 )
 
 type msgServer struct {
@@ -87,25 +84,13 @@ func (server msgServer) getEVMMessage(ctx sdk.Context, tx *ethtypes.Transaction)
 }
 
 func (server msgServer) applyEVMMessage(ctx sdk.Context, msg *core.Message, stateDB vm.StateDB, gp core.GasPool) (*core.ExecutionResult, error) {
-	coinbase, err := server.GetFeeCollectorAddress(ctx)
+	blockCtx, err := server.GetVMBlockContext(ctx, gp)
 	if err != nil {
 		return nil, err
 	}
 	cfg := server.GetChainConfig(ctx).EthereumConfig(server.ChainID())
-	blockCtx := vm.BlockContext{
-		CanTransfer: core.CanTransfer,
-		Transfer:    core.Transfer,
-		GetHash:     server.getHashFn(ctx),
-		Coinbase:    coinbase,
-		GasLimit:    gp.Gas(),
-		BlockNumber: big.NewInt(ctx.BlockHeight()),
-		Time:        uint64(ctx.BlockHeader().Time.Unix()),
-		Difficulty:  big.NewInt(0),                                    // only needed for PoW
-		BaseFee:     server.GetBaseFeePerGas(ctx).RoundInt().BigInt(), // feemarket not enabled
-		Random:      nil,                                              // not supported
-	}
 	txCtx := core.NewEVMTxContext(msg)
-	evmInstance := vm.NewEVM(blockCtx, txCtx, stateDB, cfg, vm.Config{})
+	evmInstance := vm.NewEVM(*blockCtx, txCtx, stateDB, cfg, vm.Config{})
 	st := core.NewStateTransition(evmInstance, msg, &gp)
 	return st.TransitionDb()
 }
@@ -152,41 +137,4 @@ func (server msgServer) writeReceipt(ctx sdk.Context, tx *ethtypes.Transaction, 
 	}
 
 	return server.SetReceipt(ctx, tx.Hash(), receipt)
-}
-
-// returns a function that provides block header hash based on block number
-func (server msgServer) getHashFn(ctx sdk.Context) vm.GetHashFunc {
-	return func(height uint64) common.Hash {
-		if height > math.MaxInt64 {
-			ctx.Logger().Error("Sei block height is bounded by int64 range")
-			return common.Hash{}
-		}
-		h := int64(height)
-		if ctx.BlockHeight() == h {
-			// current header hash is in the context already
-			return common.BytesToHash(ctx.HeaderHash())
-		}
-		if ctx.BlockHeight() < h {
-			// future block doesn't have a hash yet
-			return common.Hash{}
-		}
-		// fetch historical hash from historical info
-		return server.getHistoricalHash(ctx, h)
-	}
-}
-
-func (server msgServer) getHistoricalHash(ctx sdk.Context, h int64) common.Hash {
-	histInfo, found := server.stakingKeeper.GetHistoricalInfo(ctx, h)
-	if !found {
-		// too old, already pruned
-		return common.Hash{}
-	}
-	header, err := tmtypes.HeaderFromProto(&histInfo.Header)
-	if err != nil {
-		// parsing issue
-		ctx.Logger().Error(fmt.Sprintf("failed to parse historical info header %s due to %s", histInfo.Header.String(), err))
-		return common.Hash{}
-	}
-
-	return common.BytesToHash(header.Hash())
 }

--- a/x/evm/state/balance_test.go
+++ b/x/evm/state/balance_test.go
@@ -71,6 +71,19 @@ func TestSubBalance(t *testing.T) {
 	require.NotNil(t, db.Err())
 }
 
+func TestSetBalance(t *testing.T) {
+	k, _, ctx := keeper.MockEVMKeeper()
+	db := state.NewDBImpl(ctx, k)
+	_, evmAddr := keeper.MockAddressPair()
+	db.SetBalance(evmAddr, big.NewInt(10))
+	require.Equal(t, big.NewInt(10), db.GetBalance(evmAddr))
+
+	seiAddr2, evmAddr2 := keeper.MockAddressPair()
+	k.SetAddressMapping(db.Ctx(), seiAddr2, evmAddr2)
+	db.SetBalance(evmAddr2, big.NewInt(10))
+	require.Equal(t, big.NewInt(10), db.GetBalance(evmAddr2))
+}
+
 func TestCheckBalance(t *testing.T) {
 	k, _, ctx := keeper.MockEVMKeeper()
 	db := state.NewDBImpl(ctx, k)

--- a/x/evm/state/log.go
+++ b/x/evm/state/log.go
@@ -3,6 +3,7 @@ package state
 import (
 	"encoding/json"
 
+	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
@@ -15,7 +16,7 @@ func (s *DBImpl) AddLog(l *ethtypes.Log) {
 	// TODO: potentially decorate log with block/tx metadata
 	store := s.k.PrefixStore(s.ctx, types.TransientModuleStateKeyPrefix)
 	logs := Logs{Ls: []*ethtypes.Log{}}
-	ls, err := s.GetLogs()
+	ls, err := s.GetAllLogs()
 	if err != nil {
 		s.err = err
 		return
@@ -29,7 +30,7 @@ func (s *DBImpl) AddLog(l *ethtypes.Log) {
 	store.Set(LogsKey, logsbz)
 }
 
-func (s *DBImpl) GetLogs() ([]*ethtypes.Log, error) {
+func (s *DBImpl) GetAllLogs() ([]*ethtypes.Log, error) {
 	store := s.k.PrefixStore(s.ctx, types.TransientModuleStateKeyPrefix)
 	logsbz := store.Get(LogsKey)
 	logs := Logs{Ls: []*ethtypes.Log{}}
@@ -40,4 +41,13 @@ func (s *DBImpl) GetLogs() ([]*ethtypes.Log, error) {
 		return []*ethtypes.Log{}, err
 	}
 	return logs.Ls, nil
+}
+
+func (s *DBImpl) GetLogs(hash common.Hash, blockNumber uint64, blockHash common.Hash) []*ethtypes.Log {
+	logs, err := s.GetAllLogs()
+	if err != nil {
+		s.err = err
+		return []*ethtypes.Log{}
+	}
+	return logs
 }

--- a/x/evm/state/log.go
+++ b/x/evm/state/log.go
@@ -43,7 +43,7 @@ func (s *DBImpl) GetAllLogs() ([]*ethtypes.Log, error) {
 	return logs.Ls, nil
 }
 
-func (s *DBImpl) GetLogs(hash common.Hash, blockNumber uint64, blockHash common.Hash) []*ethtypes.Log {
+func (s *DBImpl) GetLogs(common.Hash, uint64, common.Hash) []*ethtypes.Log {
 	logs, err := s.GetAllLogs()
 	if err != nil {
 		s.err = err

--- a/x/evm/state/log_test.go
+++ b/x/evm/state/log_test.go
@@ -14,14 +14,14 @@ func TestAddLog(t *testing.T) {
 	k, _, ctx := keeper.MockEVMKeeper()
 	statedb := state.NewDBImpl(ctx, k)
 
-	logs, err := statedb.GetLogs()
+	logs, err := statedb.GetAllLogs()
 	require.Nil(t, err)
 	require.Empty(t, logs)
 
 	log1 := ethtypes.Log{Address: common.BytesToAddress([]byte{1}), Topics: []common.Hash{}, Data: []byte{}}
 	statedb.AddLog(&log1)
 	require.Nil(t, statedb.Err())
-	logs, err = statedb.GetLogs()
+	logs, err = statedb.GetAllLogs()
 	require.Nil(t, err)
 	require.Equal(t, 1, len(logs))
 	require.Equal(t, log1, *logs[0])
@@ -29,7 +29,7 @@ func TestAddLog(t *testing.T) {
 	log2 := ethtypes.Log{Address: common.BytesToAddress([]byte{2}), Topics: []common.Hash{}, Data: []byte{3}}
 	statedb.AddLog(&log2)
 	require.Nil(t, statedb.Err())
-	logs, err = statedb.GetLogs()
+	logs, err = statedb.GetAllLogs()
 	require.Nil(t, err)
 	require.Equal(t, 2, len(logs))
 	require.Equal(t, log1, *logs[0])

--- a/x/evm/state/log_test.go
+++ b/x/evm/state/log_test.go
@@ -34,4 +34,7 @@ func TestAddLog(t *testing.T) {
 	require.Equal(t, 2, len(logs))
 	require.Equal(t, log1, *logs[0])
 	require.Equal(t, log2, *logs[1])
+
+	logs = statedb.GetLogs(common.Hash{}, 0, common.Hash{})
+	require.Equal(t, 2, len(logs))
 }

--- a/x/evm/state/state.go
+++ b/x/evm/state/state.go
@@ -114,3 +114,10 @@ func (s *DBImpl) Created(acc common.Address) bool {
 	store := s.k.PrefixStore(s.ctx, types.AccountTransientStateKeyPrefix)
 	return bytes.Equal(store.Get(acc[:]), AccountCreated)
 }
+
+func (s *DBImpl) SetStorage(addr common.Address, states map[common.Hash]common.Hash) {
+	s.clearAccountState(addr)
+	for key, val := range states {
+		s.SetState(addr, key, val)
+	}
+}

--- a/x/evm/state/state_test.go
+++ b/x/evm/state/state_test.go
@@ -43,6 +43,9 @@ func TestState(t *testing.T) {
 	require.Equal(t, common.Hash{}, statedb.GetCommittedState(evmAddr, key))
 	require.Equal(t, big.NewInt(0), statedb.GetBalance(evmAddr))
 	require.True(t, statedb.HasSelfDestructed(evmAddr))
+	// set storage
+	statedb.SetStorage(evmAddr, map[common.Hash]common.Hash{{}: {}})
+	require.Equal(t, common.Hash{}, statedb.GetState(evmAddr, common.Hash{}))
 }
 
 func TestCreate(t *testing.T) {

--- a/x/evm/state/statedb.go
+++ b/x/evm/state/statedb.go
@@ -104,8 +104,8 @@ func (s *DBImpl) Copy() vm.StateDB {
 	}
 }
 
-func (s *DBImpl) Finalise(deleteEmptyObjects bool) {
-	panic("Finalise is not implemented and called unexpectedly")
+func (s *DBImpl) Finalise(bool) {
+	s.ctx.Logger().Info("Finalise should only be called during simulation and will no-op")
 }
 
 func (s *DBImpl) Commit(block uint64, deleteEmptyObjects bool) (common.Hash, error) {

--- a/x/evm/state/statedb.go
+++ b/x/evm/state/statedb.go
@@ -108,15 +108,15 @@ func (s *DBImpl) Finalise(bool) {
 	s.ctx.Logger().Info("Finalise should only be called during simulation and will no-op")
 }
 
-func (s *DBImpl) Commit(block uint64, deleteEmptyObjects bool) (common.Hash, error) {
+func (s *DBImpl) Commit(uint64, bool) (common.Hash, error) {
 	panic("Commit is not implemented and called unexpectedly")
 }
 
-func (s *DBImpl) SetTxContext(thash common.Hash, ti int) {
+func (s *DBImpl) SetTxContext(common.Hash, int) {
 	//noop
 }
 
-func (s *DBImpl) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
+func (s *DBImpl) IntermediateRoot(bool) common.Hash {
 	panic("IntermediateRoot is not implemented and called unexpectedly")
 }
 

--- a/x/evm/state/statedb.go
+++ b/x/evm/state/statedb.go
@@ -6,6 +6,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/sei-protocol/sei-chain/utils"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
@@ -46,7 +47,7 @@ func (s *DBImpl) Finalize() error {
 		return err
 	}
 
-	logs, err := s.GetLogs()
+	logs, err := s.GetAllLogs()
 	if err != nil {
 		return err
 	}
@@ -82,6 +83,49 @@ func (s *DBImpl) flushCtx(ctx sdk.Context) {
 	s.k.PurgePrefix(ctx, types.AccountTransientStateKeyPrefix)
 	s.k.PurgePrefix(ctx, types.TransientModuleStateKeyPrefix)
 	ctx.MultiStore().(sdk.CacheMultiStore).Write()
+}
+
+// Backward-compatibility functions
+func (s *DBImpl) Error() error {
+	return s.Err()
+}
+
+func (s *DBImpl) GetStorageRoot(common.Address) common.Hash {
+	panic("GetStorageRoot is not implemented and called unexpectedly")
+}
+
+func (s *DBImpl) Copy() vm.StateDB {
+	newCtx := s.ctx.WithMultiStore(s.ctx.MultiStore().CacheMultiStore())
+	return &DBImpl{
+		ctx:             newCtx,
+		snapshottedCtxs: append(s.snapshottedCtxs, s.ctx),
+		k:               s.k,
+		err:             s.err,
+	}
+}
+
+func (s *DBImpl) Finalise(deleteEmptyObjects bool) {
+	panic("Finalise is not implemented and called unexpectedly")
+}
+
+func (s *DBImpl) Commit(block uint64, deleteEmptyObjects bool) (common.Hash, error) {
+	panic("Commit is not implemented and called unexpectedly")
+}
+
+func (s *DBImpl) SetTxContext(thash common.Hash, ti int) {
+	//noop
+}
+
+func (s *DBImpl) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
+	panic("IntermediateRoot is not implemented and called unexpectedly")
+}
+
+func (s *DBImpl) TxIndex() int {
+	return s.ctx.TxIndex()
+}
+
+func (s *DBImpl) Preimages() map[common.Hash][]byte {
+	return map[common.Hash][]byte{}
 }
 
 // ** TEST ONLY FUNCTIONS **//


### PR DESCRIPTION
## Describe your changes and provide context
Implement the following simulation endpoints:
`createAccessList`
`estimateGas`

The endpoint makes use of an implementation of interface `Backend` that drives the core simulation logic in go-ethereum. It only implemented the functions that may be called by `createAccessList` or `estimateGas`, and simplified logics such as `SuggestTipCap` to be config-based.

It also involves changes in our go-ethereum fork to expose private functions/types so that we don't have to copy them here.

## Testing performed to validate your change
unit tests
