### PR TITLE
gracefully handle panics in TX decoding

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1599,6 +1599,12 @@ func (app *App) DecodeTransactionsConcurrently(ctx sdk.Context, txs [][]byte) []
 		wg.Add(1)
 		go func(idx int, encodedTx []byte) {
 			defer wg.Done()
+			defer func() {
+				if err := recover(); err != nil {
+					ctx.Logger().Error(fmt.Sprintf("encountered panic during transaction decoding: %s", err))
+					typedTxs[idx] = nil
+				}
+			}()
 			typedTx, err := app.txDecoder(encodedTx)
 			// get txkey from tx
 			if err != nil {
@@ -1897,6 +1903,11 @@ func (app *App) BlacklistedAccAddrs() map[string]bool {
 	}
 
 	return blacklistedAddrs
+}
+
+// test-only
+func (app *App) SetTxDecoder(txDecoder sdk.TxDecoder) {
+	app.txDecoder = txDecoder
 }
 
 func init() {


### PR DESCRIPTION
## Describe your changes and provide context
Right now panics from transaction decoding are not caught. In case of a bad validator (which is the only way for decoding to panic), we want such panics to be handled gracefully (i.e. as if it encountered a non-panicking decoding error).

## Testing performed to validate your change
unit tests

