### PR TITLE
Fix events in 2-hop scenarios

### DIFF
--- a/contracts/test/CW20toERC20PointerTest.js
+++ b/contracts/test/CW20toERC20PointerTest.js
@@ -184,6 +184,14 @@ describe("CW20 to ERC20 Pointer", function () {
                     const response = await wasmd.execute(pointer, transferBz, coinsBz);
                     const receipt = await response.wait();
                     expect(receipt.status).to.equal(1);
+
+                    const filter = {
+                        fromBlock: receipt["blockNumber"],
+                        toBlock: 'latest',
+                        topics: [ethers.id("Transfer(address,address,uint256)")]
+                    };
+                    const logs = await ethers.provider.getLogs(filter);
+                    expect(logs.length).to.equal(1);
                 });
             });
         });


### PR DESCRIPTION
## Describe your changes and provide context
We need to call `Finalize` before writing receipts; otherwise receipts/events written in inner calls will not be visible for outer receipt writes

## Testing performed to validate your change
integration test
