### PR TITLE
fix tx byte arr in synthetic endpoints

### DIFF
--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -3,6 +3,7 @@ package evmrpc
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -254,7 +255,7 @@ func EncodeTmBlock(
 					continue
 				}
 				if !fullTx {
-					transactions = append(transactions, th)
+					transactions = append(transactions, "0x"+hex.EncodeToString(th[:]))
 				} else {
 					ti := uint64(receipt.TransactionIndex)
 					to := k.GetEVMAddressOrDefault(ctx, sdk.MustAccAddressFromBech32(m.Contract))


### PR DESCRIPTION
## Describe your changes and provide context

Minor fix for issue where transaction bytes were showing up for synthetic txs on sei_getTransactionReceipt. This is what the error looks like:
```
curl http://127.0.0.1:8545 -X POST -H "Content-Type: application/json" --data '{"method":"sei_getBlockByNumber","params":["0x56A54",false],"id":1,"jsonrpc":"2.0"}'
{"jsonrpc":"2.0","id":1,"result":{"baseFeePerGas":"0x0","difficulty":"0x0","extraData":"0x","gasLimit":"0x12a05f200","gasUsed":"0x2da14","hash":"0xe1aadee07615cc4e6c7c4dbcd0311d020569f5b9cb03daab3cc80d3ee94e01c2","logsBloom":"0x00000000000000000002000000000000000010000000000000000001000000000000000800040000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000010000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000042000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000","miner":"0x83e931d146ede5ea923c9fa4f159bf721bd493d0","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0000000000000000","number":"0x56a54","parentHash":"0x5a6936adde4fa8d11199637693602db662b493234b662dcb539fa5cba9282340","receiptsRoot":"0xbfbeffdf7835528a08cfcb23fd792c68c3a35ee224c7daaf9e513381a18fa04b","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","size":"0xb43","stateRoot":"0x248a2a9642924883b61af363fbe1f3672bd09c348716151d02e44883848525d7","timestamp":"0x66f5ca02","transactions":[[193,85,38,130,171,20,251,163,180,83,218,84,92,99,105,64,210,109,63,19,40,93,94,147,170,93,108,106,103,96,90,136]],"transactionsRoot":"0xc725479e1e2af34da71911548a663905227c9c562556f2401334c44f6c7b48cd","uncles":[]}}
```

This is what it looks like after the fix:
```
curl http://127.0.0.1:8545 -X POST -H "Content-Type: application/json" --data '{"method":"sei_getBlockByNumber","params":["0x56A54",false],"id":1,"jsonrpc":"2.0"}'
{"jsonrpc":"2.0","id":1,"result":{"baseFeePerGas":"0x0","difficulty":"0x0","extraData":"0x","gasLimit":"0x12a05f200","gasUsed":"0x2da14","hash":"0xe1aadee07615cc4e6c7c4dbcd0311d020569f5b9cb03daab3cc80d3ee94e01c2","logsBloom":"0x00000000000000000002000000000000000010000000000000000001000000000000000800040000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000010000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000042000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000","miner":"0x83e931d146ede5ea923c9fa4f159bf721bd493d0","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0000000000000000","number":"0x56a54","parentHash":"0x5a6936adde4fa8d11199637693602db662b493234b662dcb539fa5cba9282340","receiptsRoot":"0xbfbeffdf7835528a08cfcb23fd792c68c3a35ee224c7daaf9e513381a18fa04b","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","size":"0xb43","stateRoot":"0x248a2a9642924883b61af363fbe1f3672bd09c348716151d02e44883848525d7","timestamp":"0x66f5ca02","transactions":["0xc1552682ab14fba3b453da545c636940d26d3f13285d5e93aa5d6c6a67605a88"],"transactionsRoot":"0xc725479e1e2af34da71911548a663905227c9c562556f2401334c44f6c7b48cd","uncles":[]}}
```

## Testing performed to validate your change
manual testing on loadtest cluster

