### PR TITLE
Loadtest producer consumer various fixes

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1334,7 +1334,6 @@ func (app *App) ProcessBlock(ctx sdk.Context, txs [][]byte, req BlockProcessRequ
 		},
 	}
 	beginBlockResp := app.BeginBlock(ctx, beginBlockReq)
-
 	events = append(events, beginBlockResp.Events...)
 
 	txResults := make([]*abci.ExecTxResult, len(txs))
@@ -1348,14 +1347,12 @@ func (app *App) ProcessBlock(ctx sdk.Context, txs [][]byte, req BlockProcessRequ
 
 	// Finalize all Bank Module Transfers here so that events are included for prioritiezd txs
 	deferredWriteEvents := app.BankKeeper.WriteDeferredBalances(ctx)
-
 	events = append(events, deferredWriteEvents...)
 
 	midBlockEvents := app.MidBlock(ctx, req.GetHeight())
 	events = append(events, midBlockEvents...)
 
 	otherResults, ctx := app.BuildDependenciesAndRunTxs(ctx, otherTxs)
-
 	for relativeOtherIndex, originalIndex := range otherIndices {
 		txResults[originalIndex] = otherResults[relativeOtherIndex]
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -1308,10 +1308,6 @@ func (app *App) BuildDependenciesAndRunTxs(ctx sdk.Context, txs [][]byte) ([]*ab
 }
 
 func (app *App) ProcessBlock(ctx sdk.Context, txs [][]byte, req BlockProcessRequest, lastCommit abci.CommitInfo) ([]abci.Event, []*abci.ExecTxResult, abci.ResponseEndBlock, error) {
-	startTime := time.Now()
-	defer func() {
-		fmt.Printf("PSUDEBUG - Process block time ms: %d\n", time.Now().Sub(startTime).Milliseconds())
-	}()
 	goCtx := app.decorateContextWithDexMemState(ctx.Context())
 	ctx = ctx.WithContext(goCtx)
 
@@ -1337,38 +1333,28 @@ func (app *App) ProcessBlock(ctx sdk.Context, txs [][]byte, req BlockProcessRequ
 			ProposerAddress: ctx.BlockHeader().ProposerAddress,
 		},
 	}
-	beginBlockStart := time.Now()
 	beginBlockResp := app.BeginBlock(ctx, beginBlockReq)
-	fmt.Printf("PSUDEBUG - Begin block time ms: %d\n", time.Now().Sub(beginBlockStart).Milliseconds())
 
 	events = append(events, beginBlockResp.Events...)
 
 	txResults := make([]*abci.ExecTxResult, len(txs))
-	partitionPrioritizedTxsStart := time.Now()
 	prioritizedTxs, otherTxs, prioritizedIndices, otherIndices := app.PartitionPrioritizedTxs(ctx, txs)
-	fmt.Printf("PSUDEBUG - Partition Prioritized Txs ms: %d\n", time.Now().Sub(partitionPrioritizedTxsStart).Milliseconds())
 
 	// run the prioritized txs
-	buildDependenciesAndRunTxsStart := time.Now()
 	prioritizedResults, ctx := app.BuildDependenciesAndRunTxs(ctx, prioritizedTxs)
-	fmt.Printf("PSUDEBUG - BuildDependenciesAndRunTxs1 ms: %d\n", time.Now().Sub(buildDependenciesAndRunTxsStart).Milliseconds())
 	for relativePrioritizedIndex, originalIndex := range prioritizedIndices {
 		txResults[originalIndex] = prioritizedResults[relativePrioritizedIndex]
 	}
 
 	// Finalize all Bank Module Transfers here so that events are included for prioritiezd txs
-	writeDeferredBalanceStart := time.Now()
 	deferredWriteEvents := app.BankKeeper.WriteDeferredBalances(ctx)
-	fmt.Printf("PSUDEBUG - writeDeferredBalanceStart ms: %d\n", time.Now().Sub(writeDeferredBalanceStart).Milliseconds())
 
 	events = append(events, deferredWriteEvents...)
 
 	midBlockEvents := app.MidBlock(ctx, req.GetHeight())
 	events = append(events, midBlockEvents...)
 
-	buildDependenciesAndRunTxsStart2 := time.Now()
 	otherResults, ctx := app.BuildDependenciesAndRunTxs(ctx, otherTxs)
-	fmt.Printf("PSUDEBUG - buildDependenciesAndRunTxsStart2 ms: %d\n", time.Now().Sub(buildDependenciesAndRunTxsStart2).Milliseconds())
 
 	for relativeOtherIndex, originalIndex := range otherIndices {
 		txResults[originalIndex] = otherResults[relativeOtherIndex]

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -93,7 +93,7 @@ func (c *LoadTestClient) Close() {
 	}
 }
 
-func (c *LoadTestClient) BuildTxs(txQueue chan<- []byte, producerId int, wg *sync.WaitGroup, done <-chan struct{}, producedCount *int64) {
+func (c *LoadTestClient) BuildTxs(txQueue chan<- []byte, producerId int, wg *sync.WaitGroup, done <-chan struct{}, producedCount *int64, rateLimiter *rate.Limiter) {
 	defer wg.Done()
 	config := c.LoadTestConfig
 	accountIdentifier := fmt.Sprint(producerId)
@@ -106,38 +106,52 @@ func (c *LoadTestClient) BuildTxs(txQueue chan<- []byte, producerId int, wg *syn
 			fmt.Printf("Stopping producer %d\n", producerId)
 			return
 		default:
-			msgs, _, _, gas, fee := c.generateMessage(config, key, config.MsgsPerTx)
-			txBuilder := TestConfig.TxConfig.NewTxBuilder()
-			_ = txBuilder.SetMsgs(msgs...)
-			txBuilder.SetGasLimit(gas)
-			txBuilder.SetFeeAmount([]types.Coin{
-				types.NewCoin("usei", types.NewInt(fee)),
-			})
-			// Use random seqno to get around txs that might already be seen in mempool
+			if rateLimiter.Allow() {
+				msgs, _, _, gas, fee := c.generateMessage(config, key, config.MsgsPerTx)
+				txBuilder := TestConfig.TxConfig.NewTxBuilder()
+				_ = txBuilder.SetMsgs(msgs...)
+				txBuilder.SetGasLimit(gas)
+				txBuilder.SetFeeAmount([]types.Coin{
+					types.NewCoin("usei", types.NewInt(fee)),
+				})
+				// Use random seqno to get around txs that might already be seen in mempool
 
-			c.SignerClient.SignTx(c.ChainID, &txBuilder, key, uint64(rand.Intn(math.MaxInt)))
-			txBytes, _ := TestConfig.TxConfig.TxEncoder()(txBuilder.GetTx())
-			txQueue <- txBytes
-			atomic.AddInt64(producedCount, 1)
+				c.SignerClient.SignTx(c.ChainID, &txBuilder, key, uint64(rand.Intn(math.MaxInt)))
+				txBytes, _ := TestConfig.TxConfig.TxEncoder()(txBuilder.GetTx())
+				txQueue <- txBytes
+				atomic.AddInt64(producedCount, 1)
+			}
 		}
 	}
 }
 
 func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, sentCount *int64, rateLimit int) {
-	rateLimiter := rate.NewLimiter(rate.Limit(rateLimit), rateLimit)
+	//rateLimiter := rate.NewLimiter(rate.Limit(rateLimit), rateLimit)
+	wg := sync.WaitGroup{}
+
 	for {
 
 		select {
 		case <-done:
 			fmt.Printf("Stopping consumers\n")
+			wg.Wait()
 			return
 		case tx, ok := <-txQueue:
 			if !ok {
 				fmt.Printf("Stopping consumers\n")
+				wg.Wait()
+				return
 			}
-			if rateLimiter.Allow() {
-				go SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_BLOCK, false, *c, sentCount)
-			}
+			wg.Add(1)
+			go func(tx []byte) {
+				defer wg.Done()
+				// Wait blocks until the limiter allows another event.
+				//if err := rateLimiter.Wait(context.Background()); err == nil {
+				SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_BLOCK, false, *c, sentCount)
+				//} else {
+				//	fmt.Printf("Error waiting for rate limiter: %v\n", err)
+				//}
+			}(tx)
 		}
 	}
 }

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -162,7 +162,7 @@ func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, se
 				if err := rateLimiter.Wait(localCtx); err != nil {
 					return
 				}
-				SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_BLOCK, false, *c, sentCount)
+				SendTx(ctx, tx, typestx.BroadcastMode_BROADCAST_MODE_BLOCK, false, *c, sentCount)
 			}(tx)
 		}
 	}

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -124,37 +124,6 @@ func (c *LoadTestClient) BuildTxs(txQueue chan<- []byte, producerId int, wg *syn
 	}
 }
 
-//func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, sentCount *int64, rateLimit int) {
-//	rateLimiter := rate.NewLimiter(rate.Limit(rateLimit), rateLimit)
-//	wg := sync.WaitGroup{}
-//
-//	for {
-//
-//		select {
-//		case <-done:
-//			fmt.Printf("Stopping consumers\n")
-//			wg.Wait()
-//			return
-//		case tx, ok := <-txQueue:
-//			if !ok {
-//				fmt.Printf("Stopping consumers\n")
-//				wg.Wait()
-//				return
-//			}
-//			wg.Add(1)
-//			go func(tx []byte) {
-//				defer wg.Done()
-//				// Wait blocks until the limiter allows another event.
-//				if err := rateLimiter.Wait(context.Background()); err == nil {
-//					SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_BLOCK, false, *c, sentCount)
-//				} else {
-//					fmt.Printf("Error waiting for rate limiter: %v\n", err)
-//				}
-//			}(tx)
-//		}
-//	}
-//}
-
 func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, sentCount *int64, rateLimit int, wg *sync.WaitGroup) {
 	rateLimiter := rate.NewLimiter(rate.Limit(rateLimit), rateLimit)
 	maxConcurrent := rateLimit // Set the maximum number of concurrent SendTx calls
@@ -174,7 +143,7 @@ func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, se
 			}
 
 			if err := sem.Acquire(context.Background(), 1); err != nil {
-				fmt.Printf("Failed to acquire semaphore: %v", err)
+				fmt.Printf("Failed to acquire semaphore: %s", err)
 				break
 			}
 
@@ -183,12 +152,9 @@ func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, se
 				defer wg.Done()
 				defer sem.Release(1)
 
-				if err := rateLimiter.Wait(context.Background()); err != nil {
-					fmt.Printf("Error waiting for rate limiter: %v\n", err)
-					return
+				if err := rateLimiter.Wait(context.Background()); err == nil {
+					SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_BLOCK, false, *c, sentCount)
 				}
-
-				SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_BLOCK, false, *c, sentCount)
 			}(tx)
 		}
 	}

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -126,49 +126,6 @@ func (c *LoadTestClient) BuildTxs(txQueue chan<- []byte, producerId int, keys []
 	}
 }
 
-//func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, sentCount *int64, rateLimit int, wg *sync.WaitGroup) {
-//	rateLimiter := rate.NewLimiter(rate.Limit(rateLimit), rateLimit)
-//	maxConcurrent := rateLimit // Set the maximum number of concurrent SendTx calls
-//	sem := semaphore.NewWeighted(int64(maxConcurrent))
-//
-//	lastHeight := getLastHeight(c.LoadTestConfig.BlockchainEndpoint)
-//	for {
-//		newHeight := getLastHeight(c.LoadTestConfig.BlockchainEndpoint)
-//		for newHeight == lastHeight {
-//			time.Sleep(10 * time.Millisecond)
-//			newHeight = getLastHeight(c.LoadTestConfig.BlockchainEndpoint)
-//		}
-//		for i := 0; i < maxConcurrent; i++ {
-//			select {
-//			case <-done:
-//				fmt.Printf("Stopping consumers\n")
-//				wg.Wait()
-//				return
-//			case tx, ok := <-txQueue:
-//				if !ok {
-//					fmt.Printf("Stopping consumers\n")
-//					wg.Wait()
-//					return
-//				}
-//
-//				if err := sem.Acquire(context.Background(), 1); err != nil {
-//					fmt.Printf("Failed to acquire semaphore: %s", err)
-//					break
-//				}
-//
-//				wg.Add(1)
-//				go func(tx []byte) {
-//					defer wg.Done()
-//					defer sem.Release(1)
-//					SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_BLOCK, false, *c, sentCount)
-//				}(tx)
-//			}
-//
-//		}
-//		lastHeight = newHeight
-//	}
-//}
-
 func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, sentCount *int64, rateLimit int, wg *sync.WaitGroup) {
 	rateLimiter := rate.NewLimiter(rate.Limit(rateLimit), rateLimit)
 	maxConcurrent := rateLimit // Set the maximum number of concurrent SendTx calls
@@ -201,7 +158,6 @@ func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, se
 					fmt.Printf("Error waiting for rate limiter: %v\n", err)
 					return
 				}
-
 				SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_BLOCK, false, *c, sentCount)
 			}(tx)
 		}

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -49,7 +49,6 @@ func NewLoadTestClient(config Config) *LoadTestClient {
 		grpc.MaxCallSendMsgSize(20*1024*1024)),
 	)
 	dialOptions = append(dialOptions, grpc.WithBlock())
-	// NOTE: Will likely need to whitelist node from elb rate limits - add ip to producer ip set
 	if config.TLS {
 		dialOptions = append(dialOptions, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true}))) //nolint:gosec // Use insecure skip verify.
 	} else {

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -159,7 +159,7 @@ func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, se
 				//	defer sem.Release(1)
 
 				if err := rateLimiter.Wait(context.Background()); err == nil {
-					SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_ASYNC, false, *c, sentCount)
+					SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_SYNC, false, *c, sentCount)
 				}
 				//}(tx)
 			}

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -3,16 +3,17 @@ package main
 import (
 	"context"
 	"fmt"
-	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
-	"golang.org/x/sync/semaphore"
-	"golang.org/x/time/rate"
-	"google.golang.org/grpc/connectivity"
 	"math"
 	"math/rand"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"golang.org/x/sync/semaphore"
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc/connectivity"
 
 	"github.com/cosmos/cosmos-sdk/types"
 	typestx "github.com/cosmos/cosmos-sdk/types/tx"

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -160,7 +160,6 @@ func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, se
 				defer sem.Release(1)
 
 				if err := rateLimiter.Wait(localCtx); err != nil {
-					fmt.Printf("Error waiting for rate limiter: %v\n", err)
 					return
 				}
 				SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_BLOCK, false, *c, sentCount)

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -157,7 +157,6 @@ func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, se
 
 				go SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_SYNC, false, *c, sentCount)
 			}
-			SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_BLOCK, false, *c, sentCount)
 			lastHeight = newHeight
 			//if i >= maxConcurrent {
 			//	SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_BLOCK, false, *c, sentCount)

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -148,9 +148,8 @@ func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, se
 				fmt.Printf("Failed to acquire semaphore: %v", err)
 				break
 			}
-
-			wg.Add(1)
 			go func(tx []byte) {
+				wg.Add(1)
 				defer wg.Done()
 				defer sem.Release(1)
 

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -10,8 +10,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.org/x/time/rate"
-
 	"github.com/cosmos/cosmos-sdk/types"
 	typestx "github.com/cosmos/cosmos-sdk/types/tx"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -124,7 +122,7 @@ func (c *LoadTestClient) BuildTxs(txQueue chan<- []byte, producerId int, wg *syn
 }
 
 func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, sentCount *int64, rateLimit int, wg *sync.WaitGroup) {
-	rateLimiter := rate.NewLimiter(rate.Limit(rateLimit), rateLimit)
+	//rateLimiter := rate.NewLimiter(rate.Limit(rateLimit), rateLimit)
 	maxConcurrent := rateLimit // Set the maximum number of concurrent SendTx calls
 	//sem := semaphore.NewWeighted(int64(maxConcurrent))
 

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -124,7 +124,6 @@ func (c *LoadTestClient) BuildTxs(txQueue chan<- []byte, producerId int, keys []
 				atomic.AddInt64(producedCount, 1)
 			case <-done:
 				// Exit if done signal is received while trying to send to txQueue
-				fmt.Printf("Stopping producer %d due to done signal while sending to txQueue\n", producerId)
 				return
 			}
 		}
@@ -132,7 +131,7 @@ func (c *LoadTestClient) BuildTxs(txQueue chan<- []byte, producerId int, keys []
 }
 
 func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, sentCount *int64, rateLimit int, wg *sync.WaitGroup) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	rateLimiter := rate.NewLimiter(rate.Limit(rateLimit), rateLimit)
 	maxConcurrent := rateLimit // Set the maximum number of concurrent SendTx calls

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -155,7 +155,7 @@ func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, se
 			wg.Add(1)
 			for i := 0; i < maxConcurrent; i++ {
 
-				SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_SYNC, false, *c, sentCount)
+				go SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_SYNC, false, *c, sentCount)
 			}
 			SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_BLOCK, false, *c, sentCount)
 			lastHeight = newHeight

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -157,7 +157,7 @@ func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, se
 				//}
 
 				wg.Add(1)
-				go SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_SYNC, false, *c, sentCount)
+				go SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_BLOCK, false, *c, sentCount)
 				//if i >= maxConcurrent {
 				//	SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_BLOCK, false, *c, sentCount)
 				//	i = 0

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"golang.org/x/sync/semaphore"
 	"math"
 	"math/rand"
 	"strings"
@@ -127,7 +126,7 @@ func (c *LoadTestClient) BuildTxs(txQueue chan<- []byte, producerId int, wg *syn
 func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, sentCount *int64, rateLimit int, wg *sync.WaitGroup) {
 	rateLimiter := rate.NewLimiter(rate.Limit(rateLimit), rateLimit)
 	maxConcurrent := rateLimit // Set the maximum number of concurrent SendTx calls
-	sem := semaphore.NewWeighted(int64(maxConcurrent))
+	//sem := semaphore.NewWeighted(int64(maxConcurrent))
 
 	i := 0
 	for {

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -143,14 +143,14 @@ func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, se
 				return
 			}
 
-			if err := sem.Acquire(context.Background(), 1); err != nil {
-				fmt.Printf("Failed to acquire semaphore: %s", err)
-				break
-			}
+			//if err := sem.Acquire(context.Background(), 1); err != nil {
+			//	fmt.Printf("Failed to acquire semaphore: %s", err)
+			//	break
+			//}
 
 			wg.Add(1)
 			i += 1
-			if i == maxConcurrent {
+			if i >= maxConcurrent {
 				SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_BLOCK, false, *c, sentCount)
 				i = 0
 

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -153,7 +153,7 @@ func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, se
 				defer sem.Release(1)
 
 				if err := rateLimiter.Wait(context.Background()); err == nil {
-					SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_BLOCK, false, *c, sentCount)
+					SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_SYNC, false, *c, sentCount)
 				}
 			}(tx)
 		}

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -155,6 +155,7 @@ func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, se
 			wg.Add(1)
 			for i := 0; i < maxConcurrent; i++ {
 
+				fmt.Printf("%s\n", i)
 				go SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_SYNC, false, *c, sentCount)
 			}
 			lastHeight = newHeight

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -171,6 +171,7 @@ func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, se
 			}
 
 		}
+		time.Sleep(1 * time.Second)
 		lastHeight = newHeight
 	}
 }

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -169,9 +169,8 @@ func (c *LoadTestClient) BuildTxs(txQueue chan<- []byte, producerId int, keys []
 //	}
 //}
 
-func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, sentCount *int64, rateLimit int) {
+func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, sentCount *int64, rateLimit int, wg *sync.WaitGroup) {
 	rateLimiter := rate.NewLimiter(rate.Limit(rateLimit), rateLimit)
-	wg := sync.WaitGroup{}
 	maxConcurrent := rateLimit // Set the maximum number of concurrent SendTx calls
 	sem := semaphore.NewWeighted(int64(maxConcurrent))
 

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -148,12 +148,14 @@ func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, se
 				fmt.Printf("Failed to acquire semaphore: %v", err)
 				break
 			}
+			wg.Add(1)
 			go func(tx []byte) {
-				wg.Add(1)
+				localCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+				defer cancel()
 				defer wg.Done()
 				defer sem.Release(1)
 
-				if err := rateLimiter.Wait(ctx); err != nil {
+				if err := rateLimiter.Wait(localCtx); err != nil {
 					fmt.Printf("Error waiting for rate limiter: %v\n", err)
 					return
 				}

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -43,6 +43,11 @@ type LoadTestClient struct {
 func NewLoadTestClient(config Config) *LoadTestClient {
 	var dialOptions []grpc.DialOption
 
+	dialOptions = append(dialOptions, grpc.WithDefaultCallOptions(
+		grpc.MaxCallRecvMsgSize(20*1024*1024),
+		grpc.MaxCallSendMsgSize(20*1024*1024)),
+	)
+	dialOptions = append(dialOptions, grpc.WithBlock())
 	// NOTE: Will likely need to whitelist node from elb rate limits - add ip to producer ip set
 	if config.TLS {
 		dialOptions = append(dialOptions, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true}))) //nolint:gosec // Use insecure skip verify.

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -154,7 +154,6 @@ func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, se
 
 				wg.Add(1)
 				go SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_SYNC, false, *c, sentCount)
-				lastHeight = newHeight
 				//if i >= maxConcurrent {
 				//	SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_BLOCK, false, *c, sentCount)
 				//	i = 0
@@ -172,6 +171,7 @@ func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, se
 			}
 
 		}
+		lastHeight = newHeight
 	}
 }
 

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -155,14 +155,14 @@ func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, se
 				i = 0
 
 			} else {
-				go func(tx []byte) {
-					defer wg.Done()
-					defer sem.Release(1)
+				//go func(tx []byte) {
+				//	defer wg.Done()
+				//	defer sem.Release(1)
 
-					if err := rateLimiter.Wait(context.Background()); err == nil {
-						SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_SYNC, false, *c, sentCount)
-					}
-				}(tx)
+				if err := rateLimiter.Wait(context.Background()); err == nil {
+					SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_ASYNC, false, *c, sentCount)
+				}
+				//}(tx)
 			}
 
 		}

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -155,7 +155,6 @@ func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, se
 			wg.Add(1)
 			for i := 0; i < maxConcurrent; i++ {
 
-				fmt.Printf("%s\n", i)
 				go SendTx(tx, typestx.BroadcastMode_BROADCAST_MODE_SYNC, false, *c, sentCount)
 			}
 			lastHeight = newHeight

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -171,7 +171,6 @@ func (c *LoadTestClient) SendTxs(txQueue <-chan []byte, done <-chan struct{}, se
 			}
 
 		}
-		time.Sleep(1 * time.Second)
 		lastHeight = newHeight
 	}
 }

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -94,7 +94,7 @@ func startLoadtestWorkers(config Config) {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(1 * time.Second)
 	start := time.Now()
 	var producedCount int64 = 0
 	var sentCount int64 = 0

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -78,7 +78,7 @@ func run(config Config) {
 // starts loadtest workers. If config.Constant is true, then we don't gather loadtest results and let producer/consumer
 // workers continue running. If config.Constant is false, then we will gather load test results in a file
 func startLoadtestWorkers(config Config) {
-	fmt.Printf("Starting loadtest workers")
+	fmt.Printf("Starting loadtest workers\n")
 	client := NewLoadTestClient(config)
 	client.SetValidators()
 
@@ -104,7 +104,7 @@ func startLoadtestWorkers(config Config) {
 	var startHeight = getLastHeight(config.BlockchainEndpoint)
 	fmt.Printf("Starting loadtest producers\n")
 	// preload all accounts
-	keys := client.SignerClient.GetAllTestAccountsKeys()
+	keys := client.SignerClient.GetTestAccountsKeys(int(config.TargetTps))
 	for i := 0; i < numProducers; i++ {
 		wg.Add(1)
 		go client.BuildTxs(txQueue, i, keys, &wg, done, &producedCount)

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -149,10 +149,8 @@ func startLoadtestWorkers(config Config) {
 	<-signals
 	fmt.Println("SIGINT received, shutting down...")
 	close(done)
-	fmt.Println("closed done")
 
 	wg.Wait()
-	fmt.Println("wg wait complete")
 	close(txQueue)
 }
 

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -132,7 +132,6 @@ func startLoadtestWorkers(config Config) {
 					blockHeights = append(blockHeights, i)
 					blockTimes = append(blockTimes, blockTime)
 				}
-				fmt.Printf("TxQueue len: %d", len(txQueue))
 
 				printStats(start, &producedCount, &sentCount, &prevSentCount, blockHeights, blockTimes)
 				startHeight = currHeight

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"golang.org/x/time/rate"
 	"io"
 	"math/rand"
 	"net/http"
@@ -104,14 +103,13 @@ func startLoadtestWorkers(config Config) {
 	var blockTimes []string
 	var startHeight = getLastHeight(config.BlockchainEndpoint)
 	fmt.Printf("Starting loadtest producers\n")
-	rateLimiter := rate.NewLimiter(rate.Limit(config.TargetTps), int(config.TargetTps))
 	for i := 0; i < numProducers; i++ {
 		wg.Add(1)
-		go client.BuildTxs(txQueue, i, &wg, done, &producedCount, rateLimiter)
+		go client.BuildTxs(txQueue, i, &wg, done, &producedCount)
 	}
 
 	fmt.Printf("Starting loadtest consumers\n")
-	go client.SendTxs(txQueue, done, &sentCount, int(config.TargetTps))
+	go client.SendTxs(txQueue, done, &sentCount, int(config.TargetTps), &wg)
 	// Statistics reporting goroutine
 	go func() {
 		for {

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -87,7 +87,7 @@ func startLoadtestWorkers(config Config) {
 
 	txQueue := make(chan []byte, 10000)
 	done := make(chan struct{})
-	numProducers := 5
+	numProducers := 1000
 	var wg sync.WaitGroup
 
 	// Catch OS signals for graceful shutdown

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -149,7 +149,10 @@ func startLoadtestWorkers(config Config) {
 	<-signals
 	fmt.Println("SIGINT received, shutting down...")
 	close(done)
+	fmt.Println("closed done")
+
 	wg.Wait()
+	fmt.Println("wg wait complete")
 	close(txQueue)
 }
 

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -87,7 +87,7 @@ func startLoadtestWorkers(config Config) {
 
 	txQueue := make(chan []byte, 10000)
 	done := make(chan struct{})
-	numProducers := 1000
+	numProducers := 5
 	var wg sync.WaitGroup
 
 	// Catch OS signals for graceful shutdown
@@ -103,9 +103,11 @@ func startLoadtestWorkers(config Config) {
 	var blockTimes []string
 	var startHeight = getLastHeight(config.BlockchainEndpoint)
 	fmt.Printf("Starting loadtest producers\n")
+	// preload all accounts
+	keys := client.SignerClient.GetAllTestAccountsKeys()
 	for i := 0; i < numProducers; i++ {
 		wg.Add(1)
-		go client.BuildTxs(txQueue, i, &wg, done, &producedCount)
+		go client.BuildTxs(txQueue, i, keys, &wg, done, &producedCount)
 	}
 
 	fmt.Printf("Starting loadtest consumers\n")

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"golang.org/x/time/rate"
 	"io"
 	"math/rand"
 	"net/http"
@@ -103,9 +104,10 @@ func startLoadtestWorkers(config Config) {
 	var blockTimes []string
 	var startHeight = getLastHeight(config.BlockchainEndpoint)
 	fmt.Printf("Starting loadtest producers\n")
+	rateLimiter := rate.NewLimiter(rate.Limit(config.TargetTps), int(config.TargetTps))
 	for i := 0; i < numProducers; i++ {
 		wg.Add(1)
-		go client.BuildTxs(txQueue, i, &wg, done, &producedCount)
+		go client.BuildTxs(txQueue, i, &wg, done, &producedCount, rateLimiter)
 	}
 
 	fmt.Printf("Starting loadtest consumers\n")

--- a/loadtest/sign.go
+++ b/loadtest/sign.go
@@ -66,7 +66,17 @@ func (sc *SignerClient) GetTestAccountsKeys(maxAccounts int) []cryptotypes.PrivK
 	userHomeDir, _ := os.UserHomeDir()
 	files, _ := os.ReadDir(filepath.Join(userHomeDir, "test_accounts"))
 	var testAccountsKeys []cryptotypes.PrivKey
+	fmt.Printf("Loading accounts\n")
 	for i, file := range files {
+		if i == len(files)/4 {
+			fmt.Printf("Loading accounts 1/4 done")
+		}
+		if i == len(files)/2 {
+			fmt.Printf("Loading accounts 1/2 done")
+		}
+		if i == 3*len(files)/4 {
+			fmt.Printf("Loading accounts 3/4 done")
+		}
 		testAccountsKeys = append(testAccountsKeys, sc.GetKey(fmt.Sprint(i), "test", file.Name()))
 		if i >= maxAccounts {
 			break

--- a/loadtest/sign.go
+++ b/loadtest/sign.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"sync"
@@ -65,7 +66,8 @@ func NewSignerClient(nodeURI string) *SignerClient {
 func (sc *SignerClient) GetTestAccountsKeys(maxAccounts int) []cryptotypes.PrivKey {
 	userHomeDir, _ := os.UserHomeDir()
 	files, _ := os.ReadDir(filepath.Join(userHomeDir, "test_accounts"))
-	var testAccountsKeys []cryptotypes.PrivKey
+
+	var testAccountsKeys = make([]cryptotypes.PrivKey, math.Min(float64(len(files)), float64(maxAccounts)))
 	var wg sync.WaitGroup
 	keysChan := make(chan cryptotypes.PrivKey, maxAccounts)
 	fmt.Printf("Loading accounts\n")

--- a/loadtest/sign.go
+++ b/loadtest/sign.go
@@ -62,12 +62,15 @@ func NewSignerClient(nodeURI string) *SignerClient {
 	}
 }
 
-func (sc *SignerClient) GetAllTestAccountsKeys() []cryptotypes.PrivKey {
+func (sc *SignerClient) GetTestAccountsKeys(maxAccounts int) []cryptotypes.PrivKey {
 	userHomeDir, _ := os.UserHomeDir()
 	files, _ := os.ReadDir(filepath.Join(userHomeDir, "test_accounts"))
 	var testAccountsKeys []cryptotypes.PrivKey
 	for i, file := range files {
 		testAccountsKeys = append(testAccountsKeys, sc.GetKey(fmt.Sprint(i), "test", file.Name()))
+		if i >= maxAccounts {
+			break
+		}
 	}
 	return testAccountsKeys
 }

--- a/loadtest/sign.go
+++ b/loadtest/sign.go
@@ -62,9 +62,14 @@ func NewSignerClient(nodeURI string) *SignerClient {
 	}
 }
 
-func (sc *SignerClient) GetTestAccountKeyPath(accountID uint64) string {
+func (sc *SignerClient) GetAllTestAccountsKeys() []cryptotypes.PrivKey {
 	userHomeDir, _ := os.UserHomeDir()
-	return filepath.Join(userHomeDir, "test_accounts", fmt.Sprintf("ta%d.json", accountID))
+	files, _ := os.ReadDir(filepath.Join(userHomeDir, "test_accounts"))
+	var testAccountsKeys []cryptotypes.PrivKey
+	for i, file := range files {
+		testAccountsKeys = append(testAccountsKeys, sc.GetKey(fmt.Sprint(i), "test", file.Name()))
+	}
+	return testAccountsKeys
 }
 
 func (sc *SignerClient) GetAdminAccountKeyPath() string {

--- a/loadtest/sign.go
+++ b/loadtest/sign.go
@@ -83,13 +83,11 @@ func (sc *SignerClient) GetTestAccountsKeys(maxAccounts int) []cryptotypes.PrivK
 	wg.Wait()
 	close(keysChan)
 	// Collect keys from the channel
-	idx := 0
 	for key := range keysChan {
-		testAccountsKeys[idx] = key
-		idx++
+		testAccountsKeys = append(testAccountsKeys, key)
 	}
 
-	return testAccountsKeys[:idx]
+	return testAccountsKeys
 }
 
 func (sc *SignerClient) GetAdminAccountKeyPath() string {

--- a/loadtest/sign.go
+++ b/loadtest/sign.go
@@ -68,15 +68,6 @@ func (sc *SignerClient) GetTestAccountsKeys(maxAccounts int) []cryptotypes.PrivK
 	var testAccountsKeys []cryptotypes.PrivKey
 	fmt.Printf("Loading accounts\n")
 	for i, file := range files {
-		if i == len(files)/4 {
-			fmt.Printf("Loading accounts 1/4 done")
-		}
-		if i == len(files)/2 {
-			fmt.Printf("Loading accounts 1/2 done")
-		}
-		if i == 3*len(files)/4 {
-			fmt.Printf("Loading accounts 3/4 done")
-		}
 		testAccountsKeys = append(testAccountsKeys, sc.GetKey(fmt.Sprint(i), "test", filepath.Join(userHomeDir, "test_accounts", file.Name())))
 		if i >= maxAccounts {
 			break

--- a/loadtest/sign.go
+++ b/loadtest/sign.go
@@ -67,7 +67,7 @@ func (sc *SignerClient) GetTestAccountsKeys(maxAccounts int) []cryptotypes.PrivK
 	userHomeDir, _ := os.UserHomeDir()
 	files, _ := os.ReadDir(filepath.Join(userHomeDir, "test_accounts"))
 
-	var testAccountsKeys = make([]cryptotypes.PrivKey, math.Min(float64(len(files)), float64(maxAccounts)))
+	var testAccountsKeys = make([]cryptotypes.PrivKey, int(math.Min(float64(len(files)), float64(maxAccounts))))
 	var wg sync.WaitGroup
 	keysChan := make(chan cryptotypes.PrivKey, maxAccounts)
 	fmt.Printf("Loading accounts\n")

--- a/loadtest/sign.go
+++ b/loadtest/sign.go
@@ -77,7 +77,7 @@ func (sc *SignerClient) GetTestAccountsKeys(maxAccounts int) []cryptotypes.PrivK
 		if i == 3*len(files)/4 {
 			fmt.Printf("Loading accounts 3/4 done")
 		}
-		testAccountsKeys = append(testAccountsKeys, sc.GetKey(fmt.Sprint(i), "test", filepath.Join(userHomeDir, file.Name())))
+		testAccountsKeys = append(testAccountsKeys, sc.GetKey(fmt.Sprint(i), "test", filepath.Join(userHomeDir, "test_accounts", file.Name())))
 		if i >= maxAccounts {
 			break
 		}

--- a/loadtest/sign.go
+++ b/loadtest/sign.go
@@ -77,7 +77,7 @@ func (sc *SignerClient) GetTestAccountsKeys(maxAccounts int) []cryptotypes.PrivK
 		if i == 3*len(files)/4 {
 			fmt.Printf("Loading accounts 3/4 done")
 		}
-		testAccountsKeys = append(testAccountsKeys, sc.GetKey(fmt.Sprint(i), "test", file.Name()))
+		testAccountsKeys = append(testAccountsKeys, sc.GetKey(fmt.Sprint(i), "test", filepath.Join(userHomeDir, file.Name())))
 		if i >= maxAccounts {
 			break
 		}

--- a/loadtest/tx.go
+++ b/loadtest/tx.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	typestx "github.com/cosmos/cosmos-sdk/types/tx"
 	"sync/atomic"
 )
@@ -16,27 +15,13 @@ func SendTx(
 	sentCount *int64,
 ) {
 
-	grpcRes, err := loadtestClient.GetTxClient().BroadcastTx(
+	grpcRes, _ := loadtestClient.GetTxClient().BroadcastTx(
 		ctx,
 		&typestx.BroadcastTxRequest{
 			Mode:    mode,
 			TxBytes: txBytes,
 		},
 	)
-	if err != nil {
-		if failureExpected {
-			fmt.Printf("Error: %s\n", err)
-		} else {
-			panic(err)
-		}
-
-		if grpcRes == nil || grpcRes.TxResponse == nil {
-			return
-		}
-		if grpcRes.TxResponse.Code == 0 {
-			atomic.AddInt64(sentCount, 1)
-		}
-	}
 
 	if grpcRes.TxResponse.Code == 0 {
 		atomic.AddInt64(sentCount, 1)

--- a/loadtest/tx.go
+++ b/loadtest/tx.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"context"
-	typestx "github.com/cosmos/cosmos-sdk/types/tx"
 	"sync/atomic"
+
+	typestx "github.com/cosmos/cosmos-sdk/types/tx"
 )
 
 func SendTx(

--- a/loadtest/tx.go
+++ b/loadtest/tx.go
@@ -17,6 +17,7 @@ func SendTx(
 	loadtestClient LoadTestClient,
 	sentCount *int64,
 ) {
+	fmt.Printf("PSUDEBUG - sending txs")
 	grpcRes, err := loadtestClient.GetTxClient().BroadcastTx(
 		context.Background(),
 		&typestx.BroadcastTxRequest{

--- a/loadtest/tx.go
+++ b/loadtest/tx.go
@@ -23,7 +23,11 @@ func SendTx(
 		},
 	)
 
-	if grpcRes.TxResponse.Code == 0 {
+	if failureExpected {
 		atomic.AddInt64(sentCount, 1)
+		return
+	} else if grpcRes != nil && grpcRes.TxResponse.Code == 0 {
+		atomic.AddInt64(sentCount, 1)
+		return
 	}
 }

--- a/loadtest/tx.go
+++ b/loadtest/tx.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	typestx "github.com/cosmos/cosmos-sdk/types/tx"
 	"sync/atomic"
 )
@@ -12,31 +13,30 @@ func SendTx(
 	loadtestClient LoadTestClient,
 	sentCount *int64,
 ) {
-	atomic.AddInt64(sentCount, 1)
 
-	//grpcRes, err := loadtestClient.GetTxClient().BroadcastTx(
-	//	context.Background(),
-	//	&typestx.BroadcastTxRequest{
-	//		Mode:    mode,
-	//		TxBytes: txBytes,
-	//	},
-	//)
-	//if err != nil {
-	//	if failureExpected {
-	//		fmt.Printf("Error: %s\n", err)
-	//	} else {
-	//		panic(err)
-	//	}
-	//
-	//	if grpcRes == nil || grpcRes.TxResponse == nil {
-	//		return
-	//	}
-	//	if grpcRes.TxResponse.Code == 0 {
-	//		atomic.AddInt64(sentCount, 1)
-	//	}
-	//}
-	//
-	//if grpcRes.TxResponse.Code == 0 {
-	//	atomic.AddInt64(sentCount, 1)
-	//}
+	grpcRes, err := loadtestClient.GetTxClient().BroadcastTx(
+		context.Background(),
+		&typestx.BroadcastTxRequest{
+			Mode:    mode,
+			TxBytes: txBytes,
+		},
+	)
+	if err != nil {
+		if failureExpected {
+			fmt.Printf("Error: %s\n", err)
+		} else {
+			panic(err)
+		}
+
+		if grpcRes == nil || grpcRes.TxResponse == nil {
+			return
+		}
+		if grpcRes.TxResponse.Code == 0 {
+			atomic.AddInt64(sentCount, 1)
+		}
+	}
+
+	if grpcRes.TxResponse.Code == 0 {
+		atomic.AddInt64(sentCount, 1)
+	}
 }

--- a/loadtest/tx.go
+++ b/loadtest/tx.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	typestx "github.com/cosmos/cosmos-sdk/types/tx"
 	"sync/atomic"

--- a/loadtest/tx.go
+++ b/loadtest/tx.go
@@ -8,6 +8,7 @@ import (
 )
 
 func SendTx(
+	ctx context.Context,
 	txBytes []byte,
 	mode typestx.BroadcastMode,
 	failureExpected bool,
@@ -16,7 +17,7 @@ func SendTx(
 ) {
 
 	grpcRes, err := loadtestClient.GetTxClient().BroadcastTx(
-		context.Background(),
+		ctx,
 		&typestx.BroadcastTxRequest{
 			Mode:    mode,
 			TxBytes: txBytes,

--- a/loadtest/tx.go
+++ b/loadtest/tx.go
@@ -57,9 +57,7 @@ func SendTx(
 			}
 		}
 	}
-	if grpcRes.TxResponse.Code != 0 {
-		fmt.Printf("Error: %d, %s\n", grpcRes.TxResponse.Code, grpcRes.TxResponse.RawLog)
-	} else {
+	if grpcRes.TxResponse.Code == 0 {
 		atomic.AddInt64(sentCount, 1)
 	}
 }

--- a/loadtest/tx.go
+++ b/loadtest/tx.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"context"
-	"fmt"
 	typestx "github.com/cosmos/cosmos-sdk/types/tx"
 	"sync/atomic"
 )
@@ -14,29 +12,31 @@ func SendTx(
 	loadtestClient LoadTestClient,
 	sentCount *int64,
 ) {
-	grpcRes, err := loadtestClient.GetTxClient().BroadcastTx(
-		context.Background(),
-		&typestx.BroadcastTxRequest{
-			Mode:    mode,
-			TxBytes: txBytes,
-		},
-	)
-	if err != nil {
-		if failureExpected {
-			fmt.Printf("Error: %s\n", err)
-		} else {
-			panic(err)
-		}
+	atomic.AddInt64(sentCount, 1)
 
-		if grpcRes == nil || grpcRes.TxResponse == nil {
-			return
-		}
-		if grpcRes.TxResponse.Code == 0 {
-			atomic.AddInt64(sentCount, 1)
-		}
-	}
-
-	if grpcRes.TxResponse.Code == 0 {
-		atomic.AddInt64(sentCount, 1)
-	}
+	//grpcRes, err := loadtestClient.GetTxClient().BroadcastTx(
+	//	context.Background(),
+	//	&typestx.BroadcastTxRequest{
+	//		Mode:    mode,
+	//		TxBytes: txBytes,
+	//	},
+	//)
+	//if err != nil {
+	//	if failureExpected {
+	//		fmt.Printf("Error: %s\n", err)
+	//	} else {
+	//		panic(err)
+	//	}
+	//
+	//	if grpcRes == nil || grpcRes.TxResponse == nil {
+	//		return
+	//	}
+	//	if grpcRes.TxResponse.Code == 0 {
+	//		atomic.AddInt64(sentCount, 1)
+	//	}
+	//}
+	//
+	//if grpcRes.TxResponse.Code == 0 {
+	//	atomic.AddInt64(sentCount, 1)
+	//}
 }

--- a/loadtest/tx.go
+++ b/loadtest/tx.go
@@ -3,11 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
-	"sync/atomic"
-	"time"
-
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	typestx "github.com/cosmos/cosmos-sdk/types/tx"
+	"sync/atomic"
 )
 
 func SendTx(
@@ -17,7 +14,6 @@ func SendTx(
 	loadtestClient LoadTestClient,
 	sentCount *int64,
 ) {
-	fmt.Printf("PSUDEBUG - sending txs")
 	grpcRes, err := loadtestClient.GetTxClient().BroadcastTx(
 		context.Background(),
 		&typestx.BroadcastTxRequest{
@@ -40,25 +36,27 @@ func SendTx(
 		}
 	}
 
-	for grpcRes.TxResponse.Code == sdkerrors.ErrMempoolIsFull.ABCICode() {
-		// retry after a second until either succeed or fail for some other reason
-		fmt.Printf("Mempool full\n")
-		time.Sleep(1 * time.Second)
-		grpcRes, err = loadtestClient.GetTxClient().BroadcastTx(
-			context.Background(),
-			&typestx.BroadcastTxRequest{
-				Mode:    mode,
-				TxBytes: txBytes,
-			},
-		)
-		if err != nil {
-			if failureExpected {
-			} else {
-				panic(err)
-			}
-		}
-	}
+	//for grpcRes.TxResponse.Code == sdkerrors.ErrMempoolIsFull.ABCICode() {
+	//	// retry after a second until either succeed or fail for some other reason
+	//	fmt.Printf("Mempool full\n")
+	//	time.Sleep(1 * time.Second)
+	//	grpcRes, err = loadtestClient.GetTxClient().BroadcastTx(
+	//		context.Background(),
+	//		&typestx.BroadcastTxRequest{
+	//			Mode:    mode,
+	//			TxBytes: txBytes,
+	//		},
+	//	)
+	//	if err != nil {
+	//		if failureExpected {
+	//		} else {
+	//			panic(err)
+	//		}
+	//	}
+	//}
 	if grpcRes.TxResponse.Code == 0 {
 		atomic.AddInt64(sentCount, 1)
+	} else {
+		fmt.Printf("PSUDEBUTG - failed: %s\n", grpcRes.TxResponse)
 	}
 }

--- a/loadtest/tx.go
+++ b/loadtest/tx.go
@@ -36,27 +36,7 @@ func SendTx(
 		}
 	}
 
-	//for grpcRes.TxResponse.Code == sdkerrors.ErrMempoolIsFull.ABCICode() {
-	//	// retry after a second until either succeed or fail for some other reason
-	//	fmt.Printf("Mempool full\n")
-	//	time.Sleep(1 * time.Second)
-	//	grpcRes, err = loadtestClient.GetTxClient().BroadcastTx(
-	//		context.Background(),
-	//		&typestx.BroadcastTxRequest{
-	//			Mode:    mode,
-	//			TxBytes: txBytes,
-	//		},
-	//	)
-	//	if err != nil {
-	//		if failureExpected {
-	//		} else {
-	//			panic(err)
-	//		}
-	//	}
-	//}
 	if grpcRes.TxResponse.Code == 0 {
 		atomic.AddInt64(sentCount, 1)
-	} else {
-		fmt.Printf("PSUDEBUTG - failed: %s\n", grpcRes.TxResponse)
 	}
 }


### PR DESCRIPTION
## Describe your changes and provide context
A few more fixes after noticing some performance issues:
- only numProducer accounts were used, limiting the throughput
- parallelize loading keys to make startup faster
- increase numProducers
- add a buffer for highTps tests to allow producers to populate the queue
- fix hanging threads
## Testing performed to validate your change
ran against loadtest cluster:
<img width="907" alt="image" src="https://github.com/sei-protocol/sei-chain/assets/3821073/9a9576cb-9f77-4a4d-b290-208fe6967af9">


