### PR TITLE
fix the dex module deletion logic

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -416,6 +416,7 @@ func New(
 		evmtypes.StoreKey, wasm.StoreKey,
 		epochmoduletypes.StoreKey,
 		tokenfactorytypes.StoreKey,
+		"dex", // TODO: remove after module deletion
 		// this line is used by starport scaffolding # stargate/app/storeKey
 	)
 	tkeys := sdk.NewTransientStoreKeys(paramstypes.TStoreKey, evmtypes.TransientStoreKey)
@@ -1040,7 +1041,7 @@ func (app *App) SetStoreUpgradeHandlers() {
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}
 	// TODO: change this upgrade name if the planned upgrade version number ends up changing more
-	if ((app.ChainID == "arctic-1" && upgradeInfo.Name == "v5.7.1") || (app.ChainID != "arctic-1" && upgradeInfo.Name == "v5.7.2")) && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+	if (upgradeInfo.Name == "v5.7.3") && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		dexStoreKeyName := "dex"
 		storeUpgrades := storetypes.StoreUpgrades{
 			Deleted: []string{dexStoreKeyName},

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -107,6 +107,7 @@ var upgradesList = []string{
 	"v5.7.0",
 	"v5.7.1",
 	"v5.7.2",
+	"v5.7.3",
 }
 
 // if there is an override list, use that instead, for integration tests


### PR DESCRIPTION
## Describe your changes and provide context
The unregistration of the dex store key in KV mounting resulted it in not being mounted for deletion at the upgrade, so this fixes that by mounting the KV store key.

## Testing performed to validate your change
Tested on local chain, will do testing with loadtest clusters

