### PR TITLE
Add occ metrics for gas used

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1331,6 +1331,9 @@ func (app *App) ProcessTXsWithOCC(ctx sdk.Context, txs [][]byte) ([]*abci.ExecTx
 
 	execResults := make([]*abci.ExecTxResult, 0, len(batchResult.Results))
 	for _, r := range batchResult.Results {
+		metrics.IncrTxProcessTypeCounter(metrics.OCC_CONCURRENT)
+		metrics.IncrGasCounter("gas_used", r.Response.GasUsed)
+		metrics.IncrGasCounter("gas_wanted", r.Response.GasWanted)
 		execResults = append(execResults, &abci.ExecTxResult{
 			Code:      r.Response.Code,
 			Data:      r.Response.Data,

--- a/utils/metrics/labels.go
+++ b/utils/metrics/labels.go
@@ -1,8 +1,9 @@
 package metrics
 
 const (
-	CONCURRENT    = "concurrent"
-	SYNCHRONOUS   = "synchronous"
-	GovMsgInBlock = "gov-msg-in-block"
-	FailedToBuild = "failed-to-build"
+	CONCURRENT     = "concurrent"
+	SYNCHRONOUS    = "synchronous"
+	OCC_CONCURRENT = "optimistic_concurrency"
+	GovMsgInBlock  = "gov-msg-in-block"
+	FailedToBuild  = "failed-to-build"
 )


### PR DESCRIPTION
## Describe your changes and provide context
This adds metrics for the OCC logic paths to properly show gas used and gas wanted for nodes running OCC execution as well.

## Testing performed to validate your change

