### PR TITLE
CLI(refactor): remove ValidateBasic in cli

### DIFF
--- a/x/dex/client/cli/tx/tx_cancel_orders.go
+++ b/x/dex/client/cli/tx/tx_cancel_orders.go
@@ -62,9 +62,7 @@ func CmdCancelOrders() *cobra.Command {
 				cancellations,
 				argContractAddr,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/dex/client/cli/tx/tx_contract_deposit_rent.go
+++ b/x/dex/client/cli/tx/tx_contract_deposit_rent.go
@@ -39,9 +39,7 @@ func CmdContractDepositRent() *cobra.Command {
 				argDeposit,
 				clientCtx.GetFromAddress().String(),
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/dex/client/cli/tx/tx_register_contract.go
+++ b/x/dex/client/cli/tx/tx_register_contract.go
@@ -55,9 +55,7 @@ func CmdRegisterContract() *cobra.Command {
 				dependencies,
 				argDeposit,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/dex/client/cli/tx/tx_register_pairs.go
+++ b/x/dex/client/cli/tx/tx_register_pairs.go
@@ -41,9 +41,7 @@ func CmdRegisterPairs() *cobra.Command {
 				clientCtx.GetFromAddress().String(),
 				txBatchContractPair,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/dex/client/cli/tx/tx_unregister_contract.go
+++ b/x/dex/client/cli/tx/tx_unregister_contract.go
@@ -33,9 +33,7 @@ func CmdUnregisterContract() *cobra.Command {
 				clientCtx.GetFromAddress().String(),
 				argContractAddr,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/dex/client/cli/tx/tx_unsuspend_contract.go
+++ b/x/dex/client/cli/tx/tx_unsuspend_contract.go
@@ -33,9 +33,7 @@ func CmdUnsuspendContract() *cobra.Command {
 				clientCtx.GetFromAddress().String(),
 				argContractAddr,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/dex/client/cli/tx/tx_update_price_tick_size.go
+++ b/x/dex/client/cli/tx/tx_update_price_tick_size.go
@@ -41,9 +41,7 @@ func CmdUpdatePriceTickSize() *cobra.Command {
 				clientCtx.GetFromAddress().String(),
 				txTick,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/dex/client/cli/tx/tx_update_quantity_tick_size.go
+++ b/x/dex/client/cli/tx/tx_update_quantity_tick_size.go
@@ -41,9 +41,7 @@ func CmdUpdateQuantityTickSize() *cobra.Command {
 				clientCtx.GetFromAddress().String(),
 				txTick,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/oracle/client/cli/tx.go
+++ b/x/oracle/client/cli/tx.go
@@ -68,11 +68,6 @@ where "terra1..." is the address you want to delegate your voting rights to.
 			}
 
 			msgs := []sdk.Msg{types.NewMsgDelegateFeedConsent(validator, feeder)}
-			for _, msg := range msgs {
-				if err := msg.ValidateBasic(); err != nil {
-					return err
-				}
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msgs...)
 		},
@@ -127,11 +122,6 @@ $ seid tx oracle aggregate-vote 1234 8888.0ukrw,1.243uusd,0.99usdr seivaloper1..
 			}
 
 			msgs := []sdk.Msg{types.NewMsgAggregateExchangeRateVote(exchangeRatesStr, voter, validator)}
-			for _, msg := range msgs {
-				if err := msg.ValidateBasic(); err != nil {
-					return err
-				}
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msgs...)
 		},


### PR DESCRIPTION
## Describe your changes and provide context
The `ValidateBasic` function has been called in the `GenerateOrBroadcastTxWithFactory` function, so we no longer need to add the `ValidateBasic` function when writing Cli. 

## Testing performed to validate your change

