### PR TITLE
Update EVMFeeCheckDecorator to run in Deliver Mode

### DIFF
--- a/x/evm/ante/fee.go
+++ b/x/evm/ante/fee.go
@@ -25,8 +25,7 @@ func NewEVMFeeCheckDecorator(evmKeeper *evmkeeper.Keeper) *EVMFeeCheckDecorator 
 }
 
 func (fc EVMFeeCheckDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
-	// only check fee in CheckTx (similar to normal Sei tx)
-	if !ctx.IsCheckTx() || simulate {
+	if simulate {
 		return next(ctx, tx, simulate)
 	}
 

--- a/x/evm/ante/fee_test.go
+++ b/x/evm/ante/fee_test.go
@@ -21,7 +21,6 @@ import (
 
 func TestEVMFeeCheckDecoratorCancun(t *testing.T) {
 	k, ctx := testkeeper.MockEVMKeeper()
-	ctx = ctx.WithIsCheckTx(true)
 	handler := ante.NewEVMFeeCheckDecorator(k)
 	privKey := testkeeper.MockPrivateKey()
 	testPrivHex := hex.EncodeToString(privKey.Bytes())


### PR DESCRIPTION
## Describe your changes and provide context
- Updated `EVMFeeCheckDecorator` to not just run in checkTx mode 

## Testing performed to validate your change
- Minor updated unit tests
- Verifying on chain
