### PR TITLE
[EVM] --slow config for send raw txn

### DIFF
--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -477,6 +477,9 @@ filter_timeout = "{{ .EVM.FilterTimeout }}"
 
 # checkTx timeout for sig verify
 checktx_timeout = "{{ .EVM.CheckTxTimeout }}"
+
+# controls whether to have txns go through one by one
+slow = {{ .EVM.Slow }}
 `
 
 	return customAppTemplate, customAppConfig

--- a/docker/rpcnode/config/config.toml
+++ b/docker/rpcnode/config/config.toml
@@ -40,7 +40,7 @@ mode = "full"
 # * badgerdb (uses github.com/dgraph-io/badger)
 #   - EXPERIMENTAL
 #   - use badgerdb build tag (go build -tags badgerdb)
-db-ba"ckend = "goleveldb
+db-backend = "goleveldb"
 
 # Database directory
 db-dir = "data"

--- a/docker/rpcnode/config/config.toml
+++ b/docker/rpcnode/config/config.toml
@@ -40,7 +40,7 @@ mode = "full"
 # * badgerdb (uses github.com/dgraph-io/badger)
 #   - EXPERIMENTAL
 #   - use badgerdb build tag (go build -tags badgerdb)
-db-backend = "goleveldb"
+db-ba"ckend = "goleveldb
 
 # Database directory
 db-dir = "data"

--- a/evmrpc/config.go
+++ b/evmrpc/config.go
@@ -64,6 +64,9 @@ type Config struct {
 
 	// checkTx timeout for sig verify
 	CheckTxTimeout time.Duration `mapstructure:"checktx_timeout"`
+
+	// controls whether to have txns go through one by one
+	Slow bool `mapstructure:"slow"`
 }
 
 var DefaultConfig = Config{
@@ -81,6 +84,7 @@ var DefaultConfig = Config{
 	WSOrigins:            "*",
 	FilterTimeout:        120 * time.Second,
 	CheckTxTimeout:       5 * time.Second,
+	Slow:                 false,
 }
 
 const (
@@ -98,6 +102,7 @@ const (
 	flagWSOrigins            = "evm.ws_origins"
 	flagFilterTimeout        = "evm.filter_timeout"
 	flagCheckTxTimeout       = "evm.checktx_timeout"
+	flagSlow                 = "evm.slow"
 )
 
 func ReadConfig(opts servertypes.AppOptions) (Config, error) {
@@ -170,6 +175,11 @@ func ReadConfig(opts servertypes.AppOptions) (Config, error) {
 	}
 	if v := opts.Get(flagCheckTxTimeout); v != nil {
 		if cfg.CheckTxTimeout, err = cast.ToDurationE(v); err != nil {
+			return cfg, err
+		}
+	}
+	if v := opts.Get(flagSlow); v != nil {
+		if cfg.Slow, err = cast.ToBoolE(v); err != nil {
 			return cfg, err
 		}
 	}

--- a/evmrpc/config_test.go
+++ b/evmrpc/config_test.go
@@ -23,6 +23,7 @@ type opts struct {
 	wsOrigins            interface{}
 	filterTimeout        interface{}
 	checkTxTimeout       interface{}
+	slow                 interface{}
 }
 
 func (o *opts) Get(k string) interface{} {
@@ -67,6 +68,9 @@ func (o *opts) Get(k string) interface{} {
 	}
 	if k == "evm.checktx_timeout" {
 		return o.checkTxTimeout
+	}
+	if k == "evm.slow" {
+		return o.slow
 	}
 	panic("unknown key")
 }

--- a/evmrpc/config_test.go
+++ b/evmrpc/config_test.go
@@ -91,6 +91,7 @@ func TestReadConfig(t *testing.T) {
 		"",
 		time.Duration(5),
 		time.Duration(5),
+		false,
 	}
 	_, err := evmrpc.ReadConfig(&goodOpts)
 	require.Nil(t, err)
@@ -148,6 +149,10 @@ func TestReadConfig(t *testing.T) {
 	require.NotNil(t, err)
 	badOpts = goodOpts
 	badOpts.checkTxTimeout = "bad"
+	_, err = evmrpc.ReadConfig(&badOpts)
+	require.NotNil(t, err)
+	badOpts = goodOpts
+	badOpts.slow = "bad"
 	_, err = evmrpc.ReadConfig(&badOpts)
 	require.NotNil(t, err)
 }

--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -1,7 +1,6 @@
 package evmrpc
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -102,7 +101,6 @@ func NewEVMWebSocketServer(
 	if err := httpServer.SetListenAddr(LocalAddress, config.WSPort); err != nil {
 		return nil, err
 	}
-	fmt.Println("GOT SLOW = ", config.Slow)
 	apis := []rpc.API{
 		{
 			Namespace: "echo",

--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -1,6 +1,7 @@
 package evmrpc
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -57,7 +58,7 @@ func NewEVMHTTPServer(
 		},
 		{
 			Namespace: "eth",
-			Service:   NewSendAPI(tmClient, txConfig),
+			Service:   NewSendAPI(tmClient, txConfig, &SendConfig{slow: config.Slow}),
 		},
 		{
 			Namespace: "eth",
@@ -101,6 +102,7 @@ func NewEVMWebSocketServer(
 	if err := httpServer.SetListenAddr(LocalAddress, config.WSPort); err != nil {
 		return nil, err
 	}
+	fmt.Println("GOT SLOW = ", config.Slow)
 	apis := []rpc.API{
 		{
 			Namespace: "echo",
@@ -124,7 +126,7 @@ func NewEVMWebSocketServer(
 		},
 		{
 			Namespace: "eth",
-			Service:   NewSendAPI(tmClient, txConfig),
+			Service:   NewSendAPI(tmClient, txConfig, &SendConfig{slow: config.Slow}),
 		},
 		{
 			Namespace: "eth",

--- a/scripts/initialize_local_chain.sh
+++ b/scripts/initialize_local_chain.sh
@@ -75,6 +75,12 @@ else
   CONFIG_PATH="$HOME/.sei/config/config.toml"
 fi
 
+if [ ! -z "$2" ]; then
+  APP_PATH="$2"
+else
+  APP_PATH="$HOME/.sei/config/app.toml"
+fi
+
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   sed -i 's/mode = "full"/mode = "validator"/g' $CONFIG_PATH
   sed -i 's/indexer = \["null"\]/indexer = \["kv"\]/g' $CONFIG_PATH
@@ -82,6 +88,8 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   sed -i 's/timeout_precommit =.*/timeout_precommit = "2000ms"/g' $CONFIG_PATH
   sed -i 's/timeout_commit =.*/timeout_commit = "2000ms"/g' $CONFIG_PATH
   sed -i 's/skip_timeout_commit =.*/skip_timeout_commit = false/g' $CONFIG_PATH
+  sed -i 's/slow = false/slow = true/g' $APP_PATH
+  echo "Slow mode enabled for linux"
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   sed -i '' 's/mode = "full"/mode = "validator"/g' $CONFIG_PATH
   sed -i '' 's/indexer = \["null"\]/indexer = \["kv"\]/g' $CONFIG_PATH
@@ -90,6 +98,8 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
   sed -i '' 's/unsafe-vote-timeout-override =.*/unsafe-vote-timeout-override = "2s"/g' $CONFIG_PATH
   sed -i '' 's/unsafe-vote-timeout-delta-override =.*/unsafe-vote-timeout-delta-override = "2s"/g' $CONFIG_PATH
   sed -i '' 's/unsafe-commit-timeout-override =.*/unsafe-commit-timeout-override = "2s"/g' $CONFIG_PATH
+  sed -i '' 's/slow = false/slow = true/g' $APP_PATH
+  echo "Slow mode enabled for darwin"
 else
   printf "Platform not supported, please ensure that the following values are set in your config.toml:\n"
   printf "###         Consensus Configuration Options         ###\n"

--- a/scripts/initialize_local_chain.sh
+++ b/scripts/initialize_local_chain.sh
@@ -89,7 +89,6 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   sed -i 's/timeout_commit =.*/timeout_commit = "2000ms"/g' $CONFIG_PATH
   sed -i 's/skip_timeout_commit =.*/skip_timeout_commit = false/g' $CONFIG_PATH
   sed -i 's/slow = false/slow = true/g' $APP_PATH
-  echo "Slow mode enabled for linux"
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   sed -i '' 's/mode = "full"/mode = "validator"/g' $CONFIG_PATH
   sed -i '' 's/indexer = \["null"\]/indexer = \["kv"\]/g' $CONFIG_PATH
@@ -99,7 +98,6 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
   sed -i '' 's/unsafe-vote-timeout-delta-override =.*/unsafe-vote-timeout-delta-override = "2s"/g' $CONFIG_PATH
   sed -i '' 's/unsafe-commit-timeout-override =.*/unsafe-commit-timeout-override = "2s"/g' $CONFIG_PATH
   sed -i '' 's/slow = false/slow = true/g' $APP_PATH
-  echo "Slow mode enabled for darwin"
 else
   printf "Platform not supported, please ensure that the following values are set in your config.toml:\n"
   printf "###         Consensus Configuration Options         ###\n"


### PR DESCRIPTION
## Describe your changes and provide context
Added a slow config for sending raw txns. When set to true, it should only our RPC to process one transaction at a time.

## Testing performed to validate your change
local testing, however uniswap hardhat tests still don't work.

