### PR TITLE
Add catch all panic handler in dex endblock

### DIFF
--- a/x/dex/contract/abci.go
+++ b/x/dex/contract/abci.go
@@ -228,6 +228,15 @@ func handleUnfulfilledMarketOrders(ctx context.Context, sdkCtx sdk.Context, env 
 }
 
 func orderMatchingRunnable(ctx context.Context, sdkContext sdk.Context, env *environment, keeper *keeper.Keeper, contractInfo types.ContractInfoV2, tracer *otrace.Tracer) {
+	defer func() {
+		if err := recover(); err != nil {
+			msg := fmt.Sprintf("PANIC RECOVERED during order matching: %s", err)
+			sdkContext.Logger().Error(msg)
+			if env != nil {
+				env.addError(contractInfo.ContractAddr, errors.New(msg))
+			}
+		}
+	}()
 	_, span := (*tracer).Start(ctx, "orderMatchingRunnable")
 	defer span.End()
 	defer telemetry.MeasureSince(time.Now(), "dex", "order_matching_runnable")

--- a/x/dex/contract/abci.go
+++ b/x/dex/contract/abci.go
@@ -230,6 +230,7 @@ func handleUnfulfilledMarketOrders(ctx context.Context, sdkCtx sdk.Context, env 
 func OrderMatchingRunnable(ctx context.Context, sdkContext sdk.Context, env *environment, keeper *keeper.Keeper, contractInfo types.ContractInfoV2, tracer *otrace.Tracer) {
 	defer func() {
 		if err := recover(); err != nil {
+			telemetry.IncrCounter(1, "recovered_panics")
 			msg := fmt.Sprintf("PANIC RECOVERED during order matching: %s", err)
 			sdkContext.Logger().Error(msg)
 			if env != nil {

--- a/x/dex/contract/abci.go
+++ b/x/dex/contract/abci.go
@@ -58,7 +58,7 @@ func EndBlockerAtomic(ctx sdk.Context, keeper *keeper.Keeper, validContractsInfo
 	handleDeposits(spanCtx, cachedCtx, env, keeper, tracer)
 
 	runner := NewParallelRunner(func(contract types.ContractInfoV2) {
-		orderMatchingRunnable(spanCtx, cachedCtx, env, keeper, contract, tracer)
+		OrderMatchingRunnable(spanCtx, cachedCtx, env, keeper, contract, tracer)
 	}, validContractsInfo, cachedCtx)
 
 	_, err := logging.LogIfNotDoneAfter(ctx.Logger(), func() (struct{}, error) {
@@ -227,7 +227,7 @@ func handleUnfulfilledMarketOrders(ctx context.Context, sdkCtx sdk.Context, env 
 	}
 }
 
-func orderMatchingRunnable(ctx context.Context, sdkContext sdk.Context, env *environment, keeper *keeper.Keeper, contractInfo types.ContractInfoV2, tracer *otrace.Tracer) {
+func OrderMatchingRunnable(ctx context.Context, sdkContext sdk.Context, env *environment, keeper *keeper.Keeper, contractInfo types.ContractInfoV2, tracer *otrace.Tracer) {
 	defer func() {
 		if err := recover(); err != nil {
 			msg := fmt.Sprintf("PANIC RECOVERED during order matching: %s", err)
@@ -237,7 +237,7 @@ func orderMatchingRunnable(ctx context.Context, sdkContext sdk.Context, env *env
 			}
 		}
 	}()
-	_, span := (*tracer).Start(ctx, "orderMatchingRunnable")
+	_, span := (*tracer).Start(ctx, "OrderMatchingRunnable")
 	defer span.End()
 	defer telemetry.MeasureSince(time.Now(), "dex", "order_matching_runnable")
 	defer func() {

--- a/x/dex/contract/abci_test.go
+++ b/x/dex/contract/abci_test.go
@@ -1,6 +1,7 @@
 package contract_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -31,4 +32,12 @@ func TestTransferRentFromDexToCollector(t *testing.T) {
 	require.Equal(t, int64(20), dexBalance.Amount.Int64())
 	collectorBalance := bankkeeper.GetBalance(ctx, testApp.AccountKeeper.GetModuleAddress(authtypes.FeeCollectorName), "usei")
 	require.Equal(t, int64(80), collectorBalance.Amount.Int64())
+}
+
+func TestOrderMatchingRunnablePanicHandler(t *testing.T) {
+	testApp := keepertest.TestApp()
+	ctx := testApp.BaseApp.NewContext(false, tmproto.Header{Time: time.Now()})
+	require.NotPanics(t, func() {
+		contract.OrderMatchingRunnable(context.Background(), ctx, nil, nil, types.ContractInfoV2{}, nil)
+	})
 }

--- a/x/dex/contract/runner.go
+++ b/x/dex/contract/runner.go
@@ -5,6 +5,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/sei-protocol/sei-chain/utils/datastructures"
 	"github.com/sei-protocol/sei-chain/utils/logging"
@@ -136,6 +137,7 @@ func (r *ParallelRunner) Run() {
 func (r *ParallelRunner) wrapRunnable(contractAddr types.ContractAddress) {
 	defer func() {
 		if err := recover(); err != nil {
+			telemetry.IncrCounter(1, "recovered_panics")
 			r.sdkCtx.Logger().Error(fmt.Sprintf("panic in parallel runner recovered: %s", err))
 		}
 

--- a/x/dex/contract/runner.go
+++ b/x/dex/contract/runner.go
@@ -134,6 +134,12 @@ func (r *ParallelRunner) Run() {
 }
 
 func (r *ParallelRunner) wrapRunnable(contractAddr types.ContractAddress) {
+	defer func() {
+		if err := recover(); err != nil {
+			r.sdkCtx.Logger().Error(fmt.Sprintf("panic in parallel runner recovered: %s", err))
+		}
+	}()
+
 	contractInfo, _ := r.contractAddrToInfo.Load(contractAddr)
 	r.runnable(*contractInfo)
 

--- a/x/dex/contract/runner_test.go
+++ b/x/dex/contract/runner_test.go
@@ -29,6 +29,10 @@ func idleRunnable(_ types.ContractInfoV2) {
 	atomic.AddInt64(&counter, 1)
 }
 
+func panicRunnable(_ types.ContractInfoV2) {
+	panic("")
+}
+
 func dependencyCheckRunnable(contractInfo types.ContractInfoV2) {
 	if contractInfo.ContractAddr == "C" {
 		_, hasA := dependencyCheck.Load("A")
@@ -125,4 +129,13 @@ func TestRunnerParallelContractWithInvalidDependency(t *testing.T) {
 	runner.Run()
 	_, hasC := dependencyCheck.Load("C")
 	require.False(t, hasC)
+}
+
+func TestRunnerPanicContract(t *testing.T) {
+	contractInfo := types.ContractInfoV2{
+		ContractAddr:            "A",
+		NumIncomingDependencies: 0,
+	}
+	runner := contract.NewParallelRunner(panicRunnable, []types.ContractInfoV2{contractInfo}, sdkCtx)
+	require.NotPanics(t, runner.Run)
 }

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -304,6 +304,11 @@ func (am AppModule) getPriceToDelete(
 // EndBlock executes all ABCI EndBlock logic respective to the capability module. It
 // returns no validator updates.
 func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) (ret []abci.ValidatorUpdate) {
+	defer func() {
+		if err := recover(); err != nil {
+			ctx.Logger().Error(fmt.Sprintf("panic in endblock recovered: %s", err))
+		}
+	}()
 	_, span := am.tracingInfo.Start("DexEndBlock")
 	defer span.End()
 	defer dexutils.GetMemState(ctx.Context()).Clear(ctx)

--- a/x/dex/module.go
+++ b/x/dex/module.go
@@ -306,6 +306,7 @@ func (am AppModule) getPriceToDelete(
 func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) (ret []abci.ValidatorUpdate) {
 	defer func() {
 		if err := recover(); err != nil {
+			telemetry.IncrCounter(1, "recovered_panics")
 			ctx.Logger().Error(fmt.Sprintf("panic in endblock recovered: %s", err))
 		}
 	}()


### PR DESCRIPTION
## Describe your changes and provide context
Any panic in EndBlock would cause the chain to halt, so we decide to add back panic recovery handler. Also made executions for multiple pairs sequential for each contract so that panics are easier to manage.

After this fix, there will be:
- `EndBlock` function, the main goroutine, with a panic handler at https://github.com/sei-protocol/sei-chain/compare/fix-dex?expand=1#diff-f32c70484252fadec70cda9a6ad7888fd568f6afffb3750bb9621090e2ac88bbR307
- ParallelRunner, which is the only place where goroutines will be spawned under the main goroutine, with a panic handler inside the spawned goroutine function at https://github.com/sei-protocol/sei-chain/compare/fix-dex?expand=1#diff-e2db42e8d9bee39dc72e4b409b496fd72ca1959186d8b81f000dfc16ccc26a14R137

## Testing performed to validate your change
<img width="1864" alt="Screen Shot 2023-12-29 at 12 25 42 PM" src="https://github.com/sei-protocol/sei-chain/assets/6227889/11e374be-dc76-4e5d-98d6-a7d2970075f7">
Tested locally by reproducing the reported bug POC
