### PR TITLE
Fix `github.com/ledgerwatch/interfaces` revision

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/sei-protocol/sei-chain
 
 go 1.21
 
+replace github.com/ledgerwatch/interfaces => github.com/ledgerwatch/interfaces v0.0.0-20240802131416-fd1e1f60b2d7
+
 require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/CosmWasm/wasmd v0.27.0


### PR DESCRIPTION
Command

```
sudo rm -rf $(go env GOPATH)/pkg/mod/github.com/ledgerwatch/
go list -modfile=./go.mod -m -json -mod=mod all
```

produces error:

```
go: github.com/ledgerwatch/interfaces@v0.0.0-20230210062155-539b8171d9f0: invalid version: unknown revision 539b8171d9f0
```

It's because that commit does not exist in the repo anymore.

Our code does not depend on `github.com/ledgerwatch/interfaces`. It is required only because imported `github.com/ledgerwatch/erigon-lib` uses it for code generation here: https://github.com/ledgerwatch/erigon-lib/blob/main/tools.go
