### PR TITLE
Create account for sendNative receiver

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -692,6 +692,7 @@ func New(
 			app.IBCKeeper.ClientKeeper,
 			app.IBCKeeper.ConnectionKeeper,
 			app.IBCKeeper.ChannelKeeper,
+			app.AccountKeeper,
 		); err != nil {
 			panic(err)
 		}

--- a/precompiles/bank/bank.go
+++ b/precompiles/bank/bank.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -54,9 +55,10 @@ func GetABI() abi.ABI {
 
 type Precompile struct {
 	pcommon.Precompile
-	bankKeeper pcommon.BankKeeper
-	evmKeeper  pcommon.EVMKeeper
-	address    common.Address
+	accountKeeper pcommon.AccountKeeper
+	bankKeeper    pcommon.BankKeeper
+	evmKeeper     pcommon.EVMKeeper
+	address       common.Address
 
 	SendID        []byte
 	SendNativeID  []byte
@@ -73,14 +75,15 @@ type CoinBalance struct {
 	Denom  string
 }
 
-func NewPrecompile(bankKeeper pcommon.BankKeeper, evmKeeper pcommon.EVMKeeper) (*Precompile, error) {
+func NewPrecompile(bankKeeper pcommon.BankKeeper, evmKeeper pcommon.EVMKeeper, accountKeeper pcommon.AccountKeeper) (*Precompile, error) {
 	newAbi := GetABI()
 
 	p := &Precompile{
-		Precompile: pcommon.Precompile{ABI: newAbi},
-		bankKeeper: bankKeeper,
-		evmKeeper:  evmKeeper,
-		address:    common.HexToAddress(BankAddress),
+		Precompile:    pcommon.Precompile{ABI: newAbi},
+		bankKeeper:    bankKeeper,
+		evmKeeper:     evmKeeper,
+		accountKeeper: accountKeeper,
+		address:       common.HexToAddress(BankAddress),
 	}
 
 	for name, m := range newAbi.Methods {
@@ -239,6 +242,11 @@ func (p Precompile) sendNative(ctx sdk.Context, method *abi.Method, args []inter
 
 	if err := p.bankKeeper.SendCoinsAndWei(ctx, senderSeiAddr, receiverSeiAddr, usei, wei); err != nil {
 		return nil, err
+	}
+	accExists := p.accountKeeper.HasAccount(ctx, receiverSeiAddr)
+	if !accExists {
+		defer telemetry.IncrCounter(1, "new", "account")
+		p.accountKeeper.SetAccount(ctx, p.accountKeeper.NewAccountWithAddress(ctx, receiverSeiAddr))
 	}
 
 	return method.Outputs.Pack(true)

--- a/precompiles/common/expected_keepers.go
+++ b/precompiles/common/expected_keepers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cosmos/ibc-go/v3/modules/core/exported"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -39,6 +40,12 @@ type EVMKeeper interface {
 	GetERC20CW20Pointer(ctx sdk.Context, cw20Address string) (addr common.Address, version uint16, exists bool)
 	SetERC721CW721Pointer(ctx sdk.Context, cw721Address string, addr common.Address) error
 	GetERC721CW721Pointer(ctx sdk.Context, cw721Address string) (addr common.Address, version uint16, exists bool)
+}
+
+type AccountKeeper interface {
+	HasAccount(ctx sdk.Context, addr sdk.AccAddress) bool
+	SetAccount(ctx sdk.Context, acc authtypes.AccountI)
+	NewAccountWithAddress(ctx sdk.Context, addr sdk.AccAddress) authtypes.AccountI
 }
 
 type OracleKeeper interface {

--- a/precompiles/setup.go
+++ b/precompiles/setup.go
@@ -52,13 +52,14 @@ func InitializePrecompiles(
 	clientKeeper common.ClientKeeper,
 	connectionKeeper common.ConnectionKeeper,
 	channelKeeper common.ChannelKeeper,
+	accountKeeper common.AccountKeeper,
 ) error {
 	SetupMtx.Lock()
 	defer SetupMtx.Unlock()
 	if Initialized {
 		panic("precompiles already initialized")
 	}
-	bankp, err := bank.NewPrecompile(bankKeeper, evmKeeper)
+	bankp, err := bank.NewPrecompile(bankKeeper, evmKeeper, accountKeeper)
 	if err != nil {
 		return err
 	}
@@ -133,7 +134,7 @@ func InitializePrecompiles(
 func GetPrecompileInfo(name string) PrecompileInfo {
 	if !Initialized {
 		// Precompile Info does not require any keeper state
-		_ = InitializePrecompiles(true, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		_ = InitializePrecompiles(true, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	}
 	i, ok := PrecompileNamesToInfo[name]
 	if !ok {


### PR DESCRIPTION
## Describe your changes and provide context
Usually in EVM we don't create accounts for receiver because we don't want to create accounts for cast addresses to reduce storage footprint and make execution more parallelized. `SendNative` is unique in that the receiver is not expected to be (though not impossible) cast addresses, so we should treat account creation the same as regular bank sends.

## Testing performed to validate your change
unit test

