### PR TITLE
Priority big int conversion should not causing underflow

### DIFF
--- a/x/evm/ante/fee.go
+++ b/x/evm/ante/fee.go
@@ -124,6 +124,8 @@ func (fc EVMFeeCheckDecorator) CalculatePriority(ctx sdk.Context, txData ethtx.T
 	priority := sdk.NewDecFromBigInt(gp).Quo(fc.evmKeeper.GetPriorityNormalizer(ctx)).TruncateInt().BigInt()
 	if priority.Cmp(big.NewInt(antedecorators.MaxPriority)) > 0 {
 		priority = big.NewInt(antedecorators.MaxPriority)
+	} else if priority.Sign() < 0 {
+		priority = big.NewInt(0)
 	}
 	return priority
 }

--- a/x/evm/ante/fee.go
+++ b/x/evm/ante/fee.go
@@ -94,7 +94,11 @@ func (fc EVMFeeCheckDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 
 	// calculate the priority by dividing the total fee with the native gas limit (i.e. the effective native gas price)
 	priority := fc.CalculatePriority(ctx, txData)
-	ctx = ctx.WithPriority(priority.Int64())
+
+	// only set priority if it is valid
+	if priority.IsInt64() {
+		ctx = ctx.WithPriority(priority.Int64())
+	}
 
 	return next(ctx, tx, simulate)
 }

--- a/x/evm/ante/fee.go
+++ b/x/evm/ante/fee.go
@@ -98,6 +98,8 @@ func (fc EVMFeeCheckDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 	// only set priority if it is valid
 	if priority.IsInt64() {
 		ctx = ctx.WithPriority(priority.Int64())
+	} else {
+		ctx = ctx.WithPriority(0)
 	}
 
 	return next(ctx, tx, simulate)


### PR DESCRIPTION
## Describe your changes and provide context
This PR fixes the immunify bug report: https://bugs.immunefi.com/dashboard/submission/32602?resolvedFilter=unresolved

The actual problem is:
[this section of code](https://github.com/sei-protocol/sei-chain/blob/v5.6.1/x/evm/ante/fee.go#L96-L97):

```
	// calculate the priority by dividing the total fee with the native gas limit (i.e. the effective native gas price)
	priority := fc.CalculatePriority(ctx, txData)
	ctx = ctx.WithPriority(priority.Int64())
```
priority is a big.Int that's converted to an int64 without first checking if such a conversion is possible with IsInt64(). If priority is negative, converting to int64 causes the final value to underflow and wrap around to a very large integer (for example MaxInt64 – max priority).

The code that sets priority for non-EVM transactions correctly calls IsInt64() (https://github.com/sei-protocol/sei-cosmos/blob/10546b70331d5f13e52b38acbf366a527566c3f1/x/auth/ante/validator_tx_fee.go#L77-L79), but the EVM version is missing this check.
## Testing performed to validate your change

