### PR TITLE
Always consider CosmWasm contract address as associated

### DIFF
--- a/x/evm/keeper/address.go
+++ b/x/evm/keeper/address.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
@@ -27,6 +28,12 @@ func (k *Keeper) DeleteAddressMapping(ctx sdk.Context, seiAddress sdk.AccAddress
 }
 
 func (k *Keeper) GetEVMAddress(ctx sdk.Context, seiAddress sdk.AccAddress) (common.Address, bool) {
+	// CW address has a different length and should always be considered associated
+	// Note that this association is one-way since CW address is longer than EOA address
+	// and would need to be cropped.
+	if len(seiAddress) == wasmtypes.ContractAddrLen {
+		return common.BytesToAddress(seiAddress), true
+	}
 	store := ctx.KVStore(k.storeKey)
 	bz := store.Get(types.SeiAddressToEVMAddressKey(seiAddress))
 	addr := common.Address{}

--- a/x/evm/keeper/address_test.go
+++ b/x/evm/keeper/address_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"testing"
 
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/stretchr/testify/require"
 )
@@ -49,4 +51,12 @@ func TestGetAddressOrDefault(t *testing.T) {
 	require.True(t, bytes.Equal(seiAddr, defaultEvmAddr[:]))
 	defaultSeiAddr := k.GetSeiAddressOrDefault(ctx, evmAddr)
 	require.True(t, bytes.Equal(defaultSeiAddr, evmAddr[:]))
+}
+
+func TestGetEVMAddressForCW(t *testing.T) {
+	k, ctx := keeper.MockEVMKeeper()
+	cwAddr := wasmkeeper.BuildContractAddress(123, 456)
+	cwEvmAddr, associated := k.GetEVMAddress(ctx, cwAddr)
+	require.True(t, associated)
+	require.Equal(t, common.BytesToAddress(cwAddr), cwEvmAddr)
 }


### PR DESCRIPTION
## Describe your changes and provide context
We want to be able to get EVM address for a CW contract address so that a CW contract can for example receive ERC20 tokens via pointer. We notice that there is a size difference between CW address and normal address so we leverage that fact to determine whether we should direct cast and early return.

Note that this is only one-way - getting Sei address for an EVM address obtained this way will not work, because the EVM address only contains a truncated version of the original Sei address.

## Testing performed to validate your change
uint test

