### PR TITLE
Set unknown method call on precompiles to be non-zero

### DIFF
--- a/precompiles/addr/addr.go
+++ b/precompiles/addr/addr.go
@@ -72,13 +72,13 @@ func NewPrecompile(evmKeeper pcommon.EVMKeeper) (*Precompile, error) {
 func (p Precompile) RequiredGas(input []byte) uint64 {
 	methodID, err := pcommon.ExtractMethodID(input)
 	if err != nil {
-		return 0
+		return pcommon.UnknownMethodCallGas
 	}
 
 	method, err := p.ABI.MethodById(methodID)
 	if err != nil {
 		// This should never happen since this method is going to fail during Run
-		return 0
+		return pcommon.UnknownMethodCallGas
 	}
 
 	return p.Precompile.RequiredGas(input, p.IsTransaction(method.Name))

--- a/precompiles/bank/bank.go
+++ b/precompiles/bank/bank.go
@@ -101,13 +101,13 @@ func NewPrecompile(bankKeeper pcommon.BankKeeper, evmKeeper pcommon.EVMKeeper) (
 func (p Precompile) RequiredGas(input []byte) uint64 {
 	methodID, err := pcommon.ExtractMethodID(input)
 	if err != nil {
-		return 0
+		return pcommon.UnknownMethodCallGas
 	}
 
 	method, err := p.ABI.MethodById(methodID)
 	if err != nil {
 		// This should never happen since this method is going to fail during Run
-		return 0
+		return pcommon.UnknownMethodCallGas
 	}
 
 	return p.Precompile.RequiredGas(input, p.IsTransaction(method.Name))

--- a/precompiles/bank/bank_test.go
+++ b/precompiles/bank/bank_test.go
@@ -196,7 +196,7 @@ func TestRequiredGas(t *testing.T) {
 	balanceRequiredGas := p.RequiredGas(p.BalanceID)
 	require.Equal(t, uint64(1000), balanceRequiredGas)
 	// invalid method
-	require.Equal(t, uint64(0), p.RequiredGas([]byte{1, 1, 1, 1}))
+	require.Equal(t, uint64(3000), p.RequiredGas([]byte{1, 1, 1, 1}))
 }
 
 func TestAddress(t *testing.T) {

--- a/precompiles/common/precompiles.go
+++ b/precompiles/common/precompiles.go
@@ -12,6 +12,8 @@ import (
 	"github.com/sei-protocol/sei-chain/x/evm/state"
 )
 
+const UnknownMethodCallGas uint64 = 3000
+
 type Contexter interface {
 	Ctx() sdk.Context
 }

--- a/precompiles/distribution/distribution.go
+++ b/precompiles/distribution/distribution.go
@@ -78,7 +78,7 @@ func NewPrecompile(distrKeeper pcommon.DistributionKeeper, evmKeeper pcommon.EVM
 func (p Precompile) RequiredGas(input []byte) uint64 {
 	methodID, err := pcommon.ExtractMethodID(input)
 	if err != nil {
-		return 0
+		return pcommon.UnknownMethodCallGas
 	}
 
 	if bytes.Equal(methodID, p.SetWithdrawAddrID) {
@@ -88,7 +88,7 @@ func (p Precompile) RequiredGas(input []byte) uint64 {
 	}
 
 	// This should never happen since this is going to fail during Run
-	return 0
+	return pcommon.UnknownMethodCallGas
 }
 
 func (p Precompile) Address() common.Address {

--- a/precompiles/gov/gov.go
+++ b/precompiles/gov/gov.go
@@ -81,7 +81,7 @@ func NewPrecompile(govKeeper pcommon.GovKeeper, evmKeeper pcommon.EVMKeeper, ban
 func (p Precompile) RequiredGas(input []byte) uint64 {
 	methodID, err := pcommon.ExtractMethodID(input)
 	if err != nil {
-		return 0
+		return pcommon.UnknownMethodCallGas
 	}
 
 	if bytes.Equal(methodID, p.VoteID) {
@@ -91,7 +91,7 @@ func (p Precompile) RequiredGas(input []byte) uint64 {
 	}
 
 	// This should never happen since this is going to fail during Run
-	return 0
+	return pcommon.UnknownMethodCallGas
 }
 
 func (p Precompile) Address() common.Address {

--- a/precompiles/ibc/ibc.go
+++ b/precompiles/ibc/ibc.go
@@ -82,13 +82,13 @@ func NewPrecompile(transferKeeper pcommon.TransferKeeper, evmKeeper pcommon.EVMK
 func (p Precompile) RequiredGas(input []byte) uint64 {
 	methodID, err := pcommon.ExtractMethodID(input)
 	if err != nil {
-		return 0
+		return pcommon.UnknownMethodCallGas
 	}
 
 	method, err := p.ABI.MethodById(methodID)
 	if err != nil {
 		// This should never happen since this method is going to fail during Run
-		return 0
+		return pcommon.UnknownMethodCallGas
 	}
 
 	return p.Precompile.RequiredGas(input, p.IsTransaction(method.Name))

--- a/precompiles/json/json.go
+++ b/precompiles/json/json.go
@@ -75,7 +75,7 @@ func NewPrecompile() (*Precompile, error) {
 // RequiredGas returns the required bare minimum gas to execute the precompile.
 func (p Precompile) RequiredGas(input []byte) uint64 {
 	if len(input) < 4 {
-		return 0
+		return pcommon.UnknownMethodCallGas
 	}
 	return uint64(GasCostPerByte * (len(input) - 4))
 }

--- a/precompiles/oracle/oracle.go
+++ b/precompiles/oracle/oracle.go
@@ -97,13 +97,13 @@ func NewPrecompile(oracleKeeper pcommon.OracleKeeper, evmKeeper pcommon.EVMKeepe
 func (p Precompile) RequiredGas(input []byte) uint64 {
 	methodID, err := pcommon.ExtractMethodID(input)
 	if err != nil {
-		return 0
+		return pcommon.UnknownMethodCallGas
 	}
 
 	method, err := p.ABI.MethodById(methodID)
 	if err != nil {
 		// This should never happen since this method is going to fail during Run
-		return 0
+		return pcommon.UnknownMethodCallGas
 	}
 
 	return p.Precompile.RequiredGas(input, p.IsTransaction(method.Name))

--- a/precompiles/pointer/pointer.go
+++ b/precompiles/pointer/pointer.go
@@ -84,7 +84,7 @@ func NewPrecompile(evmKeeper pcommon.EVMKeeper, bankKeeper pcommon.BankKeeper, w
 // RequiredGas returns the required bare minimum gas to execute the precompile.
 func (p Precompile) RequiredGas(input []byte) uint64 {
 	// gas is calculated dynamically
-	return 0
+	return pcommon.UnknownMethodCallGas
 }
 
 func (p Precompile) Address() common.Address {

--- a/precompiles/staking/staking.go
+++ b/precompiles/staking/staking.go
@@ -86,7 +86,7 @@ func NewPrecompile(stakingKeeper pcommon.StakingKeeper, evmKeeper pcommon.EVMKee
 func (p Precompile) RequiredGas(input []byte) uint64 {
 	methodID, err := pcommon.ExtractMethodID(input)
 	if err != nil {
-		return 0
+		return pcommon.UnknownMethodCallGas
 	}
 
 	if bytes.Equal(methodID, p.DelegateID) {
@@ -98,7 +98,7 @@ func (p Precompile) RequiredGas(input []byte) uint64 {
 	}
 
 	// This should never happen since this is going to fail during Run
-	return 0
+	return pcommon.UnknownMethodCallGas
 }
 
 func (p Precompile) Address() common.Address {

--- a/precompiles/wasmd/wasmd.go
+++ b/precompiles/wasmd/wasmd.go
@@ -85,13 +85,13 @@ func NewPrecompile(evmKeeper pcommon.EVMKeeper, wasmdKeeper pcommon.WasmdKeeper,
 func (p Precompile) RequiredGas(input []byte) uint64 {
 	methodID, err := pcommon.ExtractMethodID(input)
 	if err != nil {
-		return 0
+		return pcommon.UnknownMethodCallGas
 	}
 
 	method, err := p.ABI.MethodById(methodID)
 	if err != nil {
 		// This should never happen since this method is going to fail during Run
-		return 0
+		return pcommon.UnknownMethodCallGas
 	}
 
 	return p.Precompile.RequiredGas(input, p.IsTransaction(method.Name))

--- a/precompiles/wasmd/wasmd_test.go
+++ b/precompiles/wasmd/wasmd_test.go
@@ -25,7 +25,7 @@ func TestRequiredGas(t *testing.T) {
 	require.Equal(t, uint64(2000), p.RequiredGas(p.ExecuteID))
 	require.Equal(t, uint64(2000), p.RequiredGas(p.InstantiateID))
 	require.Equal(t, uint64(1000), p.RequiredGas(p.QueryID))
-	require.Equal(t, uint64(0), p.RequiredGas([]byte{15, 15, 15, 15})) // invalid method
+	require.Equal(t, uint64(3000), p.RequiredGas([]byte{15, 15, 15, 15})) // invalid method
 }
 
 func TestAddress(t *testing.T) {


### PR DESCRIPTION
## Describe your changes and provide context
Ottersec:
```
Not collecting gas for unknown precompile contract calls. This is not a critical issue in itself, since the evm call opcode already consumes gas, but we'd like to confirm whether this is intended behavior
```
This is not intended and this PR fixes it

## Testing performed to validate your change
const change
