### PR TITLE
Allow big ints to be passed into erc20-send

### DIFF
--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -11,7 +11,6 @@ import (
 	"math/big"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
@@ -374,15 +373,15 @@ func CmdERC20Send() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			contract := common.HexToAddress(args[0])
 			recipient := common.HexToAddress(args[1])
-			amt, err := strconv.ParseUint(args[2], 10, 64)
-			if err != nil {
-				return err
+			amt, ok := new(big.Int).SetString(args[2], 10)
+			if !ok {
+				return errors.New(fmt.Sprintf("Unable to parse amount: %s\n", args[2]))
 			}
 			abi, err := native.NativeMetaData.GetAbi()
 			if err != nil {
 				return err
 			}
-			payload, err := abi.Pack("transfer", recipient, new(big.Int).SetUint64(amt))
+			payload, err := abi.Pack("transfer", recipient, amt)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Describe your changes and provide context
`wei` is a small unit, so when using cli you can run into:
```
root@ip-172-31-4-247:/home/ubuntu/sei-chain# seid tx evm erc20-send 0x6b481a6cfd3e62bf71fd17f5ccb4aedd56ed43d9 0x7B177Ab8381073865a908A637D480f6BE2eF537e 10000000000000000000000 --from=psu
Error: strconv.ParseUint: parsing "10000000000000000000000": value out of range
```
Since it is ultimately parsed to big int, we should just use it at the beginning
## Testing performed to validate your change
Was able to do the send:
```
root@ip-172-31-4-247:/home/ubuntu/sei-chain# seid tx evm erc20-send 0x6b481a6cfd3e62bf71fd17f5ccb4aedd56ed43d9 0x7B177Ab8381073865a908A637D480f6BE2eF537e 90000000000000000000000 --from=psu
Enter keyring passphrase:
Transaction hash: 0xfa501ded7e4efa9a8a19dbf1684947b493b2ae74321463fa58b750e1769995dc
root@ip-172-31-4-247:/home/ubuntu/sei-chain# seid q evm erc20 0x6b481a6cfd3e62bf71fd17f5ccb4aedd56ed43d9 balanceOf 0x7B177Ab8381073865a908A637D480f6BE2eF537e
```
