### PR TITLE
[EVM] Add tx replacement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -328,7 +328,7 @@ replace (
 	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
-	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.2.30-evm-5
+	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.2.31-0.20231228144141-0673d5ca06ab
 	github.com/tendermint/tm-db => github.com/sei-protocol/tm-db v0.0.4
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1331,8 +1331,8 @@ github.com/sei-protocol/sei-iavl v0.1.7 h1:cUdHDBkxs0FF/kOt1qCVLm0K+Bqaw92/dbZSg
 github.com/sei-protocol/sei-iavl v0.1.7/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-ibc-go/v3 v3.2.0 h1:T8V75OEWKvYDraPZZKilprl7ZkahZYGo40crxNL4unc=
 github.com/sei-protocol/sei-ibc-go/v3 v3.2.0/go.mod h1:DrDYXJjWNwgv72cK1Il+BegtyGIDXcx+cnJwWGzve6o=
-github.com/sei-protocol/sei-tendermint v0.2.30-evm-5 h1:WmzJQbkmryBMeEHAbZvQ+Me79lcKd2+7LnFonOq+3uo=
-github.com/sei-protocol/sei-tendermint v0.2.30-evm-5/go.mod h1:+BtDvAwTkE64BlxzpH9ZP7S6vUYT9wRXiZa/WW8/o4g=
+github.com/sei-protocol/sei-tendermint v0.2.31-0.20231228144141-0673d5ca06ab h1:JGmsx/SHWiTGFfULkt+QSAP0NlgKoCZTFqJOK5wugAk=
+github.com/sei-protocol/sei-tendermint v0.2.31-0.20231228144141-0673d5ca06ab/go.mod h1:+BtDvAwTkE64BlxzpH9ZP7S6vUYT9wRXiZa/WW8/o4g=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
 github.com/sei-protocol/sei-wasmd v0.0.2 h1:I0FVTMSWWVVssBQtDgwcDAyDF+ZT2+RqT20ItTBYih8=

--- a/x/evm/types/message_evm_transaction.go
+++ b/x/evm/types/message_evm_transaction.go
@@ -3,6 +3,7 @@ package types
 import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/gogo/protobuf/proto"
 	"github.com/sei-protocol/sei-chain/x/evm/types/ethtx"
@@ -65,6 +66,11 @@ func (msg *MsgEVMTransaction) IsAssociateTx() bool {
 	}
 	_, ok := txData.(*ethtx.AssociateTx)
 	return ok
+}
+
+func RecoverAddressFromSignature(evmTx *ethtypes.Transaction) (common.Address, error) {
+	signer := ethtypes.NewEIP155Signer(evmTx.ChainId())
+	return signer.Sender(evmTx)
 }
 
 func MustGetEVMTransactionMessage(tx sdk.Tx) *MsgEVMTransaction {


### PR DESCRIPTION
## Describe your changes and provide context
- EVM transactions populate sender with a pattern `{address}|{nonce}`
- The sender is used to de-dupe in the mempool (sei-tendermint)
- A replacement transaction must have a higher priority number to replace (else reject)

## Testing performed to validate your change
- sei-tendermint mempool unit tests

