### PR TITLE
Fix log index on synthetic receipt

### DIFF
--- a/app/receipt.go
+++ b/app/receipt.go
@@ -74,6 +74,9 @@ func (app *App) AddCosmosEventsToEVMReceiptIfApplicable(ctx sdk.Context, tx sdk.
 	var bloom ethtypes.Bloom
 	if r, err := app.EvmKeeper.GetTransientReceipt(ctx, txHash); err == nil && r != nil {
 		r.Logs = append(r.Logs, utils.Map(logs, evmkeeper.ConvertSyntheticEthLog)...)
+		for i, l := range r.Logs {
+			l.Index = uint32(i)
+		}
 		bloom = ethtypes.CreateBloom(ethtypes.Receipts{&ethtypes.Receipt{Logs: evmkeeper.GetLogsForTx(r)}})
 		r.LogsBloom = bloom[:]
 		_ = app.EvmKeeper.SetTransientReceipt(ctx, txHash, r)

--- a/app/receipt_test.go
+++ b/app/receipt_test.go
@@ -257,6 +257,7 @@ func TestEvmEventsForCw721(t *testing.T) {
 	require.Equal(t, 1, len(receipt.Logs))
 	require.NotEmpty(t, receipt.LogsBloom)
 	require.Equal(t, mockPointerAddr.Hex(), receipt.Logs[0].Address)
+	require.Equal(t, uint32(0), receipt.Logs[0].Index)
 	_, found = testkeeper.EVMTestApp.EvmKeeper.GetEVMTxDeferredInfo(ctx)
 	require.True(t, found)
 	require.Equal(t, common.HexToHash("0x2").Bytes(), receipt.Logs[0].Data)


### PR DESCRIPTION
## Describe your changes and provide context
Previously if we append synthetic logs to an existing receipt, the synthetic logs would start from index 0, but we want it to continue from where the real logs end.

## Testing performed to validate your change
unit test
