### PR TITLE
Fix mnemonic for populate accounts

### DIFF
--- a/loadtest/scripts/populate_genesis_accounts.py
+++ b/loadtest/scripts/populate_genesis_accounts.py
@@ -27,7 +27,7 @@ def add_key(account_name, local=False):
 
     splitted_outputs = add_key_output.split('\n')
     address = splitted_outputs[3].split(': ')[1]
-    mnemonic = splitted_outputs[11]
+    mnemonic = splitted_outputs[-1]
     return address, mnemonic
 
 


### PR DESCRIPTION
## Describe your changes and provide context
We introduced an "evm_address" field which caused the position of the mnemonic to change. Instead, use the last value in array.
```
- name: psu-test
  type: local
  address: sei179ep77c0x4d5gccfpk5wq2dm0sfpsxp9mllaru
  evm_address: ""
  pubkey: '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AvHWnr1680gyFscSzqJpFgRFA6l6p6m7NPXiKIMmV67t"}'
  mnemonic: ""


**Important** write this mnemonic phrase in a safe place.
It is the only way to recover your account if you ever forget your password.

mountain uphold immune nuclear tomato educate number capital orbit horse body under giraffe trumpet rural aisle grocery drive shallow gather merge manage stand spare
```
## Testing performed to validate your change
Tested locally
