### PR TITLE
Remove command output that breaks loadtest deploying

### DIFF
--- a/loadtest/contracts/deploy_erc20.sh
+++ b/loadtest/contracts/deploy_erc20.sh
@@ -7,8 +7,8 @@ evm_endpoint=$1
 
 cd loadtest/contracts/evm || exit 1
 
-./setup.sh
+./setup.sh > /dev/null
 
-git submodule update --init --recursive
+git submodule update --init --recursive > /dev/null
 
 /root/.foundry/bin/forge create -r "$evm_endpoint" --private-key 57acb95d82739866a5c29e40b0aa2590742ae50425b7dd5b5d279a986370189e src/NoopToken.sol:NoopToken --json --constructor-args "NoopToken" "NT" | jq -r '.deployedTo'

--- a/loadtest/contracts/deploy_erc20.sh
+++ b/loadtest/contracts/deploy_erc20.sh
@@ -5,6 +5,13 @@
 
 evm_endpoint=$1
 
+# first fund account if necessary
+THRESHOLD=100000000000000000000 # 100 Eth
+ACCOUNT="0xF87A299e6bC7bEba58dbBe5a5Aa21d49bCD16D52"
+BALANCE=$(cast balance $ACCOUNT --rpc-url "$evm_endpoint")
+if (( $(echo "$BALANCE < $THRESHOLD" | bc -l) )); then
+  printf "12345678\n" | ~/go/bin/seid tx evm send $ACCOUNT 100000000000000000000 --from admin --evm-rpc "$evm_endpoint"
+fi
 cd loadtest/contracts/evm || exit 1
 
 ./setup.sh > /dev/null


### PR DESCRIPTION
## Describe your changes and provide context
Deploying evm contracts was previously broken. See this output:
```
{"ERC20":"0x0000000000000000000000000000000000000000","ERC721":"0x0000000000000000000000000000000000000000"}}
```
This is because https://github.com/sei-protocol/sei-chain/blob/evm/loadtest/main.go#L83 it expects only one output. However, before other outputs were breaking this.
## Testing performed to validate your change
Tested:
```
:{"ERC20":"0x0eb8cd1440c7d6beee12ea511b9b7bcd84810921","ERC721":"0x0000000000000000000000000000000000000000"}}
```

