### PR TITLE
Disallow balance change for self-destructed address

### DIFF
--- a/x/evm/state/balance.go
+++ b/x/evm/state/balance.go
@@ -18,6 +18,10 @@ func (s *DBImpl) SubBalance(evmAddr common.Address, amt *big.Int, reason tracing
 		s.AddBalance(evmAddr, new(big.Int).Neg(amt), reason)
 		return
 	}
+	if s.HasSelfDestructed(evmAddr) {
+		// redirect coins to fee collector, since simply burning here would cause coin supply mismatch
+		evmAddr, _ = s.k.GetFeeCollectorAddress(s.ctx)
+	}
 
 	usei, wei := SplitUseiWeiAmount(amt)
 	addr := s.getSeiAddress(evmAddr)
@@ -49,6 +53,10 @@ func (s *DBImpl) AddBalance(evmAddr common.Address, amt *big.Int, reason tracing
 	if amt.Sign() < 0 {
 		s.SubBalance(evmAddr, new(big.Int).Neg(amt), reason)
 		return
+	}
+	if s.HasSelfDestructed(evmAddr) {
+		// redirect coins to fee collector, since simply burning here would cause coin supply mismatch
+		evmAddr, _ = s.k.GetFeeCollectorAddress(s.ctx)
 	}
 
 	usei, wei := SplitUseiWeiAmount(amt)

--- a/x/evm/state/balance_test.go
+++ b/x/evm/state/balance_test.go
@@ -31,6 +31,12 @@ func TestAddBalance(t *testing.T) {
 	require.Nil(t, db.Err())
 	require.Equal(t, db.GetBalance(evmAddr), big.NewInt(10000000000000))
 	require.Equal(t, db.GetBalance(evmAddr2), big.NewInt(5000000000000))
+
+	_, evmAddr3 := testkeeper.MockAddressPair()
+	db.SelfDestruct(evmAddr3)
+	db.AddBalance(evmAddr2, big.NewInt(5000000000000), tracing.BalanceChangeUnspecified)
+	require.Nil(t, db.Err())
+	require.Equal(t, db.GetBalance(evmAddr3), big.NewInt(0))
 }
 
 func TestSubBalance(t *testing.T) {
@@ -62,6 +68,12 @@ func TestSubBalance(t *testing.T) {
 	// insufficient balance
 	db.SubBalance(evmAddr2, big.NewInt(10000000000000), tracing.BalanceChangeUnspecified)
 	require.NotNil(t, db.Err())
+
+	_, evmAddr3 := testkeeper.MockAddressPair()
+	db.SelfDestruct(evmAddr3)
+	db.SubBalance(evmAddr2, big.NewInt(5000000000000), tracing.BalanceChangeUnspecified)
+	require.Nil(t, db.Err())
+	require.Equal(t, db.GetBalance(evmAddr3), big.NewInt(0))
 }
 
 func TestSetBalance(t *testing.T) {


### PR DESCRIPTION
## Describe your changes and provide context
If a contract is self-destructed in the same block, we want subsequent balance changes to it to no-op, as this is the behavior in Ethereum. Note that `HasSelfDestructed`  will only return true if the self-destruct happened in the same block AND the account is not recreated in the same block

## Testing performed to validate your change
unit test

