### PR TITLE
[EVM] allow passing in private key hex for address association

### DIFF
--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -63,31 +63,37 @@ func GetTxCmd() *cobra.Command {
 
 func CmdAssociateAddress() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "associate-address --rpc=<url> --from=<sender>",
+		Use:   "associate-address [optional priv key hex] --rpc=<url> --from=<sender>",
 		Short: "associate EVM and Sei address for the sender",
 		Long:  "",
-		Args:  cobra.NoArgs,
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
 			}
-			txf := tx.NewFactoryCLI(clientCtx, cmd.Flags())
-			kb := txf.Keybase()
+			var privHex string
+			if len(args) == 1 {
+				privHex = args[0]
+			} else {
+				txf := tx.NewFactoryCLI(clientCtx, cmd.Flags())
+				kb := txf.Keybase()
+				info, err := kb.Key(clientCtx.GetFromName())
+				if err != nil {
+					return err
+				}
+				localInfo, ok := info.(keyring.LocalInfo)
+				if !ok {
+					return errors.New("can only associate address for local keys")
+				}
+				priv, err := legacy.PrivKeyFromBytes([]byte(localInfo.PrivKeyArmor))
+				if err != nil {
+					return err
+				}
+				privHex = hex.EncodeToString(priv.Bytes())
+			}
+
 			emptyHash := common.Hash{}
-			info, err := kb.Key(clientCtx.GetFromName())
-			if err != nil {
-				return err
-			}
-			localInfo, ok := info.(keyring.LocalInfo)
-			if !ok {
-				return errors.New("can only associate address for local keys")
-			}
-			priv, err := legacy.PrivKeyFromBytes([]byte(localInfo.PrivKeyArmor))
-			if err != nil {
-				return err
-			}
-			privHex := hex.EncodeToString(priv.Bytes())
 			key, _ := crypto.HexToECDSA(privHex)
 			sig, err := crypto.Sign(emptyHash[:], key)
 			if err != nil {


### PR DESCRIPTION
## Describe your changes and provide context
We want to allow accounts that are not managed by `seid keys` to also be able to associate address through CLI. Note that the private key will not be transferred via network; it's only used locally (local to where the seid command is run) to compute the signature and only the signature will be transferred to remote sei node.

## Testing performed to validate your change
local sei testing

