### PR TITLE
Clear txDeferredInfo in EndBlock

### DIFF
--- a/x/evm/keeper/keeper_test.go
+++ b/x/evm/keeper/keeper_test.go
@@ -198,4 +198,8 @@ func TestDeferredInfo(t *testing.T) {
 	require.Equal(t, 2, infoList[1].TxIndx)
 	require.Equal(t, ethtypes.Bloom{7, 8}, infoList[1].TxBloom)
 	require.Equal(t, common.Hash{9, 0}, infoList[1].TxHash)
+	// test clear tx deferred info
+	k.ClearEVMTxDeferredInfo(ctx)
+	infoList = k.GetEVMTxDeferredInfo(ctx)
+	require.Empty(t, len(infoList))
 }

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -189,5 +189,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 	}
 	am.keeper.SetTxHashesOnHeight(ctx, ctx.BlockHeight(), utils.Map(evmTxDeferredInfoList, func(i keeper.EvmTxDeferredInfo) common.Hash { return i.TxHash }))
 	am.keeper.SetBlockBloom(ctx, ctx.BlockHeight(), utils.Map(evmTxDeferredInfoList, func(i keeper.EvmTxDeferredInfo) ethtypes.Bloom { return i.TxBloom }))
+	// clear the TxDeferredInfo
+	am.keeper.ClearEVMTxDeferredInfo(ctx)
 	return []abci.ValidatorUpdate{}
 }

--- a/x/evm/module_test.go
+++ b/x/evm/module_test.go
@@ -40,8 +40,10 @@ func TestABCI(t *testing.T) {
 	s.SubBalance(evmAddr2, big.NewInt(5000000000000))
 	s.AddBalance(evmAddr1, big.NewInt(5000000000000))
 	require.Nil(t, s.Finalize())
-	m.EndBlock(ctx, abci.RequestEndBlock{})
 	k.AppendToEvmTxDeferredInfo(ctx.WithTxIndex(3), ethtypes.Bloom{}, common.Hash{})
+	m.EndBlock(ctx, abci.RequestEndBlock{})
+	deferredInfo := k.GetEVMTxDeferredInfo(ctx)
+	require.Empty(t, deferredInfo)
 	require.Equal(t, uint64(0), k.BankKeeper().GetBalance(ctx, k.AccountKeeper().GetModuleAddress(types.ModuleName), "usei").Amount.Uint64())
 	require.Equal(t, uint64(2), k.BankKeeper().GetBalance(ctx, k.AccountKeeper().GetModuleAddress(authtypes.FeeCollectorName), "usei").Amount.Uint64())
 
@@ -56,4 +58,6 @@ func TestABCI(t *testing.T) {
 	m.EndBlock(ctx, abci.RequestEndBlock{})
 	require.Equal(t, uint64(1), k.BankKeeper().GetBalance(ctx, k.AccountKeeper().GetModuleAddress(types.ModuleName), "usei").Amount.Uint64())
 	require.Equal(t, uint64(2), k.BankKeeper().GetBalance(ctx, k.AccountKeeper().GetModuleAddress(authtypes.FeeCollectorName), "usei").Amount.Uint64())
+	deferredInfo = k.GetEVMTxDeferredInfo(ctx)
+	require.Empty(t, deferredInfo)
 }


### PR DESCRIPTION
## Describe your changes and provide context
We previously refactored the in memory golang struct containing txHashes for EVM transactions into a mem KV such that the state generated would be revertible as necessary by OCC. Previously with the in memory list, we would clear it out int he following beginblock, but a similar change wasn't included when moving to an in memory KV store. As a result, stale tx hashes can build up for tx indices not overwritten in a block, resulting in potential appHash errors when nodes restart since the in memory KV stores arent restored. This change introduces the appropriate `Clear` function and calls it in EndBlock as soon as evm is done with the txHash data.

## Testing performed to validate your change
unit tests
