### PR TITLE
[EVM] Meaningful error message for eth_call balance override overflow

### DIFF
--- a/evmrpc/setup_test.go
+++ b/evmrpc/setup_test.go
@@ -871,6 +871,12 @@ func formatParam(p interface{}) string {
 			kvs = append(kvs, fmt.Sprintf("\"%s\":%s", k, formatParam(v)))
 		}
 		return fmt.Sprintf("{%s}", strings.Join(kvs, ","))
+	case map[string]map[string]interface{}:
+		kvs := []string{}
+		for k, v := range v {
+			kvs = append(kvs, fmt.Sprintf("\"%s\":%s", k, formatParam(v)))
+		}
+		return fmt.Sprintf("{%s}", strings.Join(kvs, ","))
 	default:
 		panic("did not match on type")
 	}

--- a/evmrpc/simulate_test.go
+++ b/evmrpc/simulate_test.go
@@ -132,6 +132,31 @@ func TestCall(t *testing.T) {
 	Ctx = Ctx.WithBlockHeight(8)
 }
 
+func TestEthCallHighAmount(t *testing.T) {
+	Ctx = Ctx.WithBlockHeight(1)
+	_, from := testkeeper.MockAddressPair()
+	_, to := testkeeper.MockAddressPair()
+	txArgs := map[string]interface{}{
+		"from":    from.Hex(),
+		"to":      to.Hex(),
+		"value":   "0x0",
+		"nonce":   "0x2",
+		"chainId": fmt.Sprintf("%#x", EVMKeeper.ChainID(Ctx)),
+	}
+
+	overrides := map[string]map[string]interface{}{
+		from.Hex(): {"balance": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"},
+	}
+	resObj := sendRequestGood(t, "call", txArgs, "latest", overrides)
+	fmt.Println("resObj = ", resObj)
+	errMap := resObj["error"].(map[string]interface{})
+	result := errMap["message"]
+	fmt.Println("res = ", result)
+	require.Equal(t, result, "error: balance override overflow")
+
+	Ctx = Ctx.WithBlockHeight(8)
+}
+
 func TestNewRevertError(t *testing.T) {
 	err := evmrpc.NewRevertError(&core.ExecutionResult{})
 	require.NotNil(t, err)


### PR DESCRIPTION
## Describe your changes and provide context

If a user calls `eth_call` with a very high balance override, it isn't possible for us to actually set that address to uint256 max due to how our usei, wei logic works as well as a constraint we have that any intermediate balance must have at most 256 bits.

Specifically, when we set balances in the statedb, we need to set so that the usei balance * 10^12 + 10^12 is less than uint256 max. However, there is no integer such that usei balance * 10^12 + 10^12 == uint256 max, so if the user wanted to actually do a balance override to uint256 max, we are not able to do so.

Therefore, the best can do is produce a meaningful error message when the balance overflows.

## Testing performed to validate your change
unit test

