### PR TITLE
[EVM] return gas info in message handler correctly

### DIFF
--- a/x/evm/ante/gas.go
+++ b/x/evm/ante/gas.go
@@ -1,0 +1,29 @@
+package ante
+
+import (
+	"errors"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	evmkeeper "github.com/sei-protocol/sei-chain/x/evm/keeper"
+	evmtypes "github.com/sei-protocol/sei-chain/x/evm/types"
+)
+
+type GasLimitDecorator struct {
+	evmKeeper *evmkeeper.Keeper
+}
+
+func NewGasLimitDecorator(evmKeeper *evmkeeper.Keeper) *GasLimitDecorator {
+	return &GasLimitDecorator{evmKeeper: evmKeeper}
+}
+
+// Called at the end of the ante chain to set gas limit properly
+func (gl GasLimitDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	txData, found := evmtypes.GetContextTxData(ctx)
+	if !found {
+		return ctx, errors.New("could not find eth tx")
+	}
+
+	adjustedGasLimit := gl.evmKeeper.GetPriorityNormalizer(ctx).MulInt64(int64(txData.GetGas()))
+	ctx = ctx.WithGasMeter(sdk.NewGasMeter(adjustedGasLimit.RoundInt().Uint64()))
+	return next(ctx, tx, simulate)
+}

--- a/x/evm/ante/gas_test.go
+++ b/x/evm/ante/gas_test.go
@@ -1,0 +1,26 @@
+package ante
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/x/evm/keeper"
+	"github.com/sei-protocol/sei-chain/x/evm/types"
+	"github.com/sei-protocol/sei-chain/x/evm/types/ethtx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGasLimitDecorator(t *testing.T) {
+	k, _, ctx := keeper.MockEVMKeeper()
+	a := NewGasLimitDecorator(k)
+	ctx, err := a.AnteHandle(ctx, nil, false, func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+		return ctx, nil
+	})
+	require.NotNil(t, err)
+	ctx = types.SetContextTxData(ctx, &ethtx.LegacyTx{GasLimit: 100})
+	ctx, err = a.AnteHandle(ctx, nil, false, func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+		return ctx, nil
+	})
+	require.Nil(t, err)
+	require.Equal(t, 100, int(ctx.GasMeter().Limit()))
+}

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -28,6 +28,13 @@ var _ types.MsgServer = msgServer{}
 
 func (server msgServer) EVMTransaction(goCtx context.Context, msg *types.MsgEVMTransaction) (serverRes *types.MsgEVMTransactionResponse, err error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+	// EVM has a special case here, mainly because for an EVM transaction the gas limit is set on EVM payload level, not on top-level GasWanted field
+	// as normal transactions (because existing eth client can't). As a result EVM has its own dedicated ante handler chain. The full sequence is:
+
+	// 	1. At the beginning of the ante handler chain, gas meter is set to infinite so that the ante processing itself won't run out of gas (EVM ante is pretty light but it does read a parameter or two)
+	// 	2. At the end of the ante handler chain, gas meter is set based on the gas limit specified in the EVM payload; this is only to provide a GasWanted return value to tendermint mempool when CheckTx returns, and not used for anything else.
+	// 	3. At the beginning of message server (here), gas meter is set to infinite again, because EVM internal logic will then take over and manage out-of-gas scenarios.
+	// 	4. At the end of message server, gas consumed by EVM is adjusted to Sei's unit and counted in the original gas meter, because that original gas meter will be used to count towards block gas after message server returns
 	originalGasMeter := ctx.GasMeter()
 	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
 
@@ -47,6 +54,11 @@ func (server msgServer) EVMTransaction(goCtx context.Context, msg *types.MsgEVMT
 		}
 		err = stateDB.Finalize()
 
+		// GasUsed in serverRes is in EVM's gas unit, not Sei's gas unit.
+		// PriorityNormalizer is the coefficient that's used to adjust EVM
+		// transactions' priority, which is based on gas limit in EVM unit,
+		// to Sei transactions' priority, which is based on gas limit in
+		// Sei unit, so we use the same coefficient to convert gas unit here.
 		adjustedGasUsed := server.GetPriorityNormalizer(ctx).MulInt64(int64(serverRes.GasUsed))
 		originalGasMeter.ConsumeGas(adjustedGasUsed.RoundInt().Uint64(), "evm transaction")
 	}()


### PR DESCRIPTION
## Describe your changes and provide context
There were two issues with gas return value previously:
1. Mempool uses the `gasWanted` field in the return value of `CheckTx` to determine priority. This field is populated based on the gas meter limit that's read from the context returned by ante handlers. So we must set gas meter limit properly when evm ante handlers return.
2. `DeliverTx` will read the `gasUsed` field from the gas meter returned by the message handler and add it to block gas meter. So even though we let EVM handle gas checks internally, we still need to add the consumed gas to the gas meter before the message handler returns.

One thing to note is that, because of the changes made to address 1, the evm transaction handler will no longer have an infinite gas meter when its processing starts, so we need to overwrite it back to an infinite gas meter so that we keep gas management delegated to the EVM internals.

## Testing performed to validate your change
unit tests
