### PR TITLE
[EVM] fix empty tx root value

### DIFF
--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -185,6 +185,9 @@ func EncodeTmBlock(
 			}
 		}
 	}
+	if len(transactions) == 0 {
+		txHash = ethtypes.EmptyTxsHash
+	}
 	result := map[string]interface{}{
 		"number":           (*hexutil.Big)(number),
 		"hash":             blockhash,

--- a/evmrpc/block_test.go
+++ b/evmrpc/block_test.go
@@ -1,6 +1,7 @@
 package evmrpc_test
 
 import (
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -106,6 +107,30 @@ func verifyBlockResult(t *testing.T, resObj map[string]interface{}) {
 	require.Equal(t, []interface{}{}, resObj["uncles"])
 	require.Equal(t, "0x0", resObj["baseFeePerGas"])
 	require.Equal(t, "0x0", resObj["totalDifficulty"])
+}
+
+func TestEncodeTmBlock_EmptyTransactions(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper()
+	block := &coretypes.ResultBlock{
+		BlockID: MockBlockID,
+		Block: &tmtypes.Block{
+			Header: mockBlockHeader(MockHeight),
+			Data:   tmtypes.Data{},
+			LastCommit: &tmtypes.Commit{
+				Height: MockHeight - 1,
+			},
+		},
+	}
+	blockRes := &coretypes.ResultBlockResults{
+		TxsResults: []*abci.ExecTxResult{},
+	}
+
+	// Call EncodeTmBlock with empty transactions
+	result, err := evmrpc.EncodeTmBlock(ctx, block, blockRes, k, Decoder, true)
+	require.Nil(t, err)
+
+	// Assert txHash is equal to ethtypes.EmptyTxsHash
+	require.Equal(t, ethtypes.EmptyTxsHash, result["transactionsRoot"])
 }
 
 func TestEncodeBankMsg(t *testing.T) {

--- a/evmrpc/block_test.go
+++ b/evmrpc/block_test.go
@@ -1,11 +1,11 @@
 package evmrpc_test
 
 import (
-	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/sei-protocol/sei-chain/evmrpc"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
## Describe your changes and provide context
- if no transactions, there is a special value that the transacitonRoot should have
- otherwise, clients will fail to parse the value
## Testing performed to validate your change
- new unit test

