### PR TITLE
Fix loadtest metric script

### DIFF
--- a/loadtest/scripts/metrics.py
+++ b/loadtest/scripts/metrics.py
@@ -100,8 +100,13 @@ def get_metrics():
     # Skip first and last block since it may have high deviation if we start it at the end of the block
 
     skip_edge_blocks = block_info_list[1:-1]
-    total_duration = skip_edge_blocks[-1]["timestamp"] - skip_edge_blocks[0]["timestamp"]
-    average_block_time = total_duration.total_seconds() / (len(skip_edge_blocks) - 1)
+    total_duration = 0
+    for i in range(len(skip_edge_blocks) - 1):
+        block = skip_edge_blocks[i]
+        next_block_time = get_block_time(block["height"] + 1)
+        block_time = (next_block_time - block["timestamp"]) // timedelta(milliseconds=1)
+        total_duration += block_time
+    average_block_time = total_duration / 1000 / len(skip_edge_blocks)
     total_txs_num = sum([block["number_of_txs"] for block in skip_edge_blocks])
     average_txs_num = total_txs_num / len(skip_edge_blocks)
 

--- a/loadtest/scripts/metrics.py
+++ b/loadtest/scripts/metrics.py
@@ -84,7 +84,7 @@ def get_best_block_stats(block_info_list):
         next_block_time = get_block_time(block["height"] + 1)
         block_time = (next_block_time - block["timestamp"]) // timedelta(milliseconds=1)
         throughput = block["number_of_txs"] * 1000 / block_time
-        print(f"Block {block['height']} has throughput {throughput} and time {block_time}")
+        print(f"Block {block['height']} has throughput {throughput} and block time {block_time} ms")
         if throughput > max_throughput:
             max_throughput = throughput
             max_block_height = block["height"]

--- a/loadtest/scripts/metrics.py
+++ b/loadtest/scripts/metrics.py
@@ -83,7 +83,8 @@ def get_best_block_stats(block_info_list):
         next_block_time = get_block_time(block["height"] + 1)
         block_time = (next_block_time - block["timestamp"]) // timedelta(milliseconds=1)
         max_throughput, max_block_height, max_block_time = -1, -1, -1
-        throughput = block["number_of_txs"] / block_time
+        throughput = block["number_of_txs"] * 1000 / block_time
+        print(f"Block {block['height']} has throughput {throughput} and time {block_time}")
         if throughput > max_throughput:
             max_throughput = throughput
             max_block_height = block["height"]
@@ -101,7 +102,7 @@ def get_metrics():
 
     skip_edge_blocks = block_info_list[1:-1]
     total_duration = 0
-    for i in range(len(skip_edge_blocks) - 1):
+    for i in range(len(skip_edge_blocks)):
         block = skip_edge_blocks[i]
         next_block_time = get_block_time(block["height"] + 1)
         block_time = (next_block_time - block["timestamp"]) // timedelta(milliseconds=1)

--- a/loadtest/scripts/metrics.py
+++ b/loadtest/scripts/metrics.py
@@ -78,11 +78,11 @@ def get_transaction_breakdown(height):
     return tx_mapping
 
 def get_best_block_stats(block_info_list):
+    max_throughput, max_block_height, max_block_time = -1, -1, -1
     for i in range(len(block_info_list)):
         block = block_info_list[i]
         next_block_time = get_block_time(block["height"] + 1)
         block_time = (next_block_time - block["timestamp"]) // timedelta(milliseconds=1)
-        max_throughput, max_block_height, max_block_time = -1, -1, -1
         throughput = block["number_of_txs"] * 1000 / block_time
         print(f"Block {block['height']} has throughput {throughput} and time {block_time}")
         if throughput > max_throughput:
@@ -131,7 +131,7 @@ def get_metrics():
         },
         "Best block": {
             "height": max_block_height,
-            "tps": max_throughput * 1000,
+            "tps": max_throughput,
             "tx_mapping": tx_mapping,
             "block_time_ms": max_block_time
         }


### PR DESCRIPTION
## Describe your changes and provide context
The script for loadtest result is not accurate in terms of calculating `average_block_time` and `average_throughput_per_sec`.

This is because the total duration is over-estimated for the current logic.

The correct way to calculate total duration is to only add up the block time that we send transactions to since the current loadtest client has to wait and stop sending tx between rounds.
## Testing performed to validate your change

