### PR TITLE
[EVM] Fix contract deploy receipts

### DIFF
--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -268,13 +268,13 @@ func encodeReceipt(receipt *types.Receipt, decoder sdk.TxDecoder, block *coretyp
 	}
 	bloom := ethtypes.Bloom{}
 	bloom.SetBytes(receipt.LogsBloom)
+
 	fields := map[string]interface{}{
 		"blockHash":         bh,
 		"blockNumber":       hexutil.Uint64(receipt.BlockNumber),
 		"transactionHash":   common.HexToHash(receipt.TxHashHex),
 		"transactionIndex":  hexutil.Uint64(evmTxIndex),
 		"from":              common.HexToAddress(receipt.From),
-		"to":                common.HexToAddress(receipt.To),
 		"gasUsed":           hexutil.Uint64(receipt.GasUsed),
 		"cumulativeGasUsed": hexutil.Uint64(receipt.CumulativeGasUsed),
 		"logs":              logs,
@@ -283,10 +283,13 @@ func encodeReceipt(receipt *types.Receipt, decoder sdk.TxDecoder, block *coretyp
 		"effectiveGasPrice": (*hexutil.Big)(big.NewInt(int64(receipt.EffectiveGasPrice))),
 		"status":            hexutil.Uint(receipt.Status),
 	}
-	if receipt.ContractAddress != "" {
+	if receipt.ContractAddress != "" && receipt.To == "" {
 		fields["contractAddress"] = common.HexToAddress(receipt.ContractAddress)
 	} else {
 		fields["contractAddress"] = nil
+	}
+	if receipt.To != "" {
+		fields["to"] = common.HexToAddress(receipt.To)
 	}
 	return fields, nil
 }

--- a/evmrpc/tx_test.go
+++ b/evmrpc/tx_test.go
@@ -21,6 +21,11 @@ import (
 )
 
 func TestGetTxReceipt(t *testing.T) {
+	receipt, err := EVMKeeper.GetReceipt(Ctx, common.HexToHash("0xf02362077ac075a397344172496b28e913ce5294879d811bb0269b3be20a872e"))
+	require.Nil(t, err)
+	receipt.To = ""
+	EVMKeeper.SetReceipt(Ctx, common.HexToHash("0xf02362077ac075a397344172496b28e913ce5294879d811bb0269b3be20a872e"), receipt)
+
 	body := "{\"jsonrpc\": \"2.0\",\"method\": \"eth_getTransactionReceipt\",\"params\":[\"0xf02362077ac075a397344172496b28e913ce5294879d811bb0269b3be20a872e\"],\"id\":\"test\"}"
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s:%d", TestAddr, TestPort), strings.NewReader(body))
 	require.Nil(t, err)
@@ -53,15 +58,16 @@ func TestGetTxReceipt(t *testing.T) {
 	require.Equal(t, "0x0", log["logIndex"].(string))
 	require.False(t, log["removed"].(bool))
 	require.Equal(t, "0x0", resObj["status"].(string))
-	require.Equal(t, "0x1234567890123456789012345678901234567890", resObj["to"].(string))
+	require.Equal(t, nil, resObj["to"])
 	require.Equal(t, "0xf02362077ac075a397344172496b28e913ce5294879d811bb0269b3be20a872e", resObj["transactionHash"].(string))
 	require.Equal(t, "0x0", resObj["transactionIndex"].(string))
 	require.Equal(t, "0x1", resObj["type"].(string))
 	require.Equal(t, "0x1234567890123456789012345678901234567890", resObj["contractAddress"].(string))
 
-	receipt, err := EVMKeeper.GetReceipt(Ctx, common.HexToHash("0xf02362077ac075a397344172496b28e913ce5294879d811bb0269b3be20a872e"))
+	receipt, err = EVMKeeper.GetReceipt(Ctx, common.HexToHash("0xf02362077ac075a397344172496b28e913ce5294879d811bb0269b3be20a872e"))
 	require.Nil(t, err)
 	receipt.ContractAddress = ""
+	receipt.To = "0x1234567890123456789012345678901234567890"
 	EVMKeeper.SetReceipt(Ctx, common.HexToHash("0xf02362077ac075a397344172496b28e913ce5294879d811bb0269b3be20a872e"), receipt)
 	body = "{\"jsonrpc\": \"2.0\",\"method\": \"eth_getTransactionReceipt\",\"params\":[\"0xf02362077ac075a397344172496b28e913ce5294879d811bb0269b3be20a872e\"],\"id\":\"test\"}"
 	req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s:%d", TestAddr, TestPort), strings.NewReader(body))
@@ -75,6 +81,7 @@ func TestGetTxReceipt(t *testing.T) {
 	require.Nil(t, json.Unmarshal(resBody, &resObj))
 	resObj = resObj["result"].(map[string]interface{})
 	require.Nil(t, resObj["contractAddress"])
+	require.Equal(t, "0x1234567890123456789012345678901234567890", resObj["to"].(string))
 
 	req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s:%d", TestAddr, TestBadPort), strings.NewReader(body))
 	require.Nil(t, err)


### PR DESCRIPTION
## Describe your changes and provide context
- to should be nil (instead of 0x00000..) on contract deploy
- contractAddress should only be populated if to is nil (not for factory deploys)

## Testing performed to validate your change
- unit test
