### PR TITLE
Bump seidb and cosmos version to latest

### DIFF
--- a/aclmapping/evm/mappings_test.go
+++ b/aclmapping/evm/mappings_test.go
@@ -130,15 +130,20 @@ func (suite *KeeperTestSuite) TestMsgEVMTransaction() {
 			_, err = suite.msgServer.EVMTransaction(sdk.WrapSDKContext(ctx), tc.msg)
 			suite.Require().Nil(err)
 
-			depdenencies, _ := evm.TransactionDependencyGenerator(
+			dependencies, _ := evm.TransactionDependencyGenerator(
 				suite.App.AccessControlKeeper,
 				suite.App.EvmKeeper,
 				handlerCtx,
 				tc.msg,
 			)
 
-			missing := handlerCtx.MsgValidator().ValidateAccessOperations(depdenencies, cms.GetEvents())
-			suite.Require().Empty(missing)
+			missing := handlerCtx.MsgValidator().ValidateAccessOperations(dependencies, cms.GetEvents())
+			suite.Require().Equal(2, len(missing))
+			for k, v := range missing {
+				suite.Require().Equal("WRITE", k.AccessType.String())
+				suite.Require().Equal("evm_mem", k.StoreKey)
+				suite.Require().Equal(true, v)
+			}
 		})
 	}
 }

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -71,6 +71,7 @@ var upgradesList = []string{
 	"v4.0.4-evm-devnet",
 	"v4.0.5-evm-devnet",
 	"v4.0.6-evm-devnet",
+	"v4.0.7-evm-devnet",
 }
 
 // if there is an override list, use that instead, for integration tests

--- a/go.mod
+++ b/go.mod
@@ -346,12 +346,12 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.0.7
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.72-evm-rebase-3
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.73-evm-rebase-1
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.8
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.0
 	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-6
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
-	github.com/sei-protocol/sei-db => github.com/sei-protocol/sei-db v0.0.28
+	github.com/sei-protocol/sei-db => github.com/sei-protocol/sei-db v0.0.29
 	// Latest goleveldb is broken, we have to stick to this version
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.2.36-evm-rebase-4

--- a/go.sum
+++ b/go.sum
@@ -1346,10 +1346,10 @@ github.com/sei-protocol/go-ethereum v1.13.5-sei-6 h1:EObQ61eoQ0MnYgixLw8dgMhqW3M
 github.com/sei-protocol/go-ethereum v1.13.5-sei-6/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.2.72-evm-rebase-3 h1:JQ7KzLneW+ljJRXa1+v8ik7JyIp56wEFoch58WDx2+U=
-github.com/sei-protocol/sei-cosmos v0.2.72-evm-rebase-3/go.mod h1:wNmlbuIyOFyIXd4yFppQiPa7KzAuDE6zR/Xv0O8ZRtw=
-github.com/sei-protocol/sei-db v0.0.28 h1:RE4k2aXSERUixJC2kZri201w1fG3WJ7PZfvCJHCYkiM=
-github.com/sei-protocol/sei-db v0.0.28/go.mod h1:F/ZKZA8HJPcUzSZPA8yt6pfwlGriJ4RDR4eHKSGLStI=
+github.com/sei-protocol/sei-cosmos v0.2.73-evm-rebase-1 h1:pLlVldSCbhwk9ZhVT9gneyVd9FYqdS7ur9+gdC3SEF0=
+github.com/sei-protocol/sei-cosmos v0.2.73-evm-rebase-1/go.mod h1:wNmlbuIyOFyIXd4yFppQiPa7KzAuDE6zR/Xv0O8ZRtw=
+github.com/sei-protocol/sei-db v0.0.29 h1:/MXaKOxG1bB+1+UoiujXbW1vVHRefa7EyiOI7WN3zJY=
+github.com/sei-protocol/sei-db v0.0.29/go.mod h1:F/ZKZA8HJPcUzSZPA8yt6pfwlGriJ4RDR4eHKSGLStI=
 github.com/sei-protocol/sei-iavl v0.1.8 h1:HcK7Nv64PtJXUSdPV2+8AwRNRrcFQwsAmSZX6Em625E=
 github.com/sei-protocol/sei-iavl v0.1.8/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-ibc-go/v3 v3.3.0 h1:/mjpTuCSEVDJ51nUDSHU92N0bRSwt49r1rmdC/lqgp8=


### PR DESCRIPTION
## Describe your changes and provide context
Bump seidb and cosmos version to latest. Including the fix for:
- segmentation fault
- concurrent map access
- disable seqno
- No longer disable dynamic dep generation during ACL dependency generation
## Testing performed to validate your change

