### PR TITLE
Make occ caused evm panics less noisy

### DIFF
--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -65,7 +65,6 @@ func (server msgServer) EVMTransaction(goCtx context.Context, msg *types.MsgEVMT
 	defer func() {
 		if pe := recover(); pe != nil {
 			debug.PrintStack()
-			// if this panic is due to occ conflict, then we should not log it as error
 			if !strings.Contains(fmt.Sprintf("%s", pe), occtypes.ErrReadEstimate.Error()) {
 				ctx.Logger().Error(fmt.Sprintf("EVM PANIC: %s", pe))
 				telemetry.IncrCounter(1, types.ModuleName, "panics")

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -63,9 +63,7 @@ func (server msgServer) EVMTransaction(goCtx context.Context, msg *types.MsgEVMT
 	gp := server.GetGasPool()
 
 	defer func() {
-		fmt.Println("IN DEFER")
 		if pe := recover(); pe != nil {
-			fmt.Println("In RECOVER")
 			debug.PrintStack()
 			// if this panic is due to occ conflict, then we should not log it as error
 			if !strings.Contains(fmt.Sprintf("%s", pe), occtypes.ErrReadEstimate.Error()) {

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -8,10 +8,12 @@ import (
 	"math"
 	"math/big"
 	"runtime/debug"
+	"strings"
 
 	"github.com/armon/go-metrics"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	occtypes "github.com/cosmos/cosmos-sdk/types/occ"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -64,8 +66,10 @@ func (server msgServer) EVMTransaction(goCtx context.Context, msg *types.MsgEVMT
 		if pe := recover(); pe != nil {
 			// there is not supposed to be any panic
 			debug.PrintStack()
-			ctx.Logger().Error(fmt.Sprintf("EVM PANIC: %s", pe))
-			telemetry.IncrCounter(1, types.ModuleName, "panics")
+			if !strings.Contains(fmt.Sprintf("%s", pe), occtypes.ErrReadEstimate.Error()) {
+				ctx.Logger().Error(fmt.Sprintf("EVM PANIC: %s", pe))
+				telemetry.IncrCounter(1, types.ModuleName, "panics")
+			}
 			server.AppendErrorToEvmTxDeferredInfo(ctx, tx.Hash(), fmt.Sprintf("%s", pe))
 
 			panic(pe)

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -64,8 +64,8 @@ func (server msgServer) EVMTransaction(goCtx context.Context, msg *types.MsgEVMT
 
 	defer func() {
 		if pe := recover(); pe != nil {
-			debug.PrintStack()
 			if !strings.Contains(fmt.Sprintf("%s", pe), occtypes.ErrReadEstimate.Error()) {
+				debug.PrintStack()
 				ctx.Logger().Error(fmt.Sprintf("EVM PANIC: %s", pe))
 				telemetry.IncrCounter(1, types.ModuleName, "panics")
 			}

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -63,9 +63,11 @@ func (server msgServer) EVMTransaction(goCtx context.Context, msg *types.MsgEVMT
 	gp := server.GetGasPool()
 
 	defer func() {
+		fmt.Println("IN DEFER")
 		if pe := recover(); pe != nil {
-			// there is not supposed to be any panic
+			fmt.Println("In RECOVER")
 			debug.PrintStack()
+			// if this panic is due to occ conflict, then we should not log it as error
 			if !strings.Contains(fmt.Sprintf("%s", pe), occtypes.ErrReadEstimate.Error()) {
 				ctx.Logger().Error(fmt.Sprintf("EVM PANIC: %s", pe))
 				telemetry.IncrCounter(1, types.ModuleName, "panics")


### PR DESCRIPTION
## Describe your changes and provide context

If there is an evm panic due to occ conflict, don't log or increment metrics for this evm panic

## Testing performed to validate your change
existing tests
