### PR TITLE
Pass `.git` folder to Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 build/
-.git/
+# The .git folder must be transferred to Docker context since the Makefile
+# uses git commands to get the current commit hash and tag for versioning.
+# .git/


### PR DESCRIPTION
## Describe your changes and provide context

The problem this commit fix was that the `seid` binary built via Docker didn't contain the correct version when doing `seid version` because `.dockerignore` was specifying that `.git` should not be copied to the Docker context.

However, without copying it, the version cannot be computed anymore since the Makefile is defining version to be `VERSION := $(shell echo $(shell git describe --tags))` and of course if the `.git` is not copied, then this command cannot work.

Removing the `.git` from `.dockerignore` fixes the problem, it brings context transfer from `~78 MB` to `~295 MB` which added `1.1s` to a Docker build (0.4s vs 1.5s) on a Mac M1 Max.

## Testing performed to validate your change

```

$ git checkout seiv2 && docker build . -t "sei-chain:test-docker" --load && docker run --rm -it sei-chain:test-docker version

$ git checkout fix/docker-build-version && docker build . -t "sei-chain:test-docker" --load && docker run --rm -it sei-chain:test-docker version
v3.7.0-196-gd9744359
```
