### PR TITLE
Only consider spendable coins when transferring in EVM

### DIFF
--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -225,10 +225,10 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 		}
 		idx := deferredInfo.TxIndx
 		coinbaseAddress := state.GetCoinbaseAddress(idx)
-		balance := am.keeper.BankKeeper().GetBalance(ctx, coinbaseAddress, denom)
+		balance := am.keeper.BankKeeper().SpendableCoins(ctx, coinbaseAddress).AmountOf(denom)
 		weiBalance := am.keeper.BankKeeper().GetWeiBalance(ctx, coinbaseAddress)
-		if !balance.Amount.IsZero() || !weiBalance.IsZero() {
-			if err := am.keeper.BankKeeper().SendCoinsAndWei(ctx, coinbaseAddress, coinbase, balance.Amount, weiBalance); err != nil {
+		if !balance.IsZero() || !weiBalance.IsZero() {
+			if err := am.keeper.BankKeeper().SendCoinsAndWei(ctx, coinbaseAddress, coinbase, balance, weiBalance); err != nil {
 				panic(err)
 			}
 		}

--- a/x/evm/module_test.go
+++ b/x/evm/module_test.go
@@ -1,11 +1,14 @@
 package evm_test
 
 import (
+	"math"
 	"math/big"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/vesting"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -74,4 +77,28 @@ func TestABCI(t *testing.T) {
 	receipt, err := k.GetReceipt(ctx, common.Hash{1})
 	require.Nil(t, err)
 	require.Equal(t, receipt.VmError, "test error")
+
+	// fourth block with locked tokens in coinbase address
+	m.BeginBlock(ctx, abci.RequestBeginBlock{})
+	coinbase := state.GetCoinbaseAddress(2)
+	vms := vesting.NewMsgServerImpl(*k.AccountKeeper(), k.BankKeeper())
+	_, err = vms.CreateVestingAccount(sdk.WrapSDKContext(ctx), &vestingtypes.MsgCreateVestingAccount{
+		FromAddress: sdk.AccAddress(evmAddr1[:]).String(),
+		ToAddress:   coinbase.String(),
+		Amount:      sdk.NewCoins(sdk.NewCoin("usei", sdk.OneInt())),
+		EndTime:     math.MaxInt64,
+	})
+	require.Nil(t, err)
+	s = state.NewDBImpl(ctx.WithTxIndex(2), k, false)
+	s.SubBalance(evmAddr1, big.NewInt(2000000000000), tracing.BalanceChangeUnspecified)
+	s.AddBalance(evmAddr2, big.NewInt(1000000000000), tracing.BalanceChangeUnspecified)
+	s.AddBalance(feeCollectorAddr, big.NewInt(1000000000000), tracing.BalanceChangeUnspecified)
+	surplus, err = s.Finalize()
+	require.Nil(t, err)
+	k.AppendToEvmTxDeferredInfo(ctx.WithTxIndex(2), ethtypes.Bloom{}, common.Hash{}, surplus)
+	k.SetTxResults([]*abci.ExecTxResult{{Code: 0}, {Code: 0}, {Code: 0}})
+	require.Equal(t, sdk.OneInt(), k.BankKeeper().SpendableCoins(ctx, coinbase).AmountOf("usei"))
+	m.EndBlock(ctx, abci.RequestEndBlock{}) // should not crash
+	require.Equal(t, sdk.OneInt(), k.BankKeeper().GetBalance(ctx, coinbase, "usei").Amount)
+	require.Equal(t, sdk.ZeroInt(), k.BankKeeper().SpendableCoins(ctx, coinbase).AmountOf("usei"))
 }

--- a/x/evm/state/balance.go
+++ b/x/evm/state/balance.go
@@ -28,12 +28,14 @@ func (s *DBImpl) SubBalance(evmAddr common.Address, amt *big.Int, reason tracing
 
 	usei, wei := SplitUseiWeiAmount(amt)
 	addr := s.getSeiAddress(evmAddr)
-	s.err = s.k.BankKeeper().SubUnlockedCoins(ctx, addr, sdk.NewCoins(sdk.NewCoin(s.k.GetBaseDenom(s.ctx), usei)), true)
-	if s.err != nil {
+	err := s.k.BankKeeper().SubUnlockedCoins(ctx, addr, sdk.NewCoins(sdk.NewCoin(s.k.GetBaseDenom(s.ctx), usei)), true)
+	if err != nil {
+		s.err = err
 		return
 	}
-	s.err = s.k.BankKeeper().SubWei(ctx, addr, wei)
-	if s.err != nil {
+	err = s.k.BankKeeper().SubWei(ctx, addr, wei)
+	if err != nil {
+		s.err = err
 		return
 	}
 
@@ -66,12 +68,14 @@ func (s *DBImpl) AddBalance(evmAddr common.Address, amt *big.Int, reason tracing
 
 	usei, wei := SplitUseiWeiAmount(amt)
 	addr := s.getSeiAddress(evmAddr)
-	s.err = s.k.BankKeeper().AddCoins(ctx, addr, sdk.NewCoins(sdk.NewCoin(s.k.GetBaseDenom(s.ctx), usei)), true)
-	if s.err != nil {
+	err := s.k.BankKeeper().AddCoins(ctx, addr, sdk.NewCoins(sdk.NewCoin(s.k.GetBaseDenom(s.ctx), usei)), true)
+	if err != nil {
+		s.err = err
 		return
 	}
-	s.err = s.k.BankKeeper().AddWei(ctx, addr, wei)
-	if s.err != nil {
+	err = s.k.BankKeeper().AddWei(ctx, addr, wei)
+	if err != nil {
+		s.err = err
 		return
 	}
 
@@ -88,7 +92,7 @@ func (s *DBImpl) AddBalance(evmAddr common.Address, amt *big.Int, reason tracing
 
 func (s *DBImpl) GetBalance(evmAddr common.Address) *big.Int {
 	s.k.PrepareReplayedAddr(s.ctx, evmAddr)
-	usei := s.k.BankKeeper().GetBalance(s.ctx, s.getSeiAddress(evmAddr), s.k.GetBaseDenom(s.ctx)).Amount
+	usei := s.k.BankKeeper().SpendableCoins(s.ctx, s.getSeiAddress(evmAddr)).AmountOf(s.k.GetBaseDenom(s.ctx))
 	wei := s.k.BankKeeper().GetWeiBalance(s.ctx, s.getSeiAddress(evmAddr))
 	return usei.Mul(SdkUseiToSweiMultiplier).Add(wei).BigInt()
 }
@@ -124,5 +128,8 @@ func (s *DBImpl) getSeiAddress(evmAddr common.Address) sdk.AccAddress {
 
 func (s *DBImpl) send(from sdk.AccAddress, to sdk.AccAddress, amt *big.Int) {
 	usei, wei := SplitUseiWeiAmount(amt)
-	s.err = s.k.BankKeeper().SendCoinsAndWei(s.ctx, from, to, usei, wei)
+	err := s.k.BankKeeper().SendCoinsAndWei(s.ctx, from, to, usei, wei)
+	if err != nil {
+		s.err = err
+	}
 }

--- a/x/evm/state/balance_test.go
+++ b/x/evm/state/balance_test.go
@@ -69,6 +69,7 @@ func TestSubBalance(t *testing.T) {
 	db.SubBalance(evmAddr2, big.NewInt(10000000000000), tracing.BalanceChangeUnspecified)
 	require.NotNil(t, db.Err())
 
+	db.WithErr(nil)
 	_, evmAddr3 := testkeeper.MockAddressPair()
 	db.SelfDestruct(evmAddr3)
 	db.SubBalance(evmAddr2, big.NewInt(5000000000000), tracing.BalanceChangeUnspecified)


### PR DESCRIPTION
## Describe your changes and provide context
Fix for https://linear.app/seilabs/issue/SEI-7179/immunefi-evm-module-panic-report

For operations that aim to transfer the whole balance from an address to the other, we should use `SpendableCoins` instead of `GetBalance` so that locked tokens won't be attempted

## Testing performed to validate your change
unit test
