### PR TITLE
Handle unprotected TXs properly

### DIFF
--- a/x/evm/ante/sig.go
+++ b/x/evm/ante/sig.go
@@ -25,10 +25,6 @@ func NewEVMSigVerifyDecorator(evmKeeper *evmkeeper.Keeper, latestCtxGetter func(
 func (svd *EVMSigVerifyDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
 	ethTx, _ := types.MustGetEVMTransactionMessage(tx).AsTransaction()
 
-	if !ethTx.Protected() {
-		return ctx, sdkerrors.ErrNoSignatures
-	}
-
 	evmAddr := types.MustGetEVMTransactionMessage(tx).Derived.SenderEVMAddr
 
 	nextNonce := svd.evmKeeper.GetNonce(ctx, evmAddr)


### PR DESCRIPTION
## Describe your changes and provide context
Previously there were two issues with our handling of unprotected TXs:
- They are outright not allowed (checked in sig.go), but they do still exist in today's Ethereum mainnet
- The pubkey derivation logic for unprotected TXs was wrong. Specifically we need to use Frontier's hashing logic for unprotected TXs.

## Testing performed to validate your change
unit tests & replay
