### PR TITLE
Simplify pending nonce logics

### DIFF
--- a/x/evm/ante/sig.go
+++ b/x/evm/ante/sig.go
@@ -54,7 +54,7 @@ func (svd *EVMSigVerifyDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulat
 		// if the mempool expires a transaction, this handler is invoked
 		ctx = ctx.WithExpireTxHandler(func() {
 			txKey := tmtypes.Tx(ctx.TxBytes()).Key()
-			svd.evmKeeper.ExpirePendingNonce(txKey)
+			svd.evmKeeper.RemovePendingNonce(txKey)
 		})
 
 		if txNonce > nextNonce {

--- a/x/evm/keeper/keeper_test.go
+++ b/x/evm/keeper/keeper_test.go
@@ -119,8 +119,9 @@ func TestKeeper_CalculateNextNonce(t *testing.T) {
 				k.SetNonce(ctx, address1, 50)
 				k.AddPendingNonce(key1, address1, 50)
 				k.AddPendingNonce(key2, address1, 51)
-				k.CompletePendingNonce(key1)
-				k.CompletePendingNonce(key2)
+				k.SetNonce(ctx, address1, 52)
+				k.RemovePendingNonce(key1)
+				k.RemovePendingNonce(key2)
 			},
 			expectedNonce: 52,
 		},
@@ -132,7 +133,7 @@ func TestKeeper_CalculateNextNonce(t *testing.T) {
 				k.SetNonce(ctx, address1, 50)
 				k.AddPendingNonce(key1, address1, 50)
 				k.AddPendingNonce(key2, address1, 51)
-				k.ExpirePendingNonce(key1)
+				k.RemovePendingNonce(key1)
 			},
 			expectedNonce: 50,
 		},


### PR DESCRIPTION
## Describe your changes and provide context
This PR simplifies pending nonce logics by removing `completedNonces`. The only two states related to nonce would be:
1. nonce stored in state (persistent nonce)
2. pending nonce map
To maintain these two states:
- Pending nonce is added by CheckTx (multiple addition for the same nonce is allowed as long as the tx is different)
- Pending nonce is removed by mempool removal. A mempool removal may happen in 1. expiration 2. pending tx becomes invalid 3. [post commit](https://github.com/sei-protocol/sei-tendermint/blob/evm-temp/internal/mempool/mempool.go#L497)
- Nonce state is committed in application state

Since we update pending nonce after committing application state nonce, pending nonce will never be more "up-to-date" than state nonce, and since we always query state nonce first then pending nonce, the user would have a consistent view of nonces.

## Testing performed to validate your change
to be tested on local cluster
