### PR TITLE
Refactor oracle spam counter to use mem store instead of in memory map

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -416,7 +416,7 @@ func New(
 		// this line is used by starport scaffolding # stargate/app/storeKey
 	)
 	tkeys := sdk.NewTransientStoreKeys(paramstypes.TStoreKey)
-	memKeys := sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey, dexmoduletypes.MemStoreKey, banktypes.DeferredCacheStoreKey, evmtypes.MemStoreKey)
+	memKeys := sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey, dexmoduletypes.MemStoreKey, banktypes.DeferredCacheStoreKey, evmtypes.MemStoreKey, oracletypes.MemStoreKey)
 
 	app := &App{
 		BaseApp:           bApp,
@@ -511,7 +511,7 @@ func New(
 	app.EvidenceKeeper = *evidenceKeeper
 
 	app.OracleKeeper = oraclekeeper.NewKeeper(
-		appCodec, keys[oracletypes.StoreKey], app.GetSubspace(oracletypes.ModuleName),
+		appCodec, keys[oracletypes.StoreKey], memKeys[oracletypes.MemStoreKey], app.GetSubspace(oracletypes.ModuleName),
 		app.AccountKeeper, app.BankKeeper, app.DistrKeeper, &stakingKeeper, distrtypes.ModuleName,
 	)
 

--- a/x/oracle/keeper/keeper_test.go
+++ b/x/oracle/keeper/keeper_test.go
@@ -813,3 +813,18 @@ func TestCalculateTwapsWithUnsupportedDenom(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, types.ErrInvalidTwapLookback, err)
 }
+
+func TestSpamPreventionCounter(t *testing.T) {
+	input := CreateTestInput(t)
+
+	// verify value == -1 when not set
+	require.Equal(t, int64(-1), input.OracleKeeper.GetSpamPreventionCounter(input.Ctx, sdk.ValAddress(Addrs[0])))
+
+	input.Ctx = input.Ctx.WithBlockHeight(3)
+
+	input.OracleKeeper.SetSpamPreventionCounter(input.Ctx, sdk.ValAddress(Addrs[0]))
+	// verify counter value correct when set
+	require.Equal(t, int64(3), input.OracleKeeper.GetSpamPreventionCounter(input.Ctx, sdk.ValAddress(Addrs[0])))
+	// verify value == -1 for a different address
+	require.Equal(t, int64(-1), input.OracleKeeper.GetSpamPreventionCounter(input.Ctx, sdk.ValAddress(Addrs[1])))
+}

--- a/x/oracle/keeper/test_utils.go
+++ b/x/oracle/keeper/test_utils.go
@@ -138,6 +138,7 @@ func CreateTestInput(t *testing.T) TestInput {
 	keyParams := sdk.NewKVStoreKey(paramstypes.StoreKey)
 	tKeyParams := sdk.NewTransientStoreKey(paramstypes.TStoreKey)
 	keyOracle := sdk.NewKVStoreKey(types.StoreKey)
+	memKeys := sdk.NewMemoryStoreKeys(types.MemStoreKey)
 	keyStaking := sdk.NewKVStoreKey(stakingtypes.StoreKey)
 	keyDistr := sdk.NewKVStoreKey(distrtypes.StoreKey)
 
@@ -152,6 +153,7 @@ func CreateTestInput(t *testing.T) TestInput {
 	ms.MountStoreWithDB(tKeyParams, sdk.StoreTypeTransient, db)
 	ms.MountStoreWithDB(keyParams, sdk.StoreTypeIAVL, db)
 	ms.MountStoreWithDB(keyOracle, sdk.StoreTypeIAVL, db)
+	ms.MountStoreWithDB(memKeys[types.MemStoreKey], sdk.StoreTypeMemory, nil)
 	ms.MountStoreWithDB(keyStaking, sdk.StoreTypeIAVL, db)
 	ms.MountStoreWithDB(keyDistr, sdk.StoreTypeIAVL, db)
 
@@ -230,6 +232,7 @@ func CreateTestInput(t *testing.T) TestInput {
 	keeper := NewKeeper(
 		appCodec,
 		keyOracle,
+		memKeys[types.MemStoreKey],
 		paramsKeeper.Subspace(types.ModuleName),
 		accountKeeper,
 		bankKeeper,

--- a/x/oracle/types/keys.go
+++ b/x/oracle/types/keys.go
@@ -14,6 +14,9 @@ const (
 	// StoreKey is the string store representation
 	StoreKey = ModuleName
 
+	// StoreKey is the string store representation
+	MemStoreKey = "oracle_mem"
+
 	// RouterKey is the msg router key for the oracle module
 	RouterKey = ModuleName
 
@@ -44,6 +47,7 @@ var (
 	AggregateExchangeRateVoteKey = []byte{0x05} // prefix for each key to a aggregate vote
 	VoteTargetKey                = []byte{0x06} // prefix for each key to a vote target
 	PriceSnapshotKey             = []byte{0x07} // key for price snapshots history
+	SpamPreventionCounter        = []byte{0x08} // key for spam prevention counter
 )
 
 // GetExchangeRateKey - stored by *denom*
@@ -64,6 +68,11 @@ func GetVotePenaltyCounterKey(v sdk.ValAddress) []byte {
 // GetAggregateExchangeRateVoteKey - stored by *Validator* address
 func GetAggregateExchangeRateVoteKey(v sdk.ValAddress) []byte {
 	return append(AggregateExchangeRateVoteKey, address.MustLengthPrefix(v)...)
+}
+
+// GetSpamPreventionCounterKey - stored by *Validator* address
+func GetSpamPreventionCounterKey(v sdk.ValAddress) []byte {
+	return append(SpamPreventionCounter, address.MustLengthPrefix(v)...)
 }
 
 func GetVoteTargetKey(d string) []byte {


### PR DESCRIPTION
## Describe your changes and provide context
This refactors the oracle spam prevention decorator from using an in memory map and instead uses an in memory KV store to improve its compatibility with OCC execution

## Testing performed to validate your change
Updated unit tests
