### PR TITLE
Cleanup EVM CLI

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -670,6 +670,7 @@ func New(
 
 	if enableCustomEVMPrecompiles {
 		if err := precompiles.InitializePrecompiles(
+			false,
 			&app.EvmKeeper,
 			app.BankKeeper,
 			wasmkeeper.NewDefaultPermissionKeeper(app.WasmKeeper),

--- a/precompiles/addr/addr.go
+++ b/precompiles/addr/addr.go
@@ -88,6 +88,10 @@ func (p Precompile) Address() common.Address {
 	return p.address
 }
 
+func (p Precompile) GetName() string {
+	return "addr"
+}
+
 func (p Precompile) Run(evm *vm.EVM, _ common.Address, _ common.Address, input []byte, value *big.Int, _ bool) (bz []byte, err error) {
 	ctx, method, args, err := p.Prepare(evm, input)
 	if err != nil {

--- a/precompiles/bank/bank.go
+++ b/precompiles/bank/bank.go
@@ -126,6 +126,10 @@ func (p Precompile) Address() common.Address {
 	return p.address
 }
 
+func (p Precompile) GetName() string {
+	return "bank"
+}
+
 func (p Precompile) Run(evm *vm.EVM, caller common.Address, callingContract common.Address, input []byte, value *big.Int, readOnly bool) (bz []byte, err error) {
 	ctx, method, args, err := p.Prepare(evm, input)
 	if err != nil {

--- a/precompiles/common/precompiles.go
+++ b/precompiles/common/precompiles.go
@@ -55,6 +55,10 @@ func (p Precompile) Prepare(evm *vm.EVM, input []byte) (sdk.Context, *abi.Method
 	return ctxer.Ctx(), method, args, nil
 }
 
+func (p Precompile) GetABI() abi.ABI {
+	return p.ABI
+}
+
 func ValidateArgsLength(args []interface{}, length int) error {
 	if len(args) != length {
 		return fmt.Errorf("expected %d arguments but got %d", length, len(args))

--- a/precompiles/distribution/distribution.go
+++ b/precompiles/distribution/distribution.go
@@ -96,6 +96,10 @@ func (p Precompile) Address() common.Address {
 	return p.address
 }
 
+func (p Precompile) GetName() string {
+	return "distribution"
+}
+
 func (p Precompile) Run(evm *vm.EVM, caller common.Address, callingContract common.Address, input []byte, value *big.Int, readOnly bool) (bz []byte, err error) {
 	if readOnly {
 		return nil, errors.New("cannot call distr precompile from staticcall")

--- a/precompiles/gov/gov.go
+++ b/precompiles/gov/gov.go
@@ -99,6 +99,10 @@ func (p Precompile) Address() common.Address {
 	return p.address
 }
 
+func (p Precompile) GetName() string {
+	return "gov"
+}
+
 func (p Precompile) Run(evm *vm.EVM, caller common.Address, callingContract common.Address, input []byte, value *big.Int, readOnly bool) (bz []byte, err error) {
 	if readOnly {
 		return nil, errors.New("cannot call gov precompile from staticcall")

--- a/precompiles/ibc/ibc.go
+++ b/precompiles/ibc/ibc.go
@@ -251,6 +251,10 @@ func (p Precompile) Address() common.Address {
 	return p.address
 }
 
+func (p Precompile) GetName() string {
+	return "ibc"
+}
+
 func (p Precompile) accAddressFromArg(ctx sdk.Context, arg interface{}) (sdk.AccAddress, error) {
 	addr := arg.(common.Address)
 	if addr == (common.Address{}) {

--- a/precompiles/json/json.go
+++ b/precompiles/json/json.go
@@ -88,6 +88,10 @@ func (p Precompile) Address() common.Address {
 	return p.address
 }
 
+func (p Precompile) GetName() string {
+	return "json"
+}
+
 func (p Precompile) Run(evm *vm.EVM, _ common.Address, _ common.Address, input []byte, value *big.Int, _ bool) (bz []byte, err error) {
 	ctx, method, args, err := p.Prepare(evm, input)
 	if err != nil {

--- a/precompiles/oracle/oracle.go
+++ b/precompiles/oracle/oracle.go
@@ -113,6 +113,10 @@ func (p Precompile) Address() common.Address {
 	return p.address
 }
 
+func (p Precompile) GetName() string {
+	return "oracle"
+}
+
 func (p Precompile) Run(evm *vm.EVM, _ common.Address, _ common.Address, input []byte, value *big.Int, _ bool) (bz []byte, err error) {
 	ctx, method, args, err := p.Prepare(evm, input)
 	if err != nil {

--- a/precompiles/pointer/pointer.go
+++ b/precompiles/pointer/pointer.go
@@ -93,6 +93,10 @@ func (p Precompile) Address() common.Address {
 	return p.address
 }
 
+func (p Precompile) GetName() string {
+	return "pointer"
+}
+
 func (p Precompile) RunAndCalculateGas(evm *vm.EVM, caller common.Address, callingContract common.Address, input []byte, suppliedGas uint64, value *big.Int, _ *tracing.Hooks, readOnly bool) (ret []byte, remainingGas uint64, err error) {
 	if readOnly {
 		return nil, 0, errors.New("cannot call pointer precompile from staticcall")

--- a/precompiles/pointerview/pointerview.go
+++ b/precompiles/pointerview/pointerview.go
@@ -78,6 +78,10 @@ func (p Precompile) Address() common.Address {
 	return p.address
 }
 
+func (p Precompile) GetName() string {
+	return "pointerview"
+}
+
 func (p Precompile) Run(evm *vm.EVM, _ common.Address, _ common.Address, input []byte, _ *big.Int, _ bool) (ret []byte, err error) {
 	ctx, method, args, err := p.Prepare(evm, input)
 	if err != nil {

--- a/precompiles/setup.go
+++ b/precompiles/setup.go
@@ -3,6 +3,7 @@ package precompiles
 import (
 	"sync"
 
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	ecommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/sei-protocol/sei-chain/precompiles/addr"
@@ -22,7 +23,23 @@ import (
 var SetupMtx = &sync.Mutex{}
 var Initialized = false
 
+type PrecompileInfo struct {
+	ABI     abi.ABI
+	Address ecommon.Address
+}
+
+// PrecompileNamesToInfo is Populated by InitializePrecompiles
+var PrecompileNamesToInfo = map[string]PrecompileInfo{}
+
+type IPrecompile interface {
+	vm.PrecompiledContract
+	GetABI() abi.ABI
+	GetName() string
+	Address() ecommon.Address
+}
+
 func InitializePrecompiles(
+	dryRun bool,
 	evmKeeper common.EVMKeeper,
 	bankKeeper common.BankKeeper,
 	wasmdKeeper common.WasmdKeeper,
@@ -42,73 +59,98 @@ func InitializePrecompiles(
 	if err != nil {
 		return err
 	}
-	addPrecompileToVM(bankp, bankp.Address())
 	wasmdp, err := wasmd.NewPrecompile(evmKeeper, wasmdKeeper, wasmdViewKeeper, bankKeeper)
 	if err != nil {
 		return err
 	}
-	addPrecompileToVM(wasmdp, wasmdp.Address())
 	jsonp, err := json.NewPrecompile()
 	if err != nil {
 		return err
 	}
-	addPrecompileToVM(jsonp, jsonp.Address())
 	addrp, err := addr.NewPrecompile(evmKeeper)
 	if err != nil {
 		return err
 	}
-	addPrecompileToVM(addrp, addrp.Address())
 	stakingp, err := staking.NewPrecompile(stakingKeeper, evmKeeper, bankKeeper)
 	if err != nil {
 		return err
 	}
-	addPrecompileToVM(stakingp, stakingp.Address())
 	govp, err := gov.NewPrecompile(govKeeper, evmKeeper, bankKeeper)
 	if err != nil {
 		return err
 	}
-	addPrecompileToVM(govp, govp.Address())
 	distrp, err := distribution.NewPrecompile(distrKeeper, evmKeeper)
 	if err != nil {
 		return err
 	}
-	addPrecompileToVM(distrp, distrp.Address())
 	oraclep, err := oracle.NewPrecompile(oracleKeeper, evmKeeper)
 	if err != nil {
 		return err
 	}
-	addPrecompileToVM(oraclep, oraclep.Address())
 	ibcp, err := ibc.NewPrecompile(transferKeeper, evmKeeper)
 	if err != nil {
 		return err
 	}
-	addPrecompileToVM(ibcp, ibcp.Address())
 	pointerp, err := pointer.NewPrecompile(evmKeeper, bankKeeper, wasmdViewKeeper)
 	if err != nil {
 		return err
 	}
-	addPrecompileToVM(pointerp, pointerp.Address())
 	pointerviewp, err := pointerview.NewPrecompile(evmKeeper)
 	if err != nil {
 		return err
 	}
-	addPrecompileToVM(pointerviewp, pointerviewp.Address())
-	Initialized = true
+	PrecompileNamesToInfo[bankp.GetName()] = PrecompileInfo{ABI: bankp.GetABI(), Address: bankp.Address()}
+	PrecompileNamesToInfo[wasmdp.GetName()] = PrecompileInfo{ABI: wasmdp.GetABI(), Address: wasmdp.Address()}
+	PrecompileNamesToInfo[jsonp.GetName()] = PrecompileInfo{ABI: jsonp.GetABI(), Address: jsonp.Address()}
+	PrecompileNamesToInfo[addrp.GetName()] = PrecompileInfo{ABI: addrp.GetABI(), Address: addrp.Address()}
+	PrecompileNamesToInfo[stakingp.GetName()] = PrecompileInfo{ABI: stakingp.GetABI(), Address: stakingp.Address()}
+	PrecompileNamesToInfo[govp.GetName()] = PrecompileInfo{ABI: govp.GetABI(), Address: govp.Address()}
+	PrecompileNamesToInfo[distrp.GetName()] = PrecompileInfo{ABI: distrp.GetABI(), Address: distrp.Address()}
+	PrecompileNamesToInfo[oraclep.GetName()] = PrecompileInfo{ABI: oraclep.GetABI(), Address: oraclep.Address()}
+	PrecompileNamesToInfo[ibcp.GetName()] = PrecompileInfo{ABI: ibcp.GetABI(), Address: ibcp.Address()}
+	PrecompileNamesToInfo[pointerp.GetName()] = PrecompileInfo{ABI: pointerp.GetABI(), Address: pointerp.Address()}
+	PrecompileNamesToInfo[pointerviewp.GetName()] = PrecompileInfo{ABI: pointerviewp.GetABI(), Address: pointerviewp.Address()}
+	if !dryRun {
+		addPrecompileToVM(bankp)
+		addPrecompileToVM(wasmdp)
+		addPrecompileToVM(jsonp)
+		addPrecompileToVM(addrp)
+		addPrecompileToVM(stakingp)
+		addPrecompileToVM(govp)
+		addPrecompileToVM(distrp)
+		addPrecompileToVM(oraclep)
+		addPrecompileToVM(ibcp)
+		addPrecompileToVM(pointerp)
+		addPrecompileToVM(pointerviewp)
+		Initialized = true
+	}
 	return nil
+}
+
+func GetPrecompileInfo(name string) PrecompileInfo {
+	if !Initialized {
+		// Precompile Info does not require any keeper state
+		_ = InitializePrecompiles(true, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	}
+	i, ok := PrecompileNamesToInfo[name]
+	if !ok {
+		panic(name + "doesn't exist as a precompile")
+	}
+	return i
 }
 
 // This function modifies global variable in `vm` module. It should only be called once
 // per precompile during initialization
-func addPrecompileToVM(p vm.PrecompiledContract, addr ecommon.Address) {
-	vm.PrecompiledContractsHomestead[addr] = p
-	vm.PrecompiledContractsByzantium[addr] = p
-	vm.PrecompiledContractsIstanbul[addr] = p
-	vm.PrecompiledContractsBerlin[addr] = p
-	vm.PrecompiledContractsCancun[addr] = p
-	vm.PrecompiledContractsBLS[addr] = p
-	vm.PrecompiledAddressesHomestead = append(vm.PrecompiledAddressesHomestead, addr)
-	vm.PrecompiledAddressesByzantium = append(vm.PrecompiledAddressesByzantium, addr)
-	vm.PrecompiledAddressesIstanbul = append(vm.PrecompiledAddressesIstanbul, addr)
-	vm.PrecompiledAddressesBerlin = append(vm.PrecompiledAddressesBerlin, addr)
-	vm.PrecompiledAddressesCancun = append(vm.PrecompiledAddressesCancun, addr)
+func addPrecompileToVM(p IPrecompile) {
+	vm.PrecompiledContractsHomestead[p.Address()] = p
+	vm.PrecompiledContractsByzantium[p.Address()] = p
+	vm.PrecompiledContractsIstanbul[p.Address()] = p
+	vm.PrecompiledContractsBerlin[p.Address()] = p
+	vm.PrecompiledContractsCancun[p.Address()] = p
+	vm.PrecompiledContractsBLS[p.Address()] = p
+	vm.PrecompiledAddressesHomestead = append(vm.PrecompiledAddressesHomestead, p.Address())
+	vm.PrecompiledAddressesByzantium = append(vm.PrecompiledAddressesByzantium, p.Address())
+	vm.PrecompiledAddressesIstanbul = append(vm.PrecompiledAddressesIstanbul, p.Address())
+	vm.PrecompiledAddressesBerlin = append(vm.PrecompiledAddressesBerlin, p.Address())
+	vm.PrecompiledAddressesCancun = append(vm.PrecompiledAddressesCancun, p.Address())
 }

--- a/precompiles/staking/staking.go
+++ b/precompiles/staking/staking.go
@@ -105,6 +105,10 @@ func (p Precompile) Address() common.Address {
 	return p.address
 }
 
+func (p Precompile) GetName() string {
+	return "staking"
+}
+
 func (p Precompile) Run(evm *vm.EVM, caller common.Address, callingContract common.Address, input []byte, value *big.Int, readOnly bool) (bz []byte, err error) {
 	if readOnly {
 		return nil, errors.New("cannot call staking precompile from staticcall")

--- a/precompiles/wasmd/wasmd.go
+++ b/precompiles/wasmd/wasmd.go
@@ -125,6 +125,10 @@ func (p Precompile) Address() common.Address {
 	return p.address
 }
 
+func (p Precompile) GetName() string {
+	return "wasmd"
+}
+
 func (p Precompile) RunAndCalculateGas(evm *vm.EVM, caller common.Address, callingContract common.Address, input []byte, suppliedGas uint64, value *big.Int, _ *tracing.Hooks, readOnly bool) (ret []byte, remainingGas uint64, err error) {
 	ctx, method, args, err := p.Prepare(evm, input)
 	if err != nil {

--- a/x/evm/client/cli/common.go
+++ b/x/evm/client/cli/common.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"strconv"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func getMethodPayload(newAbi abi.ABI, args []string) ([]byte, error) {
+	method := newAbi.Methods[args[0]]
+	abiArgs := []interface{}{}
+	for i, input := range method.Inputs {
+		idx := i + 1
+		if idx >= len(args) {
+			return nil, errors.New("not enough arguments")
+		}
+		var arg interface{}
+		var err error
+		switch input.Type.T {
+		case abi.IntTy:
+			if input.Type.Size > 64 {
+				bi, success := new(big.Int).SetString(args[idx], 10)
+				if !success {
+					return nil, errors.New("invalid big.Int")
+				} else {
+					arg = bi
+				}
+			} else {
+				val, e := strconv.ParseInt(args[idx], 10, 64)
+				err = e
+				switch input.Type.Size {
+				case 8:
+					if val > math.MaxInt8 {
+						return nil, errors.New("int8 overflow")
+					}
+					arg = int8(val)
+				case 16:
+					if val > math.MaxInt16 {
+						return nil, errors.New("int16 overflow")
+					}
+					arg = int16(val)
+				case 32:
+					if val > math.MaxInt32 {
+						return nil, errors.New("int32 overflow")
+					}
+					arg = int32(val)
+				case 64:
+					arg = val
+				}
+			}
+		case abi.UintTy:
+			if input.Type.Size > 64 {
+				bi, success := new(big.Int).SetString(args[idx], 10)
+				if !success {
+					return nil, errors.New("invalid big.Int")
+				} else {
+					arg = bi
+				}
+			} else {
+				val, e := strconv.ParseUint(args[idx], 10, 64)
+				err = e
+				switch input.Type.Size {
+				case 8:
+					if val > math.MaxUint8 {
+						return nil, errors.New("uint8 overflow")
+					}
+					arg = uint8(val)
+				case 16:
+					if val > math.MaxUint16 {
+						return nil, errors.New("uint16 overflow")
+					}
+					arg = uint16(val)
+				case 32:
+					if val > math.MaxUint32 {
+						return nil, errors.New("uint32 overflow")
+					}
+					arg = uint32(val)
+				case 64:
+					arg = val
+				}
+			}
+		case abi.BoolTy:
+			if args[idx] != TrueStr && args[idx] != FalseStr {
+				return nil, fmt.Errorf("boolean argument has to be either \"%s\" or \"%s\"", TrueStr, FalseStr)
+			} else {
+				arg = args[idx] == TrueStr
+			}
+		case abi.StringTy:
+			arg = args[idx]
+		case abi.AddressTy:
+			arg = common.HexToAddress(args[idx])
+		default:
+			return nil, errors.New("argument type not supported yet")
+		}
+		if err != nil {
+			return nil, err
+		}
+		abiArgs = append(abiArgs, arg)
+	}
+
+	return newAbi.Pack(args[0], abiArgs...)
+}

--- a/x/evm/client/cli/query.go
+++ b/x/evm/client/cli/query.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"strconv"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -172,80 +171,7 @@ func CmdQueryPayload() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			method := newAbi.Methods[args[1]]
-			abiArgs := []interface{}{}
-			for i, input := range method.Inputs {
-				idx := i + 2
-				if idx >= len(args) {
-					return errors.New("not enough arguments")
-				}
-				var arg interface{}
-				var err error
-				switch input.Type.T {
-				case abi.IntTy:
-					if input.Type.Size > 64 {
-						bi, success := new(big.Int).SetString(args[idx], 10)
-						if !success {
-							err = errors.New("invalid big.Int")
-						} else {
-							arg = bi
-						}
-					} else {
-						val, e := strconv.ParseInt(args[idx], 10, 64)
-						err = e
-						switch input.Type.Size {
-						case 8:
-							arg = int8(val)
-						case 16:
-							arg = int16(val)
-						case 32:
-							arg = int32(val)
-						case 64:
-							arg = val
-						}
-					}
-				case abi.UintTy:
-					if input.Type.Size > 64 {
-						bi, success := new(big.Int).SetString(args[idx], 10)
-						if !success {
-							err = errors.New("invalid big.Int")
-						} else {
-							arg = bi
-						}
-					} else {
-						val, e := strconv.ParseUint(args[idx], 10, 64)
-						err = e
-						switch input.Type.Size {
-						case 8:
-							arg = uint8(val)
-						case 16:
-							arg = uint16(val)
-						case 32:
-							arg = uint32(val)
-						case 64:
-							arg = val
-						}
-					}
-				case abi.BoolTy:
-					if args[idx] != TrueStr && args[idx] != FalseStr {
-						err = fmt.Errorf("boolean argument has to be either \"%s\" or \"%s\"", TrueStr, FalseStr)
-					} else {
-						arg = args[idx] == TrueStr
-					}
-				case abi.StringTy:
-					arg = args[idx]
-				case abi.AddressTy:
-					arg = common.HexToAddress(args[idx])
-				default:
-					return errors.New("argument type not supported yet")
-				}
-				if err != nil {
-					return err
-				}
-				abiArgs = append(abiArgs, arg)
-			}
-
-			bz, err := newAbi.Pack(args[1], abiArgs...)
+			bz, err := getMethodPayload(newAbi, args[1:])
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Describe your changes and provide context
- remove deprecated pointer deployment CLIs (pointer are now deployed via precompiles)
- generalize the delegate CLI for all precompiles (usage: `seid tx evm call-precompile [precompile name] [method] [args...] --value=`
## Testing performed to validate your change
local sei
<img width="1896" alt="Screen Shot 2024-04-22 at 12 11 09 PM" src="https://github.com/sei-protocol/sei-chain/assets/6227889/ef855222-e835-457a-914e-91feb3d05d1f">

