### PR TITLE
Return ErrExecutionReverted for precompile errors

### DIFF
--- a/precompiles/common/precompiles.go
+++ b/precompiles/common/precompiles.go
@@ -58,6 +58,10 @@ func (p Precompile) Run(evm *vm.EVM, caller common.Address, callingContract comm
 	operation := fmt.Sprintf("%s_unknown", p.name)
 	defer func() {
 		HandlePrecompileError(err, evm, operation)
+		if err != nil {
+			bz = []byte(err.Error())
+			err = vm.ErrExecutionReverted
+		}
 	}()
 	ctx, method, args, err := p.Prepare(evm, input)
 	if err != nil {
@@ -144,6 +148,10 @@ func (d DynamicGasPrecompile) RunAndCalculateGas(evm *vm.EVM, caller common.Addr
 	operation := fmt.Sprintf("%s_unknown", d.name)
 	defer func() {
 		HandlePrecompileError(err, evm, operation)
+		if err != nil {
+			ret = []byte(err.Error())
+			err = vm.ErrExecutionReverted
+		}
 	}()
 	ctx, method, args, err := d.Prepare(evm, input)
 	if err != nil {

--- a/precompiles/common/precompiles_test.go
+++ b/precompiles/common/precompiles_test.go
@@ -82,7 +82,7 @@ func TestPrecompileRun(t *testing.T) {
 	stateDB.WithCtx(ctx.WithEventManager(sdk.NewEventManager()))
 	precompile = common.NewPrecompile(newAbi, &MockPrecompileExecutor{throw: true}, ethcommon.Address{}, "test")
 	res, err = precompile.Run(&vm.EVM{StateDB: stateDB}, ethcommon.Address{}, ethcommon.Address{}, input, big.NewInt(0), false)
-	require.Nil(t, res)
+	require.NotNil(t, res)
 	require.NotNil(t, err)
 	// should not emit any event
 	require.Empty(t, stateDB.Ctx().EventManager().Events())
@@ -122,7 +122,7 @@ func TestDynamicGasPrecompileRun(t *testing.T) {
 	stateDB.WithCtx(ctx.WithEventManager(sdk.NewEventManager()))
 	precompile = common.NewDynamicGasPrecompile(newAbi, &MockDynamicGasPrecompileExecutor{throw: true, evmKeeper: k}, ethcommon.Address{}, "test")
 	res, _, err = precompile.RunAndCalculateGas(&vm.EVM{StateDB: stateDB}, ethcommon.Address{}, ethcommon.Address{}, input, 0, big.NewInt(0), nil, false)
-	require.Nil(t, res)
+	require.NotNil(t, res)
 	require.NotNil(t, err)
 	// should not emit any event
 	require.Empty(t, stateDB.Ctx().EventManager().Events())

--- a/precompiles/distribution/distribution_test.go
+++ b/precompiles/distribution/distribution_test.go
@@ -441,9 +441,9 @@ func TestPrecompile_RunAndCalculateGas_WithdrawDelegationRewards(t *testing.T) {
 				return
 			}
 			if err != nil {
-				require.Equal(t, tt.wantErrMsg, err.Error())
-			}
-			if !reflect.DeepEqual(gotRet, tt.wantRet) {
+				require.Equal(t, vm.ErrExecutionReverted, err)
+				require.Equal(t, tt.wantErrMsg, string(gotRet))
+			} else if !reflect.DeepEqual(gotRet, tt.wantRet) {
 				t.Errorf("RunAndCalculateGas() gotRet = %v, want %v", gotRet, tt.wantRet)
 			}
 			if gotRemainingGas != tt.wantRemainingGas {
@@ -550,9 +550,9 @@ func TestPrecompile_RunAndCalculateGas_WithdrawMultipleDelegationRewards(t *test
 				return
 			}
 			if err != nil {
-				require.Equal(t, tt.wantErrMsg, err.Error())
-			}
-			if !reflect.DeepEqual(gotRet, tt.wantRet) {
+				require.Equal(t, vm.ErrExecutionReverted, err)
+				require.Equal(t, tt.wantErrMsg, string(gotRet))
+			} else if !reflect.DeepEqual(gotRet, tt.wantRet) {
 				t.Errorf("RunAndCalculateGas() gotRet = %v, want %v", gotRet, tt.wantRet)
 			}
 			if gotRemainingGas != tt.wantRemainingGas {
@@ -674,9 +674,9 @@ func TestPrecompile_RunAndCalculateGas_SetWithdrawAddress(t *testing.T) {
 				return
 			}
 			if err != nil {
-				require.Equal(t, tt.wantErrMsg, err.Error())
-			}
-			if !reflect.DeepEqual(gotRet, tt.wantRet) {
+				require.Equal(t, vm.ErrExecutionReverted, err)
+				require.Equal(t, tt.wantErrMsg, string(gotRet))
+			} else if !reflect.DeepEqual(gotRet, tt.wantRet) {
 				t.Errorf("RunAndCalculateGas() gotRet = %v, want %v", gotRet, tt.wantRet)
 			}
 			if gotRemainingGas != tt.wantRemainingGas {

--- a/precompiles/ibc/ibc_test.go
+++ b/precompiles/ibc/ibc_test.go
@@ -284,12 +284,12 @@ func TestPrecompile_Run(t *testing.T) {
 				return
 			}
 			if err != nil {
-				require.Equal(t, tt.wantErrMsg, err.Error())
+				require.Equal(t, vm.ErrExecutionReverted, err)
+				require.Equal(t, tt.wantErrMsg, string(gotBz))
+			} else if !reflect.DeepEqual(gotBz, tt.wantBz) {
+				t.Errorf("Run() gotRet = %v, want %v", gotBz, tt.wantBz)
 			}
 
-			if !reflect.DeepEqual(gotBz, tt.wantBz) {
-				t.Errorf("Run() gotBz = %v, want %v", gotBz, tt.wantBz)
-			}
 			if !reflect.DeepEqual(gotRemainingGas, tt.wantRemainingGas) {
 				t.Errorf("Run() gotRemainingGas = %v, want %v", gotRemainingGas, tt.wantRemainingGas)
 			}
@@ -471,11 +471,10 @@ func TestTransferWithDefaultTimeoutPrecompile_Run(t *testing.T) {
 				return
 			}
 			if err != nil {
-				require.Equal(t, tt.wantErrMsg, err.Error())
-			}
-
-			if !reflect.DeepEqual(gotBz, tt.wantBz) {
-				t.Errorf("Run() gotBz = %v, want %v", gotBz, tt.wantBz)
+				require.Equal(t, vm.ErrExecutionReverted, err)
+				require.Equal(t, tt.wantErrMsg, string(gotBz))
+			} else if !reflect.DeepEqual(gotBz, tt.wantBz) {
+				t.Errorf("Run() gotRet = %v, want %v", gotBz, tt.wantBz)
 			}
 			if !reflect.DeepEqual(gotRemainingGas, tt.wantRemainingGas) {
 				t.Errorf("Run() gotRemainingGas = %v, want %v", gotRemainingGas, tt.wantRemainingGas)

--- a/precompiles/wasmd/wasmd_test.go
+++ b/precompiles/wasmd/wasmd_test.go
@@ -154,8 +154,9 @@ func TestExecute(t *testing.T) {
 	testApp.BankKeeper.SendCoins(ctx, mockAddr, testApp.EvmKeeper.GetSeiAddressOrDefault(ctx, common.HexToAddress(wasmd.WasmdAddress)), amts)
 	// circular interop
 	statedb.WithCtx(statedb.Ctx().WithIsEVM(false))
-	_, _, err = p.RunAndCalculateGas(&evm, mockEVMAddr, mockEVMAddr, append(p.GetExecutor().(*wasmd.PrecompileExecutor).ExecuteID, args...), suppliedGas, big.NewInt(1000_000_000_000_000), nil, false)
-	require.Equal(t, "sei does not support CW->EVM->CW call pattern", err.Error())
+	res, _, err := p.RunAndCalculateGas(&evm, mockEVMAddr, mockEVMAddr, append(p.GetExecutor().(*wasmd.PrecompileExecutor).ExecuteID, args...), suppliedGas, big.NewInt(1000_000_000_000_000), nil, false)
+	require.Equal(t, "sei does not support CW->EVM->CW call pattern", string(res))
+	require.Equal(t, vm.ErrExecutionReverted, err)
 	statedb.WithCtx(statedb.Ctx().WithIsEVM(true))
 	res, g, err := p.RunAndCalculateGas(&evm, mockEVMAddr, mockEVMAddr, append(p.GetExecutor().(*wasmd.PrecompileExecutor).ExecuteID, args...), suppliedGas, big.NewInt(1000_000_000_000_000), nil, false)
 	require.Nil(t, err)


### PR DESCRIPTION
## Describe your changes and provide context
Follow geth's convention by setting revert reason in `ret` and replace any error with `ErrExecutionReverted`

## Testing performed to validate your change

