### PR TITLE
Fix ante surplus handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -348,7 +348,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.1.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.8
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.10
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.9
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.0
 	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-16

--- a/go.sum
+++ b/go.sum
@@ -1350,8 +1350,8 @@ github.com/sei-protocol/go-ethereum v1.13.5-sei-16 h1:bPQw44//5XHDZWfwO98g2Hie5H
 github.com/sei-protocol/go-ethereum v1.13.5-sei-16/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.3.8 h1:YojcJLDNkerH7owwJlzuIWfKP0RNM2K9FKtjZkValow=
-github.com/sei-protocol/sei-cosmos v0.3.8/go.mod h1:WWwx6XlJc9SrjdRwLW69o511hFpfUiHapYb+V9OqOG4=
+github.com/sei-protocol/sei-cosmos v0.3.10 h1:1sgxeVno1uy10/F0Mkqlc0Jy14alDRepdvBftLIByaE=
+github.com/sei-protocol/sei-cosmos v0.3.10/go.mod h1:WWwx6XlJc9SrjdRwLW69o511hFpfUiHapYb+V9OqOG4=
 github.com/sei-protocol/sei-db v0.0.36 h1:Qg8MlO/4btECyAB/XrbEexhpaS7OmYsrs9IUYULf+bY=
 github.com/sei-protocol/sei-db v0.0.36/go.mod h1:F/ZKZA8HJPcUzSZPA8yt6pfwlGriJ4RDR4eHKSGLStI=
 github.com/sei-protocol/sei-iavl v0.1.9 h1:y4mVYftxLNRs6533zl7N0/Ch+CzRQc04JDfHolIxgBE=

--- a/x/evm/ante/fee.go
+++ b/x/evm/ante/fee.go
@@ -87,7 +87,9 @@ func (fc EVMFeeCheckDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 		if err != nil {
 			return ctx, err
 		}
-		msg.Derived.AnteSurplus = surplus
+		if err := fc.evmKeeper.AddAnteSurplus(ctx, etx.Hash(), surplus); err != nil {
+			return ctx, err
+		}
 	}
 
 	// calculate the priority by dividing the total fee with the native gas limit (i.e. the effective native gas price)

--- a/x/evm/derived/derived.go
+++ b/x/evm/derived/derived.go
@@ -19,7 +19,6 @@ type Derived struct {
 	PubKey        *secp256k1.PubKey
 	IsAssociate   bool
 	Version       SignerVersion
-	AnteSurplus   sdk.Int
 }
 
 // Derived should never come from deserialization or be transmitted after serialization,

--- a/x/evm/genesis.go
+++ b/x/evm/genesis.go
@@ -68,6 +68,7 @@ func ExportGenesis(ctx sdk.Context, k *keeper.Keeper) *types.GenesisState {
 		types.TxHashesPrefix,
 		types.PointerRegistryPrefix,
 		types.PointerCWCodePrefix,
+		types.PointerReverseRegistryPrefix,
 	} {
 		k.IterateAll(ctx, prefix, func(key, val []byte) bool {
 			genesis.Serialized = append(genesis.Serialized, &types.Serialized{

--- a/x/evm/keeper/ante.go
+++ b/x/evm/keeper/ante.go
@@ -1,0 +1,34 @@
+package keeper
+
+import (
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/sei-protocol/sei-chain/x/evm/types"
+)
+
+func (k *Keeper) AddAnteSurplus(ctx sdk.Context, txHash common.Hash, surplus sdk.Int) error {
+	store := prefix.NewStore(ctx.KVStore(k.memStoreKey), types.AnteSurplusPrefix)
+	bz, err := surplus.Marshal()
+	if err != nil {
+		return err
+	}
+	store.Set(txHash[:], bz)
+	return nil
+}
+
+func (k *Keeper) GetAnteSurplusSum(ctx sdk.Context) sdk.Int {
+	iter := prefix.NewStore(ctx.KVStore(k.memStoreKey), types.AnteSurplusPrefix).Iterator(nil, nil)
+	defer iter.Close()
+	res := sdk.ZeroInt()
+	for ; iter.Valid(); iter.Next() {
+		surplus := sdk.Int{}
+		_ = surplus.Unmarshal(iter.Value())
+		res = res.Add(surplus)
+	}
+	return res
+}
+
+func (k *Keeper) DeleteAllAnteSurplus(ctx sdk.Context) {
+	_ = prefix.NewStore(ctx.KVStore(k.memStoreKey), types.AnteSurplusPrefix).DeleteAll(nil, nil)
+}

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -58,7 +58,6 @@ func (server msgServer) EVMTransaction(goCtx context.Context, msg *types.MsgEVMT
 	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeterWithMultiplier(ctx))
 
 	stateDB := state.NewDBImpl(ctx, &server, false)
-	stateDB.AddSurplus(msg.Derived.AnteSurplus)
 	tx, _ := msg.AsTransaction()
 	emsg := server.GetEVMMessage(ctx, tx, msg.Derived.SenderEVMAddr)
 	gp := server.GetGasPool()

--- a/x/evm/migrations/fix_total_supply.go
+++ b/x/evm/migrations/fix_total_supply.go
@@ -29,6 +29,9 @@ func FixTotalSupply(ctx sdk.Context, k *keeper.Keeper) error {
 		weiInUsei = weiInUsei.Add(sdk.OneInt())
 	}
 	correctSupply = correctSupply.Add(weiInUsei)
-	k.BankKeeper().SetSupply(ctx, sdk.NewCoin(sdk.MustGetBaseDenom(), correctSupply))
+	currentSupply := k.BankKeeper().GetSupply(ctx, sdk.MustGetBaseDenom()).Amount
+	if !currentSupply.Equal(correctSupply) {
+		k.BankKeeper().SetSupply(ctx, sdk.NewCoin(sdk.MustGetBaseDenom(), correctSupply))
+	}
 	return nil
 }

--- a/x/evm/migrations/fix_total_supply.go
+++ b/x/evm/migrations/fix_total_supply.go
@@ -1,0 +1,34 @@
+package migrations
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	"github.com/sei-protocol/sei-chain/x/evm/keeper"
+	"github.com/sei-protocol/sei-chain/x/evm/types"
+)
+
+// This migration is to fix total supply mismatch caused by mishandled
+// ante surplus
+func FixTotalSupply(ctx sdk.Context, k *keeper.Keeper) error {
+	balances := k.BankKeeper().GetAccountsBalances(ctx)
+	correctSupply := sdk.ZeroInt()
+	for _, balance := range balances {
+		correctSupply = correctSupply.Add(balance.Coins.AmountOf(sdk.MustGetBaseDenom()))
+	}
+	totalWeiBalance := sdk.ZeroInt()
+	k.BankKeeper().IterateAllWeiBalances(ctx, func(aa sdk.AccAddress, i sdk.Int) bool {
+		totalWeiBalance = totalWeiBalance.Add(i)
+		return false
+	})
+	weiInUsei, weiRemainder := bankkeeper.SplitUseiWeiAmount(totalWeiBalance)
+	if !weiRemainder.IsZero() {
+		ctx.Logger().Error("wei total supply has been compromised as well; rounding up and adding to reserve")
+		if err := k.BankKeeper().AddWei(ctx, k.AccountKeeper().GetModuleAddress(types.ModuleName), bankkeeper.OneUseiInWei.Sub(weiRemainder)); err != nil {
+			return err
+		}
+		weiInUsei = weiInUsei.Add(sdk.OneInt())
+	}
+	correctSupply = correctSupply.Add(weiInUsei)
+	k.BankKeeper().SetSupply(ctx, sdk.NewCoin(sdk.MustGetBaseDenom(), correctSupply))
+	return nil
+}

--- a/x/evm/migrations/fix_total_supply_test.go
+++ b/x/evm/migrations/fix_total_supply_test.go
@@ -1,0 +1,26 @@
+package migrations_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/x/evm/migrations"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFixTotalSupply(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper()
+	addr, _ := testkeeper.MockAddressPair()
+	balance := sdk.NewCoins(sdk.NewCoin(sdk.MustGetBaseDenom(), sdk.OneInt()))
+	k.BankKeeper().MintCoins(ctx, "evm", balance)
+	k.BankKeeper().SendCoinsFromModuleToAccount(ctx, "evm", addr, balance)
+	k.BankKeeper().AddWei(ctx, addr, sdk.OneInt())
+	oldSupply := k.BankKeeper().GetSupply(ctx, sdk.MustGetBaseDenom()).Amount
+	require.Nil(t, migrations.FixTotalSupply(ctx, k))
+	require.Equal(t, oldSupply.Add(sdk.OneInt()), k.BankKeeper().GetSupply(ctx, sdk.MustGetBaseDenom()).Amount)
+	require.Equal(t, sdk.OneInt(), k.BankKeeper().GetBalance(ctx, addr, sdk.MustGetBaseDenom()).Amount)
+	require.Equal(t, sdk.ZeroInt(), k.BankKeeper().GetBalance(ctx, k.AccountKeeper().GetModuleAddress("evm"), sdk.MustGetBaseDenom()).Amount)
+	require.Equal(t, sdk.OneInt(), k.BankKeeper().GetWeiBalance(ctx, addr))
+	require.Equal(t, sdk.NewInt(999_999_999_999), k.BankKeeper().GetWeiBalance(ctx, k.AccountKeeper().GetModuleAddress("evm")))
+}

--- a/x/evm/state/balance_test.go
+++ b/x/evm/state/balance_test.go
@@ -98,16 +98,14 @@ func TestSurplus(t *testing.T) {
 	db := state.NewDBImpl(ctx, k, false)
 	db.AddBalance(evmAddr, big.NewInt(1_000_000_000_001), tracing.BalanceChangeUnspecified)
 	_, err := db.Finalize()
-	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "negative surplus value")
+	require.Nil(t, err)
 
 	// test negative usei surplus positive wei surplus (negative total)
 	db = state.NewDBImpl(ctx, k, false)
 	db.AddBalance(evmAddr, big.NewInt(1_000_000_000_000), tracing.BalanceChangeUnspecified)
 	db.SubBalance(evmAddr, big.NewInt(1), tracing.BalanceChangeUnspecified)
 	_, err = db.Finalize()
-	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "negative surplus value")
+	require.Nil(t, err)
 
 	// test negative usei surplus positive wei surplus (positive total)
 	db = state.NewDBImpl(ctx, k, false)
@@ -124,8 +122,7 @@ func TestSurplus(t *testing.T) {
 	db.AddBalance(evmAddr, big.NewInt(2), tracing.BalanceChangeUnspecified)
 	db.AddBalance(evmAddr, big.NewInt(999_999_999_999), tracing.BalanceChangeUnspecified)
 	_, err = db.Finalize()
-	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "negative surplus value")
+	require.Nil(t, err)
 
 	// test positive usei surplus negative wei surplus (positive total)
 	db = state.NewDBImpl(ctx, k, false)

--- a/x/evm/state/statedb.go
+++ b/x/evm/state/statedb.go
@@ -1,8 +1,6 @@
 package state
 
 import (
-	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -114,9 +112,6 @@ func (s *DBImpl) Finalize() (surplus sdk.Int, err error) {
 	surplus = s.tempStateCurrent.surplus
 	for _, ts := range s.tempStatesHist {
 		surplus = surplus.Add(ts.surplus)
-	}
-	if surplus.IsNegative() {
-		err = fmt.Errorf("negative surplus value: %s", surplus.String())
 	}
 	return
 }

--- a/x/evm/types/keys.go
+++ b/x/evm/types/keys.go
@@ -49,6 +49,8 @@ var (
 	PointerRegistryPrefix        = []byte{0x15}
 	PointerCWCodePrefix          = []byte{0x16}
 	PointerReverseRegistryPrefix = []byte{0x17}
+
+	AnteSurplusPrefix = []byte{0x18}
 )
 
 var (


### PR DESCRIPTION
## Describe your changes and provide context
Background:
Because EVM updates balance on one side at a time, it is possible to incur surplus during the execution (e.g. one credit of 100wei and one debit of 110wei would result in a surplus of 10wei). Such surplus are handled at `EndBlock` (sent to EVM module account) to make sure no coin is burnt/minted silently (as in, total supply would not be updated). However, surplus incurred in the ante handler (specifically the fee handler) may not be handled if the transaction fails during processing, in which case silent burning/minting would happen.

Fix:
Instead of setting state of ante surplus in the message server, we will set it inside ante handler to make sure it's always carried over. To do that, we can no longer use in-memory state, so we use memstate instead, and clear it up at the end of EndBlock.

A migration handler is also added to fix total supply for existing chains affected (i.e. arctic-1/atlantic-2)

## Testing performed to validate your change
unit test

