### PR TITLE
Make PlaceOrder tx not gasless

### DIFF
--- a/app/antedecorators/gasless.go
+++ b/app/antedecorators/gasless.go
@@ -137,7 +137,7 @@ func IsTxGasless(tx sdk.Tx, ctx sdk.Context, oracleKeeper oraclekeeper.Keeper) (
 }
 
 func dexPlaceOrdersIsGasless(_ *dextypes.MsgPlaceOrders) bool {
-	return true
+	return false
 }
 
 // WhitelistedGaslessCancellationAddrs TODO: migrate this into params state

--- a/integration_test/dex_module/cancel_order_test.yaml
+++ b/integration_test/dex_module/cancel_order_test.yaml
@@ -7,7 +7,7 @@
     - cmd: echo "LONG?1.01?5?SEI?ATOM?LIMIT?{\"leverage\":\"1\",\"position_effect\":\"Open\"}"
       env: PARAMS
     # Place an order and set ORDER_ID
-    - cmd: printf "12345678\n" | seid tx dex place-orders $CONTRACT_ADDR $PARAMS --amount=1000000000usei -y --from=admin --chain-id=sei --fees=1000000usei --gas=5000000 --broadcast-mode=block --output json|jq -M -r ".logs[].events[].attributes[] | select(.key == \"order_id\").value"
+    - cmd: printf "12345678\n" | seid tx dex place-orders $CONTRACT_ADDR $PARAMS --amount=1000000000usei -y --from=admin --chain-id=sei --fees=1000000usei --gas=500000 --broadcast-mode=block --output json|jq -M -r ".logs[].events[].attributes[] | select(.key == \"order_id\").value"
       env: ORDER_ID
     # Prepare parameter to cancel the placed order
     - cmd: echo $ORDER_ID"?LONG?1.01?SEI?ATOM"
@@ -22,4 +22,4 @@
       env: NUMORDER
   verifiers:
     - type: eval
-      expr: NUMORDER == 5 # placed from the place_order test
+      expr: NUMORDER == 4 # placed from the place_order test

--- a/integration_test/dex_module/place_order_test.yaml
+++ b/integration_test/dex_module/place_order_test.yaml
@@ -6,19 +6,14 @@
     # Prepare parameter
     - cmd: echo "LONG?1.01?5?SEI?ATOM?LIMIT?{\"leverage\":\"1\",\"position_effect\":\"Open\"}"
       env: PARAMS
-    # Verify that placing a dex order with gas > max block gas is okay since gas will be ignored
-    - cmd: printf "12345678\n" | seid tx dex place-orders $CONTRACT_ADDR $PARAMS --amount=1000000000usei -y --from=admin --chain-id=sei --fees=1000000usei --gas=500000000 --broadcast-mode=block --output json|jq -M -r ".logs[].events[].attributes[] | select(.key == \"order_id\").value"
-      env: MAX_GAS_ORDER_ID
     # Place an order and set ORDER_ID
-    - cmd: printf "12345678\n" | seid tx dex place-orders $CONTRACT_ADDR $PARAMS --amount=1000000000usei -y --from=admin --chain-id=sei --fees=1000000usei --gas=5000000 --broadcast-mode=block --output json|jq -M -r ".logs[].events[].attributes[] | select(.key == \"order_id\").value"
+    - cmd: printf "12345678\n" | seid tx dex place-orders $CONTRACT_ADDR $PARAMS --amount=1000000000usei -y --from=admin --chain-id=sei --fees=1000000usei --gas=500000 --broadcast-mode=block --output json|jq -M -r ".logs[].events[].attributes[] | select(.key == \"order_id\").value"
       env: ORDER_ID
     # Query the order by id
     - cmd: seid q dex get-orders-by-id $CONTRACT_ADDR SEI ATOM $ORDER_ID --output json |jq .order.status
       env: RESULT
   verifiers:
     # Order ids should be greater or equal to 0
-    - type: eval
-      expr: MAX_GAS_ORDER_ID >= 0
     - type: eval
       expr: ORDER_ID >= 0
     # Order status should be something like PLACED
@@ -40,7 +35,7 @@
     - cmd: echo "LONG?1.0?10?usei?uatom?LIMIT? LONG?3.0?3000?usei?uatomatomatom?LIMIT? LONG?3.0?1000?usei?uatomatom?LIMIT?"
       env: PARAMS
     # Place 3 orders
-    - cmd: printf "12345678\n" | seid tx dex place-orders $CONTRACT_ADDR $PARAMS --amount=1000000000usei -y --from=admin --chain-id=sei --fees=1000000usei --gas=5000000 --broadcast-mode=block --output json| jq .code
+    - cmd: printf "12345678\n" | seid tx dex place-orders $CONTRACT_ADDR $PARAMS --amount=1000000000usei -y --from=admin --chain-id=sei --fees=1000000usei --gas=500000 --broadcast-mode=block --output json| jq .code
 
     # Query all the orders
     - cmd: seid q dex get-orders $CONTRACT_ADDR $ADMIN_ADDR --output json |jq ".[] | length"


### PR DESCRIPTION
## Describe your changes and provide context
There is a potential exploit on tx body size. Given the infrequent usage of `dex` order placement, the safest way to prevent the exploit is to start charging fees on PlaceOrder messages.

## Testing performed to validate your change
unit test

