### PR TITLE
[EVM] call SendCoinsAndWei to support 18-decimal point precision

### DIFF
--- a/.github/workflows/compatiblity_check.yml
+++ b/.github/workflows/compatiblity_check.yml
@@ -17,8 +17,8 @@ jobs:
 
       - name: Check Latest Dependencies
         run: |
-          git clone https://github.com/sei-protocol/sei-cosmos.git
-          git clone https://github.com/sei-protocol/sei-tendermint.git
+          git clone -b evm-temp https://github.com/sei-protocol/sei-cosmos.git
+          git clone -b evm-temp https://github.com/sei-protocol/sei-tendermint.git
           git clone https://github.com/sei-protocol/sei-iavl.git
           git clone https://github.com/sei-protocol/go-ethereum.git
           go mod edit -replace github.com/cosmos/iavl=./sei-iavl

--- a/aclmapping/evm/mappings.go
+++ b/aclmapping/evm/mappings.go
@@ -47,6 +47,13 @@ func TransactionDependencyGenerator(_ aclkeeper.Keeper, evmKeeper evmkeeper.Keep
 	ops = appendRWBalanceOps(ops, state.GetCoinbaseAddress(ctx))
 	sender := sdk.AccAddress(evmMsg.Derived.SenderSeiAddr)
 	ops = appendRWBalanceOps(ops, sender)
+	ops = append(ops,
+		sdkacltypes.AccessOperation{
+			AccessType:         sdkacltypes.AccessType_READ,
+			ResourceType:       sdkacltypes.ResourceType_KV_BANK_WEI_BALANCE,
+			IdentifierTemplate: hex.EncodeToString(append(banktypes.WeiBalancesPrefix, sender...)),
+		},
+	)
 
 	tx, _ := evmMsg.AsTransaction()
 	toAddress := tx.To()

--- a/aclmapping/evm/mappings_test.go
+++ b/aclmapping/evm/mappings_test.go
@@ -75,8 +75,8 @@ func cacheTxContext(ctx sdk.Context) (sdk.Context, sdk.CacheMultiStore) {
 func (suite *KeeperTestSuite) buildSendMsgTo(to common.Address, amt *big.Int) *types.MsgEVMTransaction {
 	txData := ethtypes.DynamicFeeTx{
 		Nonce:     0,
-		GasFeeCap: big.NewInt(1),
-		Gas:       21000,
+		GasFeeCap: big.NewInt(1000000000),
+		Gas:       30000,
 		To:        &to,
 		Value:     amt,
 		Data:      []byte(""),

--- a/aclmapping/utils/resource_type.go
+++ b/aclmapping/utils/resource_type.go
@@ -62,10 +62,11 @@ var StoreKeyToResourceTypePrefixMap = aclsdktypes.StoreKeyToResourceTypePrefixMa
 		aclsdktypes.ResourceType_KV_DEX_MEM_DEPOSIT: dextypes.KeyPrefix(dextypes.MemDepositKey),
 	},
 	banktypes.StoreKey: {
-		aclsdktypes.ResourceType_KV_BANK:          aclsdktypes.EmptyPrefix,
-		aclsdktypes.ResourceType_KV_BANK_BALANCES: banktypes.BalancesPrefix,
-		aclsdktypes.ResourceType_KV_BANK_SUPPLY:   banktypes.SupplyKey,
-		aclsdktypes.ResourceType_KV_BANK_DENOM:    banktypes.DenomMetadataPrefix,
+		aclsdktypes.ResourceType_KV_BANK:             aclsdktypes.EmptyPrefix,
+		aclsdktypes.ResourceType_KV_BANK_BALANCES:    banktypes.BalancesPrefix,
+		aclsdktypes.ResourceType_KV_BANK_SUPPLY:      banktypes.SupplyKey,
+		aclsdktypes.ResourceType_KV_BANK_DENOM:       banktypes.DenomMetadataPrefix,
+		aclsdktypes.ResourceType_KV_BANK_WEI_BALANCE: banktypes.WeiBalancesPrefix,
 	},
 	banktypes.DeferredCacheStoreKey: {
 		aclsdktypes.ResourceType_KV_BANK_DEFERRED:                 aclsdktypes.EmptyPrefix,

--- a/app/app.go
+++ b/app/app.go
@@ -223,6 +223,7 @@ var (
 		evmtypes.ModuleName:            {authtypes.Minter, authtypes.Burner},
 		dexmoduletypes.ModuleName:      nil,
 		tokenfactorytypes.ModuleName:   {authtypes.Minter, authtypes.Burner},
+		banktypes.WeiEscrowName:        nil,
 		// this line is used by starport scaffolding # stargate/app/maccPerms
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -322,7 +322,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.66-evm-11
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.66-evm-12
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.7
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.2.0
 	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei

--- a/go.mod
+++ b/go.mod
@@ -322,7 +322,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.66-evm-12
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.66-evm-13
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.7
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.2.0
 	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei

--- a/go.sum
+++ b/go.sum
@@ -1325,8 +1325,8 @@ github.com/sei-protocol/go-ethereum v1.13.5-sei h1:050SdAmqc3JWULg69daOXaVRvowwp
 github.com/sei-protocol/go-ethereum v1.13.5-sei/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.2.66-evm-12 h1:gBT79tL0sRKn/tIRxONNTfe2Gpqlf1L7QU1MErnY/ms=
-github.com/sei-protocol/sei-cosmos v0.2.66-evm-12/go.mod h1:FrJ75cMf1+Mx/AVWGzpcrCtvBoXd1wurJSRHCtP0cvQ=
+github.com/sei-protocol/sei-cosmos v0.2.66-evm-13 h1:BK9WSVu66oY8p8Cx8EbwvDJO0G/MQPq35gI5rc1lcmY=
+github.com/sei-protocol/sei-cosmos v0.2.66-evm-13/go.mod h1:FrJ75cMf1+Mx/AVWGzpcrCtvBoXd1wurJSRHCtP0cvQ=
 github.com/sei-protocol/sei-iavl v0.1.7 h1:cUdHDBkxs0FF/kOt1qCVLm0K+Bqaw92/dbZSgn4kxiA=
 github.com/sei-protocol/sei-iavl v0.1.7/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-ibc-go/v3 v3.2.0 h1:T8V75OEWKvYDraPZZKilprl7ZkahZYGo40crxNL4unc=

--- a/go.sum
+++ b/go.sum
@@ -1325,8 +1325,8 @@ github.com/sei-protocol/go-ethereum v1.13.5-sei h1:050SdAmqc3JWULg69daOXaVRvowwp
 github.com/sei-protocol/go-ethereum v1.13.5-sei/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.2.66-evm-11 h1:IZUtYzhdFbMaE9H4VGQBjcYEQSrARGfeizDp0wvCECw=
-github.com/sei-protocol/sei-cosmos v0.2.66-evm-11/go.mod h1:FrJ75cMf1+Mx/AVWGzpcrCtvBoXd1wurJSRHCtP0cvQ=
+github.com/sei-protocol/sei-cosmos v0.2.66-evm-12 h1:gBT79tL0sRKn/tIRxONNTfe2Gpqlf1L7QU1MErnY/ms=
+github.com/sei-protocol/sei-cosmos v0.2.66-evm-12/go.mod h1:FrJ75cMf1+Mx/AVWGzpcrCtvBoXd1wurJSRHCtP0cvQ=
 github.com/sei-protocol/sei-iavl v0.1.7 h1:cUdHDBkxs0FF/kOt1qCVLm0K+Bqaw92/dbZSgn4kxiA=
 github.com/sei-protocol/sei-iavl v0.1.7/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-ibc-go/v3 v3.2.0 h1:T8V75OEWKvYDraPZZKilprl7ZkahZYGo40crxNL4unc=

--- a/x/evm/state/statedb.go
+++ b/x/evm/state/statedb.go
@@ -109,10 +109,13 @@ func (s *DBImpl) GetStorageRoot(common.Address) common.Hash {
 func (s *DBImpl) Copy() vm.StateDB {
 	newCtx := s.ctx.WithMultiStore(s.ctx.MultiStore().CacheMultiStore())
 	return &DBImpl{
-		ctx:             newCtx,
-		snapshottedCtxs: append(s.snapshottedCtxs, s.ctx),
-		k:               s.k,
-		err:             s.err,
+		ctx:              newCtx,
+		snapshottedCtxs:  append(s.snapshottedCtxs, s.ctx),
+		k:                s.k,
+		middleManAddress: s.middleManAddress,
+		coinbaseAddress:  s.coinbaseAddress,
+		simulation:       s.simulation,
+		err:              s.err,
 	}
 }
 

--- a/x/evm/state/utils.go
+++ b/x/evm/state/utils.go
@@ -25,3 +25,9 @@ func GetCoinbaseAddress(ctx sdk.Context) sdk.AccAddress {
 	binary.BigEndian.PutUint64(txIndexBz, uint64(ctx.TxIndex()))
 	return sdk.AccAddress(append(CoinbaseAddressPrefix, txIndexBz...))
 }
+
+func SplitUseiWeiAmount(amt *big.Int) (usei *big.Int, wei *big.Int) {
+	wei = new(big.Int).Mod(amt, UseiToSweiMultiplier)
+	usei = new(big.Int).Quo(amt, UseiToSweiMultiplier)
+	return
+}

--- a/x/evm/state/utils_test.go
+++ b/x/evm/state/utils_test.go
@@ -1,0 +1,47 @@
+package state_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/sei-protocol/sei-chain/x/evm/state"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitUseiWeiAmount(t *testing.T) {
+	for _, test := range []struct {
+		amt         *big.Int
+		expectedSei *big.Int
+		expectedWei *big.Int
+	}{
+		{
+			amt:         big.NewInt(0),
+			expectedSei: big.NewInt(0),
+			expectedWei: big.NewInt(0),
+		}, {
+			amt:         big.NewInt(1),
+			expectedSei: big.NewInt(0),
+			expectedWei: big.NewInt(1),
+		}, {
+			amt:         big.NewInt(999_999_999_999),
+			expectedSei: big.NewInt(0),
+			expectedWei: big.NewInt(999_999_999_999),
+		}, {
+			amt:         big.NewInt(1_000_000_000_000),
+			expectedSei: big.NewInt(1),
+			expectedWei: big.NewInt(0),
+		}, {
+			amt:         big.NewInt(1_000_000_000_001),
+			expectedSei: big.NewInt(1),
+			expectedWei: big.NewInt(1),
+		}, {
+			amt:         big.NewInt(123_456_789_123_456_789),
+			expectedSei: big.NewInt(123456),
+			expectedWei: big.NewInt(789_123_456_789),
+		},
+	} {
+		usei, wei := state.SplitUseiWeiAmount(test.amt)
+		require.Equal(t, test.expectedSei, usei)
+		require.Equal(t, test.expectedWei, wei)
+	}
+}


### PR DESCRIPTION
## Describe your changes and provide context
Previously we were truncating any amount after the sixth decimal point in balance operations, which could cause confusion to some developers or just outright render some applications unusable.  This PR makes use of the new bank keeper functions introduced in https://github.com/sei-protocol/sei-cosmos/pull/386 to handle amounts up to 18 decimal points properly.

## Testing performed to validate your change
unit test
integrated with local sei
