### PR TITLE
[occ] enable occ prefill estimates from sei chain

### DIFF
--- a/aclmapping/utils/resource_type.go
+++ b/aclmapping/utils/resource_type.go
@@ -152,7 +152,7 @@ var StoreKeyToResourceTypePrefixMap = aclsdktypes.StoreKeyToResourceTypePrefixMa
 	},
 }
 
-// this maps between resource types and their respective storekey
+// ResourceTypeToStoreKeyMap this maps between resource types and their respective storekey
 var ResourceTypeToStoreKeyMap = aclsdktypes.ResourceTypeToStoreKeyMap{
 	// ANY, KV, and MEM are intentionally excluded because they don't map to a specific store key
 

--- a/aclmapping/utils/resource_type.go
+++ b/aclmapping/utils/resource_type.go
@@ -151,3 +151,129 @@ var StoreKeyToResourceTypePrefixMap = aclsdktypes.StoreKeyToResourceTypePrefixMa
 		aclsdktypes.ResourceType_KV_WASM_PINNED_CODE_INDEX:     wasmtypes.PinnedCodeIndexPrefix,
 	},
 }
+
+// this maps between resource types and their respective storekey
+var ResourceTypeToStoreKeyMap = aclsdktypes.ResourceTypeToStoreKeyMap{
+	// ANY, KV, and MEM are intentionally excluded because they don't map to a specific store key
+
+	// ~~~~ DEX Resource Types ~~~~
+	aclsdktypes.ResourceType_KV_DEX:                    dextypes.StoreKey,
+	aclsdktypes.ResourceType_DexMem:                    dextypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DEX_CONTRACT_LONGBOOK:  dextypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DEX_CONTRACT_SHORTBOOK: dextypes.StoreKey,
+	// pricedenom and assetdenoms are the prefixes
+	aclsdktypes.ResourceType_KV_DEX_PAIR_PREFIX:           dextypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DEX_TWAP:                  dextypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DEX_PRICE:                 dextypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DEX_SETTLEMENT_ENTRY:      dextypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DEX_REGISTERED_PAIR:       dextypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DEX_ORDER:                 dextypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DEX_CANCEL:                dextypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DEX_ACCOUNT_ACTIVE_ORDERS: dextypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DEX_ASSET_LIST:            dextypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DEX_NEXT_ORDER_ID:         dextypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DEX_NEXT_SETTLEMENT_ID:    dextypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DEX_MATCH_RESULT:          dextypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DEX_CONTRACT:              dextypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DEX_ORDER_BOOK:            dextypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DEX_LONG_ORDER_COUNT:      dextypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DEX_SHORT_ORDER_COUNT:     dextypes.StoreKey,
+	// SETTLEMENT keys are prefixed with account and order id
+	aclsdktypes.ResourceType_KV_DEX_SETTLEMENT_ORDER_ID: dextypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DEX_SETTLEMENT:          dextypes.StoreKey,
+
+	// ~~~~ DEX MEM Resource Types ~~~~
+	aclsdktypes.ResourceType_KV_DEX_MEM_ORDER:   dextypes.MemStoreKey,
+	aclsdktypes.ResourceType_KV_DEX_MEM_CANCEL:  dextypes.MemStoreKey,
+	aclsdktypes.ResourceType_KV_DEX_MEM_DEPOSIT: dextypes.MemStoreKey,
+
+	// ~~~~ BANK Resource Types ~~~~
+	aclsdktypes.ResourceType_KV_BANK:          banktypes.StoreKey,
+	aclsdktypes.ResourceType_KV_BANK_BALANCES: banktypes.StoreKey,
+	aclsdktypes.ResourceType_KV_BANK_SUPPLY:   banktypes.StoreKey,
+	aclsdktypes.ResourceType_KV_BANK_DENOM:    banktypes.StoreKey,
+
+	// ~~~~ BANK DEFERRED Resource Types ~~~~
+	aclsdktypes.ResourceType_KV_BANK_DEFERRED:                 banktypes.DeferredCacheStoreKey,
+	aclsdktypes.ResourceType_KV_BANK_DEFERRED_MODULE_TX_INDEX: banktypes.DeferredCacheStoreKey,
+
+	// ~~~~ AUTH Resource Types ~~~~
+	aclsdktypes.ResourceType_KV_AUTH:                       authtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_AUTH_ADDRESS_STORE:         authtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_AUTH_GLOBAL_ACCOUNT_NUMBER: authtypes.StoreKey,
+
+	// ~~~~ AUTHZ Resource Types ~~~~
+	aclsdktypes.ResourceType_KV_AUTHZ: authztypes.StoreKey,
+
+	// ~~~~ DISTRIBUTION Resource Types ~~~~
+	aclsdktypes.ResourceType_KV_DISTRIBUTION:                         distributiontypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DISTRIBUTION_FEE_POOL:                distributiontypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DISTRIBUTION_PROPOSER_KEY:            distributiontypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DISTRIBUTION_OUTSTANDING_REWARDS:     distributiontypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DISTRIBUTION_DELEGATOR_WITHDRAW_ADDR: distributiontypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DISTRIBUTION_DELEGATOR_STARTING_INFO: distributiontypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DISTRIBUTION_VAL_HISTORICAL_REWARDS:  distributiontypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DISTRIBUTION_VAL_CURRENT_REWARDS:     distributiontypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DISTRIBUTION_VAL_ACCUM_COMMISSION:    distributiontypes.StoreKey,
+	aclsdktypes.ResourceType_KV_DISTRIBUTION_SLASH_EVENT:             distributiontypes.StoreKey,
+
+	// ~~~~ FEEGRANT Resource Types ~~~~
+	aclsdktypes.ResourceType_KV_FEEGRANT:           feegranttypes.StoreKey,
+	aclsdktypes.ResourceType_KV_FEEGRANT_ALLOWANCE: feegranttypes.StoreKey,
+
+	// ~~~~ ORACLE Resource Types ~~~~
+	aclsdktypes.ResourceType_KV_ORACLE:                      oracletypes.StoreKey,
+	aclsdktypes.ResourceType_KV_ORACLE_VOTE_TARGETS:         oracletypes.StoreKey,
+	aclsdktypes.ResourceType_KV_ORACLE_AGGREGATE_VOTES:      oracletypes.StoreKey,
+	aclsdktypes.ResourceType_KV_ORACLE_FEEDERS:              oracletypes.StoreKey,
+	aclsdktypes.ResourceType_KV_ORACLE_PRICE_SNAPSHOT:       oracletypes.StoreKey,
+	aclsdktypes.ResourceType_KV_ORACLE_EXCHANGE_RATE:        oracletypes.StoreKey,
+	aclsdktypes.ResourceType_KV_ORACLE_VOTE_PENALTY_COUNTER: oracletypes.StoreKey,
+
+	// ~~~~ STAKING Resource Types ~~~~
+	aclsdktypes.ResourceType_KV_STAKING:                          stakingtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_STAKING_VALIDATION_POWER:         stakingtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_STAKING_TOTAL_POWER:              stakingtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_STAKING_VALIDATOR:                stakingtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_STAKING_VALIDATORS_CON_ADDR:      stakingtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_STAKING_VALIDATORS_BY_POWER:      stakingtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_STAKING_DELEGATION:               stakingtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_STAKING_UNBONDING_DELEGATION:     stakingtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_STAKING_UNBONDING_DELEGATION_VAL: stakingtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_STAKING_REDELEGATION:             stakingtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_STAKING_REDELEGATION_VAL_SRC:     stakingtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_STAKING_REDELEGATION_VAL_DST:     stakingtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_STAKING_UNBONDING:                stakingtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_STAKING_REDELEGATION_QUEUE:       stakingtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_STAKING_VALIDATOR_QUEUE:          stakingtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_STAKING_HISTORICAL_INFO:          stakingtypes.StoreKey,
+
+	// ~~~~ SLASHING Resource Types ~~~~
+	aclsdktypes.ResourceType_KV_SLASHING:                          slashingtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_SLASHING_VAL_SIGNING_INFO:         slashingtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_SLASHING_ADDR_PUBKEY_RELATION_KEY: slashingtypes.StoreKey,
+
+	// ~~~~ TOKENFACTORY Resource Types ~~~~
+	aclsdktypes.ResourceType_KV_TOKENFACTORY:          tokenfactorytypes.StoreKey,
+	aclsdktypes.ResourceType_KV_TOKENFACTORY_DENOM:    tokenfactorytypes.StoreKey,
+	aclsdktypes.ResourceType_KV_TOKENFACTORY_METADATA: tokenfactorytypes.StoreKey,
+	aclsdktypes.ResourceType_KV_TOKENFACTORY_ADMIN:    tokenfactorytypes.StoreKey,
+	aclsdktypes.ResourceType_KV_TOKENFACTORY_CREATOR:  tokenfactorytypes.StoreKey,
+
+	// ~~~~ EPOCH Resource Types ~~~~
+	aclsdktypes.ResourceType_KV_EPOCH: epochtypes.StoreKey,
+
+	// ~~~~ ACCESSCONTROL Resource Types ~~~~
+	aclsdktypes.ResourceType_KV_ACCESSCONTROL:                         acltypes.StoreKey,
+	aclsdktypes.ResourceType_KV_ACCESSCONTROL_WASM_DEPENDENCY_MAPPING: acltypes.StoreKey,
+
+	// ~~~~ WASM Resource Types ~~~~
+	aclsdktypes.ResourceType_KV_WASM:                       wasmtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_WASM_CODE:                  wasmtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_WASM_CONTRACT_ADDRESS:      wasmtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_WASM_CONTRACT_STORE:        wasmtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_WASM_SEQUENCE_KEY:          wasmtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_WASM_CONTRACT_CODE_HISTORY: wasmtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_WASM_CONTRACT_BY_CODE_ID:   wasmtypes.StoreKey,
+	aclsdktypes.ResourceType_KV_WASM_PINNED_CODE_INDEX:     wasmtypes.StoreKey,
+}

--- a/aclmapping/utils/resource_type_test.go
+++ b/aclmapping/utils/resource_type_test.go
@@ -26,3 +26,24 @@ func TestAllResourcesInTree(t *testing.T) {
 	}
 
 }
+
+func TestAllResourcesInStoreKeyMap(t *testing.T) {
+	resourceToStoreKeyMap := aclutils.ResourceTypeToStoreKeyMap
+	resourceTree := sdkacltypes.ResourceTree
+
+	storeKeyAllResourceTypes := make(map[sdkacltypes.ResourceType]bool)
+	for resourceType := range resourceToStoreKeyMap {
+		storeKeyAllResourceTypes[resourceType] = true
+	}
+
+	for resourceType := range resourceTree {
+		// omit ANY, KV, and MEM
+		if resourceType == sdkacltypes.ResourceType_ANY || resourceType == sdkacltypes.ResourceType_KV || resourceType == sdkacltypes.ResourceType_Mem {
+			continue
+		}
+		if _, ok := storeKeyAllResourceTypes[resourceType]; !ok {
+			panic(fmt.Sprintf("Missing resourceType=%s in the storekey to resource type prefix mapping", resourceType))
+		}
+	}
+
+}

--- a/go.mod
+++ b/go.mod
@@ -273,7 +273,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027205606-c930b887300d
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027210312-bcd20caeb4db
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.7
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.2.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.mod
+++ b/go.mod
@@ -271,7 +271,7 @@ require (
 )
 
 replace (
-	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.2
+	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.3-0.20231031145448-477bc8749e39
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027223908-157d75690bbe
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.7

--- a/go.mod
+++ b/go.mod
@@ -273,7 +273,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.64-0.20231024155214-27484e42caff
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.64-0.20231025141710-f079aaca9d3f
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.7
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.2.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.mod
+++ b/go.mod
@@ -273,7 +273,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027210312-bcd20caeb4db
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027214813-e89a4bd67538
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.7
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.2.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.mod
+++ b/go.mod
@@ -271,9 +271,9 @@ require (
 )
 
 replace (
-	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.3-0.20231031145448-477bc8749e39
+	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.3-0.20231031145448-477bc8749e39 // TODO: replace with tagged version
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.64-0.20231031163741-889027482462
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.64-0.20231031163741-889027482462 // TODO: replace with tagged version
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.7
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.2.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.mod
+++ b/go.mod
@@ -273,7 +273,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.64-0.20231025141710-f079aaca9d3f
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027160458-5c53868237c0
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.7
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.2.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.mod
+++ b/go.mod
@@ -273,7 +273,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.3-0.20231031145448-477bc8749e39
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027223908-157d75690bbe
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.64-0.20231031163741-889027482462
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.7
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.2.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.mod
+++ b/go.mod
@@ -273,7 +273,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027160458-5c53868237c0
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027205606-c930b887300d
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.7
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.2.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.mod
+++ b/go.mod
@@ -273,7 +273,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027214813-e89a4bd67538
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027223908-157d75690bbe
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.7
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.2.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.sum
+++ b/go.sum
@@ -1084,8 +1084,8 @@ github.com/sei-protocol/sei-tendermint v0.2.28 h1:5PB1a/zu6H2iDbxIMnXgDtB4QwV5PZ
 github.com/sei-protocol/sei-tendermint v0.2.28/go.mod h1:+BtDvAwTkE64BlxzpH9ZP7S6vUYT9wRXiZa/WW8/o4g=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
-github.com/sei-protocol/sei-wasmd v0.0.2 h1:I0FVTMSWWVVssBQtDgwcDAyDF+ZT2+RqT20ItTBYih8=
-github.com/sei-protocol/sei-wasmd v0.0.2/go.mod h1:IZhrNqhpuoWMIgWR686rzmsTaksn0oylWQG/A0a70ig=
+github.com/sei-protocol/sei-wasmd v0.0.3-0.20231031145448-477bc8749e39 h1:iVuuFrquWUjBWWPhSNbKaJ2EkOLZ2Dm/f6d/raLB4gg=
+github.com/sei-protocol/sei-wasmd v0.0.3-0.20231031145448-477bc8749e39/go.mod h1:I9XVXrL56kR5UFsacF15CCcuaI/pdVB/xa76PN9IvDI=
 github.com/sei-protocol/tm-db v0.0.4 h1:7Y4EU62Xzzg6wKAHEotm7SXQR0aPLcGhKHkh3qd0tnk=
 github.com/sei-protocol/tm-db v0.0.4/go.mod h1:PWsIWOTwdwC7Ow/GUvx8HgUJTO691pBuorIQD8JvwAs=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/go.sum
+++ b/go.sum
@@ -1074,8 +1074,8 @@ github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+f
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027210312-bcd20caeb4db h1:cc2rjRtTwPWe7JP9j4hk/v56twHzNbxX3OcX3mHiKqM=
-github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027210312-bcd20caeb4db/go.mod h1:retCl6F8SWQ8ookwdQXIGkK56AHSKNUN2X3u9nVzo7g=
+github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027214813-e89a4bd67538 h1:wPVnpK3SQ7hJuf2IPxTl2mjSpMT2v2s3NTpckeJMQqQ=
+github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027214813-e89a4bd67538/go.mod h1:retCl6F8SWQ8ookwdQXIGkK56AHSKNUN2X3u9nVzo7g=
 github.com/sei-protocol/sei-iavl v0.1.7 h1:cUdHDBkxs0FF/kOt1qCVLm0K+Bqaw92/dbZSgn4kxiA=
 github.com/sei-protocol/sei-iavl v0.1.7/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-ibc-go/v3 v3.2.0 h1:T8V75OEWKvYDraPZZKilprl7ZkahZYGo40crxNL4unc=

--- a/go.sum
+++ b/go.sum
@@ -1074,8 +1074,8 @@ github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+f
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027160458-5c53868237c0 h1:zvZxXGZ+YIcc1LWOODpoTuYlgbwILuVxqwRwe1wug7I=
-github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027160458-5c53868237c0/go.mod h1:retCl6F8SWQ8ookwdQXIGkK56AHSKNUN2X3u9nVzo7g=
+github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027205606-c930b887300d h1:P8h+pdMDsANlOVG8acvTl+49+jctvWsRy1wv9y5zWYY=
+github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027205606-c930b887300d/go.mod h1:retCl6F8SWQ8ookwdQXIGkK56AHSKNUN2X3u9nVzo7g=
 github.com/sei-protocol/sei-iavl v0.1.7 h1:cUdHDBkxs0FF/kOt1qCVLm0K+Bqaw92/dbZSgn4kxiA=
 github.com/sei-protocol/sei-iavl v0.1.7/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-ibc-go/v3 v3.2.0 h1:T8V75OEWKvYDraPZZKilprl7ZkahZYGo40crxNL4unc=

--- a/go.sum
+++ b/go.sum
@@ -1074,8 +1074,8 @@ github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+f
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.2.64-0.20231024155214-27484e42caff h1:syybKnV7akmSYS1YxmWxKdX1RcFH0w3Wotyj5iWV8Hs=
-github.com/sei-protocol/sei-cosmos v0.2.64-0.20231024155214-27484e42caff/go.mod h1:retCl6F8SWQ8ookwdQXIGkK56AHSKNUN2X3u9nVzo7g=
+github.com/sei-protocol/sei-cosmos v0.2.64-0.20231025141710-f079aaca9d3f h1:+6Zyykg/4PSvHWlq7dRHhr9f/j265Fwt+hh7mX4sUkw=
+github.com/sei-protocol/sei-cosmos v0.2.64-0.20231025141710-f079aaca9d3f/go.mod h1:retCl6F8SWQ8ookwdQXIGkK56AHSKNUN2X3u9nVzo7g=
 github.com/sei-protocol/sei-iavl v0.1.7 h1:cUdHDBkxs0FF/kOt1qCVLm0K+Bqaw92/dbZSgn4kxiA=
 github.com/sei-protocol/sei-iavl v0.1.7/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-ibc-go/v3 v3.2.0 h1:T8V75OEWKvYDraPZZKilprl7ZkahZYGo40crxNL4unc=

--- a/go.sum
+++ b/go.sum
@@ -1074,8 +1074,8 @@ github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+f
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027214813-e89a4bd67538 h1:wPVnpK3SQ7hJuf2IPxTl2mjSpMT2v2s3NTpckeJMQqQ=
-github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027214813-e89a4bd67538/go.mod h1:retCl6F8SWQ8ookwdQXIGkK56AHSKNUN2X3u9nVzo7g=
+github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027223908-157d75690bbe h1:x7qc1aabZlHTDTL+QdGzW+dy0OqnkYbd1UUBcwKvQik=
+github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027223908-157d75690bbe/go.mod h1:retCl6F8SWQ8ookwdQXIGkK56AHSKNUN2X3u9nVzo7g=
 github.com/sei-protocol/sei-iavl v0.1.7 h1:cUdHDBkxs0FF/kOt1qCVLm0K+Bqaw92/dbZSgn4kxiA=
 github.com/sei-protocol/sei-iavl v0.1.7/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-ibc-go/v3 v3.2.0 h1:T8V75OEWKvYDraPZZKilprl7ZkahZYGo40crxNL4unc=

--- a/go.sum
+++ b/go.sum
@@ -1074,8 +1074,8 @@ github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+f
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.2.64-0.20231025141710-f079aaca9d3f h1:+6Zyykg/4PSvHWlq7dRHhr9f/j265Fwt+hh7mX4sUkw=
-github.com/sei-protocol/sei-cosmos v0.2.64-0.20231025141710-f079aaca9d3f/go.mod h1:retCl6F8SWQ8ookwdQXIGkK56AHSKNUN2X3u9nVzo7g=
+github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027160458-5c53868237c0 h1:zvZxXGZ+YIcc1LWOODpoTuYlgbwILuVxqwRwe1wug7I=
+github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027160458-5c53868237c0/go.mod h1:retCl6F8SWQ8ookwdQXIGkK56AHSKNUN2X3u9nVzo7g=
 github.com/sei-protocol/sei-iavl v0.1.7 h1:cUdHDBkxs0FF/kOt1qCVLm0K+Bqaw92/dbZSgn4kxiA=
 github.com/sei-protocol/sei-iavl v0.1.7/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-ibc-go/v3 v3.2.0 h1:T8V75OEWKvYDraPZZKilprl7ZkahZYGo40crxNL4unc=

--- a/go.sum
+++ b/go.sum
@@ -1074,8 +1074,8 @@ github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+f
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027205606-c930b887300d h1:P8h+pdMDsANlOVG8acvTl+49+jctvWsRy1wv9y5zWYY=
-github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027205606-c930b887300d/go.mod h1:retCl6F8SWQ8ookwdQXIGkK56AHSKNUN2X3u9nVzo7g=
+github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027210312-bcd20caeb4db h1:cc2rjRtTwPWe7JP9j4hk/v56twHzNbxX3OcX3mHiKqM=
+github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027210312-bcd20caeb4db/go.mod h1:retCl6F8SWQ8ookwdQXIGkK56AHSKNUN2X3u9nVzo7g=
 github.com/sei-protocol/sei-iavl v0.1.7 h1:cUdHDBkxs0FF/kOt1qCVLm0K+Bqaw92/dbZSgn4kxiA=
 github.com/sei-protocol/sei-iavl v0.1.7/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-ibc-go/v3 v3.2.0 h1:T8V75OEWKvYDraPZZKilprl7ZkahZYGo40crxNL4unc=

--- a/go.sum
+++ b/go.sum
@@ -1074,8 +1074,8 @@ github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+f
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027223908-157d75690bbe h1:x7qc1aabZlHTDTL+QdGzW+dy0OqnkYbd1UUBcwKvQik=
-github.com/sei-protocol/sei-cosmos v0.2.64-0.20231027223908-157d75690bbe/go.mod h1:retCl6F8SWQ8ookwdQXIGkK56AHSKNUN2X3u9nVzo7g=
+github.com/sei-protocol/sei-cosmos v0.2.64-0.20231031163741-889027482462 h1:dD03qVUHXlvJjR7HcO4s0O/+f9XYBkAmIKYEZt43Rn8=
+github.com/sei-protocol/sei-cosmos v0.2.64-0.20231031163741-889027482462/go.mod h1:retCl6F8SWQ8ookwdQXIGkK56AHSKNUN2X3u9nVzo7g=
 github.com/sei-protocol/sei-iavl v0.1.7 h1:cUdHDBkxs0FF/kOt1qCVLm0K+Bqaw92/dbZSgn4kxiA=
 github.com/sei-protocol/sei-iavl v0.1.7/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-ibc-go/v3 v3.2.0 h1:T8V75OEWKvYDraPZZKilprl7ZkahZYGo40crxNL4unc=

--- a/loadtest/config.json
+++ b/loadtest/config.json
@@ -20,7 +20,7 @@
     "message_configs": {
       "default": {
         "gas": 3000000,
-        "fee": 50000
+        "fee": 300000
       },
       "collect_rewards": {
         "gas": 10000000,


### PR DESCRIPTION
## Describe your changes and provide context
This generates the estimates similar to how dependencies are generated in the original parallelism model, and then bundle it with the deliverTX request.

## Testing performed to validate your change
local chain + ongoing testing on loadtest cluster
