### PR TITLE
Associate Tx Prefix fix

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1414,6 +1414,7 @@ func (app *App) ProcessBlock(ctx sdk.Context, txs [][]byte, req BlockProcessRequ
 		} else {
 			if isEVM, _ := evmante.IsEVMMessage(typedTx); isEVM {
 				msg := evmtypes.MustGetEVMTransactionMessage(typedTx)
+				fmt.Printf("DEBUG - PREPROCESS ANTE")
 				if err := evmante.Preprocess(ctx, msg); err != nil {
 					ctx.Logger().Error(fmt.Sprintf("error preprocessing EVM tx due to %s", err))
 					typedTxs = append(typedTxs, nil)

--- a/evmrpc/association.go
+++ b/evmrpc/association.go
@@ -17,6 +17,8 @@ import (
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 )
 
+const EthSignedMessage = "\x19Ethereum Signed Message:\n"
+
 type AssociationAPI struct {
 	tmClient    rpcclient.Client
 	keeper      *keeper.Keeper
@@ -40,14 +42,20 @@ func (t *AssociationAPI) Associate(ctx context.Context, req *AssociateRequest) (
 	defer recordMetrics("sei_associate", startTime, returnErr == nil)
 	rBytes, err := decodeHexString(req.R)
 	if err != nil {
+		panic(err)
 		return err
 	}
 	sBytes, err := decodeHexString(req.S)
 	if err != nil {
+		panic(err)
 		return err
 	}
-	vBytes, err := decodeHexString(req.V)
+
+	// Handle prefix for the v part
+	vString := strings.TrimPrefix(req.V, EthSignedMessage)
+	vBytes, err := decodeHexString(vString)
 	if err != nil {
+		panic(err)
 		return err
 	}
 
@@ -59,14 +67,17 @@ func (t *AssociationAPI) Associate(ctx context.Context, req *AssociateRequest) (
 
 	msg, err := types.NewMsgEVMTransaction(&associateTx)
 	if err != nil {
+		panic(err)
 		return err
 	}
 	txBuilder := t.sendAPI.txConfig.NewTxBuilder()
 	if err = txBuilder.SetMsgs(msg); err != nil {
+		panic(err)
 		return err
 	}
 	txbz, encodeErr := t.sendAPI.txConfig.TxEncoder()(txBuilder.GetTx())
 	if encodeErr != nil {
+		panic(err)
 		return encodeErr
 	}
 
@@ -109,5 +120,6 @@ func decodeHexString(hexString string) ([]byte, error) {
 	if len(trimmed)%2 != 0 {
 		trimmed = "0" + trimmed
 	}
+	fmt.Printf("decodeHexString - len %+v\n", len(trimmed))
 	return hex.DecodeString(trimmed)
 }

--- a/evmrpc/association_test.go
+++ b/evmrpc/association_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 )
@@ -23,6 +24,8 @@ func TestAssocation(t *testing.T) {
 	if err != nil {
 		log.Fatalf("Failed to sign payload: %v", err)
 	}
+	fmt.Printf("signature %+v\n", signature)
+	fmt.Printf("signature string %+v\n", string(signature))
 
 	txArgs := map[string]interface{}{
 		"r": fmt.Sprintf("0x%v", new(big.Int).SetBytes(signature[:32]).Text(16)),
@@ -42,4 +45,31 @@ func TestGetSeiAddress(t *testing.T) {
 func TestGetEvmAddress(t *testing.T) {
 	body := sendRequestGoodWithNamespace(t, "sei", "getEVMAddress", "sei1mf0llhmqane5w2y8uynmghmk2w4mh0xll9seym")
 	require.Equal(t, body["result"], "0x1df809C639027b465B931BD63Ce71c8E5834D9d6")
+}
+
+func TestBug(t *testing.T) {
+	key, err := crypto.HexToECDSA("57acb95d82739866a5c29e40b0aa2590742ae50425b7dd5b5d279a986370189e")
+	if err != nil {
+		panic(err)
+	}
+	emptyHash := common.Hash{}
+	sig, err := crypto.Sign(emptyHash[:], key)
+	if err != nil {
+		panic(err)
+	}
+
+	// Extract R, S, and V from the signature
+	R := new(big.Int).SetBytes(sig[:32])
+	S := new(big.Int).SetBytes(sig[32:64])
+	V := big.NewInt(int64(sig[64]))
+
+	// Adjust V from Ethereum format (27 or 28) to compact format (0 or 1)
+	if V.Cmp(big.NewInt(27)) == 0 || V.Cmp(big.NewInt(28)) == 0 {
+		V.Sub(V, big.NewInt(27))
+	}
+
+	fmt.Printf("r: %s\n", hexutil.EncodeBig(R))
+	fmt.Printf("s: %s\n", hexutil.EncodeBig(S))
+	fmt.Printf("v: %d\n", V)
+	panic("here")
 }

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -31,6 +31,7 @@ var _ types.MsgServer = msgServer{}
 
 func (server msgServer) EVMTransaction(goCtx context.Context, msg *types.MsgEVMTransaction) (serverRes *types.MsgEVMTransactionResponse, err error) {
 	if msg.IsAssociateTx() {
+		fmt.Printf("DEBUG - EVMTransaction IsAssociateTx empty response\n")
 		// no-op in msg server for associate tx; all the work have been done in ante handler
 		return &types.MsgEVMTransactionResponse{}, nil
 	}


### PR DESCRIPTION
## Describe your changes and provide context
- Fixes issue where `Associate` evm tx didn't work when signature had `Ethereum Signed Message` Prepended

## Testing performed to validate your change

