### PR TITLE
Added data location to Solidity interfaces

### DIFF
--- a/precompiles/distribution/Distribution.sol
+++ b/precompiles/distribution/Distribution.sol
@@ -16,7 +16,7 @@ interface IDistr {
     function withdrawMultipleDelegationRewards(string[] memory validators) external returns (bool success);
 
     // Queries
-    function rewards(address delegatorAddress) external view returns (Rewards rewards);
+    function rewards(address delegatorAddress) external view returns (Rewards memory rewards);
 
     struct Coin {
         uint256 amount;

--- a/precompiles/ibc/IBC.sol
+++ b/precompiles/ibc/IBC.sol
@@ -10,7 +10,7 @@ IBC constant IBC_CONTRACT = IBC(
 interface IBC {
     // Transactions
     function transfer(
-        string toAddress,
+        string memory toAddress,
         string memory port,
         string memory channel,
         string memory denom,
@@ -18,15 +18,15 @@ interface IBC {
         uint64 revisionNumber,
         uint64 revisionHeight,
         uint64 timeoutTimestamp,
-        string memo
+        string memory memo
     ) external returns (bool success);
 
     function transferWithDefaultTimeout(
-        string toAddress,
+        string memory toAddress,
         string memory port,
         string memory channel,
         string memory denom,
         uint256 amount,
-        string memo
+        string memory memo
     ) external returns (bool success);
 }

--- a/precompiles/staking/Staking.sol
+++ b/precompiles/staking/Staking.sol
@@ -28,7 +28,7 @@ interface IStaking {
     function delegation(
         address delegator,
         string memory valAddress
-    ) external view returns (Delegation delegation);
+    ) external view returns (Delegation memory delegation);
 
     struct Delegation {
         Balance balance;


### PR DESCRIPTION
## Describe your changes and provide context

Added data location to the IBC, Distribution, and Staking interfaces. While working on my contracts, Foundry threw errors due to missing data locations in these 3 interfaces, so I added them and created this PR.

I’ve based the data locations on similar function arguments and return values. If any of these assumptions are incorrect, please let me know.

## Testing performed to validate your change

Not really sure. I am using Foundry and copied these interfaces in my project.