### PR TITLE
update buf.yaml dependencies

### DIFF
--- a/proto/buf.lock
+++ b/proto/buf.lock
@@ -2,22 +2,12 @@
 version: v1
 deps:
   - remote: buf.build
-    owner: cosmos
-    repository: cosmos-proto
-    commit: 1935555c206d4afb9e94615dfd0fad31
-    digest: shake256:c74d91a3ac7ae07d579e90eee33abf9b29664047ac8816500cf22c081fec0d72d62c89ce0bebafc1f6fec7aa5315be72606717740ca95007248425102c365377
-  - remote: buf.build
-    owner: cosmos
+    owner: sei-protocol
     repository: cosmos-sdk
-    commit: a12828247088412292af47c7232aa5e3
-    digest: shake256:0deca7ecbb30b9f28457b5d4d666bddc9d29d8575c8ca9afcaa7285a072cb52c9bc6ea67f05cc49f55e683d37eecb0d059a288a8c2911727a45577276d1f11cb
+    commit: 3d29d814d0f9416a83a1db65d5ef4b9b
+    digest: shake256:a28bddd252a07da38e1aa523a957e8fa837a92531090dce461e5b588716669688df8eb855a8e441f8edac0dfac6b59a16c6b07d8f23f5252af6a5db25684f5c9
   - remote: buf.build
-    owner: cosmos
-    repository: gogo-proto
-    commit: 5e5b9fdd01804356895f8f79a6f1ddc1
-    digest: shake256:0b85da49e2e5f9ebc4806eae058e2f56096ff3b1c59d1fb7c190413dd15f45dd456f0b69ced9059341c80795d2b6c943de15b120a9e0308b499e43e4b5fc2952
-  - remote: buf.build
-    owner: googleapis
-    repository: googleapis
-    commit: 28151c0d0a1641bf938a7672c500e01d
-    digest: shake256:49215edf8ef57f7863004539deff8834cfb2195113f0b890dd1f67815d9353e28e668019165b9d872395871eeafcbab3ccfdb2b5f11734d3cca95be9e8d139de
+    owner: sei-protocol
+    repository: third-party
+    commit: ec63a6f27ea04039953185599c21efc2
+    digest: shake256:a4e513745f8b44d28ab1fe93e633424b8dc7f6275bcab228376fbf27b8dafc08360bcae8255c1d65339db5d4f38665273fa844302b6e048f992929dbdc919a5e

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,10 +1,7 @@
 version: v1
 name: buf.build/sei-protocol/sei-chain
 deps:
-  - buf.build/cosmos/cosmos-sdk
-  - buf.build/cosmos/cosmos-proto
-  - buf.build/cosmos/gogo-proto
-  - buf.build/googleapis/googleapis
+  - buf.build/sei-protocol/cosmos-sdk
 breaking:
   use:
     - FILE


### PR DESCRIPTION
## Describe your changes and provide context

Update `buf.yaml` dependencies to point to `buf.build/sei-protocol/cosmos-sdk` rather than `buf.build/cosmos/cosmos-sdk`

This PR should fix https://github.com/sei-protocol/sei-chain/actions/runs/10966410259

## Testing performed to validate your change

- local buf linting
- buf push (from local)
- ignite generate proto-go

