### PR TITLE
Add gas limit for EVM static call query

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -123,6 +123,7 @@ import (
 	evmante "github.com/sei-protocol/sei-chain/x/evm/ante"
 	"github.com/sei-protocol/sei-chain/x/evm/blocktest"
 	evmkeeper "github.com/sei-protocol/sei-chain/x/evm/keeper"
+	"github.com/sei-protocol/sei-chain/x/evm/querier"
 	"github.com/sei-protocol/sei-chain/x/evm/replay"
 	evmtypes "github.com/sei-protocol/sei-chain/x/evm/types"
 	"github.com/spf13/cast"
@@ -593,6 +594,11 @@ func New(
 	if err != nil {
 		panic(fmt.Sprintf("error reading EVM config due to %s", err))
 	}
+	evmQueryConfig, err := querier.ReadConfig(appOpts)
+	if err != nil {
+		panic(fmt.Sprintf("error reading evm query config due to %s", err))
+	}
+	app.EvmKeeper.QueryConfig = &evmQueryConfig
 	ethReplayConfig, err := replay.ReadConfig(appOpts)
 	if err != nil {
 		panic(fmt.Sprintf("error reading eth replay config due to %s", err))

--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -39,6 +39,7 @@ import (
 	"github.com/sei-protocol/sei-chain/evmrpc"
 	"github.com/sei-protocol/sei-chain/tools"
 	"github.com/sei-protocol/sei-chain/x/evm/blocktest"
+	"github.com/sei-protocol/sei-chain/x/evm/querier"
 	"github.com/sei-protocol/sei-chain/x/evm/replay"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
@@ -378,6 +379,8 @@ func initAppConfig() (string, interface{}) {
 		ETHReplay replay.Config `mapstructure:"eth_replay"`
 
 		ETHBlockTest blocktest.Config `mapstructure:"eth_block_test"`
+
+		EvmQuery querier.Config `mapstructure:"evm_query"`
 	}
 
 	// Optionally allow the chain developer to overwrite the SDK's default
@@ -420,6 +423,7 @@ func initAppConfig() (string, interface{}) {
 		EVM:          evmrpc.DefaultConfig,
 		ETHReplay:    replay.DefaultConfig,
 		ETHBlockTest: blocktest.DefaultConfig,
+		EvmQuery:     querier.DefaultConfig,
 	}
 
 	customAppTemplate := serverconfig.DefaultConfigTemplate + `
@@ -496,6 +500,9 @@ eth_data_dir = "{{ .ETHReplay.EthDataDir }}"
 [eth_blocktest]
 eth_blocktest_enabled = {{ .ETHBlockTest.Enabled }}
 eth_blocktest_test_data_path = "{{ .ETHBlockTest.TestDataPath }}"
+
+[evm_query]
+evm_query_gas_limit = {{ .EvmQuery.GasLimit }}
 `
 
 	return customAppTemplate, customAppConfig

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -54,6 +54,9 @@ func (q Querier) StaticCall(c context.Context, req *types.QueryStaticCallRequest
 	if req.To == "" {
 		return nil, errors.New("cannot use static call to create contracts")
 	}
+	if ctx.GasMeter().Limit() == 0 {
+		ctx = ctx.WithGasMeter(sdk.NewGasMeter(q.QueryConfig.GasLimit))
+	}
 	to := common.HexToAddress(req.To)
 	res, err := q.Keeper.StaticCallEVM(ctx, q.Keeper.AccountKeeper().GetModuleAddress(types.ModuleName), &to, req.Data)
 	if err != nil {

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/sei-protocol/sei-chain/utils"
 	"github.com/sei-protocol/sei-chain/x/evm/blocktest"
+	"github.com/sei-protocol/sei-chain/x/evm/querier"
 	"github.com/sei-protocol/sei-chain/x/evm/replay"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
@@ -57,6 +58,8 @@ type Keeper struct {
 	nonceMx                      *sync.RWMutex
 	pendingTxs                   map[string][]*PendingTx
 	keyToNonce                   map[tmtypes.TxKey]*AddressNoncePair
+
+	QueryConfig *querier.Config
 
 	// only used during ETH replay. Not used in chain critical path.
 	EthClient       *ethclient.Client

--- a/x/evm/querier/config.go
+++ b/x/evm/querier/config.go
@@ -1,0 +1,29 @@
+package querier
+
+import (
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	"github.com/spf13/cast"
+)
+
+type Config struct {
+	GasLimit uint64 `mapstructure:"evm_query_gas_limit"`
+}
+
+var DefaultConfig = Config{
+	GasLimit: 300000,
+}
+
+const (
+	flagGasLimit = "evm_query.evm_query_gas_limit"
+)
+
+func ReadConfig(opts servertypes.AppOptions) (Config, error) {
+	cfg := DefaultConfig // copy
+	var err error
+	if v := opts.Get(flagGasLimit); v != nil {
+		if cfg.GasLimit, err = cast.ToUint64E(v); err != nil {
+			return cfg, err
+		}
+	}
+	return cfg, nil
+}


### PR DESCRIPTION
## Describe your changes and provide context
Right now EVM static call query uses an infinite gas meter that may be subject to DoS attacks. This PR adds a config-based gas limit to this query endpoint.

## Testing performed to validate your change
local sei with config gas limit setting to 1
