### PR TITLE
Added possibility in `seid tx evm deploy` to pass constructor's payload

### DIFF
--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -224,10 +224,10 @@ type Response struct {
 
 func CmdDeployContract() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "deploy [path to binary] --from=<sender> --gas-fee-cap=<cap> --gas-limt=<limit> --evm-rpc=<url>",
+		Use:   "deploy [path to binary] ([constructor payload hex]) --from=<sender> --gas-fee-cap=<cap> --gas-limt=<limit> --evm-rpc=<url>",
 		Short: "Deploy an EVM contract for binary at specified path",
 		Long:  "",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			code, err := os.ReadFile(args[0])
 			if err != nil {
@@ -264,6 +264,15 @@ func CmdDeployContract() *cobra.Command {
 			txData.Nonce = nonce
 			txData.Value = utils.Big0
 			txData.Data = bz
+
+			if len(args) == 2 {
+				payload, err := hex.DecodeString(args[1])
+				if err != nil {
+					return err
+				}
+
+				txData.Data = append(txData.Data, payload...)
+			}
 
 			resp, err := sendTx(txData, rpc, key)
 			if err != nil {


### PR DESCRIPTION
## Describe your changes and provide context
Usage: ` seid tx evm deploy ./artifacts/src/ERC20PreTransferWrapper.sol/ERC20PreTransferWrapper.bin "0000000000000000000000007d4b7b8ca7e1a24928bb96d59249c7a5bd1dfbe6" --from=admin`

## Testing performed to validate your change

Manual deployment of constructor with argument(s).
