### PR TITLE
Add limit to filter logs

### DIFF
--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -496,6 +496,15 @@ checktx_timeout = "{{ .EVM.CheckTxTimeout }}"
 # controls whether to have txns go through one by one
 slow = {{ .EVM.Slow }}
 
+# Deny list defines list of methods that EVM RPC should fail fast
+deny_list = {{ .EVM.DenyList }}
+
+# max number of logs returned if block range is open-ended
+max_log_no_block = {{ .EVM.MaxLogNoBlock }}
+
+# max number of blocks to query logs for
+max_blocks_for_log = {{ .EVM.MaxBlocksForLog }}
+
 [eth_replay]
 eth_replay_enabled = {{ .ETHReplay.Enabled }}
 eth_rpc = "{{ .ETHReplay.EthRPC }}"

--- a/evmrpc/config.go
+++ b/evmrpc/config.go
@@ -73,6 +73,12 @@ type Config struct {
 
 	// Deny list defines list of methods that EVM RPC should fail fast
 	DenyList []string `mapstructure:"deny_list"`
+
+	// max number of logs returned if block range is open-ended
+	MaxLogNoBlock int64 `mapstructure:"max_log_no_block"`
+
+	// max number of blocks to query logs for
+	MaxBlocksForLog int64 `mapstructure:"max_blocks_for_log"`
 }
 
 var DefaultConfig = Config{
@@ -93,6 +99,8 @@ var DefaultConfig = Config{
 	MaxTxPoolTxs:         1000,
 	Slow:                 false,
 	DenyList:             make([]string, 0),
+	MaxLogNoBlock:        10000,
+	MaxBlocksForLog:      2000,
 }
 
 const (
@@ -113,6 +121,8 @@ const (
 	flagCheckTxTimeout       = "evm.checktx_timeout"
 	flagSlow                 = "evm.slow"
 	flagDenyList             = "evm.deny_list"
+	flagMaxLogNoBlock        = "evm.max_log_no_block"
+	flagMaxBlocksForLog      = "evm.max_blocks_for_log"
 )
 
 func ReadConfig(opts servertypes.AppOptions) (Config, error) {
@@ -200,6 +210,16 @@ func ReadConfig(opts servertypes.AppOptions) (Config, error) {
 	}
 	if v := opts.Get(flagDenyList); v != nil {
 		if cfg.DenyList, err = cast.ToStringSliceE(v); err != nil {
+			return cfg, err
+		}
+	}
+	if v := opts.Get(flagMaxLogNoBlock); v != nil {
+		if cfg.MaxLogNoBlock, err = cast.ToInt64E(v); err != nil {
+			return cfg, err
+		}
+	}
+	if v := opts.Get(flagMaxBlocksForLog); v != nil {
+		if cfg.MaxBlocksForLog, err = cast.ToInt64E(v); err != nil {
 			return cfg, err
 		}
 	}

--- a/evmrpc/config_test.go
+++ b/evmrpc/config_test.go
@@ -26,6 +26,8 @@ type opts struct {
 	maxTxPoolTxs         interface{}
 	slow                 interface{}
 	denyList             interface{}
+	maxLogNoBlock        interface{}
+	maxBlocksForLog      interface{}
 }
 
 func (o *opts) Get(k string) interface{} {
@@ -80,6 +82,12 @@ func (o *opts) Get(k string) interface{} {
 	if k == "evm.deny_list" {
 		return o.denyList
 	}
+	if k == "evm.max_log_no_block" {
+		return o.maxLogNoBlock
+	}
+	if k == "evm.max_blocks_for_log" {
+		return o.maxBlocksForLog
+	}
 	panic("unknown key")
 }
 
@@ -102,6 +110,8 @@ func TestReadConfig(t *testing.T) {
 		1000,
 		false,
 		make([]string, 0),
+		20000,
+		1000,
 	}
 	_, err := evmrpc.ReadConfig(&goodOpts)
 	require.Nil(t, err)

--- a/evmrpc/filter_test.go
+++ b/evmrpc/filter_test.go
@@ -246,7 +246,7 @@ func TestFilterGetFilterChanges(t *testing.T) {
 
 	resObj = sendRequest(t, TestPort, "getFilterChanges", filterId)
 	logs := resObj["result"].([]interface{})
-	require.Equal(t, 5, len(logs))
+	require.Equal(t, 4, len(logs)) // limited by MaxLogNoBlock config to 4
 	logObj := logs[0].(map[string]interface{})
 	require.Equal(t, "0x2", logObj["blockNumber"].(string))
 

--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -72,7 +72,7 @@ func NewEVMHTTPServer(
 		},
 		{
 			Namespace: "eth",
-			Service:   NewFilterAPI(tmClient, &LogFetcher{tmClient: tmClient, k: k, ctxProvider: ctxProvider}, &FilterConfig{timeout: config.FilterTimeout}),
+			Service:   NewFilterAPI(tmClient, &LogFetcher{tmClient: tmClient, k: k, ctxProvider: ctxProvider}, &FilterConfig{timeout: config.FilterTimeout, maxLog: config.MaxLogNoBlock, maxBlock: config.MaxBlocksForLog}),
 		},
 		{
 			Namespace: "sei",

--- a/evmrpc/setup_test.go
+++ b/evmrpc/setup_test.go
@@ -407,6 +407,7 @@ func init() {
 	goodConfig.HTTPPort = TestPort
 	goodConfig.WSPort = TestWSPort
 	goodConfig.FilterTimeout = 500 * time.Millisecond
+	goodConfig.MaxLogNoBlock = 4
 	infoLog, err := log.NewDefaultLogger("text", "info")
 	if err != nil {
 		panic(err)

--- a/evmrpc/subscribe.go
+++ b/evmrpc/subscribe.go
@@ -33,6 +33,7 @@ type SubscriptionConfig struct {
 }
 
 func NewSubscriptionAPI(tmClient rpcclient.Client, logFetcher *LogFetcher, subscriptionConfig *SubscriptionConfig) *SubscriptionAPI {
+	logFetcher.filterConfig = &FilterConfig{}
 	return &SubscriptionAPI{
 		tmClient:            tmClient,
 		subscriptionManager: NewSubscriptionManager(tmClient),


### PR DESCRIPTION
## Describe your changes and provide context
We want to apply a limit for log-related queries similar to how Alchemy does for its endpoints:
<img width="634" alt="Screen Shot 2024-04-17 at 11 53 57 AM" src="https://github.com/sei-protocol/sei-chain/assets/6227889/7e61a539-28f3-4e8b-a48f-579492a88fb7">


## Testing performed to validate your change
unit test
