### PR TITLE
Increase timeout for evm hardhat tests

### DIFF
--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -14,6 +14,9 @@ module.exports = {
       },
     },
   },
+  mocha: {
+    timeout: 100000000,
+  },
   paths: {
     sources: "./src", // contracts are in ./src
   },


### PR DESCRIPTION
## Describe your changes and provide context
There has been a high occurrence of EVM integration tests flaking recently due to timeouts being exceeded during tests, this increases timeouts such that we no longer have this flakiness during the first run of integration tests where all of them are running at the same time.

## Testing performed to validate your change
CI
