### PR TITLE
Add reverse mapping for pointers

### DIFF
--- a/x/evm/keeper/pointer.go
+++ b/x/evm/keeper/pointer.go
@@ -16,11 +16,19 @@ import (
 )
 
 func (k *Keeper) SetERC20NativePointer(ctx sdk.Context, token string, addr common.Address) error {
-	return k.SetPointerInfo(ctx, types.PointerERC20NativeKey(token), addr[:], native.CurrentVersion)
+	err := k.SetPointerInfo(ctx, types.PointerERC20NativeKey(token), addr[:], native.CurrentVersion)
+	if err != nil {
+		return err
+	}
+	return k.SetPointerInfo(ctx, types.PointerReverseRegistryKey(addr), []byte(token), native.CurrentVersion)
 }
 
 func (k *Keeper) SetERC20NativePointerWithVersion(ctx sdk.Context, token string, addr common.Address, version uint16) error {
-	return k.SetPointerInfo(ctx, types.PointerERC20NativeKey(token), addr[:], version)
+	err := k.SetPointerInfo(ctx, types.PointerERC20NativeKey(token), addr[:], version)
+	if err != nil {
+		return err
+	}
+	return k.SetPointerInfo(ctx, types.PointerReverseRegistryKey(addr), []byte(token), version)
 }
 
 func (k *Keeper) GetERC20NativePointer(ctx sdk.Context, token string) (addr common.Address, version uint16, exists bool) {
@@ -31,16 +39,37 @@ func (k *Keeper) GetERC20NativePointer(ctx sdk.Context, token string) (addr comm
 	return
 }
 
+func (k *Keeper) GetERC20NativeByPointer(ctx sdk.Context, addr common.Address) (token string, version uint16, exists bool) {
+	tokenBz, version, exists := k.GetPointerInfo(ctx, types.PointerReverseRegistryKey(addr))
+	if exists {
+		token = string(tokenBz)
+	}
+	return
+}
+
 func (k *Keeper) DeleteERC20NativePointer(ctx sdk.Context, token string, version uint16) {
-	k.DeletePointerInfo(ctx, types.PointerERC20NativeKey(token), version)
+	addr, _, exists := k.GetERC20NativePointer(ctx, token)
+	if exists {
+		k.DeletePointerInfo(ctx, types.PointerERC20NativeKey(token), version)
+		k.DeletePointerInfo(ctx, types.PointerReverseRegistryKey(addr), version)
+	}
+
 }
 
 func (k *Keeper) SetERC20CW20Pointer(ctx sdk.Context, cw20Address string, addr common.Address) error {
-	return k.SetPointerInfo(ctx, types.PointerERC20CW20Key(cw20Address), addr[:], cw20.CurrentVersion)
+	err := k.SetPointerInfo(ctx, types.PointerERC20CW20Key(cw20Address), addr[:], cw20.CurrentVersion)
+	if err != nil {
+		return err
+	}
+	return k.SetPointerInfo(ctx, types.PointerReverseRegistryKey(addr), []byte(cw20Address), cw20.CurrentVersion)
 }
 
 func (k *Keeper) SetERC20CW20PointerWithVersion(ctx sdk.Context, cw20Address string, addr common.Address, version uint16) error {
-	return k.SetPointerInfo(ctx, types.PointerERC20CW20Key(cw20Address), addr[:], version)
+	err := k.SetPointerInfo(ctx, types.PointerERC20CW20Key(cw20Address), addr[:], version)
+	if err != nil {
+		return err
+	}
+	return k.SetPointerInfo(ctx, types.PointerReverseRegistryKey(addr), []byte(cw20Address), version)
 }
 
 func (k *Keeper) GetERC20CW20Pointer(ctx sdk.Context, cw20Address string) (addr common.Address, version uint16, exists bool) {
@@ -51,16 +80,37 @@ func (k *Keeper) GetERC20CW20Pointer(ctx sdk.Context, cw20Address string) (addr 
 	return
 }
 
+func (k *Keeper) GetERC20CW20ByPointer(ctx sdk.Context, addr common.Address) (cw20Address string, version uint16, exists bool) {
+	cw20AddressBz, version, exists := k.GetPointerInfo(ctx, types.PointerReverseRegistryKey(addr))
+	if exists {
+		cw20Address = string(cw20AddressBz)
+	}
+	return
+}
+
 func (k *Keeper) DeleteERC20CW20Pointer(ctx sdk.Context, cw20Address string, version uint16) {
-	k.DeletePointerInfo(ctx, types.PointerERC20CW20Key(cw20Address), version)
+	addr, _, exists := k.GetERC20CW20Pointer(ctx, cw20Address)
+	if exists {
+		k.DeletePointerInfo(ctx, types.PointerERC20CW20Key(cw20Address), version)
+		k.DeletePointerInfo(ctx, types.PointerReverseRegistryKey(addr), version)
+	}
+
 }
 
 func (k *Keeper) SetERC721CW721Pointer(ctx sdk.Context, cw721Address string, addr common.Address) error {
-	return k.SetPointerInfo(ctx, types.PointerERC721CW721Key(cw721Address), addr[:], cw721.CurrentVersion)
+	err := k.SetPointerInfo(ctx, types.PointerERC721CW721Key(cw721Address), addr[:], cw721.CurrentVersion)
+	if err != nil {
+		return err
+	}
+	return k.SetPointerInfo(ctx, types.PointerReverseRegistryKey(addr), []byte(cw721Address), cw721.CurrentVersion)
 }
 
 func (k *Keeper) SetERC721CW721PointerWithVersion(ctx sdk.Context, cw721Address string, addr common.Address, version uint16) error {
-	return k.SetPointerInfo(ctx, types.PointerERC721CW721Key(cw721Address), addr[:], version)
+	err := k.SetPointerInfo(ctx, types.PointerERC721CW721Key(cw721Address), addr[:], version)
+	if err != nil {
+		return err
+	}
+	return k.SetPointerInfo(ctx, types.PointerReverseRegistryKey(addr), []byte(cw721Address), version)
 }
 
 func (k *Keeper) GetERC721CW721Pointer(ctx sdk.Context, cw721Address string) (addr common.Address, version uint16, exists bool) {
@@ -71,12 +121,28 @@ func (k *Keeper) GetERC721CW721Pointer(ctx sdk.Context, cw721Address string) (ad
 	return
 }
 
+func (k *Keeper) GetERC721CW721ByPointer(ctx sdk.Context, addr common.Address) (cw721Address string, version uint16, exists bool) {
+	cw721AddressBz, version, exists := k.GetPointerInfo(ctx, types.PointerReverseRegistryKey(addr))
+	if exists {
+		cw721Address = string(cw721AddressBz)
+	}
+	return
+}
+
 func (k *Keeper) DeleteERC721CW721Pointer(ctx sdk.Context, cw721Address string, version uint16) {
-	k.DeletePointerInfo(ctx, types.PointerERC721CW721Key(cw721Address), version)
+	addr, _, exists := k.GetERC721CW721Pointer(ctx, cw721Address)
+	if exists {
+		k.DeletePointerInfo(ctx, types.PointerERC721CW721Key(cw721Address), version)
+		k.DeletePointerInfo(ctx, types.PointerReverseRegistryKey(addr), version)
+	}
 }
 
 func (k *Keeper) SetCW20ERC20Pointer(ctx sdk.Context, erc20Address common.Address, addr string) error {
-	return k.SetPointerInfo(ctx, types.PointerCW20ERC20Key(erc20Address), []byte(addr), erc20.CurrentVersion)
+	err := k.SetPointerInfo(ctx, types.PointerCW20ERC20Key(erc20Address), []byte(addr), erc20.CurrentVersion)
+	if err != nil {
+		return err
+	}
+	return k.SetPointerInfo(ctx, types.PointerReverseRegistryKey(common.HexToAddress(addr)), erc20Address[:], erc20.CurrentVersion)
 }
 
 func (k *Keeper) GetCW20ERC20Pointer(ctx sdk.Context, erc20Address common.Address) (addr sdk.AccAddress, version uint16, exists bool) {
@@ -88,7 +154,11 @@ func (k *Keeper) GetCW20ERC20Pointer(ctx sdk.Context, erc20Address common.Addres
 }
 
 func (k *Keeper) SetCW721ERC721Pointer(ctx sdk.Context, erc721Address common.Address, addr string) error {
-	return k.SetPointerInfo(ctx, types.PointerCW721ERC721Key(erc721Address), []byte(addr), erc721.CurrentVersion)
+	err := k.SetPointerInfo(ctx, types.PointerCW721ERC721Key(erc721Address), []byte(addr), erc721.CurrentVersion)
+	if err != nil {
+		return err
+	}
+	return k.SetPointerInfo(ctx, types.PointerReverseRegistryKey(common.HexToAddress(addr)), erc721Address[:], erc721.CurrentVersion)
 }
 
 func (k *Keeper) GetCW721ERC721Pointer(ctx sdk.Context, erc721Address common.Address) (addr sdk.AccAddress, version uint16, exists bool) {

--- a/x/evm/keeper/pointer_test.go
+++ b/x/evm/keeper/pointer_test.go
@@ -7,15 +7,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSetPointer(t *testing.T) {
+func TestERC20NativePointer(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper()
+	_, pointer := testkeeper.MockAddressPair()
+	require.Nil(t, k.SetERC20NativePointer(ctx, "test", pointer))
+	require.NotNil(t, k.SetERC20NativePointer(ctx, "test", pointer)) // already set
+	addr, _, _ := k.GetERC20NativePointer(ctx, "test")
+	require.Equal(t, pointer, addr)
+	token, _, _ := k.GetERC20NativeByPointer(ctx, addr)
+	require.Equal(t, "test", token)
+}
+
+func TestSetERC20CW20Pointer(t *testing.T) {
 	k, ctx := testkeeper.MockEVMKeeper()
 	_, pointer := testkeeper.MockAddressPair()
 	cw20, _ := testkeeper.MockAddressPair()
-	cw721, _ := testkeeper.MockAddressPair()
-	require.Nil(t, k.SetERC20NativePointer(ctx, "test", pointer))
-	require.NotNil(t, k.SetERC20NativePointer(ctx, "test", pointer)) // already set
 	require.Nil(t, k.SetERC20CW20Pointer(ctx, cw20.String(), pointer))
 	require.NotNil(t, k.SetERC20CW20Pointer(ctx, cw20.String(), pointer)) // already set
+	addr, _, _ := k.GetERC20CW20Pointer(ctx, cw20.String())
+	require.Equal(t, pointer, addr)
+	cw20Addr, _, _ := k.GetERC20CW20ByPointer(ctx, addr)
+	require.Equal(t, cw20.String(), cw20Addr)
+}
+
+func TestERC721CW721Pointer(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper()
+	_, pointer := testkeeper.MockAddressPair()
+	cw721, _ := testkeeper.MockAddressPair()
 	require.Nil(t, k.SetERC721CW721Pointer(ctx, cw721.String(), pointer))
 	require.NotNil(t, k.SetERC721CW721Pointer(ctx, cw721.String(), pointer)) // already set
+	addr, _, _ := k.GetERC721CW721Pointer(ctx, cw721.String())
+	require.Equal(t, pointer, addr)
+	cw721Addr, _, _ := k.GetERC721CW721ByPointer(ctx, addr)
+	require.Equal(t, cw721.String(), cw721Addr)
 }

--- a/x/evm/types/keys.go
+++ b/x/evm/types/keys.go
@@ -46,8 +46,9 @@ var (
 	ReplayedHeight       = []byte{0x13}
 	ReplayInitialHeight  = []byte{0x14}
 
-	PointerRegistryPrefix = []byte{0x15}
-	PointerCWCodePrefix   = []byte{0x16}
+	PointerRegistryPrefix        = []byte{0x15}
+	PointerCWCodePrefix          = []byte{0x16}
+	PointerReverseRegistryPrefix = []byte{0x17}
 )
 
 var (
@@ -119,4 +120,8 @@ func PointerCW721ERC721Key(erc721Addr common.Address) []byte {
 		append(PointerRegistryPrefix, PointerCW721ERC721Prefix...),
 		erc721Addr[:]...,
 	)
+}
+
+func PointerReverseRegistryKey(addr common.Address) []byte {
+	return append(PointerReverseRegistryPrefix, addr[:]...)
 }


### PR DESCRIPTION
## Describe your changes and provide context
Currently, there's only one directional mapping to record the pointer address, this PR is going to make it bidirectional. Instead of only keeping track of A->B, now we record both A->B and B->A, which makes search easier.

## Testing performed to validate your change
Added and fixed existing unit test
