### PR TITLE
Transfer wei when account is associated

### DIFF
--- a/x/evm/ante/preprocess.go
+++ b/x/evm/ante/preprocess.go
@@ -108,6 +108,12 @@ func (p *EVMPreprocessDecorator) associateAddresses(ctx sdk.Context, seiAddr sdk
 			return err
 		}
 	}
+	castAddrWei := p.evmKeeper.BankKeeper().GetWeiBalance(ctx, castAddr)
+	if !castAddrWei.IsZero() {
+		if err := p.evmKeeper.BankKeeper().SendCoinsAndWei(ctx, castAddr, seiAddr, sdk.ZeroInt(), castAddrWei); err != nil {
+			return err
+		}
+	}
 	p.evmKeeper.AccountKeeper().RemoveAccount(ctx, authtypes.NewBaseAccountWithAddress(castAddr))
 	return nil
 }

--- a/x/evm/ante/preprocess_test.go
+++ b/x/evm/ante/preprocess_test.go
@@ -28,6 +28,9 @@ func TestPreprocessAnteHandler(t *testing.T) {
 	k, ctx := testkeeper.MockEVMKeeper()
 	handler := ante.NewEVMPreprocessDecorator(k, k.AccountKeeper())
 	privKey := testkeeper.MockPrivateKey()
+	seiAddr, evmAddr := testkeeper.PrivateKeyToAddresses(privKey)
+	require.Nil(t, k.BankKeeper().AddCoins(ctx, sdk.AccAddress(evmAddr[:]), sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(100))), true))
+	require.Nil(t, k.BankKeeper().AddWei(ctx, sdk.AccAddress(evmAddr[:]), sdk.NewInt(10)))
 	testPrivHex := hex.EncodeToString(privKey.Bytes())
 	key, _ := crypto.HexToECDSA(testPrivHex)
 	to := new(common.Address)
@@ -56,6 +59,10 @@ func TestPreprocessAnteHandler(t *testing.T) {
 	})
 	require.Nil(t, err)
 	require.Equal(t, sdk.AccAddress(privKey.PubKey().Address()), sdk.AccAddress(msg.Derived.SenderSeiAddr))
+	require.Equal(t, sdk.NewInt(100), k.BankKeeper().GetBalance(ctx, seiAddr, "usei").Amount)
+	require.Equal(t, sdk.NewInt(10), k.BankKeeper().GetWeiBalance(ctx, seiAddr))
+	require.Equal(t, sdk.ZeroInt(), k.BankKeeper().GetBalance(ctx, sdk.AccAddress(evmAddr[:]), "usei").Amount)
+	require.Equal(t, sdk.ZeroInt(), k.BankKeeper().GetWeiBalance(ctx, sdk.AccAddress(evmAddr[:])))
 }
 
 func TestPreprocessAnteHandlerUnprotected(t *testing.T) {


### PR DESCRIPTION
## Describe your changes and provide context
When an account gets associated, if it has ever received any tokens, we want to transfer all of those from the temporary location to the correct sei address. This was done for all bank tokens except for wei. This PR adds such transfer for wei.

## Testing performed to validate your change
unit test

