### PR TITLE
Set receipt for CW->EVM calls

### DIFF
--- a/contracts/test/CW20toERC20PointerTest.js
+++ b/contracts/test/CW20toERC20PointerTest.js
@@ -100,7 +100,7 @@ describe("CW20 to ERC20 Pointer", function () {
 
                     const res = await executeWasm(pointer,  { transfer: { recipient: accounts[1].seiAddress, amount: "100" } });
                     const txHash = res["txhash"];
-                    const receipt = await ethers.provider.getTransactionReceipt("0x" + txHash);
+                    const receipt = await ethers.provider.getTransactionReceipt(`0x${txHash}`); 
                     expect(receipt).not.to.be.null;
                     const filter = {
                         fromBlock: receipt["blockNumber"],
@@ -109,7 +109,8 @@ describe("CW20 to ERC20 Pointer", function () {
                         topics: [ethers.id("Transfer(address,address,uint256)")]
                     };
                     const logs = await ethers.provider.getLogs(filter);
-                    expect(logs.length).to.equal(1)
+                    expect(logs.length).to.equal(1);
+                    expect(logs[0]["topics"][0]).to.equal(ethers.id("Transfer(address,address,uint256)"));
                     const respAfter = await queryWasm(pointer, "balance", {address: accounts[1].seiAddress});
                     const balanceAfter = respAfter.data.balance;
 

--- a/contracts/test/CW20toERC20PointerTest.js
+++ b/contracts/test/CW20toERC20PointerTest.js
@@ -99,7 +99,9 @@ describe("CW20 to ERC20 Pointer", function () {
                     const balanceBefore = respBefore.data.balance;
 
                     const res = await executeWasm(pointer,  { transfer: { recipient: accounts[1].seiAddress, amount: "100" } });
-                    console.log(res);
+                    const txHash = res["txhash"];
+                    const receipt = await ethers.provider.getTransactionReceipt("0x" + txHash);
+                    expect(receipt).not.to.be.null;
                     const respAfter = await queryWasm(pointer, "balance", {address: accounts[1].seiAddress});
                     const balanceAfter = respAfter.data.balance;
 

--- a/contracts/test/CW20toERC20PointerTest.js
+++ b/contracts/test/CW20toERC20PointerTest.js
@@ -98,7 +98,8 @@ describe("CW20 to ERC20 Pointer", function () {
                     const respBefore = await queryWasm(pointer, "balance", {address: accounts[1].seiAddress});
                     const balanceBefore = respBefore.data.balance;
 
-                    await executeWasm(pointer,  { transfer: { recipient: accounts[1].seiAddress, amount: "100" } });
+                    const res = await executeWasm(pointer,  { transfer: { recipient: accounts[1].seiAddress, amount: "100" } });
+                    console.log(res);
                     const respAfter = await queryWasm(pointer, "balance", {address: accounts[1].seiAddress});
                     const balanceAfter = respAfter.data.balance;
 

--- a/contracts/test/CW20toERC20PointerTest.js
+++ b/contracts/test/CW20toERC20PointerTest.js
@@ -102,6 +102,14 @@ describe("CW20 to ERC20 Pointer", function () {
                     const txHash = res["txhash"];
                     const receipt = await ethers.provider.getTransactionReceipt("0x" + txHash);
                     expect(receipt).not.to.be.null;
+                    const filter = {
+                        fromBlock: receipt["blockNumber"],
+                        toBlock: 'latest',
+                        address: receipt["to"],
+                        topics: [ethers.id("Transfer(address,address,uint256)")]
+                    };
+                    const logs = await ethers.provider.getLogs(filter);
+                    expect(logs.length).to.equal(1)
                     const respAfter = await queryWasm(pointer, "balance", {address: accounts[1].seiAddress});
                     const balanceAfter = respAfter.data.balance;
 

--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -128,7 +128,10 @@ func (a *BlockAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.Block
 					mtx.Unlock()
 				}
 			} else {
-				encodedReceipt, err := encodeReceipt(receipt, a.txConfig.TxDecoder(), block)
+				encodedReceipt, err := encodeReceipt(receipt, a.txConfig.TxDecoder(), block, func(h common.Hash) bool {
+					_, err := a.keeper.GetReceipt(a.ctxProvider(height), h)
+					return err == nil
+				})
 				if err != nil {
 					mtx.Lock()
 					returnErr = err

--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -186,7 +186,10 @@ func (b *Backend) GetTransaction(ctx context.Context, txHash common.Hash) (tx *e
 	txIndex := hexutil.Uint(receipt.TransactionIndex)
 	tmTx := block.Block.Txs[int(txIndex)]
 	// We need to find the ethIndex
-	evmTxIndex, found := GetEvmTxIndex(block.Block.Txs, receipt.TransactionIndex, b.txDecoder)
+	evmTxIndex, found := GetEvmTxIndex(block.Block.Txs, receipt.TransactionIndex, b.txDecoder, func(h common.Hash) bool {
+		_, err := b.keeper.GetReceipt(sdkCtx, h)
+		return err == nil
+	})
 	if !found {
 		return nil, common.Hash{}, 0, 0, errors.New("failed to find transaction in block")
 	}

--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -246,27 +246,22 @@ func getEthTxForTxBz(tx tmtypes.Tx, decoder sdk.TxDecoder) *ethtypes.Transaction
 // Gets the EVM tx index based on the tx index (typically from receipt.TransactionIndex
 // Essentially loops through and calculates the index if we ignore cosmos txs
 func GetEvmTxIndex(txs tmtypes.Txs, txIndex uint32, decoder sdk.TxDecoder, receiptChecker func(common.Hash) bool) (index int, found bool) {
-	evmTxIndex := 0
-	foundTx := false
+	var evmTxIndex int
 	for i, tx := range txs {
 		etx := getEthTxForTxBz(tx, decoder)
-		if etx == nil { // cosmos tx, check if it has a receipt
-			if !receiptChecker(sha256.Sum256(tx)) {
-				continue
-			}
+		// does not exist and has no receipt (cosmos)
+		if etx == nil && !receiptChecker(sha256.Sum256(tx)) {
+			continue
 		}
+
+		// found the index
 		if i == int(txIndex) {
-			foundTx = true
-			break
+			return evmTxIndex, true
 		}
+
 		evmTxIndex++
 	}
-	if !foundTx {
-		return -1, false
-	} else {
-		return evmTxIndex, true
-
-	}
+	return -1, false
 }
 
 func encodeReceipt(receipt *types.Receipt, decoder sdk.TxDecoder, block *coretypes.ResultBlock, receiptChecker func(common.Hash) bool) (map[string]interface{}, error) {

--- a/x/evm/keeper/deferred.go
+++ b/x/evm/keeper/deferred.go
@@ -14,14 +14,14 @@ import (
 func (k *Keeper) GetAllEVMTxDeferredInfo(ctx sdk.Context) (res []*types.DeferredInfo) {
 	store := prefix.NewStore(ctx.TransientStore(k.transientStoreKey), types.DeferredInfoPrefix)
 	for txIdx, msg := range k.msgs {
-		if msg == nil {
-			continue
-		}
 		txRes := k.txResults[txIdx]
 		key := make([]byte, 8)
 		binary.BigEndian.PutUint64(key, uint64(txIdx))
 		val := store.Get(key)
 		if val == nil {
+			if msg == nil {
+				continue
+			}
 			// this means the transaction got reverted during execution, either in ante handler
 			// or due to a panic in msg server
 			etx, _ := msg.AsTransaction()

--- a/x/evm/keeper/evm.go
+++ b/x/evm/keeper/evm.go
@@ -114,7 +114,17 @@ func (k *Keeper) CallEVM(ctx sdk.Context, from common.Address, to *common.Addres
 	if err != nil {
 		return nil, err
 	}
-	k.AppendToEvmTxDeferredInfo(ctx, ethtypes.Bloom{}, ethtypes.EmptyTxsHash, surplus)
+	vmErr := ""
+	if res.Err != nil {
+		vmErr = res.Err.Error()
+	}
+	receipt, err := k.WriteReceipt(ctx, stateDB, evmMsg, ethtypes.LegacyTxType, ctx.TxSum(), res.UsedGas, vmErr)
+	if err != nil {
+		return nil, err
+	}
+	bloom := ethtypes.Bloom{}
+	bloom.SetBytes(receipt.LogsBloom)
+	k.AppendToEvmTxDeferredInfo(ctx, bloom, ctx.TxSum(), surplus)
 	return res.ReturnData, nil
 }
 

--- a/x/evm/keeper/evm.go
+++ b/x/evm/keeper/evm.go
@@ -87,7 +87,7 @@ func (k *Keeper) CallEVM(ctx sdk.Context, from common.Address, to *common.Addres
 		value = val.BigInt()
 	}
 	// This call was not part of an existing StateTransition, so it should trigger one
-	executionCtx := ctx.WithGasMeter(sdk.NewInfiniteGasMeterWithMultiplier(ctx))
+	executionCtx := ctx.WithGasMeter(sdk.NewInfiniteGasMeterWithMultiplier(ctx)).WithIsEVM(true)
 	stateDB := state.NewDBImpl(executionCtx, k, false)
 	gp := k.GetGasPool()
 	evmMsg := &core.Message{

--- a/x/evm/keeper/evm_test.go
+++ b/x/evm/keeper/evm_test.go
@@ -41,7 +41,7 @@ func TestInternalCallCreateContract(t *testing.T) {
 	ctx = ctx.WithIsEVM(false)
 	_, err = k.HandleInternalEVMCall(ctx, req)
 	require.Nil(t, err)
-	receipt, err := k.GetReceipt(ctx, [32]byte{1, 2, 3})
+	receipt, err := k.GetTransientReceipt(ctx, [32]byte{1, 2, 3})
 	require.Nil(t, err)
 	require.NotNil(t, receipt)
 }

--- a/x/evm/keeper/evm_test.go
+++ b/x/evm/keeper/evm_test.go
@@ -25,7 +25,7 @@ func TestInternalCallCreateContract(t *testing.T) {
 	contractData := append(bytecode, args...)
 
 	k := testkeeper.EVMTestApp.EvmKeeper
-	ctx := testkeeper.EVMTestApp.NewContext(false, tmtypes.Header{}).WithBlockHeight(2)
+	ctx := testkeeper.EVMTestApp.NewContext(false, tmtypes.Header{}).WithBlockHeight(2).WithTxSum([32]byte{1, 2, 3})
 	testAddr, _ := testkeeper.MockAddressPair()
 	amt := sdk.NewCoins(sdk.NewCoin(k.GetBaseDenom(ctx), sdk.NewInt(200000000)))
 	require.Nil(t, k.BankKeeper().MintCoins(ctx, types.ModuleName, sdk.NewCoins(sdk.NewCoin(k.GetBaseDenom(ctx), sdk.NewInt(200000000)))))
@@ -41,6 +41,9 @@ func TestInternalCallCreateContract(t *testing.T) {
 	ctx = ctx.WithIsEVM(false)
 	_, err = k.HandleInternalEVMCall(ctx, req)
 	require.Nil(t, err)
+	receipt, err := k.GetReceipt(ctx, [32]byte{1, 2, 3})
+	require.Nil(t, err)
+	require.NotNil(t, receipt)
 }
 
 func TestInternalCall(t *testing.T) {

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -21,8 +21,6 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/sei-protocol/sei-chain/utils"
 	"github.com/sei-protocol/sei-chain/x/evm/artifacts/erc20"
 	"github.com/sei-protocol/sei-chain/x/evm/artifacts/erc721"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
@@ -83,7 +81,7 @@ func (server msgServer) EVMTransaction(goCtx context.Context, msg *types.MsgEVMT
 			)
 			return
 		}
-		receipt, rerr := server.writeReceipt(ctx, msg, tx, emsg, serverRes, stateDB)
+		receipt, rerr := server.WriteReceipt(ctx, stateDB, emsg, uint32(tx.Type()), tx.Hash(), serverRes.GasUsed, serverRes.VmError)
 		if rerr != nil {
 			err = rerr
 			ctx.Logger().Error(fmt.Sprintf("failed to write EVM receipt: %s", err))
@@ -208,51 +206,6 @@ func (k Keeper) applyEVMMessage(ctx sdk.Context, msg *core.Message, stateDB *sta
 	st := core.NewStateTransition(evmInstance, msg, &gp, true) // fee already charged in ante handler
 	res, err := st.TransitionDb()
 	return res, err
-}
-
-func (server msgServer) writeReceipt(ctx sdk.Context, origMsg *types.MsgEVMTransaction, tx *ethtypes.Transaction, msg *core.Message, response *types.MsgEVMTransactionResponse, stateDB *state.DBImpl) (*types.Receipt, error) {
-	ethLogs := stateDB.GetAllLogs()
-	bloom := ethtypes.CreateBloom(ethtypes.Receipts{&ethtypes.Receipt{Logs: ethLogs}})
-	receipt := &types.Receipt{
-		TxType:            uint32(tx.Type()),
-		CumulativeGasUsed: uint64(0),
-		TxHashHex:         tx.Hash().Hex(),
-		GasUsed:           response.GasUsed,
-		BlockNumber:       uint64(ctx.BlockHeight()),
-		TransactionIndex:  uint32(ctx.TxIndex()),
-		EffectiveGasPrice: tx.GasPrice().Uint64(),
-		VmError:           response.VmError,
-		Logs:              utils.Map(ethLogs, ConvertEthLog),
-		LogsBloom:         bloom[:],
-	}
-
-	if msg.To == nil {
-		receipt.ContractAddress = crypto.CreateAddress(msg.From, msg.Nonce).Hex()
-	} else {
-		receipt.To = msg.To.Hex()
-		if len(msg.Data) > 0 {
-			receipt.ContractAddress = msg.To.Hex()
-		}
-	}
-
-	if response.VmError == "" {
-		receipt.Status = uint32(ethtypes.ReceiptStatusSuccessful)
-	} else {
-		receipt.Status = uint32(ethtypes.ReceiptStatusFailed)
-	}
-
-	if perr := stateDB.GetPrecompileError(); perr != nil {
-		if receipt.Status > 0 {
-			ctx.Logger().Error(fmt.Sprintf("Transaction %s succeeded in execution but has precompile error %s", receipt.TxHashHex, perr.Error()))
-		} else {
-			// append precompile error to VM error
-			receipt.VmError = fmt.Sprintf("%s|%s", receipt.VmError, perr.Error())
-		}
-	}
-
-	receipt.From = origMsg.Derived.SenderEVMAddr.Hex()
-
-	return receipt, server.SetTransientReceipt(ctx, tx.Hash(), receipt)
 }
 
 func (server msgServer) Send(goCtx context.Context, msg *types.MsgSend) (*types.MsgSendResponse, error) {

--- a/x/evm/keeper/msg_server_test.go
+++ b/x/evm/keeper/msg_server_test.go
@@ -10,6 +10,7 @@ import (
 
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	"github.com/ethereum/go-ethereum/common"
@@ -676,8 +677,8 @@ func TestEvmError(t *testing.T) {
 	require.Nil(t, err)
 
 	res = testkeeper.EVMTestApp.DeliverTx(ctx, abci.RequestDeliverTx{Tx: txbz}, sdktx, sha256.Sum256(txbz))
-	require.Equal(t, uint32(45), res.Code)
 	require.NoError(t, k.FlushTransientReceipts(ctx))
+	require.Equal(t, sdkerrors.ErrEVMVMError.ABCICode(), res.Code)
 	receipt, err = k.GetReceipt(ctx, common.HexToHash(res.EvmTxInfo.TxHash))
 	require.Nil(t, err)
 	require.Equal(t, receipt.VmError, res.EvmTxInfo.VmError)

--- a/x/evm/keeper/receipt.go
+++ b/x/evm/keeper/receipt.go
@@ -9,6 +9,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/sei-protocol/sei-db/proto"
 
+	"github.com/ethereum/go-ethereum/core"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/sei-protocol/sei-chain/utils"
+	"github.com/sei-protocol/sei-chain/x/evm/state"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
 
@@ -99,4 +104,57 @@ func (k *Keeper) FlushTransientReceipts(ctx sdk.Context) error {
 	changesets = append(changesets, ncs)
 
 	return k.receiptStore.ApplyChangesetAsync(ctx.BlockHeight(), changesets)
+}
+
+func (k *Keeper) WriteReceipt(
+	ctx sdk.Context,
+	stateDB *state.DBImpl,
+	msg *core.Message,
+	txType uint32,
+	txHash common.Hash,
+	gasUsed uint64,
+	vmError string,
+) (*types.Receipt, error) {
+	ethLogs := stateDB.GetAllLogs()
+	bloom := ethtypes.CreateBloom(ethtypes.Receipts{&ethtypes.Receipt{Logs: ethLogs}})
+	receipt := &types.Receipt{
+		TxType:            txType,
+		CumulativeGasUsed: uint64(0),
+		TxHashHex:         txHash.Hex(),
+		GasUsed:           gasUsed,
+		BlockNumber:       uint64(ctx.BlockHeight()),
+		TransactionIndex:  uint32(ctx.TxIndex()),
+		EffectiveGasPrice: msg.GasPrice.Uint64(),
+		VmError:           vmError,
+		Logs:              utils.Map(ethLogs, ConvertEthLog),
+		LogsBloom:         bloom[:],
+	}
+
+	if msg.To == nil {
+		receipt.ContractAddress = crypto.CreateAddress(msg.From, msg.Nonce).Hex()
+	} else {
+		receipt.To = msg.To.Hex()
+		if len(msg.Data) > 0 {
+			receipt.ContractAddress = msg.To.Hex()
+		}
+	}
+
+	if vmError == "" {
+		receipt.Status = uint32(ethtypes.ReceiptStatusSuccessful)
+	} else {
+		receipt.Status = uint32(ethtypes.ReceiptStatusFailed)
+	}
+
+	if perr := stateDB.GetPrecompileError(); perr != nil {
+		if receipt.Status > 0 {
+			ctx.Logger().Error(fmt.Sprintf("Transaction %s succeeded in execution but has precompile error %s", receipt.TxHashHex, perr.Error()))
+		} else {
+			// append precompile error to VM error
+			receipt.VmError = fmt.Sprintf("%s|%s", receipt.VmError, perr.Error())
+		}
+	}
+
+	receipt.From = msg.From.Hex()
+
+	return receipt, k.SetTransientReceipt(ctx, txHash, receipt)
 }


### PR DESCRIPTION
## Describe your changes and provide context
Create receipt for CosmWasm transactions that invoked EVM contracts. Tx hash for such receipt is set to be the Cosmos tx hash of the originating tx, which happens to also be a 20-byte array same as EVM tx hash.

## Testing performed to validate your change
unit test
integration tests
