### PR TITLE
Add endpoint to estimate gas after simulating calls

### DIFF
--- a/evmrpc/simulate_test.go
+++ b/evmrpc/simulate_test.go
@@ -67,6 +67,48 @@ func TestEstimateGas(t *testing.T) {
 	Ctx = Ctx.WithBlockHeight(8)
 }
 
+func TestEstimateGasAfterCalls(t *testing.T) {
+	Ctx = Ctx.WithBlockHeight(1)
+	// estimate get after set
+	_, from := testkeeper.MockAddressPair()
+	amts := sdk.NewCoins(sdk.NewCoin(EVMKeeper.GetBaseDenom(Ctx), sdk.NewInt(20)))
+	EVMKeeper.BankKeeper().MintCoins(Ctx, types.ModuleName, amts)
+	EVMKeeper.BankKeeper().SendCoinsFromModuleToAccount(Ctx, types.ModuleName, sdk.AccAddress(from[:]), amts)
+	_, contractAddr := testkeeper.MockAddressPair()
+	code, err := os.ReadFile("../example/contracts/simplestorage/SimpleStorage.bin")
+	require.Nil(t, err)
+	bz, err := hex.DecodeString(string(code))
+	require.Nil(t, err)
+	abi, err := simplestorage.SimplestorageMetaData.GetAbi()
+	require.Nil(t, err)
+	call, err := abi.Pack("set", big.NewInt(20))
+	require.Nil(t, err)
+	input, err := abi.Pack("get")
+	require.Nil(t, err)
+	EVMKeeper.SetCode(Ctx, contractAddr, bz)
+	txArgs := map[string]interface{}{
+		"from":    from.Hex(),
+		"to":      contractAddr.Hex(),
+		"value":   "0x0",
+		"nonce":   "0x2",
+		"chainId": fmt.Sprintf("%#x", EVMKeeper.ChainID(Ctx)),
+		"input":   fmt.Sprintf("%#x", input),
+	}
+	callArgs := map[string]interface{}{
+		"from":    from.Hex(),
+		"to":      contractAddr.Hex(),
+		"value":   "0x0",
+		"nonce":   "0x2",
+		"chainId": fmt.Sprintf("%#x", EVMKeeper.ChainID(Ctx)),
+		"input":   fmt.Sprintf("%#x", call),
+	}
+	resObj := sendRequestGood(t, "estimateGasAfterCalls", txArgs, []interface{}{callArgs}, nil, map[string]interface{}{})
+	result := resObj["result"].(string)
+	require.Equal(t, "0x536d", result) // 21357 for get
+
+	Ctx = Ctx.WithBlockHeight(8)
+}
+
 func TestCreateAccessList(t *testing.T) {
 	Ctx = Ctx.WithBlockHeight(1)
 

--- a/go.mod
+++ b/go.mod
@@ -351,7 +351,7 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.37-0.20240923023912-aa7a702d42cc
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.2.0
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.2
-	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20240925211216-af807e581c3a
+	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-23
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/sei-protocol/sei-db => github.com/sei-protocol/sei-db v0.0.44
 	// Latest goleveldb is broken, we have to stick to this version

--- a/go.sum
+++ b/go.sum
@@ -1346,8 +1346,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20240925211216-af807e581c3a h1:eicGeFgoEmKaSEPXMUMbTvYFk385iw2+u5/Wmqiz/JY=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20240925211216-af807e581c3a/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-23 h1:rkgeOHC56QTco4mIyGd6cZHtlonulLsaPLZCaMY6TAw=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-23/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-cosmos v0.3.37-0.20240923023912-aa7a702d42cc h1:srWLbsoS0NYBIl8OjZOFuPmIeqf+fJTkfsK39MmG3+k=


### PR DESCRIPTION
## Describe your changes and provide context
There are cases when gas estimation needs to be done based on certain simulated states which cannot be statically inputted as state overrides. One example is to estimate gas for an ERC20 transferFrom while assuming the allowance is in place.

This PR (together with https://github.com/sei-protocol/go-ethereum/pull/35) adds a new endpoint `eth_estimateGasAfterCalls` to support such use cases.

## Testing performed to validate your change
unit test

