### PR TITLE
Prevent ddos against associate msgs

### DIFF
--- a/app/antedecorators/gasless.go
+++ b/app/antedecorators/gasless.go
@@ -125,6 +125,8 @@ func IsTxGasless(tx sdk.Tx, ctx sdk.Context, oracleKeeper oraclekeeper.Keeper, e
 			if !evmAssociateIsGasless(m, ctx, evmKeeper) {
 				return false, nil
 			}
+			// ddos prevention
+			return len(tx.GetMsgs()) == 1, nil
 		default:
 			return false, nil
 		}

--- a/evmrpc/block_test.go
+++ b/evmrpc/block_test.go
@@ -224,7 +224,8 @@ func TestEncodeBankMsg(t *testing.T) {
 }
 
 func TestEncodeWasmExecuteMsg(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	fromSeiAddr, fromEvmAddr := testkeeper.MockAddressPair()
 	toSeiAddr, _ := testkeeper.MockAddressPair()
 	b := TxConfig.NewTxBuilder()

--- a/evmrpc/block_test.go
+++ b/evmrpc/block_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"math/big"
 	"testing"
+	"time"
 
 	types2 "github.com/tendermint/tendermint/proto/tendermint/types"
 
@@ -150,7 +151,8 @@ func verifyBlockResult(t *testing.T, resObj map[string]interface{}) {
 }
 
 func TestEncodeTmBlock_EmptyTransactions(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	block := &coretypes.ResultBlock{
 		BlockID: MockBlockID,
 		Block: &tmtypes.Block{
@@ -180,7 +182,8 @@ func TestEncodeTmBlock_EmptyTransactions(t *testing.T) {
 }
 
 func TestEncodeBankMsg(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	fromSeiAddr, _ := testkeeper.MockAddressPair()
 	toSeiAddr, _ := testkeeper.MockAddressPair()
 	b := TxConfig.NewTxBuilder()

--- a/precompiles/bank/bank_test.go
+++ b/precompiles/bank/bank_test.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"strings"
 	"testing"
+	"time"
 
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -338,7 +339,8 @@ func TestSendForUnlinkedReceiver(t *testing.T) {
 }
 
 func TestMetadata(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	k.BankKeeper().SetDenomMetaData(ctx, banktypes.Metadata{Name: "SEI", Symbol: "usei", Base: "usei"})
 	p, err := bank.NewPrecompile(k.BankKeeper(), k, k.AccountKeeper())
 	require.Nil(t, err)
@@ -375,20 +377,10 @@ func TestMetadata(t *testing.T) {
 	outputs, err = decimal.Outputs.Unpack(res)
 	require.Nil(t, err)
 	require.Equal(t, uint8(0), outputs[0])
-
-	supply, err := p.ABI.MethodById(p.GetExecutor().(*bank.PrecompileExecutor).SupplyID)
-	require.Nil(t, err)
-	args, err = supply.Inputs.Pack("usei")
-	require.Nil(t, err)
-	res, err = p.Run(&evm, common.Address{}, common.Address{}, append(p.GetExecutor().(*bank.PrecompileExecutor).SupplyID, args...), nil, false)
-	require.Nil(t, err)
-	outputs, err = supply.Outputs.Unpack(res)
-	require.Nil(t, err)
-	require.Equal(t, big.NewInt(10), outputs[0])
 }
 
 func TestRequiredGas(t *testing.T) {
-	k, _ := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
 	p, err := bank.NewPrecompile(k.BankKeeper(), k, k.AccountKeeper())
 	require.Nil(t, err)
 	balanceRequiredGas := p.RequiredGas(p.GetExecutor().(*bank.PrecompileExecutor).BalanceID)
@@ -398,7 +390,7 @@ func TestRequiredGas(t *testing.T) {
 }
 
 func TestAddress(t *testing.T) {
-	k, _ := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
 	p, err := bank.NewPrecompile(k.BankKeeper(), k, k.AccountKeeper())
 	require.Nil(t, err)
 	require.Equal(t, common.HexToAddress(bank.BankAddress), p.Address())

--- a/precompiles/common/precompiles_test.go
+++ b/precompiles/common/precompiles_test.go
@@ -39,7 +39,8 @@ func TestValidteNonPayable(t *testing.T) {
 
 func TestHandlePrecompileError(t *testing.T) {
 	_, evmAddr := testkeeper.MockAddressPair()
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	stateDB := state.NewDBImpl(ctx, k, false)
 	evm := &vm.EVM{StateDB: stateDB}
 
@@ -66,7 +67,8 @@ func (e *MockPrecompileExecutor) Execute(ctx sdk.Context, method *abi.Method, ca
 }
 
 func TestPrecompileRun(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	abiBz, err := os.ReadFile("erc20_abi.json")
 	require.Nil(t, err)
 	newAbi, err := abi.JSON(bytes.NewReader(abiBz))
@@ -106,7 +108,8 @@ func (e *MockDynamicGasPrecompileExecutor) EVMKeeper() common.EVMKeeper {
 }
 
 func TestDynamicGasPrecompileRun(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	abiBz, err := os.ReadFile("erc20_abi.json")
 	require.Nil(t, err)
 	newAbi, err := abi.JSON(bytes.NewReader(abiBz))

--- a/precompiles/pointerview/pointerview_test.go
+++ b/precompiles/pointerview/pointerview_test.go
@@ -2,6 +2,7 @@ package pointerview_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/sei-protocol/sei-chain/precompiles/pointerview"
@@ -13,7 +14,8 @@ import (
 )
 
 func TestPointerView(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	p, err := pointerview.NewPrecompile(k)
 	require.Nil(t, err)
 	_, pointer := testkeeper.MockAddressPair()

--- a/x/evm/ante/basic_test.go
+++ b/x/evm/ante/basic_test.go
@@ -2,6 +2,7 @@ package ante_test
 
 import (
 	"testing"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -14,7 +15,8 @@ import (
 )
 
 func TestBasicDecorator(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	a := ante.NewBasicDecorator(k)
 	msg, _ := types.NewMsgEVMTransaction(&ethtx.LegacyTx{})
 	ctx, err := a.AnteHandle(ctx, &mockTx{msgs: []sdk.Msg{msg}}, false, func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {

--- a/x/evm/ante/fee_test.go
+++ b/x/evm/ante/fee_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"math/big"
 	"testing"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -20,7 +21,8 @@ import (
 )
 
 func TestEVMFeeCheckDecorator(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	handler := ante.NewEVMFeeCheckDecorator(k)
 	privKey := testkeeper.MockPrivateKey()
 	testPrivHex := hex.EncodeToString(privKey.Bytes())
@@ -113,7 +115,8 @@ func TestEVMFeeCheckDecorator(t *testing.T) {
 }
 
 func TestCalculatePriorityScenarios(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	decorator := ante.NewEVMFeeCheckDecorator(k)
 
 	_1gwei := big.NewInt(100000000000)

--- a/x/evm/ante/gas_test.go
+++ b/x/evm/ante/gas_test.go
@@ -2,6 +2,7 @@ package ante_test
 
 import (
 	"testing"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
@@ -12,7 +13,8 @@ import (
 )
 
 func TestGasLimitDecorator(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	a := ante.NewGasLimitDecorator(k)
 	limitMsg, _ := types.NewMsgEVMTransaction(&ethtx.LegacyTx{GasLimit: 100})
 	ctx, err := a.AnteHandle(ctx, &mockTx{msgs: []sdk.Msg{limitMsg}}, false, func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {

--- a/x/evm/ante/preprocess_test.go
+++ b/x/evm/ante/preprocess_test.go
@@ -29,7 +29,8 @@ import (
 )
 
 func TestPreprocessAnteHandler(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	handler := ante.NewEVMPreprocessDecorator(k, k.AccountKeeper())
 	privKey := testkeeper.MockPrivateKey()
 	seiAddr, evmAddr := testkeeper.PrivateKeyToAddresses(privKey)
@@ -70,7 +71,8 @@ func TestPreprocessAnteHandler(t *testing.T) {
 }
 
 func TestPreprocessAnteHandlerUnprotected(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	handler := ante.NewEVMPreprocessDecorator(k, k.AccountKeeper())
 	gasPrice := sdk.NewInt(73141930316)
 	amt := sdk.NewInt(270000000000000000)
@@ -98,7 +100,8 @@ func TestPreprocessAnteHandlerUnprotected(t *testing.T) {
 }
 
 func TestPreprocessAssociateTx(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	handler := ante.NewEVMPreprocessDecorator(k, k.AccountKeeper())
 	privKey := testkeeper.MockPrivateKey()
 	testPrivHex := hex.EncodeToString(privKey.Bytes())
@@ -141,7 +144,8 @@ func TestPreprocessAssociateTx(t *testing.T) {
 }
 
 func TestPreprocessAssociateTxWithWeiBalance(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	handler := ante.NewEVMPreprocessDecorator(k, k.AccountKeeper())
 	privKey := testkeeper.MockPrivateKey()
 	testPrivHex := hex.EncodeToString(privKey.Bytes())
@@ -188,7 +192,7 @@ func TestGetVersion(t *testing.T) {
 }
 
 func TestAnteDeps(t *testing.T) {
-	k, _ := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
 	handler := ante.NewEVMPreprocessDecorator(k, k.AccountKeeper())
 	msg, _ := types.NewMsgEVMTransaction(&ethtx.LegacyTx{GasLimit: 100})
 	msg.Derived = &derived.Derived{
@@ -204,7 +208,8 @@ func TestAnteDeps(t *testing.T) {
 }
 
 func TestEVMAddressDecorator(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	privKey := testkeeper.MockPrivateKey()
 	sender, evmAddr := testkeeper.PrivateKeyToAddresses(privKey)
 	recipient, _ := testkeeper.MockAddressPair()
@@ -221,7 +226,8 @@ func TestEVMAddressDecorator(t *testing.T) {
 }
 
 func TestIsAccountBalancePositive(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	s1, e1 := testkeeper.MockAddressPair()
 	s2, e2 := testkeeper.MockAddressPair()
 	s3, e3 := testkeeper.MockAddressPair()
@@ -253,7 +259,8 @@ func (m MockTxIncompatible) ValidateBasic() error {
 }
 
 func TestEVMAddressDecoratorContinueDespiteErrors(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	handler := ante.NewEVMAddressDecorator(k, k.AccountKeeper())
 
 	_, err := handler.AnteHandle(ctx, MockTxIncompatible{}, false, func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
@@ -294,7 +301,8 @@ func TestEVMAddressDecoratorContinueDespiteErrors(t *testing.T) {
 }
 
 func TestMigrateBalance(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	admin, _ := testkeeper.MockAddressPair()
 	seiAddr, evmAddr := testkeeper.MockAddressPair()
 	k.BankKeeper().AddCoins(ctx, sdk.AccAddress(evmAddr[:]), sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(2))), false)

--- a/x/evm/ante/sig_test.go
+++ b/x/evm/ante/sig_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"math/big"
 	"testing"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -18,7 +19,8 @@ import (
 )
 
 func TestEVMSigVerifyDecorator(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	handler := ante.NewEVMSigVerifyDecorator(k, func() sdk.Context { return ctx })
 	privKey := testkeeper.MockPrivateKey()
 	testPrivHex := hex.EncodeToString(privKey.Bytes())
@@ -99,7 +101,8 @@ func TestEVMSigVerifyDecorator(t *testing.T) {
 }
 
 func TestSigVerifyPendingTransaction(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	ctx = ctx.WithIsCheckTx(true)
 	handler := ante.NewEVMSigVerifyDecorator(k, func() sdk.Context { return ctx })
 	privKey := testkeeper.MockPrivateKey()

--- a/x/evm/genesis_test.go
+++ b/x/evm/genesis_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 func TestExportImportGenesis(t *testing.T) {
-	keeper, origctx := testkeeper.MockEVMKeeper()
+	keeper := &testkeeper.EVMTestApp.EvmKeeper
+	origctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	ctx := origctx.WithMultiStore(origctx.MultiStore().CacheMultiStore())
 	seiAddr, evmAddr := testkeeper.MockAddressPair()
 	keeper.SetAddressMapping(ctx, seiAddr, evmAddr)

--- a/x/evm/gov_test.go
+++ b/x/evm/gov_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestAddERCNativePointerProposalsV2(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	require.Nil(t, evm.HandleAddERCNativePointerProposalV2(ctx, k, &types.AddERCNativePointerProposalV2{
 		Token:    "test",
 		Name:     "NAME",

--- a/x/evm/keeper/address_test.go
+++ b/x/evm/keeper/address_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func TestSetGetAddressMapping(t *testing.T) {
-	k, ctx := keeper.MockEVMKeeper()
+	k := &keeper.EVMTestApp.EvmKeeper
+	ctx := keeper.EVMTestApp.GetContextForDeliverTx([]byte{})
 	seiAddr, evmAddr := keeper.MockAddressPair()
 	_, ok := k.GetEVMAddress(ctx, seiAddr)
 	require.False(t, ok)
@@ -27,7 +28,8 @@ func TestSetGetAddressMapping(t *testing.T) {
 }
 
 func TestDeleteAddressMapping(t *testing.T) {
-	k, ctx := keeper.MockEVMKeeper()
+	k := &keeper.EVMTestApp.EvmKeeper
+	ctx := keeper.EVMTestApp.GetContextForDeliverTx([]byte{})
 	seiAddr, evmAddr := keeper.MockAddressPair()
 	k.SetAddressMapping(ctx, seiAddr, evmAddr)
 	foundEVM, ok := k.GetEVMAddress(ctx, seiAddr)
@@ -44,7 +46,8 @@ func TestDeleteAddressMapping(t *testing.T) {
 }
 
 func TestGetAddressOrDefault(t *testing.T) {
-	k, ctx := keeper.MockEVMKeeper()
+	k := &keeper.EVMTestApp.EvmKeeper
+	ctx := keeper.EVMTestApp.GetContextForDeliverTx([]byte{})
 	seiAddr, evmAddr := keeper.MockAddressPair()
 	defaultEvmAddr := k.GetEVMAddressOrDefault(ctx, seiAddr)
 	require.True(t, bytes.Equal(seiAddr, defaultEvmAddr[:]))

--- a/x/evm/keeper/code_test.go
+++ b/x/evm/keeper/code_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 func TestCode(t *testing.T) {
-	k, ctx := keeper.MockEVMKeeper()
+	k := &keeper.EVMTestApp.EvmKeeper
+	ctx := keeper.EVMTestApp.GetContextForDeliverTx([]byte{})
 	_, addr := keeper.MockAddressPair()
 
 	require.Equal(t, common.Hash{}, k.GetCodeHash(ctx, addr))
@@ -32,7 +33,8 @@ func TestCode(t *testing.T) {
 }
 
 func TestNilCode(t *testing.T) {
-	k, ctx := keeper.MockEVMKeeper()
+	k := &keeper.EVMTestApp.EvmKeeper
+	ctx := keeper.EVMTestApp.GetContextForDeliverTx([]byte{})
 	_, addr := keeper.MockAddressPair()
 
 	k.SetCode(ctx, addr, nil)

--- a/x/evm/keeper/coinbase_test.go
+++ b/x/evm/keeper/coinbase_test.go
@@ -3,13 +3,14 @@ package keeper_test
 import (
 	"testing"
 
-	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
+	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/keeper"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGetFeeCollectorAddress(t *testing.T) {
-	k, ctx := keepertest.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{})
 	addr, err := k.GetFeeCollectorAddress(ctx)
 	require.Nil(t, err)
 	expected := k.GetEVMAddressOrDefault(ctx, k.AccountKeeper().GetModuleAddress("fee_collector"))

--- a/x/evm/keeper/genesis.go
+++ b/x/evm/keeper/genesis.go
@@ -37,21 +37,23 @@ func (k *Keeper) InitGenesis(ctx sdk.Context, genState types.GenesisState) {
 
 	erc20CodeID, err := k.wasmKeeper.Create(ctx, k.accountKeeper.GetModuleAddress(types.ModuleName), erc20.GetBin(), nil)
 	if err != nil {
-		panic(err)
+		ctx.Logger().Error(fmt.Sprintf("error creating CWERC20 pointer code due to %s", err))
+	} else {
+		prefix.NewStore(k.PrefixStore(ctx, types.PointerCWCodePrefix), types.PointerCW20ERC20Prefix).Set(
+			artifactsutils.GetVersionBz(erc20.CurrentVersion),
+			artifactsutils.GetCodeIDBz(erc20CodeID),
+		)
 	}
-	prefix.NewStore(k.PrefixStore(ctx, types.PointerCWCodePrefix), types.PointerCW20ERC20Prefix).Set(
-		artifactsutils.GetVersionBz(erc20.CurrentVersion),
-		artifactsutils.GetCodeIDBz(erc20CodeID),
-	)
 
 	erc721CodeID, err := k.wasmKeeper.Create(ctx, k.accountKeeper.GetModuleAddress(types.ModuleName), erc721.GetBin(), nil)
 	if err != nil {
-		panic(err)
+		ctx.Logger().Error(fmt.Sprintf("error creating CWERC721 pointer code due to %s", err))
+	} else {
+		prefix.NewStore(k.PrefixStore(ctx, types.PointerCWCodePrefix), types.PointerCW721ERC721Prefix).Set(
+			artifactsutils.GetVersionBz(erc721.CurrentVersion),
+			artifactsutils.GetCodeIDBz(erc721CodeID),
+		)
 	}
-	prefix.NewStore(k.PrefixStore(ctx, types.PointerCWCodePrefix), types.PointerCW721ERC721Prefix).Set(
-		artifactsutils.GetVersionBz(erc721.CurrentVersion),
-		artifactsutils.GetCodeIDBz(erc721CodeID),
-	)
 
 	if k.EthReplayConfig.Enabled && !ethReplayInitialied {
 		header := k.OpenEthDatabase()

--- a/x/evm/keeper/genesis_test.go
+++ b/x/evm/keeper/genesis_test.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"testing"
 
-	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
+	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/keeper"
 	"github.com/stretchr/testify/require"
 )
 
 func TestInitGenesis(t *testing.T) {
-	k, ctx := keepertest.MockEVMKeeper() // this would call `InitGenesis`
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{})
 	// coinbase address must be associated
 	coinbaseSeiAddr, associated := k.GetSeiAddress(ctx, keeper.GetCoinbaseAddress())
 	require.True(t, associated)

--- a/x/evm/keeper/grpc_query_test.go
+++ b/x/evm/keeper/grpc_query_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"testing"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
@@ -16,7 +17,8 @@ import (
 )
 
 func TestQueryPointer(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	seiAddr1, evmAddr1 := testkeeper.MockAddressPair()
 	seiAddr2, evmAddr2 := testkeeper.MockAddressPair()
 	seiAddr3, evmAddr3 := testkeeper.MockAddressPair()

--- a/x/evm/keeper/nonce_test.go
+++ b/x/evm/keeper/nonce_test.go
@@ -3,13 +3,14 @@ package keeper_test
 import (
 	"testing"
 
-	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
+	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNonce(t *testing.T) {
-	k, ctx := keepertest.MockEVMKeeper()
-	_, evmAddr := keepertest.MockAddressPair()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{})
+	_, evmAddr := testkeeper.MockAddressPair()
 	require.Equal(t, uint64(0), k.GetNonce(ctx, evmAddr))
 	k.SetNonce(ctx, evmAddr, 1)
 	require.Equal(t, uint64(1), k.GetNonce(ctx, evmAddr))

--- a/x/evm/keeper/params_test.go
+++ b/x/evm/keeper/params_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"testing"
+	"time"
 
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
@@ -9,7 +10,8 @@ import (
 )
 
 func TestParams(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	require.Equal(t, "usei", k.GetBaseDenom(ctx))
 	require.Equal(t, types.DefaultPriorityNormalizer, k.GetPriorityNormalizer(ctx))
 	require.Equal(t, types.DefaultBaseFeePerGas, k.GetBaseFeePerGas(ctx))

--- a/x/evm/keeper/pointer_test.go
+++ b/x/evm/keeper/pointer_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -31,7 +32,7 @@ type seiPointerTest struct {
 }
 
 func TestEVMtoCWPointers(t *testing.T) {
-	_, ctx := testkeeper.MockEVMKeeper()
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{})
 
 	tests := []seiPointerTest{
 		{
@@ -115,7 +116,8 @@ func TestEVMtoCWPointers(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			k, ctx := testkeeper.MockEVMKeeper()
+			k := &testkeeper.EVMTestApp.EvmKeeper
+			ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 			handlers := test.getHandlers(k)
 			cwAddress, evmAddress := testkeeper.MockAddressPair()
 
@@ -219,7 +221,8 @@ func TestCWtoEVMPointers(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			k, ctx := testkeeper.MockEVMKeeper()
+			k := &testkeeper.EVMTestApp.EvmKeeper
+			ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 			handlers := test.getHandlers(k)
 			cwAddress, evmAddress := testkeeper.MockAddressPair()
 

--- a/x/evm/keeper/pointer_upgrade_test.go
+++ b/x/evm/keeper/pointer_upgrade_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -13,7 +14,8 @@ import (
 )
 
 func TestRunWithOneOffEVMInstance(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	errLog := ""
 	errRunner := func(*vm.EVM) error { return errors.New("test") }
 	errLogger := func(a string, b string) { errLog = a + " " + b }
@@ -27,7 +29,8 @@ func TestRunWithOneOffEVMInstance(t *testing.T) {
 }
 
 func TestUpsertERCNativePointer(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	var addr common.Address
 	err := k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
 		a, _, err := k.UpsertERCNativePointer(ctx, e, math.MaxUint64, "test", utils.ERCMetadata{
@@ -65,7 +68,8 @@ func TestUpsertERCNativePointer(t *testing.T) {
 }
 
 func TestUpsertERC20Pointer(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	var addr common.Address
 	err := k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
 		a, _, err := k.UpsertERCCW20Pointer(ctx, e, math.MaxUint64, "test", utils.ERCMetadata{
@@ -90,7 +94,8 @@ func TestUpsertERC20Pointer(t *testing.T) {
 }
 
 func TestUpsertERC721Pointer(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	var addr common.Address
 	err := k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
 		a, _, err := k.UpsertERCCW721Pointer(ctx, e, math.MaxUint64, "test", utils.ERCMetadata{

--- a/x/evm/keeper/receipt_test.go
+++ b/x/evm/keeper/receipt_test.go
@@ -4,13 +4,14 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
+	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestReceipt(t *testing.T) {
-	k, ctx := keepertest.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{})
 	txHash := common.HexToHash("0x0750333eac0be1203864220893d8080dd8a8fd7a2ed098dfd92a718c99d437f2")
 	_, err := k.GetReceipt(ctx, txHash)
 	require.NotNil(t, err)

--- a/x/evm/keeper/state_test.go
+++ b/x/evm/keeper/state_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
@@ -9,7 +10,8 @@ import (
 )
 
 func TestState(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	_, addr := testkeeper.MockAddressPair()
 
 	initialState := k.GetState(ctx, addr, common.HexToHash("0xabc"))

--- a/x/evm/keeper/tx_test.go
+++ b/x/evm/keeper/tx_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	keepertest "github.com/sei-protocol/sei-chain/testutil/keeper"
+	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTxHashesOnHeight(t *testing.T) {
-	k, ctx := keepertest.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{})
 	require.Empty(t, k.GetTxHashesOnHeight(ctx, 1234))
 	hashes := []common.Hash{
 		common.HexToHash("0x0750333eac0be1203864220893d8080dd8a8fd7a2ed098dfd92a718c99d437f2"),

--- a/x/evm/migrations/fix_total_supply_test.go
+++ b/x/evm/migrations/fix_total_supply_test.go
@@ -2,6 +2,7 @@ package migrations_test
 
 import (
 	"testing"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
@@ -10,7 +11,8 @@ import (
 )
 
 func TestFixTotalSupply(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	addr, _ := testkeeper.MockAddressPair()
 	balance := sdk.NewCoins(sdk.NewCoin(sdk.MustGetBaseDenom(), sdk.OneInt()))
 	k.BankKeeper().MintCoins(ctx, "evm", balance)

--- a/x/evm/module_test.go
+++ b/x/evm/module_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/tracing"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/sei-protocol/sei-chain/app"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
@@ -30,26 +29,27 @@ import (
 )
 
 func TestModuleName(t *testing.T) {
-	k, _ := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
 	module := evm.NewAppModule(nil, k)
 	assert.Equal(t, "evm", module.Name())
 }
 
 func TestModuleRoute(t *testing.T) {
-	k, _ := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
 	module := evm.NewAppModule(nil, k)
 	assert.Equal(t, "evm", module.Route().Path())
 	assert.Equal(t, false, module.Route().Empty())
 }
 
 func TestQuerierRoute(t *testing.T) {
-	k, _ := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
 	module := evm.NewAppModule(nil, k)
 	assert.Equal(t, "evm", module.QuerierRoute())
 }
 
 func TestModuleExportGenesis(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	module := evm.NewAppModule(nil, k)
 	jsonMsg := module.ExportGenesis(ctx, types.ModuleCdc)
 	jsonStr := string(jsonMsg)
@@ -57,13 +57,14 @@ func TestModuleExportGenesis(t *testing.T) {
 }
 
 func TestConsensusVersion(t *testing.T) {
-	k, _ := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
 	module := evm.NewAppModule(nil, k)
 	assert.Equal(t, uint64(11), module.ConsensusVersion())
 }
 
 func TestABCI(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	_, evmAddr1 := testkeeper.MockAddressPair()
 	_, evmAddr2 := testkeeper.MockAddressPair()
 	amt := sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(10)))
@@ -154,7 +155,7 @@ func TestABCI(t *testing.T) {
 }
 
 func TestAnteSurplus(t *testing.T) {
-	a := app.Setup(false, false)
+	a := testkeeper.EVMTestApp
 	k := a.EvmKeeper
 	ctx := a.GetContextForDeliverTx([]byte{})
 	m := evm.NewAppModule(nil, &k)
@@ -172,7 +173,7 @@ func TestAnteSurplus(t *testing.T) {
 
 // This test is just to make sure that the routes can be added without crashing
 func TestRoutesAddition(t *testing.T) {
-	k, _ := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
 	appModule := evm.NewAppModule(nil, k)
 	mux := runtime.NewServeMux()
 	appModule.RegisterGRPCGatewayRoutes(client.Context{}, mux)
@@ -181,7 +182,8 @@ func TestRoutesAddition(t *testing.T) {
 }
 
 func mockEVMTransactionMessage(t *testing.T) *types.MsgEVMTransaction {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	chainID := k.ChainID(ctx)
 	chainCfg := types.DefaultChainConfig()
 	ethCfg := chainCfg.EthereumConfig(chainID)

--- a/x/evm/module_test.go
+++ b/x/evm/module_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/tracing"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/sei-protocol/sei-chain/app"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
@@ -29,27 +30,26 @@ import (
 )
 
 func TestModuleName(t *testing.T) {
-	k := &testkeeper.EVMTestApp.EvmKeeper
+	k, _ := testkeeper.MockEVMKeeper()
 	module := evm.NewAppModule(nil, k)
 	assert.Equal(t, "evm", module.Name())
 }
 
 func TestModuleRoute(t *testing.T) {
-	k := &testkeeper.EVMTestApp.EvmKeeper
+	k, _ := testkeeper.MockEVMKeeper()
 	module := evm.NewAppModule(nil, k)
 	assert.Equal(t, "evm", module.Route().Path())
 	assert.Equal(t, false, module.Route().Empty())
 }
 
 func TestQuerierRoute(t *testing.T) {
-	k := &testkeeper.EVMTestApp.EvmKeeper
+	k, _ := testkeeper.MockEVMKeeper()
 	module := evm.NewAppModule(nil, k)
 	assert.Equal(t, "evm", module.QuerierRoute())
 }
 
 func TestModuleExportGenesis(t *testing.T) {
-	k := &testkeeper.EVMTestApp.EvmKeeper
-	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
+	k, ctx := testkeeper.MockEVMKeeper()
 	module := evm.NewAppModule(nil, k)
 	jsonMsg := module.ExportGenesis(ctx, types.ModuleCdc)
 	jsonStr := string(jsonMsg)
@@ -57,14 +57,13 @@ func TestModuleExportGenesis(t *testing.T) {
 }
 
 func TestConsensusVersion(t *testing.T) {
-	k := &testkeeper.EVMTestApp.EvmKeeper
+	k, _ := testkeeper.MockEVMKeeper()
 	module := evm.NewAppModule(nil, k)
 	assert.Equal(t, uint64(11), module.ConsensusVersion())
 }
 
 func TestABCI(t *testing.T) {
-	k := &testkeeper.EVMTestApp.EvmKeeper
-	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
+	k, ctx := testkeeper.MockEVMKeeper()
 	_, evmAddr1 := testkeeper.MockAddressPair()
 	_, evmAddr2 := testkeeper.MockAddressPair()
 	amt := sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(10)))
@@ -155,7 +154,7 @@ func TestABCI(t *testing.T) {
 }
 
 func TestAnteSurplus(t *testing.T) {
-	a := testkeeper.EVMTestApp
+	a := app.Setup(false, false)
 	k := a.EvmKeeper
 	ctx := a.GetContextForDeliverTx([]byte{})
 	m := evm.NewAppModule(nil, &k)
@@ -173,7 +172,7 @@ func TestAnteSurplus(t *testing.T) {
 
 // This test is just to make sure that the routes can be added without crashing
 func TestRoutesAddition(t *testing.T) {
-	k := &testkeeper.EVMTestApp.EvmKeeper
+	k, _ := testkeeper.MockEVMKeeper()
 	appModule := evm.NewAppModule(nil, k)
 	mux := runtime.NewServeMux()
 	appModule.RegisterGRPCGatewayRoutes(client.Context{}, mux)
@@ -182,8 +181,7 @@ func TestRoutesAddition(t *testing.T) {
 }
 
 func mockEVMTransactionMessage(t *testing.T) *types.MsgEVMTransaction {
-	k := &testkeeper.EVMTestApp.EvmKeeper
-	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
+	k, ctx := testkeeper.MockEVMKeeper()
 	chainID := k.ChainID(ctx)
 	chainCfg := types.DefaultChainConfig()
 	ethCfg := chainCfg.EthereumConfig(chainID)

--- a/x/evm/state/accesslist_test.go
+++ b/x/evm/state/accesslist_test.go
@@ -2,6 +2,7 @@ package state_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -12,7 +13,8 @@ import (
 )
 
 func TestAddAddressToAccessList(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	statedb := state.NewDBImpl(ctx, k, false)
 
 	_, addr := testkeeper.MockAddressPair()
@@ -28,7 +30,8 @@ func TestAddAddressToAccessList(t *testing.T) {
 }
 
 func TestAddSlotToAccessList(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	statedb := state.NewDBImpl(ctx, k, false)
 
 	_, addr := testkeeper.MockAddressPair()
@@ -45,7 +48,8 @@ func TestAddSlotToAccessList(t *testing.T) {
 }
 
 func TestAddSlotToAccessListWithNonExistentAddress(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	statedb := state.NewDBImpl(ctx, k, false)
 
 	_, addr := testkeeper.MockAddressPair()
@@ -55,7 +59,8 @@ func TestAddSlotToAccessListWithNonExistentAddress(t *testing.T) {
 }
 
 func TestPrepare(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	statedb := state.NewDBImpl(ctx, k, false)
 
 	_, sender := testkeeper.MockAddressPair()

--- a/x/evm/state/balance_test.go
+++ b/x/evm/state/balance_test.go
@@ -3,6 +3,7 @@ package state_test
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -13,7 +14,8 @@ import (
 )
 
 func TestAddBalance(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	db := state.NewDBImpl(ctx, k, false)
 	seiAddr, evmAddr := testkeeper.MockAddressPair()
 	require.Equal(t, big.NewInt(0), db.GetBalance(evmAddr))
@@ -40,7 +42,8 @@ func TestAddBalance(t *testing.T) {
 }
 
 func TestSubBalance(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	db := state.NewDBImpl(ctx, k, false)
 	seiAddr, evmAddr := testkeeper.MockAddressPair()
 	require.Equal(t, big.NewInt(0), db.GetBalance(evmAddr))
@@ -78,7 +81,8 @@ func TestSubBalance(t *testing.T) {
 }
 
 func TestSetBalance(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	db := state.NewDBImpl(ctx, k, true)
 	_, evmAddr := testkeeper.MockAddressPair()
 	db.SetBalance(evmAddr, big.NewInt(10000000000000), tracing.BalanceChangeUnspecified)
@@ -91,7 +95,8 @@ func TestSetBalance(t *testing.T) {
 }
 
 func TestSurplus(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	_, evmAddr := testkeeper.MockAddressPair()
 
 	// test negative usei surplus negative wei surplus

--- a/x/evm/state/check_test.go
+++ b/x/evm/state/check_test.go
@@ -3,6 +3,7 @@ package state_test
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/core/tracing"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
@@ -12,7 +13,8 @@ import (
 
 func TestExist(t *testing.T) {
 	// not exist
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	_, addr := testkeeper.MockAddressPair()
 	statedb := state.NewDBImpl(ctx, k, false)
 	require.False(t, statedb.Exist(addr))
@@ -35,7 +37,8 @@ func TestExist(t *testing.T) {
 
 func TestEmpty(t *testing.T) {
 	// empty
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	_, addr := testkeeper.MockAddressPair()
 	statedb := state.NewDBImpl(ctx, k, false)
 	require.True(t, statedb.Empty(addr))

--- a/x/evm/state/code_test.go
+++ b/x/evm/state/code_test.go
@@ -2,6 +2,7 @@ package state_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -11,7 +12,8 @@ import (
 )
 
 func TestCode(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	_, addr := testkeeper.MockAddressPair()
 	statedb := state.NewDBImpl(ctx, k, false)
 

--- a/x/evm/state/log_test.go
+++ b/x/evm/state/log_test.go
@@ -2,6 +2,7 @@ package state_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -11,7 +12,8 @@ import (
 )
 
 func TestAddLog(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	statedb := state.NewDBImpl(ctx, k, false)
 
 	logs := statedb.GetAllLogs()
@@ -37,7 +39,8 @@ func TestAddLog(t *testing.T) {
 }
 
 func TestLogIndex(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	statedb := state.NewDBImpl(ctx, k, false)
 	statedb.AddLog(&ethtypes.Log{})
 	statedb.Snapshot()

--- a/x/evm/state/nonce_test.go
+++ b/x/evm/state/nonce_test.go
@@ -1,15 +1,18 @@
 package state_test
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
 
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
 )
 
 func TestNonce(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	stateDB := state.NewDBImpl(ctx, k, false)
 	_, addr := testkeeper.MockAddressPair()
 	stateDB.SetNonce(addr, 1)

--- a/x/evm/state/refund_test.go
+++ b/x/evm/state/refund_test.go
@@ -2,6 +2,7 @@ package state_test
 
 import (
 	"testing"
+	"time"
 
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
@@ -9,7 +10,8 @@ import (
 )
 
 func TestGasRefund(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	statedb := state.NewDBImpl(ctx, k, false)
 
 	require.Equal(t, uint64(0), statedb.GetRefund())

--- a/x/evm/state/state_test.go
+++ b/x/evm/state/state_test.go
@@ -3,6 +3,7 @@ package state_test
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -14,7 +15,8 @@ import (
 )
 
 func TestState(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	_, evmAddr := testkeeper.MockAddressPair()
 	statedb := state.NewDBImpl(ctx, k, false)
 	statedb.CreateAccount(evmAddr)
@@ -53,7 +55,8 @@ func TestState(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	_, evmAddr := testkeeper.MockAddressPair()
 	statedb := state.NewDBImpl(ctx, k, false)
 	statedb.CreateAccount(evmAddr)
@@ -86,7 +89,8 @@ func TestCreate(t *testing.T) {
 }
 
 func TestSelfDestructAssociated(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	seiAddr, evmAddr := testkeeper.MockAddressPair()
 	k.SetAddressMapping(ctx, seiAddr, evmAddr)
 	statedb := state.NewDBImpl(ctx, k, false)
@@ -130,7 +134,8 @@ func TestSelfDestructAssociated(t *testing.T) {
 }
 
 func TestSnapshot(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	seiAddr, evmAddr := testkeeper.MockAddressPair()
 	k.SetAddressMapping(ctx, seiAddr, evmAddr)
 	eventCount := len(ctx.EventManager().Events())

--- a/x/evm/state/transfer_test.go
+++ b/x/evm/state/transfer_test.go
@@ -3,6 +3,7 @@ package state_test
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
@@ -10,7 +11,8 @@ import (
 )
 
 func TestEventlessTransfer(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	db := state.NewDBImpl(ctx, k, false)
 	_, fromAddr := testkeeper.MockAddressPair()
 	_, toAddr := testkeeper.MockAddressPair()

--- a/x/evm/types/constants.go
+++ b/x/evm/types/constants.go
@@ -1,0 +1,3 @@
+package types
+
+const MaxAssociateCustomMessageLength = 64

--- a/x/evm/types/message_associate.go
+++ b/x/evm/types/message_associate.go
@@ -40,6 +40,9 @@ func (msg *MsgAssociate) ValidateBasic() error {
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "Invalid sender address (%s)", err)
 	}
+	if len(msg.CustomMessage) > MaxAssociateCustomMessageLength {
+		return sdkerrors.Wrapf(sdkerrors.ErrTxTooLarge, "custom message can have at most 64 characters")
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Describe your changes and provide context
- add length check for `CustomMessage` field on associate message type (both cosmos and EVM)
- add number of message check to so that only tx with exactly 1 associate message will be considered gasless

## Testing performed to validate your change
integration tests

