### PR TITLE
Allow bank precompile to use the unassociated casted address for receiving balances

### DIFF
--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -1,4 +1,5 @@
-const { exec } = require("child_process"); // Importing exec from child_process
+const { exec } = require("child_process");
+const {ethers} = require("hardhat"); // Importing exec from child_process
 
 const adminKeyName = "admin"
 
@@ -334,6 +335,10 @@ async function getEvmAddress(seiAddress) {
     return response.evm_address
 }
 
+function generateWallet() {
+    const wallet = ethers.Wallet.createRandom();
+    return wallet.connect(ethers.provider);
+}
 
 async function deployEvmContract(name, args=[]) {
     const Contract = await ethers.getContractFactory(name);
@@ -478,6 +483,7 @@ module.exports = {
     testAPIEnabled,
     incrementPointerVersion,
     associateWasm,
+    generateWallet,
     WASM,
     ABI,
 };

--- a/precompiles/bank/bank.go
+++ b/precompiles/bank/bank.go
@@ -187,7 +187,6 @@ func (p Precompile) send(ctx sdk.Context, caller common.Address, method *abi.Met
 		// short circuit
 		return method.Outputs.Pack(true)
 	}
-	// TODO: it's possible to extend evm module's balance to handle non-usei tokens as well
 	senderSeiAddr, err := p.accAddressFromArg(ctx, args[0])
 	if err != nil {
 		return nil, err

--- a/precompiles/bank/bank.go
+++ b/precompiles/bank/bank.go
@@ -359,7 +359,8 @@ func (p Precompile) accAddressFromArg(ctx sdk.Context, arg interface{}) (sdk.Acc
 	}
 	seiAddr, found := p.evmKeeper.GetSeiAddress(ctx, addr)
 	if !found {
-		return nil, fmt.Errorf("EVM address %s is not associated", addr.Hex())
+		// return the casted version instead
+		return sdk.AccAddress(addr[:]), nil
 	}
 	return seiAddr, nil
 }


### PR DESCRIPTION
## Describe your changes and provide context
This modifies bank precompile behavior to allow receiving native tokens to an unassociated address in a casted way such that they will be migrated in `migrate_balance` upon association.

## Testing performed to validate your change
Need to add unit tests + integration tests, have performed some local chain testing but need to perform more for thoroughness.