### PR TITLE
Check TX nonce before registering hook to bump nonce for failed tx

### DIFF
--- a/x/evm/ante/basic.go
+++ b/x/evm/ante/basic.go
@@ -28,7 +28,8 @@ func (gl BasicDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, n
 
 	if msg.Derived != nil && !gl.k.EthReplayConfig.Enabled && !gl.k.EthBlockTestConfig.Enabled {
 		startingNonce := gl.k.GetNonce(ctx, msg.Derived.SenderEVMAddr)
-		if !ctx.IsCheckTx() && !ctx.IsReCheckTx() {
+		txNonce := etx.Nonce()
+		if !ctx.IsCheckTx() && !ctx.IsReCheckTx() && startingNonce == txNonce {
 			ctx = ctx.WithDeliverTxCallback(func(callCtx sdk.Context) {
 				// bump nonce if it is for some reason not incremented (e.g. ante failure)
 				if gl.k.GetNonce(callCtx, msg.Derived.SenderEVMAddr) == startingNonce {

--- a/x/evm/ante/fee.go
+++ b/x/evm/ante/fee.go
@@ -76,7 +76,7 @@ func (fc EVMFeeCheckDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 		// we don't want to run nonce check here for CheckTx because we have special
 		// logic for pending nonce during CheckTx in sig.go
 		if err := st.StatelessChecks(); err != nil {
-			return ctx, err
+			return ctx, sdkerrors.Wrap(sdkerrors.ErrWrongSequence, err.Error())
 		}
 	}
 	if err := st.BuyGas(); err != nil {

--- a/x/evm/integration_test.go
+++ b/x/evm/integration_test.go
@@ -288,6 +288,11 @@ func TestNonceIncrementsForInsufficientFunds(t *testing.T) {
 	res := testkeeper.EVMTestApp.DeliverTx(ctx, abci.RequestDeliverTx{Tx: txbz}, cosmosTx, sha256.Sum256(txbz))
 	require.Equal(t, uint32(5), res.Code)                 // insufficient funds has error code 5
 	require.Equal(t, uint64(1), k.GetNonce(ctx, evmAddr)) // make sure nonce is incremented regardless
+
+	// ensure that old txs cannot be used by malicious party to bump nonces
+	res = testkeeper.EVMTestApp.DeliverTx(ctx, abci.RequestDeliverTx{Tx: txbz}, cosmosTx, sha256.Sum256(txbz))
+	require.Equal(t, uint32(32), res.Code)                // wrong nonce has error code 32
+	require.Equal(t, uint64(1), k.GetNonce(ctx, evmAddr)) // nonce should not be incremented this time because the tx is an old one
 }
 
 func TestInvalidAssociateMsg(t *testing.T) {


### PR DESCRIPTION
## Describe your changes and provide context
We want a failed tx to still bump account's nonce only if that tx is having a valid nonce and failing for other reasons. This PR adds a check so that the bump-for-failed logic only runs for txs with valid nonces.

## Testing performed to validate your change
unit test

