### PR TITLE
Reduce Default TTL configs

### DIFF
--- a/app/params/config.go
+++ b/app/params/config.go
@@ -91,8 +91,8 @@ func SetTendermintConfigs(config *tmcfg.Config) {
 	config.Mempool.Size = 1000
 	config.Mempool.MaxTxsBytes = 10737418240
 	config.Mempool.MaxTxBytes = 2048576
-	config.Mempool.TTLDuration = 30 * time.Second
-	config.Mempool.TTLNumBlocks = 100
+	config.Mempool.TTLDuration = 15 * time.Second
+	config.Mempool.TTLNumBlocks = 30
 	// Consensus Configs
 	config.Consensus.GossipTransactionKeyOnly = true
 	config.Consensus.UnsafeProposeTimeoutOverride = 300 * time.Millisecond

--- a/docs/migration/seiv2_config_migration.md
+++ b/docs/migration/seiv2_config_migration.md
@@ -347,7 +347,7 @@ max-batch-bytes = 0
 # Note, if ttl-num-blocks is also defined, a transaction will be removed if it
 # has existed in the mempool at least ttl-num-blocks number of blocks or if it's
 # insertion time into the mempool is beyond ttl-duration.
-ttl-duration = "30s"
+ttl-duration = "15s"
 
 # ttl-num-blocks, if non-zero, defines the maximum number of blocks a transaction
 # can exist for in the mempool.
@@ -355,7 +355,7 @@ ttl-duration = "30s"
 # Note, if ttl-duration is also defined, a transaction will be removed if it
 # has existed in the mempool at least ttl-num-blocks number of blocks or if
 # it's insertion time into the mempool is beyond ttl-duration.
-ttl-num-blocks = 100
+ttl-num-blocks = 30
 
 tx-notify-threshold = 0
 


### PR DESCRIPTION
## Describe your changes and provide context
- Reduce defaults for ttl-duration to 15s and ttl-num-blocks to 30

## Testing performed to validate your change
- Verified on local chain
