### PR TITLE
Fork event manager when creating EVM snapshots

### DIFF
--- a/precompiles/pointer/pointer_test.go
+++ b/precompiles/pointer/pointer_test.go
@@ -52,7 +52,7 @@ func TestAddNative(t *testing.T) {
 			Aliases:  []string{"DENOM"},
 		}},
 	})
-	statedb = state.NewDBImpl(ctx, &testApp.EvmKeeper, true)
+	statedb = state.NewDBImpl(ctx, &testApp.EvmKeeper, false)
 	evm = vm.NewEVM(*blockCtx, vm.TxContext{}, statedb, cfg, vm.Config{})
 	ret, g, err := p.RunAndCalculateGas(evm, caller, caller, append(p.GetExecutor().(*pointer.PrecompileExecutor).AddNativePointerID, args...), suppliedGas, nil, nil, false)
 	require.Nil(t, err)
@@ -64,6 +64,8 @@ func TestAddNative(t *testing.T) {
 	require.Equal(t, addr, pointerAddr)
 	require.Equal(t, native.CurrentVersion, version)
 	require.True(t, exists)
+	_, err = statedb.Finalize()
+	require.Nil(t, err)
 	hasRegisteredEvent := false
 	for _, e := range ctx.EventManager().Events() {
 		if e.Type != types.EventTypePointerRegistered {

--- a/x/evm/state/state.go
+++ b/x/evm/state/state.go
@@ -93,7 +93,7 @@ func (s *DBImpl) HasSelfDestructed(acc common.Address) bool {
 }
 
 func (s *DBImpl) Snapshot() int {
-	newCtx := s.ctx.WithMultiStore(s.ctx.MultiStore().CacheMultiStore())
+	newCtx := s.ctx.WithMultiStore(s.ctx.MultiStore().CacheMultiStore()).WithEventManager(sdk.NewEventManager())
 	s.snapshottedCtxs = append(s.snapshottedCtxs, s.ctx)
 	s.ctx = newCtx
 	s.tempStatesHist = append(s.tempStatesHist, s.tempStateCurrent)


### PR DESCRIPTION
## Describe your changes and provide context
Create a new event manager when snapshots are created so that events created in the new snapshot can be cleanly reverted when the snapshot itself is reverted.

Not apphash-breaking because events are not part of consensus

## Testing performed to validate your change
unit test
