### PR TITLE
[EVM] add getProof endpoint

### DIFF
--- a/evmrpc/testutils.go
+++ b/evmrpc/testutils.go
@@ -38,6 +38,8 @@ const TestPort = 7777
 const TestWSPort = 7778
 const TestBadPort = 7779
 
+const MockHeight = 8
+
 var EncodingConfig = app.MakeEncodingConfig()
 var TxConfig = EncodingConfig.TxConfig
 var Encoder = TxConfig.TxEncoder()
@@ -58,7 +60,7 @@ func (c *MockClient) mockBlock() *coretypes.ResultBlock {
 		Block: &tmtypes.Block{
 			Header: tmtypes.Header{
 				ChainID:         "test",
-				Height:          8,
+				Height:          MockHeight,
 				Time:            time.Unix(1696941649, 0),
 				DataHash:        bytes.HexBytes([]byte("0000000000000000000000000000000000000000000000000000000000000002")),
 				AppHash:         bytes.HexBytes([]byte("0000000000000000000000000000000000000000000000000000000000000003")),

--- a/x/evm/keeper/testutils.go
+++ b/x/evm/keeper/testutils.go
@@ -38,12 +38,15 @@ func MockEVMKeeper() (*Keeper, *paramskeeper.Keeper, sdk.Context) {
 
 	db := tmdb.NewMemDB()
 	stateStore := store.NewCommitMultiStore(db)
-	stateStore.MountStoreWithDB(evmStoreKey, sdk.StoreTypeIAVL, db)
-	stateStore.MountStoreWithDB(authStoreKey, sdk.StoreTypeIAVL, db)
-	stateStore.MountStoreWithDB(bankStoreKey, sdk.StoreTypeIAVL, db)
-	stateStore.MountStoreWithDB(stakingStoreKey, sdk.StoreTypeIAVL, db)
-	stateStore.MountStoreWithDB(tKeyParams, sdk.StoreTypeTransient, db)
-	stateStore.MountStoreWithDB(keyParams, sdk.StoreTypeIAVL, db)
+	getPref := func(name string) []byte {
+		return []byte("s/k:" + name + "/")
+	}
+	stateStore.MountStoreWithDB(evmStoreKey, sdk.StoreTypeIAVL, tmdb.NewPrefixDB(db, getPref(types.ModuleName)))
+	stateStore.MountStoreWithDB(authStoreKey, sdk.StoreTypeIAVL, tmdb.NewPrefixDB(db, getPref(authtypes.ModuleName)))
+	stateStore.MountStoreWithDB(bankStoreKey, sdk.StoreTypeIAVL, tmdb.NewPrefixDB(db, getPref(banktypes.ModuleName)))
+	stateStore.MountStoreWithDB(stakingStoreKey, sdk.StoreTypeIAVL, tmdb.NewPrefixDB(db, getPref(stakingtypes.ModuleName)))
+	stateStore.MountStoreWithDB(tKeyParams, sdk.StoreTypeTransient, tmdb.NewPrefixDB(db, getPref("tparams")))
+	stateStore.MountStoreWithDB(keyParams, sdk.StoreTypeIAVL, tmdb.NewPrefixDB(db, getPref("params")))
 	_ = stateStore.LoadLatestVersion()
 
 	cdc := codec.NewProtoCodec(app.MakeEncodingConfig().InterfaceRegistry)


### PR DESCRIPTION
## Describe your changes and provide context
Implement `eth_getProof` endpoint. The response differs from normal Ethereum's because:
1. on Sei there is no per-account storage root
2. Sei stores data with a regular Merkle tree instead of a Patricia tree, so the proof format is different

## Testing performed to validate your change
unit tests

