### PR TITLE
Set association and account for EVM contracts

### DIFF
--- a/precompiles/staking/staking_test.go
+++ b/precompiles/staking/staking_test.go
@@ -65,10 +65,11 @@ func TestStaking(t *testing.T) {
 	req, err := evmtypes.NewMsgEVMTransaction(txwrapper)
 	require.Nil(t, err)
 
-	_, evmAddr := testkeeper.PrivateKeyToAddresses(privKey)
+	seiAddr, evmAddr := testkeeper.PrivateKeyToAddresses(privKey)
+	k.SetAddressMapping(ctx, seiAddr, evmAddr)
 	amt := sdk.NewCoins(sdk.NewCoin(k.GetBaseDenom(ctx), sdk.NewInt(200000000)))
 	require.Nil(t, k.BankKeeper().MintCoins(ctx, evmtypes.ModuleName, sdk.NewCoins(sdk.NewCoin(k.GetBaseDenom(ctx), sdk.NewInt(200000000)))))
-	require.Nil(t, k.BankKeeper().SendCoinsFromModuleToAccount(ctx, evmtypes.ModuleName, evmAddr[:], amt))
+	require.Nil(t, k.BankKeeper().SendCoinsFromModuleToAccount(ctx, evmtypes.ModuleName, seiAddr, amt))
 
 	msgServer := keeper.NewMsgServerImpl(k)
 
@@ -77,7 +78,7 @@ func TestStaking(t *testing.T) {
 	require.Nil(t, err)
 	require.Empty(t, res.VmError)
 
-	d, found := testApp.StakingKeeper.GetDelegation(ctx, evmAddr[:], val)
+	d, found := testApp.StakingKeeper.GetDelegation(ctx, seiAddr, val)
 	require.True(t, found)
 	require.Equal(t, int64(100), d.Shares.RoundInt().Int64())
 
@@ -104,7 +105,7 @@ func TestStaking(t *testing.T) {
 	require.Nil(t, err)
 	require.Empty(t, res.VmError)
 
-	d, found = testApp.StakingKeeper.GetDelegation(ctx, evmAddr[:], val)
+	d, found = testApp.StakingKeeper.GetDelegation(ctx, seiAddr, val)
 	require.True(t, found)
 	require.Equal(t, int64(50), d.Shares.RoundInt().Int64())
 
@@ -131,7 +132,7 @@ func TestStaking(t *testing.T) {
 	require.Nil(t, err)
 	require.Empty(t, res.VmError)
 
-	d, found = testApp.StakingKeeper.GetDelegation(ctx, evmAddr[:], val)
+	d, found = testApp.StakingKeeper.GetDelegation(ctx, seiAddr, val)
 	require.True(t, found)
 	require.Equal(t, int64(20), d.Shares.RoundInt().Int64())
 }

--- a/x/evm/ante/preprocess.go
+++ b/x/evm/ante/preprocess.go
@@ -95,9 +95,6 @@ func (p *EVMPreprocessDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate
 
 func (p *EVMPreprocessDecorator) associateAddresses(ctx sdk.Context, seiAddr sdk.AccAddress, evmAddr common.Address, pubkey cryptotypes.PubKey) error {
 	p.evmKeeper.SetAddressMapping(ctx, seiAddr, evmAddr)
-	if !p.accountKeeper.HasAccount(ctx, seiAddr) {
-		p.accountKeeper.SetAccount(ctx, p.accountKeeper.NewAccountWithAddress(ctx, seiAddr))
-	}
 	if acc := p.accountKeeper.GetAccount(ctx, seiAddr); acc.GetPubKey() == nil {
 		if err := acc.SetPubKey(pubkey); err != nil {
 			return err

--- a/x/evm/keeper/address.go
+++ b/x/evm/keeper/address.go
@@ -10,6 +10,9 @@ func (k *Keeper) SetAddressMapping(ctx sdk.Context, seiAddress sdk.AccAddress, e
 	store := ctx.KVStore(k.storeKey)
 	store.Set(types.EVMAddressToSeiAddressKey(evmAddress), seiAddress)
 	store.Set(types.SeiAddressToEVMAddressKey(seiAddress), evmAddress[:])
+	if !k.accountKeeper.HasAccount(ctx, seiAddress) {
+		k.accountKeeper.SetAccount(ctx, k.accountKeeper.NewAccountWithAddress(ctx, seiAddress))
+	}
 }
 
 func (k *Keeper) DeleteAddressMapping(ctx sdk.Context, seiAddress sdk.AccAddress, evmAddress common.Address) {

--- a/x/evm/keeper/address_test.go
+++ b/x/evm/keeper/address_test.go
@@ -21,6 +21,7 @@ func TestSetGetAddressMapping(t *testing.T) {
 	foundSei, ok = k.GetSeiAddress(ctx, evmAddr)
 	require.True(t, ok)
 	require.Equal(t, seiAddr, foundSei)
+	require.Equal(t, seiAddr, k.AccountKeeper().GetAccount(ctx, seiAddr).GetAddress())
 }
 
 func TestDeleteAddressMapping(t *testing.T) {

--- a/x/evm/keeper/code.go
+++ b/x/evm/keeper/code.go
@@ -27,6 +27,8 @@ func (k *Keeper) SetCode(ctx sdk.Context, addr common.Address, code []byte) {
 	k.PrefixStore(ctx, types.CodeSizeKeyPrefix).Set(addr[:], length)
 	h := crypto.Keccak256Hash(code)
 	k.PrefixStore(ctx, types.CodeHashKeyPrefix).Set(addr[:], h[:])
+	// set association with direct cast Sei address for the contract address
+	k.SetAddressMapping(ctx, k.GetSeiAddressOrDefault(ctx, addr), addr)
 }
 
 func (k *Keeper) GetCodeHash(ctx sdk.Context, addr common.Address) common.Hash {

--- a/x/evm/keeper/code_test.go
+++ b/x/evm/keeper/code_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -23,6 +24,7 @@ func TestCode(t *testing.T) {
 	require.Equal(t, crypto.Keccak256Hash(code), k.GetCodeHash(ctx, addr))
 	require.Equal(t, code, k.GetCode(ctx, addr))
 	require.Equal(t, 5, k.GetCodeSize(ctx, addr))
+	require.Equal(t, sdk.AccAddress(addr[:]), k.AccountKeeper().GetAccount(ctx, k.GetSeiAddressOrDefault(ctx, addr)).GetAddress())
 }
 
 func TestNilCode(t *testing.T) {


### PR DESCRIPTION
## Describe your changes and provide context
Right now there is no association or `Account` object set for EVM contracts, which makes it impossible for them to become delegators. This PR:
- sets association and `Account` for EVM contract when its code is set. The associated Sei address is directly cast from the EVM address bytes
- refactored `Account` setting logic so that it becomes part of `SetAddressMapping`, since we need the invariant that any associated address has `Account` set
- made staking precompile errors message more explicit if the delegator is not associated

## Testing performed to validate your change
unit test

