### PR TITLE
Precompiles Raise Error over Panic

### DIFF
--- a/precompiles/addr/addr.go
+++ b/precompiles/addr/addr.go
@@ -101,15 +101,26 @@ func (p Precompile) Run(evm *vm.EVM, _ common.Address, input []byte, value *big.
 }
 
 func (p Precompile) getSeiAddr(ctx sdk.Context, method *abi.Method, args []interface{}, value *big.Int) ([]byte, error) {
-	pcommon.AssertNonPayable(value)
-	pcommon.AssertArgsLength(args, 1)
+	if err := pcommon.ValidateNonPayable(value); err != nil {
+		return nil, err
+	}
+
+	if err := pcommon.ValidateArgsLength(args, 1); err != nil {
+		return nil, err
+	}
+
 	seiAddrStr := p.evmKeeper.GetSeiAddressOrDefault(ctx, args[0].(common.Address)).String()
 	return method.Outputs.Pack(seiAddrStr)
 }
 
 func (p Precompile) getEvmAddr(ctx sdk.Context, method *abi.Method, args []interface{}, value *big.Int) ([]byte, error) {
-	pcommon.AssertNonPayable(value)
-	pcommon.AssertArgsLength(args, 1)
+	if err := pcommon.ValidateNonPayable(value); err != nil {
+		return nil, err
+	}
+
+	if err := pcommon.ValidateArgsLength(args, 1); err != nil {
+		return nil, err
+	}
 	evmAddr := p.evmKeeper.GetEVMAddressFromBech32OrDefault(ctx, args[0].(string))
 	return method.Outputs.Pack(evmAddr)
 }

--- a/precompiles/bank/bank.go
+++ b/precompiles/bank/bank.go
@@ -152,8 +152,13 @@ func (p Precompile) validateCaller(ctx sdk.Context, caller common.Address) error
 }
 
 func (p Precompile) send(ctx sdk.Context, method *abi.Method, args []interface{}, value *big.Int) ([]byte, error) {
-	pcommon.AssertNonPayable(value)
-	pcommon.AssertArgsLength(args, 4)
+	if err := pcommon.ValidateNonPayable(value); err != nil {
+		return nil, err
+	}
+
+	if err := pcommon.ValidateArgsLength(args, 4); err != nil {
+		return nil, err
+	}
 	denom := args[2].(string)
 	if denom == "" {
 		return nil, errors.New("invalid denom")
@@ -181,7 +186,9 @@ func (p Precompile) send(ctx sdk.Context, method *abi.Method, args []interface{}
 }
 
 func (p Precompile) sendNative(ctx sdk.Context, method *abi.Method, args []interface{}, caller common.Address, value *big.Int) ([]byte, error) {
-	pcommon.AssertArgsLength(args, 1)
+	if err := pcommon.ValidateArgsLength(args, 1); err != nil {
+		return nil, err
+	}
 	if value == nil || value.Sign() == 0 {
 		return nil, errors.New("set `value` field to non-zero to send")
 	}
@@ -214,8 +221,13 @@ func (p Precompile) sendNative(ctx sdk.Context, method *abi.Method, args []inter
 }
 
 func (p Precompile) balance(ctx sdk.Context, method *abi.Method, args []interface{}, value *big.Int) ([]byte, error) {
-	pcommon.AssertNonPayable(value)
-	pcommon.AssertArgsLength(args, 2)
+	if err := pcommon.ValidateNonPayable(value); err != nil {
+		return nil, err
+	}
+
+	if err := pcommon.ValidateArgsLength(args, 2); err != nil {
+		return nil, err
+	}
 
 	addr, err := p.accAddressFromArg(ctx, args[0])
 	if err != nil {
@@ -230,8 +242,13 @@ func (p Precompile) balance(ctx sdk.Context, method *abi.Method, args []interfac
 }
 
 func (p Precompile) name(ctx sdk.Context, method *abi.Method, args []interface{}, value *big.Int) ([]byte, error) {
-	pcommon.AssertNonPayable(value)
-	pcommon.AssertArgsLength(args, 1)
+	if err := pcommon.ValidateNonPayable(value); err != nil {
+		return nil, err
+	}
+
+	if err := pcommon.ValidateArgsLength(args, 1); err != nil {
+		return nil, err
+	}
 
 	denom := args[0].(string)
 	metadata, found := p.bankKeeper.GetDenomMetaData(ctx, denom)
@@ -242,8 +259,13 @@ func (p Precompile) name(ctx sdk.Context, method *abi.Method, args []interface{}
 }
 
 func (p Precompile) symbol(ctx sdk.Context, method *abi.Method, args []interface{}, value *big.Int) ([]byte, error) {
-	pcommon.AssertNonPayable(value)
-	pcommon.AssertArgsLength(args, 1)
+	if err := pcommon.ValidateNonPayable(value); err != nil {
+		return nil, err
+	}
+
+	if err := pcommon.ValidateArgsLength(args, 1); err != nil {
+		return nil, err
+	}
 
 	denom := args[0].(string)
 	metadata, found := p.bankKeeper.GetDenomMetaData(ctx, denom)
@@ -254,14 +276,22 @@ func (p Precompile) symbol(ctx sdk.Context, method *abi.Method, args []interface
 }
 
 func (p Precompile) decimals(_ sdk.Context, method *abi.Method, _ []interface{}, value *big.Int) ([]byte, error) {
-	pcommon.AssertNonPayable(value)
+	if err := pcommon.ValidateNonPayable(value); err != nil {
+		return nil, err
+	}
+
 	// all native tokens are integer-based
 	return method.Outputs.Pack(uint8(0))
 }
 
 func (p Precompile) totalSupply(ctx sdk.Context, method *abi.Method, args []interface{}, value *big.Int) ([]byte, error) {
-	pcommon.AssertNonPayable(value)
-	pcommon.AssertArgsLength(args, 1)
+	if err := pcommon.ValidateNonPayable(value); err != nil {
+		return nil, err
+	}
+
+	if err := pcommon.ValidateArgsLength(args, 1); err != nil {
+		return nil, err
+	}
 
 	denom := args[0].(string)
 	coin := p.bankKeeper.GetSupply(ctx, denom)

--- a/precompiles/common/precompiles.go
+++ b/precompiles/common/precompiles.go
@@ -51,16 +51,20 @@ func (p Precompile) Prepare(evm *vm.EVM, input []byte) (sdk.Context, *abi.Method
 	return ctxer.Ctx(), method, args, nil
 }
 
-func AssertArgsLength(args []interface{}, length int) {
+func ValidateArgsLength(args []interface{}, length int) error {
 	if len(args) != length {
-		panic(fmt.Sprintf("expected %d arguments but got %d", length, len(args)))
+		return fmt.Errorf("expected %d arguments but got %d", length, len(args))
 	}
+
+	return nil
 }
 
-func AssertNonPayable(value *big.Int) {
+func ValidateNonPayable(value *big.Int) error {
 	if value != nil && value.Sign() != 0 {
-		panic("sending funds to a non-payable function")
+		return errors.New("sending funds to a non-payable function")
 	}
+
+	return nil
 }
 
 func HandlePaymentUsei(ctx sdk.Context, precompileAddr sdk.AccAddress, payer sdk.AccAddress, value *big.Int, bankKeeper BankKeeper) (sdk.Coin, error) {

--- a/precompiles/common/precompiles_test.go
+++ b/precompiles/common/precompiles_test.go
@@ -8,14 +8,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAssertArgsLength(t *testing.T) {
-	require.NotPanics(t, func() { common.AssertArgsLength(nil, 0) })
-	require.NotPanics(t, func() { common.AssertArgsLength([]interface{}{1, ""}, 2) })
-	require.Panics(t, func() { common.AssertArgsLength([]interface{}{""}, 2) })
+func TestValidateArgsLength(t *testing.T) {
+	err := common.ValidateArgsLength(nil, 0)
+	require.Nil(t, err)
+	err = common.ValidateArgsLength([]interface{}{1, ""}, 2)
+	require.Nil(t, err)
+	err = common.ValidateArgsLength([]interface{}{""}, 2)
+	require.NotNil(t, err)
 }
 
-func TestAssertNonPayable(t *testing.T) {
-	require.NotPanics(t, func() { common.AssertNonPayable(nil) })
-	require.NotPanics(t, func() { common.AssertNonPayable(big.NewInt(0)) })
-	require.Panics(t, func() { common.AssertNonPayable(big.NewInt(1)) })
+func TestValidteNonPayable(t *testing.T) {
+	err := common.ValidateNonPayable(nil)
+	require.Nil(t, err)
+	err = common.ValidateNonPayable(big.NewInt(0))
+	require.Nil(t, err)
+	err = common.ValidateNonPayable(big.NewInt(1))
+	require.NotNil(t, err)
 }

--- a/precompiles/distribution/distribution.go
+++ b/precompiles/distribution/distribution.go
@@ -106,8 +106,13 @@ func (p Precompile) Run(evm *vm.EVM, caller common.Address, input []byte, value 
 }
 
 func (p Precompile) setWithdrawAddress(ctx sdk.Context, method *abi.Method, caller common.Address, args []interface{}, value *big.Int) ([]byte, error) {
-	pcommon.AssertNonPayable(value)
-	pcommon.AssertArgsLength(args, 1)
+	if err := pcommon.ValidateNonPayable(value); err != nil {
+		return nil, err
+	}
+
+	if err := pcommon.ValidateArgsLength(args, 1); err != nil {
+		return nil, err
+	}
 	delegator := p.evmKeeper.GetSeiAddressOrDefault(ctx, caller)
 	withdrawAddr, err := p.accAddressFromArg(ctx, args[0])
 	if err != nil {
@@ -121,8 +126,13 @@ func (p Precompile) setWithdrawAddress(ctx sdk.Context, method *abi.Method, call
 }
 
 func (p Precompile) withdrawDelegationRewards(ctx sdk.Context, method *abi.Method, caller common.Address, args []interface{}, value *big.Int) ([]byte, error) {
-	pcommon.AssertNonPayable(value)
-	pcommon.AssertArgsLength(args, 1)
+	if err := pcommon.ValidateNonPayable(value); err != nil {
+		return nil, err
+	}
+
+	if err := pcommon.ValidateArgsLength(args, 1); err != nil {
+		return nil, err
+	}
 	delegator := p.evmKeeper.GetSeiAddressOrDefault(ctx, caller)
 	validator, err := sdk.ValAddressFromBech32(args[0].(string))
 	if err != nil {

--- a/precompiles/gov/gov.go
+++ b/precompiles/gov/gov.go
@@ -109,8 +109,13 @@ func (p Precompile) Run(evm *vm.EVM, caller common.Address, input []byte, value 
 }
 
 func (p Precompile) vote(ctx sdk.Context, method *abi.Method, caller common.Address, args []interface{}, value *big.Int) ([]byte, error) {
-	pcommon.AssertNonPayable(value)
-	pcommon.AssertArgsLength(args, 2)
+	if err := pcommon.ValidateNonPayable(value); err != nil {
+		return nil, err
+	}
+
+	if err := pcommon.ValidateArgsLength(args, 2); err != nil {
+		return nil, err
+	}
 	voter := p.evmKeeper.GetSeiAddressOrDefault(ctx, caller)
 	proposalID := args[0].(uint64)
 	voteOption := args[1].(int32)
@@ -122,7 +127,9 @@ func (p Precompile) vote(ctx sdk.Context, method *abi.Method, caller common.Addr
 }
 
 func (p Precompile) deposit(ctx sdk.Context, method *abi.Method, caller common.Address, args []interface{}, value *big.Int) ([]byte, error) {
-	pcommon.AssertArgsLength(args, 1)
+	if err := pcommon.ValidateArgsLength(args, 1); err != nil {
+		return nil, err
+	}
 	depositor := p.evmKeeper.GetSeiAddressOrDefault(ctx, caller)
 	proposalID := args[0].(uint64)
 	if value == nil || value.Sign() == 0 {

--- a/precompiles/ibc/ibc.go
+++ b/precompiles/ibc/ibc.go
@@ -125,7 +125,11 @@ func (p Precompile) transfer(ctx sdk.Context, method *abi.Method, args []interfa
 			return
 		}
 	}()
-	pcommon.AssertArgsLength(args, 8)
+
+	if err := pcommon.ValidateArgsLength(args, 8); err != nil {
+		rerr = err
+		return
+	}
 	senderSeiAddr, ok := p.evmKeeper.GetSeiAddress(ctx, caller)
 	if !ok {
 		rerr = errors.New("caller is not a valid SEI address")

--- a/precompiles/json/json.go
+++ b/precompiles/json/json.go
@@ -108,8 +108,13 @@ func (p Precompile) Run(evm *vm.EVM, _ common.Address, input []byte, value *big.
 }
 
 func (p Precompile) extractAsBytes(_ sdk.Context, method *abi.Method, args []interface{}, value *big.Int) ([]byte, error) {
-	pcommon.AssertNonPayable(value)
-	pcommon.AssertArgsLength(args, 2)
+	if err := pcommon.ValidateNonPayable(value); err != nil {
+		return nil, err
+	}
+
+	if err := pcommon.ValidateArgsLength(args, 2); err != nil {
+		return nil, err
+	}
 
 	// type assertion will always succeed because it's already validated in p.Prepare call in Run()
 	bz := args[0].([]byte)
@@ -131,8 +136,13 @@ func (p Precompile) extractAsBytes(_ sdk.Context, method *abi.Method, args []int
 }
 
 func (p Precompile) extractAsBytesList(_ sdk.Context, method *abi.Method, args []interface{}, value *big.Int) ([]byte, error) {
-	pcommon.AssertNonPayable(value)
-	pcommon.AssertArgsLength(args, 2)
+	if err := pcommon.ValidateNonPayable(value); err != nil {
+		return nil, err
+	}
+
+	if err := pcommon.ValidateArgsLength(args, 2); err != nil {
+		return nil, err
+	}
 
 	// type assertion will always succeed because it's already validated in p.Prepare call in Run()
 	bz := args[0].([]byte)
@@ -150,8 +160,13 @@ func (p Precompile) extractAsBytesList(_ sdk.Context, method *abi.Method, args [
 }
 
 func (p Precompile) ExtractAsUint256(_ sdk.Context, _ *abi.Method, args []interface{}, value *big.Int) (*big.Int, error) {
-	pcommon.AssertNonPayable(value)
-	pcommon.AssertArgsLength(args, 2)
+	if err := pcommon.ValidateNonPayable(value); err != nil {
+		return nil, err
+	}
+
+	if err := pcommon.ValidateArgsLength(args, 2); err != nil {
+		return nil, err
+	}
 
 	// type assertion will always succeed because it's already validated in p.Prepare call in Run()
 	bz := args[0].([]byte)

--- a/precompiles/oracle/oracle.go
+++ b/precompiles/oracle/oracle.go
@@ -126,8 +126,13 @@ func (p Precompile) Run(evm *vm.EVM, _ common.Address, input []byte, value *big.
 }
 
 func (p Precompile) getExchangeRates(ctx sdk.Context, method *abi.Method, args []interface{}, value *big.Int) ([]byte, error) {
-	pcommon.AssertNonPayable(value)
-	pcommon.AssertArgsLength(args, 0)
+	if err := pcommon.ValidateNonPayable(value); err != nil {
+		return nil, err
+	}
+
+	if err := pcommon.ValidateArgsLength(args, 0); err != nil {
+		return nil, err
+	}
 	exchangeRates := []DenomOracleExchangeRatePair{}
 	p.oracleKeeper.IterateBaseExchangeRates(ctx, func(denom string, rate types.OracleExchangeRate) (stop bool) {
 		exchangeRates = append(exchangeRates, DenomOracleExchangeRatePair{Denom: denom, OracleExchangeRateVal: OracleExchangeRate{ExchangeRate: rate.ExchangeRate.String(), LastUpdate: rate.LastUpdate.String(), LastUpdateTimestamp: rate.LastUpdateTimestamp}})
@@ -138,8 +143,13 @@ func (p Precompile) getExchangeRates(ctx sdk.Context, method *abi.Method, args [
 }
 
 func (p Precompile) getOracleTwaps(ctx sdk.Context, method *abi.Method, args []interface{}, value *big.Int) ([]byte, error) {
-	pcommon.AssertNonPayable(value)
-	pcommon.AssertArgsLength(args, 1)
+	if err := pcommon.ValidateNonPayable(value); err != nil {
+		return nil, err
+	}
+
+	if err := pcommon.ValidateArgsLength(args, 1); err != nil {
+		return nil, err
+	}
 	lookbackSeconds := args[0].(uint64)
 	twaps, err := p.oracleKeeper.CalculateTwaps(ctx, lookbackSeconds)
 	if err != nil {

--- a/precompiles/pointer/pointer.go
+++ b/precompiles/pointer/pointer.go
@@ -113,7 +113,9 @@ func (p Precompile) Run(*vm.EVM, common.Address, []byte, *big.Int) ([]byte, erro
 }
 
 func (p Precompile) AddNative(ctx sdk.Context, method *ethabi.Method, caller common.Address, args []interface{}, value *big.Int, evm *vm.EVM, suppliedGas uint64) (ret []byte, remainingGas uint64, err error) {
-	pcommon.AssertArgsLength(args, 1)
+	if err := pcommon.ValidateArgsLength(args, 1); err != nil {
+		return nil, 0, err
+	}
 	token := args[0].(string)
 	existingAddr, existingVersion, exists := p.evmKeeper.GetERC20NativePointer(ctx, token)
 	if exists && existingVersion >= native.CurrentVersion {
@@ -161,7 +163,9 @@ func (p Precompile) AddNative(ctx sdk.Context, method *ethabi.Method, caller com
 }
 
 func (p Precompile) AddCW20(ctx sdk.Context, method *ethabi.Method, caller common.Address, args []interface{}, value *big.Int, evm *vm.EVM, suppliedGas uint64) (ret []byte, remainingGas uint64, err error) {
-	pcommon.AssertArgsLength(args, 1)
+	if err := pcommon.ValidateArgsLength(args, 1); err != nil {
+		return nil, 0, err
+	}
 	cwAddr := args[0].(string)
 	existingAddr, existingVersion, exists := p.evmKeeper.GetERC20CW20Pointer(ctx, cwAddr)
 	if exists && existingVersion >= cw20.CurrentVersion {
@@ -202,7 +206,9 @@ func (p Precompile) AddCW20(ctx sdk.Context, method *ethabi.Method, caller commo
 }
 
 func (p Precompile) AddCW721(ctx sdk.Context, method *ethabi.Method, caller common.Address, args []interface{}, value *big.Int, evm *vm.EVM, suppliedGas uint64) (ret []byte, remainingGas uint64, err error) {
-	pcommon.AssertArgsLength(args, 1)
+	if err := pcommon.ValidateArgsLength(args, 1); err != nil {
+		return nil, 0, err
+	}
 	cwAddr := args[0].(string)
 	existingAddr, existingVersion, exists := p.evmKeeper.GetERC721CW721Pointer(ctx, cwAddr)
 	if exists && existingVersion >= cw721.CurrentVersion {

--- a/precompiles/pointerview/pointerview.go
+++ b/precompiles/pointerview/pointerview.go
@@ -98,21 +98,27 @@ func (p Precompile) Run(evm *vm.EVM, _ common.Address, input []byte, _ *big.Int)
 }
 
 func (p Precompile) GetNative(ctx sdk.Context, method *abi.Method, args []interface{}) (ret []byte, err error) {
-	pcommon.AssertArgsLength(args, 1)
+	if err := pcommon.ValidateArgsLength(args, 1); err != nil {
+		return nil, err
+	}
 	token := args[0].(string)
 	existingAddr, existingVersion, exists := p.evmKeeper.GetERC20NativePointer(ctx, token)
 	return method.Outputs.Pack(existingAddr, existingVersion, exists)
 }
 
 func (p Precompile) GetCW20(ctx sdk.Context, method *abi.Method, args []interface{}) (ret []byte, err error) {
-	pcommon.AssertArgsLength(args, 1)
+	if err := pcommon.ValidateArgsLength(args, 1); err != nil {
+		return nil, err
+	}
 	addr := args[0].(string)
 	existingAddr, existingVersion, exists := p.evmKeeper.GetERC20CW20Pointer(ctx, addr)
 	return method.Outputs.Pack(existingAddr, existingVersion, exists)
 }
 
 func (p Precompile) GetCW721(ctx sdk.Context, method *abi.Method, args []interface{}) (ret []byte, err error) {
-	pcommon.AssertArgsLength(args, 1)
+	if err := pcommon.ValidateArgsLength(args, 1); err != nil {
+		return nil, err
+	}
 	addr := args[0].(string)
 	existingAddr, existingVersion, exists := p.evmKeeper.GetERC721CW721Pointer(ctx, addr)
 	return method.Outputs.Pack(existingAddr, existingVersion, exists)

--- a/precompiles/staking/staking.go
+++ b/precompiles/staking/staking.go
@@ -118,7 +118,9 @@ func (p Precompile) Run(evm *vm.EVM, caller common.Address, input []byte, value 
 }
 
 func (p Precompile) delegate(ctx sdk.Context, method *abi.Method, caller common.Address, args []interface{}, value *big.Int) ([]byte, error) {
-	pcommon.AssertArgsLength(args, 1)
+	if err := pcommon.ValidateArgsLength(args, 1); err != nil {
+		return nil, err
+	}
 	// if delegator is associated, then it must have Account set already
 	// if delegator is not associated, then it can't delegate anyway (since
 	// there is no good way to merge delegations if it becomes associated)
@@ -146,8 +148,13 @@ func (p Precompile) delegate(ctx sdk.Context, method *abi.Method, caller common.
 }
 
 func (p Precompile) redelegate(ctx sdk.Context, method *abi.Method, caller common.Address, args []interface{}, value *big.Int) ([]byte, error) {
-	pcommon.AssertNonPayable(value)
-	pcommon.AssertArgsLength(args, 3)
+	if err := pcommon.ValidateNonPayable(value); err != nil {
+		return nil, err
+	}
+
+	if err := pcommon.ValidateArgsLength(args, 3); err != nil {
+		return nil, err
+	}
 	delegator, associated := p.evmKeeper.GetSeiAddress(ctx, caller)
 	if !associated {
 		return nil, fmt.Errorf("redelegator %s is not associated/doesn't have an Account set yet", caller.Hex())
@@ -168,8 +175,13 @@ func (p Precompile) redelegate(ctx sdk.Context, method *abi.Method, caller commo
 }
 
 func (p Precompile) undelegate(ctx sdk.Context, method *abi.Method, caller common.Address, args []interface{}, value *big.Int) ([]byte, error) {
-	pcommon.AssertNonPayable(value)
-	pcommon.AssertArgsLength(args, 2)
+	if err := pcommon.ValidateNonPayable(value); err != nil {
+		return nil, err
+	}
+
+	if err := pcommon.ValidateArgsLength(args, 2); err != nil {
+		return nil, err
+	}
 	delegator, associated := p.evmKeeper.GetSeiAddress(ctx, caller)
 	if !associated {
 		return nil, fmt.Errorf("undelegator %s is not associated/doesn't have an Account set yet", caller.Hex())

--- a/precompiles/wasmd/wasmd.go
+++ b/precompiles/wasmd/wasmd.go
@@ -145,7 +145,10 @@ func (p Precompile) instantiate(ctx sdk.Context, method *abi.Method, caller comm
 			return
 		}
 	}()
-	pcommon.AssertArgsLength(args, 5)
+	if err := pcommon.ValidateArgsLength(args, 5); err != nil {
+		rerr = err
+		return
+	}
 
 	// type assertion will always succeed because it's already validated in p.Prepare call in Run()
 	codeID := args[0].(uint64)
@@ -200,7 +203,10 @@ func (p Precompile) execute(ctx sdk.Context, method *abi.Method, caller common.A
 			return
 		}
 	}()
-	pcommon.AssertArgsLength(args, 3)
+	if err := pcommon.ValidateArgsLength(args, 3); err != nil {
+		rerr = err
+		return
+	}
 
 	// type assertion will always succeed because it's already validated in p.Prepare call in Run()
 	contractAddrStr := args[0].(string)
@@ -249,8 +255,15 @@ func (p Precompile) query(ctx sdk.Context, method *abi.Method, args []interface{
 			return
 		}
 	}()
-	pcommon.AssertNonPayable(value)
-	pcommon.AssertArgsLength(args, 2)
+	if err := pcommon.ValidateNonPayable(value); err != nil {
+		rerr = err
+		return
+	}
+
+	if err := pcommon.ValidateArgsLength(args, 2); err != nil {
+		rerr = err
+		return
+	}
 
 	contractAddrStr := args[0].(string)
 	// addresses will be sent in Sei format

--- a/x/evm/state/check_test.go
+++ b/x/evm/state/check_test.go
@@ -24,7 +24,7 @@ func TestExist(t *testing.T) {
 
 	// has balance
 	_, addr3 := testkeeper.MockAddressPair()
-	statedb.AddBalance(addr3, big.NewInt(1000000000000))
+	statedb.AddBalance(addr3, big.NewInt(1000000000000), tracing.BalanceChangeUnspecified)
 	require.True(t, statedb.Exist(addr3))
 
 	// destructed


### PR DESCRIPTION
## Describe your changes and provide context
- Previously we panicked for incorrect arg length and asserting non payable
- Remove panic in favor of raising errors

## Testing performed to validate your change
- Verified on unit tests
- Verified on chain
