### PR TITLE
Disallow using sr25519 addresses for evm send and other funcs

### DIFF
--- a/evmrpc/utils.go
+++ b/evmrpc/utils.go
@@ -5,9 +5,10 @@ import (
 	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"math/big"
 	"time"
+
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/config"

--- a/evmrpc/utils.go
+++ b/evmrpc/utils.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"math/big"
 	"time"
 
@@ -195,6 +196,10 @@ func getAddressPrivKeyMap(kb keyring.Keyring) map[string]*ecdsa.PrivateKey {
 		localInfo, ok := key.(keyring.LocalInfo)
 		if !ok {
 			// will only show local key
+			continue
+		}
+		if localInfo.GetAlgo() != hd.Secp256k1Type {
+			fmt.Printf("Skipping address %s because it isn't signed with secp256k1\n", localInfo.Name)
 			continue
 		}
 		priv, err := legacy.PrivKeyFromBytes([]byte(localInfo.PrivKeyArmor))

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -7,13 +7,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"io"
 	"math/big"
 	"net/http"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"io"
 	"math/big"
 	"net/http"
@@ -94,6 +95,9 @@ func CmdAssociateAddress() *cobra.Command {
 				localInfo, ok := info.(keyring.LocalInfo)
 				if !ok {
 					return errors.New("can only associate address for local keys")
+				}
+				if localInfo.GetAlgo() != hd.Secp256k1Type {
+					return errors.New("can only use addresses using secp256k1")
 				}
 				priv, err := legacy.PrivKeyFromBytes([]byte(localInfo.PrivKeyArmor))
 				if err != nil {
@@ -579,20 +583,20 @@ func getPrivateKey(cmd *cobra.Command) (*ecdsa.PrivateKey, error) {
 	kb := txf.Keybase()
 	info, err := kb.Key(clientCtx.GetFromName())
 	if err != nil {
-		fmt.Printf("PSUDEBUG err from kb.key: %s\n", err)
 		return nil, err
 	}
 	localInfo, ok := info.(keyring.LocalInfo)
 	if !ok {
 		return nil, errors.New("can only associate address for local keys")
 	}
+	if localInfo.GetAlgo() != hd.Secp256k1Type {
+		return nil, errors.New("can only use addresses using secp256k1")
+	}
 	priv, err := legacy.PrivKeyFromBytes([]byte(localInfo.PrivKeyArmor))
 	if err != nil {
-		fmt.Printf("PSUDEBUG err from PrivKeyFromBytes: %s\n", err)
 		return nil, err
 	}
 	privHex := hex.EncodeToString(priv.Bytes())
-	fmt.Printf("PSUDEBUG hex to dedcsa\n", err)
 	key, _ := crypto.HexToECDSA(privHex)
 	return key, nil
 }

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -172,8 +172,11 @@ func CmdSend() *cobra.Command {
 			if n, err := cmd.Flags().GetInt64(FlagNonce); err == nil && n >= 0 {
 				nonce = uint64(n)
 			} else {
+				fmt.Printf("Getting nonce\n")
 				nonce, err = getNonce(rpc, key.PublicKey)
+				fmt.Printf("Finished getting nonce\n")
 				if err != nil {
+					fmt.Printf("Get none errord: %s\n", err)
 					return err
 				}
 			}
@@ -184,6 +187,7 @@ func CmdSend() *cobra.Command {
 				return fmt.Errorf("%s is an invalid amount to send", args[1])
 			}
 			txData, err := getTxData(cmd)
+			fmt.Printf("Finished getting txdata\n")
 			if err != nil {
 				return err
 			}
@@ -192,7 +196,9 @@ func CmdSend() *cobra.Command {
 			txData.Data = []byte("")
 			txData.To = &to
 			resp, err := sendTx(txData, rpc, key)
+			fmt.Printf("Finished send tx\n")
 			if err != nil {
+				fmt.Printf("Send tx error'd %s\n", err)
 				return err
 			}
 

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -172,11 +172,8 @@ func CmdSend() *cobra.Command {
 			if n, err := cmd.Flags().GetInt64(FlagNonce); err == nil && n >= 0 {
 				nonce = uint64(n)
 			} else {
-				fmt.Printf("Getting nonce\n")
 				nonce, err = getNonce(rpc, key.PublicKey)
-				fmt.Printf("Finished getting nonce\n")
 				if err != nil {
-					fmt.Printf("Get none errord: %s\n", err)
 					return err
 				}
 			}
@@ -187,7 +184,6 @@ func CmdSend() *cobra.Command {
 				return fmt.Errorf("%s is an invalid amount to send", args[1])
 			}
 			txData, err := getTxData(cmd)
-			fmt.Printf("Finished getting txdata\n")
 			if err != nil {
 				return err
 			}
@@ -196,9 +192,7 @@ func CmdSend() *cobra.Command {
 			txData.Data = []byte("")
 			txData.To = &to
 			resp, err := sendTx(txData, rpc, key)
-			fmt.Printf("Finished send tx\n")
 			if err != nil {
-				fmt.Printf("Send tx error'd %s\n", err)
 				return err
 			}
 
@@ -585,6 +579,7 @@ func getPrivateKey(cmd *cobra.Command) (*ecdsa.PrivateKey, error) {
 	kb := txf.Keybase()
 	info, err := kb.Key(clientCtx.GetFromName())
 	if err != nil {
+		fmt.Printf("PSUDEBUG err from kb.key: %s\n", err)
 		return nil, err
 	}
 	localInfo, ok := info.(keyring.LocalInfo)
@@ -593,9 +588,11 @@ func getPrivateKey(cmd *cobra.Command) (*ecdsa.PrivateKey, error) {
 	}
 	priv, err := legacy.PrivKeyFromBytes([]byte(localInfo.PrivKeyArmor))
 	if err != nil {
+		fmt.Printf("PSUDEBUG err from PrivKeyFromBytes: %s\n", err)
 		return nil, err
 	}
 	privHex := hex.EncodeToString(priv.Bytes())
+	fmt.Printf("PSUDEBUG hex to dedcsa\n", err)
 	key, _ := crypto.HexToECDSA(privHex)
 	return key, nil
 }


### PR DESCRIPTION
## Describe your changes and provide context
Similar to https://github.com/sei-protocol/sei-cosmos/pull/495/files, ```priv, err := legacy.PrivKeyFromBytes([]byte(localInfo.PrivKeyArmor))``` only works with secp256k1 algo, so we should disallow using sr25519 addresses
## Testing performed to validate your change
```
root@ip-172-31-4-247:/home/ubuntu/sei-chain# printf "12345678\n" | seid tx evm send 0xF87A299e6bC7bEba58dbBe5a5Aa21d49bCD16D52  100000000000000000 --from sei-foundation
Error: can only use addresses using secp256k1
```
