### PR TITLE
optimize WS newhead

### DIFF
--- a/evmrpc/filter.go
+++ b/evmrpc/filter.go
@@ -98,7 +98,8 @@ func (a *FilterAPI) timeoutLoop(timeout time.Duration) {
 func (a *FilterAPI) NewFilter(
 	_ context.Context,
 	crit filters.FilterCriteria,
-) (ethrpc.ID, error) {
+) (id ethrpc.ID, err error) {
+	defer recordMetrics("eth_newFilter", time.Now(), err == nil)
 	a.filtersMu.Lock()
 	defer a.filtersMu.Unlock()
 	curFilterID := ethrpc.NewID()
@@ -113,7 +114,8 @@ func (a *FilterAPI) NewFilter(
 
 func (a *FilterAPI) NewBlockFilter(
 	_ context.Context,
-) (ethrpc.ID, error) {
+) (id ethrpc.ID, err error) {
+	defer recordMetrics("eth_newBlockFilter", time.Now(), err == nil)
 	a.filtersMu.Lock()
 	defer a.filtersMu.Unlock()
 	curFilterID := ethrpc.NewID()
@@ -128,7 +130,8 @@ func (a *FilterAPI) NewBlockFilter(
 func (a *FilterAPI) GetFilterChanges(
 	ctx context.Context,
 	filterID ethrpc.ID,
-) (interface{}, error) {
+) (res interface{}, err error) {
+	defer recordMetrics("eth_getFilterChanges", time.Now(), err == nil)
 	a.filtersMu.Lock()
 	defer a.filtersMu.Unlock()
 	filter, ok := a.filters[filterID]
@@ -178,7 +181,8 @@ func (a *FilterAPI) GetFilterChanges(
 func (a *FilterAPI) GetFilterLogs(
 	ctx context.Context,
 	filterID ethrpc.ID,
-) ([]*ethtypes.Log, error) {
+) (res []*ethtypes.Log, err error) {
+	defer recordMetrics("eth_getFilterLogs", time.Now(), err == nil)
 	a.filtersMu.Lock()
 	defer a.filtersMu.Unlock()
 	filter, ok := a.filters[filterID]
@@ -206,7 +210,8 @@ func (a *FilterAPI) GetFilterLogs(
 func (a *FilterAPI) GetLogs(
 	ctx context.Context,
 	crit filters.FilterCriteria,
-) ([]*ethtypes.Log, error) {
+) (res []*ethtypes.Log, err error) {
+	defer recordMetrics("eth_getLogs", time.Now(), err == nil)
 	logs, _, err := a.logFetcher.GetLogsByFilters(ctx, crit, 0)
 	return logs, err
 }
@@ -252,7 +257,8 @@ func (a *FilterAPI) getBlockHeadersAfter(
 func (a *FilterAPI) UninstallFilter(
 	_ context.Context,
 	filterID ethrpc.ID,
-) bool {
+) (res bool) {
+	defer recordMetrics("eth_uninstallFilter", time.Now(), res)
 	a.filtersMu.Lock()
 	defer a.filtersMu.Unlock()
 	_, found := a.filters[filterID]

--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -154,7 +154,7 @@ func NewEVMWebSocketServer(
 		},
 		{
 			Namespace: "eth",
-			Service:   NewSubscriptionAPI(tmClient, &LogFetcher{tmClient: tmClient, k: k, ctxProvider: ctxProvider}, &SubscriptionConfig{subscriptionCapacity: 100}),
+			Service:   NewSubscriptionAPI(tmClient, &LogFetcher{tmClient: tmClient, k: k, ctxProvider: ctxProvider}, &SubscriptionConfig{subscriptionCapacity: 100}, &FilterConfig{timeout: config.FilterTimeout, maxLog: config.MaxLogNoBlock, maxBlock: config.MaxBlocksForLog}),
 		},
 		{
 			Namespace: "web3",

--- a/evmrpc/setup_test.go
+++ b/evmrpc/setup_test.go
@@ -80,6 +80,8 @@ var MockBlockID = tmtypes.BlockID{
 	Hash: bytes.HexBytes(mustHexToBytes("0000000000000000000000000000000000000000000000000000000000000001")),
 }
 
+var NewHeadsCalled = make(chan struct{})
+
 type MockClient struct {
 	mock.Client
 }
@@ -271,6 +273,7 @@ func (c *MockClient) Subscribe(ctx context.Context, subscriber string, query str
 	if query == "tm.event = 'NewBlockHeader'" {
 		resCh := make(chan coretypes.ResultEvent, 5)
 		go func() {
+			<-NewHeadsCalled
 			for i := uint64(0); i < 5; i++ {
 				resCh <- coretypes.ResultEvent{
 					SubscriptionID: subscriber,

--- a/evmrpc/subscribe.go
+++ b/evmrpc/subscribe.go
@@ -25,61 +25,98 @@ type SubscriptionAPI struct {
 	subscriptionManager *SubscriptionManager
 	subscriptonConfig   *SubscriptionConfig
 
-	logFetcher *LogFetcher
+	logFetcher          *LogFetcher
+	newHeadListenersMtx *sync.Mutex
+	newHeadListeners    map[rpc.ID]chan map[string]interface{}
 }
 
 type SubscriptionConfig struct {
 	subscriptionCapacity int
 }
 
-func NewSubscriptionAPI(tmClient rpcclient.Client, logFetcher *LogFetcher, subscriptionConfig *SubscriptionConfig) *SubscriptionAPI {
-	logFetcher.filterConfig = &FilterConfig{}
-	return &SubscriptionAPI{
+func NewSubscriptionAPI(tmClient rpcclient.Client, logFetcher *LogFetcher, subscriptionConfig *SubscriptionConfig, filterConfig *FilterConfig) *SubscriptionAPI {
+	logFetcher.filterConfig = filterConfig
+	api := &SubscriptionAPI{
 		tmClient:            tmClient,
 		subscriptionManager: NewSubscriptionManager(tmClient),
 		subscriptonConfig:   subscriptionConfig,
 		logFetcher:          logFetcher,
+		newHeadListenersMtx: &sync.Mutex{},
+		newHeadListeners:    make(map[rpc.ID]chan map[string]interface{}),
 	}
+	id, subCh, err := api.subscriptionManager.Subscribe(context.Background(), NewHeadQueryBuilder(), api.subscriptonConfig.subscriptionCapacity)
+	if err != nil {
+		panic(err)
+	}
+	go func() {
+		defer func() {
+			_ = api.subscriptionManager.Unsubscribe(context.Background(), id)
+		}()
+		for {
+			res := <-subCh
+			ethHeader, err := encodeTmHeader(res.Data.(tmtypes.EventDataNewBlockHeader))
+			if err != nil {
+				fmt.Printf("error encoding new head event %#v due to %s\n", res.Data, err)
+				continue
+			}
+			api.newHeadListenersMtx.Lock()
+			for _, c := range api.newHeadListeners {
+				c := c
+				go func() {
+					defer func() {
+						// if the channel is already closed, sending to it will panic
+						if err := recover(); err != nil {
+							return
+						}
+					}()
+					c <- ethHeader
+				}()
+			}
+			api.newHeadListenersMtx.Unlock()
+		}
+	}()
+	return api
 }
 
-func (a *SubscriptionAPI) NewHeads(ctx context.Context) (*rpc.Subscription, error) {
+func (a *SubscriptionAPI) NewHeads(ctx context.Context) (s *rpc.Subscription, err error) {
+	defer recordMetrics("eth_newHeads", time.Now(), err == nil)
 	notifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {
 		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
 	}
 
 	rpcSub := notifier.CreateSubscription()
-	subscriberID, subCh, err := a.subscriptionManager.Subscribe(context.Background(), NewHeadQueryBuilder(), a.subscriptonConfig.subscriptionCapacity)
-	if err != nil {
-		return nil, err
-	}
+	listener := make(chan map[string]interface{})
 
 	go func() {
-		defer func() {
-			_ = a.subscriptionManager.Unsubscribe(context.Background(), subscriberID)
-		}()
+	OUTER:
 		for {
 			select {
-			case res := <-subCh:
-				ethHeader, err := encodeTmHeader(res.Data.(tmtypes.EventDataNewBlockHeader))
+			case res := <-listener:
+				err = notifier.Notify(rpcSub.ID, res)
 				if err != nil {
-					return
-				}
-				err = notifier.Notify(rpcSub.ID, ethHeader)
-				if err != nil {
-					return
+					break OUTER
 				}
 			case <-rpcSub.Err():
-				return
+				break OUTER
 			case <-notifier.Closed():
-				return
+				break OUTER
 			}
 		}
+		a.newHeadListenersMtx.Lock()
+		defer a.newHeadListenersMtx.Unlock()
+		delete(a.newHeadListeners, rpcSub.ID)
+		close(listener)
 	}()
+	a.newHeadListenersMtx.Lock()
+	defer a.newHeadListenersMtx.Unlock()
+	a.newHeadListeners[rpcSub.ID] = listener
+
 	return rpcSub, nil
 }
 
-func (a *SubscriptionAPI) Logs(ctx context.Context, filter *filters.FilterCriteria) (*rpc.Subscription, error) {
+func (a *SubscriptionAPI) Logs(ctx context.Context, filter *filters.FilterCriteria) (s *rpc.Subscription, err error) {
+	defer recordMetrics("eth_logs", time.Now(), err == nil)
 	notifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {
 		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported

--- a/evmrpc/subscribe_test.go
+++ b/evmrpc/subscribe_test.go
@@ -15,6 +15,7 @@ import (
 func TestSubscribeNewHeads(t *testing.T) {
 	t.Parallel()
 	recvCh, done := sendWSRequestGood(t, "subscribe", "newHeads")
+	NewHeadsCalled <- struct{}{}
 	defer func() { done <- struct{}{} }()
 
 	receivedSubMsg := false


### PR DESCRIPTION
## Describe your changes and provide context
instead of having each subscription subscribing to tendermint and encode to JSON independently, we will maintain a single subscription with tendermint and a single copy of encoded JSON per head, then fan it out to all outgoing subscriptions

## Testing performed to validate your change

