### PR TITLE
Separate endpoint for associateTx

### DIFF
--- a/contracts/test/EVMCompatabilityTester.js
+++ b/contracts/test/EVMCompatabilityTester.js
@@ -308,8 +308,7 @@ describe("EVM Test", function () {
         await expect(evmTester.revertIfFalse(false)).to.be.reverted;
       });
 
-      // TODO: fix this test the re-enable, it's breaking on CI
-      it.skip("Should not revert when true is passed to revertIfFalse", async function () {
+      it("Should not revert when true is passed to revertIfFalse", async function () {
         await evmTester.revertIfFalse(true)
       });
     })

--- a/evmrpc/send.go
+++ b/evmrpc/send.go
@@ -55,20 +55,14 @@ func (s *SendAPI) SendRawTransaction(ctx context.Context, input hexutil.Bytes) (
 		s.slowMu.Lock()
 		defer s.slowMu.Unlock()
 	}
-	var txData ethtx.TxData
-	associateTx := ethtx.AssociateTx{}
-	if associateTx.Unmarshal(input) == nil {
-		txData = &associateTx
-	} else {
-		tx := new(ethtypes.Transaction)
-		if err = tx.UnmarshalBinary(input); err != nil {
-			return
-		}
-		hash = tx.Hash()
-		txData, err = ethtx.NewTxDataFromTx(tx)
-		if err != nil {
-			return
-		}
+	tx := new(ethtypes.Transaction)
+	if err = tx.UnmarshalBinary(input); err != nil {
+		return
+	}
+	hash = tx.Hash()
+	txData, err := ethtx.NewTxDataFromTx(tx)
+	if err != nil {
+		return
 	}
 	msg, err := types.NewMsgEVMTransaction(txData)
 	if err != nil {

--- a/evmrpc/send_test.go
+++ b/evmrpc/send_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
-	"github.com/sei-protocol/sei-chain/x/evm/types/ethtx"
 	"github.com/stretchr/testify/require"
 )
 
@@ -64,23 +62,4 @@ func TestSendRawTransaction(t *testing.T) {
 	resObj = sendRequestBad(t, "sendRawTransaction", payload)
 	errMap = resObj["error"].(map[string]interface{})
 	require.Equal(t, ": invalid sequence", errMap["message"].(string))
-}
-
-func TestSendAssociateTransaction(t *testing.T) {
-	privKey := testkeeper.MockPrivateKey()
-	testPrivHex := hex.EncodeToString(privKey.Bytes())
-	key, _ := crypto.HexToECDSA(testPrivHex)
-	emptyHash := common.Hash{}
-	sig, err := crypto.Sign(emptyHash[:], key)
-	require.Nil(t, err)
-	R, S, _, _ := ethtx.DecodeSignature(sig)
-	V := big.NewInt(int64(sig[64]))
-	txData := ethtx.AssociateTx{V: V.Bytes(), R: R.Bytes(), S: S.Bytes()}
-	bz, err := txData.Marshal()
-	require.Nil(t, err)
-	payload := "0x" + hex.EncodeToString(bz)
-
-	resObj := sendRequestGood(t, "sendRawTransaction", payload)
-	result := resObj["result"].(string)
-	require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000000", result)
 }


### PR DESCRIPTION
## Describe your changes and provide context
Previously `sendRawTransaction` would send associate TX if the payload can be unmarshaled into an AssociateTx, and `Associate` endpoint would delegate the call to `sendRawTransaction`. This PR removes the associate tx logic in `sendRawTransaction` and make `Associate` directly broadcast to tendermint.

## Testing performed to validate your change
unit test (existing)

