### PR TITLE
Write receipt for txs with non VM errors

### DIFF
--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -81,6 +81,7 @@ type EvmTxDeferredInfo struct {
 	TxHash  common.Hash
 	TxBloom ethtypes.Bloom
 	Surplus sdk.Int
+	Error   string
 }
 
 type AddressNoncePair struct {
@@ -222,7 +223,7 @@ func (k *Keeper) GetEVMTxDeferredInfo(ctx sdk.Context) (res []EvmTxDeferredInfo)
 			ctx.Logger().Error(fmt.Sprintf("getting invalid tx index in EVM deferred info: %d, num of txs: %d", txIdx, len(k.txResults)))
 			return true
 		}
-		if k.txResults[txIdx].Code == 0 {
+		if k.txResults[txIdx].Code == 0 || value.(*EvmTxDeferredInfo).Error != "" {
 			res = append(res, *(value.(*EvmTxDeferredInfo)))
 		}
 		return true
@@ -237,6 +238,14 @@ func (k *Keeper) AppendToEvmTxDeferredInfo(ctx sdk.Context, bloom ethtypes.Bloom
 		TxBloom: bloom,
 		TxHash:  txHash,
 		Surplus: surplus,
+	})
+}
+
+func (k *Keeper) AppendErrorToEvmTxDeferredInfo(ctx sdk.Context, txHash common.Hash, err string) {
+	k.deferredInfo.Store(ctx.TxIndex(), &EvmTxDeferredInfo{
+		TxIndx: ctx.TxIndex(),
+		TxHash: txHash,
+		Error:  err,
 	})
 }
 

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -68,6 +68,7 @@ func (server msgServer) EVMTransaction(goCtx context.Context, msg *types.MsgEVMT
 			debug.PrintStack()
 			ctx.Logger().Error(fmt.Sprintf("EVM PANIC: %s", pe))
 			telemetry.IncrCounter(1, types.ModuleName, "panics")
+			server.AppendErrorToEvmTxDeferredInfo(ctx, tx.Hash(), fmt.Sprintf("%s", pe))
 
 			panic(pe)
 		}

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -215,6 +215,14 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 	denom := am.keeper.GetBaseDenom(ctx)
 	surplus := utils.Sdk0
 	for _, deferredInfo := range evmTxDeferredInfoList {
+		if deferredInfo.Error != "" {
+			_ = am.keeper.SetReceipt(ctx, deferredInfo.TxHash, &types.Receipt{
+				TxHashHex:        deferredInfo.TxHash.Hex(),
+				TransactionIndex: uint32(deferredInfo.TxIndx),
+				VmError:          deferredInfo.Error,
+			})
+			continue
+		}
 		idx := deferredInfo.TxIndx
 		coinbaseAddress := state.GetCoinbaseAddress(idx)
 		balance := am.keeper.BankKeeper().GetBalance(ctx, coinbaseAddress, denom)

--- a/x/evm/module_test.go
+++ b/x/evm/module_test.go
@@ -65,4 +65,13 @@ func TestABCI(t *testing.T) {
 	m.EndBlock(ctx, abci.RequestEndBlock{})
 	require.Equal(t, uint64(1), k.BankKeeper().GetBalance(ctx, k.AccountKeeper().GetModuleAddress(types.ModuleName), "usei").Amount.Uint64())
 	require.Equal(t, uint64(2), k.BankKeeper().GetBalance(ctx, k.AccountKeeper().GetModuleAddress(authtypes.FeeCollectorName), "usei").Amount.Uint64())
+
+	// third block
+	m.BeginBlock(ctx, abci.RequestBeginBlock{})
+	k.AppendErrorToEvmTxDeferredInfo(ctx.WithTxIndex(0), common.Hash{1}, "test error")
+	k.SetTxResults([]*abci.ExecTxResult{{Code: 1}})
+	m.EndBlock(ctx, abci.RequestEndBlock{})
+	receipt, err := k.GetReceipt(ctx, common.Hash{1})
+	require.Nil(t, err)
+	require.Equal(t, receipt.VmError, "test error")
 }


### PR DESCRIPTION
## Describe your changes and provide context
We want to have some records for transactions that fail with a panic. This PR write receipts for transactions that had a panic during processing.

## Testing performed to validate your change
unit test
