### PR TITLE
Fix docker setup for local cluster

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -149,12 +149,6 @@ jobs:
         with:
           go-version: 1.21
 
-      - name: Install Docker Compose
-        run: |
-          sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-          sudo chmod +x /usr/local/bin/docker-compose
-          docker-compose --version
-
       - name: Start 4 node docker cluster
         run: make clean && INVARIANT_CHECK_INTERVAL=10 ${{matrix.test.env}} make docker-cluster-start &
 

--- a/Makefile
+++ b/Makefile
@@ -183,19 +183,19 @@ kill-rpc-node:
 # Run a 4-node docker containers
 docker-cluster-start: docker-cluster-stop build-docker-node
 	@rm -rf $(PROJECT_HOME)/build/generated
-	@cd docker && NUM_ACCOUNTS=10 INVARIANT_CHECK_INTERVAL=${INVARIANT_CHECK_INTERVAL} UPGRADE_VERSION_LIST=${UPGRADE_VERSION_LIST} docker-compose up
+	@cd docker && USERID=$(shell id -u) GROUPID=$(shell id -g) GOCACHE=$(shell go env GOCACHE) NUM_ACCOUNTS=10 INVARIANT_CHECK_INTERVAL=${INVARIANT_CHECK_INTERVAL} UPGRADE_VERSION_LIST=${UPGRADE_VERSION_LIST} docker-compose up
 
 .PHONY: localnet-start
 
 # Use this to skip the seid build process
 docker-cluster-start-skipbuild: docker-cluster-stop build-docker-node
 	@rm -rf $(PROJECT_HOME)/build/generated
-	@cd docker && NUM_ACCOUNTS=10 SKIP_BUILD=true docker-compose up
+	@cd docker && USERID=$(shell id -u) GROUPID=$(shell id -g) GOCACHE=$(shell go env GOCACHE) NUM_ACCOUNTS=10 SKIP_BUILD=true docker-compose up
 .PHONY: localnet-start
 
 # Stop 4-node docker containers
 docker-cluster-stop:
-	@cd docker && docker-compose down
+	@cd docker && USERID=$(shell id -u) GROUPID=$(shell id -g) GOCACHE=$(shell go env GOCACHE) docker-compose down
 .PHONY: localnet-stop
 
 

--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,8 @@ kill-rpc-node:
 # Run a 4-node docker containers
 docker-cluster-start: docker-cluster-stop build-docker-node
 	@rm -rf $(PROJECT_HOME)/build/generated
+	@mkdir -p $(shell go env GOPATH)/pkg/mod
+	@mkdir -p $(shell go env GOCACHE)
 	@cd docker && USERID=$(shell id -u) GROUPID=$(shell id -g) GOCACHE=$(shell go env GOCACHE) NUM_ACCOUNTS=10 INVARIANT_CHECK_INTERVAL=${INVARIANT_CHECK_INTERVAL} UPGRADE_VERSION_LIST=${UPGRADE_VERSION_LIST} docker-compose up
 
 .PHONY: localnet-start

--- a/Makefile
+++ b/Makefile
@@ -138,8 +138,10 @@ run-local-node: kill-sei-node build-docker-node
 	docker run --rm \
 	--name sei-node \
 	--network host \
+	--user="$(shell id -u):$(shell id -g)" \
 	-v $(PROJECT_HOME):/sei-protocol/sei-chain:Z \
 	-v $(GO_PKG_PATH)/mod:/root/go/pkg/mod:Z \
+	-v $(shell go env GOCACHE):/root/.cache/go-build:Z \
 	--platform linux/x86_64 \
 	sei-chain/localnode
 .PHONY: run-local-node
@@ -149,11 +151,13 @@ run-rpc-node: build-rpc-node
 	docker run --rm \
 	--name sei-rpc-node \
 	--network docker_localnet \
+	--user="$(shell id -u):$(shell id -g)" \
 	-v $(PROJECT_HOME):/sei-protocol/sei-chain:Z \
 	-v $(PROJECT_HOME)/../sei-tendermint:/sei-protocol/sei-tendermint:Z \
     -v $(PROJECT_HOME)/../sei-cosmos:/sei-protocol/sei-cosmos:Z \
     -v $(PROJECT_HOME)/../sei-db:/sei-protocol/sei-db:Z \
 	-v $(GO_PKG_PATH)/mod:/root/go/pkg/mod:Z \
+	-v $(shell go env GOCACHE):/root/.cache/go-build:Z \
 	-p 26668-26670:26656-26658 \
 	--platform linux/x86_64 \
 	sei-chain/rpcnode
@@ -163,11 +167,13 @@ run-rpc-node-skipbuild: build-rpc-node
 	docker run --rm \
 	--name sei-rpc-node \
 	--network docker_localnet \
+	--user="$(shell id -u):$(shell id -g)" \
 	-v $(PROJECT_HOME):/sei-protocol/sei-chain:Z \
 	-v $(PROJECT_HOME)/../sei-tendermint:/sei-protocol/sei-tendermint:Z \
     -v $(PROJECT_HOME)/../sei-cosmos:/sei-protocol/sei-cosmos:Z \
     -v $(PROJECT_HOME)/../sei-db:/sei-protocol/sei-db:Z \
 	-v $(GO_PKG_PATH)/mod:/root/go/pkg/mod:Z \
+	-v $(shell go env GOCACHE):/root/.cache/go-build:Z \
 	-p 26668-26670:26656-26658 \
 	--platform linux/x86_64 \
 	--env SKIP_BUILD=true \
@@ -175,10 +181,10 @@ run-rpc-node-skipbuild: build-rpc-node
 .PHONY: run-rpc-node
 
 kill-sei-node:
-	docker ps --filter name=sei-node --filter status=running -aq | xargs docker kill
+	docker ps --filter name=sei-node --filter status=running -aq | xargs docker kill 2> /dev/null || true
 
 kill-rpc-node:
-	docker ps --filter name=sei-rpc-node --filter status=running -aq | xargs docker kill
+	docker ps --filter name=sei-rpc-node --filter status=running -aq | xargs docker kill 2> /dev/null || true
 
 # Run a 4-node docker containers
 docker-cluster-start: docker-cluster-stop build-docker-node

--- a/Makefile
+++ b/Makefile
@@ -191,19 +191,19 @@ docker-cluster-start: docker-cluster-stop build-docker-node
 	@rm -rf $(PROJECT_HOME)/build/generated
 	@mkdir -p $(shell go env GOPATH)/pkg/mod
 	@mkdir -p $(shell go env GOCACHE)
-	@cd docker && USERID=$(shell id -u) GROUPID=$(shell id -g) GOCACHE=$(shell go env GOCACHE) NUM_ACCOUNTS=10 INVARIANT_CHECK_INTERVAL=${INVARIANT_CHECK_INTERVAL} UPGRADE_VERSION_LIST=${UPGRADE_VERSION_LIST} docker-compose up
+	@cd docker && USERID=$(shell id -u) GROUPID=$(shell id -g) GOCACHE=$(shell go env GOCACHE) NUM_ACCOUNTS=10 INVARIANT_CHECK_INTERVAL=${INVARIANT_CHECK_INTERVAL} UPGRADE_VERSION_LIST=${UPGRADE_VERSION_LIST} docker compose up
 
 .PHONY: localnet-start
 
 # Use this to skip the seid build process
 docker-cluster-start-skipbuild: docker-cluster-stop build-docker-node
 	@rm -rf $(PROJECT_HOME)/build/generated
-	@cd docker && USERID=$(shell id -u) GROUPID=$(shell id -g) GOCACHE=$(shell go env GOCACHE) NUM_ACCOUNTS=10 SKIP_BUILD=true docker-compose up
+	@cd docker && USERID=$(shell id -u) GROUPID=$(shell id -g) GOCACHE=$(shell go env GOCACHE) NUM_ACCOUNTS=10 SKIP_BUILD=true docker compose up
 .PHONY: localnet-start
 
 # Stop 4-node docker containers
 docker-cluster-stop:
-	@cd docker && USERID=$(shell id -u) GROUPID=$(shell id -g) GOCACHE=$(shell go env GOCACHE) docker-compose down
+	@cd docker && USERID=$(shell id -u) GROUPID=$(shell id -g) GOCACHE=$(shell go env GOCACHE) docker compose down
 .PHONY: localnet-stop
 
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,8 +23,8 @@ services:
       - "${PROJECT_HOME}/../sei-cosmos:/sei-protocol/sei-cosmos:Z"
       - "${PROJECT_HOME}/../sei-db:/sei-protocol/sei-db:Z"
       - "${PROJECT_HOME}/../go-ethereum:/sei-protocol/go-ethereum:Z"
-      - "${GO_PKG_PATH}/mod:/home/ubuntu/go/pkg/mod:Z"
-      - "${GOCACHE}:/home/ubuntu/.cache/go-build:Z"
+      - "${GO_PKG_PATH}/mod:/root/go/pkg/mod:Z"
+      - "${GOCACHE}:/root/.cache/go-build:Z"
     networks:
       localnet:
         ipv4_address: 192.168.10.10
@@ -50,8 +50,8 @@ services:
       - "${PROJECT_HOME}/../sei-cosmos:/sei-protocol/sei-cosmos:Z"
       - "${PROJECT_HOME}/../sei-db:/sei-protocol/sei-db:Z"
       - "${PROJECT_HOME}/../go-ethereum:/sei-protocol/go-ethereum:Z"
-      - "${GO_PKG_PATH}/mod:/home/ubuntu/go/pkg/mod:Z"
-      - "${GOCACHE}:/home/ubuntu/.cache/go-build:Z"
+      - "${GO_PKG_PATH}/mod:/root/go/pkg/mod:Z"
+      - "${GOCACHE}:/root/.cache/go-build:Z"
     networks:
       localnet:
         ipv4_address: 192.168.10.11
@@ -77,8 +77,8 @@ services:
       - "${PROJECT_HOME}/../sei-cosmos:/sei-protocol/sei-cosmos:Z"
       - "${PROJECT_HOME}/../sei-db:/sei-protocol/sei-db:Z"
       - "${PROJECT_HOME}/../go-ethereum:/sei-protocol/go-ethereum:Z"
-      - "${GO_PKG_PATH}/mod:/home/ubuntu/go/pkg/mod:Z"
-      - "${GOCACHE}:/home/ubuntu/.cache/go-build:Z"
+      - "${GO_PKG_PATH}/mod:/root/go/pkg/mod:Z"
+      - "${GOCACHE}:/root/.cache/go-build:Z"
     networks:
       localnet:
         ipv4_address: 192.168.10.12
@@ -104,8 +104,8 @@ services:
       - "${PROJECT_HOME}/../sei-cosmos:/sei-protocol/sei-cosmos:Z"
       - "${PROJECT_HOME}/../sei-db:/sei-protocol/sei-db:Z"
       - "${PROJECT_HOME}/../go-ethereum:/sei-protocol/go-ethereum:Z"
-      - "${GO_PKG_PATH}/mod:/home/ubuntu/go/pkg/mod:Z"
-      - "${GOCACHE}:/home/ubuntu/.cache/go-build:Z"
+      - "${GO_PKG_PATH}/mod:/root/go/pkg/mod:Z"
+      - "${GOCACHE}:/root/.cache/go-build:Z"
     networks:
       localnet:
         ipv4_address: 192.168.10.13

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     platform: linux/amd64
     container_name: sei-node-0
     image: "sei-chain/localnode"
+    user: "${USERID}:${GROUPID}"
     ports:
       - "26656-26658:26656-26658"
       - "9090-9091:9090-9091"
@@ -22,7 +23,8 @@ services:
       - "${PROJECT_HOME}/../sei-cosmos:/sei-protocol/sei-cosmos:Z"
       - "${PROJECT_HOME}/../sei-db:/sei-protocol/sei-db:Z"
       - "${PROJECT_HOME}/../go-ethereum:/sei-protocol/go-ethereum:Z"
-      - "${GO_PKG_PATH}/mod:/root/go/pkg/mod:Z"
+      - "${GO_PKG_PATH}/mod:/home/ubuntu/go/pkg/mod:Z"
+      - "${GOCACHE}:/home/ubuntu/.cache/go-build:Z"
     networks:
       localnet:
         ipv4_address: 192.168.10.10
@@ -31,6 +33,7 @@ services:
     platform: linux/amd64
     container_name: sei-node-1
     image: "sei-chain/localnode"
+    user: "${USERID}:${GROUPID}"
     ports:
       - "26659-26661:26656-26658"
       - "9092-9093:9090-9091"
@@ -47,7 +50,8 @@ services:
       - "${PROJECT_HOME}/../sei-cosmos:/sei-protocol/sei-cosmos:Z"
       - "${PROJECT_HOME}/../sei-db:/sei-protocol/sei-db:Z"
       - "${PROJECT_HOME}/../go-ethereum:/sei-protocol/go-ethereum:Z"
-      - "${GO_PKG_PATH}/mod:/root/go/pkg/mod:Z"
+      - "${GO_PKG_PATH}/mod:/home/ubuntu/go/pkg/mod:Z"
+      - "${GOCACHE}:/home/ubuntu/.cache/go-build:Z"
     networks:
       localnet:
         ipv4_address: 192.168.10.11
@@ -56,6 +60,7 @@ services:
     platform: linux/amd64
     container_name: sei-node-2
     image: "sei-chain/localnode"
+    user: "${USERID}:${GROUPID}"
     environment:
       - ID=2
       - CLUSTER_SIZE=4
@@ -72,7 +77,8 @@ services:
       - "${PROJECT_HOME}/../sei-cosmos:/sei-protocol/sei-cosmos:Z"
       - "${PROJECT_HOME}/../sei-db:/sei-protocol/sei-db:Z"
       - "${PROJECT_HOME}/../go-ethereum:/sei-protocol/go-ethereum:Z"
-      - "${GO_PKG_PATH}/mod:/root/go/pkg/mod:Z"
+      - "${GO_PKG_PATH}/mod:/home/ubuntu/go/pkg/mod:Z"
+      - "${GOCACHE}:/home/ubuntu/.cache/go-build:Z"
     networks:
       localnet:
         ipv4_address: 192.168.10.12
@@ -81,6 +87,7 @@ services:
     platform: linux/amd64
     container_name: sei-node-3
     image: "sei-chain/localnode"
+    user: "${USERID}:${GROUPID}"
     environment:
       - ID=3
       - CLUSTER_SIZE=4
@@ -97,7 +104,8 @@ services:
       - "${PROJECT_HOME}/../sei-cosmos:/sei-protocol/sei-cosmos:Z"
       - "${PROJECT_HOME}/../sei-db:/sei-protocol/sei-db:Z"
       - "${PROJECT_HOME}/../go-ethereum:/sei-protocol/go-ethereum:Z"
-      - "${GO_PKG_PATH}/mod:/root/go/pkg/mod:Z"
+      - "${GO_PKG_PATH}/mod:/home/ubuntu/go/pkg/mod:Z"
+      - "${GOCACHE}:/home/ubuntu/.cache/go-build:Z"
     networks:
       localnet:
         ipv4_address: 192.168.10.13

--- a/docker/localnode/Dockerfile
+++ b/docker/localnode/Dockerfile
@@ -1,14 +1,13 @@
 FROM ubuntu:latest
 ENV HOME="/home/ubuntu" PATH="$HOME/go/bin:/sei-protocol/sei-chain/integration_test/upgrade_module/scripts/:$PATH"
 RUN apt-get update && \
-    apt-get install -y make git build-essential jq python3 curl vim uuid-runtime
+    apt-get install -y make git build-essential jq python3 curl vim uuid-runtime nodejs
 RUN curl -L https://go.dev/dl/go1.22.4.linux-amd64.tar.gz | tar xvzf - -C /usr/local/
 RUN curl -L https://foundry.paradigm.xyz | bash
-RUN /home/ubuntu/.foundry/bin/foundryup
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash
-RUN apt-get install -y nodejs
+RUN /home/ubuntu/.foundry/bin/foundryup
 RUN mkdir -p /home/ubuntu/.config && \
-    mkdir -p /home/ubuntu/go && \
+    mkdir -p /home/ubuntu/go/pkg/mod && \
     chown -R ubuntu:ubuntu /home/ubuntu && \
     chmod -R a+rwX /home/ubuntu
 SHELL ["/bin/bash", "-c"]

--- a/docker/localnode/Dockerfile
+++ b/docker/localnode/Dockerfile
@@ -1,15 +1,14 @@
 FROM ubuntu:latest
-ENV HOME="/home/ubuntu" PATH="/home/ubuntu/go/bin:/sei-protocol/sei-chain/integration_test/upgrade_module/scripts/:$PATH"
+ENV HOME="/root" PATH="/root/go/bin:/sei-protocol/sei-chain/integration_test/upgrade_module/scripts/:$PATH"
 RUN apt-get update && \
     apt-get install -y make git build-essential jq python3 curl vim uuid-runtime nodejs
 RUN curl -L https://go.dev/dl/go1.22.4.linux-amd64.tar.gz | tar xvzf - -C /usr/local/
 RUN curl -L https://foundry.paradigm.xyz | bash
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash
-RUN /home/ubuntu/.foundry/bin/foundryup
-RUN mkdir -p /home/ubuntu/.config && \
-    mkdir -p /home/ubuntu/go/pkg/mod && \
-    chown -R ubuntu:ubuntu /home/ubuntu && \
-    chmod -R a+rwX /home/ubuntu
+RUN /root/.foundry/bin/foundryup
+RUN mkdir -p /root/.config && \
+    mkdir -p /root/go/pkg/mod && \
+    chmod -R a+rwX /root
 SHELL ["/bin/bash", "-c"]
 
 WORKDIR /sei-protocol/sei-chain

--- a/docker/localnode/Dockerfile
+++ b/docker/localnode/Dockerfile
@@ -6,8 +6,7 @@ RUN curl -L https://go.dev/dl/go1.22.4.linux-amd64.tar.gz | tar xvzf - -C /usr/l
 RUN curl -L https://foundry.paradigm.xyz | bash
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash
 RUN /root/.foundry/bin/foundryup
-RUN mkdir -p /root/.config && \
-    mkdir -p /root/go/pkg/mod && \
+RUN mkdir -p /root/go/pkg/mod && \
     chmod -R a+rwX /root
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/localnode/Dockerfile
+++ b/docker/localnode/Dockerfile
@@ -1,21 +1,17 @@
 FROM ubuntu:latest
+ENV HOME="/home/ubuntu" PATH="$HOME/go/bin:/sei-protocol/sei-chain/integration_test/upgrade_module/scripts/:$PATH"
 RUN apt-get update && \
-    apt-get install -y make git wget build-essential jq python3 curl vim uuid-runtime
-RUN rm -rf build/generated
-RUN wget https://go.dev/dl/go1.22.4.linux-amd64.tar.gz
-RUN tar -xvf go1.22.4.linux-amd64.tar.gz
-RUN mv go /usr/local/
+    apt-get install -y make git build-essential jq python3 curl vim uuid-runtime
+RUN curl -L https://go.dev/dl/go1.22.4.linux-amd64.tar.gz | tar xvzf - -C /usr/local/
 RUN curl -L https://foundry.paradigm.xyz | bash
-RUN /root/.foundry/bin/foundryup
+RUN /home/ubuntu/.foundry/bin/foundryup
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash
 RUN apt-get install -y nodejs
-RUN mkdir -p /root/.config && \
-    chmod -R 777 /root/.config
+RUN mkdir -p /home/ubuntu/.config && \
+    mkdir -p /home/ubuntu/go && \
+    chown -R ubuntu:ubuntu /home/ubuntu && \
+    chmod -R a+rwX /home/ubuntu
 SHELL ["/bin/bash", "-c"]
-
-
-VOLUME [ "/sei-protocol" ]
-VOLUME [ "/root/go/pkg/mod" ]
 
 WORKDIR /sei-protocol/sei-chain
 
@@ -33,4 +29,4 @@ COPY scripts/step3_add_validator_to_genesis.sh /usr/bin/add_validator_to_gensis.
 COPY scripts/step4_config_override.sh /usr/bin/config_override.sh
 COPY scripts/step5_start_sei.sh /usr/bin/start_sei.sh
 COPY scripts/step6_start_price_feeder.sh /usr/bin/start_price_feeder.sh
-ENV PATH "$PATH:$HOME/go/bin:/sei-protocol/sei-chain/integration_test/upgrade_module/scripts/"
+

--- a/docker/localnode/Dockerfile
+++ b/docker/localnode/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:latest
-ENV HOME="/home/ubuntu" PATH="$HOME/go/bin:/sei-protocol/sei-chain/integration_test/upgrade_module/scripts/:$PATH"
+ENV HOME="/home/ubuntu" PATH="/home/ubuntu/go/bin:/sei-protocol/sei-chain/integration_test/upgrade_module/scripts/:$PATH"
 RUN apt-get update && \
     apt-get install -y make git build-essential jq python3 curl vim uuid-runtime nodejs
 RUN curl -L https://go.dev/dl/go1.22.4.linux-amd64.tar.gz | tar xvzf - -C /usr/local/

--- a/docker/localnode/Dockerfile
+++ b/docker/localnode/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 ENV HOME="/root" PATH="/root/go/bin:/sei-protocol/sei-chain/integration_test/upgrade_module/scripts/:$PATH"
 RUN apt-get update && \
-    apt-get install -y make git build-essential jq python3 curl vim uuid-runtime nodejs
+    apt-get install -y make git build-essential jq python3 curl vim uuid-runtime nodejs npm
 RUN curl -L https://go.dev/dl/go1.22.4.linux-amd64.tar.gz | tar xvzf - -C /usr/local/
 RUN curl -L https://foundry.paradigm.xyz | bash
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash

--- a/docker/localnode/Dockerfile
+++ b/docker/localnode/Dockerfile
@@ -7,6 +7,7 @@ RUN curl -L https://foundry.paradigm.xyz | bash
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash
 RUN /root/.foundry/bin/foundryup
 RUN mkdir -p /root/go/pkg/mod && \
+    mkdir -p /root/.cache && \
     chmod -R a+rwX /root
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/localnode/Dockerfile
+++ b/docker/localnode/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 ENV HOME="/root" PATH="/root/go/bin:/sei-protocol/sei-chain/integration_test/upgrade_module/scripts/:$PATH"
 RUN apt-get update && \
-    apt-get install -y make git build-essential jq python3 curl vim uuid-runtime nodejs npm
+    apt-get install -y make git build-essential jq python3 curl vim uuid-runtime nodejs
 RUN curl -L https://go.dev/dl/go1.22.4.linux-amd64.tar.gz | tar xvzf - -C /usr/local/
 RUN curl -L https://foundry.paradigm.xyz | bash
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash

--- a/docker/localnode/scripts/deploy.sh
+++ b/docker/localnode/scripts/deploy.sh
@@ -3,16 +3,16 @@
 NODE_ID=${ID:-0}
 CLUSTER_SIZE=${CLUSTER_SIZE:-1}
 
-
 # Clean up and env set up
 export GOPATH=$HOME/go
 export GOBIN=$GOPATH/bin
 export BUILD_PATH=/sei-protocol/sei-chain/build
 export PATH=$GOBIN:$PATH:/usr/local/go/bin:$BUILD_PATH
-echo "export GOPATH=$HOME/go" >> /root/.bashrc
-echo "GOBIN=$GOPATH/bin" >> /root/.bashrc
-echo "export PATH=$GOBIN:$PATH:/usr/local/go/bin:$BUILD_PATH:/root/.foundry/bin" >> /root/.bashrc
-/bin/bash -c "source /root/.bashrc"
+echo "export GOPATH=$HOME/go" >> "$HOME/.bashrc"
+echo "GOBIN=$GOPATH/bin" >> "$HOME/.bashrc"
+echo "export PATH=$GOBIN:$PATH:/usr/local/go/bin:$BUILD_PATH:$HOME/.foundry/bin" >> "$HOME/.bashrc"
+rm -rf build/generated
+/bin/bash -c "source $HOME/.bashrc"
 mkdir -p $GOBIN
 # Step 0: Build on node 0
 if [ "$NODE_ID" = 0 ] && [ -z "$SKIP_BUILD" ]

--- a/docker/localnode/scripts/step6_start_price_feeder.sh
+++ b/docker/localnode/scripts/step6_start_price_feeder.sh
@@ -9,11 +9,11 @@ ORACLE_ACCOUNT="oracle"
 VALIDATOR_ACCOUNT="node_admin"
 
 # Create an oracle account
-printf "12345678\n" | /root/go/bin/seid keys add $ORACLE_ACCOUNT --output json > /root/.sei/config/oracle_key.json
-ORACLE_ACCOUNT_ADDRESS=$(printf "12345678\n" | /root/go/bin/seid keys show $ORACLE_ACCOUNT -a)
-SEIVALOPER=$(printf "12345678\n" | /root/go/bin/seid keys show $VALIDATOR_ACCOUNT --bech=val -a)
-printf "12345678\n" | /root/go/bin/seid tx oracle set-feeder "$ORACLE_ACCOUNT_ADDRESS" --from $VALIDATOR_ACCOUNT --fees 2000usei -b block -y --chain-id sei >/dev/null 2>&1
-printf "12345678\n" | /root/go/bin/seid tx bank send $VALIDATOR_ACCOUNT "$ORACLE_ACCOUNT_ADDRESS" --from $VALIDATOR_ACCOUNT 1000sei --fees 2000usei -b block -y >/dev/null 2>&1
+printf "12345678\n" | "$HOME/go/bin/seid" keys add $ORACLE_ACCOUNT --output json > "$HOME/.sei/config/oracle_key.json"
+ORACLE_ACCOUNT_ADDRESS=$(printf "12345678\n" | "$HOME/go/bin/seid" keys show $ORACLE_ACCOUNT -a)
+SEIVALOPER=$(printf "12345678\n" | "$HOME/go/bin/seid" keys show $VALIDATOR_ACCOUNT --bech=val -a)
+printf "12345678\n" | "$HOME/go/bin/seid" tx oracle set-feeder "$ORACLE_ACCOUNT_ADDRESS" --from $VALIDATOR_ACCOUNT --fees 2000usei -b block -y --chain-id sei >/dev/null 2>&1
+printf "12345678\n" | "$HOME/go/bin/seid" tx bank send $VALIDATOR_ACCOUNT "$ORACLE_ACCOUNT_ADDRESS" --from $VALIDATOR_ACCOUNT 1000sei --fees 2000usei -b block -y >/dev/null 2>&1
 
 
 sed -i.bak -e "s|^address *=.*|address = \"$ORACLE_ACCOUNT_ADDRESS\"|" $ORACLE_CONFIG_FILE

--- a/docker/rpcnode/Dockerfile
+++ b/docker/rpcnode/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && \
     apt-get install -y make git build-essential jq python3 curl vim uuid-runtime
 RUN curl -L https://go.dev/dl/go1.21.4.linux-amd64.tar.gz | tar xvzf - -C /usr/local/
 RUN mkdir -p /root/go/pkg/mod && \
+    mkdir -p /root/.cache && \
     chmod -R a+rwX /root
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/rpcnode/Dockerfile
+++ b/docker/rpcnode/Dockerfile
@@ -1,13 +1,12 @@
 FROM ubuntu:latest
+ENV HOME="/root" PATH="/root/go/bin:$PATH"
 RUN apt-get update && \
-    apt-get install -y make git wget build-essential jq python3 curl vim uuid-runtime
-RUN wget https://go.dev/dl/go1.21.4.linux-amd64.tar.gz
-RUN tar -xvf go1.21.4.linux-amd64.tar.gz
-RUN mv go /usr/local/
+    apt-get install -y make git build-essential jq python3 curl vim uuid-runtime
+RUN curl -L https://go.dev/dl/go1.21.4.linux-amd64.tar.gz | tar xvzf - -C /usr/local/
+RUN mkdir -p /root/go/pkg/mod && \
+    chmod -R a+rwX /root
 SHELL ["/bin/bash", "-c"]
 
-VOLUME [ "/sei-protocol" ]
-VOLUME [ "/root/go/pkg/mod" ]
 WORKDIR /sei-protocol/sei-chain
 
 EXPOSE 26656 26657 26658 9090 9091
@@ -20,4 +19,3 @@ COPY scripts/deploy.sh /usr/bin/deploy.sh
 COPY scripts/step0_build.sh /usr/bin/build.sh
 COPY scripts/step1_configure_init.sh /usr/bin/configure_init.sh
 COPY scripts/step2_start_sei.sh /usr/bin/start_sei.sh
-ENV PATH "$PATH:$HOME/go/bin"


### PR DESCRIPTION
- on linux files created inside `build/generated` are owned by root - fixed it by providing the current user to the docker compose
- due to that everything is now stored under `/home/ubuntu` rather than `/root`
- `rm -rf build/generated` command is moved from Dockerfile to `deploy.sh` because it should be run on every cluster creation (correct me if I'm wrong)
- `HOME` env variable does not exist in Dockerfile during `docker build` phase - defined it
- to build `seid` faster the local `GOCACHE` is mounted inside the containers

Tested on Linux, please test on Darwin
