### PR TITLE
cache block during eth replay

### DIFF
--- a/app/eth_replay.go
+++ b/app/eth_replay.go
@@ -63,6 +63,7 @@ func Replay(a *App) {
 		if err != nil {
 			panic(err)
 		}
+		a.EvmKeeper.ReplayBlock = b
 		hash := make([]byte, 8)
 		binary.BigEndian.PutUint64(hash, uint64(h))
 		_, err = a.FinalizeBlock(context.Background(), &abci.RequestFinalizeBlock{


### PR DESCRIPTION
## Describe your changes and provide context
Prevent having to query block for every transaction

## Testing performed to validate your change
replay

