### PR TITLE
Edge case fixes for height-based queries

### DIFF
--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -211,6 +211,13 @@ func (b *Backend) getBlockHeight(ctx context.Context, blockNrOrHash rpc.BlockNum
 		if blockNumErr != nil {
 			return 0, blockNumErr
 		}
+		if blockNumber == nil {
+			// we don't want to get the latest block from Tendermint's perspective, because
+			// Tendermint writes store in TM store before commits application state. The
+			// latest block in Tendermint may not have its application state committed yet.
+			currentHeight := b.ctxProvider(LatestCtxHeight).BlockHeight()
+			blockNumber = &currentHeight
+		}
 		block, err = b.tmClient.Block(ctx, blockNumber)
 	} else {
 		block, err = b.tmClient.BlockByHash(ctx, blockNrOrHash.BlockHash[:])


### PR DESCRIPTION
## Describe your changes and provide context
- we do not want to read latest Tendermint block because it's not committed atomically with (and before) application state for that height. So when "latest" (or equivalent) is requested, we should use the latest application height (obtained from latest context) instead
- even though we check if a version exists in store before querying, it's possible for that version to be pruned in the short window between the check and the query. So we'd still need to add a panic catcher at the query to account for such cases.

## Testing performed to validate your change
need to test on loadtest cluster

