### PR TITLE
Clear self-destructed account state at the end of tx

### DIFF
--- a/x/evm/state/state.go
+++ b/x/evm/state/state.go
@@ -70,9 +70,6 @@ func (s *DBImpl) SelfDestruct(acc common.Address) {
 
 	s.SubBalance(acc, s.GetBalance(acc), tracing.BalanceDecreaseSelfdestruct)
 
-	// clear account state
-	s.clearAccountState(acc)
-
 	// mark account as self-destructed
 	s.MarkAccount(acc, AccountDeleted)
 }
@@ -109,6 +106,15 @@ func (s *DBImpl) RevertToSnapshot(rev int) {
 	s.tempStateCurrent = s.tempStatesHist[rev]
 	s.tempStatesHist = s.tempStatesHist[:rev]
 	s.Snapshot()
+}
+
+func (s *DBImpl) clearAccountStateIfDestructed(st *TemporaryState) {
+	for acc, status := range st.transientAccounts {
+		if !bytes.Equal(status, AccountDeleted) {
+			return
+		}
+		s.clearAccountState(common.HexToAddress(acc))
+	}
 }
 
 func (s *DBImpl) clearAccountState(acc common.Address) {

--- a/x/evm/state/statedb.go
+++ b/x/evm/state/statedb.go
@@ -78,9 +78,13 @@ func (s *DBImpl) Finalize() (surplus sdk.Int, err error) {
 	for i := len(s.snapshottedCtxs) - 1; i > 0; i-- {
 		s.flushCtx(s.snapshottedCtxs[i])
 	}
+
+	// delete state of self-destructed accoutns
+	s.clearAccountStateIfDestructed(s.tempStateCurrent)
 	surplus = s.tempStateCurrent.surplus
 	for _, ts := range s.tempStatesHist {
 		surplus = surplus.Add(ts.surplus)
+		s.clearAccountStateIfDestructed(ts)
 	}
 	if surplus.IsNegative() {
 		err = fmt.Errorf("negative surplus value: %s", surplus.String())


### PR DESCRIPTION
## Describe your changes and provide context
Geth's behavior of SelfDestruct is to only clear account balance when SelfDestruct is called but clear other account states at the end of the transaction. This PR aligns sei's behavior to that of Geth's

## Testing performed to validate your change
unit test
