### PR TITLE
change eth replay config names

### DIFF
--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -484,7 +484,7 @@ checktx_timeout = "{{ .EVM.CheckTxTimeout }}"
 slow = {{ .EVM.Slow }}
 
 [eth_replay]
-enabled = {{ .ETHReplay.Enabled }}
+eth_replay_enabled = {{ .ETHReplay.Enabled }}
 eth_rpc = "{{ .ETHReplay.EthRPC }}"
 eth_data_dir = "{{ .ETHReplay.EthDataDir }}"
 `

--- a/x/evm/replay/config.go
+++ b/x/evm/replay/config.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Config struct {
-	Enabled    bool   `mapstructure:"enabled"`
+	Enabled    bool   `mapstructure:"eth_replay_enabled"`
 	EthRPC     string `mapstructure:"eth_rpc"`
 	EthDataDir string `mapstructure:"eth_data_dir"`
 }
@@ -18,7 +18,7 @@ var DefaultConfig = Config{
 }
 
 const (
-	flagEnabled    = "eth_replay.enabled"
+	flagEnabled    = "eth_replay.eth_replay_enabled"
 	flagEthRPC     = "eth_replay.eth_rpc"
 	flagEthDataDir = "eth_replay.eth_data_dir"
 )


### PR DESCRIPTION
## Describe your changes and provide context
Our `sed` commands in nodes setup would set all fields called `enabled` to be true, which is not what we want with replay. Changing the config to a more unique name.

## Testing performed to validate your change
local sei
