### PR TITLE
Remove interoperability hop limit with isolated EVM instances

### DIFF
--- a/contracts/test/CW20toERC20PointerTest.js
+++ b/contracts/test/CW20toERC20PointerTest.js
@@ -1,6 +1,6 @@
 const {getAdmin, queryWasm, executeWasm, associateWasm, deployEvmContract, setupSigners, deployErc20PointerForCw20, deployWasm, WASM,
     registerPointerForERC20,
-    proposeCW20toERC20Upgrade
+    proposeCW20toERC20Upgrade, callWasmViaPrecompile
 } = require("./lib");
 const { expect } = require("chai");
 
@@ -151,6 +151,17 @@ describe("CW20 to ERC20 Pointer", function () {
                     const respAfter = await queryWasm(pointer, "balance", {address: accounts[0].seiAddress});
                     const balanceAfter = respAfter.data.balance;
                     expect(balanceAfter).to.equal((parseInt(balanceBefore) - 100).toString());
+                });
+
+                it("should be callable via wasmd precompile", async function() {
+                    const respBefore = await queryWasm(pointer, "balance", {address: accounts[1].seiAddress});
+                    const balanceBefore = respBefore.data.balance;
+
+                    await callWasmViaPrecompile(pointer, { transfer: { recipient: accounts[1].seiAddress, amount: "100" } });
+                    const respAfter = await queryWasm(pointer, "balance", {address: accounts[1].seiAddress});
+                    const balanceAfter = respAfter.data.balance;
+
+                    expect(balanceAfter).to.equal((parseInt(balanceBefore) + 100).toString());
                 });
             });
         });

--- a/contracts/test/CW20toERC20PointerTest.js
+++ b/contracts/test/CW20toERC20PointerTest.js
@@ -157,11 +157,21 @@ describe("CW20 to ERC20 Pointer", function () {
                     const respBefore = await queryWasm(pointer, "balance", {address: accounts[1].seiAddress});
                     const balanceBefore = respBefore.data.balance;
 
-                    await callWasmViaPrecompile(pointer, { transfer: { recipient: accounts[1].seiAddress, amount: "100" } });
+                    const receipt = await callWasmViaPrecompile(ethers.provider, pointer, { transfer: { recipient: accounts[1].seiAddress, amount: "100" } });
                     const respAfter = await queryWasm(pointer, "balance", {address: accounts[1].seiAddress});
                     const balanceAfter = respAfter.data.balance;
 
                     expect(balanceAfter).to.equal((parseInt(balanceBefore) + 100).toString());
+
+                    // make sure log is emitted
+                    console.log(receipt);
+                    const filter = {
+                        fromBlock: receipt["blockNumber"],
+                        toBlock: 'latest',
+                        topics: [ethers.id("Transfer(address,address,uint256)")]
+                    };
+                    const logs = await ethers.provider.getLogs(filter);
+                    expect(logs.length).to.equal(1)
                 });
             });
         });

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -320,6 +320,22 @@ async function registerPointerForERC721(erc721Address, fees="20000usei", from=ad
     return getEventAttribute(response, "pointer_registered", "pointer_address")
 }
 
+async function callWasmViaPrecompile(cwAddress, payload, from=adminKeyName) {
+    const jsonString = JSON.stringify(payload).replace(/"/g, '\\"'); // Properly escape JSON string
+    const command = `seid tx evm call-precompile wasmd execute ${cwAddress} "${jsonString}" 0usei --from=${from}`;
+    const output = await execute(command);
+    const txHash = output.replace(/.*0x/, "0x").trim()
+    let attempt = 0;
+    while(attempt < 10) {
+        const receipt = await provider.getTransactionReceipt(txHash);
+        if(receipt) {
+            return
+        }
+        await sleep(500)
+        attempt++
+    }
+    throw new Error("call wasm via precompile failed")
+}
 
 async function getSeiAddress(evmAddress) {
     const command = `seid q evm sei-addr ${evmAddress} -o json`
@@ -483,7 +499,11 @@ module.exports = {
     testAPIEnabled,
     incrementPointerVersion,
     associateWasm,
+<<<<<<< HEAD
     generateWallet,
+=======
+    callWasmViaPrecompile,
+>>>>>>> 76c43ddb (remove hop limit)
     WASM,
     ABI,
 };

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -320,16 +320,16 @@ async function registerPointerForERC721(erc721Address, fees="20000usei", from=ad
     return getEventAttribute(response, "pointer_registered", "pointer_address")
 }
 
-async function callWasmViaPrecompile(cwAddress, payload, from=adminKeyName) {
+async function callWasmViaPrecompile(provider, cwAddress, payload, from=adminKeyName) {
     const jsonString = JSON.stringify(payload).replace(/"/g, '\\"'); // Properly escape JSON string
-    const command = `seid tx evm call-precompile wasmd execute ${cwAddress} "${jsonString}" 0usei --from=${from}`;
+    const command = `seid tx evm call-precompile wasmd execute ${cwAddress} "${jsonString}" "[]" --from=${from}`;
     const output = await execute(command);
-    const txHash = output.replace(/.*0x/, "0x").trim()
+    const txHash = output.replace(/.*0x/, "0x").trim();
     let attempt = 0;
     while(attempt < 10) {
         const receipt = await provider.getTransactionReceipt(txHash);
         if(receipt) {
-            return
+            return receipt
         }
         await sleep(500)
         attempt++
@@ -499,11 +499,8 @@ module.exports = {
     testAPIEnabled,
     incrementPointerVersion,
     associateWasm,
-<<<<<<< HEAD
     generateWallet,
-=======
     callWasmViaPrecompile,
->>>>>>> 76c43ddb (remove hop limit)
     WASM,
     ABI,
 };

--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -39,7 +39,8 @@ func NewTransactionAPI(tmClient rpcclient.Client, k *keeper.Keeper, ctxProvider 
 	return &TransactionAPI{tmClient: tmClient, keeper: k, ctxProvider: ctxProvider, txConfig: txConfig, homeDir: homeDir, connectionType: connectionType}
 }
 
-func (t *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (result map[string]interface{}, returnErr error) {
+func (t *TransactionAPI) GetTransactionReceipt(ctx context.Context, hashStr string) (result map[string]interface{}, returnErr error) {
+	hash := common.HexToHash(hashStr)
 	startTime := time.Now()
 	defer recordMetrics("eth_getTransactionReceipt", t.connectionType, startTime, returnErr == nil)
 	receipt, err := t.keeper.GetReceipt(t.ctxProvider(LatestCtxHeight), hash)

--- a/go.mod
+++ b/go.mod
@@ -346,7 +346,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.1.5
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => ../sei-cosmos // github.com/sei-protocol/sei-cosmos v0.3.16
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.19
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.9
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.1
 	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-21

--- a/go.mod
+++ b/go.mod
@@ -346,7 +346,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.1.5
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.18
+	github.com/cosmos/cosmos-sdk => ../sei-cosmos // github.com/sei-protocol/sei-cosmos v0.3.16
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.9
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.1
 	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-21

--- a/go.sum
+++ b/go.sum
@@ -1347,8 +1347,6 @@ github.com/sei-protocol/go-ethereum v1.13.5-sei-21 h1:uzBquo71kOMs2bZjmYsiDQb7t5
 github.com/sei-protocol/go-ethereum v1.13.5-sei-21/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.3.18 h1:QB7R+U3TEkCfSqUXPS2aX273D6EorXZtEZ9H+WwJxt4=
-github.com/sei-protocol/sei-cosmos v0.3.18/go.mod h1:xZYuJxxS6zdhNq+pKQPiaAjSZGU5EXe9bjrCdMBXxUQ=
 github.com/sei-protocol/sei-db v0.0.38 h1:GiQl3qBd6XgGsHkJd4I8GnOmGjGoWQg3SJAS82TTNao=
 github.com/sei-protocol/sei-db v0.0.38/go.mod h1:F/ZKZA8HJPcUzSZPA8yt6pfwlGriJ4RDR4eHKSGLStI=
 github.com/sei-protocol/sei-iavl v0.1.9 h1:y4mVYftxLNRs6533zl7N0/Ch+CzRQc04JDfHolIxgBE=

--- a/go.sum
+++ b/go.sum
@@ -1347,6 +1347,8 @@ github.com/sei-protocol/go-ethereum v1.13.5-sei-21 h1:uzBquo71kOMs2bZjmYsiDQb7t5
 github.com/sei-protocol/go-ethereum v1.13.5-sei-21/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
+github.com/sei-protocol/sei-cosmos v0.3.19 h1:EQZ+i0virWhmE6XY4w9Dc4tYhVOdZos6Gl9qU39eMGU=
+github.com/sei-protocol/sei-cosmos v0.3.19/go.mod h1:rWb90yP2YTqF3CxcdcMvxHYsdLihTNMA5wZi7FwtaeI=
 github.com/sei-protocol/sei-db v0.0.38 h1:GiQl3qBd6XgGsHkJd4I8GnOmGjGoWQg3SJAS82TTNao=
 github.com/sei-protocol/sei-db v0.0.38/go.mod h1:F/ZKZA8HJPcUzSZPA8yt6pfwlGriJ4RDR4eHKSGLStI=
 github.com/sei-protocol/sei-iavl v0.1.9 h1:y4mVYftxLNRs6533zl7N0/Ch+CzRQc04JDfHolIxgBE=

--- a/precompiles/wasmd/wasmd.go
+++ b/precompiles/wasmd/wasmd.go
@@ -254,9 +254,7 @@ func (p Precompile) instantiate(ctx sdk.Context, method *abi.Method, caller comm
 		rerr = err
 		return
 	}
-	for _, e := range ctx.EVMEventManager().Events() {
-		evm.StateDB.AddLog(e)
-	}
+	AddEvents(ctx, evm)
 	ret, rerr = method.Outputs.Pack(addr.String(), data)
 	remainingGas = pcommon.GetRemainingGas(ctx, p.evmKeeper)
 	return
@@ -382,9 +380,7 @@ func (p Precompile) executeBatch(ctx sdk.Context, method *abi.Method, caller com
 			rerr = err
 			return
 		}
-		for _, e := range ctx.EVMEventManager().Events() {
-			evm.StateDB.AddLog(e)
-		}
+		AddEvents(ctx, evm)
 		responses = append(responses, res)
 	}
 	if valueCopy != nil && valueCopy.Sign() != 0 {
@@ -480,9 +476,7 @@ func (p Precompile) execute(ctx sdk.Context, method *abi.Method, caller common.A
 		rerr = err
 		return
 	}
-	for _, e := range ctx.EVMEventManager().Events() {
-		evm.StateDB.AddLog(e)
-	}
+	AddEvents(ctx, evm)
 	ret, rerr = method.Outputs.Pack(res)
 	remainingGas = pcommon.GetRemainingGas(ctx, p.evmKeeper)
 	return
@@ -530,4 +524,10 @@ func (p Precompile) query(ctx sdk.Context, method *abi.Method, args []interface{
 	ret, rerr = method.Outputs.Pack(res)
 	remainingGas = pcommon.GetRemainingGas(ctx, p.evmKeeper)
 	return
+}
+
+func AddEvents(ctx sdk.Context, evm *vm.EVM) {
+	for _, e := range ctx.EVMEventManager().Events() {
+		evm.StateDB.AddLog(e)
+	}
 }

--- a/x/evm/client/cli/common.go
+++ b/x/evm/client/cli/common.go
@@ -94,6 +94,8 @@ func getMethodPayload(newAbi abi.ABI, args []string) ([]byte, error) {
 			arg = args[idx]
 		case abi.AddressTy:
 			arg = common.HexToAddress(args[idx])
+		case abi.BytesTy:
+			arg = []byte(args[idx])
 		default:
 			return nil, errors.New("argument type not supported yet")
 		}

--- a/x/evm/keeper/evm.go
+++ b/x/evm/keeper/evm.go
@@ -73,9 +73,6 @@ func (k *Keeper) HandleInternalEVMDelegateCall(ctx sdk.Context, req *types.MsgIn
 }
 
 func (k *Keeper) CallEVM(ctx sdk.Context, from common.Address, to *common.Address, val *sdk.Int, data []byte) (retdata []byte, reterr error) {
-	if ctx.IsEVM() {
-		return nil, errors.New("sei does not support EVM->CW->EVM call pattern")
-	}
 	if to == nil && len(data) > params.MaxInitCodeSize {
 		return nil, fmt.Errorf("%w: code size %v, limit %v", core.ErrMaxInitCodeSizeExceeded, len(data), params.MaxInitCodeSize)
 	}
@@ -115,6 +112,7 @@ func (k *Keeper) CallEVM(ctx sdk.Context, from common.Address, to *common.Addres
 		return nil, err
 	}
 	k.AppendToEvmTxDeferredInfo(ctx, ethtypes.Bloom{}, ethtypes.EmptyTxsHash, surplus)
+	ctx.EVMEventManager().EmitEvents(stateDB.GetAllLogs())
 	return res.ReturnData, nil
 }
 

--- a/x/evm/keeper/evm_test.go
+++ b/x/evm/keeper/evm_test.go
@@ -35,9 +35,6 @@ func TestInternalCallCreateContract(t *testing.T) {
 		Data:   contractData,
 	}
 	// circular interop call
-	ctx = ctx.WithIsEVM(true)
-	_, err = k.HandleInternalEVMCall(ctx, req)
-	require.Equal(t, "sei does not support EVM->CW->EVM call pattern", err.Error())
 	ctx = ctx.WithIsEVM(false)
 	_, err = k.HandleInternalEVMCall(ctx, req)
 	require.Nil(t, err)
@@ -62,9 +59,6 @@ func TestInternalCall(t *testing.T) {
 		Sender: testAddr.String(),
 		Data:   contractData,
 	}
-	ctx = ctx.WithIsEVM(true)
-	_, err = k.HandleInternalEVMCall(ctx, req)
-	require.Equal(t, "sei does not support EVM->CW->EVM call pattern", err.Error())
 	ctx = ctx.WithIsEVM(false)
 	ret, err := k.HandleInternalEVMCall(ctx, req)
 	require.Nil(t, err)


### PR DESCRIPTION
## Describe your changes and provide context
Previously interop hop was limited to 1 due to concerns of reentrancy attacks. This PR removes the limit and now relies on the fact that each hop would instantiate a new, isolated EVM instance as base of operation. This creates the need of bubbling up EVM events generated  in those isolated EVM instances, which is solved by a dedicated event manager in context.

## Testing performed to validate your change
integration test that calls the wasmd precompile which calls a CW->ERC pointer
