### PR TITLE
[CLI] Add seid tools command and tx scanner tool for sei chain

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,7 @@ linters:
     - staticcheck
     # - structcheck ## author abandoned project
     - stylecheck
-    - revive
+    # - revive
     - typecheck
     - unconvert
     - unused

--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cosmos/iavl"
 	"github.com/sei-protocol/sei-chain/app"
 	"github.com/sei-protocol/sei-chain/app/params"
+	"github.com/sei-protocol/sei-chain/tools"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 	tmcfg "github.com/tendermint/tendermint/config"
@@ -134,6 +135,7 @@ func initRootCmd(
 		config.Cmd(),
 		pruning.PruningCmd(newApp),
 		CompactCmd(app.DefaultNodeHome),
+		tools.ToolCmd(),
 	)
 
 	tracingProviderOpts, err := tracing.GetTracerProviderOptions(tracing.DefaultTracingURL)

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	golang.org/x/exp v0.0.0-20221031165847-c99f073a8326
 	golang.org/x/sync v0.1.0
 	golang.org/x/text v0.9.0
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
 	google.golang.org/genproto/googleapis/api v0.0.0-20230530153820-e85fd2cbaebc
 	google.golang.org/grpc v1.55.0
 	google.golang.org/protobuf v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -1591,6 +1591,8 @@ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac h1:7zkz7BUtwNFFqcowJ+RIgu2MaV/MapERkDIy+mwPyjs=
+golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,46 @@
+# Sei Tools
+This page provides an overview of a couple of built-in tools provided by seid command line. 
+
+## TX-Scanner 
+TX-Scanner is a tool that helps to scan transactions that are missing or failed 
+to be indexed. This is usually used on archive nodes where all historical transactions
+need to be persisted and queryable. 
+
+In the current COSMOS SDK, there's a known bug: during shutdown, transactions for the 
+current block might not be correctly indexed. The consequence of not indexing transactions properly 
+is that those transactions can't be queried, even though they exist in the block data.
+
+This tool helps to scan archive nodes to find out all the missing transactions so that
+later on you can reindex all the missing transactions to make them queryable again.
+
+### Usage
+It is recommended this tool as a background daemon process:
+```
+# Run in the background
+seid tools scan-tx --start-height 1 --state-dir ./ > scan.log &
+```
+The tool will keep scanning from the start height, if there's already
+some state file exist, it will instead start from the previous height.
+
+The tool won't stop until you manually stop it, once it hit latest
+block height, it will keep running as new blocks get produced it will
+keep scanning all the newly produced blocks.
+
+### State Format
+A typical state file would look like this:
+```
+{
+    "last_processed_height": 44394319,
+    "blocks_missing_txs": [123400, 2124542]
+}
+```
+last_processed_height: int64, represent last processed block height
+blocks_missing_txs: []int64, represent all the block heights that is missing transactions
+
+### ReIndex Transactions
+Once you finish scanning and found some missing transactions, you can
+use the tendermint cli tool to reindex these blocks. You need to stop
+the seid process before running the below command:
+```
+seid tendermint reindex-event --start-height 2124542 --end-height 2124543
+```

--- a/tools/README.md
+++ b/tools/README.md
@@ -14,20 +14,20 @@ This tool helps to scan archive nodes to find out all the missing transactions s
 later on you can reindex all the missing transactions to make them queryable again.
 
 ### Usage
-It is recommended this tool as a background daemon process:
+It is recommended to run this tool as a background daemon process:
 ```
 # Run in the background
 seid tools scan-tx --start-height 1 --state-dir ./ > scan.log &
 ```
 The tool will keep scanning from the start height, if there's already
-some state file exist, it will instead start from the previous height.
+a state file exist in `state-dir`, it will instead start from the previous height.
 
 The tool won't stop until you manually stop it, once it hit latest
-block height, it will keep running as new blocks get produced it will
-keep scanning all the newly produced blocks.
+block height, it will keep running and waiting for new blocks to come,
+it keep scanning all the newly produced blocks once they are committed.
 
 ### State Format
-A typical state file would look like this:
+A typical state file (`tx-scanner-state.json`) would look like this:
 ```
 {
     "last_processed_height": 44394319,

--- a/tools/cmd.go
+++ b/tools/cmd.go
@@ -1,7 +1,7 @@
 package tools
 
 import (
-	tx_scanner "github.com/sei-protocol/sei-chain/tools/tx-scanner"
+	"github.com/sei-protocol/sei-chain/tools/tx-scanner/cmd"
 	"github.com/spf13/cobra"
 )
 
@@ -10,6 +10,6 @@ func ToolCmd() *cobra.Command {
 		Use:   "tools",
 		Short: "A set of useful tools for sei chain",
 	}
-	toolsCmd.AddCommand(tx_scanner.ScanCmd())
+	toolsCmd.AddCommand(cmd.ScanCmd())
 	return toolsCmd
 }

--- a/tools/cmd.go
+++ b/tools/cmd.go
@@ -1,0 +1,15 @@
+package tools
+
+import (
+	tx_scanner "github.com/sei-protocol/sei-chain/tools/tx-scanner"
+	"github.com/spf13/cobra"
+)
+
+func ToolCmd() *cobra.Command {
+	toolsCmd := &cobra.Command{
+		Use:   "tools",
+		Short: "A set of useful tools for sei chain",
+	}
+	toolsCmd.AddCommand(tx_scanner.ScanCmd())
+	return toolsCmd
+}

--- a/tools/tx-scanner/client/grpc.go
+++ b/tools/tx-scanner/client/grpc.go
@@ -1,0 +1,61 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"time"
+)
+
+var GrpcConn *grpc.ClientConn
+
+func InitializeGRPCClient(targetEndpoint string, port int) {
+	var dialOptions []grpc.DialOption
+
+	// Use default insecure if we don't have credentials setup
+	dialOptions = append(dialOptions, grpc.WithInsecure())
+	dialOptions = append(dialOptions, grpc.WithDefaultCallOptions(
+		grpc.MaxCallRecvMsgSize(20*1024*1024),
+		grpc.MaxCallSendMsgSize(20*1024*1024)),
+	)
+	dialOptions = append(dialOptions, grpc.WithBlock())
+
+	go func() {
+		for {
+			if GrpcConn == nil {
+				grpcConn, err := grpc.Dial(
+					fmt.Sprintf("%s:%d", targetEndpoint, port),
+					dialOptions...,
+				)
+				if err != nil {
+					fmt.Printf("Failed to connect to %s:%d: %s\n", targetEndpoint, port, err.Error())
+				} else {
+					GrpcConn = grpcConn
+				}
+			} else {
+				state := GrpcConn.GetState()
+				if state == connectivity.TransientFailure || state == connectivity.Shutdown {
+					fmt.Println("GRPC Connection lost, attempting to reconnect...")
+					for {
+						if GrpcConn.WaitForStateChange(context.Background(), state) {
+							break
+						}
+						time.Sleep(30 * time.Second)
+					}
+				}
+			}
+			time.Sleep(10 * time.Second)
+		}
+	}()
+}
+
+func GetTmServiceClient() tmservice.ServiceClient {
+	return tmservice.NewServiceClient(GrpcConn)
+}
+
+func GetTxClient() txtypes.ServiceClient {
+	return txtypes.NewServiceClient(GrpcConn)
+}

--- a/tools/tx-scanner/client/grpc.go
+++ b/tools/tx-scanner/client/grpc.go
@@ -33,6 +33,7 @@ func InitializeGRPCClient(targetEndpoint string, port int) {
 		}
 		GrpcConn = grpcConn
 	}
+	// spin up goroutine for monitoring and reconnect purposes
 	go func() {
 		for {
 			state := GrpcConn.GetState()

--- a/tools/tx-scanner/client/grpc.go
+++ b/tools/tx-scanner/client/grpc.go
@@ -42,7 +42,7 @@ func InitializeGRPCClient(targetEndpoint string, port int) {
 					if GrpcConn.WaitForStateChange(context.Background(), state) {
 						break
 					}
-					time.Sleep(30 * time.Second)
+					time.Sleep(10 * time.Second)
 				}
 			}
 			time.Sleep(10 * time.Second)

--- a/tools/tx-scanner/client/grpc.go
+++ b/tools/tx-scanner/client/grpc.go
@@ -3,11 +3,12 @@ package client
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
 	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
-	"time"
 )
 
 var GrpcConn *grpc.ClientConn

--- a/tools/tx-scanner/cmd/scan.go
+++ b/tools/tx-scanner/cmd/scan.go
@@ -1,4 +1,4 @@
-package tx_scanner
+package cmd
 
 import (
 	"fmt"
@@ -28,7 +28,7 @@ func ScanCmd() *cobra.Command {
 	return cmd
 }
 
-func execute(cmd *cobra.Command, args []string) {
+func execute(cmd *cobra.Command, _ []string) {
 	endpoint, _ := cmd.Flags().GetString("endpoint")
 	port, _ := cmd.Flags().GetInt("port")
 	bpsLimit, _ := cmd.Flags().GetInt("bps-limit")

--- a/tools/tx-scanner/cmd/scan.go
+++ b/tools/tx-scanner/cmd/scan.go
@@ -84,7 +84,6 @@ func execute(cmd *cobra.Command, _ []string) {
 				defer mtx.Unlock()
 				if err != nil {
 					errors = append(errors, err)
-					fmt.Println(err.Error())
 					return
 				}
 				if isBad {

--- a/tools/tx-scanner/query/block.go
+++ b/tools/tx-scanner/query/block.go
@@ -1,0 +1,22 @@
+package query
+
+import (
+	"context"
+
+	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
+	"github.com/sei-protocol/sei-chain/tools/tx-scanner/client"
+)
+
+// GetLatestBlock query the latest block data
+func GetLatestBlock() (*tmservice.GetLatestBlockResponse, error) {
+	request := &tmservice.GetLatestBlockRequest{}
+	return client.GetTmServiceClient().GetLatestBlock(context.Background(), request)
+}
+
+// GetBlockByHeight query the block data at height
+func GetBlockByHeight(height int64) (*tmservice.GetBlockByHeightResponse, error) {
+	request := &tmservice.GetBlockByHeightRequest{
+		Height: height,
+	}
+	return client.GetTmServiceClient().GetBlockByHeight(context.Background(), request)
+}

--- a/tools/tx-scanner/query/tx.go
+++ b/tools/tx-scanner/query/tx.go
@@ -1,0 +1,26 @@
+package query
+
+import (
+	"context"
+	"fmt"
+
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
+	"github.com/sei-protocol/sei-chain/tools/tx-scanner/client"
+)
+
+// GetTxsEvent query the detailed transaction data, same as `seid q txs --events`
+func GetTxsEvent(blockHeight int64) (*txtypes.GetTxsEventResponse, error) {
+	request := &txtypes.GetTxsEventRequest{
+		Events: []string{fmt.Sprintf("tx.height=%d", blockHeight)},
+	}
+
+	return client.GetTxClient().GetTxsEvent(context.Background(), request)
+}
+
+// GetTxByHash query the transaction by TX hash, same as `seid q tx --hash`
+func GetTxByHash(txHash string) (*txtypes.GetTxResponse, error) {
+	request := &txtypes.GetTxRequest{
+		Hash: txHash,
+	}
+	return client.GetTxClient().GetTx(context.Background(), request)
+}

--- a/tools/tx-scanner/scan_cmd.go
+++ b/tools/tx-scanner/scan_cmd.go
@@ -116,7 +116,7 @@ func execute(cmd *cobra.Command, args []string) {
 
 // processBlock processes a single block to find missing transactions
 func processBlock(height int64) (bool, error) {
-	if height%10000 == 0 {
+	if height%1000 == 0 {
 		fmt.Printf("Processing block height %d\n", height)
 	}
 	// Query the block to get the number of TXs

--- a/tools/tx-scanner/scan_cmd.go
+++ b/tools/tx-scanner/scan_cmd.go
@@ -44,10 +44,7 @@ func execute(cmd *cobra.Command, args []string) {
 		startHeight = 1
 	}
 	if stateDir != "" {
-		scanState, err := state.ReadState(stateDir)
-		if err != nil {
-			panic(err)
-		}
+		scanState, _ := state.ReadState(stateDir)
 		if scanState.LastProcessedHeight > 0 {
 			fmt.Printf("Detected last processed height: %d\n", scanState.LastProcessedHeight)
 			currentState = scanState

--- a/tools/tx-scanner/scan_cmd.go
+++ b/tools/tx-scanner/scan_cmd.go
@@ -40,6 +40,9 @@ func execute(cmd *cobra.Command, args []string) {
 	if batchSize > bpsLimit {
 		batchSize = bpsLimit
 	}
+	if startHeight <= 0 {
+		startHeight = 1
+	}
 	if stateDir != "" {
 		scanState, err := state.ReadState(stateDir)
 		if err != nil {

--- a/tools/tx-scanner/scan_cmd.go
+++ b/tools/tx-scanner/scan_cmd.go
@@ -15,7 +15,7 @@ import (
 
 func ScanCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "scan",
+		Use:   "scan-tx",
 		Short: "A tool to scan missing transactions",
 		Run:   execute,
 	}

--- a/tools/tx-scanner/scan_cmd.go
+++ b/tools/tx-scanner/scan_cmd.go
@@ -1,0 +1,154 @@
+package tx_scanner
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/sei-protocol/sei-chain/tools/tx-scanner/client"
+	"github.com/sei-protocol/sei-chain/tools/tx-scanner/query"
+	"github.com/sei-protocol/sei-chain/tools/tx-scanner/state"
+	"github.com/spf13/cobra"
+	"golang.org/x/time/rate"
+)
+
+func ScanCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "scan",
+		Short: "A tool to scan missing transactions",
+		Run:   execute,
+	}
+	cmd.PersistentFlags().String("endpoint", "127.0.0.1", "GRPC server endpoint")
+	cmd.PersistentFlags().Int("port", 9090, "GRPC server port")
+	cmd.PersistentFlags().Int("batch-size", 100, "Batch size to query")
+	cmd.PersistentFlags().Int("bps-limit", 400, "Blocks per second limit")
+	cmd.PersistentFlags().Int64("start-height", 0, "Start height")
+	cmd.PersistentFlags().String("state-dir", "", "State file directory, the scanner will record the last scanned offset and scan results")
+	return cmd
+}
+
+func execute(cmd *cobra.Command, args []string) {
+	endpoint, _ := cmd.Flags().GetString("endpoint")
+	port, _ := cmd.Flags().GetInt("port")
+	bpsLimit, _ := cmd.Flags().GetInt("bps-limit")
+	batchSize, _ := cmd.Flags().GetInt("batch-size")
+	stateDir, _ := cmd.Flags().GetString("state-dir")
+	startHeight, _ := cmd.Flags().GetInt64("start-height")
+	var badBlocks []int64
+	var currentState = state.State{}
+	if batchSize > bpsLimit {
+		batchSize = bpsLimit
+	}
+	if stateDir != "" {
+		scanState, err := state.ReadState(stateDir)
+		if err != nil {
+			panic(err)
+		}
+		if scanState.LastProcessedHeight > 0 {
+			fmt.Printf("Detected last processed height: %d\n", scanState.LastProcessedHeight)
+			currentState = scanState
+			startHeight = currentState.LastProcessedHeight
+			badBlocks = currentState.BlocksMissingTxs
+		}
+	}
+	fmt.Printf("Starting the scan from height: %d\n", startHeight)
+	client.InitializeGRPCClient(endpoint, port)
+	rateLimiter := rate.NewLimiter(rate.Limit(bpsLimit), bpsLimit)
+	latestHeight := getLatestBlockHeight()
+	var currBlockHeight = startHeight
+	for {
+		if currBlockHeight >= latestHeight {
+			time.Sleep(10 * time.Second)
+			latestHeight = getLatestBlockHeight()
+			continue
+		}
+		if !rateLimiter.AllowN(time.Now(), batchSize) {
+			time.Sleep(1 * time.Millisecond)
+			continue
+		}
+
+		wg := sync.WaitGroup{}
+
+		// Handle ALL the queries in a batch concurrently
+		var adjustedBatchSize = int(math.Min(float64(batchSize), float64(latestHeight-currBlockHeight)))
+		var mtx = sync.Mutex{}
+		var errors []error
+		for i := 0; i < adjustedBatchSize; i++ {
+			height := currBlockHeight + int64(i)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				isBad, err := processBlock(height)
+				mtx.Lock()
+				defer mtx.Unlock()
+				if err != nil {
+					errors = append(errors, err)
+					fmt.Println(err.Error())
+					return
+				}
+				if isBad {
+					badBlocks = append(badBlocks, height)
+				}
+			}()
+		}
+		// Wait for ALL queries in this batch to finish and then check any failures
+		wg.Wait()
+		if len(errors) > 0 {
+			fmt.Printf("Failed to process some blocks between heights %d and %d\n", currBlockHeight, currBlockHeight+int64(adjustedBatchSize))
+		} else {
+			// update the state
+			currBlockHeight += int64(adjustedBatchSize)
+			currentState.LastProcessedHeight = currBlockHeight
+			currentState.BlocksMissingTxs = badBlocks
+			if stateDir != "" {
+				err := state.WriteState(stateDir, currentState)
+				if err != nil {
+					fmt.Println(err.Error())
+				}
+			}
+		}
+	}
+}
+
+// processBlock processes a single block to find missing transactions
+func processBlock(height int64) (bool, error) {
+	if height%10000 == 0 {
+		fmt.Printf("Processing block height %d\n", height)
+	}
+	// Query the block to get the number of TXs
+	blockResp, err := query.GetBlockByHeight(height)
+	if err != nil {
+		return false, err
+	}
+	numTxInBlock := len(blockResp.Block.Data.Txs)
+	// Get all indexed TXs events
+	txResp, err := query.GetTxsEvent(height)
+	if err != nil {
+		return false, err
+	}
+	numTxIndexed := len(txResp.Txs)
+	// Check if the number matches
+	if numTxIndexed == 0 && numTxIndexed != numTxInBlock {
+		fmt.Printf("[Fatal] Missing TXs at blcok height %d\n", height)
+		return true, nil
+	}
+	// Now make sure each TX does exist
+	for _, resp := range txResp.TxResponses {
+		hash := resp.TxHash
+		txByHashResponse, err := query.GetTxByHash(hash)
+		if err != nil || txByHashResponse.TxResponse == nil || txByHashResponse.TxResponse.TxHash != hash {
+			fmt.Printf("[Fatal] Failed to find transaction hash %s at block height %d \n", hash, height)
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func getLatestBlockHeight() int64 {
+	response, err := query.GetLatestBlock()
+	if err != nil {
+		return -1
+	}
+	return response.GetBlock().Header.Height
+}

--- a/tools/tx-scanner/state/types.go
+++ b/tools/tx-scanner/state/types.go
@@ -1,0 +1,52 @@
+package state
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+type State struct {
+	LastProcessedHeight int64   `json:"last_processed_height"`
+	BlocksMissingTxs    []int64 `json:"blocks_missing_txs"`
+}
+
+// WriteState write the state to a JSON file.
+func WriteState(dir string, s State) error {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		err = os.MkdirAll(dir, 0755)
+		if err != nil {
+			return err
+		}
+	}
+	filename := filepath.Join(dir, "tx-scanner-state.json")
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = file.Write(data)
+	return err
+}
+
+// ReadState reads the state from a JSON file.
+func ReadState(dir string) (State, error) {
+	state := State{}
+	filename := filepath.Join(dir, "tx-scanner-state.json")
+	file, err := os.Open(filename)
+	if err != nil {
+		return State{}, err
+	}
+	defer file.Close()
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return state, err
+	}
+	err = json.Unmarshal(data, &state)
+	return state, err
+}

--- a/tools/tx-scanner/state/types.go
+++ b/tools/tx-scanner/state/types.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -38,9 +39,13 @@ func WriteState(dir string, s State) error {
 func ReadState(dir string) (State, error) {
 	state := State{}
 	filename := filepath.Join(dir, "tx-scanner-state.json")
-	file, err := os.Open(filename)
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
 	if err != nil {
-		return State{}, err
+		if os.IsExist(err) {
+			fmt.Println("State file detected!")
+		} else {
+			return State{}, err
+		}
 	}
 	defer file.Close()
 	data, err := io.ReadAll(file)

--- a/tools/tx-scanner/state/types.go
+++ b/tools/tx-scanner/state/types.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -39,13 +38,9 @@ func WriteState(dir string, s State) error {
 func ReadState(dir string) (State, error) {
 	state := State{}
 	filename := filepath.Join(dir, "tx-scanner-state.json")
-	file, err := os.OpenFile(filename, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	file, err := os.Open(filename)
 	if err != nil {
-		if os.IsExist(err) {
-			fmt.Println("State file detected!")
-		} else {
-			return State{}, err
-		}
+		return State{}, err
 	}
 	defer file.Close()
 	data, err := io.ReadAll(file)


### PR DESCRIPTION
## Describe your changes and provide context
Add a command line for seid to scan missing transactions:
- The tool will persist the state (offset and detected heights) to a json file if --state-dir is specified
- The tool can be run as a background daemon and won't crash even if seid is stopped
- The tool will resume from where it was left for each restart and will keep running after it hits latest height
- All the missing tx blocks will be output and persisted into tx-scanner-state.json
- Added a readme for sei tools

## Testing performed to validate your change
Tested on testnet rpc nodes:
```
root@ip-172-31-20-148:/home/ubuntu/sei-chain# cat tx-scanner-state.json  |jq
{
  "last_processed_height": 44394319,
  "blocks_missing_txs": null
}

root@ip-172-31-20-148:/home/ubuntu/sei-chain# seid tools scan-tx --start-height 44392219 --state-dir ./
Detected last processed height: 44394319
Starting the scan from height: 44394319
Processing block height 44395000
Processing block height 44396000
Processing block height 44397000
Processing block height 44398000
Processing block height 44399000
Processing block height 44400000


```
