### PR TITLE
[EVM] several bug fixes

### DIFF
--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -107,7 +107,7 @@ func encodeTmBlock(
 			continue
 		}
 		evmTx, ok := decoded.GetMsgs()[0].(*types.MsgEVMTransaction)
-		if !ok {
+		if !ok || evmTx.IsAssociateTx() {
 			continue
 		}
 		ethtx, _ := evmTx.AsTransaction()

--- a/evmrpc/setup_test.go
+++ b/evmrpc/setup_test.go
@@ -49,6 +49,7 @@ var TxConfig = EncodingConfig.TxConfig
 var Encoder = TxConfig.TxEncoder()
 var Decoder = TxConfig.TxDecoder()
 var Tx sdk.Tx
+var UnconfirmedTx sdk.Tx
 
 var SConfig = evmrpc.SimulateConfig{GasCap: 10000000}
 
@@ -230,6 +231,11 @@ func (c *MockClient) BroadcastTx(context.Context, tmtypes.Tx) (*coretypes.Result
 	return &coretypes.ResultBroadcastTx{Code: 0}, nil
 }
 
+func (c *MockClient) UnconfirmedTxs(ctx context.Context, page, perPage *int) (*coretypes.ResultUnconfirmedTxs, error) {
+	tx, _ := Encoder(UnconfirmedTx)
+	return &coretypes.ResultUnconfirmedTxs{Txs: []tmtypes.Tx{tx}}, nil
+}
+
 type MockBadClient struct {
 	MockClient
 }
@@ -356,6 +362,34 @@ func init() {
 		common.BytesToHash([]byte("value")),
 	)
 	EVMKeeper.SetNonce(Ctx, common.HexToAddress("0x1234567890123456789012345678901234567890"), 1)
+
+	unconfirmedTxData := ethtypes.DynamicFeeTx{
+		Nonce:     2,
+		GasFeeCap: big.NewInt(10),
+		Gas:       1000,
+		To:        &to,
+		Value:     big.NewInt(2000),
+		Data:      []byte("abc"),
+		ChainID:   big.NewInt(1),
+	}
+	tx = ethtypes.NewTx(&unconfirmedTxData)
+	tx, err = ethtypes.SignTx(tx, signer, key)
+	if err != nil {
+		panic(err)
+	}
+	typedTx, err = ethtx.NewDynamicFeeTx(tx)
+	if err != nil {
+		panic(err)
+	}
+	msg, err = types.NewMsgEVMTransaction(typedTx)
+	if err != nil {
+		panic(err)
+	}
+	b = TxConfig.NewTxBuilder()
+	if err := b.SetMsgs(msg); err != nil {
+		panic(err)
+	}
+	UnconfirmedTx = b.GetTx()
 }
 
 //nolint:deadcode

--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -80,6 +80,44 @@ func (t *TransactionAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, 
 }
 
 func (t *TransactionAPI) GetTransactionByHash(ctx context.Context, hash common.Hash) (*RPCTransaction, error) {
+	sdkCtx := t.ctxProvider(LatestCtxHeight)
+	// first try get from mempool
+	page := 1
+	for {
+		res, err := t.tmClient.UnconfirmedTxs(ctx, &page, nil)
+		if err != nil || len(res.Txs) == 0 {
+			break
+		}
+		for _, tx := range res.Txs {
+			etx := getEthTxForTxBz(tx, t.txConfig.TxDecoder())
+			if etx != nil && etx.Hash() == hash {
+				signer := ethtypes.MakeSigner(
+					t.keeper.GetChainConfig(sdkCtx).EthereumConfig(t.keeper.ChainID(sdkCtx)),
+					big.NewInt(sdkCtx.BlockHeight()),
+					uint64(sdkCtx.BlockTime().Second()),
+				)
+				from, _ := ethtypes.Sender(signer, etx)
+				v, r, s := etx.RawSignatureValues()
+				return &RPCTransaction{
+					Type:     hexutil.Uint64(etx.Type()),
+					From:     from,
+					Gas:      hexutil.Uint64(etx.Gas()),
+					GasPrice: (*hexutil.Big)(etx.GasPrice()),
+					Hash:     etx.Hash(),
+					Input:    hexutil.Bytes(etx.Data()),
+					Nonce:    hexutil.Uint64(etx.Nonce()),
+					To:       etx.To(),
+					Value:    (*hexutil.Big)(etx.Value()),
+					V:        (*hexutil.Big)(v),
+					R:        (*hexutil.Big)(r),
+					S:        (*hexutil.Big)(s),
+				}, nil
+			}
+		}
+		page++
+	}
+
+	// then try get from committed
 	receipt, err := t.keeper.GetReceipt(t.ctxProvider(LatestCtxHeight), hash)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
@@ -141,7 +179,7 @@ func getEthTxForTxBz(tx tmtypes.Tx, decoder sdk.TxDecoder) *ethtypes.Transaction
 		return nil
 	}
 	evmTx, ok := decoded.GetMsgs()[0].(*types.MsgEVMTransaction)
-	if !ok {
+	if !ok || evmTx.IsAssociateTx() {
 		return nil
 	}
 	ethtx, _ := evmTx.AsTransaction()

--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -22,6 +22,8 @@ import (
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
+const UnconfirmedTxQueryMaxPage = 5
+
 type TransactionAPI struct {
 	tmClient    rpcclient.Client
 	keeper      *keeper.Keeper
@@ -82,8 +84,7 @@ func (t *TransactionAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, 
 func (t *TransactionAPI) GetTransactionByHash(ctx context.Context, hash common.Hash) (*RPCTransaction, error) {
 	sdkCtx := t.ctxProvider(LatestCtxHeight)
 	// first try get from mempool
-	page := 1
-	for {
+	for page := 1; page <= UnconfirmedTxQueryMaxPage; page++ {
 		res, err := t.tmClient.UnconfirmedTxs(ctx, &page, nil)
 		if err != nil || len(res.Txs) == 0 {
 			break
@@ -114,7 +115,6 @@ func (t *TransactionAPI) GetTransactionByHash(ctx context.Context, hash common.H
 				}, nil
 			}
 		}
-		page++
 	}
 
 	// then try get from committed

--- a/evmrpc/tx_test.go
+++ b/evmrpc/tx_test.go
@@ -122,6 +122,12 @@ func TestGetTransaction(t *testing.T) {
 	}
 }
 
+func TestGetPendingTransactionByHash(t *testing.T) {
+	resObj := sendRequestGood(t, "getTransactionByHash", "0x74452c2b9b4482f34eba843725cc99625bc89fe55d9a67d4a506e584ba1f334b")
+	result := resObj["result"].(map[string]interface{})
+	require.Equal(t, "0x2", result["nonce"])
+}
+
 func TestGetTransactionCount(t *testing.T) {
 	// happy path
 	bodyByNumber := "{\"jsonrpc\": \"2.0\",\"method\": \"eth_getTransactionCount\",\"params\":[\"0x1234567890123456789012345678901234567890\",\"0x8\"],\"id\":\"test\"}"

--- a/x/evm/ante/sig.go
+++ b/x/evm/ante/sig.go
@@ -3,6 +3,7 @@ package ante
 import (
 	"encoding/binary"
 	"errors"
+	"sync"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -10,15 +11,38 @@ import (
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
 
+type CtxKeyType string
+type CtxValueTypeCheckTxNonces map[string]uint64
+
+const CtxKeyCheckTxNonces CtxKeyType = CtxKeyType("CtxKeyCheckTxNonces")
+
 type EVMSigVerifyDecorator struct {
 	evmKeeper *evmkeeper.Keeper
+
+	checkTxMtx      *sync.Mutex
+	checkTxHeight   int64
+	checkTxNonceMap map[string]uint64
 }
 
 func NewEVMSigVerifyDecorator(evmKeeper *evmkeeper.Keeper) *EVMSigVerifyDecorator {
-	return &EVMSigVerifyDecorator{evmKeeper: evmKeeper}
+	return &EVMSigVerifyDecorator{
+		evmKeeper:  evmKeeper,
+		checkTxMtx: &sync.Mutex{},
+	}
 }
 
-func (svd EVMSigVerifyDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+func (svd *EVMSigVerifyDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	if ctx.IsCheckTx() {
+		// Sig verify for EVM CheckTx needs to run sequentially to handle applications that rapid-fires transactions under the same
+		// account with incrementing nonce correctly
+		svd.checkTxMtx.Lock()
+		defer svd.checkTxMtx.Unlock()
+		if ctx.BlockHeight() > svd.checkTxHeight {
+			svd.checkTxHeight = ctx.BlockHeight()
+			svd.checkTxNonceMap = map[string]uint64{}
+		}
+	}
+
 	ethTx, found := types.GetContextEthTx(ctx)
 	if !found {
 		return ctx, errors.New("EVM transaction is not found in EVM ante route")
@@ -38,14 +62,18 @@ func (svd EVMSigVerifyDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate
 		nextNonce = binary.BigEndian.Uint64(noncebz)
 	}
 
+	// overwrite nextNonce with temporary value if the check is under CheckTx
+	if ctx.IsCheckTx() {
+		if nonce, ok := svd.checkTxNonceMap[evmAddr.Hex()]; ok {
+			nextNonce = nonce
+		}
+	}
 	if ethTx.Nonce() != nextNonce {
 		return ctx, sdkerrors.ErrWrongSequence
 	}
 
 	if ctx.IsCheckTx() {
-		bz := make([]byte, 8)
-		binary.BigEndian.PutUint64(bz, nextNonce+1)
-		svd.evmKeeper.PrefixStore(ctx, types.NonceKeyPrefix).Set(evmAddr[:], bz)
+		svd.checkTxNonceMap[evmAddr.Hex()] = nextNonce + 1
 	}
 
 	return next(ctx, tx, simulate)

--- a/x/evm/ante/sig.go
+++ b/x/evm/ante/sig.go
@@ -42,5 +42,11 @@ func (svd EVMSigVerifyDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate
 		return ctx, sdkerrors.ErrWrongSequence
 	}
 
+	if ctx.IsCheckTx() {
+		bz := make([]byte, 8)
+		binary.BigEndian.PutUint64(bz, nextNonce+1)
+		svd.evmKeeper.PrefixStore(ctx, types.NonceKeyPrefix).Set(evmAddr[:], bz)
+	}
+
 	return next(ctx, tx, simulate)
 }

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -30,7 +30,7 @@ const (
 	FlagGasFeeCap  = "gas-fee-cap"
 	FlagGas        = "gas-limit"
 	FlagEVMChainID = "evm-chain-id"
-	FlagRPC        = "rpc"
+	FlagRPC        = "evm-rpc"
 )
 
 // GetTxCmd returns the transaction commands for this module

--- a/x/evm/types/message_evm_transaction.go
+++ b/x/evm/types/message_evm_transaction.go
@@ -56,3 +56,13 @@ func (msg *MsgEVMTransaction) AsTransaction() (*ethtypes.Transaction, ethtx.TxDa
 func (msg MsgEVMTransaction) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
 	return unpacker.UnpackAny(msg.Data, new(ethtx.TxData))
 }
+
+func (msg MsgEVMTransaction) IsAssociateTx() bool {
+	txData, err := UnpackTxData(msg.Data)
+	if err != nil {
+		// should never happen
+		panic(err)
+	}
+	_, ok := txData.(*ethtx.AssociateTx)
+	return ok
+}

--- a/x/evm/types/message_evm_transaction_test.go
+++ b/x/evm/types/message_evm_transaction_test.go
@@ -1,0 +1,15 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/sei-protocol/sei-chain/x/evm/types"
+	"github.com/sei-protocol/sei-chain/x/evm/types/ethtx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsAssociate(t *testing.T) {
+	msg, err := types.NewMsgEVMTransaction(&ethtx.AssociateTx{})
+	require.Nil(t, err)
+	require.True(t, msg.IsAssociateTx())
+}


### PR DESCRIPTION
## Describe your changes and provide context
Fixes the following:
- `rpc` flag conflicts with existing flag name. Changing it to `evm-rpc`
- `to` address might be nil in the case of contract creation. Handle it properly in dependency generator
- Exclude `AssociateTx` from EthereumTx decoding since it's not standard Ethereum TX but a Sei-specific utility type
- Return pending transaction (i.e. unconfirmed transactions in mempool) in `getTransactionByHash`

## Testing performed to validate your change
local sei
