### PR TITLE
Avoid using iterator when getting spendable coins

### DIFF
--- a/x/evm/state/balance.go
+++ b/x/evm/state/balance.go
@@ -92,8 +92,12 @@ func (s *DBImpl) AddBalance(evmAddr common.Address, amt *big.Int, reason tracing
 
 func (s *DBImpl) GetBalance(evmAddr common.Address) *big.Int {
 	s.k.PrepareReplayedAddr(s.ctx, evmAddr)
-	usei := s.k.BankKeeper().SpendableCoins(s.ctx, s.getSeiAddress(evmAddr)).AmountOf(s.k.GetBaseDenom(s.ctx))
-	wei := s.k.BankKeeper().GetWeiBalance(s.ctx, s.getSeiAddress(evmAddr))
+	seiAddr := s.getSeiAddress(evmAddr)
+	denom := s.k.GetBaseDenom(s.ctx)
+	allUsei := s.k.BankKeeper().GetBalance(s.ctx, seiAddr, denom).Amount
+	lockedUsei := s.k.BankKeeper().LockedCoins(s.ctx, seiAddr).AmountOf(denom) // LockedCoins doesn't use iterators
+	usei := allUsei.Sub(lockedUsei)
+	wei := s.k.BankKeeper().GetWeiBalance(s.ctx, seiAddr)
 	return usei.Mul(SdkUseiToSweiMultiplier).Add(wei).BigInt()
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
`SpendableCoins` uses an iterator to get all coin balances first and then subtract those with `LockedCoins` (`LockedCoins` in itself doesn't require iterators), but using iterator is gonna cause huge performance issue within EVM. So this PR changes `SpendableCoins` with a point query and then do the subtraction inside stateDB.

## Testing performed to validate your change
replay test

