### PR TITLE
Invoke StateTransition for initial EVM entrance

### DIFF
--- a/contracts/test/CW20toERC20PointerTest.js
+++ b/contracts/test/CW20toERC20PointerTest.js
@@ -83,22 +83,22 @@ describe("CW20 to ERC20 Pointer", function () {
 
         //TODO: other execute methods
 
-        // it("should increase and decrease allowance for a spender", async function() {
-        //     const spender = accounts[1].seiAddress
-        //     const result = await executeWasm(cw20Pointer, { increase_allowance: { spender: spender, amount: "300" } });
-        //     console.log(result)
-        //
-        //     let allowance = await queryWasm(cw20Pointer, "allowance", { owner: admin.seiAddress, spender: spender });
-        //     console.log(allowance)
-        //     expect(allowance.data.allowance).to.equal("300");
-        //
-        //     const result2 = await executeWasm(cw20Pointer, { decrease_allowance: { spender: spender, amount: "300" } });
-        //     console.log(result2)
-        //
-        //     allowance = await queryWasm(cw20Pointer, "allowance", { owner: admin.seiAddress, spender: spender });
-        //     console.log(allowance)
-        //     expect(allowance.data.allowance).to.equal("0");
-        // });
+        it("should increase and decrease allowance for a spender", async function() {
+            const spender = accounts[1].seiAddress
+            const result = await executeWasm(cw20Pointer, { increase_allowance: { spender: spender, amount: "300" } });
+            console.log(result)
+        
+            let allowance = await queryWasm(cw20Pointer, "allowance", { owner: admin.seiAddress, spender: spender });
+            console.log(allowance)
+            expect(allowance.data.allowance).to.equal("300");
+        
+            const result2 = await executeWasm(cw20Pointer, { decrease_allowance: { spender: spender, amount: "300" } });
+            console.log(result2)
+        
+            allowance = await queryWasm(cw20Pointer, "allowance", { owner: admin.seiAddress, spender: spender });
+            console.log(allowance)
+            expect(allowance.data.allowance).to.equal("0");
+        });
 
     })
 

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -1,5 +1,13 @@
 const { exec } = require("child_process"); // Importing exec from child_process
 
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function delay() {
+    await sleep(1000)
+}
+
 async function fundAddress(addr) {
     return await execute(`seid tx evm send ${addr} 10000000000000000000 --from admin`);
 }
@@ -88,6 +96,7 @@ async function setupSigners(signers) {
     for(let signer of signers) {
         const evmAddress = await signer.getAddress();
         await fundAddress(evmAddress);
+        await delay()
         const resp = await signer.sendTransaction({
             to: evmAddress,
             value: 0

--- a/x/evm/keeper/evm.go
+++ b/x/evm/keeper/evm.go
@@ -8,6 +8,8 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/sei-protocol/sei-chain/utils"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
@@ -28,7 +30,7 @@ func (k *Keeper) HandleInternalEVMCall(ctx sdk.Context, req *types.MsgInternalEV
 	if err != nil {
 		return nil, err
 	}
-	ret, err := k.CallEVM(ctx, senderAddr, to, req.Value, req.Data)
+	ret, err := k.CallEVM(ctx, k.GetEVMAddressOrDefault(ctx, senderAddr), to, req.Value, req.Data)
 	if err != nil {
 		return nil, err
 	}
@@ -51,30 +53,56 @@ func (k *Keeper) HandleInternalEVMDelegateCall(ctx sdk.Context, req *types.MsgIn
 	}
 	// delegatecall caller must be associated; otherwise any state change on EVM contract will be lost
 	// after they asssociate.
-	_, found := k.GetEVMAddress(ctx, senderAddr)
+	senderEvmAddr, found := k.GetEVMAddress(ctx, senderAddr)
 	if !found {
 		return nil, fmt.Errorf("sender %s is not associated", req.Sender)
 	}
-	ret, err := k.CallEVM(ctx, senderAddr, to, &zeroInt, req.Data)
+	ret, err := k.CallEVM(ctx, senderEvmAddr, to, &zeroInt, req.Data)
 	if err != nil {
 		return nil, err
 	}
 	return &sdk.Result{Data: ret}, nil
 }
 
-func (k *Keeper) CallEVM(ctx sdk.Context, from sdk.AccAddress, to *common.Address, val *sdk.Int, data []byte) (retdata []byte, reterr error) {
-	evm, finalizer, err := k.getOrCreateEVM(ctx, from)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if finalizer != nil {
-			if err := finalizer(); err != nil {
-				reterr = err
-				return
-			}
+func (k *Keeper) CallEVM(ctx sdk.Context, from common.Address, to *common.Address, val *sdk.Int, data []byte) (retdata []byte, reterr error) {
+	evm := types.GetCtxEVM(ctx)
+	if evm == nil {
+		// This call was not part of an existing StateTransition, so it should trigger one
+		executionCtx := ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
+		stateDB := state.NewDBImpl(executionCtx, k, false)
+		gp := k.GetGasPool()
+		value := utils.Big0
+		if val != nil {
+			value = val.BigInt()
 		}
-	}()
+		evmMsg := &core.Message{
+			Nonce:             stateDB.GetNonce(from), // replay attack is prevented by the AccountSequence number set on the CW transaction that triggered this call
+			GasLimit:          k.getEvmGasLimitFromCtx(ctx),
+			GasPrice:          utils.Big0, // fees are already paid on the CW transaction
+			GasFeeCap:         utils.Big0,
+			GasTipCap:         utils.Big0,
+			To:                to,
+			Value:             value,
+			Data:              data,
+			SkipAccountChecks: false,
+			From:              from,
+		}
+		res, err := k.applyEVMMessage(ctx, evmMsg, stateDB, gp)
+		if err != nil {
+			return nil, err
+		}
+		k.consumeEvmGas(ctx, res.UsedGas)
+		if res.Err != nil {
+			return nil, res.Err
+		}
+		surplus, err := stateDB.Finalize()
+		if err != nil {
+			return nil, err
+		}
+		k.AppendToEvmTxDeferredInfo(ctx, ethtypes.Bloom{}, ethtypes.EmptyTxsHash, surplus)
+		return res.ReturnData, nil
+	}
+	// This call is part of an existing StateTransition, so directly invoking `Call`
 	var f EVMCallFunc
 	if to == nil {
 		// contract creation
@@ -91,57 +119,61 @@ func (k *Keeper) CallEVM(ctx sdk.Context, from sdk.AccAddress, to *common.Addres
 }
 
 func (k *Keeper) StaticCallEVM(ctx sdk.Context, from sdk.AccAddress, to *common.Address, data []byte) ([]byte, error) {
-	evm, _, err := k.getOrCreateEVM(ctx, from)
+	evm, err := k.getOrCreateEVM(ctx, from)
 	if err != nil {
 		return nil, err
 	}
-	return k.callEVM(ctx, from, to, nil, data, func(caller vm.ContractRef, addr *common.Address, input []byte, gas uint64, _ *big.Int) ([]byte, uint64, error) {
+	return k.callEVM(ctx, k.GetEVMAddressOrDefault(ctx, from), to, nil, data, func(caller vm.ContractRef, addr *common.Address, input []byte, gas uint64, _ *big.Int) ([]byte, uint64, error) {
 		return evm.StaticCall(caller, *addr, input, gas)
 	})
 }
 
-func (k *Keeper) callEVM(ctx sdk.Context, from sdk.AccAddress, to *common.Address, val *sdk.Int, data []byte, f EVMCallFunc) ([]byte, error) {
-	sender := k.GetEVMAddressOrDefault(ctx, from)
-	seiGasRemaining := ctx.GasMeter().Limit() - ctx.GasMeter().GasConsumedToLimit()
-	if ctx.GasMeter().Limit() <= 0 {
-		// infinite gas meter (used in queries)
-		seiGasRemaining = math.MaxUint64
-	}
-	multiplier := k.GetPriorityNormalizer(ctx)
-	evmGasRemaining := sdk.NewDecFromInt(sdk.NewIntFromUint64(seiGasRemaining)).Quo(multiplier).TruncateInt().BigInt()
-	if evmGasRemaining.Cmp(MaxUint64BigInt) > 0 {
-		evmGasRemaining = MaxUint64BigInt
-	}
+func (k *Keeper) callEVM(ctx sdk.Context, from common.Address, to *common.Address, val *sdk.Int, data []byte, f EVMCallFunc) ([]byte, error) {
+	evmGasLimit := k.getEvmGasLimitFromCtx(ctx)
 	value := utils.Big0
 	if val != nil {
 		value = val.BigInt()
 	}
-	ret, leftoverGas, err := f(vm.AccountRef(sender), to, data, evmGasRemaining.Uint64(), value)
-	ctx.GasMeter().ConsumeGas(ctx.GasMeter().Limit()-sdk.NewDecFromInt(sdk.NewIntFromUint64(leftoverGas)).Mul(multiplier).TruncateInt().Uint64(), "call EVM")
+	ret, leftoverGas, err := f(vm.AccountRef(from), to, data, evmGasLimit, value)
+	k.consumeEvmGas(ctx, evmGasLimit-leftoverGas)
 	if err != nil {
 		return nil, err
 	}
 	return ret, nil
 }
 
-func (k *Keeper) getOrCreateEVM(ctx sdk.Context, from sdk.AccAddress) (*vm.EVM, func() error, error) {
+// only used for StaticCalls
+func (k *Keeper) getOrCreateEVM(ctx sdk.Context, from sdk.AccAddress) (*vm.EVM, error) {
 	evm := types.GetCtxEVM(ctx)
 	if evm != nil {
-		return evm, nil, nil
+		return evm, nil
 	}
 	executionCtx := ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
 	stateDB := state.NewDBImpl(executionCtx, k, false)
 	gp := k.GetGasPool()
 	blockCtx, err := k.GetVMBlockContext(executionCtx, gp)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	cfg := types.DefaultChainConfig().EthereumConfig(k.ChainID())
 	txCtx := vm.TxContext{Origin: k.GetEVMAddressOrDefault(ctx, from)}
 	evm = vm.NewEVM(*blockCtx, txCtx, stateDB, cfg, vm.Config{})
 	stateDB.SetEVM(evm)
-	return evm, func() error {
-		_, err := stateDB.Finalize()
-		return err
-	}, nil
+	return evm, nil
+}
+
+func (k *Keeper) getEvmGasLimitFromCtx(ctx sdk.Context) uint64 {
+	seiGasRemaining := ctx.GasMeter().Limit() - ctx.GasMeter().GasConsumedToLimit()
+	if ctx.GasMeter().Limit() <= 0 {
+		return math.MaxUint64
+	}
+	evmGasBig := sdk.NewDecFromInt(sdk.NewIntFromUint64(seiGasRemaining)).Quo(k.GetPriorityNormalizer(ctx)).TruncateInt().BigInt()
+	if evmGasBig.Cmp(MaxUint64BigInt) > 0 {
+		evmGasBig = MaxUint64BigInt
+	}
+	return evmGasBig.Uint64()
+}
+
+func (k *Keeper) consumeEvmGas(ctx sdk.Context, usedEvmGas uint64) {
+	ctx.GasMeter().ConsumeGas(sdk.NewDecFromInt(sdk.NewIntFromUint64(usedEvmGas)).Mul(k.GetPriorityNormalizer(ctx)).TruncateInt().Uint64(), "call EVM")
 }

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -191,12 +191,12 @@ func (k *Keeper) GetEVMMessage(ctx sdk.Context, tx *ethtypes.Transaction, sender
 	return msg
 }
 
-func (server msgServer) applyEVMMessage(ctx sdk.Context, msg *core.Message, stateDB *state.DBImpl, gp core.GasPool) (*core.ExecutionResult, error) {
-	blockCtx, err := server.GetVMBlockContext(ctx, gp)
+func (k Keeper) applyEVMMessage(ctx sdk.Context, msg *core.Message, stateDB *state.DBImpl, gp core.GasPool) (*core.ExecutionResult, error) {
+	blockCtx, err := k.GetVMBlockContext(ctx, gp)
 	if err != nil {
 		return nil, err
 	}
-	cfg := types.DefaultChainConfig().EthereumConfig(server.ChainID())
+	cfg := types.DefaultChainConfig().EthereumConfig(k.ChainID())
 	txCtx := core.NewEVMTxContext(msg)
 	evmInstance := vm.NewEVM(*blockCtx, txCtx, stateDB, cfg, vm.Config{})
 	stateDB.SetEVM(evmInstance)

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -215,7 +215,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 	denom := am.keeper.GetBaseDenom(ctx)
 	surplus := utils.Sdk0
 	for _, deferredInfo := range evmTxDeferredInfoList {
-		if deferredInfo.Error != "" {
+		if deferredInfo.Error != "" && deferredInfo.TxHash.Cmp(ethtypes.EmptyTxsHash) != 0 {
 			_ = am.keeper.SetReceipt(ctx, deferredInfo.TxHash, &types.Receipt{
 				TxHashHex:        deferredInfo.TxHash.Hex(),
 				TransactionIndex: uint32(deferredInfo.TxIndx),
@@ -229,7 +229,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 		weiBalance := am.keeper.BankKeeper().GetWeiBalance(ctx, coinbaseAddress)
 		if !balance.IsZero() || !weiBalance.IsZero() {
 			if err := am.keeper.BankKeeper().SendCoinsAndWei(ctx, coinbaseAddress, coinbase, balance, weiBalance); err != nil {
-				panic(err)
+				ctx.Logger().Error(fmt.Sprintf("failed to send usei surplus from %s to coinbase account due to %s", coinbaseAddress.String(), err))
 			}
 		}
 		surplus = surplus.Add(deferredInfo.Surplus)
@@ -245,7 +245,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 			ctx.Logger().Error("failed to send wei surplus of %s to EVM module account", surplusWei)
 		}
 	}
-	am.keeper.SetTxHashesOnHeight(ctx, ctx.BlockHeight(), utils.Map(evmTxDeferredInfoList, func(i keeper.EvmTxDeferredInfo) common.Hash { return i.TxHash }))
+	am.keeper.SetTxHashesOnHeight(ctx, ctx.BlockHeight(), utils.Filter(utils.Map(evmTxDeferredInfoList, func(i keeper.EvmTxDeferredInfo) common.Hash { return i.TxHash }), func(h common.Hash) bool { return h.Cmp(ethtypes.EmptyTxsHash) != 0 }))
 	am.keeper.SetBlockBloom(ctx, ctx.BlockHeight(), utils.Map(evmTxDeferredInfoList, func(i keeper.EvmTxDeferredInfo) ethtypes.Bloom { return i.TxBloom }))
 	return []abci.ValidatorUpdate{}
 }


### PR DESCRIPTION
## Describe your changes and provide context
Previously for a CosmWasm transaction that enters EVM space (i.e. via wasmbinding) for the first time in its transaction lifecycle, we are merely calling `evm.Call` or `evm.Create`, which is problematic because that omits a bunch of checks and preparation logic in `StateTransition::TransitionDb`. This is not a problem for transactions that have already invoked `TransitionDb` at some point earlier in its lifecycle (e.g. an EVM tx that calls CW via precompile which then calls back to EVM via wasmbinding), for which we can detect via checking for `evm` in the context

```
TransitionDb
    Prechecks
    Charge Intrinsic Gas
    Prepare StateDB (including setting AccessLists)
    evm.Call
```
Note a couple things with TransitionDb invoked this way:
- no receipt will be created (because there is no EVM tx hash associated)
- nonce will still be incremented, automatically (no risk of replay attack because the outer CosmWasm transaction would have sequence number checks)
- gas limit will be inherited from `ctx` and any usage will be reflected back
- fees are set to 0 because the outer CosmWasm transaction has already paid for fees

## Testing performed to validate your change
hardhat tests
