### PR TITLE
Set big int constants

### DIFF
--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ethereum/go-ethereum/lib/ethapi"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/sei-protocol/sei-chain/utils"
 	"github.com/sei-protocol/sei-chain/x/evm/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
@@ -321,7 +322,7 @@ func (b *Backend) CurrentHeader() *ethtypes.Header {
 }
 
 func (b *Backend) SuggestGasTipCap(context.Context) (*big.Int, error) {
-	return big.NewInt(0), nil
+	return utils.Big0, nil
 }
 
 func (b *Backend) getBlockHeight(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (int64, error) {

--- a/evmrpc/subscribe.go
+++ b/evmrpc/subscribe.go
@@ -12,6 +12,7 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/filters"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/sei-protocol/sei-chain/utils"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 	"github.com/tendermint/tendermint/rpc/coretypes"
 	tmtypes "github.com/tendermint/tendermint/types"
@@ -196,8 +197,8 @@ func encodeTmHeader(
 		gasWanted += txRes.GasUsed
 	}
 	result := map[string]interface{}{
-		"difficulty":            (*hexutil.Big)(big.NewInt(0)), // inapplicable to Sei
-		"extraData":             hexutil.Bytes{},               // inapplicable to Sei
+		"difficulty":            (*hexutil.Big)(utils.Big0), // inapplicable to Sei
+		"extraData":             hexutil.Bytes{},            // inapplicable to Sei
 		"gasLimit":              hexutil.Uint64(gasLimit),
 		"gasUsed":               hexutil.Uint64(gasWanted),
 		"logsBloom":             ethtypes.Bloom{}, // inapplicable to Sei

--- a/precompiles/bank/bank.go
+++ b/precompiles/bank/bank.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
 	pcommon "github.com/sei-protocol/sei-chain/precompiles/common"
+	"github.com/sei-protocol/sei-chain/utils"
 	"github.com/tendermint/tendermint/libs/log"
 )
 
@@ -158,7 +159,7 @@ func (p Precompile) send(ctx sdk.Context, method *abi.Method, args []interface{}
 		return nil, errors.New("invalid denom")
 	}
 	amount := args[3].(*big.Int)
-	if amount.Cmp(big.NewInt(0)) == 0 {
+	if amount.Cmp(utils.Big0) == 0 {
 		// short circuit
 		return method.Outputs.Pack(true)
 	}

--- a/utils/constants.go
+++ b/utils/constants.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"math"
+	"math/big"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var Big0 = big.NewInt(0)
+var Big1 = big.NewInt(1)
+var Big2 = big.NewInt(2)
+var Big8 = big.NewInt(8)
+var Big27 = big.NewInt(27)
+var Big35 = big.NewInt(35)
+var BigMaxI64 = big.NewInt(math.MaxInt64)
+
+var Sdk0 = sdk.NewInt(0)

--- a/x/evm/ante/fee.go
+++ b/x/evm/ante/fee.go
@@ -1,12 +1,12 @@
 package ante
 
 import (
-	"math"
 	"math/big"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
+	"github.com/sei-protocol/sei-chain/utils"
 	"github.com/sei-protocol/sei-chain/x/evm/derived"
 	evmkeeper "github.com/sei-protocol/sei-chain/x/evm/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
@@ -83,10 +83,10 @@ func (fc EVMFeeCheckDecorator) getMinimumFee(ctx sdk.Context) *big.Int {
 
 // CalculatePriority returns a priority based on the effective gas price of the transaction
 func (fc EVMFeeCheckDecorator) CalculatePriority(ctx sdk.Context, txData ethtx.TxData) *big.Int {
-	gp := txData.EffectiveGasPrice(big.NewInt(0))
+	gp := txData.EffectiveGasPrice(utils.Big0)
 	priority := new(big.Int).Quo(gp, fc.evmKeeper.GetPriorityNormalizer(ctx).RoundInt().BigInt())
-	if priority.Cmp(big.NewInt(math.MaxInt64)) > 0 {
-		priority = big.NewInt(math.MaxInt64)
+	if priority.Cmp(utils.BigMaxI64) > 0 {
+		priority = utils.BigMaxI64
 	}
 	return priority
 }

--- a/x/evm/ante/preprocess.go
+++ b/x/evm/ante/preprocess.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/sei-protocol/sei-chain/app/antedecorators"
+	"github.com/sei-protocol/sei-chain/utils"
 	"github.com/sei-protocol/sei-chain/x/evm/derived"
 	evmkeeper "github.com/sei-protocol/sei-chain/x/evm/keeper"
 	evmtypes "github.com/sei-protocol/sei-chain/x/evm/types"
@@ -135,7 +136,7 @@ func Preprocess(ctx sdk.Context, msgEVMTransaction *evmtypes.MsgEVMTransaction) 
 
 	if atx, ok := txData.(*ethtx.AssociateTx); ok {
 		V, R, S := atx.GetRawSignatureValues()
-		V = new(big.Int).Add(V, big.NewInt(27))
+		V = new(big.Int).Add(V, utils.Big27)
 		// Hash custom message passed in
 		customMessageHash := crypto.Keccak256Hash([]byte(atx.CustomMessage))
 		evmAddr, seiAddr, pubkey, err := getAddresses(V, R, S, customMessageHash)
@@ -298,12 +299,12 @@ func isTxTypeAllowed(version derived.SignerVersion, txType uint8) bool {
 func AdjustV(V *big.Int, txType uint8, chainID *big.Int) *big.Int {
 	// Non-legacy TX always needs to be bumped by 27
 	if txType != ethtypes.LegacyTxType {
-		return new(big.Int).Add(V, big.NewInt(27))
+		return new(big.Int).Add(V, utils.Big27)
 	}
 
 	// legacy TX needs to be adjusted based on chainID
-	V = new(big.Int).Sub(V, new(big.Int).Mul(chainID, big.NewInt(2)))
-	return V.Sub(V, big.NewInt(8))
+	V = new(big.Int).Sub(V, new(big.Int).Mul(chainID, utils.Big2))
+	return V.Sub(V, utils.Big8)
 }
 
 func GetVersion(ctx sdk.Context, ethCfg *params.ChainConfig) derived.SignerVersion {

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -31,6 +31,7 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/sei-protocol/sei-chain/evmrpc"
 	"github.com/sei-protocol/sei-chain/precompiles/staking"
+	"github.com/sei-protocol/sei-chain/utils"
 	"github.com/sei-protocol/sei-chain/x/evm/artifacts/cw20"
 	"github.com/sei-protocol/sei-chain/x/evm/artifacts/cw721"
 	"github.com/sei-protocol/sei-chain/x/evm/artifacts/native"
@@ -277,7 +278,7 @@ func CmdDeployErc20() *cobra.Command {
 				return err
 			}
 			txData.Nonce = nonce
-			txData.Value = big.NewInt(0)
+			txData.Value = utils.Big0
 			txData.Data = contractData
 
 			resp, err := sendTx(txData, rpc, key)
@@ -363,7 +364,7 @@ func CmdDeployErcCw20() *cobra.Command {
 				return err
 			}
 			txData.Nonce = nonce
-			txData.Value = big.NewInt(0)
+			txData.Value = utils.Big0
 			txData.Data = contractData
 
 			resp, err := sendTx(txData, rpc, key)
@@ -449,7 +450,7 @@ func CmdDeployErcCw721() *cobra.Command {
 				return err
 			}
 			txData.Nonce = nonce
-			txData.Value = big.NewInt(0)
+			txData.Value = utils.Big0
 			txData.Data = contractData
 
 			resp, err := sendTx(txData, rpc, key)
@@ -519,7 +520,7 @@ func CmdCallContract() *cobra.Command {
 				return err
 			}
 			txData.Nonce = nonce
-			txData.Value = big.NewInt(0)
+			txData.Value = utils.Big0
 			txData.Data = payload
 			txData.To = &contract
 
@@ -588,7 +589,7 @@ func CmdERC20Send() *cobra.Command {
 				return err
 			}
 			txData.Nonce = nonce
-			txData.Value = big.NewInt(0)
+			txData.Value = utils.Big0
 			txData.Data = payload
 			txData.To = &contract
 
@@ -652,7 +653,7 @@ func CmdDelegate() *cobra.Command {
 				return err
 			}
 			txData.Nonce = nonce
-			txData.Value = big.NewInt(0)
+			txData.Value = utils.Big0
 			txData.Data = payload
 			to := common.HexToAddress(staking.StakingAddress)
 			txData.To = &to
@@ -781,7 +782,7 @@ func getTxData(cmd *cobra.Command) (*ethtypes.DynamicFeeTx, error) {
 
 func sendTx(txData *ethtypes.DynamicFeeTx, rpcUrl string, key *ecdsa.PrivateKey) (common.Hash, error) {
 	ethCfg := types.DefaultChainConfig().EthereumConfig(txData.ChainID)
-	signer := ethtypes.MakeSigner(ethCfg, big.NewInt(1), 1)
+	signer := ethtypes.MakeSigner(ethCfg, utils.Big1, 1)
 	signedTx, err := ethtypes.SignTx(ethtypes.NewTx(txData), signer, key)
 	if err != nil {
 		return common.Hash{}, err

--- a/x/evm/keeper/evm.go
+++ b/x/evm/keeper/evm.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/sei-protocol/sei-chain/utils"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
@@ -101,7 +102,7 @@ func (k *Keeper) callEVM(ctx sdk.Context, from sdk.AccAddress, to *common.Addres
 	if evmGasRemaining.Cmp(MaxUint64BigInt) > 0 {
 		evmGasRemaining = MaxUint64BigInt
 	}
-	value := big.NewInt(0)
+	value := utils.Big0
 	if val != nil {
 		value = val.BigInt()
 	}

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -28,6 +28,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmtypes "github.com/tendermint/tendermint/types"
 
+	"github.com/sei-protocol/sei-chain/utils"
 	"github.com/sei-protocol/sei-chain/x/evm/replay"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
@@ -161,7 +162,7 @@ func (k *Keeper) GetVMBlockContext(ctx sdk.Context, gp core.GasPool) (*vm.BlockC
 		GasLimit:    gp.Gas(),
 		BlockNumber: big.NewInt(ctx.BlockHeight()),
 		Time:        uint64(ctx.BlockHeader().Time.Unix()),
-		Difficulty:  big.NewInt(0),                               // only needed for PoW
+		Difficulty:  utils.Big0,                                  // only needed for PoW
 		BaseFee:     k.GetBaseFeePerGas(ctx).RoundInt().BigInt(), // feemarket not enabled
 		Random:      &rh,
 	}, nil
@@ -362,7 +363,7 @@ func (k *Keeper) PrepareReplayedAddr(ctx sdk.Context, addr common.Address) {
 		return
 	}
 	store.Set(addr[:], a.Root[:])
-	if a.Balance != big.NewInt(0) {
+	if a.Balance != nil && a.Balance.Cmp(utils.Big0) != 0 {
 		usei, wei := state.SplitUseiWeiAmount(a.Balance)
 		err = k.BankKeeper().AddCoins(ctx, k.GetSeiAddressOrDefault(ctx, addr), sdk.NewCoins(sdk.NewCoin("usei", usei)), true)
 		if err != nil {

--- a/x/evm/keeper/params.go
+++ b/x/evm/keeper/params.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/utils"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
 
@@ -38,7 +39,7 @@ func (k *Keeper) GetMinimumFeePerGas(ctx sdk.Context) sdk.Dec {
 func (k *Keeper) ChainID(ctx sdk.Context) *big.Int {
 	if k.EthReplayConfig.Enabled {
 		// replay is for eth mainnet so always return 1
-		return big.NewInt(1)
+		return utils.Big1
 	}
 	return k.GetParams(ctx).ChainId.BigInt()
 }

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -188,7 +188,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 	}
 	evmTxDeferredInfoList := am.keeper.GetEVMTxDeferredInfo(ctx)
 	denom := am.keeper.GetBaseDenom(ctx)
-	surplus := sdk.NewInt(0)
+	surplus := utils.Sdk0
 	for _, deferredInfo := range evmTxDeferredInfoList {
 		idx := deferredInfo.TxIndx
 		coinbaseAddress := state.GetCoinbaseAddress(idx)

--- a/x/evm/state/balance.go
+++ b/x/evm/state/balance.go
@@ -58,7 +58,7 @@ func (s *DBImpl) GetBalance(evmAddr common.Address) *big.Int {
 	s.k.PrepareReplayedAddr(s.ctx, evmAddr)
 	usei := s.k.BankKeeper().GetBalance(s.ctx, s.getSeiAddress(evmAddr), s.k.GetBaseDenom(s.ctx)).Amount
 	wei := s.k.BankKeeper().GetWeiBalance(s.ctx, s.getSeiAddress(evmAddr))
-	return usei.Mul(sdk.NewIntFromBigInt(UseiToSweiMultiplier)).Add(wei).BigInt()
+	return usei.Mul(SdkUseiToSweiMultiplier).Add(wei).BigInt()
 }
 
 // should only be called during simulation

--- a/x/evm/state/check.go
+++ b/x/evm/state/check.go
@@ -2,10 +2,10 @@ package state
 
 import (
 	"bytes"
-	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/sei-protocol/sei-chain/utils"
 )
 
 // Exist reports whether the given account exists in state.
@@ -31,5 +31,5 @@ func (s *DBImpl) Exist(addr common.Address) bool {
 // is defined according to EIP161 (balance = nonce = code = 0).
 func (s *DBImpl) Empty(addr common.Address) bool {
 	s.k.PrepareReplayedAddr(s.ctx, addr)
-	return s.GetBalance(addr).Cmp(big.NewInt(0)) == 0 && s.GetNonce(addr) == 0 && bytes.Equal(s.GetCodeHash(addr).Bytes(), ethtypes.EmptyCodeHash.Bytes())
+	return s.GetBalance(addr).Cmp(utils.Big0) == 0 && s.GetNonce(addr) == 0 && bytes.Equal(s.GetCodeHash(addr).Bytes(), ethtypes.EmptyCodeHash.Bytes())
 }

--- a/x/evm/state/statedb.go
+++ b/x/evm/state/statedb.go
@@ -165,6 +165,6 @@ func NewTemporaryState() *TemporaryState {
 		transientStates:       make(map[string]map[string]common.Hash),
 		transientAccounts:     make(map[string][]byte),
 		transientModuleStates: make(map[string][]byte),
-		surplus:               sdk.NewInt(0),
+		surplus:               utils.Sdk0,
 	}
 }

--- a/x/evm/state/utils.go
+++ b/x/evm/state/utils.go
@@ -10,6 +10,7 @@ import (
 // UseiToSweiMultiplier Fields that were denominated in usei will be converted to swei (1usei = 10^12swei)
 // for existing Ethereum application (which assumes 18 decimal points) to display properly.
 var UseiToSweiMultiplier = big.NewInt(1_000_000_000_000)
+var SdkUseiToSweiMultiplier = sdk.NewIntFromBigInt(UseiToSweiMultiplier)
 
 var CoinbaseAddressPrefix = []byte("evm_coinbase")
 

--- a/x/evm/types/config.go
+++ b/x/evm/types/config.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/sei-protocol/sei-chain/utils"
 )
 
 /*
@@ -19,22 +20,22 @@ config for backward compatibility with the official EVM lib.
 func (cc ChainConfig) EthereumConfig(chainID *big.Int) *params.ChainConfig {
 	return &params.ChainConfig{
 		ChainID:             chainID,
-		HomesteadBlock:      big.NewInt(0),
-		DAOForkBlock:        big.NewInt(0),
+		HomesteadBlock:      utils.Big0,
+		DAOForkBlock:        utils.Big0,
 		DAOForkSupport:      false, // fork of Sei is supported outside EVM
-		EIP150Block:         big.NewInt(0),
-		EIP155Block:         big.NewInt(0),
-		EIP158Block:         big.NewInt(0),
-		ByzantiumBlock:      big.NewInt(0),
-		ConstantinopleBlock: big.NewInt(0),
-		PetersburgBlock:     big.NewInt(0),
-		IstanbulBlock:       big.NewInt(0),
-		MuirGlacierBlock:    big.NewInt(0),
-		BerlinBlock:         big.NewInt(0),
-		LondonBlock:         big.NewInt(0),
-		ArrowGlacierBlock:   big.NewInt(0),
-		GrayGlacierBlock:    big.NewInt(0),
-		MergeNetsplitBlock:  big.NewInt(0),
+		EIP150Block:         utils.Big0,
+		EIP155Block:         utils.Big0,
+		EIP158Block:         utils.Big0,
+		ByzantiumBlock:      utils.Big0,
+		ConstantinopleBlock: utils.Big0,
+		PetersburgBlock:     utils.Big0,
+		IstanbulBlock:       utils.Big0,
+		MuirGlacierBlock:    utils.Big0,
+		BerlinBlock:         utils.Big0,
+		LondonBlock:         utils.Big0,
+		ArrowGlacierBlock:   utils.Big0,
+		GrayGlacierBlock:    utils.Big0,
+		MergeNetsplitBlock:  utils.Big0,
 		ShanghaiTime:        getUpgradeTimestamp(0),
 		CancunTime:          getUpgradeTimestamp(cc.CancunTime),
 		PragueTime:          getUpgradeTimestamp(cc.PragueTime),

--- a/x/evm/types/ethtx/legacy_tx.go
+++ b/x/evm/types/ethtx/legacy_tx.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/sei-protocol/sei-chain/utils"
 )
 
 func NewLegacyTx(tx *ethtypes.Transaction) (*LegacyTx, error) {
@@ -57,8 +58,8 @@ func (tx *LegacyTx) GetChainID() *big.Int {
 		}
 		return new(big.Int).SetUint64((v - 35) / 2)
 	}
-	v = new(big.Int).Sub(v, big.NewInt(35))
-	return v.Div(v, big.NewInt(2))
+	v = new(big.Int).Sub(v, utils.Big35)
+	return v.Div(v, utils.Big2)
 }
 
 func (tx *LegacyTx) GetAccessList() ethtypes.AccessList {

--- a/x/evm/types/ethtx/txdata.go
+++ b/x/evm/types/ethtx/txdata.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	proto "github.com/gogo/protobuf/proto"
+	"github.com/sei-protocol/sei-chain/utils"
 )
 
 var (
@@ -74,17 +75,17 @@ func rawSignatureValues(vBz, rBz, sBz []byte) (v, r, s *big.Int) {
 	if len(vBz) > 0 {
 		v = new(big.Int).SetBytes(vBz)
 	} else {
-		v = big.NewInt(0)
+		v = utils.Big0
 	}
 	if len(rBz) > 0 {
 		r = new(big.Int).SetBytes(rBz)
 	} else {
-		r = big.NewInt(0)
+		r = utils.Big0
 	}
 	if len(sBz) > 0 {
 		s = new(big.Int).SetBytes(sBz)
 	} else {
-		s = big.NewInt(0)
+		s = utils.Big0
 	}
 	return v, r, s
 }


### PR DESCRIPTION
## Describe your changes and provide context
Use constants instead of keep allocating new variables whenever values like `big.NewInt(0)` is needed

## Testing performed to validate your change
unit tests

