### PR TITLE
Fix debug trace tx

### DIFF
--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -172,10 +172,15 @@ func (b *Backend) GetTransaction(ctx context.Context, txHash common.Hash) (tx *e
 		return nil, common.Hash{}, 0, 0, err
 	}
 	txIndex := hexutil.Uint(receipt.TransactionIndex)
-	tmTx := block.Block.Txs[int(index)]
+	tmTx := block.Block.Txs[int(txIndex)]
+	// We need to find the ethIndex
+	evmTxIndex, found := GetEvmTxIndex(block.Block.Txs, receipt.TransactionIndex, b.txDecoder)
+	if !found {
+		return nil, common.Hash{}, 0, 0, errors.New("failed to find transaction in block")
+	}
 	tx = getEthTxForTxBz(tmTx, b.txDecoder)
 	blockHash = common.BytesToHash(block.Block.Header.Hash().Bytes())
-	return tx, blockHash, uint64(txHeight), uint64(txIndex), nil
+	return tx, blockHash, uint64(txHeight), uint64(evmTxIndex), nil
 }
 
 func (b *Backend) ChainDb() ethdb.Database {


### PR DESCRIPTION
## Describe your changes and provide context
Fixed 2 small bugs:
1. txIndex should be used not index (which was automatically 0)
2. we need to return the evmIndex. THis is already used elsewhere so move that to a helper function
## Testing performed to validate your change
- unit tests still pass
- tested on evm-devnet:
```
root@ip-172-31-38-43:/home/ubuntu/sei-chain# curl http://localhost:8545 -X POST -H "Content-Type: application/json" --data '{"method":"debug_traceTransaction","params":["0xf2192a7d0fa48f41d382bbc55e9c6852ae6b4b374cbdf15a527049b94e029723", {"tracer": "callTracer"}], "id":1,"jsonrpc":"2.0"}'
{"jsonrpc":"2.0","id":1,"result":{"from":"0xf87a299e6bc7beba58dbbe5a5aa21d49bcd16d52","gas":"0x5208","gasUsed":"0x5208","to":"0xf87a299e6bc7beba58dbbe5a5aa21d49bcd16d52","input":"0x","value":"0x1","type":"CALL"}}
```
