### PR TITLE
Cleanup removed oracle feeds

### DIFF
--- a/wasmbinding/test/query_test.go
+++ b/wasmbinding/test/query_test.go
@@ -136,6 +136,7 @@ func TestWasmGetOracleTwaps(t *testing.T) {
 		oracletypes.NewPriceSnapshotItem(oracleutils.MicroAtomDenom, oracletypes.OracleExchangeRate{ExchangeRate: sdk.NewDec(20), LastUpdate: sdk.NewInt(10)}),
 	}}
 	testWrapper.App.OracleKeeper.AddPriceSnapshot(testWrapper.Ctx, priceSnapshot)
+	testWrapper.App.OracleKeeper.SetVoteTarget(testWrapper.Ctx, oracleutils.MicroAtomDenom)
 
 	testWrapper.Ctx = testWrapper.Ctx.WithBlockHeight(14).WithBlockTime(time.Unix(3700, 0))
 

--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -162,5 +162,7 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
 	// reset miss counters of all validators at the last block of slash window
 	if utils.IsPeriodLastBlock(ctx, params.SlashWindow) {
 		k.SlashAndResetCounters(ctx)
+		// Compare vote targets and actives and remove excess feeds
+		k.RemoveExcessFeeds(ctx)
 	}
 }

--- a/x/oracle/abci_test.go
+++ b/x/oracle/abci_test.go
@@ -640,7 +640,6 @@ func makeAggregateVote(t *testing.T, input keeper.TestInput, h sdk.Handler, heig
 	require.NoError(t, err)
 }
 
-// TODO: test when we remove an oracle feed
 func TestEndWindowClearExcessFeeds(t *testing.T) {
 	input, _ := setup(t)
 	params := input.OracleKeeper.GetParams(input.Ctx)

--- a/x/oracle/abci_test.go
+++ b/x/oracle/abci_test.go
@@ -639,3 +639,37 @@ func makeAggregateVote(t *testing.T, input keeper.TestInput, h sdk.Handler, heig
 	_, err := h(input.Ctx.WithBlockHeight(height), voteMsg)
 	require.NoError(t, err)
 }
+
+// TODO: test when we remove an oracle feed
+func TestEndWindowClearExcessFeeds(t *testing.T) {
+	input, _ := setup(t)
+	params := input.OracleKeeper.GetParams(input.Ctx)
+	params.Whitelist = types.DenomList{{Name: utils.MicroAtomDenom}}
+	input.OracleKeeper.SetParams(input.Ctx, params)
+
+	input.OracleKeeper.SetBaseExchangeRate(input.Ctx, utils.MicroAtomDenom, randomExchangeRate)
+	input.OracleKeeper.SetBaseExchangeRate(input.Ctx, utils.MicroEthDenom, randomExchangeRate)
+
+	input.OracleKeeper.ClearVoteTargets(input.Ctx)
+	input.OracleKeeper.SetVoteTarget(input.Ctx, utils.MicroAtomDenom)
+
+	earlyCtx := sdk.WrapSDKContext(input.Ctx)
+	earlyQuerier := keeper.NewQuerier(input.OracleKeeper)
+
+	response, err := earlyQuerier.Actives(earlyCtx, &types.QueryActivesRequest{})
+	require.NoError(t, err)
+	require.Equal(t, 2, len(response.Actives))
+
+	votePeriodsPerWindow := sdk.NewDec(int64(input.OracleKeeper.SlashWindow(input.Ctx))).QuoInt64(int64(input.OracleKeeper.VotePeriod(input.Ctx))).TruncateInt64()
+
+	input.Ctx = input.Ctx.WithBlockHeight(votePeriodsPerWindow - 1)
+	oracle.MidBlocker(input.Ctx, input.OracleKeeper)
+	oracle.EndBlocker(input.Ctx, input.OracleKeeper)
+
+	ctx := sdk.WrapSDKContext(input.Ctx)
+	querier := keeper.NewQuerier(input.OracleKeeper)
+
+	response2, err := querier.Actives(ctx, &types.QueryActivesRequest{})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(response2.Actives))
+}

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -132,9 +132,11 @@ func (k Keeper) RemoveExcessFeeds(ctx sdk.Context) {
 		return false
 	})
 	// compare
-	var activesToClear []string
+	activesToClear := make([]string, 0, len(excessActives))
+	i := 0
 	for denom := range excessActives {
-		activesToClear = append(activesToClear, denom)
+		activesToClear[i] = denom
+		i++
 	}
 	sort.Strings(activesToClear)
 	for _, denom := range activesToClear {

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -132,7 +132,7 @@ func (k Keeper) RemoveExcessFeeds(ctx sdk.Context) {
 		return false
 	})
 	// compare
-	activesToClear := make([]string, 0, len(excessActives))
+	activesToClear := make([]string, len(excessActives))
 	i := 0
 	for denom := range excessActives {
 		activesToClear[i] = denom

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -132,7 +132,7 @@ func (k Keeper) RemoveExcessFeeds(ctx sdk.Context) {
 		return false
 	})
 	// compare
-	activesToClear := []string{}
+	var activesToClear []string
 	for denom := range excessActives {
 		activesToClear = append(activesToClear, denom)
 	}

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -118,6 +118,31 @@ func (k Keeper) IterateBaseExchangeRates(ctx sdk.Context, handler func(denom str
 	}
 }
 
+func (k Keeper) RemoveExcessFeeds(ctx sdk.Context) {
+	// get actives
+	excessActives := make(map[string]struct{})
+	k.IterateBaseExchangeRates(ctx, func(denom string, rate types.OracleExchangeRate) (stop bool) {
+		excessActives[denom] = struct{}{}
+		return false
+	})
+	// get vote targets
+	k.IterateVoteTargets(ctx, func(denom string, denomInfo types.Denom) (stop bool) {
+		// remove vote targets from actives
+		delete(excessActives, denom)
+		return false
+	})
+	// compare
+	activesToClear := []string{}
+	for denom := range excessActives {
+		activesToClear = append(activesToClear, denom)
+	}
+	sort.Strings(activesToClear)
+	for _, denom := range activesToClear {
+		// clear exchange rates
+		k.DeleteBaseExchangeRate(ctx, denom)
+	}
+}
+
 //-----------------------------------
 // Oracle delegation logic
 
@@ -452,6 +477,13 @@ func (k Keeper) CalculateTwaps(ctx sdk.Context, lookbackSeconds uint64) (types.O
 	denomToTimeWeightedMap := make(map[string]sdk.Dec)
 	denomDurationMap := make(map[string]int64)
 
+	// get targets - only calculate for the targets
+	targetsMap := make(map[string]struct{})
+	k.IterateVoteTargets(ctx, func(denom string, denomInfo types.Denom) (stop bool) {
+		targetsMap[denom] = struct{}{}
+		return false
+	})
+
 	k.IteratePriceSnapshotsReverse(ctx, func(snapshot types.PriceSnapshot) (stop bool) {
 		stop = false
 		snapshotTimestamp := snapshot.SnapshotTimestamp
@@ -468,6 +500,9 @@ func (k Keeper) CalculateTwaps(ctx sdk.Context, lookbackSeconds uint64) (types.O
 		snapshotPriceItems := snapshot.PriceSnapshotItems
 		for _, priceItem := range snapshotPriceItems {
 			denom := priceItem.Denom
+			if _, ok := targetsMap[denom]; !ok {
+				continue
+			}
 
 			_, exists := denomToTimeWeightedMap[denom]
 			if !exists {

--- a/x/oracle/keeper/keeper_test.go
+++ b/x/oracle/keeper/keeper_test.go
@@ -84,6 +84,18 @@ func TestExchangeRate(t *testing.T) {
 	input.OracleKeeper.IterateBaseExchangeRates(input.Ctx, handler)
 
 	require.Equal(t, 2, numExchangeRates)
+
+	// eth removed
+	input.OracleKeeper.ClearVoteTargets(input.Ctx)
+	input.OracleKeeper.SetVoteTarget(input.Ctx, utils.MicroSeiDenom)
+	input.OracleKeeper.SetVoteTarget(input.Ctx, utils.MicroAtomDenom)
+	// should remove eth
+	input.OracleKeeper.RemoveExcessFeeds(input.Ctx)
+
+	numExchangeRates = 0
+	input.OracleKeeper.IterateBaseExchangeRates(input.Ctx, handler)
+	require.Equal(t, 1, numExchangeRates)
+
 }
 
 func TestIterateSeiExchangeRates(t *testing.T) {
@@ -670,6 +682,126 @@ func TestCalculateTwaps(t *testing.T) {
 	require.Equal(t, utils.MicroEthDenom, ethTwap.Denom)
 	require.Equal(t, int64(0), ethTwap.LookbackSeconds)
 	require.Equal(t, sdk.ZeroDec(), ethTwap.Twap)
+
+	// test error when lookback too large
+	_, err = input.OracleKeeper.CalculateTwaps(input.Ctx, 3700)
+	require.Error(t, err)
+	require.Equal(t, types.ErrInvalidTwapLookback, err)
+
+	// test error when lookback is 0
+	_, err = input.OracleKeeper.CalculateTwaps(input.Ctx, 0)
+	require.Error(t, err)
+	require.Equal(t, types.ErrInvalidTwapLookback, err)
+}
+
+func TestCalculateTwapsWithUnsupportedDenom(t *testing.T) {
+	input := CreateTestInput(t)
+
+	_, err := input.OracleKeeper.CalculateTwaps(input.Ctx, 3600)
+	require.Error(t, err)
+	require.Equal(t, types.ErrNoTwapData, err)
+
+	priceSnapshots := types.PriceSnapshots{
+		types.NewPriceSnapshot(types.PriceSnapshotItems{
+			types.NewPriceSnapshotItem(utils.MicroAtomDenom, types.OracleExchangeRate{
+				ExchangeRate: sdk.NewDec(40),
+				LastUpdate:   sdk.NewInt(1800),
+			}),
+		}, 1200),
+		types.NewPriceSnapshot(types.PriceSnapshotItems{
+			types.NewPriceSnapshotItem(utils.MicroEthDenom, types.OracleExchangeRate{
+				ExchangeRate: sdk.NewDec(10),
+				LastUpdate:   sdk.NewInt(3600),
+			}),
+			types.NewPriceSnapshotItem(utils.MicroAtomDenom, types.OracleExchangeRate{
+				ExchangeRate: sdk.NewDec(20),
+				LastUpdate:   sdk.NewInt(3600),
+			}),
+		}, 3600),
+		types.NewPriceSnapshot(types.PriceSnapshotItems{
+			types.NewPriceSnapshotItem(utils.MicroEthDenom, types.OracleExchangeRate{
+				ExchangeRate: sdk.NewDec(20),
+				LastUpdate:   sdk.NewInt(4500),
+			}),
+			types.NewPriceSnapshotItem(utils.MicroAtomDenom, types.OracleExchangeRate{
+				ExchangeRate: sdk.NewDec(40),
+				LastUpdate:   sdk.NewInt(4500),
+			}),
+		}, 4500),
+	}
+	for _, snap := range priceSnapshots {
+		input.OracleKeeper.SetPriceSnapshot(input.Ctx, snap)
+	}
+	// eth removed
+	input.OracleKeeper.ClearVoteTargets(input.Ctx)
+	input.OracleKeeper.SetVoteTarget(input.Ctx, utils.MicroAtomDenom)
+
+	input.Ctx = input.Ctx.WithBlockTime(time.Unix(5400, 0))
+	twaps, err := input.OracleKeeper.CalculateTwaps(input.Ctx, 3600)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(twaps))
+	atomTwap := twaps[0]
+	require.Equal(t, utils.MicroAtomDenom, atomTwap.Denom)
+	require.Equal(t, int64(3600), atomTwap.LookbackSeconds)
+	require.Equal(t, sdk.NewDec(35), atomTwap.Twap)
+
+	input.Ctx = input.Ctx.WithBlockTime(time.Unix(6000, 0))
+
+	// we still expect the out of range data point from 1200 to be kept for calculating TWAP for the full interval
+	input.OracleKeeper.AddPriceSnapshot(input.Ctx, types.NewPriceSnapshot(types.PriceSnapshotItems{
+		types.NewPriceSnapshotItem(utils.MicroAtomDenom, types.OracleExchangeRate{
+			ExchangeRate: sdk.NewDec(30),
+			LastUpdate:   sdk.NewInt(6000),
+		}),
+	}, 6000))
+
+	input.Ctx = input.Ctx.WithBlockTime(time.Unix(6600, 0))
+
+	twaps, err = input.OracleKeeper.CalculateTwaps(input.Ctx, 3600)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(twaps))
+	atomTwap = twaps[0]
+	require.Equal(t, utils.MicroAtomDenom, atomTwap.Denom)
+	require.Equal(t, int64(3600), atomTwap.LookbackSeconds)
+
+	expectedTwap, _ := sdk.NewDecFromStr("33.333333333333333333")
+	require.Equal(t, expectedTwap, atomTwap.Twap)
+
+	// test with shorter lookback
+	// microeth is not in this one because it's not in the snapshot used for TWAP calculation
+	twaps, err = input.OracleKeeper.CalculateTwaps(input.Ctx, 300)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(twaps))
+	atomTwap = twaps[0]
+	require.Equal(t, utils.MicroAtomDenom, atomTwap.Denom)
+	require.Equal(t, int64(300), atomTwap.LookbackSeconds)
+	require.Equal(t, sdk.NewDec(30), atomTwap.Twap)
+
+	input.OracleKeeper.AddPriceSnapshot(input.Ctx, types.NewPriceSnapshot(types.PriceSnapshotItems{
+		types.NewPriceSnapshotItem(utils.MicroAtomDenom, types.OracleExchangeRate{
+			ExchangeRate: sdk.NewDec(20),
+			LastUpdate:   sdk.NewInt(6000),
+		}),
+	}, 6600))
+
+	input.OracleKeeper.AddPriceSnapshot(input.Ctx, types.NewPriceSnapshot(types.PriceSnapshotItems{
+		types.NewPriceSnapshotItem(utils.MicroEthDenom, types.OracleExchangeRate{
+			ExchangeRate: sdk.NewDec(20),
+			LastUpdate:   sdk.NewInt(6900),
+		}),
+	}, 6900))
+
+	input.Ctx = input.Ctx.WithBlockTime(time.Unix(6900, 0))
+
+	// the older interval weight should be appropriately shorted to the start of the lookback interval,
+	// so the TWAP should be 25 instead of 26.666 because the 20 and 30 are weighted 50-50 instead of 33.3-66.6
+	twaps, err = input.OracleKeeper.CalculateTwaps(input.Ctx, 600)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(twaps))
+	atomTwap = twaps[0]
+	require.Equal(t, utils.MicroAtomDenom, atomTwap.Denom)
+	require.Equal(t, int64(600), atomTwap.LookbackSeconds)
+	require.Equal(t, sdk.NewDec(25), atomTwap.Twap)
 
 	// test error when lookback too large
 	_, err = input.OracleKeeper.CalculateTwaps(input.Ctx, 3700)


### PR DESCRIPTION
## Describe your changes and provide context
This ensure that oracle feeds are removed at the end of the oracle slashing window IF the asset is no longer whitelisted. Additionally, it prevents the TWAPs endpoint from serving twaps for denoms that are no longer in the whitelist.

## Testing performed to validate your change
Unit tests
