### PR TITLE
Properly handle gas in pointer precompile

### DIFF
--- a/precompiles/common/expected_keepers.go
+++ b/precompiles/common/expected_keepers.go
@@ -48,14 +48,16 @@ type EVMKeeper interface {
 	GetERC721CW721Pointer(ctx sdk.Context, cw721Address string) (addr common.Address, version uint16, exists bool)
 	SetCode(ctx sdk.Context, addr common.Address, code []byte)
 	UpsertERCNativePointer(
-		ctx sdk.Context, evm *vm.EVM, suppliedGas uint64, token string, metadata utils.ERCMetadata,
-	) (contractAddr common.Address, remainingGas uint64, err error)
+		ctx sdk.Context, evm *vm.EVM, token string, metadata utils.ERCMetadata,
+	) (contractAddr common.Address, err error)
 	UpsertERCCW20Pointer(
-		ctx sdk.Context, evm *vm.EVM, suppliedGas uint64, cw20Addr string, metadata utils.ERCMetadata,
-	) (contractAddr common.Address, remainingGas uint64, err error)
+		ctx sdk.Context, evm *vm.EVM, cw20Addr string, metadata utils.ERCMetadata,
+	) (contractAddr common.Address, err error)
 	UpsertERCCW721Pointer(
-		ctx sdk.Context, evm *vm.EVM, suppliedGas uint64, cw721Addr string, metadata utils.ERCMetadata,
-	) (contractAddr common.Address, remainingGas uint64, err error)
+		ctx sdk.Context, evm *vm.EVM, cw721Addr string, metadata utils.ERCMetadata,
+	) (contractAddr common.Address, err error)
+	GetEVMGasLimitFromCtx(ctx sdk.Context) uint64
+	GetCosmosGasLimitFromEVMGas(ctx sdk.Context, evmGas uint64) uint64
 }
 
 type AccountKeeper interface {

--- a/precompiles/common/precompiles.go
+++ b/precompiles/common/precompiles.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/sei-protocol/sei-chain/utils"
 	"github.com/sei-protocol/sei-chain/utils/metrics"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
@@ -160,12 +159,7 @@ func (d DynamicGasPrecompile) RunAndCalculateGas(evm *vm.EVM, caller common.Addr
 	if err != nil {
 		return nil, 0, err
 	}
-	gasMultipler := d.executor.EVMKeeper().GetPriorityNormalizer(ctx)
-	gasLimitBigInt := sdk.NewDecFromInt(sdk.NewIntFromUint64(suppliedGas)).Mul(gasMultipler).TruncateInt().BigInt()
-	if gasLimitBigInt.Cmp(utils.BigMaxU64) > 0 {
-		gasLimitBigInt = utils.BigMaxU64
-	}
-	ctx = ctx.WithGasMeter(sdk.NewGasMeterWithMultiplier(ctx, gasLimitBigInt.Uint64()))
+	ctx = ctx.WithGasMeter(sdk.NewGasMeterWithMultiplier(ctx, d.executor.EVMKeeper().GetCosmosGasLimitFromEVMGas(ctx, suppliedGas)))
 
 	operation = method.Name
 	em := ctx.EventManager()
@@ -231,9 +225,7 @@ sei gas = evm gas * multiplier
 sei gas price = fee / sei gas = fee / (evm gas * multiplier) = evm gas / multiplier
 */
 func GetRemainingGas(ctx sdk.Context, evmKeeper EVMKeeper) uint64 {
-	gasMultipler := evmKeeper.GetPriorityNormalizer(ctx)
-	seiGasRemaining := ctx.GasMeter().Limit() - ctx.GasMeter().GasConsumedToLimit()
-	return sdk.NewDecFromInt(sdk.NewIntFromUint64(seiGasRemaining)).Quo(gasMultipler).TruncateInt().Uint64()
+	return evmKeeper.GetEVMGasLimitFromCtx(ctx)
 }
 
 func ExtractMethodID(input []byte) ([]byte, error) {

--- a/precompiles/distribution/distribution_test.go
+++ b/precompiles/distribution/distribution_test.go
@@ -148,7 +148,7 @@ func TestWithdraw(t *testing.T) {
 	res, err = msgServer.EVMTransaction(sdk.WrapSDKContext(ctx), req)
 	require.Nil(t, err)
 	require.Empty(t, res.VmError)
-	require.Equal(t, uint64(69808), res.GasUsed)
+	require.Equal(t, uint64(64124), res.GasUsed)
 
 	// reinitialized
 	d, found = testApp.StakingKeeper.GetDelegation(ctx, seiAddr, val)
@@ -301,7 +301,7 @@ func setWithdrawAddressAndWithdraw(
 	res, err = msgServer.EVMTransaction(sdk.WrapSDKContext(ctx), r)
 	require.Nil(t, err)
 	require.Empty(t, res.VmError)
-	require.Equal(t, uint64(153974), res.GasUsed)
+	require.Equal(t, uint64(148290), res.GasUsed)
 
 	// reinitialized
 	for _, val := range vals {
@@ -1051,7 +1051,7 @@ func TestPrecompile_RunAndCalculateGas_Rewards(t *testing.T) {
 				suppliedGas:      uint64(1000000),
 			},
 			wantRet:          emptyCasePackedOutput,
-			wantRemainingGas: 993193,
+			wantRemainingGas: 998877,
 			wantErr:          false,
 		},
 		{
@@ -1067,7 +1067,7 @@ func TestPrecompile_RunAndCalculateGas_Rewards(t *testing.T) {
 				suppliedGas:      uint64(1000000),
 			},
 			wantRet:          happyPathPackedOutput,
-			wantRemainingGas: 993193,
+			wantRemainingGas: 998877,
 			wantErr:          false,
 		},
 	}

--- a/precompiles/ibc/ibc_test.go
+++ b/precompiles/ibc/ibc_test.go
@@ -106,7 +106,7 @@ func TestPrecompile_Run(t *testing.T) {
 			fields:           fields{transferKeeper: &MockTransferKeeper{}},
 			args:             commonArgs,
 			wantBz:           packedTrue,
-			wantRemainingGas: 993193,
+			wantRemainingGas: 998877,
 			wantErr:          false,
 		},
 		{
@@ -235,7 +235,7 @@ func TestPrecompile_Run(t *testing.T) {
 				value:       nil,
 			},
 			wantBz:           packedTrue,
-			wantRemainingGas: 993193,
+			wantRemainingGas: 998877,
 			wantErr:          false,
 		},
 		{
@@ -255,7 +255,7 @@ func TestPrecompile_Run(t *testing.T) {
 				value:       nil,
 			},
 			wantBz:           packedTrue,
-			wantRemainingGas: 993193,
+			wantRemainingGas: 998877,
 			wantErr:          false,
 		},
 	}

--- a/precompiles/pointer/pointer_test.go
+++ b/precompiles/pointer/pointer_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
@@ -21,6 +22,7 @@ func TestAddNative(t *testing.T) {
 	p, err := pointer.NewPrecompile(&testApp.EvmKeeper, testApp.BankKeeper, testApp.WasmKeeper)
 	require.Nil(t, err)
 	ctx := testApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeterWithMultiplier(ctx))
 	_, caller := testkeeper.MockAddressPair()
 	suppliedGas := uint64(10000000)
 	cfg := types.DefaultChainConfig().EthereumConfig(testApp.EvmKeeper.ChainID(ctx))
@@ -55,7 +57,7 @@ func TestAddNative(t *testing.T) {
 	evm = vm.NewEVM(*blockCtx, vm.TxContext{}, statedb, cfg, vm.Config{})
 	ret, g, err := p.RunAndCalculateGas(evm, caller, caller, append(p.GetExecutor().(*pointer.PrecompileExecutor).AddNativePointerID, args...), suppliedGas, nil, nil, false)
 	require.Nil(t, err)
-	require.Equal(t, uint64(8907806), g)
+	require.Equal(t, uint64(8888494), g)
 	outputs, err := m.Outputs.Unpack(ret)
 	require.Nil(t, err)
 	addr := outputs[0].(common.Address)

--- a/x/evm/gov.go
+++ b/x/evm/gov.go
@@ -20,7 +20,7 @@ func HandleAddERCNativePointerProposalV2(ctx sdk.Context, k *keeper.Keeper, p *t
 	}
 	return k.RunWithOneOffEVMInstance(
 		ctx, func(e *vm.EVM) error {
-			_, _, err := k.UpsertERCNativePointer(ctx, e, math.MaxUint64, p.Token, utils.ERCMetadata{Name: p.Name, Symbol: p.Symbol, Decimals: decimals})
+			_, err := k.UpsertERCNativePointer(ctx, e, p.Token, utils.ERCMetadata{Name: p.Name, Symbol: p.Symbol, Decimals: decimals})
 			return err
 		}, func(s1, s2 string) {
 			logNativeV2Error(ctx, p, s1, s2)

--- a/x/evm/keeper/params.go
+++ b/x/evm/keeper/params.go
@@ -50,3 +50,21 @@ func (k *Keeper) ChainID(ctx sdk.Context) *big.Int {
 	return config.GetEVMChainID(ctx.ChainID())
 
 }
+
+/*
+*
+sei gas = evm gas * multiplier
+sei gas price = fee / sei gas = fee / (evm gas * multiplier) = evm gas / multiplier
+*/
+func (k *Keeper) GetEVMGasLimitFromCtx(ctx sdk.Context) uint64 {
+	return k.getEvmGasLimitFromCtx(ctx)
+}
+
+func (k *Keeper) GetCosmosGasLimitFromEVMGas(ctx sdk.Context, evmGas uint64) uint64 {
+	gasMultipler := k.GetPriorityNormalizer(ctx)
+	gasLimitBigInt := sdk.NewDecFromInt(sdk.NewIntFromUint64(evmGas)).Mul(gasMultipler).TruncateInt().BigInt()
+	if gasLimitBigInt.Cmp(utils.BigMaxU64) > 0 {
+		gasLimitBigInt = utils.BigMaxU64
+	}
+	return gasLimitBigInt.Uint64()
+}

--- a/x/evm/keeper/pointer_upgrade_test.go
+++ b/x/evm/keeper/pointer_upgrade_test.go
@@ -2,10 +2,10 @@ package keeper_test
 
 import (
 	"errors"
-	"math"
 	"testing"
 	"time"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
@@ -31,9 +31,10 @@ func TestRunWithOneOffEVMInstance(t *testing.T) {
 func TestUpsertERCNativePointer(t *testing.T) {
 	k := &testkeeper.EVMTestApp.EvmKeeper
 	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeterWithMultiplier(ctx))
 	var addr common.Address
 	err := k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
-		a, _, err := k.UpsertERCNativePointer(ctx, e, math.MaxUint64, "test", utils.ERCMetadata{
+		a, err := k.UpsertERCNativePointer(ctx, e, "test", utils.ERCMetadata{
 			Name:     "test",
 			Symbol:   "test",
 			Decimals: 6,
@@ -44,7 +45,7 @@ func TestUpsertERCNativePointer(t *testing.T) {
 	require.Nil(t, err)
 	var newAddr common.Address
 	err = k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
-		a, _, err := k.UpsertERCNativePointer(ctx, e, math.MaxUint64, "test", utils.ERCMetadata{
+		a, err := k.UpsertERCNativePointer(ctx, e, "test", utils.ERCMetadata{
 			Name:     "test2",
 			Symbol:   "test2",
 			Decimals: 12,
@@ -70,9 +71,10 @@ func TestUpsertERCNativePointer(t *testing.T) {
 func TestUpsertERC20Pointer(t *testing.T) {
 	k := &testkeeper.EVMTestApp.EvmKeeper
 	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeterWithMultiplier(ctx))
 	var addr common.Address
 	err := k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
-		a, _, err := k.UpsertERCCW20Pointer(ctx, e, math.MaxUint64, "test", utils.ERCMetadata{
+		a, err := k.UpsertERCCW20Pointer(ctx, e, "test", utils.ERCMetadata{
 			Name:   "test",
 			Symbol: "test",
 		})
@@ -82,7 +84,7 @@ func TestUpsertERC20Pointer(t *testing.T) {
 	require.Nil(t, err)
 	var newAddr common.Address
 	err = k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
-		a, _, err := k.UpsertERCCW20Pointer(ctx, e, math.MaxUint64, "test", utils.ERCMetadata{
+		a, err := k.UpsertERCCW20Pointer(ctx, e, "test", utils.ERCMetadata{
 			Name:   "test2",
 			Symbol: "test2",
 		})
@@ -96,9 +98,10 @@ func TestUpsertERC20Pointer(t *testing.T) {
 func TestUpsertERC721Pointer(t *testing.T) {
 	k := &testkeeper.EVMTestApp.EvmKeeper
 	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeterWithMultiplier(ctx))
 	var addr common.Address
 	err := k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
-		a, _, err := k.UpsertERCCW721Pointer(ctx, e, math.MaxUint64, "test", utils.ERCMetadata{
+		a, err := k.UpsertERCCW721Pointer(ctx, e, "test", utils.ERCMetadata{
 			Name:   "test",
 			Symbol: "test",
 		})
@@ -108,7 +111,7 @@ func TestUpsertERC721Pointer(t *testing.T) {
 	require.Nil(t, err)
 	var newAddr common.Address
 	err = k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
-		a, _, err := k.UpsertERCCW721Pointer(ctx, e, math.MaxUint64, "test", utils.ERCMetadata{
+		a, err := k.UpsertERCCW721Pointer(ctx, e, "test", utils.ERCMetadata{
 			Name:   "test2",
 			Symbol: "test2",
 		})

--- a/x/evm/migrations/migrate_all_pointers.go
+++ b/x/evm/migrations/migrate_all_pointers.go
@@ -3,7 +3,6 @@ package migrations
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -41,7 +40,7 @@ func MigrateERCNativePointers(ctx sdk.Context, k *keeper.Keeper) error {
 			continue
 		}
 		_ = k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
-			_, _, err := k.UpsertERCNativePointer(ctx, e, math.MaxUint64, token, utils.ERCMetadata{
+			_, err := k.UpsertERCNativePointer(ctx.WithGasMeter(sdk.NewInfiniteGasMeterWithMultiplier(ctx)), e, token, utils.ERCMetadata{
 				Name:     oName.(string),
 				Symbol:   oSymbol.(string),
 				Decimals: oDecimals.(uint8),
@@ -76,7 +75,7 @@ func MigrateERCCW20Pointers(ctx sdk.Context, k *keeper.Keeper) error {
 			continue
 		}
 		_ = k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
-			_, _, err := k.UpsertERCCW20Pointer(ctx, e, math.MaxUint64, cwAddr, utils.ERCMetadata{
+			_, err := k.UpsertERCCW20Pointer(ctx.WithGasMeter(sdk.NewInfiniteGasMeterWithMultiplier(ctx)), e, cwAddr, utils.ERCMetadata{
 				Name:   oName.(string),
 				Symbol: oSymbol.(string),
 			})
@@ -110,7 +109,7 @@ func MigrateERCCW721Pointers(ctx sdk.Context, k *keeper.Keeper) error {
 			continue
 		}
 		_ = k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
-			_, _, err := k.UpsertERCCW721Pointer(ctx, e, math.MaxUint64, cwAddr, utils.ERCMetadata{
+			_, err := k.UpsertERCCW721Pointer(ctx.WithGasMeter(sdk.NewInfiniteGasMeterWithMultiplier(ctx)), e, cwAddr, utils.ERCMetadata{
 				Name:   oName.(string),
 				Symbol: oSymbol.(string),
 			})

--- a/x/evm/migrations/migrate_all_pointers_test.go
+++ b/x/evm/migrations/migrate_all_pointers_test.go
@@ -1,7 +1,6 @@
 package migrations_test
 
 import (
-	"math"
 	"testing"
 	"time"
 
@@ -21,7 +20,7 @@ func TestMigrateERCNativePointers(t *testing.T) {
 	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	var pointerAddr common.Address
 	require.Nil(t, k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
-		a, _, err := k.UpsertERCNativePointer(ctx, e, math.MaxUint64, "test", utils.ERCMetadata{Name: "name", Symbol: "symbol", Decimals: 6})
+		a, err := k.UpsertERCNativePointer(ctx, e, "test", utils.ERCMetadata{Name: "name", Symbol: "symbol", Decimals: 6})
 		pointerAddr = a
 		return err
 	}, func(s1, s2 string) {}))
@@ -36,7 +35,7 @@ func TestMigrateERCCW20Pointers(t *testing.T) {
 	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	var pointerAddr common.Address
 	require.Nil(t, k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
-		a, _, err := k.UpsertERCCW20Pointer(ctx, e, math.MaxUint64, "test", utils.ERCMetadata{Name: "name", Symbol: "symbol"})
+		a, err := k.UpsertERCCW20Pointer(ctx, e, "test", utils.ERCMetadata{Name: "name", Symbol: "symbol"})
 		pointerAddr = a
 		return err
 	}, func(s1, s2 string) {}))
@@ -51,7 +50,7 @@ func TestMigrateERCCW721Pointers(t *testing.T) {
 	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	var pointerAddr common.Address
 	require.Nil(t, k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
-		a, _, err := k.UpsertERCCW721Pointer(ctx, e, math.MaxUint64, "test", utils.ERCMetadata{Name: "name", Symbol: "symbol"})
+		a, err := k.UpsertERCCW721Pointer(ctx, e, "test", utils.ERCMetadata{Name: "name", Symbol: "symbol"})
 		pointerAddr = a
 		return err
 	}, func(s1, s2 string) {}))


### PR DESCRIPTION
## Describe your changes and provide context
Previously gas is tracked in two places for a pointer precompile call: the gas meter in `sdk.Context`, and `suppliedGas`. This PR unifies them into `sdk.Context` so that we don't miscount or double-count gas usage.

## Testing performed to validate your change
unit tests

