### PR TITLE
Use buffered listener for NewHeads subscription

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     # - depguard ## see https://github.com/golangci/golangci-lint/issues/3906
     - dogsled
     - exportloopref


### PR DESCRIPTION
## Describe your changes and provide context
We want to close connection for consumers that are falling behind by too much, since otherwise we'd need to keep in memory all heads contained in the lag. Using a buffered channel for that purpose here

## Testing performed to validate your change

