### PR TITLE
V5.1.0 upgrade

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1001,6 +1001,15 @@ func (app *App) SetStoreUpgradeHandlers() {
 		// configure store loader that checks if version == upgradeHeight and applies store upgrades
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}
+
+	if upgradeInfo.Name == "v5.1.0" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		storeUpgrades := storetypes.StoreUpgrades{
+			Added: []string{evmtypes.StoreKey},
+		}
+
+		// configure store loader that checks if version == upgradeHeight and applies store upgrades
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+	}
 }
 
 // AppName returns the name of the App

--- a/app/app.go
+++ b/app/app.go
@@ -1001,7 +1001,7 @@ func (app *App) SetStoreUpgradeHandlers() {
 		// configure store loader that checks if version == upgradeHeight and applies store upgrades
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}
-
+	// TODO UPDATE `v5.1.0` with the final version that will be upgraded to introduce the EVM module - REMOVE THIS TODO
 	if upgradeInfo.Name == "v5.1.0" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{
 			Added: []string{evmtypes.StoreKey},

--- a/app/app.go
+++ b/app/app.go
@@ -1001,7 +1001,7 @@ func (app *App) SetStoreUpgradeHandlers() {
 		// configure store loader that checks if version == upgradeHeight and applies store upgrades
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}
-	// TODO UPDATE `v5.1.0` with the final version that will be upgraded to introduce the EVM module - REMOVE THIS TODO
+
 	if upgradeInfo.Name == "v5.1.0" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{
 			Added: []string{evmtypes.StoreKey},

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -92,6 +92,7 @@ var upgradesList = []string{
 	"v4.2.0-evm-devnet",
 	"v5.0.0",
 	"v5.0.1",
+	"v5.1.0",
 }
 
 // if there is an override list, use that instead, for integration tests


### PR DESCRIPTION
## Describe your changes and provide context
This registers the `v5.1.0` upgrade to be used on environments NOT having EVM module. This will add the evm module to the store keepers and perform related store upgrades

## Testing performed to validate your change
Tested upgrading from `v3.9.0` to `v5.1.0` locally


TODO: wait to merge until code frozen and also update changelog + remove TODO message
