### PR TITLE
Fix error handling for non-existent block

### DIFF
--- a/evmrpc/info.go
+++ b/evmrpc/info.go
@@ -143,7 +143,7 @@ func (i *InfoAPI) FeeHistory(ctx context.Context, blockCount math.HexOrDecimal64
 		}
 		result.BaseFee = append(result.BaseFee, (*hexutil.Big)(baseFee))
 		height := blockNum
-		block, err := i.tmClient.Block(ctx, &height)
+		block, err := blockWithRetry(ctx, i.tmClient, &height)
 		if err != nil {
 			// block pruned from tendermint store. Skipping
 			continue

--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -229,12 +229,9 @@ func (b Backend) BlockByNumber(ctx context.Context, bn rpc.BlockNumber) (*ethtyp
 }
 
 func (b Backend) BlockByHash(ctx context.Context, hash common.Hash) (*ethtypes.Block, error) {
-	tmBlock, err := b.tmClient.BlockByHash(ctx, hash.Bytes())
+	tmBlock, err := blockByHashWithRetry(ctx, b.tmClient, hash.Bytes())
 	if err != nil {
 		return nil, err
-	}
-	if tmBlock.Block == nil {
-		panic("tmBlock.Block is nil")
 	}
 	blockNumber := rpc.BlockNumber(tmBlock.Block.Height)
 	return b.BlockByNumber(ctx, blockNumber)
@@ -344,7 +341,7 @@ func (b *Backend) getBlockHeight(ctx context.Context, blockNrOrHash rpc.BlockNum
 		}
 		block, err = b.tmClient.Block(ctx, blockNumber)
 	} else {
-		block, err = b.tmClient.BlockByHash(ctx, blockNrOrHash.BlockHash[:])
+		block, err = blockByHashWithRetry(ctx, b.tmClient, blockNrOrHash.BlockHash[:])
 	}
 	if err != nil {
 		return 0, err

--- a/evmrpc/state.go
+++ b/evmrpc/state.go
@@ -113,7 +113,7 @@ func (a *StateAPI) GetProof(ctx context.Context, address common.Address, storage
 		}
 		block, err = a.tmClient.Block(ctx, blockNumber)
 	} else {
-		block, err = a.tmClient.BlockByHash(ctx, blockNrOrHash.BlockHash[:])
+		block, err = blockByHashWithRetry(ctx, a.tmClient, blockNrOrHash.BlockHash[:])
 	}
 	if err != nil {
 		return nil, err

--- a/evmrpc/state.go
+++ b/evmrpc/state.go
@@ -111,7 +111,7 @@ func (a *StateAPI) GetProof(ctx context.Context, address common.Address, storage
 		if blockNumErr != nil {
 			return nil, blockNumErr
 		}
-		block, err = a.tmClient.Block(ctx, blockNumber)
+		block, err = blockWithRetry(ctx, a.tmClient, blockNumber)
 	} else {
 		block, err = blockByHashWithRetry(ctx, a.tmClient, blockNrOrHash.BlockHash[:])
 	}

--- a/evmrpc/utils.go
+++ b/evmrpc/utils.go
@@ -235,6 +235,9 @@ func blockWithRetry(ctx context.Context, client rpcclient.Client, height *int64)
 			return nil, err
 		}
 	}
+	if blockRes.Block == nil {
+		return nil, fmt.Errorf("could not find block for height %d", height)
+	}
 	return blockRes, err
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
This PR improves error handling for cases where block is not found either by hash or by number. Currently, when block doesn't exist, it will panic and return "method handler crashes", this is not ideal because it makes user confusing and thought the server crashed. We should instead return a more informal response when block is not found.

## Testing performed to validate your change
Tested locally with docker chain
