### PR TITLE
Minor RPC fixes

### DIFF
--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -151,6 +151,9 @@ func EncodeTmBlock(
 		"transactions":     transactions,
 		"baseFeePerGas":    (*hexutil.Big)(k.GetBaseFeePerGas(ctx).RoundInt().BigInt()),
 	}
+	if fullTx {
+		result["totalDifficulty"] = (*hexutil.Big)(big.NewInt(0)) // inapplicable to Sei
+	}
 	return result, nil
 }
 

--- a/evmrpc/block_test.go
+++ b/evmrpc/block_test.go
@@ -1,6 +1,9 @@
 package evmrpc_test
 
 import (
+	"math/big"
+	"testing"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -11,8 +14,6 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/rpc/coretypes"
 	tmtypes "github.com/tendermint/tendermint/types"
-	"math/big"
-	"testing"
 )
 
 func TestGetBlockByHash(t *testing.T) {
@@ -90,6 +91,7 @@ func verifyBlockResult(t *testing.T, resObj map[string]interface{}) {
 	require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000002", resObj["transactionsRoot"])
 	require.Equal(t, []interface{}{}, resObj["uncles"])
 	require.Equal(t, "0x0", resObj["baseFeePerGas"])
+	require.Equal(t, "0x0", resObj["totalDifficulty"])
 }
 
 func TestEncodeBankMsg(t *testing.T) {

--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -287,6 +287,8 @@ func encodeReceipt(receipt *types.Receipt, blockHash bytes.HexBytes, txRes *abci
 	}
 	if receipt.ContractAddress != "" {
 		fields["contractAddress"] = common.HexToAddress(receipt.ContractAddress)
+	} else {
+		fields["contractAddress"] = nil
 	}
 	return fields, nil
 }

--- a/evmrpc/tx_test.go
+++ b/evmrpc/tx_test.go
@@ -60,6 +60,24 @@ func TestGetTxReceipt(t *testing.T) {
 	require.Equal(t, "0x0123456789012345678902345678901234567890123456789012345678901234", resObj["transactionHash"].(string))
 	require.Equal(t, "0x0", resObj["transactionIndex"].(string))
 	require.Equal(t, "0x1", resObj["type"].(string))
+	require.Equal(t, "0x1234567890123456789012345678901234567890", resObj["contractAddress"].(string))
+
+	receipt, err := EVMKeeper.GetReceipt(Ctx, common.HexToHash("0xf02362077ac075a397344172496b28e913ce5294879d811bb0269b3be20a872e"))
+	require.Nil(t, err)
+	receipt.ContractAddress = ""
+	EVMKeeper.SetReceipt(Ctx, common.HexToHash("0xf02362077ac075a397344172496b28e913ce5294879d811bb0269b3be20a872e"), receipt)
+	body = "{\"jsonrpc\": \"2.0\",\"method\": \"eth_getTransactionReceipt\",\"params\":[\"0xf02362077ac075a397344172496b28e913ce5294879d811bb0269b3be20a872e\"],\"id\":\"test\"}"
+	req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s:%d", TestAddr, TestPort), strings.NewReader(body))
+	require.Nil(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	res, err = http.DefaultClient.Do(req)
+	require.Nil(t, err)
+	resBody, err = io.ReadAll(res.Body)
+	require.Nil(t, err)
+	resObj = map[string]interface{}{}
+	require.Nil(t, json.Unmarshal(resBody, &resObj))
+	resObj = resObj["result"].(map[string]interface{})
+	require.Nil(t, resObj["contractAddress"])
 
 	req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s:%d", TestAddr, TestBadPort), strings.NewReader(body))
 	require.Nil(t, err)


### PR DESCRIPTION
## Describe your changes and provide context
Fixes for:

[Tony] Invalid value supplied to RpcBlockWithTransactions

[Tony] eth_getTransactionReceipt is missing contractAddress field
curl --location 'https://evm-devnet.seinetwork.io' \
--header 'Content-Type: application/json' \
--data '{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0x57beed40598914c0d90cd903d883633df9afa8117f5a4bd37ae29a3d670a5218"],"id":1}'

## Testing performed to validate your change
unit tests
