### PR TITLE
Reuse the same contract address when upgrading ERC->CW pointers

### DIFF
--- a/precompiles/common/expected_keepers.go
+++ b/precompiles/common/expected_keepers.go
@@ -41,6 +41,7 @@ type EVMKeeper interface {
 	GetERC20CW20Pointer(ctx sdk.Context, cw20Address string) (addr common.Address, version uint16, exists bool)
 	SetERC721CW721Pointer(ctx sdk.Context, cw721Address string, addr common.Address) error
 	GetERC721CW721Pointer(ctx sdk.Context, cw721Address string) (addr common.Address, version uint16, exists bool)
+	SetCode(ctx sdk.Context, addr common.Address, code []byte)
 }
 
 type AccountKeeper interface {

--- a/precompiles/common/expected_keepers.go
+++ b/precompiles/common/expected_keepers.go
@@ -15,6 +15,8 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	ibctypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/sei-protocol/sei-chain/utils"
 	oracletypes "github.com/sei-protocol/sei-chain/x/oracle/types"
 )
 
@@ -42,6 +44,15 @@ type EVMKeeper interface {
 	SetERC721CW721Pointer(ctx sdk.Context, cw721Address string, addr common.Address) error
 	GetERC721CW721Pointer(ctx sdk.Context, cw721Address string) (addr common.Address, version uint16, exists bool)
 	SetCode(ctx sdk.Context, addr common.Address, code []byte)
+	UpsertERCNativePointer(
+		ctx sdk.Context, evm *vm.EVM, suppliedGas uint64, token string, metadata utils.ERCMetadata,
+	) (contractAddr common.Address, remainingGas uint64, err error)
+	UpsertERCCW20Pointer(
+		ctx sdk.Context, evm *vm.EVM, suppliedGas uint64, cw20Addr string, metadata utils.ERCMetadata,
+	) (contractAddr common.Address, remainingGas uint64, err error)
+	UpsertERCCW721Pointer(
+		ctx sdk.Context, evm *vm.EVM, suppliedGas uint64, cw721Addr string, metadata utils.ERCMetadata,
+	) (contractAddr common.Address, remainingGas uint64, err error)
 }
 
 type AccountKeeper interface {

--- a/precompiles/pointer/pointer.go
+++ b/precompiles/pointer/pointer.go
@@ -150,7 +150,14 @@ func (p PrecompileExecutor) AddNative(ctx sdk.Context, method *ethabi.Method, ca
 	if value == nil {
 		value = utils.Big0
 	}
-	ret, contractAddr, remainingGas, err := evm.Create(vm.AccountRef(caller), bin, suppliedGas, value)
+	var contractAddr common.Address
+	if exists {
+		contractAddr = existingAddr
+		ret, remainingGas, err = evm.GetDeploymentCode(vm.AccountRef(caller), bin, suppliedGas, value, existingAddr)
+		p.evmKeeper.SetCode(ctx, contractAddr, ret)
+	} else {
+		ret, contractAddr, remainingGas, err = evm.Create(vm.AccountRef(caller), bin, suppliedGas, value)
+	}
 	if err != nil {
 		return
 	}
@@ -204,7 +211,14 @@ func (p PrecompileExecutor) AddCW20(ctx sdk.Context, method *ethabi.Method, call
 	if value == nil {
 		value = utils.Big0
 	}
-	ret, contractAddr, remainingGas, err := evm.Create(vm.AccountRef(caller), bin, suppliedGas, value)
+	var contractAddr common.Address
+	if exists {
+		contractAddr = existingAddr
+		ret, remainingGas, err = evm.GetDeploymentCode(vm.AccountRef(caller), bin, suppliedGas, value, existingAddr)
+		p.evmKeeper.SetCode(ctx, contractAddr, ret)
+	} else {
+		ret, contractAddr, remainingGas, err = evm.Create(vm.AccountRef(caller), bin, suppliedGas, value)
+	}
 	if err != nil {
 		return
 	}
@@ -258,7 +272,14 @@ func (p PrecompileExecutor) AddCW721(ctx sdk.Context, method *ethabi.Method, cal
 	if value == nil {
 		value = utils.Big0
 	}
-	ret, contractAddr, remainingGas, err := evm.Create(vm.AccountRef(caller), bin, suppliedGas, value)
+	var contractAddr common.Address
+	if exists {
+		contractAddr = existingAddr
+		ret, remainingGas, err = evm.GetDeploymentCode(vm.AccountRef(caller), bin, suppliedGas, value, existingAddr)
+		p.evmKeeper.SetCode(ctx, contractAddr, ret)
+	} else {
+		ret, contractAddr, remainingGas, err = evm.Create(vm.AccountRef(caller), bin, suppliedGas, value)
+	}
 	if err != nil {
 		return
 	}

--- a/precompiles/pointer/pointer_test.go
+++ b/precompiles/pointer/pointer_test.go
@@ -91,13 +91,9 @@ func TestAddNative(t *testing.T) {
 	evm = vm.NewEVM(*blockCtx, vm.TxContext{}, statedb, cfg, vm.Config{})
 	ret, g, err = p.RunAndCalculateGas(evm, caller, caller, append(p.GetExecutor().(*pointer.PrecompileExecutor).AddNativePointerID, args...), suppliedGas, nil, nil, false)
 	require.Nil(t, err)
-	require.Equal(t, uint64(8987406), g)
-	outputs, err = m.Outputs.Unpack(ret)
-	require.Nil(t, err)
-	addr = outputs[0].(common.Address)
-	newAddr, version, exists := testApp.EvmKeeper.GetERC20NativePointer(statedb.Ctx(), "test")
+	require.Nil(t, statedb.GetPrecompileError())
+	newAddr, _, exists := testApp.EvmKeeper.GetERC20NativePointer(statedb.Ctx(), "test")
 	require.True(t, exists)
 	require.Equal(t, addr, pointerAddr)
-	require.Equal(t, native.CurrentVersion, version)
 	require.Equal(t, newAddr, pointerAddr) // address should stay the same as before
 }

--- a/precompiles/pointer/pointer_test.go
+++ b/precompiles/pointer/pointer_test.go
@@ -89,7 +89,7 @@ func TestAddNative(t *testing.T) {
 	testApp.EvmKeeper.SetERC20NativePointerWithVersion(statedb.Ctx(), "test", pointerAddr, version-1)
 	statedb = state.NewDBImpl(statedb.Ctx(), &testApp.EvmKeeper, true)
 	evm = vm.NewEVM(*blockCtx, vm.TxContext{}, statedb, cfg, vm.Config{})
-	ret, g, err = p.RunAndCalculateGas(evm, caller, caller, append(p.AddNativePointerID, args...), suppliedGas, nil, nil, false)
+	ret, g, err = p.RunAndCalculateGas(evm, caller, caller, append(p.GetExecutor().(*pointer.PrecompileExecutor).AddNativePointerID, args...), suppliedGas, nil, nil, false)
 	require.Nil(t, err)
 	require.Equal(t, uint64(8987406), g)
 	outputs, err = m.Outputs.Unpack(ret)

--- a/precompiles/pointer/pointer_test.go
+++ b/precompiles/pointer/pointer_test.go
@@ -82,4 +82,22 @@ func TestAddNative(t *testing.T) {
 	require.NotNil(t, err)
 	require.NotNil(t, statedb.GetPrecompileError())
 	require.Equal(t, uint64(0), g)
+
+	// upgrade to a newer version
+	// hacky way to get the existing version number to be below CurrentVersion
+	testApp.EvmKeeper.DeleteERC20NativePointer(statedb.Ctx(), "test", version)
+	testApp.EvmKeeper.SetERC20NativePointerWithVersion(statedb.Ctx(), "test", pointerAddr, version-1)
+	statedb = state.NewDBImpl(statedb.Ctx(), &testApp.EvmKeeper, true)
+	evm = vm.NewEVM(*blockCtx, vm.TxContext{}, statedb, cfg, vm.Config{})
+	ret, g, err = p.RunAndCalculateGas(evm, caller, caller, append(p.AddNativePointerID, args...), suppliedGas, nil, nil, false)
+	require.Nil(t, err)
+	require.Equal(t, uint64(8987406), g)
+	outputs, err = m.Outputs.Unpack(ret)
+	require.Nil(t, err)
+	addr = outputs[0].(common.Address)
+	newAddr, version, exists := testApp.EvmKeeper.GetERC20NativePointer(statedb.Ctx(), "test")
+	require.True(t, exists)
+	require.Equal(t, addr, pointerAddr)
+	require.Equal(t, native.CurrentVersion, version)
+	require.Equal(t, newAddr, pointerAddr) // address should stay the same as before
 }

--- a/precompiles/pointer/pointer_test.go
+++ b/precompiles/pointer/pointer_test.go
@@ -75,21 +75,13 @@ func TestAddNative(t *testing.T) {
 	}
 	require.True(t, hasRegisteredEvent)
 
-	// pointer already exists
-	statedb = state.NewDBImpl(statedb.Ctx(), &testApp.EvmKeeper, true)
-	evm = vm.NewEVM(*blockCtx, vm.TxContext{}, statedb, cfg, vm.Config{})
-	_, g, err = p.RunAndCalculateGas(evm, caller, caller, append(p.GetExecutor().(*pointer.PrecompileExecutor).AddNativePointerID, args...), suppliedGas, nil, nil, false)
-	require.NotNil(t, err)
-	require.NotNil(t, statedb.GetPrecompileError())
-	require.Equal(t, uint64(0), g)
-
 	// upgrade to a newer version
 	// hacky way to get the existing version number to be below CurrentVersion
 	testApp.EvmKeeper.DeleteERC20NativePointer(statedb.Ctx(), "test", version)
 	testApp.EvmKeeper.SetERC20NativePointerWithVersion(statedb.Ctx(), "test", pointerAddr, version-1)
 	statedb = state.NewDBImpl(statedb.Ctx(), &testApp.EvmKeeper, true)
 	evm = vm.NewEVM(*blockCtx, vm.TxContext{}, statedb, cfg, vm.Config{})
-	ret, g, err = p.RunAndCalculateGas(evm, caller, caller, append(p.GetExecutor().(*pointer.PrecompileExecutor).AddNativePointerID, args...), suppliedGas, nil, nil, false)
+	_, _, err = p.RunAndCalculateGas(evm, caller, caller, append(p.GetExecutor().(*pointer.PrecompileExecutor).AddNativePointerID, args...), suppliedGas, nil, nil, false)
 	require.Nil(t, err)
 	require.Nil(t, statedb.GetPrecompileError())
 	newAddr, _, exists := testApp.EvmKeeper.GetERC20NativePointer(statedb.Ctx(), "test")

--- a/utils/metadata.go
+++ b/utils/metadata.go
@@ -1,0 +1,7 @@
+package utils
+
+type ERCMetadata struct {
+	Name     string
+	Symbol   string
+	Decimals uint8
+}

--- a/x/evm/artifacts/artifacts.go
+++ b/x/evm/artifacts/artifacts.go
@@ -1,0 +1,36 @@
+package artifacts
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/sei-protocol/sei-chain/x/evm/artifacts/cw20"
+	"github.com/sei-protocol/sei-chain/x/evm/artifacts/cw721"
+	"github.com/sei-protocol/sei-chain/x/evm/artifacts/native"
+)
+
+func GetParsedABI(typ string) *abi.ABI {
+	switch typ {
+	case "native":
+		return native.GetParsedABI()
+	case "cw20":
+		return cw20.GetParsedABI()
+	case "cw721":
+		return cw721.GetParsedABI()
+	default:
+		panic(fmt.Sprintf("unknown artifact type %s", typ))
+	}
+}
+
+func GetBin(typ string) []byte {
+	switch typ {
+	case "native":
+		return native.GetBin()
+	case "cw20":
+		return cw20.GetBin()
+	case "cw721":
+		return cw721.GetBin()
+	default:
+		panic(fmt.Sprintf("unknown artifact type %s", typ))
+	}
+}

--- a/x/evm/gov.go
+++ b/x/evm/gov.go
@@ -6,13 +6,9 @@ import (
 	"math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/sei-protocol/sei-chain/utils"
-	"github.com/sei-protocol/sei-chain/x/evm/artifacts/native"
 	"github.com/sei-protocol/sei-chain/x/evm/keeper"
-	"github.com/sei-protocol/sei-chain/x/evm/state"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
 
@@ -22,67 +18,14 @@ func HandleAddERCNativePointerProposalV2(ctx sdk.Context, k *keeper.Keeper, p *t
 		// should always be the case given validation
 		decimals = uint8(p.Decimals)
 	}
-	constructorArguments := []interface{}{
-		p.Token, p.Name, p.Symbol, decimals,
-	}
-	packedArgs, err := native.GetParsedABI().Pack("", constructorArguments...)
-	if err != nil {
-		logNativeV2Error(ctx, p, "pack arguments", err.Error())
-		return err
-	}
-	bin := append(native.GetBin(), packedArgs...)
-	stateDB := state.NewDBImpl(ctx, k, false)
-	evmModuleAddress := k.GetEVMAddressOrDefault(ctx, k.AccountKeeper().GetModuleAddress(types.ModuleName))
-	msg := core.Message{
-		From:              evmModuleAddress,
-		Nonce:             stateDB.GetNonce(evmModuleAddress),
-		Value:             utils.Big0,
-		GasLimit:          math.MaxUint64,
-		GasPrice:          utils.Big0,
-		GasFeeCap:         utils.Big0,
-		GasTipCap:         utils.Big0,
-		Data:              bin,
-		SkipAccountChecks: true,
-	}
-	gp := core.GasPool(math.MaxUint64)
-	blockCtx, err := k.GetVMBlockContext(ctx, gp)
-	if err != nil {
-		logNativeV2Error(ctx, p, "get block context", err.Error())
-		return err
-	}
-	cfg := types.DefaultChainConfig().EthereumConfig(k.ChainID(ctx))
-	txCtx := core.NewEVMTxContext(&msg)
-	evmInstance := vm.NewEVM(*blockCtx, txCtx, stateDB, cfg, vm.Config{})
-	st := core.NewStateTransition(evmInstance, &msg, &gp, true)
-	// TODO: retain existing contract address if any
-	res, err := st.TransitionDb()
-	if err != nil {
-		logNativeV2Error(ctx, p, "deploying pointer", err.Error())
-		return err
-	}
-	if res.Err != nil {
-		logNativeV2Error(ctx, p, "deploying pointer (VM)", res.Err.Error())
-		return res.Err
-	} else {
-		surplus, err := stateDB.Finalize()
-		if err != nil {
-			logNativeV2Error(ctx, p, "finalizing", err.Error())
+	return k.RunWithOneOffEVMInstance(
+		ctx, func(e *vm.EVM) error {
+			_, _, err := k.UpsertERCNativePointer(ctx, e, math.MaxUint64, p.Token, utils.ERCMetadata{Name: p.Name, Symbol: p.Symbol, Decimals: decimals})
 			return err
-		}
-		if !surplus.IsZero() {
-			// not an error worth quiting for but should be logged
-			logNativeV2Error(ctx, p, "finalizing (surplus)", surplus.String())
-		}
-	}
-	contractAddr := crypto.CreateAddress(msg.From, msg.Nonce)
-	if err := k.SetERC20NativePointer(ctx, p.Token, contractAddr); err != nil {
-		return err
-	}
-	ctx.EventManager().EmitEvent(sdk.NewEvent(
-		types.EventTypePointerRegistered, sdk.NewAttribute(types.AttributeKeyPointerType, "native"),
-		sdk.NewAttribute(types.AttributeKeyPointerAddress, contractAddr.Hex()), sdk.NewAttribute(types.AttributeKeyPointee, p.Token),
-		sdk.NewAttribute(types.AttributeKeyPointerVersion, fmt.Sprintf("%d", native.CurrentVersion))))
-	return nil
+		}, func(s1, s2 string) {
+			logNativeV2Error(ctx, p, s1, s2)
+		},
+	)
 }
 
 func logNativeV2Error(ctx sdk.Context, p *types.AddERCNativePointerProposalV2, step string, err string) {

--- a/x/evm/integration_test.go
+++ b/x/evm/integration_test.go
@@ -103,7 +103,7 @@ func TestERC2981PointerToCW2981(t *testing.T) {
 	data, err = abi.Pack("royaltyInfo", big.NewInt(1), big.NewInt(1000))
 	require.Nil(t, err)
 	txData = ethtypes.LegacyTx{
-		Nonce:    2,
+		Nonce:    1,
 		GasPrice: big.NewInt(1000000000),
 		Gas:      1000000,
 		To:       &pointerAddr,

--- a/x/evm/keeper/pointer.go
+++ b/x/evm/keeper/pointer.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"encoding/binary"
-	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -222,10 +221,6 @@ func (k *Keeper) GetPointerInfo(ctx sdk.Context, pref []byte) (addr []byte, vers
 }
 
 func (k *Keeper) setPointerInfo(ctx sdk.Context, pref []byte, addr []byte, version uint16) error {
-	existingAddr, existingVersion, exists := k.GetPointerInfo(ctx, pref)
-	if exists && existingVersion >= version {
-		return fmt.Errorf("pointer at %X with version %d exists when trying to set pointer for version %d", string(existingAddr), existingVersion, version)
-	}
 	store := prefix.NewStore(ctx.KVStore(k.GetStoreKey()), pref)
 	versionBz := make([]byte, 2)
 	binary.BigEndian.PutUint16(versionBz, version)

--- a/x/evm/keeper/pointer.go
+++ b/x/evm/keeper/pointer.go
@@ -18,6 +18,9 @@ import (
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
 
+type PointerGetter func(sdk.Context, string) (common.Address, uint16, bool)
+type PointerSetter func(sdk.Context, string, common.Address) error
+
 var ErrorPointerToPointerNotAllowed = sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "cannot create a pointer to a pointer")
 
 // ERC20 -> Native Token

--- a/x/evm/keeper/pointer_test.go
+++ b/x/evm/keeper/pointer_test.go
@@ -126,7 +126,6 @@ func TestEVMtoCWPointers(t *testing.T) {
 			addr, _, exists := handlers.evmGetter(ctx, cwAddress.String())
 			require.Equal(t, evmAddress, addr)
 			require.True(t, exists)
-			require.NotNil(t, handlers.evmSetter(ctx, cwAddress.String(), evmAddress))
 
 			// should delete
 			var version uint16 = 1
@@ -231,7 +230,6 @@ func TestCWtoEVMPointers(t *testing.T) {
 			addr, _, exists := handlers.cwGetter(ctx, evmAddress)
 			require.Equal(t, cwAddress, addr)
 			require.True(t, exists)
-			require.NotNil(t, handlers.cwSetter(ctx, evmAddress, cwAddress.String()))
 
 			// create new address to test prevention logic
 			cwAddress2, evmAddress2 := testkeeper.MockAddressPair()

--- a/x/evm/keeper/pointer_upgrade.go
+++ b/x/evm/keeper/pointer_upgrade.go
@@ -1,0 +1,108 @@
+package keeper
+
+import (
+	"math"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/sei-protocol/sei-chain/utils"
+	"github.com/sei-protocol/sei-chain/x/evm/artifacts"
+	"github.com/sei-protocol/sei-chain/x/evm/state"
+	"github.com/sei-protocol/sei-chain/x/evm/types"
+)
+
+func (k *Keeper) RunWithOneOffEVMInstance(
+	ctx sdk.Context, runner func(*vm.EVM) error, logger func(string, string),
+) error {
+	stateDB := state.NewDBImpl(ctx, k, false)
+	evmModuleAddress := k.GetEVMAddressOrDefault(ctx, k.AccountKeeper().GetModuleAddress(types.ModuleName))
+	gp := core.GasPool(math.MaxUint64)
+	blockCtx, err := k.GetVMBlockContext(ctx, gp)
+	if err != nil {
+		logger("get block context", err.Error())
+		return err
+	}
+	cfg := types.DefaultChainConfig().EthereumConfig(k.ChainID(ctx))
+	txCtx := core.NewEVMTxContext(&core.Message{From: evmModuleAddress, GasPrice: utils.Big0})
+	evmInstance := vm.NewEVM(*blockCtx, txCtx, stateDB, cfg, vm.Config{})
+	err = runner(evmInstance)
+	if err != nil {
+		logger("upserting pointer", err.Error())
+		return err
+	}
+	surplus, err := stateDB.Finalize()
+	if err != nil {
+		logger("finalizing", err.Error())
+		return err
+	}
+	if !surplus.IsZero() {
+		logger("non-zero surplus", err.Error())
+	}
+	return nil
+}
+
+func (k *Keeper) UpsertERCNativePointer(
+	ctx sdk.Context, evm *vm.EVM, suppliedGas uint64, token string, metadata utils.ERCMetadata,
+) (contractAddr common.Address, remainingGas uint64, err error) {
+	return k.UpsertERCPointer(
+		ctx, evm, suppliedGas, "native", []interface{}{
+			token, metadata.Name, metadata.Symbol, metadata.Decimals,
+		}, k.GetERC20NativePointer, k.SetERC20NativePointer,
+	)
+}
+
+func (k *Keeper) UpsertERCCW20Pointer(
+	ctx sdk.Context, evm *vm.EVM, suppliedGas uint64, cw20Addr string, metadata utils.ERCMetadata,
+) (contractAddr common.Address, remainingGas uint64, err error) {
+	return k.UpsertERCPointer(
+		ctx, evm, suppliedGas, "cw20", []interface{}{
+			cw20Addr, metadata.Name, metadata.Symbol,
+		}, k.GetERC20CW20Pointer, k.SetERC20CW20Pointer,
+	)
+}
+
+func (k *Keeper) UpsertERCCW721Pointer(
+	ctx sdk.Context, evm *vm.EVM, suppliedGas uint64, cw721Addr string, metadata utils.ERCMetadata,
+) (contractAddr common.Address, remainingGas uint64, err error) {
+	return k.UpsertERCPointer(
+		ctx, evm, suppliedGas, "cw721", []interface{}{
+			cw721Addr, metadata.Name, metadata.Symbol,
+		}, k.GetERC721CW721Pointer, k.SetERC721CW721Pointer,
+	)
+}
+
+func (k *Keeper) UpsertERCPointer(
+	ctx sdk.Context, evm *vm.EVM, suppliedGas uint64, typ string, args []interface{}, getter PointerGetter, setter PointerSetter,
+) (contractAddr common.Address, remainingGas uint64, err error) {
+	pointee := args[0].(string)
+	evmModuleAddress := k.GetEVMAddressOrDefault(ctx, k.AccountKeeper().GetModuleAddress(types.ModuleName))
+
+	var bin []byte
+	bin, err = artifacts.GetParsedABI(typ).Pack("", args...)
+	if err != nil {
+		panic(err)
+	}
+	bin = append(artifacts.GetBin(typ), bin...)
+	existingAddr, _, exists := getter(ctx, pointee)
+	if exists {
+		var ret []byte
+		contractAddr = existingAddr
+		ret, remainingGas, err = evm.GetDeploymentCode(vm.AccountRef(evmModuleAddress), bin, suppliedGas, utils.Big0, existingAddr)
+		k.SetCode(ctx, contractAddr, ret)
+	} else {
+		_, contractAddr, remainingGas, err = evm.Create(vm.AccountRef(evmModuleAddress), bin, suppliedGas, utils.Big0)
+		evm.StateDB.SetNonce(evmModuleAddress, evm.StateDB.GetNonce(evmModuleAddress)+1)
+	}
+	if err != nil {
+		return
+	}
+	if err = setter(ctx, pointee, contractAddr); err != nil {
+		return
+	}
+	ctx.EventManager().EmitEvent(sdk.NewEvent(
+		types.EventTypePointerRegistered, sdk.NewAttribute(types.AttributeKeyPointerType, typ),
+		sdk.NewAttribute(types.AttributeKeyPointerAddress, contractAddr.Hex()), sdk.NewAttribute(types.AttributeKeyPointee, pointee)))
+	return
+}

--- a/x/evm/keeper/pointer_upgrade.go
+++ b/x/evm/keeper/pointer_upgrade.go
@@ -38,7 +38,7 @@ func (k *Keeper) RunWithOneOffEVMInstance(
 		return err
 	}
 	if !surplus.IsZero() {
-		logger("non-zero surplus", err.Error())
+		logger("non-zero surplus", surplus.String())
 	}
 	return nil
 }
@@ -93,7 +93,6 @@ func (k *Keeper) UpsertERCPointer(
 		k.SetCode(ctx, contractAddr, ret)
 	} else {
 		_, contractAddr, remainingGas, err = evm.Create(vm.AccountRef(evmModuleAddress), bin, suppliedGas, utils.Big0)
-		evm.StateDB.SetNonce(evmModuleAddress, evm.StateDB.GetNonce(evmModuleAddress)+1)
 	}
 	if err != nil {
 		return

--- a/x/evm/keeper/pointer_upgrade_test.go
+++ b/x/evm/keeper/pointer_upgrade_test.go
@@ -1,0 +1,115 @@
+package keeper_test
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunWithOneOffEVMInstance(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper()
+	errLog := ""
+	errRunner := func(*vm.EVM) error { return errors.New("test") }
+	errLogger := func(a string, b string) { errLog = a + " " + b }
+	require.NotNil(t, k.RunWithOneOffEVMInstance(ctx, errRunner, errLogger))
+	require.Equal(t, "upserting pointer test", errLog)
+	succLog := ""
+	succRunner := func(*vm.EVM) error { return nil }
+	succLogger := func(string, string) { succLog = "unexpected" }
+	require.Nil(t, k.RunWithOneOffEVMInstance(ctx, succRunner, succLogger))
+	require.Empty(t, succLog)
+}
+
+func TestUpsertERCNativePointer(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper()
+	var addr common.Address
+	err := k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
+		a, _, err := k.UpsertERCNativePointer(ctx, e, math.MaxUint64, "test", utils.ERCMetadata{
+			Name:     "test",
+			Symbol:   "test",
+			Decimals: 6,
+		})
+		addr = a
+		return err
+	}, func(s1, s2 string) {})
+	require.Nil(t, err)
+	var newAddr common.Address
+	err = k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
+		a, _, err := k.UpsertERCNativePointer(ctx, e, math.MaxUint64, "test", utils.ERCMetadata{
+			Name:     "test2",
+			Symbol:   "test2",
+			Decimals: 12,
+		})
+		newAddr = a
+		return err
+	}, func(s1, s2 string) {})
+	require.Nil(t, err)
+	require.Equal(t, addr, newAddr)
+	res, err := k.QueryERCSingleOutput(ctx, "native", addr, "name")
+	require.Nil(t, err)
+	require.Equal(t, "test2", res.(string))
+	res, err = k.QueryERCSingleOutput(ctx, "native", addr, "symbol")
+	require.Nil(t, err)
+	require.Equal(t, "test2", res.(string))
+	res, err = k.QueryERCSingleOutput(ctx, "native", addr, "decimals")
+	require.Nil(t, err)
+	require.Equal(t, uint8(12), res.(uint8))
+	_, err = k.QueryERCSingleOutput(ctx, "native", addr, "nonexist")
+	require.NotNil(t, err)
+}
+
+func TestUpsertERC20Pointer(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper()
+	var addr common.Address
+	err := k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
+		a, _, err := k.UpsertERCCW20Pointer(ctx, e, math.MaxUint64, "test", utils.ERCMetadata{
+			Name:   "test",
+			Symbol: "test",
+		})
+		addr = a
+		return err
+	}, func(s1, s2 string) {})
+	require.Nil(t, err)
+	var newAddr common.Address
+	err = k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
+		a, _, err := k.UpsertERCCW20Pointer(ctx, e, math.MaxUint64, "test", utils.ERCMetadata{
+			Name:   "test2",
+			Symbol: "test2",
+		})
+		newAddr = a
+		return err
+	}, func(s1, s2 string) {})
+	require.Nil(t, err)
+	require.Equal(t, addr, newAddr)
+}
+
+func TestUpsertERC721Pointer(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper()
+	var addr common.Address
+	err := k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
+		a, _, err := k.UpsertERCCW721Pointer(ctx, e, math.MaxUint64, "test", utils.ERCMetadata{
+			Name:   "test",
+			Symbol: "test",
+		})
+		addr = a
+		return err
+	}, func(s1, s2 string) {})
+	require.Nil(t, err)
+	var newAddr common.Address
+	err = k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
+		a, _, err := k.UpsertERCCW721Pointer(ctx, e, math.MaxUint64, "test", utils.ERCMetadata{
+			Name:   "test2",
+			Symbol: "test2",
+		})
+		newAddr = a
+		return err
+	}, func(s1, s2 string) {})
+	require.Nil(t, err)
+	require.Equal(t, addr, newAddr)
+}

--- a/x/evm/keeper/view.go
+++ b/x/evm/keeper/view.go
@@ -17,7 +17,7 @@ func (k *Keeper) QueryERCSingleOutput(ctx sdk.Context, typ string, addr common.A
 		ctx.Logger().Error(fmt.Sprintf("Error calling %s for %s due to %s, skipping", addr.Hex(), query, err))
 		return nil, err
 	}
-	o, _ := artifacts.GetParsedABI(typ).Unpack("name", r)
+	o, _ := artifacts.GetParsedABI(typ).Unpack(query, r)
 	if len(o) != 1 {
 		ctx.Logger().Error(fmt.Sprintf("Getting %d outputs when %s for %s, skipping", len(o), addr.Hex(), query))
 		return nil, err

--- a/x/evm/keeper/view.go
+++ b/x/evm/keeper/view.go
@@ -1,0 +1,26 @@
+package keeper
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/sei-protocol/sei-chain/x/evm/artifacts"
+	"github.com/sei-protocol/sei-chain/x/evm/types"
+)
+
+func (k *Keeper) QueryERCSingleOutput(ctx sdk.Context, typ string, addr common.Address, query string) (interface{}, error) {
+	moduleAddr := k.AccountKeeper().GetModuleAddress(types.ModuleName)
+	q, _ := artifacts.GetParsedABI(typ).Pack(query)
+	r, err := k.StaticCallEVM(ctx, moduleAddr, &addr, q)
+	if err != nil {
+		ctx.Logger().Error(fmt.Sprintf("Error calling %s for %s due to %s, skipping", addr.Hex(), query, err))
+		return nil, err
+	}
+	o, _ := artifacts.GetParsedABI(typ).Unpack("name", r)
+	if len(o) != 1 {
+		ctx.Logger().Error(fmt.Sprintf("Getting %d outputs when %s for %s, skipping", len(o), addr.Hex(), query))
+		return nil, err
+	}
+	return o[0], nil
+}

--- a/x/evm/migrations/migrate_all_pointers.go
+++ b/x/evm/migrations/migrate_all_pointers.go
@@ -1,0 +1,115 @@
+package migrations
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/sei-protocol/sei-chain/utils"
+	"github.com/sei-protocol/sei-chain/x/evm/keeper"
+	"github.com/sei-protocol/sei-chain/x/evm/types"
+)
+
+func MigrateERCNativePointers(ctx sdk.Context, k *keeper.Keeper) error {
+	iter := prefix.NewStore(ctx.KVStore(k.GetStoreKey()), append(types.PointerRegistryPrefix, types.PointerERC20NativePrefix...)).Iterator(nil, nil)
+	defer iter.Close()
+	seen := map[string]struct{}{}
+	for ; iter.Valid(); iter.Next() {
+		token := string(iter.Key()[:len(iter.Key())-2]) // last two bytes are version
+		if _, ok := seen[token]; ok {
+			continue
+		}
+		seen[token] = struct{}{}
+		addr := common.BytesToAddress(iter.Value())
+		oName, err := k.QueryERCSingleOutput(ctx, "native", addr, "name")
+		if err != nil {
+			continue
+		}
+		oSymbol, err := k.QueryERCSingleOutput(ctx, "native", addr, "symbol")
+		if err != nil {
+			continue
+		}
+		oDecimals, err := k.QueryERCSingleOutput(ctx, "native", addr, "oDecimals")
+		if err != nil {
+			continue
+		}
+		_ = k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
+			_, _, err := k.UpsertERCNativePointer(ctx, e, math.MaxUint64, token, utils.ERCMetadata{
+				Name:     oName.(string),
+				Symbol:   oSymbol.(string),
+				Decimals: oDecimals.(uint8),
+			})
+			return err
+		}, func(s1, s2 string) {
+			ctx.Logger().Error(fmt.Sprintf("Failed to upgrade pointer for %s at step %s due to %s", token, s1, s2))
+		})
+	}
+	return nil
+}
+
+func MigrateERCCW20Pointers(ctx sdk.Context, k *keeper.Keeper) error {
+	iter := prefix.NewStore(ctx.KVStore(k.GetStoreKey()), append(types.PointerRegistryPrefix, types.PointerERC20CW20Prefix...)).Iterator(nil, nil)
+	defer iter.Close()
+	seen := map[string]struct{}{}
+	for ; iter.Valid(); iter.Next() {
+		cwAddr := string(iter.Key()[:len(iter.Key())-2]) // last two bytes are version
+		if _, ok := seen[cwAddr]; ok {
+			continue
+		}
+		seen[cwAddr] = struct{}{}
+		addr := common.BytesToAddress(iter.Value())
+		oName, err := k.QueryERCSingleOutput(ctx, "cw20", addr, "name")
+		if err != nil {
+			continue
+		}
+		oSymbol, err := k.QueryERCSingleOutput(ctx, "cw20", addr, "symbol")
+		if err != nil {
+			continue
+		}
+		_ = k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
+			_, _, err := k.UpsertERCCW20Pointer(ctx, e, math.MaxUint64, cwAddr, utils.ERCMetadata{
+				Name:   oName.(string),
+				Symbol: oSymbol.(string),
+			})
+			return err
+		}, func(s1, s2 string) {
+			ctx.Logger().Error(fmt.Sprintf("Failed to upgrade pointer for %s at step %s due to %s", cwAddr, s1, s2))
+		})
+	}
+	return nil
+}
+
+func MigrateERCCW721Pointers(ctx sdk.Context, k *keeper.Keeper) error {
+	iter := prefix.NewStore(ctx.KVStore(k.GetStoreKey()), append(types.PointerRegistryPrefix, types.PointerERC721CW721Prefix...)).Iterator(nil, nil)
+	defer iter.Close()
+	seen := map[string]struct{}{}
+	for ; iter.Valid(); iter.Next() {
+		cwAddr := string(iter.Key()[:len(iter.Key())-2]) // last two bytes are version
+		if _, ok := seen[cwAddr]; ok {
+			continue
+		}
+		seen[cwAddr] = struct{}{}
+		addr := common.BytesToAddress(iter.Value())
+		oName, err := k.QueryERCSingleOutput(ctx, "cw721", addr, "name")
+		if err != nil {
+			continue
+		}
+		oSymbol, err := k.QueryERCSingleOutput(ctx, "cw721", addr, "symbol")
+		if err != nil {
+			continue
+		}
+		_ = k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
+			_, _, err := k.UpsertERCCW721Pointer(ctx, e, math.MaxUint64, cwAddr, utils.ERCMetadata{
+				Name:   oName.(string),
+				Symbol: oSymbol.(string),
+			})
+			return err
+		}, func(s1, s2 string) {
+			ctx.Logger().Error(fmt.Sprintf("Failed to upgrade pointer for %s at step %s due to %s", cwAddr, s1, s2))
+		})
+	}
+	return nil
+}

--- a/x/evm/migrations/migrate_all_pointers.go
+++ b/x/evm/migrations/migrate_all_pointers.go
@@ -26,14 +26,17 @@ func MigrateERCNativePointers(ctx sdk.Context, k *keeper.Keeper) error {
 		addr := common.BytesToAddress(iter.Value())
 		oName, err := k.QueryERCSingleOutput(ctx, "native", addr, "name")
 		if err != nil {
+			ctx.Logger().Error(fmt.Sprintf("Failed to upgrade pointer for %s due to failed name query: %s", token, err))
 			continue
 		}
 		oSymbol, err := k.QueryERCSingleOutput(ctx, "native", addr, "symbol")
 		if err != nil {
+			ctx.Logger().Error(fmt.Sprintf("Failed to upgrade pointer for %s due to failed symbol query: %s", token, err))
 			continue
 		}
-		oDecimals, err := k.QueryERCSingleOutput(ctx, "native", addr, "oDecimals")
+		oDecimals, err := k.QueryERCSingleOutput(ctx, "native", addr, "decimals")
 		if err != nil {
+			ctx.Logger().Error(fmt.Sprintf("Failed to upgrade pointer for %s due to failed decimal query: %s", token, err))
 			continue
 		}
 		_ = k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
@@ -63,10 +66,12 @@ func MigrateERCCW20Pointers(ctx sdk.Context, k *keeper.Keeper) error {
 		addr := common.BytesToAddress(iter.Value())
 		oName, err := k.QueryERCSingleOutput(ctx, "cw20", addr, "name")
 		if err != nil {
+			ctx.Logger().Error(fmt.Sprintf("Failed to upgrade pointer for %s due to failed name query: %s", cwAddr, err))
 			continue
 		}
 		oSymbol, err := k.QueryERCSingleOutput(ctx, "cw20", addr, "symbol")
 		if err != nil {
+			ctx.Logger().Error(fmt.Sprintf("Failed to upgrade pointer for %s due to failed symbol query: %s", cwAddr, err))
 			continue
 		}
 		_ = k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
@@ -95,10 +100,12 @@ func MigrateERCCW721Pointers(ctx sdk.Context, k *keeper.Keeper) error {
 		addr := common.BytesToAddress(iter.Value())
 		oName, err := k.QueryERCSingleOutput(ctx, "cw721", addr, "name")
 		if err != nil {
+			ctx.Logger().Error(fmt.Sprintf("Failed to upgrade pointer for %s due to failed name query: %s", cwAddr, err))
 			continue
 		}
 		oSymbol, err := k.QueryERCSingleOutput(ctx, "cw721", addr, "symbol")
 		if err != nil {
+			ctx.Logger().Error(fmt.Sprintf("Failed to upgrade pointer for %s due to failed symbol query: %s", cwAddr, err))
 			continue
 		}
 		_ = k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {

--- a/x/evm/migrations/migrate_all_pointers_test.go
+++ b/x/evm/migrations/migrate_all_pointers_test.go
@@ -1,0 +1,59 @@
+package migrations_test
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/utils"
+	"github.com/sei-protocol/sei-chain/x/evm/migrations"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrateERCNativePointers(t *testing.T) {
+	k := testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	var pointerAddr common.Address
+	require.Nil(t, k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
+		a, _, err := k.UpsertERCNativePointer(ctx, e, math.MaxUint64, "test", utils.ERCMetadata{Name: "name", Symbol: "symbol", Decimals: 6})
+		pointerAddr = a
+		return err
+	}, func(s1, s2 string) {}))
+	require.Nil(t, migrations.MigrateERCNativePointers(ctx, &k))
+	// address should stay the same
+	addr, _, _ := k.GetERC20NativePointer(ctx, "test")
+	require.Equal(t, pointerAddr, addr)
+}
+
+func TestMigrateERCCW20Pointers(t *testing.T) {
+	k := testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	var pointerAddr common.Address
+	require.Nil(t, k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
+		a, _, err := k.UpsertERCCW20Pointer(ctx, e, math.MaxUint64, "test", utils.ERCMetadata{Name: "name", Symbol: "symbol"})
+		pointerAddr = a
+		return err
+	}, func(s1, s2 string) {}))
+	require.Nil(t, migrations.MigrateERCCW20Pointers(ctx, &k))
+	// address should stay the same
+	addr, _, _ := k.GetERC20CW20Pointer(ctx, "test")
+	require.Equal(t, pointerAddr, addr)
+}
+
+func TestMigrateERCCW721Pointers(t *testing.T) {
+	k := testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	var pointerAddr common.Address
+	require.Nil(t, k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
+		a, _, err := k.UpsertERCCW721Pointer(ctx, e, math.MaxUint64, "test", utils.ERCMetadata{Name: "name", Symbol: "symbol"})
+		pointerAddr = a
+		return err
+	}, func(s1, s2 string) {}))
+	require.Nil(t, migrations.MigrateERCCW721Pointers(ctx, &k))
+	// address should stay the same
+	addr, _, _ := k.GetERC721CW721Pointer(ctx, "test")
+	require.Equal(t, pointerAddr, addr)
+}

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -158,6 +158,16 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	_ = cfg.RegisterMigration(types.ModuleName, 7, func(ctx sdk.Context) error {
 		return migrations.StoreCWPointerCode(ctx, am.keeper, false, true)
 	})
+
+	_ = cfg.RegisterMigration(types.ModuleName, 8, func(ctx sdk.Context) error {
+		if err := migrations.MigrateERCNativePointers(ctx, am.keeper); err != nil {
+			return err
+		}
+		if err := migrations.MigrateERCCW20Pointers(ctx, am.keeper); err != nil {
+			return err
+		}
+		return migrations.MigrateERCCW721Pointers(ctx, am.keeper)
+	})
 }
 
 // RegisterInvariants registers the capability module's invariants.
@@ -182,7 +192,7 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 }
 
 // ConsensusVersion implements ConsensusVersion.
-func (AppModule) ConsensusVersion() uint64 { return 8 }
+func (AppModule) ConsensusVersion() uint64 { return 9 }
 
 // BeginBlock executes all ABCI BeginBlock logic respective to the capability module.
 func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {

--- a/x/evm/module_test.go
+++ b/x/evm/module_test.go
@@ -59,7 +59,7 @@ func TestModuleExportGenesis(t *testing.T) {
 func TestConsensusVersion(t *testing.T) {
 	k, _ := testkeeper.MockEVMKeeper()
 	module := evm.NewAppModule(nil, k)
-	assert.Equal(t, uint64(8), module.ConsensusVersion())
+	assert.Equal(t, uint64(9), module.ConsensusVersion())
 }
 
 func TestABCI(t *testing.T) {


### PR DESCRIPTION
## Describe your changes and provide context
Previously pointer contract will be assigned a new address when it's upgraded to a new version, which is quite inconvenient to end users and applications. Since pointer contracts themselves are stateless, it is possible to reuse the same address for a new version of code. This PR implements that for the EVM->CW direction pointers. A similar change will be made for CW->EVM pointers

## Testing performed to validate your change
unit test
