### PR TITLE
Add utils to replay ETH mainnet txs

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum/ethclient"
+	ethrpc "github.com/ethereum/go-ethereum/rpc"
 	"github.com/sei-protocol/sei-chain/app/antedecorators"
 	"github.com/sei-protocol/sei-chain/evmrpc"
 	"github.com/sei-protocol/sei-chain/precompiles"
@@ -120,6 +122,7 @@ import (
 	"github.com/sei-protocol/sei-chain/x/evm"
 	evmante "github.com/sei-protocol/sei-chain/x/evm/ante"
 	evmkeeper "github.com/sei-protocol/sei-chain/x/evm/keeper"
+	"github.com/sei-protocol/sei-chain/x/evm/replay"
 	evmtypes "github.com/sei-protocol/sei-chain/x/evm/types"
 	"github.com/spf13/cast"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -586,6 +589,18 @@ func New(
 	app.evmRPCConfig, err = evmrpc.ReadConfig(appOpts)
 	if err != nil {
 		panic(fmt.Sprintf("error reading EVM config due to %s", err))
+	}
+	ethReplayConfig, err := replay.ReadConfig(appOpts)
+	if err != nil {
+		panic(fmt.Sprintf("error reading eth replay config due to %s", err))
+	}
+	app.EvmKeeper.EthReplayConfig = ethReplayConfig
+	if ethReplayConfig.Enabled {
+		rpcclient, err := ethrpc.Dial(ethReplayConfig.EthRPC)
+		if err != nil {
+			panic(fmt.Sprintf("error dialing %s due to %s", ethReplayConfig.EthRPC, err))
+		}
+		app.EvmKeeper.EthClient = ethclient.NewClient(rpcclient)
 	}
 
 	customDependencyGenerators := aclmapping.NewCustomDependencyGenerator()
@@ -1548,6 +1563,9 @@ func (app *App) addBadWasmDependenciesToContext(ctx sdk.Context, txResults []*ab
 }
 
 func (app *App) getFinalizeBlockResponse(appHash []byte, events []abci.Event, txResults []*abci.ExecTxResult, endBlockResp abci.ResponseEndBlock) abci.ResponseFinalizeBlock {
+	if app.EvmKeeper.EthReplayConfig.Enabled {
+		return abci.ResponseFinalizeBlock{}
+	}
 	return abci.ResponseFinalizeBlock{
 		Events:    events,
 		TxResults: txResults,

--- a/app/eth_replay.go
+++ b/app/eth_replay.go
@@ -1,0 +1,93 @@
+package app
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math/big"
+	"path/filepath"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/sei-protocol/sei-chain/utils"
+	evmtypes "github.com/sei-protocol/sei-chain/x/evm/types"
+	"github.com/sei-protocol/sei-chain/x/evm/types/ethtx"
+	abci "github.com/tendermint/tendermint/abci/types"
+	tmtypes "github.com/tendermint/tendermint/types"
+)
+
+func Replay(a *App) {
+	gendoc, err := tmtypes.GenesisDocFromFile(filepath.Join(DefaultNodeHome, "config/genesis.json"))
+	if err != nil {
+		panic(err)
+	}
+	_, err = a.InitChain(context.Background(), &abci.RequestInitChain{
+		Time:          time.Now(),
+		ChainId:       "sei-chain",
+		AppStateBytes: gendoc.AppState,
+	})
+	if err != nil {
+		panic(err)
+	}
+	for h := int64(1); h <= int64(a.EvmKeeper.EthReplayConfig.NumBlocksToReplay); h++ {
+		fmt.Printf("Replaying block height %d\n", h+int64(a.EvmKeeper.EthReplayConfig.EthDataEarliestBlock))
+		b, err := a.EvmKeeper.EthClient.BlockByNumber(context.Background(), big.NewInt(h+int64(a.EvmKeeper.EthReplayConfig.EthDataEarliestBlock)))
+		if err != nil {
+			panic(err)
+		}
+		hash := make([]byte, 8)
+		binary.BigEndian.PutUint64(hash, uint64(h))
+		_, err = a.FinalizeBlock(context.Background(), &abci.RequestFinalizeBlock{
+			Txs:               utils.Map(b.Txs, func(tx *ethtypes.Transaction) []byte { return encodeTx(tx, a.GetTxConfig()) }),
+			DecidedLastCommit: abci.CommitInfo{Votes: []abci.VoteInfo{}},
+			Height:            h,
+			Hash:              hash,
+			Time:              time.Now(),
+		})
+		if err != nil {
+			panic(err)
+		}
+		for i, tx := range b.Txs {
+			if tx.To() != nil {
+				fmt.Printf("Verifying balance of tx %d\n", i)
+				a.EvmKeeper.VerifyBalance(a.GetContextForDeliverTx([]byte{}), *tx.To())
+			}
+		}
+		_, err = a.Commit(context.Background())
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func encodeTx(tx *ethtypes.Transaction, txConfig client.TxConfig) []byte {
+	var txData ethtx.TxData
+	var err error
+	switch tx.Type() {
+	case ethtypes.LegacyTxType:
+		txData, err = ethtx.NewLegacyTx(tx)
+	case ethtypes.DynamicFeeTxType:
+		txData, err = ethtx.NewDynamicFeeTx(tx)
+	case ethtypes.AccessListTxType:
+		txData, err = ethtx.NewAccessListTx(tx)
+	case ethtypes.BlobTxType:
+		txData, err = ethtx.NewBlobTx(tx)
+	}
+	if err != nil {
+		panic(err)
+	}
+	msg, err := evmtypes.NewMsgEVMTransaction(txData)
+	if err != nil {
+		panic(err)
+	}
+	txBuilder := txConfig.NewTxBuilder()
+	if err = txBuilder.SetMsgs(msg); err != nil {
+		panic(err)
+	}
+	txbz, encodeErr := txConfig.TxEncoder()(txBuilder.GetTx())
+	if encodeErr != nil {
+		panic(encodeErr)
+	}
+	return txbz
+}

--- a/cmd/seid/cmd/ethreplay.go
+++ b/cmd/seid/cmd/ethreplay.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/CosmWasm/wasmd/x/wasm"
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+	"github.com/spf13/cast"
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/cosmos/cosmos-sdk/store"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	aclkeeper "github.com/cosmos/cosmos-sdk/x/accesscontrol/keeper"
+	"github.com/sei-protocol/sei-chain/app"
+	"github.com/tendermint/tendermint/libs/log"
+	dbm "github.com/tendermint/tm-db"
+
+	"net/http"
+	//nolint:gosec,G108
+	_ "net/http/pprof"
+)
+
+//nolint:gosec
+func ReplayCmd(defaultNodeHome string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ethreplay",
+		Short: "replay EVM transactions",
+		Long:  "replay EVM transactions",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+
+			serverCtx := server.GetServerContextFromCmd(cmd)
+			if err := serverCtx.Viper.BindPFlags(cmd.Flags()); err != nil {
+				return err
+			}
+			go func() {
+				serverCtx.Logger.Info("Listening for profiling at http://localhost:6060/debug/pprof/")
+				err := http.ListenAndServe(":6060", nil)
+				if err != nil {
+					serverCtx.Logger.Error("Error from profiling server", "error", err)
+				}
+			}()
+
+			home := serverCtx.Viper.GetString(flags.FlagHome)
+			db, err := openDB(home)
+			if err != nil {
+				return err
+			}
+
+			logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
+			cache := store.NewCommitKVStoreCacheManager()
+			wasmGasRegisterConfig := wasmkeeper.DefaultGasRegisterConfig()
+			wasmGasRegisterConfig.GasMultiplier = 21_000_000
+			a := app.New(
+				logger,
+				db,
+				nil,
+				true,
+				map[int64]bool{},
+				home,
+				0,
+				true,
+				nil,
+				app.MakeEncodingConfig(),
+				wasm.EnableAllProposals,
+				serverCtx.Viper,
+				[]wasm.Option{
+					wasmkeeper.WithGasRegister(
+						wasmkeeper.NewWasmGasRegister(
+							wasmGasRegisterConfig,
+						),
+					),
+				},
+				[]aclkeeper.Option{},
+				baseapp.SetPruning(storetypes.PruneEverything),
+				baseapp.SetMinGasPrices(cast.ToString(serverCtx.Viper.Get(server.FlagMinGasPrices))),
+				baseapp.SetMinRetainBlocks(cast.ToUint64(serverCtx.Viper.Get(server.FlagMinRetainBlocks))),
+				baseapp.SetInterBlockCache(cache),
+			)
+			app.Replay(a)
+			return nil
+		},
+	}
+
+	cmd.Flags().String(flags.FlagHome, defaultNodeHome, "The database home directory")
+	cmd.Flags().String(flags.FlagChainID, "sei-chain", "chain ID")
+
+	return cmd
+}
+
+func openDB(rootDir string) (dbm.DB, error) {
+	dataDir := filepath.Join(rootDir, "data")
+	return sdk.NewLevelDB("application", dataDir)
+}

--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -38,6 +38,7 @@ import (
 	"github.com/sei-protocol/sei-chain/app/params"
 	"github.com/sei-protocol/sei-chain/evmrpc"
 	"github.com/sei-protocol/sei-chain/tools"
+	"github.com/sei-protocol/sei-chain/x/evm/replay"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 	tmcfg "github.com/tendermint/tendermint/config"
@@ -158,6 +159,7 @@ func initRootCmd(
 		queryCommand(),
 		txCommand(),
 		keys.Commands(app.DefaultNodeHome),
+		ReplayCmd(app.DefaultNodeHome),
 	)
 }
 
@@ -370,6 +372,8 @@ func initAppConfig() (string, interface{}) {
 		WASM WASMConfig `mapstructure:"wasm"`
 
 		EVM evmrpc.Config `mapstructure:"evm"`
+
+		ETHReplay replay.Config `mapstructure:"eth_replay"`
 	}
 
 	// Optionally allow the chain developer to overwrite the SDK's default
@@ -409,7 +413,8 @@ func initAppConfig() (string, interface{}) {
 			LruSize:       1,
 			QueryGasLimit: 300000,
 		},
-		EVM: evmrpc.DefaultConfig,
+		EVM:       evmrpc.DefaultConfig,
+		ETHReplay: replay.DefaultConfig,
 	}
 
 	customAppTemplate := serverconfig.DefaultConfigTemplate + `
@@ -477,6 +482,13 @@ checktx_timeout = "{{ .EVM.CheckTxTimeout }}"
 
 # controls whether to have txns go through one by one
 slow = {{ .EVM.Slow }}
+
+[eth_replay]
+enabled = {{ .ETHReplay.Enabled }}
+eth_rpc = "{{ .ETHReplay.EthRPC }}"
+eth_data_dir = "{{ .ETHReplay.EthDataDir }}"
+eth_data_earliest_block = {{ .ETHReplay.EthDataEarliestBlock }}
+num_blocks_to_replay = {{ .ETHReplay.NumBlocksToReplay }}
 `
 
 	return customAppTemplate, customAppConfig

--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -487,8 +487,6 @@ slow = {{ .EVM.Slow }}
 enabled = {{ .ETHReplay.Enabled }}
 eth_rpc = "{{ .ETHReplay.EthRPC }}"
 eth_data_dir = "{{ .ETHReplay.EthDataDir }}"
-eth_data_earliest_block = {{ .ETHReplay.EthDataEarliestBlock }}
-num_blocks_to_replay = {{ .ETHReplay.NumBlocksToReplay }}
 `
 
 	return customAppTemplate, customAppConfig

--- a/x/evm/ante/preprocess.go
+++ b/x/evm/ante/preprocess.go
@@ -171,7 +171,6 @@ func Preprocess(ctx sdk.Context, msgEVMTransaction *evmtypes.MsgEVMTransaction) 
 	} else {
 		txHash = ethtypes.FrontierSigner{}.Hash(ethTx)
 	}
-
 	evmAddr, seiAddr, seiPubkey, err := getAddresses(V, R, S, txHash)
 	if err != nil {
 		return err

--- a/x/evm/ante/preprocess.go
+++ b/x/evm/ante/preprocess.go
@@ -61,9 +61,6 @@ func (p *EVMPreprocessDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate
 	derived := msg.Derived
 	seiAddr := derived.SenderSeiAddr
 	evmAddr := derived.SenderEVMAddr
-	if p.evmKeeper.EthReplayConfig.Enabled {
-		p.evmKeeper.PrepareReplayedAddr(ctx, evmAddr)
-	}
 	pubkey := derived.PubKey
 	isAssociateTx := derived.IsAssociate
 	_, isAssociated := p.evmKeeper.GetEVMAddress(ctx, seiAddr)
@@ -87,6 +84,9 @@ func (p *EVMPreprocessDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate
 		// not associatedTx and not already associated
 		if err := p.associateAddresses(ctx, seiAddr, evmAddr, pubkey); err != nil {
 			return ctx, err
+		}
+		if p.evmKeeper.EthReplayConfig.Enabled {
+			p.evmKeeper.PrepareReplayedAddr(ctx, evmAddr)
 		}
 	}
 

--- a/x/evm/ante/preprocess.go
+++ b/x/evm/ante/preprocess.go
@@ -61,6 +61,9 @@ func (p *EVMPreprocessDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate
 	derived := msg.Derived
 	seiAddr := derived.SenderSeiAddr
 	evmAddr := derived.SenderEVMAddr
+	if p.evmKeeper.EthReplayConfig.Enabled {
+		p.evmKeeper.PrepareReplayedAddr(ctx, evmAddr)
+	}
 	pubkey := derived.PubKey
 	isAssociateTx := derived.IsAssociate
 	_, isAssociated := p.evmKeeper.GetEVMAddress(ctx, seiAddr)

--- a/x/evm/keeper/genesis.go
+++ b/x/evm/keeper/genesis.go
@@ -1,18 +1,28 @@
 package keeper
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/ethereum/go-ethereum/trie/triedb/hashdb"
+	"github.com/ethereum/go-ethereum/trie/triedb/pathdb"
 
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
 
-func (k Keeper) InitGenesis(ctx sdk.Context, genState types.GenesisState) {
+var ethReplayInitialied = false
+
+func (k *Keeper) InitGenesis(ctx sdk.Context, genState types.GenesisState) {
 	moduleAcc := authtypes.NewEmptyModuleAccount(types.ModuleName, authtypes.Minter, authtypes.Burner)
 	k.accountKeeper.SetModuleAccount(ctx, moduleAcc)
 
-	k.SetParams(ctx, types.DefaultParams())
+	k.SetParams(ctx, genState.Params)
 
 	seiAddrFc := k.accountKeeper.GetModuleAddress(authtypes.FeeCollectorName) // feeCollector == coinbase
 	k.SetAddressMapping(ctx, seiAddrFc, GetCoinbaseAddress())
@@ -20,4 +30,56 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState types.GenesisState) {
 	for _, addr := range genState.AddressAssociations {
 		k.SetAddressMapping(ctx, sdk.MustAccAddressFromBech32(addr.SeiAddress), common.HexToAddress(addr.EthAddress))
 	}
+
+	if k.EthReplayConfig.Enabled && !ethReplayInitialied {
+		header, db, trie := k.openEthDatabase()
+		k.Root = header.Root
+		k.DB = db
+		k.Trie = trie
+		params := k.GetParams(ctx)
+		params.ChainId = sdk.OneInt()
+		k.SetParams(ctx, params)
+		if k.EthReplayConfig.EthDataEarliestBlock == 0 {
+			k.EthReplayConfig.EthDataEarliestBlock = uint64(header.Number.Int64())
+		}
+		ethReplayInitialied = true
+	}
+}
+
+func (k *Keeper) openEthDatabase() (*ethtypes.Header, state.Database, state.Trie) {
+	db, err := rawdb.Open(rawdb.OpenOptions{
+		Type:              "pebble",
+		Directory:         k.EthReplayConfig.EthDataDir,
+		AncientsDirectory: fmt.Sprintf("%s/ancient", k.EthReplayConfig.EthDataDir),
+		Namespace:         "",
+		Cache:             256,
+		Handles:           256,
+		ReadOnly:          true,
+	})
+	if err != nil {
+		panic(err)
+	}
+	config := &trie.Config{
+		Preimages: true,
+		IsVerkle:  false,
+	}
+	scheme, err := rawdb.ParseStateScheme(rawdb.ReadStateScheme(db), db)
+	if err != nil {
+		panic(err)
+	}
+	var triedb *trie.Database
+	if scheme == rawdb.HashScheme {
+		config.HashDB = hashdb.Defaults
+		triedb = trie.NewDatabase(db, config)
+	} else {
+		config.PathDB = pathdb.ReadOnly
+		triedb = trie.NewDatabase(db, config)
+	}
+	header := rawdb.ReadHeadHeader(db)
+	sdb := state.NewDatabaseWithNodeDB(db, triedb)
+	tr, err := sdb.OpenTrie(header.Root)
+	if err != nil {
+		panic(err)
+	}
+	return header, sdb, tr
 }

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -389,6 +389,17 @@ func (k *Keeper) PrepareReplayedAddr(ctx sdk.Context, addr common.Address) {
 	}
 }
 
+func (k *Keeper) GetBaseFee(ctx sdk.Context) *big.Int {
+	if !k.EthReplayConfig.Enabled {
+		return nil
+	}
+	block, err := k.EthClient.BlockByNumber(ctx.Context(), big.NewInt(ctx.BlockHeight()+int64(k.EthReplayConfig.EthDataEarliestBlock)))
+	if err != nil {
+		panic(fmt.Sprintf("error getting block at height %d", ctx.BlockHeight()+int64(k.EthReplayConfig.EthDataEarliestBlock)))
+	}
+	return block.Header_.BaseFee
+}
+
 func (k *Keeper) getReplayBlockCtx(ctx sdk.Context) (*vm.BlockContext, error) {
 	block, err := k.EthClient.BlockByNumber(ctx.Context(), big.NewInt(ctx.BlockHeight()+int64(k.EthReplayConfig.EthDataEarliestBlock)))
 	if err != nil {

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -1,6 +1,9 @@
 package keeper
 
 import (
+	"bytes"
+	"context"
+	"encoding/binary"
 	"fmt"
 	"math"
 	"math/big"
@@ -15,12 +18,18 @@ import (
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core"
+	ethstate "github.com/ethereum/go-ethereum/core/state"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/ethclient"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmtypes "github.com/tendermint/tendermint/types"
 
+	"github.com/sei-protocol/sei-chain/x/evm/replay"
+	"github.com/sei-protocol/sei-chain/x/evm/state"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
 
@@ -41,6 +50,13 @@ type Keeper struct {
 	nonceMx                      *sync.RWMutex
 	pendingTxs                   map[string][]*PendingTx
 	keyToNonce                   map[tmtypes.TxKey]*AddressNoncePair
+
+	// only used during ETH replay. Not used in chain critical path
+	EthClient       *ethclient.Client
+	EthReplayConfig replay.Config
+	Trie            ethstate.Trie
+	DB              ethstate.Database
+	Root            common.Hash
 }
 
 type EvmTxDeferredInfo struct {
@@ -59,6 +75,23 @@ type PendingTx struct {
 	Key      tmtypes.TxKey
 	Nonce    uint64
 	Priority int64
+}
+
+// only used during ETH replay
+type ReplayChainContext struct {
+	ethClient *ethclient.Client
+}
+
+func (ctx *ReplayChainContext) Engine() consensus.Engine {
+	return nil
+}
+
+func (ctx *ReplayChainContext) GetHeader(hash common.Hash, number uint64) *ethtypes.Header {
+	res, err := ctx.ethClient.BlockByNumber(context.Background(), big.NewInt(int64(number)))
+	if err != nil || res.Header_.Hash() != hash {
+		return nil
+	}
+	return res.Header_
 }
 
 func NewKeeper(
@@ -108,6 +141,9 @@ func (k *Keeper) PurgePrefix(ctx sdk.Context, pref []byte) {
 }
 
 func (k *Keeper) GetVMBlockContext(ctx sdk.Context, gp core.GasPool) (*vm.BlockContext, error) {
+	if k.EthReplayConfig.Enabled {
+		return k.getReplayBlockCtx(ctx)
+	}
 	coinbase, err := k.GetFeeCollectorAddress(ctx)
 	if err != nil {
 		return nil, err
@@ -309,6 +345,84 @@ func (k *Keeper) GetPendingTxs() map[string][]*PendingTx {
 // Test use only
 func (k *Keeper) GetKeysToNonces() map[tmtypes.TxKey]*AddressNoncePair {
 	return k.keyToNonce
+}
+
+// Only usd in ETH replay
+func (k *Keeper) PrepareReplayedAddr(ctx sdk.Context, addr common.Address) {
+	if !k.EthReplayConfig.Enabled {
+		return
+	}
+	store := k.PrefixStore(ctx, types.ReplaySeenAddrPrefix)
+	bz := store.Get(addr[:])
+	if len(bz) > 0 {
+		return
+	}
+	a, err := k.Trie.GetAccount(addr)
+	if err != nil || a == nil {
+		return
+	}
+	store.Set(addr[:], a.Root[:])
+	if a.Balance != big.NewInt(0) {
+		usei, wei := state.SplitUseiWeiAmount(a.Balance)
+		err = k.BankKeeper().AddCoins(ctx, k.GetSeiAddressOrDefault(ctx, addr), sdk.NewCoins(sdk.NewCoin("usei", usei)), true)
+		if err != nil {
+			panic(err)
+		}
+		err = k.BankKeeper().AddWei(ctx, k.GetSeiAddressOrDefault(ctx, addr), wei)
+		if err != nil {
+			panic(err)
+		}
+	}
+	k.SetNonce(ctx, addr, a.Nonce)
+	if !bytes.Equal(a.CodeHash, ethtypes.EmptyCodeHash.Bytes()) {
+		k.PrefixStore(ctx, types.CodeHashKeyPrefix).Set(addr[:], a.CodeHash)
+		code, err := k.DB.ContractCode(addr, common.BytesToHash(a.CodeHash))
+		if err != nil {
+			panic(err)
+		}
+		if len(code) > 0 {
+			k.PrefixStore(ctx, types.CodeKeyPrefix).Set(addr[:], code)
+			length := make([]byte, 8)
+			binary.BigEndian.PutUint64(length, uint64(len(code)))
+			k.PrefixStore(ctx, types.CodeSizeKeyPrefix).Set(addr[:], length)
+		}
+	}
+}
+
+func (k *Keeper) getReplayBlockCtx(ctx sdk.Context) (*vm.BlockContext, error) {
+	block, err := k.EthClient.BlockByNumber(ctx.Context(), big.NewInt(ctx.BlockHeight()+int64(k.EthReplayConfig.EthDataEarliestBlock)))
+	if err != nil {
+		panic(fmt.Sprintf("error getting block at height %d", ctx.BlockHeight()+int64(k.EthReplayConfig.EthDataEarliestBlock)))
+	}
+	header := block.Header_
+	getHash := core.GetHashFn(header, &ReplayChainContext{ethClient: k.EthClient})
+	var (
+		baseFee     *big.Int
+		blobBaseFee *big.Int
+		random      *common.Hash
+	)
+	if header.BaseFee != nil {
+		baseFee = new(big.Int).Set(header.BaseFee)
+	}
+	if header.ExcessBlobGas != nil {
+		blobBaseFee = eip4844.CalcBlobFee(*header.ExcessBlobGas)
+	}
+	if header.Difficulty.Cmp(common.Big0) == 0 {
+		random = &header.MixDigest
+	}
+	return &vm.BlockContext{
+		CanTransfer: core.CanTransfer,
+		Transfer:    core.Transfer,
+		GetHash:     getHash,
+		Coinbase:    header.Coinbase,
+		GasLimit:    header.GasLimit,
+		BlockNumber: new(big.Int).Set(header.Number),
+		Time:        header.Time,
+		Difficulty:  new(big.Int).Set(header.Difficulty),
+		BaseFee:     baseFee,
+		BlobBaseFee: blobBaseFee,
+		Random:      random,
+	}, nil
 }
 
 func uint64Cmp(a, b uint64) int {

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -117,7 +117,7 @@ func (k *Keeper) getGasPool(ctx sdk.Context) (sdk.Context, core.GasPool) {
 func (server msgServer) getEVMMessage(ctx sdk.Context, tx *ethtypes.Transaction) (*core.Message, error) {
 	cfg := types.DefaultChainConfig().EthereumConfig(server.ChainID(ctx))
 	signer := ethtypes.MakeSigner(cfg, big.NewInt(ctx.BlockHeight()), uint64(ctx.BlockTime().Unix()))
-	return core.TransactionToMessage(tx, signer, nil)
+	return core.TransactionToMessage(tx, signer, server.GetBaseFee(ctx))
 }
 
 func (server msgServer) applyEVMMessage(ctx sdk.Context, msg *core.Message, stateDB *state.DBImpl, gp core.GasPool) (*core.ExecutionResult, error) {

--- a/x/evm/keeper/params.go
+++ b/x/evm/keeper/params.go
@@ -36,6 +36,10 @@ func (k *Keeper) GetMinimumFeePerGas(ctx sdk.Context) sdk.Dec {
 }
 
 func (k *Keeper) ChainID(ctx sdk.Context) *big.Int {
+	if k.EthReplayConfig.Enabled {
+		// replay is for eth mainnet so always return 1
+		return big.NewInt(1)
+	}
 	return k.GetParams(ctx).ChainId.BigInt()
 }
 

--- a/x/evm/keeper/replay.go
+++ b/x/evm/keeper/replay.go
@@ -14,7 +14,7 @@ func (k *Keeper) VerifyBalance(ctx sdk.Context, addr common.Address) {
 	useiBalance := k.BankKeeper().GetBalance(ctx, k.GetSeiAddressOrDefault(ctx, addr), "usei").Amount
 	weiBalance := k.bankKeeper.GetWeiBalance(ctx, k.GetSeiAddressOrDefault(ctx, addr))
 	totalSeiBalance := useiBalance.Mul(sdk.NewInt(1_000_000_000_000)).Add(weiBalance).BigInt()
-	ethBalance, err := k.EthClient.BalanceAt(ctx.Context(), addr, big.NewInt(int64(k.EthReplayConfig.EthDataEarliestBlock)+ctx.BlockHeight()))
+	ethBalance, err := k.EthClient.BalanceAt(ctx.Context(), addr, big.NewInt(k.GetReplayInitialHeight(ctx)+ctx.BlockHeight()))
 	if err != nil {
 		panic(err)
 	}

--- a/x/evm/keeper/replay.go
+++ b/x/evm/keeper/replay.go
@@ -1,0 +1,22 @@
+package keeper
+
+import (
+	"fmt"
+	"math/big"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func (k *Keeper) VerifyBalance(ctx sdk.Context, addr common.Address) {
+	useiBalance := k.BankKeeper().GetBalance(ctx, k.GetSeiAddressOrDefault(ctx, addr), "usei").Amount
+	weiBalance := k.bankKeeper.GetWeiBalance(ctx, k.GetSeiAddressOrDefault(ctx, addr))
+	totalSeiBalance := useiBalance.Mul(sdk.NewInt(1_000_000_000_000)).Add(weiBalance).BigInt()
+	ethBalance, err := k.EthClient.BalanceAt(ctx.Context(), addr, big.NewInt(int64(k.EthReplayConfig.EthDataEarliestBlock)+ctx.BlockHeight()))
+	if err != nil {
+		panic(err)
+	}
+	if totalSeiBalance.Cmp(ethBalance) != 0 {
+		panic(fmt.Sprintf("difference for addr %s: sei balance is %s, eth balance is %s", addr.Hex(), totalSeiBalance, ethBalance))
+	}
+}

--- a/x/evm/keeper/replay.go
+++ b/x/evm/keeper/replay.go
@@ -1,10 +1,12 @@
 package keeper
 
 import (
+	"bytes"
 	"fmt"
 	"math/big"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -18,5 +20,45 @@ func (k *Keeper) VerifyBalance(ctx sdk.Context, addr common.Address) {
 	}
 	if totalSeiBalance.Cmp(ethBalance) != 0 {
 		panic(fmt.Sprintf("difference for addr %s: sei balance is %s, eth balance is %s", addr.Hex(), totalSeiBalance, ethBalance))
+	}
+}
+
+func (k *Keeper) VerifyTxResult(ctx sdk.Context, hash common.Hash) {
+	localReceipt, err := k.GetReceipt(ctx, hash)
+	if err != nil {
+		// it's okay if remote also doesn't have receipt
+		_, err = k.EthClient.TransactionReceipt(ctx.Context(), hash)
+		if err == ethereum.NotFound {
+			return
+		}
+		panic(fmt.Sprintf("missing local receipt for %s", hash.Hex()))
+	}
+	remoteReceipt, err := k.EthClient.TransactionReceipt(ctx.Context(), hash)
+	if err != nil {
+		panic(err)
+	}
+	if localReceipt.Status != uint32(remoteReceipt.Status) {
+		panic(fmt.Sprintf("remote transaction has status %d while local has status %d", remoteReceipt.Status, localReceipt.Status))
+	}
+	if len(localReceipt.Logs) != len(remoteReceipt.Logs) {
+		panic(fmt.Sprintf("remote transaction has %d logs while local has %d logs", len(remoteReceipt.Logs), len(localReceipt.Logs)))
+	}
+	for i, log := range localReceipt.Logs {
+		rlog := remoteReceipt.Logs[i]
+		if log.Address != rlog.Address.Hex() {
+			panic(fmt.Sprintf("%d-th log has address %s on local but %s on remote", i, log.Address, rlog.Address.Hex()))
+		}
+		if !bytes.Equal(log.Data, rlog.Data) {
+			panic(fmt.Sprintf("%d-th log has data %X on local but %X on remote", i, log.Data, rlog.Data))
+		}
+		if len(log.Topics) != len(rlog.Topics) {
+			panic(fmt.Sprintf("%d-th log has %d topics on local but %d on remote", i, len(log.Topics), len(rlog.Topics)))
+		}
+		for j, topic := range log.Topics {
+			rtopic := rlog.Topics[j]
+			if topic != rtopic.Hex() {
+				panic(fmt.Sprintf("%d-th log %d-th topic is %s on local but %s on remote", i, j, topic, rtopic.Hex()))
+			}
+		}
 	}
 }

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -177,11 +177,12 @@ func (am AppModule) BeginBlock(sdk.Context, abci.RequestBeginBlock) {
 func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
 	var coinbase sdk.AccAddress
 	if am.keeper.EthReplayConfig.Enabled {
-		block, err := am.keeper.EthClient.BlockByNumber(ctx.Context(), big.NewInt(ctx.BlockHeight()+int64(am.keeper.EthReplayConfig.EthDataEarliestBlock)))
+		block, err := am.keeper.EthClient.BlockByNumber(ctx.Context(), big.NewInt(ctx.BlockHeight()+am.keeper.GetReplayInitialHeight(ctx)))
 		if err != nil {
-			panic(fmt.Sprintf("error getting block at height %d", ctx.BlockHeight()+int64(am.keeper.EthReplayConfig.EthDataEarliestBlock)))
+			panic(fmt.Sprintf("error getting block at height %d", ctx.BlockHeight()+am.keeper.GetReplayInitialHeight(ctx)))
 		}
 		coinbase = am.keeper.GetSeiAddressOrDefault(ctx, block.Header_.Coinbase)
+		am.keeper.SetReplayedHeight(ctx)
 	} else {
 		coinbase = am.keeper.AccountKeeper().GetModuleAddress(authtypes.FeeCollectorName)
 	}

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -3,6 +3,7 @@ package evm
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 
 	// this line is used by starport scaffolding # 1
 
@@ -174,6 +175,16 @@ func (am AppModule) BeginBlock(sdk.Context, abci.RequestBeginBlock) {
 // EndBlock executes all ABCI EndBlock logic respective to the evm module. It
 // returns no validator updates.
 func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
+	var coinbase sdk.AccAddress
+	if am.keeper.EthReplayConfig.Enabled {
+		block, err := am.keeper.EthClient.BlockByNumber(ctx.Context(), big.NewInt(ctx.BlockHeight()+int64(am.keeper.EthReplayConfig.EthDataEarliestBlock)))
+		if err != nil {
+			panic(fmt.Sprintf("error getting block at height %d", ctx.BlockHeight()+int64(am.keeper.EthReplayConfig.EthDataEarliestBlock)))
+		}
+		coinbase = am.keeper.GetSeiAddressOrDefault(ctx, block.Header_.Coinbase)
+	} else {
+		coinbase = am.keeper.AccountKeeper().GetModuleAddress(authtypes.FeeCollectorName)
+	}
 	evmTxDeferredInfoList := am.keeper.GetEVMTxDeferredInfo(ctx)
 	denom := am.keeper.GetBaseDenom(ctx)
 	surplus := sdk.NewInt(0)
@@ -183,7 +194,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 		balance := am.keeper.BankKeeper().GetBalance(ctx, coinbaseAddress, denom)
 		weiBalance := am.keeper.BankKeeper().GetWeiBalance(ctx, coinbaseAddress)
 		if !balance.Amount.IsZero() || !weiBalance.IsZero() {
-			if err := am.keeper.BankKeeper().SendCoinsAndWei(ctx, coinbaseAddress, am.keeper.AccountKeeper().GetModuleAddress(authtypes.FeeCollectorName), balance.Amount, weiBalance); err != nil {
+			if err := am.keeper.BankKeeper().SendCoinsAndWei(ctx, coinbaseAddress, coinbase, balance.Amount, weiBalance); err != nil {
 				panic(err)
 			}
 		}

--- a/x/evm/replay/config.go
+++ b/x/evm/replay/config.go
@@ -1,0 +1,61 @@
+package replay
+
+import (
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	"github.com/spf13/cast"
+)
+
+type Config struct {
+	Enabled              bool   `mapstructure:"enabled"`
+	EthRPC               string `mapstructure:"eth_rpc"`
+	EthDataDir           string `mapstructure:"eth_data_dir"`
+	EthDataEarliestBlock uint64 `mapstructure:"eth_data_earliest_block"`
+	NumBlocksToReplay    uint64 `mapstructure:"num_blocks_to_replay"`
+}
+
+var DefaultConfig = Config{
+	Enabled:              false,
+	EthRPC:               "http://44.234.105.54:18545",
+	EthDataDir:           "/root/.ethereum/chaindata",
+	EthDataEarliestBlock: 0,
+	NumBlocksToReplay:    10,
+}
+
+const (
+	flagEnabled              = "eth_replay.enabled"
+	flagEthRPC               = "eth_replay.eth_rpc"
+	flagEthDataDir           = "eth_replay.eth_data_dir"
+	flagEthDataEarliestBlock = "eth_replay.eth_data_earliest_block"
+	flagNumBlocksToReplay    = "eth_replay.num_blocks_to_replay"
+)
+
+func ReadConfig(opts servertypes.AppOptions) (Config, error) {
+	cfg := DefaultConfig // copy
+	var err error
+	if v := opts.Get(flagEnabled); v != nil {
+		if cfg.Enabled, err = cast.ToBoolE(v); err != nil {
+			return cfg, err
+		}
+	}
+	if v := opts.Get(flagEthRPC); v != nil {
+		if cfg.EthRPC, err = cast.ToStringE(v); err != nil {
+			return cfg, err
+		}
+	}
+	if v := opts.Get(flagEthDataDir); v != nil {
+		if cfg.EthDataDir, err = cast.ToStringE(v); err != nil {
+			return cfg, err
+		}
+	}
+	if v := opts.Get(flagEthDataEarliestBlock); v != nil {
+		if cfg.EthDataEarliestBlock, err = cast.ToUint64E(v); err != nil {
+			return cfg, err
+		}
+	}
+	if v := opts.Get(flagNumBlocksToReplay); v != nil {
+		if cfg.NumBlocksToReplay, err = cast.ToUint64E(v); err != nil {
+			return cfg, err
+		}
+	}
+	return cfg, nil
+}

--- a/x/evm/replay/config.go
+++ b/x/evm/replay/config.go
@@ -6,27 +6,21 @@ import (
 )
 
 type Config struct {
-	Enabled              bool   `mapstructure:"enabled"`
-	EthRPC               string `mapstructure:"eth_rpc"`
-	EthDataDir           string `mapstructure:"eth_data_dir"`
-	EthDataEarliestBlock uint64 `mapstructure:"eth_data_earliest_block"`
-	NumBlocksToReplay    uint64 `mapstructure:"num_blocks_to_replay"`
+	Enabled    bool   `mapstructure:"enabled"`
+	EthRPC     string `mapstructure:"eth_rpc"`
+	EthDataDir string `mapstructure:"eth_data_dir"`
 }
 
 var DefaultConfig = Config{
-	Enabled:              false,
-	EthRPC:               "http://44.234.105.54:18545",
-	EthDataDir:           "/root/.ethereum/chaindata",
-	EthDataEarliestBlock: 0,
-	NumBlocksToReplay:    10,
+	Enabled:    false,
+	EthRPC:     "http://44.234.105.54:18545",
+	EthDataDir: "/root/.ethereum/chaindata",
 }
 
 const (
-	flagEnabled              = "eth_replay.enabled"
-	flagEthRPC               = "eth_replay.eth_rpc"
-	flagEthDataDir           = "eth_replay.eth_data_dir"
-	flagEthDataEarliestBlock = "eth_replay.eth_data_earliest_block"
-	flagNumBlocksToReplay    = "eth_replay.num_blocks_to_replay"
+	flagEnabled    = "eth_replay.enabled"
+	flagEthRPC     = "eth_replay.eth_rpc"
+	flagEthDataDir = "eth_replay.eth_data_dir"
 )
 
 func ReadConfig(opts servertypes.AppOptions) (Config, error) {
@@ -44,16 +38,6 @@ func ReadConfig(opts servertypes.AppOptions) (Config, error) {
 	}
 	if v := opts.Get(flagEthDataDir); v != nil {
 		if cfg.EthDataDir, err = cast.ToStringE(v); err != nil {
-			return cfg, err
-		}
-	}
-	if v := opts.Get(flagEthDataEarliestBlock); v != nil {
-		if cfg.EthDataEarliestBlock, err = cast.ToUint64E(v); err != nil {
-			return cfg, err
-		}
-	}
-	if v := opts.Get(flagNumBlocksToReplay); v != nil {
-		if cfg.NumBlocksToReplay, err = cast.ToUint64E(v); err != nil {
 			return cfg, err
 		}
 	}

--- a/x/evm/state/balance.go
+++ b/x/evm/state/balance.go
@@ -9,6 +9,7 @@ import (
 )
 
 func (s *DBImpl) SubBalance(evmAddr common.Address, amt *big.Int) {
+	s.k.PrepareReplayedAddr(s.ctx, evmAddr)
 	if amt.Sign() == 0 {
 		return
 	}
@@ -31,6 +32,7 @@ func (s *DBImpl) SubBalance(evmAddr common.Address, amt *big.Int) {
 }
 
 func (s *DBImpl) AddBalance(evmAddr common.Address, amt *big.Int) {
+	s.k.PrepareReplayedAddr(s.ctx, evmAddr)
 	if amt.Sign() == 0 {
 		return
 	}
@@ -53,6 +55,7 @@ func (s *DBImpl) AddBalance(evmAddr common.Address, amt *big.Int) {
 }
 
 func (s *DBImpl) GetBalance(evmAddr common.Address) *big.Int {
+	s.k.PrepareReplayedAddr(s.ctx, evmAddr)
 	usei := s.k.BankKeeper().GetBalance(s.ctx, s.getSeiAddress(evmAddr), s.k.GetBaseDenom(s.ctx)).Amount
 	wei := s.k.BankKeeper().GetWeiBalance(s.ctx, s.getSeiAddress(evmAddr))
 	return usei.Mul(sdk.NewIntFromBigInt(UseiToSweiMultiplier)).Add(wei).BigInt()

--- a/x/evm/state/check.go
+++ b/x/evm/state/check.go
@@ -9,6 +9,7 @@ import (
 // Exist reports whether the given account exists in state.
 // Notably this should also return true for self-destructed accounts.
 func (s *DBImpl) Exist(addr common.Address) bool {
+	s.k.PrepareReplayedAddr(s.ctx, addr)
 	// check if the address exists as a contract
 	if s.GetCodeHash(addr).Cmp(common.Hash{}) != 0 {
 		return true
@@ -26,5 +27,6 @@ func (s *DBImpl) Exist(addr common.Address) bool {
 // Empty returns whether the given account is empty. Empty
 // is defined according to EIP161 (balance = nonce = code = 0).
 func (s *DBImpl) Empty(addr common.Address) bool {
+	s.k.PrepareReplayedAddr(s.ctx, addr)
 	return s.GetBalance(addr).Cmp(big.NewInt(0)) == 0 && s.GetNonce(addr) == 0 && s.GetCodeHash(addr).Cmp(common.Hash{}) == 0
 }

--- a/x/evm/state/code.go
+++ b/x/evm/state/code.go
@@ -5,17 +5,21 @@ import (
 )
 
 func (s *DBImpl) GetCodeHash(addr common.Address) common.Hash {
+	s.k.PrepareReplayedAddr(s.ctx, addr)
 	return s.k.GetCodeHash(s.ctx, addr)
 }
 
 func (s *DBImpl) GetCode(addr common.Address) []byte {
+	s.k.PrepareReplayedAddr(s.ctx, addr)
 	return s.k.GetCode(s.ctx, addr)
 }
 
 func (s *DBImpl) SetCode(addr common.Address, code []byte) {
+	s.k.PrepareReplayedAddr(s.ctx, addr)
 	s.k.SetCode(s.ctx, addr, code)
 }
 
 func (s *DBImpl) GetCodeSize(addr common.Address) int {
+	s.k.PrepareReplayedAddr(s.ctx, addr)
 	return s.k.GetCodeSize(s.ctx, addr)
 }

--- a/x/evm/state/expected_keepers.go
+++ b/x/evm/state/expected_keepers.go
@@ -25,4 +25,5 @@ type EVMKeeper interface {
 	GetFeeCollectorAddress(sdk.Context) (common.Address, error)
 	GetNonce(sdk.Context, common.Address) uint64
 	SetNonce(sdk.Context, common.Address, uint64)
+	PrepareReplayedAddr(ctx sdk.Context, addr common.Address)
 }

--- a/x/evm/state/nonce.go
+++ b/x/evm/state/nonce.go
@@ -5,9 +5,11 @@ import (
 )
 
 func (s *DBImpl) GetNonce(addr common.Address) uint64 {
+	s.k.PrepareReplayedAddr(s.ctx, addr)
 	return s.k.GetNonce(s.ctx, addr)
 }
 
 func (s *DBImpl) SetNonce(addr common.Address, nonce uint64) {
+	s.k.PrepareReplayedAddr(s.ctx, addr)
 	s.k.SetNonce(s.ctx, addr, nonce)
 }

--- a/x/evm/state/state.go
+++ b/x/evm/state/state.go
@@ -10,6 +10,7 @@ import (
 )
 
 func (s *DBImpl) CreateAccount(acc common.Address) {
+	s.k.PrepareReplayedAddr(s.ctx, acc)
 	// clear any existing state but keep balance untouched
 	s.clearAccountState(acc)
 	s.MarkAccount(acc, AccountCreated)
@@ -24,10 +25,12 @@ func (s *DBImpl) GetState(addr common.Address, hash common.Hash) common.Hash {
 }
 
 func (s *DBImpl) getState(ctx sdk.Context, addr common.Address, hash common.Hash) common.Hash {
+	s.k.PrepareReplayedAddr(s.ctx, addr)
 	return s.k.GetState(ctx, addr, hash)
 }
 
 func (s *DBImpl) SetState(addr common.Address, key common.Hash, val common.Hash) {
+	s.k.PrepareReplayedAddr(s.ctx, addr)
 	s.k.SetState(s.ctx, addr, key, val)
 }
 
@@ -53,6 +56,7 @@ func (s *DBImpl) SetTransientState(addr common.Address, key, val common.Hash) {
 // clear account's state except the transient state (in Ethereum transient states are
 // still available even after self destruction in the same tx)
 func (s *DBImpl) SelfDestruct(acc common.Address) {
+	s.k.PrepareReplayedAddr(s.ctx, acc)
 	if seiAddr, ok := s.k.GetSeiAddress(s.ctx, acc); ok {
 		// remove the association
 		s.k.DeleteAddressMapping(s.ctx, seiAddr, acc)
@@ -102,6 +106,7 @@ func (s *DBImpl) RevertToSnapshot(rev int) {
 }
 
 func (s *DBImpl) clearAccountState(acc common.Address) {
+	s.k.PrepareReplayedAddr(s.ctx, acc)
 	s.k.PurgePrefix(s.ctx, types.StateKey(acc))
 	deleteIfExists(s.k.PrefixStore(s.ctx, types.CodeKeyPrefix), acc[:])
 	deleteIfExists(s.k.PrefixStore(s.ctx, types.CodeSizeKeyPrefix), acc[:])

--- a/x/evm/state/state.go
+++ b/x/evm/state/state.go
@@ -25,7 +25,7 @@ func (s *DBImpl) GetState(addr common.Address, hash common.Hash) common.Hash {
 }
 
 func (s *DBImpl) getState(ctx sdk.Context, addr common.Address, hash common.Hash) common.Hash {
-	s.k.PrepareReplayedAddr(s.ctx, addr)
+	s.k.PrepareReplayedAddr(ctx, addr)
 	return s.k.GetState(ctx, addr, hash)
 }
 

--- a/x/evm/types/keys.go
+++ b/x/evm/types/keys.go
@@ -43,6 +43,8 @@ var (
 	TxBloomPrefix = []byte{0x11}
 
 	ReplaySeenAddrPrefix = []byte{0x12}
+	ReplayedHeight       = []byte{0x13}
+	ReplayInitialHeight  = []byte{0x14}
 )
 
 func EVMAddressToSeiAddressKey(evmAddress common.Address) []byte {

--- a/x/evm/types/keys.go
+++ b/x/evm/types/keys.go
@@ -41,6 +41,8 @@ var (
 	//mem
 	TxHashPrefix  = []byte{0x10}
 	TxBloomPrefix = []byte{0x11}
+
+	ReplaySeenAddrPrefix = []byte{0x12}
 )
 
 func EVMAddressToSeiAddressKey(evmAddress common.Address) []byte {


### PR DESCRIPTION
## Describe your changes and provide context
Add a new command `ethreplay` to replay transactions from ethereum mainnet. Note that currently this command only supports one-off mode (i.e. replay a predefined number of blocks and exit), but can be extended to long-running if needed in the future.

Details of operation can be found here: https://www.notion.so/3pgv/ETH-Mainnet-Replay-8887dea71cbc4f3294c264f8d8858e83

Even though this PR added a new state prefix, it would never be written/read if `eth_replay.enabled = false`, which will be the case for all actual network nodes.

## Testing performed to validate your change
replay

