### PR TITLE
[EVM] tick version for v4.0.5-evm-devnet

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -69,6 +69,7 @@ var upgradesList = []string{
 	"v4.0.1-evm-devnet",
 	"v4.0.3-evm-devnet",
 	"v4.0.4-evm-devnet",
+	"v4.0.5-evm-devnet",
 }
 
 // if there is an override list, use that instead, for integration tests


### PR DESCRIPTION
## Describe your changes and provide context
- update upgrades.go so we can test a major upgrade
- version is `v4.0.5-evm-devnet`
 
## Testing performed to validate your change
- pre-devnet evm environment upgrade 
