### PR TITLE
Remove iterator usage in EVM

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -345,7 +345,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.7
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.72-evm-expose-versionexists
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.72-evm-new
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.8
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.0
 	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-5

--- a/go.sum
+++ b/go.sum
@@ -1345,8 +1345,8 @@ github.com/sei-protocol/go-ethereum v1.13.5-sei-5 h1:7+mdflZ0EHSTjhN+6yxYwUsJSvH
 github.com/sei-protocol/go-ethereum v1.13.5-sei-5/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.2.72-evm-expose-versionexists h1:ERa7UWeNCjfWRdC5fcl1wJKzyTG1ZIryU9EmAVIhrRQ=
-github.com/sei-protocol/sei-cosmos v0.2.72-evm-expose-versionexists/go.mod h1:Bfxp77OVQBxubKj9dQSKrwAuwuYQGUQnxa3mCaonux4=
+github.com/sei-protocol/sei-cosmos v0.2.72-evm-new h1:TyJ+3ywH4EGOAtxRsQy+spHZo45ajSWNnOIJBdz+dNg=
+github.com/sei-protocol/sei-cosmos v0.2.72-evm-new/go.mod h1:Bfxp77OVQBxubKj9dQSKrwAuwuYQGUQnxa3mCaonux4=
 github.com/sei-protocol/sei-db v0.0.27-0.20240123064153-d6dfa112e760 h1:MiHIPwPH2Yo6LQQfINgFTofm+K1EqpQYmg8h5m/cFrs=
 github.com/sei-protocol/sei-db v0.0.27-0.20240123064153-d6dfa112e760/go.mod h1:F/ZKZA8HJPcUzSZPA8yt6pfwlGriJ4RDR4eHKSGLStI=
 github.com/sei-protocol/sei-iavl v0.1.8 h1:HcK7Nv64PtJXUSdPV2+8AwRNRrcFQwsAmSZX6Em625E=

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -99,14 +99,8 @@ func (k *Keeper) PrefixStore(ctx sdk.Context, pref []byte) sdk.KVStore {
 
 func (k *Keeper) PurgePrefix(ctx sdk.Context, pref []byte) {
 	store := k.PrefixStore(ctx, pref)
-	iter := store.Iterator(nil, nil)
-	keys := [][]byte{}
-	for ; iter.Valid(); iter.Next() {
-		keys = append(keys, iter.Key())
-	}
-	iter.Close()
-	for _, key := range keys {
-		store.Delete(key)
+	if err := store.DeleteAll(nil, nil); err != nil {
+		panic(err)
 	}
 }
 

--- a/x/evm/keeper/keeper_test.go
+++ b/x/evm/keeper/keeper_test.go
@@ -16,6 +16,16 @@ import (
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
+func TestPurgePrefixNotHang(t *testing.T) {
+	k, ctx := keeper.MockEVMKeeper()
+	for i := 0; i < 50; i++ {
+		ctx = ctx.WithMultiStore(ctx.MultiStore().CacheMultiStore())
+		store := k.PrefixStore(ctx, types.TransientModuleStateKey(ctx))
+		store.Set([]byte{0x03}, []byte("test"))
+	}
+	require.NotPanics(t, func() { k.PurgePrefix(ctx, types.TransientModuleStateKey(ctx)) })
+}
+
 func TestGetChainID(t *testing.T) {
 	k, ctx := keeper.MockEVMKeeper()
 	require.Equal(t, types.DefaultChainID.Int64(), k.ChainID(ctx).Int64())

--- a/x/evm/state/check.go
+++ b/x/evm/state/check.go
@@ -4,25 +4,17 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
 
 // Exist reports whether the given account exists in state.
 // Notably this should also return true for self-destructed accounts.
 func (s *DBImpl) Exist(addr common.Address) bool {
-	// if there is any entry under addr, it exists
-	store := s.k.PrefixStore(s.ctx, types.StateKey(addr))
-	iter := store.Iterator(nil, nil)
-	if iter.Valid() {
-		return true
-	}
-
-	// if there is code under addr, it exists
+	// check if the address exists as a contract
 	if s.GetCodeHash(addr).Cmp(common.Hash{}) != 0 {
 		return true
 	}
 
-	// check if nonce is non-zero
+	// check if the address exists as an EOA
 	if s.GetNonce(addr) > 0 {
 		return true
 	}

--- a/x/evm/state/check_test.go
+++ b/x/evm/state/check_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/ethereum/go-ethereum/common"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
@@ -18,10 +17,6 @@ func TestExist(t *testing.T) {
 	_, addr := testkeeper.MockAddressPair()
 	statedb := state.NewDBImpl(ctx, k, false)
 	require.False(t, statedb.Exist(addr))
-
-	// has state
-	statedb.SetState(addr, common.BytesToHash([]byte{1}), common.BytesToHash([]byte{2}))
-	require.True(t, statedb.Exist(addr))
 
 	// has code
 	_, addr2 := testkeeper.MockAddressPair()


### PR DESCRIPTION
## Describe your changes and provide context
EVM would generate cachekv with more levels than normal transactions, but iterators in cachekv with too many levels are very inefficient (to a point where it would appear that the chain has halted). There are only two iterator usage in `evm`:
- remove all keys under some prefix -> replaced by the dedicated `DeleteAll` call that doesn't have the same inefficiency as iterators
- check if account has state -> removed because only contracts can have states and we already check for code hash under the address.

## Testing performed to validate your change
unit test that would hang before the change but pass after the change
