### PR TITLE
remove block gas meter

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1210,10 +1210,6 @@ func (app *App) ProcessTxs(
 	// CacheMultiStore where it writes the data to the parent store (DeliverState) in sorted Key order to maintain
 	// deterministic ordering between validators in the case of concurrent deliverTXs
 	processBlockCtx, processBlockCache := app.CacheContext(ctx)
-	blockGasMeterConsumed := uint64(0)
-	if processBlockCtx.BlockGasMeter() != nil {
-		blockGasMeterConsumed = processBlockCtx.BlockGasMeter().GasConsumed()
-	}
 	concurrentResults, ok := processBlockConcurrentFunction(
 		processBlockCtx,
 		txs,
@@ -1238,10 +1234,6 @@ func (app *App) ProcessTxs(
 	dexMemState := dexutils.GetMemState(ctx.Context())
 	dexMemState.Clear(ctx)
 	dexMemState.ClearContractToDependencies()
-
-	if ctx.BlockGasMeter() != nil {
-		ctx.BlockGasMeter().RefundGas(ctx.BlockGasMeter().GasConsumed()-blockGasMeterConsumed, "concurrent failure rollback")
-	}
 
 	txResults := app.ProcessBlockSynchronous(ctx, txs)
 	processBlockCache.Write()

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -267,8 +267,6 @@ func TestProcessOracleAndOtherTxsSuccess(t *testing.T) {
 	_, txResults, _, _ := testWrapper.App.ProcessBlock(
 		testWrapper.Ctx.WithBlockHeight(
 			1,
-		).WithBlockGasMeter(
-			sdk.NewInfiniteGasMeter(),
 		),
 		txs,
 		req,
@@ -291,8 +289,6 @@ func TestProcessOracleAndOtherTxsSuccess(t *testing.T) {
 	_, txResults2, _, _ := testWrapper.App.ProcessBlock(
 		testWrapper.Ctx.WithBlockHeight(
 			1,
-		).WithBlockGasMeter(
-			sdk.NewInfiniteGasMeter(),
 		),
 		diffOrderTxs,
 		req,

--- a/go.mod
+++ b/go.mod
@@ -307,7 +307,8 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.4
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.72
+	// TODO: replace with tagged version
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.73-0.20240125170159-b030aa49ab82
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.9
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.sum
+++ b/go.sum
@@ -1170,8 +1170,8 @@ github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+f
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.2.72 h1:pv1J3fBIpVJwYqTV3unRSJ0/krEGDN5bByZLCkPOIG4=
-github.com/sei-protocol/sei-cosmos v0.2.72/go.mod h1:CykNPmj90YkwBorkvnc05u9k9MBNDHC3h4CIdmq3R98=
+github.com/sei-protocol/sei-cosmos v0.2.73-0.20240125170159-b030aa49ab82 h1:QMdKt7gRvste0newZnO0Dple2GilGFOlr+ULSYyFuO8=
+github.com/sei-protocol/sei-cosmos v0.2.73-0.20240125170159-b030aa49ab82/go.mod h1:CykNPmj90YkwBorkvnc05u9k9MBNDHC3h4CIdmq3R98=
 github.com/sei-protocol/sei-db v0.0.27 h1:IdmzGavY5yP6T2sAM+wLOISTPd+AXp0S5aLmzpozC7c=
 github.com/sei-protocol/sei-db v0.0.27/go.mod h1:F/ZKZA8HJPcUzSZPA8yt6pfwlGriJ4RDR4eHKSGLStI=
 github.com/sei-protocol/sei-iavl v0.1.9 h1:y4mVYftxLNRs6533zl7N0/Ch+CzRQc04JDfHolIxgBE=


### PR DESCRIPTION
## Describe your changes and provide context
This removes the block gas meter from sei-chain in accordance to similar changes made to sei-cosmos. This needs to have the go.mod dependency updated with a tag once the sei-cosmos change is eventually merged and tagged.

## Testing performed to validate your change
loadtest cluster testing. Still needs to undergo canaried testing as well
