### PR TITLE
Lt client polling height

### DIFF
--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -145,17 +145,18 @@ func startLoadtestWorkers(config Config) {
 	var wg sync.WaitGroup
 	for i := 0; i < len(keys); i++ {
 		go client.BuildTxs(txQueues[i], i, &wg, done, producerRateLimiter, &producedCount)
-		go client.SendTxs(txQueues[i], i, done, &sentCount, consumerSemaphore, &wg)
+		go client.SendTxs(txQueues[i], i, done, &sentCount, consumerSemaphore, &wg, config.BlockchainEndpoint)
 	}
 
 	// Statistics reporting goroutine
 	ticker := time.NewTicker(10 * time.Second)
+	currHeight := getLastHeight(config.BlockchainEndpoint)
 	go func() {
 		start := time.Now()
 		for {
 			select {
 			case <-ticker.C:
-				currHeight := getLastHeight(config.BlockchainEndpoint)
+				currHeight = getLastHeight(config.BlockchainEndpoint)
 				for i := startHeight; i <= currHeight; i++ {
 					_, blockTime, err := getTxBlockInfo(config.BlockchainEndpoint, strconv.Itoa(i))
 					if err != nil {


### PR DESCRIPTION
## Describe your changes and provide context
Have the senders poll the current height to ensure that each account only sends 1 tx per height to avoid seqno issues
## Testing performed to validate your change

