### PR TITLE
Fix mnemonic for populate accounts

### DIFF
--- a/loadtest/scripts/populate_genesis_accounts.py
+++ b/loadtest/scripts/populate_genesis_accounts.py
@@ -25,8 +25,8 @@ def add_key(account_name, local=False):
         shell=True,
     ).decode()
 
-    splitted_outputs = add_key_output.split('\n')
-    address = splitted_outputs[3].split(': ')[1]
+    splitted_outputs = add_key_output.strip().split('\n')
+    address = splitted_outputs[2].split(': ')[1]
     mnemonic = splitted_outputs[-1]
     return address, mnemonic
 

--- a/loadtest/scripts/populate_genesis_accounts.py
+++ b/loadtest/scripts/populate_genesis_accounts.py
@@ -27,7 +27,7 @@ def add_key(account_name, local=False):
 
     splitted_outputs = add_key_output.split('\n')
     address = splitted_outputs[3].split(': ')[1]
-    mnemonic = splitted_outputs[11]
+    mnemonic = splitted_outputs[-1]
     return address, mnemonic
 
 


### PR DESCRIPTION
## Describe your changes and provide context
We introduced an "evm_address" field which caused the position of the mnemonic to change. Instead, use the last value in array.
```
- name: psu-test
  type: local
  address: sei179ep77c0x4d5gccfpk5wq2dm0sfpsxp9mllaru
  evm_address: ""
  pubkey: '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AvHWnr1680gyFscSzqJpFgRFA6l6p6m7NPXiKIMmV67t"}'
```
## Testing performed to validate your change
Deployed LT cluster