### PR TITLE
Fix distr integration test

### DIFF
--- a/integration_test/distribution_module/rewards.yaml
+++ b/integration_test/distribution_module/rewards.yaml
@@ -11,6 +11,8 @@
       env: REWARDS_START
     # Simple tx to increase rewards
     - cmd: printf "12345678\n" | seid tx bank send $NODE_ADMIN_ACC $DISTRIBUTION_TEST_ACC 1sei -b block --fees 2000usei --chain-id sei -y
+    # Wait a couple seconds before querying to reduce likelihood of flaky test results
+    - cmd: sleep 2
     # Get rewards after tx
     - cmd: seid q distribution rewards $NODE_ADMIN_ACC -o json | jq -r ".total[0].amount | tonumber"
       env: REWARDS_AFTER_TX

--- a/integration_test/distribution_module/rewards.yaml
+++ b/integration_test/distribution_module/rewards.yaml
@@ -12,7 +12,7 @@
     # Simple tx to increase rewards
     - cmd: printf "12345678\n" | seid tx bank send $NODE_ADMIN_ACC $DISTRIBUTION_TEST_ACC 1sei -b block --fees 2000usei --chain-id sei -y
     # Wait a couple seconds before querying to reduce likelihood of flaky test results
-    - cmd: sleep 2
+    - cmd: sleep 1
     # Get rewards after tx
     - cmd: seid q distribution rewards $NODE_ADMIN_ACC -o json | jq -r ".total[0].amount | tonumber"
       env: REWARDS_AFTER_TX


### PR DESCRIPTION
## Describe your changes and provide context
The distribution integration tests tend to be flaky on PR CI due to the query for distribution rewards sometimes querying to quickly and therefore not returning the expected increase in rewards. This adds a pause such that we can give some time so the test doesnt flake due to inconsistent query timing.

## Testing performed to validate your change
Integration tests