### PR TITLE
Do not charge gas for feecollector address query

### DIFF
--- a/x/evm/keeper/coinbase.go
+++ b/x/evm/keeper/coinbase.go
@@ -20,7 +20,8 @@ func (k *Keeper) GetFeeCollectorAddress(ctx sdk.Context) (common.Address, error)
 		return *cache, nil
 	}
 	moduleAddr := k.accountKeeper.GetModuleAddress(authtypes.FeeCollectorName)
-	evmAddr, ok := k.GetEVMAddress(ctx, moduleAddr)
+	// we don't want to charge gas for this query, since it could cause non-determinism
+	evmAddr, ok := k.GetEVMAddress(ctx.WithGasMeter(sdk.NewInfiniteGasMeterWithMultiplier(ctx)), moduleAddr)
 	if !ok {
 		return common.Address{}, errors.New("fee collector's EVM address not found")
 	}


### PR DESCRIPTION
## Describe your changes and provide context
Charging gas for a potentially cached operation could cause non-determinism

## Testing performed to validate your change
applied on archive node to get it out of apphash error
