### PR TITLE
Fix extractAsBytesList in json precompile

### DIFF
--- a/precompiles/json/json.go
+++ b/precompiles/json/json.go
@@ -155,7 +155,7 @@ func (p Precompile) extractAsBytesList(_ sdk.Context, method *abi.Method, args [
 
 	// type assertion will always succeed because it's already validated in p.Prepare call in Run()
 	bz := args[0].([]byte)
-	decoded := map[string][]gjson.RawMessage{}
+	decoded := map[string]gjson.RawMessage{}
 	if err := gjson.Unmarshal(bz, &decoded); err != nil {
 		return nil, err
 	}
@@ -164,8 +164,12 @@ func (p Precompile) extractAsBytesList(_ sdk.Context, method *abi.Method, args [
 	if !ok {
 		return nil, fmt.Errorf("input does not contain key %s", key)
 	}
+	decodedResult := []gjson.RawMessage{}
+	if err := gjson.Unmarshal(result, &decodedResult); err != nil {
+		return nil, err
+	}
 
-	return method.Outputs.Pack(utils.Map(result, func(r gjson.RawMessage) []byte { return []byte(r) }))
+	return method.Outputs.Pack(utils.Map(decodedResult, func(r gjson.RawMessage) []byte { return []byte(r) }))
 }
 
 func (p Precompile) ExtractAsUint256(_ sdk.Context, _ *abi.Method, args []interface{}, value *big.Int) (*big.Int, error) {

--- a/precompiles/json/json_test.go
+++ b/precompiles/json/json_test.go
@@ -63,16 +63,16 @@ func TestExtractAsBytesList(t *testing.T) {
 		expectedOutput [][]byte
 	}{
 		{
-			[]byte("{\"key\":[]}"),
+			[]byte("{\"key\":[],\"key2\":1}"),
 			[][]byte{},
 		}, {
-			[]byte("{\"key\":[1,2,3]}"),
+			[]byte("{\"key\":[1,2,3],\"key2\":1}"),
 			[][]byte{[]byte("1"), []byte("2"), []byte("3")},
 		}, {
-			[]byte("{\"key\":[\"1\", \"2\"]}"),
+			[]byte("{\"key\":[\"1\", \"2\"],\"key2\":1}"),
 			[][]byte{[]byte("\"1\""), []byte("\"2\"")},
 		}, {
-			[]byte("{\"key\":[{\"nested\":1}, {\"nested\":2}]}"),
+			[]byte("{\"key\":[{\"nested\":1}, {\"nested\":2}],\"key2\":1}"),
 			[][]byte{[]byte("{\"nested\":1}"), []byte("{\"nested\":2}")},
 		},
 	} {


### PR DESCRIPTION
## Describe your changes and provide context
```
The json precompile extractAsBytesList [function](https://github.com/sei-protocol/sei-chain/blob/c932310d1ca1b55adfd01a9e22baed50753dcf69/precompiles/json/json.go#L140) will fail if any of the fields in the data could not be interpreted as a list.
```

## Testing performed to validate your change
unit test
