### PR TITLE
Add getPointee calls for all pointer types

### DIFF
--- a/precompiles/pointerview/Pointerview.sol
+++ b/precompiles/pointerview/Pointerview.sol
@@ -1,8 +1,6 @@
-// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 address constant POINTERVIEW_PRECOMPILE_ADDRESS = 0x000000000000000000000000000000000000100A;
-
 IPointerview constant POINTERVIEW_CONTRACT = IPointerview(POINTERVIEW_PRECOMPILE_ADDRESS);
 
 interface IPointerview {
@@ -17,4 +15,16 @@ interface IPointerview {
     function getCW721Pointer(
         string memory cwAddr
     ) view external returns (address addr, uint16 version, bool exists);
+
+    function getNativePointee(
+        address erc20Addr
+    ) view external returns (string memory token, uint16 version, bool exists);
+
+    function getCW20Pointee(
+        address erc20Addr
+    ) view external returns (string memory cwAddr, uint16 version, bool exists);
+
+    function getCW721Pointee(
+        address erc721Addr
+    ) view external returns (string memory cwAddr, uint16 version, bool exists);
 }

--- a/precompiles/pointerview/abi.json
+++ b/precompiles/pointerview/abi.json
@@ -1,1 +1,176 @@
-[{"inputs":[{"internalType":"string","name":"cwAddr","type":"string"}],"name":"getCW20Pointer","outputs":[{"internalType":"address","name":"addr","type":"address"},{"internalType":"uint16","name":"version","type":"uint16"},{"internalType":"bool","name":"exists","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"string","name":"cwAddr","type":"string"}],"name":"getCW721Pointer","outputs":[{"internalType":"address","name":"addr","type":"address"},{"internalType":"uint16","name":"version","type":"uint16"},{"internalType":"bool","name":"exists","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"string","name":"token","type":"string"}],"name":"getNativePointer","outputs":[{"internalType":"address","name":"addr","type":"address"},{"internalType":"uint16","name":"version","type":"uint16"},{"internalType":"bool","name":"exists","type":"bool"}],"stateMutability":"view","type":"function"}]
+[
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "cwAddr",
+          "type": "string"
+        }
+      ],
+      "name": "getCW20Pointer",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "addr",
+          "type": "address"
+        },
+        {
+          "internalType": "uint16",
+          "name": "version",
+          "type": "uint16"
+        },
+        {
+          "internalType": "bool",
+          "name": "exists",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "cwAddr",
+          "type": "string"
+        }
+      ],
+      "name": "getCW721Pointer",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "addr",
+          "type": "address"
+        },
+        {
+          "internalType": "uint16",
+          "name": "version",
+          "type": "uint16"
+        },
+        {
+          "internalType": "bool",
+          "name": "exists",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "token",
+          "type": "string"
+        }
+      ],
+      "name": "getNativePointer",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "addr",
+          "type": "address"
+        },
+        {
+          "internalType": "uint16",
+          "name": "version",
+          "type": "uint16"
+        },
+        {
+          "internalType": "bool",
+          "name": "exists",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "erc20Addr",
+          "type": "address"
+        }
+      ],
+      "name": "getNativePointee",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "token",
+          "type": "string"
+        },
+        {
+          "internalType": "uint16",
+          "name": "version",
+          "type": "uint16"
+        },
+        {
+          "internalType": "bool",
+          "name": "exists",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "erc20Addr",
+          "type": "address"
+        }
+      ],
+      "name": "getCW20Pointee",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "cwAddr",
+          "type": "string"
+        },
+        {
+          "internalType": "uint16",
+          "name": "version",
+          "type": "uint16"
+        },
+        {
+          "internalType": "bool",
+          "name": "exists",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "erc721Addr",
+          "type": "address"
+        }
+      ],
+      "name": "getCW721Pointee",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "cwAddr",
+          "type": "string"
+        },
+        {
+          "internalType": "uint16",
+          "name": "version",
+          "type": "uint16"
+        },
+        {
+          "internalType": "bool",
+          "name": "exists",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]

--- a/precompiles/pointerview/pointerview_test.go
+++ b/precompiles/pointerview/pointerview_test.go
@@ -18,12 +18,35 @@ func TestPointerView(t *testing.T) {
 	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	p, err := pointerview.NewPrecompile(k)
 	require.Nil(t, err)
+
 	_, pointer := testkeeper.MockAddressPair()
 	k.SetERC20NativePointer(ctx, "test", pointer)
 	k.SetERC20CW20Pointer(ctx, "test", pointer)
 	k.SetERC721CW721Pointer(ctx, "test", pointer)
+
+	// Test GetNativePointer
+	testGetNativePointer(t, ctx, p, pointer)
+
+	// Test GetCW20Pointer
+	testGetCW20Pointer(t, ctx, p, pointer)
+
+	// Test GetCW721Pointer
+	testGetCW721Pointer(t, ctx, p, pointer)
+
+	// Test GetNativePointee
+	testGetNativePointee(t, ctx, p, pointer)
+
+	// Test GetCW20Pointee
+	testGetCW20Pointee(t, ctx, p, pointer)
+
+	// Test GetCW721Pointee
+	testGetCW721Pointee(t, ctx, p, pointer)
+}
+
+func testGetNativePointer(t *testing.T, ctx testkeeper.TestContext, p *pointerview.Precompile, pointer common.Address) {
 	m, err := p.ABI.MethodById(p.GetExecutor().(*pointerview.PrecompileExecutor).GetNativePointerID)
 	require.Nil(t, err)
+
 	ret, err := p.GetExecutor().(*pointerview.PrecompileExecutor).GetNative(ctx, m, []interface{}{"test"})
 	require.Nil(t, err)
 	outputs, err := m.Outputs.Unpack(ret)
@@ -31,37 +54,106 @@ func TestPointerView(t *testing.T) {
 	require.Equal(t, pointer, outputs[0].(common.Address))
 	require.Equal(t, native.CurrentVersion, outputs[1].(uint16))
 	require.True(t, outputs[2].(bool))
+
 	ret, err = p.GetExecutor().(*pointerview.PrecompileExecutor).GetNative(ctx, m, []interface{}{"test2"})
 	require.Nil(t, err)
 	outputs, err = m.Outputs.Unpack(ret)
 	require.Nil(t, err)
 	require.False(t, outputs[2].(bool))
+}
 
-	m, err = p.ABI.MethodById(p.GetExecutor().(*pointerview.PrecompileExecutor).GetCW20PointerID)
+func testGetCW20Pointer(t *testing.T, ctx testkeeper.TestContext, p *pointerview.Precompile, pointer common.Address) {
+	m, err := p.ABI.MethodById(p.GetExecutor().(*pointerview.PrecompileExecutor).GetCW20PointerID)
 	require.Nil(t, err)
-	ret, err = p.GetExecutor().(*pointerview.PrecompileExecutor).GetCW20(ctx, m, []interface{}{"test"})
+
+	ret, err := p.GetExecutor().(*pointerview.PrecompileExecutor).GetCW20(ctx, m, []interface{}{"test"})
 	require.Nil(t, err)
-	outputs, err = m.Outputs.Unpack(ret)
+	outputs, err := m.Outputs.Unpack(ret)
 	require.Nil(t, err)
 	require.Equal(t, pointer, outputs[0].(common.Address))
 	require.Equal(t, cw20.CurrentVersion(ctx), outputs[1].(uint16))
 	require.True(t, outputs[2].(bool))
+
 	ret, err = p.GetExecutor().(*pointerview.PrecompileExecutor).GetCW20(ctx, m, []interface{}{"test2"})
 	require.Nil(t, err)
 	outputs, err = m.Outputs.Unpack(ret)
 	require.Nil(t, err)
 	require.False(t, outputs[2].(bool))
+}
 
-	m, err = p.ABI.MethodById(p.GetExecutor().(*pointerview.PrecompileExecutor).GetCW721PointerID)
+func testGetCW721Pointer(t *testing.T, ctx testkeeper.TestContext, p *pointerview.Precompile, pointer common.Address) {
+	m, err := p.ABI.MethodById(p.GetExecutor().(*pointerview.PrecompileExecutor).GetCW721PointerID)
 	require.Nil(t, err)
-	ret, err = p.GetExecutor().(*pointerview.PrecompileExecutor).GetCW721(ctx, m, []interface{}{"test"})
+
+	ret, err := p.GetExecutor().(*pointerview.PrecompileExecutor).GetCW721(ctx, m, []interface{}{"test"})
 	require.Nil(t, err)
-	outputs, err = m.Outputs.Unpack(ret)
+	outputs, err := m.Outputs.Unpack(ret)
 	require.Nil(t, err)
 	require.Equal(t, pointer, outputs[0].(common.Address))
 	require.Equal(t, cw721.CurrentVersion, outputs[1].(uint16))
 	require.True(t, outputs[2].(bool))
+
 	ret, err = p.GetExecutor().(*pointerview.PrecompileExecutor).GetCW721(ctx, m, []interface{}{"test2"})
+	require.Nil(t, err)
+	outputs, err = m.Outputs.Unpack(ret)
+	require.Nil(t, err)
+	require.False(t, outputs[2].(bool))
+}
+
+func testGetNativePointee(t *testing.T, ctx testkeeper.TestContext, p *pointerview.Precompile, pointer common.Address) {
+	m, err := p.ABI.MethodById(p.GetExecutor().(*pointerview.PrecompileExecutor).GetNativePointeeID)
+	require.Nil(t, err)
+
+	ret, err := p.GetExecutor().(*pointerview.PrecompileExecutor).GetNativePointee(ctx, m, []interface{}{pointer})
+	require.Nil(t, err)
+	outputs, err := m.Outputs.Unpack(ret)
+	require.Nil(t, err)
+	require.Equal(t, "test", outputs[0].(string))
+	require.Equal(t, native.CurrentVersion, outputs[1].(uint16))
+	require.True(t, outputs[2].(bool))
+
+	invalidAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	ret, err = p.GetExecutor().(*pointerview.PrecompileExecutor).GetNativePointee(ctx, m, []interface{}{invalidAddr})
+	require.Nil(t, err)
+	outputs, err = m.Outputs.Unpack(ret)
+	require.Nil(t, err)
+	require.False(t, outputs[2].(bool))
+}
+
+func testGetCW20Pointee(t *testing.T, ctx testkeeper.TestContext, p *pointerview.Precompile, pointer common.Address) {
+	m, err := p.ABI.MethodById(p.GetExecutor().(*pointerview.PrecompileExecutor).GetCW20PointeeID)
+	require.Nil(t, err)
+
+	ret, err := p.GetExecutor().(*pointerview.PrecompileExecutor).GetCW20Pointee(ctx, m, []interface{}{pointer})
+	require.Nil(t, err)
+	outputs, err := m.Outputs.Unpack(ret)
+	require.Nil(t, err)
+	require.Equal(t, "test", outputs[0].(string))
+	require.Equal(t, cw20.CurrentVersion(ctx), outputs[1].(uint16))
+	require.True(t, outputs[2].(bool))
+
+	invalidAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	ret, err = p.GetExecutor().(*pointerview.PrecompileExecutor).GetCW20Pointee(ctx, m, []interface{}{invalidAddr})
+	require.Nil(t, err)
+	outputs, err = m.Outputs.Unpack(ret)
+	require.Nil(t, err)
+	require.False(t, outputs[2].(bool))
+}
+
+func testGetCW721Pointee(t *testing.T, ctx testkeeper.TestContext, p *pointerview.Precompile, pointer common.Address) {
+	m, err := p.ABI.MethodById(p.GetExecutor().(*pointerview.PrecompileExecutor).GetCW721PointeeID)
+	require.Nil(t, err)
+
+	ret, err := p.GetExecutor().(*pointerview.PrecompileExecutor).GetCW721Pointee(ctx, m, []interface{}{pointer})
+	require.Nil(t, err)
+	outputs, err := m.Outputs.Unpack(ret)
+	require.Nil(t, err)
+	require.Equal(t, "test", outputs[0].(string))
+	require.Equal(t, cw721.CurrentVersion, outputs[1].(uint16))
+	require.True(t, outputs[2].(bool))
+
+	invalidAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	ret, err = p.GetExecutor().(*pointerview.PrecompileExecutor).GetCW721Pointee(ctx, m, []interface{}{invalidAddr})
 	require.Nil(t, err)
 	outputs, err = m.Outputs.Unpack(ret)
 	require.Nil(t, err)


### PR DESCRIPTION
## Describe your changes and provide context

This change exposes existing functions in the EVM keeper module for pointers that allow users to query the pointee of a pointer.

Previously this was impossible without constructor bytecode for the deployed pointer contract.

With this we can simply query the pointerView precompile and get the pointee of a pointer, ie, reverse lookups.
