### PR TITLE
Only send unlocked tokens upon address association

### DIFF
--- a/x/evm/ante/preprocess.go
+++ b/x/evm/ante/preprocess.go
@@ -107,7 +107,7 @@ func (p *EVMPreprocessDecorator) AssociateAddresses(ctx sdk.Context, seiAddr sdk
 		}
 		p.accountKeeper.SetAccount(ctx, acc)
 	}
-	return migrateBalance(ctx, p.evmKeeper, evmAddr, seiAddr)
+	return MigrateBalance(ctx, p.evmKeeper, evmAddr, seiAddr)
 }
 
 func (p *EVMPreprocessDecorator) IsAccountBalancePositive(ctx sdk.Context, seiAddr sdk.AccAddress, evmAddr common.Address) bool {
@@ -332,9 +332,9 @@ func NewEVMAddressDecorator(evmKeeper *evmkeeper.Keeper, accountKeeper *accountk
 	return &EVMAddressDecorator{evmKeeper: evmKeeper, accountKeeper: accountKeeper}
 }
 
-func migrateBalance(ctx sdk.Context, evmKeeper *evmkeeper.Keeper, evmAddr common.Address, seiAddr sdk.AccAddress) error {
+func MigrateBalance(ctx sdk.Context, evmKeeper *evmkeeper.Keeper, evmAddr common.Address, seiAddr sdk.AccAddress) error {
 	castAddr := sdk.AccAddress(evmAddr[:])
-	castAddrBalances := evmKeeper.BankKeeper().GetAllBalances(ctx, castAddr)
+	castAddrBalances := evmKeeper.BankKeeper().SpendableCoins(ctx, castAddr)
 	if !castAddrBalances.IsZero() {
 		if err := evmKeeper.BankKeeper().SendCoins(ctx, castAddr, seiAddr, castAddrBalances); err != nil {
 			return err
@@ -346,7 +346,9 @@ func migrateBalance(ctx sdk.Context, evmKeeper *evmkeeper.Keeper, evmAddr common
 			return err
 		}
 	}
-	evmKeeper.AccountKeeper().RemoveAccount(ctx, authtypes.NewBaseAccountWithAddress(castAddr))
+	if evmKeeper.BankKeeper().LockedCoins(ctx, castAddr).IsZero() {
+		evmKeeper.AccountKeeper().RemoveAccount(ctx, authtypes.NewBaseAccountWithAddress(castAddr))
+	}
 	return nil
 }
 
@@ -389,7 +391,7 @@ func (p *EVMAddressDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 			sdk.NewAttribute(evmtypes.AttributeKeyEvmAddress, evmAddr.Hex()),
 			sdk.NewAttribute(evmtypes.AttributeKeySeiAddress, signer.String())))
 		p.evmKeeper.SetAddressMapping(ctx, signer, evmAddr)
-		if err := migrateBalance(ctx, p.evmKeeper, evmAddr, signer); err != nil {
+		if err := MigrateBalance(ctx, p.evmKeeper, evmAddr, signer); err != nil {
 			ctx.Logger().Error(fmt.Sprintf("failed to migrate EVM address balance (%s) %s", evmAddr.Hex(), err))
 			return ctx, err
 		}


### PR DESCRIPTION
## Describe your changes and provide context
It is possible for a cast address to hold locked tokens since anyone (e.g. an attacker) can create vesting account for anyone before the account is first referenced on chain. So when consolidating balances we should only transfer the unlocked part. Any locked tokens under cast addresses will be frozen, since there is no real use case for creating vesting account for cast addresses.

## Testing performed to validate your change
unit tests
