### PR TITLE
Disallow unassociated EOA addresses from using precompiles

### DIFF
--- a/contracts/test/EVMPrecompileTester.js
+++ b/contracts/test/EVMPrecompileTester.js
@@ -30,12 +30,25 @@ describe("EVM Test", function () {
     
                 // Get a contract instance
                 erc20 = new ethers.Contract(contractAddress, contractABI, signer);
+
+                // force association on owner2
+                const tx1 = await signer.sendTransaction({
+                    to: owner2,
+                    value: 100000000000000
+                });
+                const receipt1 = await tx1.wait();
+                expect(receipt1.status).to.equal(1);
+                const tx2 = await signer2.sendTransaction({
+                    to: owner,
+                    value: 1
+                });
+                const receipt2 = await tx2.wait();
+                expect(receipt2.status).to.equal(1);
             });
     
             it("Transfer function", async function() {
-                const receiver = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8';
                 const beforeBalance = await erc20.balanceOf(owner);
-                const tx = await erc20.transfer(receiver, 1);
+                const tx = await erc20.transfer(owner2, 1);
                 const receipt = await tx.wait();
                 expect(receipt.status).to.equal(1);
                 const afterBalance = await erc20.balanceOf(owner);
@@ -56,7 +69,6 @@ describe("EVM Test", function () {
             });
 
             it("Approve and TransferFrom functions", async function() {
-                const receiver = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8';
                 // lets have owner approve the transfer and have owner2 do the transferring
                 const approvalAmount = await erc20.allowance(owner, owner2);
                 expect(approvalAmount).to.equal(0);
@@ -69,13 +81,13 @@ describe("EVM Test", function () {
 
     
                 // transfer from owner to owner2
-                const balanceBefore = await erc20.balanceOf(receiver);
-                const transferFromTx = await erc20AsOwner2.transferFrom(owner, receiver, 100);
+                const balanceBefore = await erc20.balanceOf(owner2);
+                const transferFromTx = await erc20AsOwner2.transferFrom(owner, owner2, 100);
     
                 // await sleep(3000);
                 const transferFromReceipt = await transferFromTx.wait();
                 expect(transferFromReceipt.status).to.equal(1);
-                const balanceAfter = await erc20.balanceOf(receiver);
+                const balanceAfter = await erc20.balanceOf(owner2);
                 const diff = balanceAfter - balanceBefore;
                 expect(diff).to.equal(100);
             });

--- a/precompiles/bank/bank.go
+++ b/precompiles/bank/bank.go
@@ -347,7 +347,11 @@ func (p Precompile) accAddressFromArg(ctx sdk.Context, arg interface{}) (sdk.Acc
 	if addr == (common.Address{}) {
 		return nil, errors.New("invalid addr")
 	}
-	return p.evmKeeper.GetSeiAddressOrDefault(ctx, addr), nil
+	seiAddr, found := p.evmKeeper.GetSeiAddress(ctx, addr)
+	if !found {
+		return nil, fmt.Errorf("EVM address %s is not associated", addr.Hex())
+	}
+	return seiAddr, nil
 }
 
 func (Precompile) IsTransaction(method string) bool {

--- a/precompiles/common/expected_keepers.go
+++ b/precompiles/common/expected_keepers.go
@@ -24,9 +24,8 @@ type BankKeeper interface {
 
 type EVMKeeper interface {
 	GetSeiAddress(sdk.Context, common.Address) (sdk.AccAddress, bool)
-	GetSeiAddressOrDefault(ctx sdk.Context, evmAddress common.Address) sdk.AccAddress
+	GetSeiAddressOrDefault(ctx sdk.Context, evmAddress common.Address) sdk.AccAddress // only used for getting precompile Sei addresses
 	GetEVMAddress(sdk.Context, sdk.AccAddress) (common.Address, bool)
-	GetEVMAddressFromBech32OrDefault(ctx sdk.Context, seiAddress string) (common.Address, error)
 	GetCodeHash(sdk.Context, common.Address) common.Hash
 	GetPriorityNormalizer(ctx sdk.Context) sdk.Dec
 	GetBaseDenom(ctx sdk.Context) string

--- a/precompiles/distribution/distribution.go
+++ b/precompiles/distribution/distribution.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"embed"
 	"errors"
+	"fmt"
 	"math/big"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -124,7 +125,10 @@ func (p Precompile) setWithdrawAddress(ctx sdk.Context, method *abi.Method, call
 	if err := pcommon.ValidateArgsLength(args, 1); err != nil {
 		return nil, err
 	}
-	delegator := p.evmKeeper.GetSeiAddressOrDefault(ctx, caller)
+	delegator, found := p.evmKeeper.GetSeiAddress(ctx, caller)
+	if !found {
+		return nil, fmt.Errorf("delegator %s is not associated", caller.Hex())
+	}
 	withdrawAddr, err := p.accAddressFromArg(ctx, args[0])
 	if err != nil {
 		return nil, err
@@ -144,7 +148,10 @@ func (p Precompile) withdrawDelegationRewards(ctx sdk.Context, method *abi.Metho
 	if err := pcommon.ValidateArgsLength(args, 1); err != nil {
 		return nil, err
 	}
-	delegator := p.evmKeeper.GetSeiAddressOrDefault(ctx, caller)
+	delegator, found := p.evmKeeper.GetSeiAddress(ctx, caller)
+	if !found {
+		return nil, fmt.Errorf("delegator %s is not associated", caller.Hex())
+	}
 	validator, err := sdk.ValAddressFromBech32(args[0].(string))
 	if err != nil {
 		return nil, err

--- a/precompiles/gov/gov_test.go
+++ b/precompiles/gov/gov_test.go
@@ -57,10 +57,11 @@ func TestVoteDeposit(t *testing.T) {
 	req, err := evmtypes.NewMsgEVMTransaction(txwrapper)
 	require.Nil(t, err)
 
-	_, evmAddr := testkeeper.PrivateKeyToAddresses(privKey)
+	seiAddr, evmAddr := testkeeper.PrivateKeyToAddresses(privKey)
+	k.SetAddressMapping(ctx, seiAddr, evmAddr)
 	amt := sdk.NewCoins(sdk.NewCoin(k.GetBaseDenom(ctx), sdk.NewInt(200000000)))
 	require.Nil(t, k.BankKeeper().MintCoins(ctx, evmtypes.ModuleName, sdk.NewCoins(sdk.NewCoin(k.GetBaseDenom(ctx), sdk.NewInt(200000000)))))
-	require.Nil(t, k.BankKeeper().SendCoinsFromModuleToAccount(ctx, evmtypes.ModuleName, evmAddr[:], amt))
+	require.Nil(t, k.BankKeeper().SendCoinsFromModuleToAccount(ctx, evmtypes.ModuleName, seiAddr, amt))
 
 	msgServer := keeper.NewMsgServerImpl(k)
 
@@ -101,10 +102,11 @@ func TestVoteDeposit(t *testing.T) {
 		req, err := evmtypes.NewMsgEVMTransaction(txwrapper)
 		require.Nil(t, err)
 
-		_, evmAddr := testkeeper.PrivateKeyToAddresses(privKey)
+		seiAddr, evmAddr := testkeeper.PrivateKeyToAddresses(privKey)
+		k.SetAddressMapping(ctx, seiAddr, evmAddr)
 		amt := sdk.NewCoins(sdk.NewCoin(k.GetBaseDenom(ctx), sdk.NewInt(200000000)))
 		require.Nil(t, k.BankKeeper().MintCoins(ctx, evmtypes.ModuleName, sdk.NewCoins(sdk.NewCoin(k.GetBaseDenom(ctx), sdk.NewInt(200000000)))))
-		require.Nil(t, k.BankKeeper().SendCoinsFromModuleToAccount(ctx, evmtypes.ModuleName, evmAddr[:], amt))
+		require.Nil(t, k.BankKeeper().SendCoinsFromModuleToAccount(ctx, evmtypes.ModuleName, seiAddr, amt))
 
 		msgServer := keeper.NewMsgServerImpl(k)
 
@@ -113,7 +115,7 @@ func TestVoteDeposit(t *testing.T) {
 		require.Nil(t, err)
 		require.Empty(t, res.VmError)
 
-		v, found := testApp.GovKeeper.GetVote(ctx, proposal.ProposalId, evmAddr[:])
+		v, found := testApp.GovKeeper.GetVote(ctx, proposal.ProposalId, seiAddr)
 		require.True(t, found)
 		require.Equal(t, 1, len(v.Options))
 		require.Equal(t, opt, v.Options[0].Option)

--- a/precompiles/ibc/ibc.go
+++ b/precompiles/ibc/ibc.go
@@ -256,5 +256,9 @@ func (p Precompile) accAddressFromArg(ctx sdk.Context, arg interface{}) (sdk.Acc
 	if addr == (common.Address{}) {
 		return nil, errors.New("invalid addr")
 	}
-	return p.evmKeeper.GetSeiAddressOrDefault(ctx, addr), nil
+	seiAddr, found := p.evmKeeper.GetSeiAddress(ctx, addr)
+	if !found {
+		return nil, fmt.Errorf("EVM address %s is not associated", addr.Hex())
+	}
+	return seiAddr, nil
 }

--- a/precompiles/wasmd/wasmd.go
+++ b/precompiles/wasmd/wasmd.go
@@ -163,7 +163,11 @@ func (p Precompile) instantiate(ctx sdk.Context, method *abi.Method, caller comm
 
 	// type assertion will always succeed because it's already validated in p.Prepare call in Run()
 	codeID := args[0].(uint64)
-	creatorAddr := p.evmKeeper.GetSeiAddressOrDefault(ctx, caller)
+	creatorAddr, found := p.evmKeeper.GetSeiAddress(ctx, caller)
+	if !found {
+		rerr = fmt.Errorf("creator %s is not associated", caller.Hex())
+		return
+	}
 	var adminAddr sdk.AccAddress
 	adminAddrStr := args[1].(string)
 	if len(adminAddrStr) > 0 {
@@ -255,7 +259,11 @@ func (p Precompile) execute(ctx sdk.Context, method *abi.Method, caller common.A
 		rerr = err
 		return
 	}
-	senderAddr := p.evmKeeper.GetSeiAddressOrDefault(ctx, caller)
+	senderAddr, found := p.evmKeeper.GetSeiAddress(ctx, caller)
+	if !found {
+		rerr = fmt.Errorf("sender %s is not associated", caller.Hex())
+		return
+	}
 	msg := args[1].([]byte)
 	coins := sdk.NewCoins()
 	coinsBz := args[2].([]byte)

--- a/precompiles/wasmd/wasmd_test.go
+++ b/precompiles/wasmd/wasmd_test.go
@@ -39,6 +39,7 @@ func TestInstantiate(t *testing.T) {
 	testApp := app.Setup(false, false)
 	mockAddr, mockEVMAddr := testkeeper.MockAddressPair()
 	ctx := testApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	testApp.EvmKeeper.SetAddressMapping(ctx, mockAddr, mockEVMAddr)
 	wasmKeeper := wasmkeeper.NewDefaultPermissionKeeper(testApp.WasmKeeper)
 	p, err := wasmd.NewPrecompile(&testApp.EvmKeeper, wasmKeeper, testApp.WasmKeeper, testApp.BankKeeper)
 	require.Nil(t, err)
@@ -70,7 +71,7 @@ func TestInstantiate(t *testing.T) {
 	require.Equal(t, 2, len(outputs))
 	require.Equal(t, "sei1hrpna9v7vs3stzyd4z3xf00676kf78zpe2u5ksvljswn2vnjp3yslucc3n", outputs[0].(string))
 	require.Empty(t, outputs[1].([]byte))
-	require.Equal(t, uint64(902898), g)
+	require.Equal(t, uint64(902838), g)
 
 	// non-existent code ID
 	args, _ = instantiateMethod.Inputs.Pack(
@@ -171,8 +172,9 @@ func TestExecute(t *testing.T) {
 
 func TestQuery(t *testing.T) {
 	testApp := app.Setup(false, false)
-	mockAddr, _ := testkeeper.MockAddressPair()
+	mockAddr, mockEVMAddr := testkeeper.MockAddressPair()
 	ctx := testApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	testApp.EvmKeeper.SetAddressMapping(ctx, mockAddr, mockEVMAddr)
 	wasmKeeper := wasmkeeper.NewDefaultPermissionKeeper(testApp.WasmKeeper)
 	p, err := wasmd.NewPrecompile(&testApp.EvmKeeper, wasmKeeper, testApp.WasmKeeper, testApp.BankKeeper)
 	require.Nil(t, err)

--- a/x/evm/client/wasm/query_test.go
+++ b/x/evm/client/wasm/query_test.go
@@ -13,8 +13,10 @@ import (
 
 func TestERC721TransferPayload(t *testing.T) {
 	k, ctx := testkeeper.MockEVMKeeper()
-	addr1, _ := testkeeper.MockAddressPair()
-	addr2, _ := testkeeper.MockAddressPair()
+	addr1, e1 := testkeeper.MockAddressPair()
+	addr2, e2 := testkeeper.MockAddressPair()
+	k.SetAddressMapping(ctx, addr1, e1)
+	k.SetAddressMapping(ctx, addr2, e2)
 	h := wasm.NewEVMQueryHandler(k)
 	res, err := h.HandleERC721TransferPayload(ctx, addr1.String(), addr2.String(), "1")
 	require.Nil(t, err)
@@ -23,7 +25,8 @@ func TestERC721TransferPayload(t *testing.T) {
 
 func TestERC721ApprovePayload(t *testing.T) {
 	k, ctx := testkeeper.MockEVMKeeper()
-	addr1, _ := testkeeper.MockAddressPair()
+	addr1, e1 := testkeeper.MockAddressPair()
+	k.SetAddressMapping(ctx, addr1, e1)
 	h := wasm.NewEVMQueryHandler(k)
 	res, err := h.HandleERC721ApprovePayload(ctx, addr1.String(), "1")
 	require.Nil(t, err)
@@ -32,7 +35,8 @@ func TestERC721ApprovePayload(t *testing.T) {
 
 func TestERC721ApproveAllPayload(t *testing.T) {
 	k, ctx := testkeeper.MockEVMKeeper()
-	addr1, _ := testkeeper.MockAddressPair()
+	addr1, e1 := testkeeper.MockAddressPair()
+	k.SetAddressMapping(ctx, addr1, e1)
 	h := wasm.NewEVMQueryHandler(k)
 	res, err := h.HandleERC721SetApprovalAllPayload(ctx, addr1.String(), true)
 	require.Nil(t, err)
@@ -41,7 +45,8 @@ func TestERC721ApproveAllPayload(t *testing.T) {
 
 func TestERC20TransferPayload(t *testing.T) {
 	k, ctx := testkeeper.MockEVMKeeper()
-	addr1, _ := testkeeper.MockAddressPair()
+	addr1, e1 := testkeeper.MockAddressPair()
+	k.SetAddressMapping(ctx, addr1, e1)
 	h := wasm.NewEVMQueryHandler(k)
 	value := types.NewInt(500)
 	res, err := h.HandleERC20TransferPayload(ctx, addr1.String(), &value)
@@ -51,8 +56,10 @@ func TestERC20TransferPayload(t *testing.T) {
 
 func TestERC20TransferFromPayload(t *testing.T) {
 	k, ctx := testkeeper.MockEVMKeeper()
-	addr1, _ := testkeeper.MockAddressPair()
-	addr2, _ := testkeeper.MockAddressPair()
+	addr1, e1 := testkeeper.MockAddressPair()
+	addr2, e2 := testkeeper.MockAddressPair()
+	k.SetAddressMapping(ctx, addr1, e1)
+	k.SetAddressMapping(ctx, addr2, e2)
 	h := wasm.NewEVMQueryHandler(k)
 	value := types.NewInt(500)
 	res, err := h.HandleERC20TransferFromPayload(ctx, addr1.String(), addr2.String(), &value)
@@ -62,7 +69,8 @@ func TestERC20TransferFromPayload(t *testing.T) {
 
 func TestERC20ApprovePayload(t *testing.T) {
 	k, ctx := testkeeper.MockEVMKeeper()
-	addr1, _ := testkeeper.MockAddressPair()
+	addr1, e1 := testkeeper.MockAddressPair()
+	k.SetAddressMapping(ctx, addr1, e1)
 	h := wasm.NewEVMQueryHandler(k)
 	value := types.NewInt(500)
 	res, err := h.HandleERC20ApprovePayload(ctx, addr1.String(), &value)
@@ -75,6 +83,7 @@ func TestGetAddress(t *testing.T) {
 	seiAddr1, evmAddr1 := testkeeper.MockAddressPair()
 	k.SetAddressMapping(ctx, seiAddr1, evmAddr1)
 	seiAddr2, evmAddr2 := testkeeper.MockAddressPair()
+	k.SetAddressMapping(ctx, seiAddr2, evmAddr2)
 	h := wasm.NewEVMQueryHandler(k)
 	getEvmAddrResp := &bindings.GetEvmAddressResponse{}
 	res, err := h.HandleGetEvmAddress(ctx, seiAddr1.String())
@@ -86,7 +95,7 @@ func TestGetAddress(t *testing.T) {
 	res, err = h.HandleGetEvmAddress(ctx, seiAddr2.String())
 	require.Nil(t, err)
 	require.Nil(t, json.Unmarshal(res, getEvmAddrResp))
-	require.False(t, getEvmAddrResp.Associated)
+	require.True(t, getEvmAddrResp.Associated)
 	getSeiAddrResp := &bindings.GetSeiAddressResponse{}
 	res, err = h.HandleGetSeiAddress(ctx, evmAddr1.Hex())
 	require.Nil(t, err)
@@ -97,5 +106,5 @@ func TestGetAddress(t *testing.T) {
 	res, err = h.HandleGetSeiAddress(ctx, evmAddr2.Hex())
 	require.Nil(t, err)
 	require.Nil(t, json.Unmarshal(res, getSeiAddrResp))
-	require.False(t, getSeiAddrResp.Associated)
+	require.True(t, getSeiAddrResp.Associated)
 }

--- a/x/evm/keeper/address.go
+++ b/x/evm/keeper/address.go
@@ -45,14 +45,6 @@ func (k *Keeper) GetEVMAddressOrDefault(ctx sdk.Context, seiAddress sdk.AccAddre
 	return common.BytesToAddress(seiAddress)
 }
 
-func (k *Keeper) GetEVMAddressFromBech32OrDefault(ctx sdk.Context, seiAddress string) (common.Address, error) {
-	seiAddr, err := sdk.AccAddressFromBech32(seiAddress)
-	if err != nil {
-		return common.Address{}, err
-	}
-	return k.GetEVMAddressOrDefault(ctx, seiAddr), nil
-}
-
 func (k *Keeper) GetSeiAddress(ctx sdk.Context, evmAddress common.Address) (sdk.AccAddress, bool) {
 	store := ctx.KVStore(k.storeKey)
 	bz := store.Get(types.EVMAddressToSeiAddressKey(evmAddress))

--- a/x/evm/keeper/evm.go
+++ b/x/evm/keeper/evm.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"math/big"
 
@@ -47,6 +48,12 @@ func (k *Keeper) HandleInternalEVMDelegateCall(ctx sdk.Context, req *types.MsgIn
 	senderAddr, err := sdk.AccAddressFromBech32(req.Sender)
 	if err != nil {
 		return nil, err
+	}
+	// delegatecall caller must be associated; otherwise any state change on EVM contract will be lost
+	// after they asssociate.
+	_, found := k.GetEVMAddress(ctx, senderAddr)
+	if !found {
+		return nil, fmt.Errorf("sender %s is not associated", req.Sender)
 	}
 	ret, err := k.CallEVM(ctx, senderAddr, to, &zeroInt, req.Data)
 	if err != nil {

--- a/x/evm/state/utils_test.go
+++ b/x/evm/state/utils_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestGetCoinbaseAddress(t *testing.T) {
-	coinbaseAddr := state.GetCoinbaseAddress(1)
-	require.Equal(t, coinbaseAddr.String(), "sei1v4mx6hmrda5kucnpwdjsqqqqqqqqqqqpz6djs7")
+	coinbaseAddr := state.GetCoinbaseAddress(1).String()
+	require.Equal(t, coinbaseAddr, "sei1v4mx6hmrda5kucnpwdjsqqqqqqqqqqqpz6djs7")
 }
 
 func TestSplitUseiWeiAmount(t *testing.T) {


### PR DESCRIPTION
## Describe your changes and provide context
This PR is to address an issue found in Sec3 audit.

If unassociated EOA addresses are allowed to use precompiles like `wasmd` or `staking`, they will leave behind states key'ed under their default address counterpart (i.e. direct casting), which will be impossible to identify and merge when the account does get associated. As a result, we need to restrict unassociated addresses from making any precompile calls.

## Testing performed to validate your change
unit tests
