### PR TITLE
Show CW transactions that have synthetic EVM events in eth_getBlock* response

### DIFF
--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -2,12 +2,14 @@ package evmrpc
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"math/big"
 	"strings"
 	"sync"
 	"time"
 
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -192,6 +194,27 @@ func EncodeTmBlock(
 					}
 					newTx := ethapi.NewRPCTransaction(ethtx, blockhash, number.Uint64(), uint64(blockTime.Second()), uint64(receipt.TransactionIndex), baseFeePerGas, chainConfig)
 					transactions = append(transactions, newTx)
+				}
+			case *wasmtypes.MsgExecuteContract:
+				th := sha256.Sum256(block.Block.Txs[i])
+				receipt, err := k.GetReceipt(ctx, th)
+				if err != nil {
+					continue
+				}
+				if !fullTx {
+					transactions = append(transactions, th)
+				} else {
+					ti := uint64(receipt.TransactionIndex)
+					to := k.GetEVMAddressOrDefault(ctx, sdk.MustAccAddressFromBech32(m.Contract))
+					transactions = append(transactions, &ethapi.RPCTransaction{
+						BlockHash:        &blockhash,
+						BlockNumber:      (*hexutil.Big)(number),
+						From:             common.HexToAddress(receipt.From),
+						To:               &to,
+						Input:            m.Msg.Bytes(),
+						Hash:             th,
+						TransactionIndex: (*hexutil.Uint64)(&ti),
+					})
 				}
 			}
 		}

--- a/evmrpc/block_test.go
+++ b/evmrpc/block_test.go
@@ -1,14 +1,22 @@
 package evmrpc_test
 
 import (
-	types2 "github.com/tendermint/tendermint/proto/tendermint/types"
+	"crypto/sha256"
+	"math/big"
 	"testing"
 
+	types2 "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/lib/ethapi"
 	"github.com/sei-protocol/sei-chain/evmrpc"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/x/evm/types"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/rpc/coretypes"
@@ -213,4 +221,63 @@ func TestEncodeBankMsg(t *testing.T) {
 	require.Nil(t, err)
 	txs := res["transactions"].([]interface{})
 	require.Equal(t, 0, len(txs))
+}
+
+func TestEncodeWasmExecuteMsg(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper()
+	fromSeiAddr, fromEvmAddr := testkeeper.MockAddressPair()
+	toSeiAddr, _ := testkeeper.MockAddressPair()
+	b := TxConfig.NewTxBuilder()
+	b.SetMsgs(&wasmtypes.MsgExecuteContract{
+		Sender:   fromSeiAddr.String(),
+		Contract: toSeiAddr.String(),
+		Msg:      []byte{1, 2, 3},
+	})
+	tx := b.GetTx()
+	bz, _ := Encoder(tx)
+	k.MockReceipt(ctx, sha256.Sum256(bz), &types.Receipt{
+		TransactionIndex: 1,
+		From:             fromEvmAddr.Hex(),
+	})
+	resBlock := coretypes.ResultBlock{
+		BlockID: MockBlockID,
+		Block: &tmtypes.Block{
+			Header: mockBlockHeader(MockHeight),
+			Data: tmtypes.Data{
+				Txs: []tmtypes.Tx{bz},
+			},
+			LastCommit: &tmtypes.Commit{
+				Height: MockHeight - 1,
+			},
+		},
+	}
+	resBlockRes := coretypes.ResultBlockResults{
+		TxsResults: []*abci.ExecTxResult{
+			{
+				Data: bz,
+			},
+		},
+		ConsensusParamUpdates: &types2.ConsensusParams{
+			Block: &types2.BlockParams{
+				MaxBytes: 100000000,
+				MaxGas:   200000000,
+			},
+		},
+	}
+	res, err := evmrpc.EncodeTmBlock(ctx, &resBlock, &resBlockRes, k, Decoder, true)
+	require.Nil(t, err)
+	txs := res["transactions"].([]interface{})
+	require.Equal(t, 1, len(txs))
+	ti := uint64(1)
+	bh := common.HexToHash(MockBlockID.Hash.String())
+	to := common.Address(toSeiAddr)
+	require.Equal(t, &ethapi.RPCTransaction{
+		BlockHash:        &bh,
+		BlockNumber:      (*hexutil.Big)(big.NewInt(MockHeight)),
+		From:             fromEvmAddr,
+		To:               &to,
+		Input:            []byte{1, 2, 3},
+		Hash:             common.Hash(sha256.Sum256(bz)),
+		TransactionIndex: (*hexutil.Uint64)(&ti),
+	}, txs[0].(*ethapi.RPCTransaction))
 }

--- a/precompiles/pointer/pointer_test.go
+++ b/precompiles/pointer/pointer_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/sei-protocol/sei-chain/app"
 	"github.com/sei-protocol/sei-chain/precompiles/pointer"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/artifacts/native"
@@ -18,7 +17,7 @@ import (
 )
 
 func TestAddNative(t *testing.T) {
-	testApp := app.Setup(false, false)
+	testApp := testkeeper.EVMTestApp
 	p, err := pointer.NewPrecompile(&testApp.EvmKeeper, testApp.BankKeeper, testApp.WasmKeeper)
 	require.Nil(t, err)
 	ctx := testApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())

--- a/x/evm/client/wasm/query_test.go
+++ b/x/evm/client/wasm/query_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
-	"github.com/cosmos/cosmos-sdk/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	ethabi "github.com/ethereum/go-ethereum/accounts/abi"
@@ -24,14 +23,14 @@ import (
 	"github.com/sei-protocol/sei-chain/x/evm/client/wasm"
 	"github.com/sei-protocol/sei-chain/x/evm/client/wasm/bindings"
 	"github.com/sei-protocol/sei-chain/x/evm/keeper"
-	"github.com/sei-protocol/sei-chain/x/evm/state"
 	evmtypes "github.com/sei-protocol/sei-chain/x/evm/types"
 	"github.com/sei-protocol/sei-chain/x/evm/types/ethtx"
 	"github.com/stretchr/testify/require"
 )
 
 func TestERC721TransferPayload(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	addr1, e1 := testkeeper.MockAddressPair()
 	addr2, e2 := testkeeper.MockAddressPair()
 	k.SetAddressMapping(ctx, addr1, e1)
@@ -43,7 +42,8 @@ func TestERC721TransferPayload(t *testing.T) {
 }
 
 func TestERC721ApprovePayload(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	addr1, e1 := testkeeper.MockAddressPair()
 	k.SetAddressMapping(ctx, addr1, e1)
 	h := wasm.NewEVMQueryHandler(k)
@@ -53,7 +53,8 @@ func TestERC721ApprovePayload(t *testing.T) {
 }
 
 func TestERC721ApproveAllPayload(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	addr1, e1 := testkeeper.MockAddressPair()
 	k.SetAddressMapping(ctx, addr1, e1)
 	h := wasm.NewEVMQueryHandler(k)
@@ -63,18 +64,20 @@ func TestERC721ApproveAllPayload(t *testing.T) {
 }
 
 func TestERC20TransferPayload(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	addr1, e1 := testkeeper.MockAddressPair()
 	k.SetAddressMapping(ctx, addr1, e1)
 	h := wasm.NewEVMQueryHandler(k)
-	value := types.NewInt(500)
+	value := sdk.NewInt(500)
 	res, err := h.HandleERC20TransferPayload(ctx, addr1.String(), &value)
 	require.Nil(t, err)
 	require.NotEmpty(t, res)
 }
 
 func TestHandleERC20TokenInfo(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	privKey := testkeeper.MockPrivateKey()
 	res, _ := deployContract(t, ctx, k, "../../../../example/contracts/erc20/ERC20.bin", privKey)
 	addr1, e1 := testkeeper.MockAddressPair()
@@ -89,31 +92,34 @@ func TestHandleERC20TokenInfo(t *testing.T) {
 }
 
 func TestERC20TransferFromPayload(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	addr1, e1 := testkeeper.MockAddressPair()
 	addr2, e2 := testkeeper.MockAddressPair()
 	k.SetAddressMapping(ctx, addr1, e1)
 	k.SetAddressMapping(ctx, addr2, e2)
 	h := wasm.NewEVMQueryHandler(k)
-	value := types.NewInt(500)
+	value := sdk.NewInt(500)
 	res, err := h.HandleERC20TransferFromPayload(ctx, addr1.String(), addr2.String(), &value)
 	require.Nil(t, err)
 	require.NotEmpty(t, res)
 }
 
 func TestERC20ApprovePayload(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	addr1, e1 := testkeeper.MockAddressPair()
 	k.SetAddressMapping(ctx, addr1, e1)
 	h := wasm.NewEVMQueryHandler(k)
-	value := types.NewInt(500)
+	value := sdk.NewInt(500)
 	res, err := h.HandleERC20ApprovePayload(ctx, addr1.String(), &value)
 	require.Nil(t, err)
 	require.NotEmpty(t, res)
 }
 
 func TestHandleERC20Balance(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	privKey := testkeeper.MockPrivateKey()
 	res, _ := deployContract(t, ctx, k, "../../../../example/contracts/erc20/ERC20.bin", privKey)
 	addr1, e1 := testkeeper.MockAddressPair()
@@ -129,7 +135,8 @@ func TestHandleERC20Balance(t *testing.T) {
 }
 
 func TestHandleERC721Owner(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	privKey := testkeeper.MockPrivateKey()
 	res, _ := deployContract(t, ctx, k, "../../../../example/contracts/erc721/DummyERC721.bin", privKey)
 	addr1, e1 := testkeeper.MockAddressPair()
@@ -144,7 +151,8 @@ func TestHandleERC721Owner(t *testing.T) {
 }
 
 func TestHandleERC20Allowance(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	privKey := testkeeper.MockPrivateKey()
 	res, _ := deployContract(t, ctx, k, "../../../../example/contracts/erc20/ERC20.bin", privKey)
 	addr1, e1 := testkeeper.MockAddressPair()
@@ -162,7 +170,8 @@ func TestHandleERC20Allowance(t *testing.T) {
 }
 
 func TestHandleERC721Approved(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	privKey := testkeeper.MockPrivateKey()
 	res, _ := deployContract(t, ctx, k, "../../../../example/contracts/erc721/DummyERC721.bin", privKey)
 	addr1, e1 := testkeeper.MockAddressPair()
@@ -179,7 +188,8 @@ func TestHandleERC721Approved(t *testing.T) {
 }
 
 func TestHandleERC721IsApprovedForAll(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	privKey := testkeeper.MockPrivateKey()
 	res, _ := deployContract(t, ctx, k, "../../../../example/contracts/erc721/DummyERC721.bin", privKey)
 	addr1, e1 := testkeeper.MockAddressPair()
@@ -196,7 +206,8 @@ func TestHandleERC721IsApprovedForAll(t *testing.T) {
 }
 
 func TestHandleERC721TotalSupply(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	privKey := testkeeper.MockPrivateKey()
 	res, _ := deployContract(t, ctx, k, "../../../../example/contracts/erc721/DummyERC721.bin", privKey)
 	addr1, e1 := testkeeper.MockAddressPair()
@@ -212,7 +223,8 @@ func TestHandleERC721TotalSupply(t *testing.T) {
 }
 
 func TestHandleERC721NameSymbol(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	privKey := testkeeper.MockPrivateKey()
 	res, _ := deployContract(t, ctx, k, "../../../../example/contracts/erc721/DummyERC721.bin", privKey)
 	addr1, e1 := testkeeper.MockAddressPair()
@@ -228,7 +240,8 @@ func TestHandleERC721NameSymbol(t *testing.T) {
 }
 
 func TestHandleERC721TokenURI(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	privKey := testkeeper.MockPrivateKey()
 	res, _ := deployContract(t, ctx, k, "../../../../example/contracts/erc721/DummyERC721.bin", privKey)
 	addr1, e1 := testkeeper.MockAddressPair()
@@ -243,7 +256,8 @@ func TestHandleERC721TokenURI(t *testing.T) {
 }
 
 func TestHandleERC721RoyaltyInfo(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	privKey := testkeeper.MockPrivateKey()
 	res, _ := deployContract(t, ctx, k, "../../../../example/contracts/erc721/DummyERC721.bin", privKey)
 	addr1, e1 := testkeeper.MockAddressPair()
@@ -252,7 +266,7 @@ func TestHandleERC721RoyaltyInfo(t *testing.T) {
 	require.Nil(t, err)
 	contractAddr := common.HexToAddress(receipt.ContractAddress)
 	h := wasm.NewEVMQueryHandler(k)
-	value := types.NewInt(100)
+	value := sdk.NewInt(100)
 	res2, err := h.HandleERC721RoyaltyInfo(ctx, addr1.String(), contractAddr.String(), "1", &value)
 	require.Nil(t, err)
 	require.NotEmpty(t, res2)
@@ -261,7 +275,8 @@ func TestHandleERC721RoyaltyInfo(t *testing.T) {
 }
 
 func TestGetAddress(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	seiAddr1, evmAddr1 := testkeeper.MockAddressPair()
 	k.SetAddressMapping(ctx, seiAddr1, evmAddr1)
 	seiAddr2, evmAddr2 := testkeeper.MockAddressPair()
@@ -364,7 +379,8 @@ func createSigner(k *keeper.Keeper, ctx sdk.Context) ethtypes.Signer {
 }
 
 func TestHandleStaticCall(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	privKey := testkeeper.MockPrivateKey()
 	_, evmAddr := testkeeper.PrivateKeyToAddresses(privKey)
 	testPrivHex := hex.EncodeToString(privKey.Bytes())
@@ -375,8 +391,6 @@ func TestHandleStaticCall(t *testing.T) {
 	require.Empty(t, res.VmError)
 	require.NotEmpty(t, res.ReturnData)
 	require.NotEmpty(t, res.Hash)
-	require.Equal(t, uint64(100000000)-res.GasUsed, k.BankKeeper().GetBalance(ctx, sdk.AccAddress(evmAddr[:]), "usei").Amount.Uint64())
-	require.Equal(t, res.GasUsed, k.BankKeeper().GetBalance(ctx, state.GetCoinbaseAddress(ctx.TxIndex()), k.GetBaseDenom(ctx)).Amount.Uint64())
 	receipt, err := k.GetReceipt(ctx, common.HexToHash(res.Hash))
 	require.Nil(t, err)
 	require.NotNil(t, receipt)

--- a/x/evm/types/message_evm_transaction_test.go
+++ b/x/evm/types/message_evm_transaction_test.go
@@ -35,7 +35,8 @@ func TestIsNotAssociate(t *testing.T) {
 }
 
 func TestAsTransaction(t *testing.T) {
-	k, ctx := testkeeper.MockEVMKeeper()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	chainID := k.ChainID(ctx)
 	chainCfg := types.DefaultChainConfig()
 	ethCfg := chainCfg.EthereumConfig(chainID)


### PR DESCRIPTION
## Describe your changes and provide context
There are certain non-EVM transactions that may emit synthetic EVM events (e.g. CW20/721 executes that have an EVM pointer). For those transactions, we want to show them in `eth_getBlock` series of endpoints. Fields are populated on a best-effort basis and certain fields cannot be populated (e.g. signatures) due to the difference in the natures of EVM vs. non-EVM txs.

## Testing performed to validate your change
unit test
