### PR TITLE
Validate pointer version set by gov

### DIFF
--- a/x/evm/gov.go
+++ b/x/evm/gov.go
@@ -5,6 +5,11 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/sei-protocol/sei-chain/x/evm/artifacts/cw20"
+	"github.com/sei-protocol/sei-chain/x/evm/artifacts/cw721"
+	"github.com/sei-protocol/sei-chain/x/evm/artifacts/erc20"
+	"github.com/sei-protocol/sei-chain/x/evm/artifacts/erc721"
+	"github.com/sei-protocol/sei-chain/x/evm/artifacts/native"
 	"github.com/sei-protocol/sei-chain/x/evm/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
@@ -18,6 +23,9 @@ func HandleAddERCNativePointerProposal(ctx sdk.Context, k *keeper.Keeper, p *typ
 		k.DeleteERC20NativePointer(ctx, p.Token, uint16(p.Version))
 		return nil
 	}
+	if uint16(p.Version) < native.CurrentVersion {
+		return fmt.Errorf("cannot register pointer with version smaller than %d", native.CurrentVersion)
+	}
 	return k.SetERC20NativePointerWithVersion(ctx, p.Token, common.HexToAddress(p.Pointer), uint16(p.Version))
 }
 
@@ -29,6 +37,9 @@ func HandleAddERCCW20PointerProposal(ctx sdk.Context, k *keeper.Keeper, p *types
 	if p.Pointer == "" {
 		k.DeleteERC20CW20Pointer(ctx, p.Pointee, uint16(p.Version))
 		return nil
+	}
+	if uint16(p.Version) < cw20.CurrentVersion(ctx) {
+		return fmt.Errorf("cannot register pointer with version smaller than %d", cw20.CurrentVersion(ctx))
 	}
 	return k.SetERC20CW20PointerWithVersion(ctx, p.Pointee, common.HexToAddress(p.Pointer), uint16(p.Version))
 }
@@ -42,6 +53,9 @@ func HandleAddERCCW721PointerProposal(ctx sdk.Context, k *keeper.Keeper, p *type
 		k.DeleteERC721CW721Pointer(ctx, p.Pointee, uint16(p.Version))
 		return nil
 	}
+	if uint16(p.Version) < cw721.CurrentVersion {
+		return fmt.Errorf("cannot register pointer with version smaller than %d", cw721.CurrentVersion)
+	}
 	return k.SetERC721CW721PointerWithVersion(ctx, p.Pointee, common.HexToAddress(p.Pointer), uint16(p.Version))
 }
 
@@ -54,6 +68,9 @@ func HandleAddCWERC20PointerProposal(ctx sdk.Context, k *keeper.Keeper, p *types
 		k.DeleteCW20ERC20Pointer(ctx, common.HexToAddress(p.Pointee), uint16(p.Version))
 		return nil
 	}
+	if uint16(p.Version) < erc20.CurrentVersion {
+		return fmt.Errorf("cannot register pointer with version smaller than %d", erc20.CurrentVersion)
+	}
 	return k.SetCW20ERC20PointerWithVersion(ctx, common.HexToAddress(p.Pointee), p.Pointer, uint16(p.Version))
 }
 
@@ -65,6 +82,9 @@ func HandleAddCWERC721PointerProposal(ctx sdk.Context, k *keeper.Keeper, p *type
 	if p.Pointer == "" {
 		k.DeleteCW721ERC721Pointer(ctx, common.HexToAddress(p.Pointee), uint16(p.Version))
 		return nil
+	}
+	if uint16(p.Version) < erc721.CurrentVersion {
+		return fmt.Errorf("cannot register pointer with version smaller than %d", erc721.CurrentVersion)
 	}
 	return k.SetCW721ERC721PointerWithVersion(ctx, common.HexToAddress(p.Pointee), p.Pointer, uint16(p.Version))
 }

--- a/x/evm/gov_test.go
+++ b/x/evm/gov_test.go
@@ -5,6 +5,11 @@ import (
 
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm"
+	"github.com/sei-protocol/sei-chain/x/evm/artifacts/cw20"
+	"github.com/sei-protocol/sei-chain/x/evm/artifacts/cw721"
+	"github.com/sei-protocol/sei-chain/x/evm/artifacts/erc20"
+	"github.com/sei-protocol/sei-chain/x/evm/artifacts/erc721"
+	"github.com/sei-protocol/sei-chain/x/evm/artifacts/native"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 	"github.com/stretchr/testify/require"
 )
@@ -13,31 +18,36 @@ func TestAddERCNativePointerProposals(t *testing.T) {
 	k, ctx := testkeeper.MockEVMKeeper()
 	_, pointer1 := testkeeper.MockAddressPair()
 	_, pointer2 := testkeeper.MockAddressPair()
+	require.NotNil(t, evm.HandleAddERCNativePointerProposal(ctx, k, &types.AddERCNativePointerProposal{
+		Token:   "test",
+		Version: uint32(native.CurrentVersion - 1),
+		Pointer: pointer1.Hex(),
+	}))
 	require.Nil(t, evm.HandleAddERCNativePointerProposal(ctx, k, &types.AddERCNativePointerProposal{
 		Token:   "test",
-		Version: 1,
+		Version: uint32(native.CurrentVersion),
 		Pointer: pointer1.Hex(),
 	}))
 	addr, ver, exists := k.GetERC20NativePointer(ctx, "test")
 	require.True(t, exists)
-	require.Equal(t, uint16(1), ver)
+	require.Equal(t, native.CurrentVersion, ver)
 	require.Equal(t, addr, pointer1)
 	require.Nil(t, evm.HandleAddERCNativePointerProposal(ctx, k, &types.AddERCNativePointerProposal{
 		Token:   "test",
-		Version: 2,
+		Version: uint32(native.CurrentVersion + 1),
 		Pointer: pointer2.Hex(),
 	}))
 	addr, ver, exists = k.GetERC20NativePointer(ctx, "test")
 	require.True(t, exists)
-	require.Equal(t, uint16(2), ver)
+	require.Equal(t, native.CurrentVersion+1, ver)
 	require.Equal(t, addr, pointer2)
 	require.Nil(t, evm.HandleAddERCNativePointerProposal(ctx, k, &types.AddERCNativePointerProposal{
 		Token:   "test",
-		Version: 2,
+		Version: uint32(native.CurrentVersion + 1),
 	}))
 	addr, ver, exists = k.GetERC20NativePointer(ctx, "test")
 	require.True(t, exists)
-	require.Equal(t, uint16(1), ver)
+	require.Equal(t, native.CurrentVersion, ver)
 	require.Equal(t, addr, pointer1)
 }
 
@@ -45,31 +55,36 @@ func TestAddERCCW20PointerProposals(t *testing.T) {
 	k, ctx := testkeeper.MockEVMKeeper()
 	_, pointer1 := testkeeper.MockAddressPair()
 	_, pointer2 := testkeeper.MockAddressPair()
+	require.NotNil(t, evm.HandleAddERCCW20PointerProposal(ctx, k, &types.AddERCCW20PointerProposal{
+		Pointee: "test",
+		Version: uint32(cw20.CurrentVersion(ctx) - 1),
+		Pointer: pointer1.Hex(),
+	}))
 	require.Nil(t, evm.HandleAddERCCW20PointerProposal(ctx, k, &types.AddERCCW20PointerProposal{
 		Pointee: "test",
-		Version: 1,
+		Version: uint32(cw20.CurrentVersion(ctx)),
 		Pointer: pointer1.Hex(),
 	}))
 	addr, ver, exists := k.GetERC20CW20Pointer(ctx, "test")
 	require.True(t, exists)
-	require.Equal(t, uint16(1), ver)
+	require.Equal(t, cw20.CurrentVersion(ctx), ver)
 	require.Equal(t, addr, pointer1)
 	require.Nil(t, evm.HandleAddERCCW20PointerProposal(ctx, k, &types.AddERCCW20PointerProposal{
 		Pointee: "test",
-		Version: 2,
+		Version: uint32(cw20.CurrentVersion(ctx) + 1),
 		Pointer: pointer2.Hex(),
 	}))
 	addr, ver, exists = k.GetERC20CW20Pointer(ctx, "test")
 	require.True(t, exists)
-	require.Equal(t, uint16(2), ver)
+	require.Equal(t, cw20.CurrentVersion(ctx)+1, ver)
 	require.Equal(t, addr, pointer2)
 	require.Nil(t, evm.HandleAddERCCW20PointerProposal(ctx, k, &types.AddERCCW20PointerProposal{
 		Pointee: "test",
-		Version: 2,
+		Version: uint32(cw20.CurrentVersion(ctx) + 1),
 	}))
 	addr, ver, exists = k.GetERC20CW20Pointer(ctx, "test")
 	require.True(t, exists)
-	require.Equal(t, uint16(1), ver)
+	require.Equal(t, cw20.CurrentVersion(ctx), ver)
 	require.Equal(t, addr, pointer1)
 }
 
@@ -77,31 +92,36 @@ func TestAddERCCW721PointerProposals(t *testing.T) {
 	k, ctx := testkeeper.MockEVMKeeper()
 	_, pointer1 := testkeeper.MockAddressPair()
 	_, pointer2 := testkeeper.MockAddressPair()
+	require.NotNil(t, evm.HandleAddERCCW721PointerProposal(ctx, k, &types.AddERCCW721PointerProposal{
+		Pointee: "test",
+		Version: uint32(cw721.CurrentVersion - 1),
+		Pointer: pointer1.Hex(),
+	}))
 	require.Nil(t, evm.HandleAddERCCW721PointerProposal(ctx, k, &types.AddERCCW721PointerProposal{
 		Pointee: "test",
-		Version: 1,
+		Version: uint32(cw721.CurrentVersion),
 		Pointer: pointer1.Hex(),
 	}))
 	addr, ver, exists := k.GetERC721CW721Pointer(ctx, "test")
 	require.True(t, exists)
-	require.Equal(t, uint16(1), ver)
+	require.Equal(t, cw721.CurrentVersion, ver)
 	require.Equal(t, addr, pointer1)
 	require.Nil(t, evm.HandleAddERCCW721PointerProposal(ctx, k, &types.AddERCCW721PointerProposal{
 		Pointee: "test",
-		Version: 2,
+		Version: uint32(cw721.CurrentVersion + 1),
 		Pointer: pointer2.Hex(),
 	}))
 	addr, ver, exists = k.GetERC721CW721Pointer(ctx, "test")
 	require.True(t, exists)
-	require.Equal(t, uint16(2), ver)
+	require.Equal(t, cw721.CurrentVersion+1, ver)
 	require.Equal(t, addr, pointer2)
 	require.Nil(t, evm.HandleAddERCCW721PointerProposal(ctx, k, &types.AddERCCW721PointerProposal{
 		Pointee: "test",
-		Version: 2,
+		Version: uint32(cw721.CurrentVersion + 1),
 	}))
 	addr, ver, exists = k.GetERC721CW721Pointer(ctx, "test")
 	require.True(t, exists)
-	require.Equal(t, uint16(1), ver)
+	require.Equal(t, cw721.CurrentVersion, ver)
 	require.Equal(t, addr, pointer1)
 }
 
@@ -110,31 +130,36 @@ func TestAddCWERC20PointerProposals(t *testing.T) {
 	_, pointee1 := testkeeper.MockAddressPair()
 	pointer1, _ := testkeeper.MockAddressPair()
 	pointer2, _ := testkeeper.MockAddressPair()
+	require.NotNil(t, evm.HandleAddCWERC20PointerProposal(ctx, k, &types.AddCWERC20PointerProposal{
+		Pointee: pointee1.Hex(),
+		Version: uint32(erc20.CurrentVersion - 1),
+		Pointer: pointer1.String(),
+	}))
 	require.Nil(t, evm.HandleAddCWERC20PointerProposal(ctx, k, &types.AddCWERC20PointerProposal{
 		Pointee: pointee1.Hex(),
-		Version: 1,
+		Version: uint32(erc20.CurrentVersion),
 		Pointer: pointer1.String(),
 	}))
 	addr, ver, exists := k.GetCW20ERC20Pointer(ctx, pointee1)
 	require.True(t, exists)
-	require.Equal(t, uint16(1), ver)
+	require.Equal(t, erc20.CurrentVersion, ver)
 	require.Equal(t, addr, pointer1)
 	require.Nil(t, evm.HandleAddCWERC20PointerProposal(ctx, k, &types.AddCWERC20PointerProposal{
 		Pointee: pointee1.Hex(),
-		Version: 2,
+		Version: uint32(erc20.CurrentVersion + 1),
 		Pointer: pointer2.String(),
 	}))
 	addr, ver, exists = k.GetCW20ERC20Pointer(ctx, pointee1)
 	require.True(t, exists)
-	require.Equal(t, uint16(2), ver)
+	require.Equal(t, erc20.CurrentVersion+1, ver)
 	require.Equal(t, addr, pointer2)
 	require.Nil(t, evm.HandleAddCWERC20PointerProposal(ctx, k, &types.AddCWERC20PointerProposal{
 		Pointee: pointee1.Hex(),
-		Version: 2,
+		Version: uint32(erc20.CurrentVersion + 1),
 	}))
 	addr, ver, exists = k.GetCW20ERC20Pointer(ctx, pointee1)
 	require.True(t, exists)
-	require.Equal(t, uint16(1), ver)
+	require.Equal(t, erc20.CurrentVersion, ver)
 	require.Equal(t, addr, pointer1)
 }
 
@@ -143,30 +168,35 @@ func TestAddCWERC721PointerProposals(t *testing.T) {
 	_, pointee1 := testkeeper.MockAddressPair()
 	pointer1, _ := testkeeper.MockAddressPair()
 	pointer2, _ := testkeeper.MockAddressPair()
+	require.NotNil(t, evm.HandleAddCWERC721PointerProposal(ctx, k, &types.AddCWERC721PointerProposal{
+		Pointee: pointee1.Hex(),
+		Version: uint32(erc721.CurrentVersion - 1),
+		Pointer: pointer1.String(),
+	}))
 	require.Nil(t, evm.HandleAddCWERC721PointerProposal(ctx, k, &types.AddCWERC721PointerProposal{
 		Pointee: pointee1.Hex(),
-		Version: 1,
+		Version: uint32(erc721.CurrentVersion),
 		Pointer: pointer1.String(),
 	}))
 	addr, ver, exists := k.GetCW721ERC721Pointer(ctx, pointee1)
 	require.True(t, exists)
-	require.Equal(t, uint16(1), ver)
+	require.Equal(t, uint16(erc721.CurrentVersion), ver)
 	require.Equal(t, addr, pointer1)
 	require.Nil(t, evm.HandleAddCWERC721PointerProposal(ctx, k, &types.AddCWERC721PointerProposal{
 		Pointee: pointee1.Hex(),
-		Version: 2,
+		Version: uint32(erc721.CurrentVersion + 1),
 		Pointer: pointer2.String(),
 	}))
 	addr, ver, exists = k.GetCW721ERC721Pointer(ctx, pointee1)
 	require.True(t, exists)
-	require.Equal(t, uint16(2), ver)
+	require.Equal(t, erc721.CurrentVersion+1, ver)
 	require.Equal(t, addr, pointer2)
 	require.Nil(t, evm.HandleAddCWERC721PointerProposal(ctx, k, &types.AddCWERC721PointerProposal{
 		Pointee: pointee1.Hex(),
-		Version: 2,
+		Version: uint32(erc721.CurrentVersion + 1),
 	}))
 	addr, ver, exists = k.GetCW721ERC721Pointer(ctx, pointee1)
 	require.True(t, exists)
-	require.Equal(t, uint16(1), ver)
+	require.Equal(t, uint16(erc721.CurrentVersion), ver)
 	require.Equal(t, addr, pointer1)
 }


### PR DESCRIPTION
## Describe your changes and provide context
Before we make pointer contract address stable, we want no pointer upgrade to happen. However if someone registers a contract via gov with a version number lower than the current version and then run a regular pointer deployment, they will upgrade the gov-deployed contract. This PR restricts the version being passed by the gov proposal to be at least as large as the current version. We may remove this restriction once the stable address change is in and upgrades become allowed.

## Testing performed to validate your change
unit test

