### PR TITLE
[EVM] add deps for EVM ante handlers

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -111,7 +111,7 @@ func NewAnteHandlerAndDepGenerator(options HandlerOptions) (sdk.AnteHandler, sdk
 	anteHandler, anteDepGenerator := sdk.ChainAnteDecorators(anteDecorators...)
 
 	evmAnteDecorators := []sdk.AnteFullDecorator{
-		sdk.DefaultWrappedAnteDecorator(evmante.NewEVMPreprocessDecorator(options.EVMKeeper, options.EVMKeeper.AccountKeeper())),
+		evmante.NewEVMPreprocessDecorator(options.EVMKeeper, options.EVMKeeper.AccountKeeper()),
 		sdk.DefaultWrappedAnteDecorator(evmante.NewEVMFeeCheckDecorator(options.EVMKeeper)),
 		sdk.DefaultWrappedAnteDecorator(evmante.NewEVMSigVerifyDecorator(options.EVMKeeper, options.EVMCheckTxTimeout)),
 		sdk.DefaultWrappedAnteDecorator(evmante.NewGasLimitDecorator(options.EVMKeeper)),

--- a/x/evm/ante/fee.go
+++ b/x/evm/ante/fee.go
@@ -6,8 +6,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	accountkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
-	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	evmkeeper "github.com/sei-protocol/sei-chain/x/evm/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
@@ -15,16 +13,12 @@ import (
 )
 
 type EVMFeeCheckDecorator struct {
-	evmKeeper     *evmkeeper.Keeper
-	bankKeeper    bankkeeper.Keeper
-	accountKeeper *accountkeeper.AccountKeeper
+	evmKeeper *evmkeeper.Keeper
 }
 
 func NewEVMFeeCheckDecorator(evmKeeper *evmkeeper.Keeper) *EVMFeeCheckDecorator {
 	return &EVMFeeCheckDecorator{
-		evmKeeper:     evmKeeper,
-		bankKeeper:    evmKeeper.BankKeeper(),
-		accountKeeper: evmKeeper.AccountKeeper(),
+		evmKeeper: evmKeeper,
 	}
 }
 

--- a/x/evm/ante/preprocess_test.go
+++ b/x/evm/ante/preprocess_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -105,4 +106,14 @@ func TestGetVersion(t *testing.T) {
 
 	ethCfg.CancunTime = nil
 	require.Equal(t, types.London, ante.GetVersion(ctx, ethCfg))
+}
+
+func TestAnteDeps(t *testing.T) {
+	k, _ := testkeeper.MockEVMKeeper()
+	handler := ante.NewEVMPreprocessDecorator(k, k.AccountKeeper())
+	deps, err := handler.AnteDeps(nil, mockTx{msgs: []sdk.Msg{}}, 0, func(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, txIndex int) ([]sdkacltypes.AccessOperation, error) {
+		return txDeps, nil
+	})
+	require.Nil(t, err)
+	require.Equal(t, 6, len(deps))
 }


### PR DESCRIPTION
## Describe your changes and provide context
Add blanket dependencies for EVM ante handlers (R/W for acc, bank ,evm). Right now it's not possible to get more granular dependencies because the `from` address is not know at the time of dependency evaluation. This may be improved with ante handler refactoring (i.e. stateless ante handler runs first, fully parallelized -> dependency graph -> stateful ante handlers)

## Testing performed to validate your change
unit tests as well as local testing
