### PR TITLE
Add deny list config for EVM RPC

### DIFF
--- a/evmrpc/config.go
+++ b/evmrpc/config.go
@@ -70,6 +70,9 @@ type Config struct {
 
 	// controls whether to have txns go through one by one
 	Slow bool `mapstructure:"slow"`
+
+	// Deny list defines list of methods that EVM RPC should fail fast
+	DenyList []string `mapstructure:"deny_list"`
 }
 
 var DefaultConfig = Config{
@@ -89,6 +92,7 @@ var DefaultConfig = Config{
 	CheckTxTimeout:       5 * time.Second,
 	MaxTxPoolTxs:         1000,
 	Slow:                 false,
+	DenyList:             make([]string, 0),
 }
 
 const (
@@ -108,6 +112,7 @@ const (
 	flagMaxTxPoolTxs         = "evm.max_tx_pool_txs"
 	flagCheckTxTimeout       = "evm.checktx_timeout"
 	flagSlow                 = "evm.slow"
+	flagDenyList             = "evm.deny_list"
 )
 
 func ReadConfig(opts servertypes.AppOptions) (Config, error) {
@@ -190,6 +195,11 @@ func ReadConfig(opts servertypes.AppOptions) (Config, error) {
 	}
 	if v := opts.Get(flagSlow); v != nil {
 		if cfg.Slow, err = cast.ToBoolE(v); err != nil {
+			return cfg, err
+		}
+	}
+	if v := opts.Get(flagDenyList); v != nil {
+		if cfg.DenyList, err = cast.ToStringSliceE(v); err != nil {
 			return cfg, err
 		}
 	}

--- a/evmrpc/config_test.go
+++ b/evmrpc/config_test.go
@@ -25,6 +25,7 @@ type opts struct {
 	checkTxTimeout       interface{}
 	maxTxPoolTxs         interface{}
 	slow                 interface{}
+	denyList             interface{}
 }
 
 func (o *opts) Get(k string) interface{} {
@@ -76,6 +77,9 @@ func (o *opts) Get(k string) interface{} {
 	if k == "evm.slow" {
 		return o.slow
 	}
+	if k == "evm.deny_list" {
+		return o.denyList
+	}
 	panic("unknown key")
 }
 
@@ -97,6 +101,7 @@ func TestReadConfig(t *testing.T) {
 		time.Duration(5),
 		1000,
 		false,
+		make([]string, 0),
 	}
 	_, err := evmrpc.ReadConfig(&goodOpts)
 	require.Nil(t, err)
@@ -162,6 +167,10 @@ func TestReadConfig(t *testing.T) {
 	require.NotNil(t, err)
 	badOpts = goodOpts
 	badOpts.slow = "bad"
+	_, err = evmrpc.ReadConfig(&badOpts)
+	require.NotNil(t, err)
+	badOpts = goodOpts
+	badOpts.denyList = map[string]interface{}{}
 	_, err = evmrpc.ReadConfig(&badOpts)
 	require.NotNil(t, err)
 }

--- a/evmrpc/rpcstack.go
+++ b/evmrpc/rpcstack.go
@@ -40,6 +40,7 @@ type HTTPConfig struct {
 	Modules            []string
 	CorsAllowedOrigins []string
 	Vhosts             []string
+	DenyList           []string
 	prefix             string // path prefix on which to mount http handler
 	RPCEndpointConfig
 }
@@ -296,6 +297,9 @@ func (h *HTTPServer) EnableRPC(apis []rpc.API, config HTTPConfig) error {
 	h.log.Info("Registering apis for evm rpc")
 	if err := RegisterApis(h.log, apis, config.Modules, srv); err != nil {
 		return err
+	}
+	for _, method := range config.DenyList {
+		srv.RegisterDenyList(method)
 	}
 	h.HTTPConfig = config
 	h.httpHandler.Store(&rpcHandler{

--- a/go.mod
+++ b/go.mod
@@ -349,7 +349,7 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.76-seiv2
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.9
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.0
-	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-10
+	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-11
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/sei-protocol/sei-db => github.com/sei-protocol/sei-db v0.0.32
 	// Latest goleveldb is broken, we have to stick to this version

--- a/go.sum
+++ b/go.sum
@@ -1342,8 +1342,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-10 h1:mg2TspU4PCdOxVlMFN06eQFJudTXZ4LaHL/3CfTAtPw=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-10/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-11 h1:SdJaJYZCwYadW/G73rJl8nMNKdktPWRQNBpiMxQwLX4=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-11/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-cosmos v0.2.76-seiv2 h1:o4bWU89Zm3B5YFlKNG6XG3hzOMMxC3LaNwSi/LaiEUY=


### PR DESCRIPTION
## Describe your changes and provide context
This PR add a new configuration for EVM RPC to configure deny list. If a method appears in deny list, the server will return an error response to indicate the method is not found.

Config would be look like:
deny_list = ["eth_a", "eth_b"]

## Testing performed to validate your change
Added unit test for deny list.
