### PR TITLE
Reuse existing EVM instance in interop calls

### DIFF
--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -362,7 +362,11 @@ func (b *Backend) GetEVM(_ context.Context, msg *core.Message, stateDB vm.StateD
 	if blockCtx == nil {
 		blockCtx, _ = b.keeper.GetVMBlockContext(b.ctxProvider(LatestCtxHeight), core.GasPool(b.RPCGasCap()))
 	}
-	return vm.NewEVM(*blockCtx, txContext, stateDB, b.ChainConfig(), *vmConfig)
+	evm := vm.NewEVM(*blockCtx, txContext, stateDB, b.ChainConfig(), *vmConfig)
+	if dbImpl, ok := stateDB.(*state.DBImpl); ok {
+		dbImpl.SetEVM(evm)
+	}
+	return evm
 }
 
 func (b *Backend) CurrentHeader() *ethtypes.Header {

--- a/go.mod
+++ b/go.mod
@@ -344,7 +344,7 @@ require (
 )
 
 replace (
-	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.2.0
+	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.2.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.26
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.9

--- a/go.sum
+++ b/go.sum
@@ -1359,8 +1359,8 @@ github.com/sei-protocol/sei-tendermint v0.3.4 h1:pAMXB2Cd0/rmmEkPgcEdIEjw7k64K7+
 github.com/sei-protocol/sei-tendermint v0.3.4/go.mod h1:4LSlJdhl3nf3OmohliwRNUFLOB1XWlrmSodrIP7fLh4=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
-github.com/sei-protocol/sei-wasmd v0.2.0 h1:DiR5u7ZRtRKMYjvGPsH+/nMnJAprcFovbaITLf1Et0Y=
-github.com/sei-protocol/sei-wasmd v0.2.0/go.mod h1:EnQkqvUA3tYpdgXjqatHK8ym9LCm1z+lM7XMqR9SA3o=
+github.com/sei-protocol/sei-wasmd v0.2.1 h1:2COAeomO22CAGQRTnAd3I1I3b4UhraQuV6Y0PASejc8=
+github.com/sei-protocol/sei-wasmd v0.2.1/go.mod h1:EnQkqvUA3tYpdgXjqatHK8ym9LCm1z+lM7XMqR9SA3o=
 github.com/sei-protocol/tm-db v0.0.4 h1:7Y4EU62Xzzg6wKAHEotm7SXQR0aPLcGhKHkh3qd0tnk=
 github.com/sei-protocol/tm-db v0.0.4/go.mod h1:PWsIWOTwdwC7Ow/GUvx8HgUJTO691pBuorIQD8JvwAs=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/wasmbinding/message_plugin.go
+++ b/wasmbinding/message_plugin.go
@@ -3,7 +3,6 @@ package wasmbinding
 import (
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
-	"github.com/cosmos/cosmos-sdk/baseapp"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
@@ -19,14 +18,14 @@ type CustomRouter struct {
 	evmKeeper *evmkeeper.Keeper
 }
 
-func (r *CustomRouter) Handler(msg sdk.Msg) baseapp.MsgServiceHandler {
+func (r *CustomRouter) Handler(msg sdk.Msg) wasmkeeper.MsgHandler {
 	switch m := msg.(type) {
 	case *evmtypes.MsgInternalEVMCall:
-		return func(ctx sdk.Context, _ sdk.Msg) (*sdk.Result, error) {
+		return func(ctx sdk.Context, _ sdk.Msg) (sdk.Context, *sdk.Result, error) {
 			return r.evmKeeper.HandleInternalEVMCall(ctx, m)
 		}
 	case *evmtypes.MsgInternalEVMDelegateCall:
-		return func(ctx sdk.Context, _ sdk.Msg) (*sdk.Result, error) {
+		return func(ctx sdk.Context, _ sdk.Msg) (sdk.Context, *sdk.Result, error) {
 			return r.evmKeeper.HandleInternalEVMDelegateCall(ctx, m)
 		}
 	default:

--- a/x/evm/ante/fee.go
+++ b/x/evm/ante/fee.go
@@ -70,6 +70,7 @@ func (fc EVMFeeCheckDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 	cfg := evmtypes.DefaultChainConfig().EthereumConfig(fc.evmKeeper.ChainID(ctx))
 	txCtx := core.NewEVMTxContext(emsg)
 	evmInstance := vm.NewEVM(*blockCtx, txCtx, stateDB, cfg, vm.Config{})
+	stateDB.SetEVM(evmInstance)
 	st := core.NewStateTransition(evmInstance, emsg, &gp, true)
 	// run stateless checks before charging gas (mimicking Geth behavior)
 	if !ctx.IsCheckTx() && !ctx.IsReCheckTx() {

--- a/x/evm/keeper/evm.go
+++ b/x/evm/keeper/evm.go
@@ -144,7 +144,7 @@ func (k *Keeper) CallEVM(ctx sdk.Context, from common.Address, to *common.Addres
 	bloom.SetBytes(receipt.LogsBloom)
 	k.AppendToEvmTxDeferredInfo(ctx, bloom, ctx.TxSum(), surplus)
 	ctx.EVMEventManager().EmitEvents(stateDB.GetAllLogs())
-	return ctx, res.ReturnData, nil
+	return stateDB.Ctx(), res.ReturnData, nil
 }
 
 func (k *Keeper) StaticCallEVM(ctx sdk.Context, from sdk.AccAddress, to *common.Address, data []byte) ([]byte, error) {

--- a/x/evm/keeper/evm_test.go
+++ b/x/evm/keeper/evm_test.go
@@ -34,10 +34,6 @@ func TestInternalCallCreateContract(t *testing.T) {
 		Sender: testAddr.String(),
 		Data:   contractData,
 	}
-	// circular interop call
-	ctx = ctx.WithIsEVM(true)
-	_, err = k.HandleInternalEVMCall(ctx, req)
-	require.Equal(t, "sei does not support EVM->CW->EVM call pattern", err.Error())
 	ctx = ctx.WithIsEVM(false)
 	_, _, err = k.HandleInternalEVMCall(ctx, req)
 	require.Nil(t, err)
@@ -65,17 +61,16 @@ func TestInternalCall(t *testing.T) {
 		Sender: testAddr.String(),
 		Data:   contractData,
 	}
-	ctx = ctx.WithIsEVM(true)
-	_, err = k.HandleInternalEVMCall(ctx, req)
-	require.Equal(t, "sei does not support EVM->CW->EVM call pattern", err.Error())
 	ctx = ctx.WithIsEVM(false)
-	_, ret, err := k.HandleInternalEVMCall(ctx, req)
+	resCtx, ret, err := k.HandleInternalEVMCall(ctx, req)
 	require.Nil(t, err)
 	contractAddr := crypto.CreateAddress(senderEvmAddr, 0)
 	require.NotEmpty(t, k.GetCode(ctx, contractAddr))
 	require.Equal(t, ret.Data, k.GetCode(ctx, contractAddr))
 	k.SetERC20NativePointer(ctx, "test", contractAddr)
 
+	ctx = resCtx
+	require.NotNil(t, types.GetCtxEVM(ctx))
 	receiverAddr, evmAddr := testkeeper.MockAddressPair()
 	k.SetAddressMapping(ctx, receiverAddr, evmAddr)
 	args, err = abi.Pack("transfer", evmAddr, big.NewInt(1000))
@@ -89,9 +84,9 @@ func TestInternalCall(t *testing.T) {
 		Data:   args,
 		Value:  &val,
 	}
-	_, _, err = k.HandleInternalEVMCall(ctx, req)
+	resCtx, _, err = k.HandleInternalEVMCall(ctx, req)
 	require.Nil(t, err)
-	require.Equal(t, int64(1000), testkeeper.EVMTestApp.BankKeeper.GetBalance(ctx, receiverAddr, "test").Amount.Int64())
+	require.Equal(t, int64(1000), testkeeper.EVMTestApp.BankKeeper.GetBalance(resCtx, receiverAddr, "test").Amount.Int64())
 }
 
 func TestStaticCall(t *testing.T) {

--- a/x/evm/keeper/evm_test.go
+++ b/x/evm/keeper/evm_test.go
@@ -39,7 +39,7 @@ func TestInternalCallCreateContract(t *testing.T) {
 	_, err = k.HandleInternalEVMCall(ctx, req)
 	require.Equal(t, "sei does not support EVM->CW->EVM call pattern", err.Error())
 	ctx = ctx.WithIsEVM(false)
-	_, err = k.HandleInternalEVMCall(ctx, req)
+	_, _, err = k.HandleInternalEVMCall(ctx, req)
 	require.Nil(t, err)
 	receipt, err := k.GetTransientReceipt(ctx, [32]byte{1, 2, 3})
 	require.Nil(t, err)
@@ -69,7 +69,7 @@ func TestInternalCall(t *testing.T) {
 	_, err = k.HandleInternalEVMCall(ctx, req)
 	require.Equal(t, "sei does not support EVM->CW->EVM call pattern", err.Error())
 	ctx = ctx.WithIsEVM(false)
-	ret, err := k.HandleInternalEVMCall(ctx, req)
+	_, ret, err := k.HandleInternalEVMCall(ctx, req)
 	require.Nil(t, err)
 	contractAddr := crypto.CreateAddress(senderEvmAddr, 0)
 	require.NotEmpty(t, k.GetCode(ctx, contractAddr))
@@ -89,7 +89,7 @@ func TestInternalCall(t *testing.T) {
 		Data:   args,
 		Value:  &val,
 	}
-	_, err = k.HandleInternalEVMCall(ctx, req)
+	_, _, err = k.HandleInternalEVMCall(ctx, req)
 	require.Nil(t, err)
 	require.Equal(t, int64(1000), testkeeper.EVMTestApp.BankKeeper.GetBalance(ctx, receiverAddr, "test").Amount.Int64())
 }
@@ -113,7 +113,7 @@ func TestStaticCall(t *testing.T) {
 		Sender: testAddr.String(),
 		Data:   contractData,
 	}
-	ret, err := k.HandleInternalEVMCall(ctx, req)
+	_, ret, err := k.HandleInternalEVMCall(ctx, req)
 	require.Nil(t, err)
 	contractAddr := crypto.CreateAddress(senderEvmAddr, 0)
 	require.NotEmpty(t, k.GetCode(ctx, contractAddr))
@@ -163,7 +163,7 @@ func TestNegativeTransfer(t *testing.T) {
 	require.Zero(t, preAttackerBal)
 	require.Equal(t, steal_amount, preVictimBal)
 
-	_, err := k.HandleInternalEVMCall(ctx, req)
+	_, _, err := k.HandleInternalEVMCall(ctx, req)
 	require.ErrorContains(t, err, "invalid coins")
 
 	// post verification
@@ -179,7 +179,7 @@ func TestNegativeTransfer(t *testing.T) {
 		Value:  &zeroVal,
 	}
 
-	_, err = k.HandleInternalEVMCall(ctx, req2)
+	_, _, err = k.HandleInternalEVMCall(ctx, req2)
 	require.ErrorContains(t, err, "max initcode size exceeded")
 }
 
@@ -205,6 +205,6 @@ func TestHandleInternalEVMDelegateCall_AssociationError(t *testing.T) {
 		FromContract: string(contractAddr.Bytes()),
 		To:           castedAddr.Hex(),
 	}
-	_, err := k.HandleInternalEVMDelegateCall(ctx, req)
+	_, _, err := k.HandleInternalEVMDelegateCall(ctx, req)
 	require.Equal(t, err.Error(), types.NewAssociationMissingErr(testAddr.String()).Error())
 }

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -203,6 +203,7 @@ func (k Keeper) applyEVMMessage(ctx sdk.Context, msg *core.Message, stateDB *sta
 	cfg := types.DefaultChainConfig().EthereumConfig(k.ChainID(ctx))
 	txCtx := core.NewEVMTxContext(msg)
 	evmInstance := vm.NewEVM(*blockCtx, txCtx, stateDB, cfg, vm.Config{})
+	stateDB.SetEVM(evmInstance)
 	st := core.NewStateTransition(evmInstance, msg, &gp, true) // fee already charged in ante handler
 	res, err := st.TransitionDb()
 	return res, err

--- a/x/evm/state/state_test.go
+++ b/x/evm/state/state_test.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/vm"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
@@ -165,4 +166,17 @@ func TestSnapshot(t *testing.T) {
 	// prev state DB committed except for transient states
 	require.Equal(t, common.Hash{}, newStateDB.GetTransientState(evmAddr, tkey))
 	require.Equal(t, val, newStateDB.GetState(evmAddr, key))
+}
+
+func TestSetEVM(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper()
+	statedb := state.NewDBImpl(ctx, k, false)
+	rev1 := statedb.Snapshot()
+	statedb.SetEVM(&vm.EVM{})
+	rev2 := statedb.Snapshot()
+	require.NotNil(t, types.GetCtxEVM(statedb.Ctx()))
+	statedb.RevertToSnapshot(rev2)
+	require.NotNil(t, types.GetCtxEVM(statedb.Ctx()))
+	statedb.RevertToSnapshot(rev1)
+	require.NotNil(t, types.GetCtxEVM(statedb.Ctx()))
 }

--- a/x/evm/state/statedb.go
+++ b/x/evm/state/statedb.go
@@ -73,7 +73,6 @@ func (s *DBImpl) SetLogger(logger *tracing.Hooks) {
 	s.logger = logger
 }
 
-// for interface compliance
 func (s *DBImpl) SetEVM(evm *vm.EVM) {
 	s.ctx = types.SetCtxEVM(s.ctx, evm)
 	s.snapshottedCtxs = utils.Map(s.snapshottedCtxs, func(ctx sdk.Context) sdk.Context { return types.SetCtxEVM(ctx, evm) })
@@ -109,6 +108,8 @@ func (s *DBImpl) Finalize() (surplus sdk.Int, err error) {
 	for i := len(s.snapshottedCtxs) - 1; i > 0; i-- {
 		s.flushCtx(s.snapshottedCtxs[i])
 	}
+	s.ctx = s.snapshottedCtxs[0]
+	s.snapshottedCtxs = []sdk.Context{}
 
 	surplus = s.tempStateCurrent.surplus
 	for _, ts := range s.tempStatesHist {

--- a/x/evm/state/statedb.go
+++ b/x/evm/state/statedb.go
@@ -7,6 +7,7 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/sei-protocol/sei-chain/utils"
+	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
 
 // Initialized for each transaction individually
@@ -73,7 +74,10 @@ func (s *DBImpl) SetLogger(logger *tracing.Hooks) {
 }
 
 // for interface compliance
-func (s *DBImpl) SetEVM(evm *vm.EVM) {}
+func (s *DBImpl) SetEVM(evm *vm.EVM) {
+	s.ctx = types.SetCtxEVM(s.ctx, evm)
+	s.snapshottedCtxs = utils.Map(s.snapshottedCtxs, func(ctx sdk.Context) sdk.Context { return types.SetCtxEVM(ctx, evm) })
+}
 
 // AddPreimage records a SHA3 preimage seen by the VM.
 // AddPreimage performs a no-op since the EnablePreimageRecording flag is disabled

--- a/x/evm/types/context.go
+++ b/x/evm/types/context.go
@@ -1,0 +1,28 @@
+package types
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+type CtxEVMKeyType string
+
+const CtxEVMKey = CtxEVMKeyType("evm")
+
+func SetCtxEVM(ctx sdk.Context, evm *vm.EVM) sdk.Context {
+	return ctx.WithContext(context.WithValue(ctx.Context(), CtxEVMKey, evm))
+}
+
+func GetCtxEVM(ctx sdk.Context) *vm.EVM {
+	rawVal := ctx.Context().Value(CtxEVMKey)
+	if rawVal == nil {
+		return nil
+	}
+	evm, ok := rawVal.(*vm.EVM)
+	if !ok {
+		return nil
+	}
+	return evm
+}

--- a/x/evm/types/context_test.go
+++ b/x/evm/types/context_test.go
@@ -1,0 +1,20 @@
+package types_test
+
+import (
+	"context"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/sei-protocol/sei-chain/x/evm/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCtxEvm(t *testing.T) {
+	ctx := sdk.Context{}.WithContext(context.Background())
+	require.Nil(t, types.GetCtxEVM(ctx))
+	ctx = types.SetCtxEVM(ctx, &vm.EVM{})
+	require.NotNil(t, types.GetCtxEVM(ctx))
+	ctx = ctx.WithContext(context.WithValue(ctx.Context(), types.CtxEVMKey, 123))
+	require.Nil(t, types.GetCtxEVM(ctx))
+}


### PR DESCRIPTION
## Describe your changes and provide context
Using new EVM instance for interop calls can cause discrepancies in behavior against ethereum. This PR changes the behavior to be reusing existing EVM instance, with an additional tweak which returns the latest `sdk.Context` from the evm instance to the wasmd message handler, so that there will never be a scenario where messages dispatched by a wasm call operate on different `sdk.Context`.

## Testing performed to validate your change
existing integration test should still work
