### PR TITLE
Add config validation logic for seidb

### DIFF
--- a/app/seidb.go
+++ b/app/seidb.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/cosmos/cosmos-sdk/storev2/rootmulti"
@@ -45,11 +46,11 @@ func SetupSeiDB(
 		logger.Info("SeiDB is disabled, falling back to IAVL")
 		return baseAppOptions
 	}
-	logger.Info("SeiDB is enabled, running node with StoreV2 commit store")
+	logger.Info("SeiDB SC is enabled, running node with StoreV2 commit store")
 	scConfig := parseSCConfigs(appOpts)
 	ssConfig := parseSSConfigs(appOpts)
 	if ssConfig.Enable {
-		logger.Info(fmt.Sprintf("StateStore is also enabled, running %s database for historical state", ssConfig.Backend))
+		logger.Info(fmt.Sprintf("SeiDB StateStore is enabled, running %s for historical state", ssConfig.Backend))
 	}
 	validateConfigs(appOpts)
 
@@ -94,6 +95,7 @@ func validateConfigs(appOpts servertypes.AppOptions) {
 	scEnabled := cast.ToBool(appOpts.Get(FlagSCEnable))
 	ssEnabled := cast.ToBool(appOpts.Get(FlagSSEnable))
 	snapshotExportInterval := cast.ToUint64(appOpts.Get(FlagSnapshotInterval))
+	// Make sure when snapshot is enabled, we should enable SS store
 	if snapshotExportInterval > 0 && scEnabled {
 		if !ssEnabled {
 			panic(fmt.Sprintf("Config validation failed, SeiDB SS store needs to be enabled when snapshot interval %d > 0", snapshotExportInterval))

--- a/app/seidb.go
+++ b/app/seidb.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/cosmos/cosmos-sdk/storev2/rootmulti"
@@ -10,6 +11,7 @@ import (
 )
 
 const (
+	// SC Store configs
 	FlagSCEnable              = "state-commit.sc-enable"
 	FlagSCDirectory           = "state-commit.sc-directory"
 	FlagSCAsyncCommitBuffer   = "state-commit.sc-async-commit-buffer"
@@ -19,6 +21,7 @@ const (
 	FlagSCSnapshotWriterLimit = "state-commit.sc-snapshot-writer-limit"
 	FlagSCCacheSize           = "state-commit.sc-cache-size"
 
+	// SS Store configs
 	FlagSSEnable            = "state-store.ss-enable"
 	FlagSSDirectory         = "state-store.ss-db-directory"
 	FlagSSBackend           = "state-store.ss-backend"
@@ -26,6 +29,9 @@ const (
 	FlagSSKeepRecent        = "state-store.ss-keep-recent"
 	FlagSSPruneInterval     = "state-store.ss-prune-interval"
 	FlagSSImportNumWorkers  = "state-store.ss-import-num-workers"
+
+	// Other configs
+	FlagSnapshotInterval = "state-sync.snapshot-interval"
 )
 
 func SetupSeiDB(
@@ -36,11 +42,16 @@ func SetupSeiDB(
 ) []func(*baseapp.BaseApp) {
 	scEnabled := cast.ToBool(appOpts.Get(FlagSCEnable))
 	if !scEnabled {
+		logger.Info("SeiDB is disabled, falling back to IAVL")
 		return baseAppOptions
 	}
-	logger.Info("SeiDB is enabled, replacing with StoreV2 RMS")
+	logger.Info("SeiDB is enabled, running node with StoreV2 commit store")
 	scConfig := parseSCConfigs(appOpts)
 	ssConfig := parseSSConfigs(appOpts)
+	if ssConfig.Enable {
+		logger.Info(fmt.Sprintf("StateStore is also enabled, running %s database for historical state", ssConfig.Backend))
+	}
+	validateConfigs(appOpts)
 
 	// cms must be overridden before the other options, because they may use the cms,
 	// make sure the cms aren't be overridden by the other options later on.
@@ -76,5 +87,16 @@ func parseSSConfigs(appOpts servertypes.AppOptions) config.StateStoreConfig {
 		PruneIntervalSeconds: cast.ToInt(appOpts.Get(FlagSSPruneInterval)),
 		ImportNumWorkers:     cast.ToInt(appOpts.Get(FlagSSImportNumWorkers)),
 		DBDirectory:          cast.ToString(appOpts.Get(FlagSSDirectory)),
+	}
+}
+
+func validateConfigs(appOpts servertypes.AppOptions) {
+	scEnabled := cast.ToBool(appOpts.Get(FlagSCEnable))
+	ssEnabled := cast.ToBool(appOpts.Get(FlagSSEnable))
+	snapshotExportInterval := cast.ToUint64(appOpts.Get(FlagSnapshotInterval))
+	if snapshotExportInterval > 0 && scEnabled {
+		if !ssEnabled {
+			panic(fmt.Sprintf("Config validation failed, SeiDB SS store needs to be enabled when snapshot interval %d > 0", snapshotExportInterval))
+		}
 	}
 }


### PR DESCRIPTION
## Describe your changes and provide context
Problem:
When seiDB is enabled, and snapshot is enabled as well, we need to make sure ss store is also enabled to provide historical state access, otherwise it would end up creating bad snapshots that could cause app hash issues for state sync.

Solution:
We can add a config validation during app initialization to make sure people have the correct setting set up.

## Testing performed to validate your change
Tested in local docker chain and verify the configs are validated, bad configs are rejected

```
6:59PM INF --tracing not passed in, tracing is not enabled
6:59PM INF Creating node metrics provider
6:59PM INF Starting Process
6:59PM INF SeiDB is enabled, running node with StoreV2 commit store
panic: Config validation failed, SeiDB SS store needs to be enabled when snapshot interval 100 > 0

goroutine 1 [running]:
github.com/sei-protocol/sei-chain/app.validateConfigs({0x2d234c0, 0xc0004c9a00})
	/sei-protocol/sei-chain/app/seidb.go:100 +0xfc
github.com/sei-protocol/sei-chain/app.SetupSeiDB({0x2d43528, 0xc000380a10}, {0xc000227b16, 0xa}, {0x2d234c0, 0xc0004c9a00}, {0xc000599fc0, 0xc, 0xc})
	/sei-protocol/sei-chain/app/seidb.go:55 +0x2a5
github.com/sei-protocol/sei-chain/app.New({0x2d43528, 0xc000380a10}, {0x2d53970, 0xc000014018}, {0x0, 0x0}, _, _, {0xc000227b16, 0xa}, ...)
	/sei-protocol/sei-chain/app/app.go:378 +0xfe
github.com/sei-protocol/sei-chain/cmd/seid/cmd.newApp({0x2d43528, 0xc000380a10}, {0x2d53970, 0xc000014018}, {0x0, 0x0}, 0x0?, {0x2d234c0?, 0xc0004c9a00?})
	/sei-protocol/sei-chain/cmd/seid/cmd/root.go:263 +0xc94
github.com/cosmos/cosmos-sdk/server.startInProcess(_, {{0x0, 0x0, 0x0}, {0x2d62f88, 0xc00017fd10}, {0xc0004f8228, 0x3}, {0x2d481a8, 0xc000032580}, ...}, ...)
	/root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.69/server/start.go:372 +0x63c
github.com/cosmos/cosmos-sdk/server.StartCmd.func2(0xc00014c300?, {0xc00039b200?, 0x0?, 0x4?})
	/root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.69/server/start.go:206 +0x805
github.com/spf13/cobra.(*Command).execute(0xc00014c300, {0xc00039b1c0, 0x4, 0x4})
	/root/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:916 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0xc000164f00)
	/root/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/root/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	/root/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:961
github.com/cosmos/cosmos-sdk/server/cmd.Execute(0x0?, {0xc000227b16, 0xa})
	/root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.69/server/cmd/execute.go:35 +0x1c5
main.main()
	/sei-protocol/sei-chain/cmd/seid/main.go:16 +0x31
```