### PR TITLE
[EVM] add ACL dependencies

### DIFF
--- a/aclmapping/dependency_generator.go
+++ b/aclmapping/dependency_generator.go
@@ -4,9 +4,11 @@ import (
 	aclkeeper "github.com/cosmos/cosmos-sdk/x/accesscontrol/keeper"
 	aclbankmapping "github.com/sei-protocol/sei-chain/aclmapping/bank"
 	acldexmapping "github.com/sei-protocol/sei-chain/aclmapping/dex"
+	aclevmmapping "github.com/sei-protocol/sei-chain/aclmapping/evm"
 	acloraclemapping "github.com/sei-protocol/sei-chain/aclmapping/oracle"
 	acltokenfactorymapping "github.com/sei-protocol/sei-chain/aclmapping/tokenfactory"
 	aclwasmmapping "github.com/sei-protocol/sei-chain/aclmapping/wasm"
+	evmkeeper "github.com/sei-protocol/sei-chain/x/evm/keeper"
 )
 
 type CustomDependencyGenerator struct{}
@@ -15,7 +17,7 @@ func NewCustomDependencyGenerator() CustomDependencyGenerator {
 	return CustomDependencyGenerator{}
 }
 
-func (customDepGen CustomDependencyGenerator) GetCustomDependencyGenerators() aclkeeper.DependencyGeneratorMap {
+func (customDepGen CustomDependencyGenerator) GetCustomDependencyGenerators(evmKeeper evmkeeper.Keeper) aclkeeper.DependencyGeneratorMap {
 	dependencyGeneratorMap := make(aclkeeper.DependencyGeneratorMap)
 	wasmDependencyGenerators := aclwasmmapping.NewWasmDependencyGenerator()
 
@@ -24,6 +26,7 @@ func (customDepGen CustomDependencyGenerator) GetCustomDependencyGenerators() ac
 	dependencyGeneratorMap = dependencyGeneratorMap.Merge(acltokenfactorymapping.GetTokenFactoryDependencyGenerators())
 	dependencyGeneratorMap = dependencyGeneratorMap.Merge(wasmDependencyGenerators.GetWasmDependencyGenerators())
 	dependencyGeneratorMap = dependencyGeneratorMap.Merge(acloraclemapping.GetOracleDependencyGenerator())
+	dependencyGeneratorMap = dependencyGeneratorMap.Merge(aclevmmapping.GetEVMDependencyGenerators(evmKeeper))
 
 	return dependencyGeneratorMap
 }

--- a/aclmapping/evm/mappings.go
+++ b/aclmapping/evm/mappings.go
@@ -1,0 +1,95 @@
+package evm
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
+	aclkeeper "github.com/cosmos/cosmos-sdk/x/accesscontrol/keeper"
+	acltypes "github.com/cosmos/cosmos-sdk/x/accesscontrol/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	evmkeeper "github.com/sei-protocol/sei-chain/x/evm/keeper"
+	evmtypes "github.com/sei-protocol/sei-chain/x/evm/types"
+)
+
+var ErrInvalidMessageType = fmt.Errorf("invalid message received for EVM Module")
+
+func GetEVMDependencyGenerators(evmKeeper evmkeeper.Keeper) aclkeeper.DependencyGeneratorMap {
+	dependencyGeneratorMap := make(aclkeeper.DependencyGeneratorMap)
+	EVMTransactionMsgKey := acltypes.GenerateMessageKey(&evmtypes.MsgEVMTransaction{})
+	dependencyGeneratorMap[EVMTransactionMsgKey] = func(k aclkeeper.Keeper, ctx sdk.Context, msg sdk.Msg) ([]sdkacltypes.AccessOperation, error) {
+		return TransactionDependencyGenerator(k, evmKeeper, ctx, msg)
+	}
+
+	return dependencyGeneratorMap
+}
+
+func TransactionDependencyGenerator(_ aclkeeper.Keeper, evmKeeper evmkeeper.Keeper, ctx sdk.Context, msg sdk.Msg) ([]sdkacltypes.AccessOperation, error) {
+	evmMsg, ok := msg.(*evmtypes.MsgEVMTransaction)
+	if !ok {
+		return []sdkacltypes.AccessOperation{}, ErrInvalidMessageType
+	}
+
+	tx, _ := evmMsg.AsTransaction()
+	// Only specifying accesses to `to` address since `from` has to be derived via signature,
+	// which happens in the ante handler (i.e. after this generator is called) and is quite heavy
+	// so we don't want to repeat it.
+	toAddress := tx.To()
+	seiAddress, associated := evmKeeper.GetSeiAddress(ctx, *toAddress)
+	var idTempl string
+	var resourceType sdkacltypes.ResourceType
+	if associated {
+		idTempl = hex.EncodeToString(banktypes.CreateAccountBalancesPrefix(seiAddress))
+		resourceType = sdkacltypes.ResourceType_KV_BANK_BALANCES
+	} else {
+		idTempl = hex.EncodeToString(evmtypes.BalanceKey(*toAddress))
+		resourceType = sdkacltypes.ResourceType_KV_EVM_BALANCE
+	}
+
+	return []sdkacltypes.AccessOperation{
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       resourceType,
+			IdentifierTemplate: idTempl,
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_WRITE,
+			ResourceType:       resourceType,
+			IdentifierTemplate: idTempl,
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV_EVM,
+			IdentifierTemplate: "*", // no way to derive what fields a contract might read
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_WRITE,
+			ResourceType:       sdkacltypes.ResourceType_KV_EVM,
+			IdentifierTemplate: "*", // no way to derive what fields a contract might write
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV_BANK,
+			IdentifierTemplate: "*", // from address access (reasoning described above)
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_WRITE,
+			ResourceType:       sdkacltypes.ResourceType_KV_BANK,
+			IdentifierTemplate: "*", // from address access (reasoning described above)
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV_AUTH,
+			IdentifierTemplate: "*", // from address access (reasoning described above)
+		},
+		{
+			AccessType:         sdkacltypes.AccessType_WRITE,
+			ResourceType:       sdkacltypes.ResourceType_KV_AUTH,
+			IdentifierTemplate: "*", // from address access (reasoning described above)
+		},
+
+		// Last Operation should always be a commit
+		*acltypes.CommitAccessOp(),
+	}, nil
+}

--- a/aclmapping/evm/mappings_test.go
+++ b/aclmapping/evm/mappings_test.go
@@ -1,0 +1,143 @@
+package evm_test
+
+import (
+	"crypto/ecdsa"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/sei-protocol/sei-chain/aclmapping/evm"
+	aclutils "github.com/sei-protocol/sei-chain/aclmapping/utils"
+	"github.com/sei-protocol/sei-chain/app/apptesting"
+	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/x/evm/ante"
+	"github.com/sei-protocol/sei-chain/x/evm/keeper"
+	"github.com/sei-protocol/sei-chain/x/evm/types"
+	"github.com/sei-protocol/sei-chain/x/evm/types/ethtx"
+	"github.com/stretchr/testify/suite"
+)
+
+type KeeperTestSuite struct {
+	apptesting.KeeperTestHelper
+
+	queryClient  types.QueryClient
+	msgServer    types.MsgServer
+	preprocessor sdk.AnteDecorator
+
+	sender          *ecdsa.PrivateKey
+	associatedAcc   common.Address
+	unassociatedAcc common.Address
+}
+
+func TestKeeperTestSuite(t *testing.T) {
+	suite.Run(t, new(KeeperTestSuite))
+}
+
+// Runs before each test case
+func (suite *KeeperTestSuite) SetupTest() {
+	suite.Setup()
+}
+
+// Explicitly only run once during setup
+func (suite *KeeperTestSuite) PrepareTest() {
+	pk := testkeeper.MockPrivateKey()
+	key, err := crypto.HexToECDSA(hex.EncodeToString(pk.Bytes()))
+	if err != nil {
+		panic(err)
+	}
+	suite.sender = key
+	_, suite.unassociatedAcc = testkeeper.MockAddressPair()
+	seiAddr, associatedAcc := testkeeper.MockAddressPair()
+	suite.App.EvmKeeper.SetAddressMapping(suite.Ctx, seiAddr, associatedAcc)
+	suite.associatedAcc = associatedAcc
+	suite.msgServer = keeper.NewMsgServerImpl(suite.App.EvmKeeper)
+	suite.preprocessor = ante.NewEVMPreprocessDecorator(&suite.App.EvmKeeper, &suite.App.AccountKeeper)
+	amt := sdk.NewCoins(sdk.NewCoin(suite.App.EvmKeeper.GetBaseDenom(suite.Ctx), sdk.NewInt(1000000)))
+	suite.App.EvmKeeper.BankKeeper().MintCoins(suite.Ctx, types.ModuleName, amt)
+	suite.App.EvmKeeper.BankKeeper().SendCoinsFromModuleToAccount(suite.Ctx, types.ModuleName, sdk.AccAddress(pk.PubKey().Address()), amt)
+
+	msgValidator := sdkacltypes.NewMsgValidator(aclutils.StoreKeyToResourceTypePrefixMap)
+	suite.Ctx = suite.Ctx.WithMsgValidator(msgValidator)
+}
+
+func cacheTxContext(ctx sdk.Context) (sdk.Context, sdk.CacheMultiStore) {
+	ms := ctx.MultiStore()
+	msCache := ms.CacheMultiStore()
+	return ctx.WithMultiStore(msCache), msCache
+}
+
+func (suite *KeeperTestSuite) buildSendMsgTo(to common.Address, amt *big.Int) *types.MsgEVMTransaction {
+	txData := ethtypes.DynamicFeeTx{
+		Nonce:     0,
+		GasFeeCap: big.NewInt(1),
+		Gas:       21000,
+		To:        &to,
+		Value:     amt,
+		Data:      []byte(""),
+		ChainID:   suite.App.EvmKeeper.ChainID(suite.Ctx),
+	}
+	evmParams := suite.App.EvmKeeper.GetParams(suite.Ctx)
+	ethCfg := evmParams.GetChainConfig().EthereumConfig(suite.App.EvmKeeper.ChainID(suite.Ctx))
+	signer := ethtypes.MakeSigner(ethCfg, big.NewInt(suite.Ctx.BlockHeight()), uint64(suite.Ctx.BlockTime().Unix()))
+	tx := ethtypes.NewTx(&txData)
+	tx, err := ethtypes.SignTx(tx, signer, suite.sender)
+	if err != nil {
+		panic(err)
+	}
+	typedTxData, err := ethtx.NewTxDataFromTx(tx)
+	if err != nil {
+		panic(err)
+	}
+	msg, err := types.NewMsgEVMTransaction(typedTxData)
+	if err != nil {
+		panic(err)
+	}
+
+	return msg
+}
+
+func (suite *KeeperTestSuite) TestMsgEVMTransaction() {
+	suite.PrepareTest()
+
+	tests := []struct {
+		name string
+		msg  *types.MsgEVMTransaction
+	}{
+		{
+			name: "associated to",
+			msg:  suite.buildSendMsgTo(suite.associatedAcc, big.NewInt(1000000000000)),
+		},
+		{
+			name: "unassociated to",
+			msg:  suite.buildSendMsgTo(suite.unassociatedAcc, big.NewInt(1000000000000)),
+		},
+	}
+	for _, tc := range tests {
+		suite.Run(fmt.Sprintf("Test Case: %s", tc.name), func() {
+			handlerCtx, cms := cacheTxContext(suite.Ctx)
+			tx := suite.App.GetTxConfig().NewTxBuilder()
+			err := tx.SetMsgs(tc.msg)
+			suite.Require().Nil(err)
+			ctx, err := suite.preprocessor.AnteHandle(handlerCtx, tx.GetTx(), false, func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) { return ctx, nil })
+			suite.Require().Nil(err)
+			_, err = suite.msgServer.EVMTransaction(sdk.WrapSDKContext(ctx), tc.msg)
+			suite.Require().Nil(err)
+
+			depdenencies, _ := evm.TransactionDependencyGenerator(
+				suite.App.AccessControlKeeper,
+				suite.App.EvmKeeper,
+				handlerCtx,
+				tc.msg,
+			)
+
+			missing := handlerCtx.MsgValidator().ValidateAccessOperations(depdenencies, cms.GetEvents())
+			suite.Require().Empty(missing)
+		})
+	}
+}

--- a/aclmapping/utils/resource_type.go
+++ b/aclmapping/utils/resource_type.go
@@ -14,6 +14,7 @@ import (
 	dexkeeper "github.com/sei-protocol/sei-chain/x/dex/keeper"
 	dextypes "github.com/sei-protocol/sei-chain/x/dex/types"
 	epochtypes "github.com/sei-protocol/sei-chain/x/epoch/types"
+	evmtypes "github.com/sei-protocol/sei-chain/x/evm/types"
 	oracletypes "github.com/sei-protocol/sei-chain/x/oracle/types"
 	tokenfactorytypes "github.com/sei-protocol/sei-chain/x/tokenfactory/types"
 )
@@ -149,5 +150,9 @@ var StoreKeyToResourceTypePrefixMap = aclsdktypes.StoreKeyToResourceTypePrefixMa
 		aclsdktypes.ResourceType_KV_WASM_CONTRACT_CODE_HISTORY: wasmtypes.ContractCodeHistoryElementPrefix,
 		aclsdktypes.ResourceType_KV_WASM_CONTRACT_BY_CODE_ID:   wasmtypes.ContractByCodeIDAndCreatedSecondaryIndexPrefix,
 		aclsdktypes.ResourceType_KV_WASM_PINNED_CODE_INDEX:     wasmtypes.PinnedCodeIndexPrefix,
+	},
+	evmtypes.StoreKey: {
+		aclsdktypes.ResourceType_KV_EVM:         aclsdktypes.EmptyPrefix,
+		aclsdktypes.ResourceType_KV_EVM_BALANCE: evmtypes.BalanceKeyPrefix,
 	},
 }

--- a/app/app.go
+++ b/app/app.go
@@ -532,9 +532,14 @@ func New(
 		app.BankKeeper.(bankkeeper.BaseKeeper).WithMintCoinsRestriction(tokenfactorytypes.NewTokenFactoryDenomMintCoinsRestriction()),
 		app.DistrKeeper,
 	)
+	app.EvmKeeper = *evmkeeper.NewKeeper(keys[evmtypes.StoreKey], app.GetSubspace(evmtypes.ModuleName), app.BankKeeper, &app.AccountKeeper, &app.StakingKeeper)
+	app.evmRPCConfig, err = evmrpc.ReadConfig(appOpts)
+	if err != nil {
+		panic(fmt.Sprintf("error reading EVM config due to %s", err))
+	}
 
 	customDependencyGenerators := aclmapping.NewCustomDependencyGenerator()
-	aclOpts = append(aclOpts, aclkeeper.WithDependencyGeneratorMappings(customDependencyGenerators.GetCustomDependencyGenerators()))
+	aclOpts = append(aclOpts, aclkeeper.WithDependencyGeneratorMappings(customDependencyGenerators.GetCustomDependencyGenerators(app.EvmKeeper)))
 	app.AccessControlKeeper = aclkeeper.NewKeeper(
 		appCodec,
 		app.keys[acltypes.StoreKey],
@@ -585,12 +590,6 @@ func New(
 	app.DexKeeper.SetWasmKeeper(&app.WasmKeeper)
 	dexModule := dexmodule.NewAppModule(appCodec, app.DexKeeper, app.AccountKeeper, app.BankKeeper, app.WasmKeeper, app.GetBaseApp().TracingInfo)
 	epochModule := epochmodule.NewAppModule(appCodec, app.EpochKeeper, app.AccountKeeper, app.BankKeeper)
-
-	app.EvmKeeper = *evmkeeper.NewKeeper(keys[evmtypes.StoreKey], app.GetSubspace(evmtypes.ModuleName), app.BankKeeper, &app.AccountKeeper, &app.StakingKeeper)
-	app.evmRPCConfig, err = evmrpc.ReadConfig(appOpts)
-	if err != nil {
-		panic(fmt.Sprintf("error reading EVM config due to %s", err))
-	}
 
 	// register the proposal types
 	govRouter := govtypes.NewRouter()
@@ -1597,6 +1596,10 @@ func (app *App) checkTotalBlockGasWanted(ctx sdk.Context, txs [][]byte) bool {
 		}
 	}
 	return true
+}
+
+func (app *App) GetTxConfig() client.TxConfig {
+	return app.encodingConfig.TxConfig
 }
 
 // GetMaccPerms returns a copy of the module account permissions

--- a/go.mod
+++ b/go.mod
@@ -320,7 +320,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.65
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.66
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.7
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.2.0
 	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.2-sei-5

--- a/go.sum
+++ b/go.sum
@@ -1294,8 +1294,8 @@ github.com/sei-protocol/go-ethereum v1.13.2-sei-5 h1:MOX1MuCfaAp0thGqYlmjfXh1Xlf
 github.com/sei-protocol/go-ethereum v1.13.2-sei-5/go.mod h1:i/Hz2ZHc7yCb+a2t8LsJOfEvT/LT7KBplwTpbceS3q0=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.2.65 h1:3FOfb0EfHL+KXoIZ/01E6JbCfthIWwOmccOXZJ/UwMg=
-github.com/sei-protocol/sei-cosmos v0.2.65/go.mod h1:retCl6F8SWQ8ookwdQXIGkK56AHSKNUN2X3u9nVzo7g=
+github.com/sei-protocol/sei-cosmos v0.2.66 h1:Q+YcQlw7ddOkA908PhkaIN17//VmyG72gxA55oPJ+ps=
+github.com/sei-protocol/sei-cosmos v0.2.66/go.mod h1:retCl6F8SWQ8ookwdQXIGkK56AHSKNUN2X3u9nVzo7g=
 github.com/sei-protocol/sei-iavl v0.1.7 h1:cUdHDBkxs0FF/kOt1qCVLm0K+Bqaw92/dbZSgn4kxiA=
 github.com/sei-protocol/sei-iavl v0.1.7/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-ibc-go/v3 v3.2.0 h1:T8V75OEWKvYDraPZZKilprl7ZkahZYGo40crxNL4unc=


### PR DESCRIPTION
## Describe your changes and provide context
Add ACL dependencies for EVM transactions. Note that it only contains non-wildcard matching for `to` address, since `from` address must be derived from signature which is a costly process that only happens during ante processing (i.e. after dependency evaluation). All contract state accesses are covered by wildcards.

## Testing performed to validate your change
unit tests

