### PR TITLE
Use in-memory map for deferred info

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1443,6 +1443,7 @@ func (app *App) ProcessBlock(ctx sdk.Context, txs [][]byte, req BlockProcessRequ
 	for relativeOtherIndex, originalIndex := range otherIndices {
 		txResults[originalIndex] = otherResults[relativeOtherIndex]
 	}
+	app.EvmKeeper.SetTxResults(txResults)
 
 	// Finalize all Bank Module Transfers here so that events are included
 	lazyWriteEvents := app.BankKeeper.WriteDeferredBalances(ctx)

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -161,6 +161,10 @@ func (AppModule) ConsensusVersion() uint64 { return 3 }
 
 // BeginBlock executes all ABCI BeginBlock logic respective to the capability module.
 func (am AppModule) BeginBlock(sdk.Context, abci.RequestBeginBlock) {
+	// clear tx responses from last block
+	am.keeper.SetTxResults([]*abci.ExecTxResult{})
+	// clear the TxDeferredInfo
+	am.keeper.ClearEVMTxDeferredInfo()
 }
 
 // EndBlock executes all ABCI EndBlock logic respective to the capability module. It
@@ -189,7 +193,5 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 	}
 	am.keeper.SetTxHashesOnHeight(ctx, ctx.BlockHeight(), utils.Map(evmTxDeferredInfoList, func(i keeper.EvmTxDeferredInfo) common.Hash { return i.TxHash }))
 	am.keeper.SetBlockBloom(ctx, ctx.BlockHeight(), utils.Map(evmTxDeferredInfoList, func(i keeper.EvmTxDeferredInfo) ethtypes.Bloom { return i.TxBloom }))
-	// clear the TxDeferredInfo
-	am.keeper.ClearEVMTxDeferredInfo(ctx)
 	return []abci.ValidatorUpdate{}
 }

--- a/x/evm/module_test.go
+++ b/x/evm/module_test.go
@@ -41,9 +41,8 @@ func TestABCI(t *testing.T) {
 	s.AddBalance(evmAddr1, big.NewInt(5000000000000))
 	require.Nil(t, s.Finalize())
 	k.AppendToEvmTxDeferredInfo(ctx.WithTxIndex(3), ethtypes.Bloom{}, common.Hash{})
+	k.SetTxResults([]*abci.ExecTxResult{{Code: 0}, {Code: 0}, {Code: 0}, {Code: 0}})
 	m.EndBlock(ctx, abci.RequestEndBlock{})
-	deferredInfo := k.GetEVMTxDeferredInfo(ctx)
-	require.Empty(t, deferredInfo)
 	require.Equal(t, uint64(0), k.BankKeeper().GetBalance(ctx, k.AccountKeeper().GetModuleAddress(types.ModuleName), "usei").Amount.Uint64())
 	require.Equal(t, uint64(2), k.BankKeeper().GetBalance(ctx, k.AccountKeeper().GetModuleAddress(authtypes.FeeCollectorName), "usei").Amount.Uint64())
 
@@ -55,9 +54,8 @@ func TestABCI(t *testing.T) {
 	s.AddBalance(evmAddr1, big.NewInt(2000000000000))
 	require.Nil(t, s.Finalize())
 	k.AppendToEvmTxDeferredInfo(ctx.WithTxIndex(2), ethtypes.Bloom{}, common.Hash{})
+	k.SetTxResults([]*abci.ExecTxResult{{Code: 0}, {Code: 0}, {Code: 0}})
 	m.EndBlock(ctx, abci.RequestEndBlock{})
 	require.Equal(t, uint64(1), k.BankKeeper().GetBalance(ctx, k.AccountKeeper().GetModuleAddress(types.ModuleName), "usei").Amount.Uint64())
 	require.Equal(t, uint64(2), k.BankKeeper().GetBalance(ctx, k.AccountKeeper().GetModuleAddress(authtypes.FeeCollectorName), "usei").Amount.Uint64())
-	deferredInfo = k.GetEVMTxDeferredInfo(ctx)
-	require.Empty(t, deferredInfo)
 }


### PR DESCRIPTION
## Describe your changes and provide context
This is a performance optimization resulted from recent load test. Specifically storing and iterating through deferred info in cachekv store is a major bottleneck. This change replaces cachekv usage with an in-memory `sync.Map`, which:
- is cleared at each `BeginBlock`
- is key'ed by tx index, so that rerun of the same tx will overwrite its previous run's entry
- may contain invalid entries (e.g. tx X finished successfully in its first run and inserted an entry to this map, but needed to rerun and finished erroneously during rerun), which are excluded based on `ExecTxResult`

## Testing performed to validate your change
local sei && unit tests

