### PR TITLE
[EVM] charge fees in ante handler

### DIFF
--- a/app/ante_test.go
+++ b/app/ante_test.go
@@ -262,5 +262,5 @@ func TestEvmAnteErrorHandler(t *testing.T) {
 	}})
 	deferredInfo := testkeeper.EVMTestApp.EvmKeeper.GetEVMTxDeferredInfo(ctx)
 	require.Equal(t, 1, len(deferredInfo))
-	require.Equal(t, "incorrect account sequence", deferredInfo[0].Error)
+	require.Contains(t, deferredInfo[0].Error, "nonce too high")
 }

--- a/cmd/seid/cmd/blocktest.go
+++ b/cmd/seid/cmd/blocktest.go
@@ -18,6 +18,7 @@ import (
 	aclkeeper "github.com/cosmos/cosmos-sdk/x/accesscontrol/keeper"
 	ethtests "github.com/ethereum/go-ethereum/tests"
 	"github.com/sei-protocol/sei-chain/app"
+	evmtypes "github.com/sei-protocol/sei-chain/x/evm/types"
 	"github.com/tendermint/tendermint/libs/log"
 
 	//nolint:gosec,G108
@@ -57,6 +58,8 @@ func BlocktestCmd(defaultNodeHome string) *cobra.Command {
 			cache := store.NewCommitKVStoreCacheManager()
 			wasmGasRegisterConfig := wasmkeeper.DefaultGasRegisterConfig()
 			wasmGasRegisterConfig.GasMultiplier = 21_000_000
+			// turn on Cancun for block test
+			evmtypes.CancunTime = 0
 			a := app.New(
 				logger,
 				db,

--- a/go.mod
+++ b/go.mod
@@ -349,7 +349,7 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.80-seiv2
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.9
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.0
-	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-13
+	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-15
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/sei-protocol/sei-db => github.com/sei-protocol/sei-db v0.0.35
 	// Latest goleveldb is broken, we have to stick to this version

--- a/go.sum
+++ b/go.sum
@@ -1343,8 +1343,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-13 h1:ied1MMoqJyTEPvT7AtJeVTn3bEuwksInfvyXxp2siLw=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-13/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-15 h1:VSFQrbWnSDCPCQzsYDW3k07EP3yPZb+4xAcED9kSKpg=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-15/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-cosmos v0.2.80-seiv2 h1:stu0hTZmQWvewzr/y40iZrKsKHFuCXFKNEJGsgivvL4=

--- a/x/evm/derived/derived.go
+++ b/x/evm/derived/derived.go
@@ -19,6 +19,7 @@ type Derived struct {
 	PubKey        *secp256k1.PubKey
 	IsAssociate   bool
 	Version       SignerVersion
+	AnteSurplus   sdk.Int
 }
 
 // Derived should never come from deserialization or be transmitted after serialization,

--- a/x/evm/keeper/evm.go
+++ b/x/evm/keeper/evm.go
@@ -131,7 +131,7 @@ func (k *Keeper) getOrCreateEVM(ctx sdk.Context, from sdk.AccAddress) (*vm.EVM, 
 	}
 	executionCtx := ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
 	stateDB := state.NewDBImpl(executionCtx, k, false)
-	executionCtx, gp := k.getGasPool(executionCtx)
+	gp := k.GetGasPool()
 	blockCtx, err := k.GetVMBlockContext(executionCtx, gp)
 	if err != nil {
 		return nil, nil, err

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -200,6 +200,7 @@ func (k *Keeper) GetVMBlockContext(ctx sdk.Context, gp core.GasPool) (*vm.BlockC
 		Time:        uint64(ctx.BlockHeader().Time.Unix()),
 		Difficulty:  utils.Big0,                                     // only needed for PoW
 		BaseFee:     k.GetBaseFeePerGas(ctx).TruncateInt().BigInt(), // feemarket not enabled
+		BlobBaseFee: utils.Big0,                                     // Cancun not enabled
 		Random:      &rh,
 	}, nil
 }

--- a/x/evm/state/statedb.go
+++ b/x/evm/state/statedb.go
@@ -53,6 +53,13 @@ func NewDBImpl(ctx sdk.Context, k EVMKeeper, simulation bool) *DBImpl {
 	return s
 }
 
+func (s *DBImpl) AddSurplus(surplus sdk.Int) {
+	if surplus.IsNil() || surplus.IsZero() {
+		return
+	}
+	s.tempStateCurrent.surplus = s.tempStateCurrent.surplus.Add(surplus)
+}
+
 func (s *DBImpl) DisableEvents() {
 	s.eventsSuppressed = true
 }

--- a/x/evm/types/config.go
+++ b/x/evm/types/config.go
@@ -8,6 +8,8 @@ import (
 	"github.com/sei-protocol/sei-chain/utils"
 )
 
+var CancunTime int64 = -1
+
 /*
 *
 XXBlock/Time fields indicate upgrade heights/timestamps. For example, a BerlinBlock
@@ -45,7 +47,7 @@ func (cc ChainConfig) EthereumConfig(chainID *big.Int) *params.ChainConfig {
 
 func DefaultChainConfig() ChainConfig {
 	return ChainConfig{
-		CancunTime: 0,
+		CancunTime: CancunTime,
 		PragueTime: -1,
 		VerkleTime: -1,
 	}


### PR DESCRIPTION
## Describe your changes and provide context
Previously gas fees are charged inside `msg_server`, which means if any non-VM error is thrown in `msg_server`, the fee charge would be reverted alongside everything else. This makes it free for attackers who are able to identify a non-VM error trigger in `msg_server` (e.g. a bug in sei code) to spam the chain. This PR frontload gas fee charges to the ante handler, so that errors in `msg_server` would not affect fee charges.

One complexity is around surplus handling: we keep track of surplus/deficit when manipulating balances within EVM world because credits and debits are disjoint in EVM. While we charge fees in ante handler, we don't want to credit those fees to fee collectors until the transaction finishes processing in `msg_server`, because that's the only time we'd know how much fees need to be refunded. As such, the single-leg debit for fee charge in ante handler will have its associated surplus carried over into `msg_server` and settled against all other surpluses.

## Testing performed to validate your change
TODO
