### PR TITLE
Add sorting to a test store to fix flaky test

### DIFF
--- a/app/test_state_store.go
+++ b/app/test_state_store.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"errors"
+	"sort"
 	"sync"
 
 	seidbproto "github.com/sei-protocol/sei-db/proto"
@@ -257,6 +258,7 @@ func NewInMemoryIterator(data map[string][]byte, start, end []byte) *InMemoryIte
 			keys = append(keys, k)
 		}
 	}
+	sort.Strings(keys)
 
 	return &InMemoryIterator{
 		data:    data,


### PR DESCRIPTION
## Describe your changes and provide context
- this store is just used for mocking a state store
- keys need to be sorted to have a stable iterator 

## Testing performed to validate your change
- existing unit test now passes
