### PR TITLE
Fix empty uncle hash

### DIFF
--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -126,10 +126,10 @@ func encodeTmBlock(
 		"number":           (*hexutil.Big)(number),
 		"hash":             blockhash,
 		"parentHash":       lastHash,
-		"nonce":            ethtypes.BlockNonce{}, // inapplicable to Sei
-		"mixHash":          common.Hash{},         // inapplicable to Sei
-		"sha3Uncles":       common.Hash{},         // inapplicable to Sei
-		"logsBloom":        ethtypes.Bloom{},      // inapplicable to Sei
+		"nonce":            ethtypes.BlockNonce{},   // inapplicable to Sei
+		"mixHash":          common.Hash{},           // inapplicable to Sei
+		"sha3Uncles":       ethtypes.EmptyUncleHash, // inapplicable to Sei
+		"logsBloom":        ethtypes.Bloom{},        // inapplicable to Sei
 		"stateRoot":        appHash,
 		"miner":            miner,
 		"difficulty":       (*hexutil.Big)(big.NewInt(0)), // inapplicable to Sei

--- a/evmrpc/block_test.go
+++ b/evmrpc/block_test.go
@@ -1,6 +1,7 @@
 package evmrpc_test
 
 import (
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -53,7 +54,7 @@ func verifyBlockResult(t *testing.T, resObj map[string]interface{}) {
 	require.Equal(t, "0x8", resObj["number"])
 	require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000006", resObj["parentHash"])
 	require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000004", resObj["receiptsRoot"])
-	require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000000", resObj["sha3Uncles"])
+	require.Equal(t, ethtypes.EmptyUncleHash.Hex(), resObj["sha3Uncles"])
 	require.Equal(t, "0x3b2", resObj["size"])
 	require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000003", resObj["stateRoot"])
 	require.Equal(t, "0x65254651", resObj["timestamp"])


### PR DESCRIPTION
## Describe your changes and provide context
This fixes this error:
```
server returned empty uncle list but block header indicates uncles
```

There's a magic value that we have to use to indicate zero uncles.

## Testing performed to validate your change
- Updated unit test

