### PR TITLE
Update synchronous execution to set tx indices properly

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1064,7 +1064,8 @@ func (app *App) ProcessBlockSynchronous(ctx sdk.Context, txs [][]byte) []*abci.E
 	defer metrics.BlockProcessLatency(time.Now(), metrics.SYNCHRONOUS)
 
 	txResults := []*abci.ExecTxResult{}
-	for _, tx := range txs {
+	for i, tx := range txs {
+		ctx := ctx.WithTxIndex(i)
 		txResults = append(txResults, app.DeliverTxWithResult(ctx, tx))
 		metrics.IncrTxProcessTypeCounter(metrics.SYNCHRONOUS)
 	}


### PR DESCRIPTION
## Describe your changes and provide context
This sets the txIndex appropriately for synchronous execution as well, which doesnt change tx outcomes, but has had impact on gas usage in the past because of memstore used for fee collection.

## Testing performed to validate your change
Verified gas usages were consistent.
