### PR TITLE
Added actual error when unable to `seid tx evm deploy` correctly

### DIFF
--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -231,11 +231,11 @@ func CmdDeployContract() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			code, err := os.ReadFile(args[0])
 			if err != nil {
-				panic("failed to read contract binary")
+				panic(fmt.Errorf("failed to read contract binary: %w", err))
 			}
 			bz, err := hex.DecodeString(string(code))
 			if err != nil {
-				panic("failed to decode contract binary")
+				panic(fmt.Errorf("failed to decode contract binary: %w", err))
 			}
 
 			key, err := getPrivateKey(cmd)


### PR DESCRIPTION
## Describe your changes and provide context

I had a spurious `\n` in my `.bin` EMV bytecode file and this was leading to decoding error but without printing the actual cause. 

This PR adds the cause to the panic when a problem happen reading the file or decoding it.

## Testing performed to validate your change

Manual validation
