### PR TITLE
Add mechanism for benchmarking EVM queries

### DIFF
--- a/integration_test/evm_module/hardhat_test.yaml
+++ b/integration_test/evm_module/hardhat_test.yaml
@@ -3,6 +3,7 @@
     # Fund owner account in hardhat tests
     - cmd: printf "12345678\n" | seid tx evm send 0xF87A299e6bC7bEba58dbBe5a5Aa21d49bCD16D52 10000000000000000000 --from admin | cut -d':' -f2-
       env: TX_HASH
+    - cmd: sleep 3
     - cmd: cast receipt "$TX_HASH" -j |jq -r ."status"
       env: RESULT
     # Setup for Hardhat Integration Test

--- a/loadtest/config.json
+++ b/loadtest/config.json
@@ -119,5 +119,6 @@
         "contract_address": "sei1nwp0ynjv84wxysf2f5ctvysl6dpm8ngm70hss6jeqt8q7e7u345s8zru6u",
         "percentage": "0.1"
       }
-  ]
+  ],
+  "ticks": 0
 }

--- a/loadtest/config.json
+++ b/loadtest/config.json
@@ -18,6 +18,10 @@
         "max": "21",
         "number_of_distinct_values": 20
     },
+    "post_tx_evm_queries": {
+      "block_by_number": 0,
+      "receipt": 0
+    },
     "message_configs": {
       "default": {
         "gas": 3000000,

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -202,6 +202,7 @@ func (c *LoadTestClient) BuildTxs(
 			switch messageType {
 			case EVM, ERC20, ERC721, UNIV2:
 				signedTx = SignedTx{EvmTx: c.generateSignedEvmTx(keyIndex, messageType), MsgType: messageType}
+				EvmTxHashes = append(EvmTxHashes, signedTx.EvmTx.Hash())
 			default:
 				msgTypeCount := atomic.LoadInt64(producedCountPerMsgType[messageType])
 				signedTx = SignedTx{TxBytes: c.generateSignedCosmosTxs(keyIndex, messageType, msgTypeCount), MsgType: messageType}

--- a/loadtest/types.go
+++ b/loadtest/types.go
@@ -70,6 +70,7 @@ type Config struct {
 	TLS                bool                  `json:"tls"`
 	SeiTesterAddress   string                `json:"sei_tester_address"`
 	PostTxEvmQueries   PostTxEvmQueries      `json:"post_tx_evm_queries"`
+	Ticks              uint64                `json:"ticks"`
 
 	// These are dynamically set at startup
 	EVMAddresses *EVMAddresses
@@ -214,7 +215,7 @@ type WasmInstantiateType struct {
 
 type PostTxEvmQueries struct {
 	BlockByNumber int `json:"block_by_number"`
-	Receipt       int `json:"receipt`
+	Receipt       int `json:"receipt"`
 }
 
 type SignedTx struct {

--- a/loadtest/types.go
+++ b/loadtest/types.go
@@ -69,6 +69,7 @@ type Config struct {
 	MetricsPort        uint64                `json:"metrics_port"`
 	TLS                bool                  `json:"tls"`
 	SeiTesterAddress   string                `json:"sei_tester_address"`
+	PostTxEvmQueries   PostTxEvmQueries      `json:"post_tx_evm_queries"`
 
 	// These are dynamically set at startup
 	EVMAddresses *EVMAddresses
@@ -209,6 +210,11 @@ type VortexContract struct {
 type WasmInstantiateType struct {
 	CodeID  uint64 `json:"code_id"`
 	Payload string `json:"payload"`
+}
+
+type PostTxEvmQueries struct {
+	BlockByNumber int `json:"block_by_number"`
+	Receipt       int `json:"receipt`
 }
 
 type SignedTx struct {


### PR DESCRIPTION
## Describe your changes and provide context
Add a new loadtest config `post_tx_evm_queries` to specify what EVM queries should be benchmarked after the normal EVM transactions are loadtested (since we need load first in order to query), and the number of concurrent queries to send. Right now we support two query types but more can be added:
- block header & transactions
- transaction receipt

## Testing performed to validate your change
load test cluster
