### PR TITLE
Fix websocket from_height

### DIFF
--- a/evmrpc/subscribe.go
+++ b/evmrpc/subscribe.go
@@ -183,6 +183,7 @@ func (a *SubscriptionAPI) Logs(ctx context.Context, filter *filters.FilterCriter
 				return
 			}
 			begin = lastToHeight
+			filter.FromBlock = big.NewInt(lastToHeight + 1)
 
 			time.Sleep(SleepInterval)
 		}


### PR DESCRIPTION
## Describe your changes and provide context
To fix https://github.com/sei-protocol/sei-chain/issues/1850

There is a bug in how `fromHeight` is set during the websocket handler loop. Specifically each iteration will only look at the latest height if we don't set `filter.FromBlock` to the last height handled by the last iteration, so in the case where multiple heights have passed between two websocket iterations, events would be lost.

## Testing performed to validate your change
difficult to simulate latest height passing in unit test. Since this is an RPC-only change, we can apply it to the RPC node the bug reporter is using and see if the error is resolved
