### PR TITLE
fix docker cluster and gen accounts evm address linking

### DIFF
--- a/docker/localnode/Dockerfile
+++ b/docker/localnode/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:latest
 RUN apt-get update && \
     apt-get install -y make git wget build-essential jq python3 curl vim uuid-runtime
 RUN rm -rf build/generated
-RUN wget https://go.dev/dl/go1.20.6.linux-amd64.tar.gz
-RUN tar -xvf go1.20.6.linux-amd64.tar.gz
+RUN wget https://go.dev/dl/go1.21.4.linux-amd64.tar.gz
+RUN tar -xvf go1.21.4.linux-amd64.tar.gz
 RUN mv go /usr/local/
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
## Describe your changes and provide context
Fixes for gen accounts command to only run for test keyring and also update docker cluster go version to 1.21.4

## Testing performed to validate your change
tested using `make docker-cluster-start`
