### PR TITLE
Add TransferFrom method to contract and bindings

### DIFF
--- a/example/cosmwasm/cw20/src/contract.rs
+++ b/example/cosmwasm/cw20/src/contract.rs
@@ -31,6 +31,9 @@ pub fn execute(
         ExecuteMsg::Transfer { recipient, amount } => {
             execute_transfer(deps, env, info, recipient, amount)
         },
+        ExecuteMsg::TransferFrom { owner, recipient, amount } => {
+            execute_transfer_from(deps, env, info, owner, recipient, amount)
+        },
         _ => Result::Ok(Response::new())
     }
 }
@@ -53,6 +56,33 @@ pub fn execute_transfer(
         .add_attribute("action", "transfer")
         .add_attribute("from", info.sender)
         .add_attribute("to", recipient)
+        .add_attribute("amount", amount)
+        .add_message(msg);
+
+    Ok(res)
+}
+
+pub fn execute_transfer_from(
+    deps: DepsMut<EvmQueryWrapper>,
+    _env: Env,
+    info: MessageInfo,
+    owner: String,
+    recipient: String,
+    amount: Uint128,
+) -> Result<Response<EvmMsg>, ContractError> {
+    deps.api.addr_validate(&owner)?;
+    deps.api.addr_validate(&recipient)?;
+
+    let erc_addr = ERC20_ADDRESS.load(deps.storage)?;
+
+    let querier = EvmQuerier::new(&deps.querier);
+    let payload = querier.erc20_transfer_from_payload(owner.clone(), recipient.clone(), amount)?;
+    let msg = EvmMsg::DelegateCallEvm { to: erc_addr.into_string(), data: payload.encoded_payload };
+    let res = Response::new()
+        .add_attribute("action", "transfer")
+        .add_attribute("from", owner)
+        .add_attribute("to", recipient)
+        .add_attribute("by", info.sender)
         .add_attribute("amount", amount)
         .add_message(msg);
 

--- a/example/cosmwasm/cw20/src/msg.rs
+++ b/example/cosmwasm/cw20/src/msg.rs
@@ -36,6 +36,11 @@ pub enum EvmQuery {
         recipient: String,
         amount: Uint128,
     },
+    Erc20TransferFromPayload {
+        owner: String,
+        recipient: String,
+        amount: Uint128,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/example/cosmwasm/cw20/src/querier.rs
+++ b/example/cosmwasm/cw20/src/querier.rs
@@ -23,4 +23,17 @@ impl<'a> EvmQuerier<'a> {
 
         self.querier.query(&request)
     }
+
+    // returns base64-encoded bytes
+    pub fn erc20_transfer_from_payload(&self, owner: String, recipient: String, amount: Uint128) -> StdResult<Erc20TransferPayloadResponse> {
+        let request = EvmQueryWrapper {
+            route: Route::Evm,
+            query_data: EvmQuery::Erc20TransferFromPayload {
+                owner, recipient, amount,
+            },
+        }
+        .into();
+
+        self.querier.query(&request)
+    }
 }

--- a/wasmbinding/queries.go
+++ b/wasmbinding/queries.go
@@ -206,6 +206,9 @@ func (qp QueryPlugin) HandleEVMQuery(ctx sdk.Context, queryData json.RawMessage)
 	case parsedQuery.ERC20TransferPayload != nil:
 		c := parsedQuery.ERC20TransferPayload
 		return qp.evmHandler.HandleERC20TransferPayload(ctx, c.Recipient, c.Amount)
+	case parsedQuery.ERC20TransferFromPayload != nil:
+		c := parsedQuery.ERC20TransferFromPayload
+		return qp.evmHandler.HandleERC20TransferFromPayload(ctx, c.Owner, c.Recipient, c.Amount)
 	default:
 		return nil, errors.New("unknown EVM query")
 	}

--- a/x/evm/client/wasm/bindings/queries.go
+++ b/x/evm/client/wasm/bindings/queries.go
@@ -5,8 +5,9 @@ import (
 )
 
 type SeiEVMQuery struct {
-	StaticCall           *StaticCallRequest           `json:"static_call,omitempty"`
-	ERC20TransferPayload *ERC20TransferPayloadRequest `json:"erc20_transfer_payload,omitempty"`
+	StaticCall               *StaticCallRequest               `json:"static_call,omitempty"`
+	ERC20TransferPayload     *ERC20TransferPayloadRequest     `json:"erc20_transfer_payload,omitempty"`
+	ERC20TransferFromPayload *ERC20TransferFromPayloadRequest `json:"erc20_transfer_from_payload,omitempty"`
 }
 
 type StaticCallRequest struct {
@@ -21,5 +22,15 @@ type ERC20TransferPayloadRequest struct {
 }
 
 type ERC20TransferPayloadResponse struct {
+	EncodedPayload string `json:"encoded_payload"`
+}
+
+type ERC20TransferFromPayloadRequest struct {
+	Owner     string   `json:"owner"`
+	Recipient string   `json:"recipient"`
+	Amount    *sdk.Int `json:"amount"`
+}
+
+type ERC20TransferFromPayloadResponse struct {
 	EncodedPayload string `json:"encoded_payload"`
 }


### PR DESCRIPTION
## Describe your changes and provide context
We want to expand the ERC20 wrapper contract to include other endpoints from the original ERC20 contract.

So far we've added TransferFrom.

## Testing performed to validate your change
In progress
