### PR TITLE
Set address association for Cosmos tx

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -103,6 +103,7 @@ func NewAnteHandlerAndDepGenerator(options HandlerOptions) (sdk.AnteHandler, sdk
 		sdk.CustomDepWrappedAnteDecorator(ante.NewSigGasConsumeDecorator(options.AccountKeeper, sigGasConsumer), depdecorators.SignerDepDecorator{ReadOnly: true}),
 		sdk.CustomDepWrappedAnteDecorator(sequentialVerifyDecorator, depdecorators.SignerDepDecorator{ReadOnly: true}),
 		sdk.CustomDepWrappedAnteDecorator(ante.NewIncrementSequenceDecorator(options.AccountKeeper), depdecorators.SignerDepDecorator{ReadOnly: false}),
+		sdk.DefaultWrappedAnteDecorator(evmante.NewEVMAddressDecorator(options.EVMKeeper, options.EVMKeeper.AccountKeeper())),
 		sdk.DefaultWrappedAnteDecorator(ibcante.NewAnteDecorator(options.IBCKeeper)),
 		sdk.DefaultWrappedAnteDecorator(dex.NewTickSizeMultipleDecorator(*options.DexKeeper)),
 		dex.NewCheckDexGasDecorator(*options.DexKeeper, options.CheckTxMemState),

--- a/precompiles/wasmd/wasmd_test.go
+++ b/precompiles/wasmd/wasmd_test.go
@@ -70,7 +70,7 @@ func TestInstantiate(t *testing.T) {
 	require.Equal(t, 2, len(outputs))
 	require.Equal(t, "sei14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sh9m79m", outputs[0].(string))
 	require.Empty(t, outputs[1].([]byte))
-	require.Equal(t, uint64(902900), g)
+	require.Equal(t, uint64(902898), g)
 
 	// non-existent code ID
 	args, _ = instantiateMethod.Inputs.Pack(
@@ -138,7 +138,7 @@ func TestExecute(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, 1, len(outputs))
 	require.Equal(t, fmt.Sprintf("received test msg from %s with 1000usei", mockAddr.String()), string(outputs[0].([]byte)))
-	require.Equal(t, uint64(906042), g)
+	require.Equal(t, uint64(906041), g)
 	require.Equal(t, int64(1000), testApp.BankKeeper.GetBalance(statedb.Ctx(), contractAddr, "usei").Amount.Int64())
 
 	// allowed delegatecall
@@ -199,7 +199,7 @@ func TestQuery(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, 1, len(outputs))
 	require.Equal(t, "{\"message\":\"query test\"}", string(outputs[0].([]byte)))
-	require.Equal(t, uint64(930368), g)
+	require.Equal(t, uint64(930367), g)
 
 	// bad contract address
 	args, _ = queryMethod.Inputs.Pack(mockAddr.String(), []byte("{\"info\":{}}"))

--- a/x/evm/ante/router_test.go
+++ b/x/evm/ante/router_test.go
@@ -3,8 +3,10 @@ package ante_test
 import (
 	"testing"
 
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/sei-protocol/sei-chain/x/evm/ante"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
@@ -37,11 +39,15 @@ func (m *mockAnteState) evmAnteDepGenerator(txDeps []sdkacltypes.AccessOperation
 }
 
 type mockTx struct {
-	msgs []sdk.Msg
+	msgs    []sdk.Msg
+	signers []sdk.AccAddress
 }
 
-func (tx mockTx) GetMsgs() []sdk.Msg   { return tx.msgs }
-func (tx mockTx) ValidateBasic() error { return nil }
+func (tx mockTx) GetMsgs() []sdk.Msg                              { return tx.msgs }
+func (tx mockTx) ValidateBasic() error                            { return nil }
+func (tx mockTx) GetSigners() []sdk.AccAddress                    { return tx.signers }
+func (tx mockTx) GetPubKeys() ([]cryptotypes.PubKey, error)       { return nil, nil }
+func (tx mockTx) GetSignaturesV2() ([]signing.SignatureV2, error) { return nil, nil }
 
 func TestRouter(t *testing.T) {
 	bankMsg := &banktypes.MsgSend{}


### PR DESCRIPTION
## Describe your changes and provide context
When a new account makes a Cosmos transaction, the chain will be able to obtain its pubkey. We can take this opportunity to also set EVM address association for it if it's not already set.

## Testing performed to validate your change
unit test & local sei

