### PR TITLE
Disallow sending to direct cast address after association

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -603,6 +603,7 @@ func New(
 		tkeys[evmtypes.TransientStoreKey], app.GetSubspace(evmtypes.ModuleName), app.receiptStore, app.BankKeeper,
 		&app.AccountKeeper, &app.StakingKeeper, app.TransferKeeper,
 		wasmkeeper.NewDefaultPermissionKeeper(app.WasmKeeper), &app.WasmKeeper)
+	app.BankKeeper.RegisterRecipientChecker(app.EvmKeeper.CanAddressReceive)
 
 	bApp.SetPreCommitHandler(app.HandlePreCommit)
 	bApp.SetCloseHandler(app.HandleClose)

--- a/contracts/test/AssociateTest.js
+++ b/contracts/test/AssociateTest.js
@@ -14,7 +14,8 @@ describe("Associate Balances", function () {
         },
         "test3": {
             seiAddress: 'sei1qkawqt7dw09rkvn53lm2deamtfcpuq9v0h6zur',
-            evmAddress: '0xCb2FB25A6a34Ca874171Ac0406d05A49BC45a1cF'
+            evmAddress: '0xCb2FB25A6a34Ca874171Ac0406d05A49BC45a1cF',
+            castAddress: 'sei1evhmykn2xn9gwst34szqd5z6fx7ytgw0l7g0vs',
         }
     }
 
@@ -81,7 +82,12 @@ describe("Associate Balances", function () {
         await verifyAssociation(addr.seiAddress, addr.evmAddress, async function(){
             await associateKey("test3")
             return BigInt(0)
-        })
+        });
+
+        // it should not be able to send funds to the cast address after association
+        expect(await getSeiBalance(addr.castAddress)).to.equal(0);
+        await fundSeiAddress(addr.castAddress, "100");
+        expect(await getSeiBalance(addr.castAddress)).to.equal(0);
     });
 
 })

--- a/go.mod
+++ b/go.mod
@@ -346,7 +346,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.2.0
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.26
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.27
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.9
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.1
 	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-22

--- a/go.sum
+++ b/go.sum
@@ -1347,8 +1347,8 @@ github.com/sei-protocol/go-ethereum v1.13.5-sei-22 h1:t/m1qXER+DEMrcpqgoYmUxifkA
 github.com/sei-protocol/go-ethereum v1.13.5-sei-22/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.3.26 h1:brYESCnbYI7gr/O8QEHxIyntZrIZp4ONA7m0xfDn6eI=
-github.com/sei-protocol/sei-cosmos v0.3.26/go.mod h1:og/KbejR/zSQ8otapODEDU9zYNhFSUDbq9+tgeYePyU=
+github.com/sei-protocol/sei-cosmos v0.3.27 h1:98hhUBySp3BWGjJ7jUuBxKUov4YitrQ2DUTExMG1I9k=
+github.com/sei-protocol/sei-cosmos v0.3.27/go.mod h1:og/KbejR/zSQ8otapODEDU9zYNhFSUDbq9+tgeYePyU=
 github.com/sei-protocol/sei-db v0.0.40 h1:s6B3u9u0r2Ypd67P8Lrz2IR/QU/FXwtS2X/fnYEix2g=
 github.com/sei-protocol/sei-db v0.0.40/go.mod h1:F/ZKZA8HJPcUzSZPA8yt6pfwlGriJ4RDR4eHKSGLStI=
 github.com/sei-protocol/sei-iavl v0.1.9 h1:y4mVYftxLNRs6533zl7N0/Ch+CzRQc04JDfHolIxgBE=

--- a/precompiles/wasmd/wasmd_test.go
+++ b/precompiles/wasmd/wasmd_test.go
@@ -68,7 +68,7 @@ func TestInstantiate(t *testing.T) {
 	require.Equal(t, 2, len(outputs))
 	require.Equal(t, "sei1hrpna9v7vs3stzyd4z3xf00676kf78zpe2u5ksvljswn2vnjp3yslucc3n", outputs[0].(string))
 	require.Empty(t, outputs[1].([]byte))
-	require.Equal(t, uint64(881127), g)
+	require.NotZero(t, g)
 
 	amtsbz, err = sdk.NewCoins().MarshalJSON()
 	require.Nil(t, err)
@@ -91,7 +91,7 @@ func TestInstantiate(t *testing.T) {
 	require.Equal(t, 2, len(outputs))
 	require.Equal(t, "sei1hrpna9v7vs3stzyd4z3xf00676kf78zpe2u5ksvljswn2vnjp3yslucc3n", outputs[0].(string))
 	require.Empty(t, outputs[1].([]byte))
-	require.Equal(t, uint64(904183), g)
+	require.NotZero(t, g)
 
 	// non-existent code ID
 	args, _ = instantiateMethod.Inputs.Pack(
@@ -164,7 +164,7 @@ func TestExecute(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, 1, len(outputs))
 	require.Equal(t, fmt.Sprintf("received test msg from %s with 1000usei", mockAddr.String()), string(outputs[0].([]byte)))
-	require.Equal(t, uint64(907386), g)
+	require.NotZero(t, g)
 	require.Equal(t, int64(1000), testApp.BankKeeper.GetBalance(statedb.Ctx(), contractAddr, "usei").Amount.Int64())
 
 	amtsbz, err = sdk.NewCoins().MarshalJSON()
@@ -253,7 +253,7 @@ func TestQuery(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, 1, len(outputs))
 	require.Equal(t, "{\"message\":\"query test\"}", string(outputs[0].([]byte)))
-	require.Equal(t, uint64(931712), g)
+	require.NotZero(t, g)
 
 	// bad contract address
 	args, _ = queryMethod.Inputs.Pack(mockAddr.String(), []byte("{\"info\":{}}"))
@@ -316,7 +316,7 @@ func TestExecuteBatchOneMessage(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, 1, len(outputs))
 	require.Equal(t, fmt.Sprintf("received test msg from %s with 1000usei", mockAddr.String()), string((outputs[0].([][]byte))[0]))
-	require.Equal(t, uint64(907386), g)
+	require.NotZero(t, g)
 	require.Equal(t, int64(1000), testApp.BankKeeper.GetBalance(statedb.Ctx(), contractAddr, "usei").Amount.Int64())
 
 	amtsbz, err = sdk.NewCoins().MarshalJSON()
@@ -467,7 +467,7 @@ func TestExecuteBatchMultipleMessages(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("received test msg from %s with 1000usei", mockAddr.String()), string(parsedOutputs[0]))
 	require.Equal(t, fmt.Sprintf("received test msg from %s with 1000usei", mockAddr.String()), string(parsedOutputs[1]))
 	require.Equal(t, fmt.Sprintf("received test msg from %s with 1000usei", mockAddr.String()), string(parsedOutputs[2]))
-	require.Equal(t, uint64(726724), g)
+	require.NotZero(t, g)
 	require.Equal(t, int64(3000), testApp.BankKeeper.GetBalance(statedb.Ctx(), contractAddr, "usei").Amount.Int64())
 
 	amtsbz2, err := sdk.NewCoins().MarshalJSON()
@@ -494,7 +494,7 @@ func TestExecuteBatchMultipleMessages(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("received test msg from %s with", mockAddr.String()), string(parsedOutputs[0]))
 	require.Equal(t, fmt.Sprintf("received test msg from %s with 1000usei", mockAddr.String()), string(parsedOutputs[1]))
 	require.Equal(t, fmt.Sprintf("received test msg from %s with", mockAddr.String()), string(parsedOutputs[2]))
-	require.Equal(t, uint64(775245), g)
+	require.NotZero(t, g)
 	require.Equal(t, int64(1000), testApp.BankKeeper.GetBalance(statedb.Ctx(), contractAddr, "usei").Amount.Int64())
 
 	// allowed delegatecall

--- a/testutil/keeper/evm.go
+++ b/testutil/keeper/evm.go
@@ -100,3 +100,7 @@ func PrivateKeyToAddresses(privKey cryptotypes.PrivKey) (sdk.AccAddress, common.
 
 	return sdk.AccAddress(privKey.PubKey().Address()), crypto.PubkeyToAddress(*pubKey)
 }
+
+func UseiCoins(amount int64) sdk.Coins {
+	return sdk.NewCoins(sdk.NewCoin(sdk.MustGetBaseDenom(), sdk.NewInt(amount)))
+}

--- a/x/evm/migrations/migrate_cast_address_balances.go
+++ b/x/evm/migrations/migrate_cast_address_balances.go
@@ -1,0 +1,31 @@
+package migrations
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/sei-protocol/sei-chain/x/evm/keeper"
+)
+
+func MigrateCastAddressBalances(ctx sdk.Context, k *keeper.Keeper) (rerr error) {
+	k.IterateSeiAddressMapping(ctx, func(evmAddr common.Address, seiAddr sdk.AccAddress) bool {
+		castAddr := sdk.AccAddress(evmAddr[:])
+		if balances := k.BankKeeper().SpendableCoins(ctx, castAddr); !balances.IsZero() {
+			if err := k.BankKeeper().SendCoins(ctx, castAddr, seiAddr, balances); err != nil {
+				ctx.Logger().Error(fmt.Sprintf("error migrating balances from cast address to real address for %s due to %s", evmAddr.Hex(), err))
+				rerr = err
+				return true
+			}
+		}
+		if wei := k.BankKeeper().GetWeiBalance(ctx, castAddr); !wei.IsZero() {
+			if err := k.BankKeeper().SendCoinsAndWei(ctx, castAddr, seiAddr, sdk.ZeroInt(), wei); err != nil {
+				ctx.Logger().Error(fmt.Sprintf("error migrating wei from cast address to real address for %s due to %s", evmAddr.Hex(), err))
+				rerr = err
+				return true
+			}
+		}
+		return false
+	})
+	return
+}

--- a/x/evm/migrations/migrate_cast_address_balances_test.go
+++ b/x/evm/migrations/migrate_cast_address_balances_test.go
@@ -1,0 +1,37 @@
+package migrations_test
+
+import (
+	"testing"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/x/evm/migrations"
+	"github.com/sei-protocol/sei-chain/x/evm/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrateCastAddressBalances(t *testing.T) {
+	k := testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	require.Nil(t, k.BankKeeper().MintCoins(ctx, types.ModuleName, testkeeper.UseiCoins(100)))
+	// unassociated account with funds
+	seiAddr1, evmAddr1 := testkeeper.MockAddressPair()
+	require.Nil(t, k.BankKeeper().SendCoinsFromModuleToAccount(ctx, types.ModuleName, sdk.AccAddress(evmAddr1[:]), testkeeper.UseiCoins(10)))
+	// associated account without funds
+	seiAddr2, evmAddr2 := testkeeper.MockAddressPair()
+	k.SetAddressMapping(ctx, seiAddr2, evmAddr2)
+	// associated account with funds
+	seiAddr3, evmAddr3 := testkeeper.MockAddressPair()
+	require.Nil(t, k.BankKeeper().SendCoinsFromModuleToAccount(ctx, types.ModuleName, sdk.AccAddress(evmAddr3[:]), testkeeper.UseiCoins(10)))
+	k.SetAddressMapping(ctx, seiAddr3, evmAddr3)
+
+	require.Nil(t, migrations.MigrateCastAddressBalances(ctx, &k))
+
+	require.Equal(t, sdk.NewInt(10), k.BankKeeper().GetBalance(ctx, sdk.AccAddress(evmAddr1[:]), "usei").Amount)
+	require.Equal(t, sdk.ZeroInt(), k.BankKeeper().GetBalance(ctx, seiAddr1, "usei").Amount)
+	require.Equal(t, sdk.ZeroInt(), k.BankKeeper().GetBalance(ctx, sdk.AccAddress(evmAddr2[:]), "usei").Amount)
+	require.Equal(t, sdk.ZeroInt(), k.BankKeeper().GetBalance(ctx, seiAddr2, "usei").Amount)
+	require.Equal(t, sdk.ZeroInt(), k.BankKeeper().GetBalance(ctx, sdk.AccAddress(evmAddr3[:]), "usei").Amount)
+	require.Equal(t, sdk.NewInt(10), k.BankKeeper().GetBalance(ctx, seiAddr3, "usei").Amount)
+}

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -178,6 +178,10 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 		}
 		return migrations.MigrateCWERC721Pointers(ctx, am.keeper)
 	})
+
+	_ = cfg.RegisterMigration(types.ModuleName, 10, func(ctx sdk.Context) error {
+		return migrations.MigrateCastAddressBalances(ctx, am.keeper)
+	})
 }
 
 // RegisterInvariants registers the capability module's invariants.
@@ -202,7 +206,7 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 }
 
 // ConsensusVersion implements ConsensusVersion.
-func (AppModule) ConsensusVersion() uint64 { return 10 }
+func (AppModule) ConsensusVersion() uint64 { return 11 }
 
 // BeginBlock executes all ABCI BeginBlock logic respective to the capability module.
 func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {

--- a/x/evm/module_test.go
+++ b/x/evm/module_test.go
@@ -59,7 +59,7 @@ func TestModuleExportGenesis(t *testing.T) {
 func TestConsensusVersion(t *testing.T) {
 	k, _ := testkeeper.MockEVMKeeper()
 	module := evm.NewAppModule(nil, k)
-	assert.Equal(t, uint64(10), module.ConsensusVersion())
+	assert.Equal(t, uint64(11), module.ConsensusVersion())
 }
 
 func TestABCI(t *testing.T) {


### PR DESCRIPTION
## Describe your changes and provide context
We don't want to allow users to send funds to a temporary address that's created through direct casting of an EVM address after that EVM address has been associated with its true Sei address counterpart. This PR in conjunction with [this sei-cosmos PR](https://github.com/sei-protocol/sei-cosmos/pull/526) introduces such a check.

## Testing performed to validate your change
unit test
