### PR TITLE
Fix amino registry for custom modules

### DIFF
--- a/testutil/keeper/epoch.go
+++ b/testutil/keeper/epoch.go
@@ -36,7 +36,7 @@ func EpochKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
 	cdc := codec.NewProtoCodec(registry)
 
 	paramsSubspace := typesparams.NewSubspace(cdc,
-		types.Amino,
+		codec.NewLegacyAmino(),
 		storeKey,
 		memStoreKey,
 		"EpochParams",

--- a/x/epoch/types/codec.go
+++ b/x/epoch/types/codec.go
@@ -15,6 +15,11 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 }
 
 var (
-	Amino     = codec.NewLegacyAmino()
-	ModuleCdc = codec.NewProtoCodec(cdctypes.NewInterfaceRegistry())
+	amino     = codec.NewLegacyAmino()
+	ModuleCdc = codec.NewAminoCodec(amino)
 )
+
+func init() {
+	RegisterCodec(amino)
+	amino.Seal()
+}

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -160,7 +160,6 @@ func (server msgServer) EVMTransaction(goCtx context.Context, msg *types.MsgEVMT
 		originalGasMeter.ConsumeGas(adjustedGasUsed.TruncateInt().Uint64(), "evm transaction")
 	}()
 
-	fmt.Println("JEREMYDEBUG: calling apply evm message from EVMTransaction")
 	res, applyErr := server.applyEVMMessage(ctx, emsg, stateDB, gp)
 	serverRes = &types.MsgEVMTransactionResponse{
 		Hash: tx.Hash().Hex(),
@@ -230,7 +229,6 @@ func (k *Keeper) GetEVMMessage(ctx sdk.Context, tx *ethtypes.Transaction, sender
 }
 
 func (k Keeper) applyEVMMessage(ctx sdk.Context, msg *core.Message, stateDB *state.DBImpl, gp core.GasPool) (*core.ExecutionResult, error) {
-	// fmt.Printf("JEREMYDEBUG: In applyEVMMessage, msg = %+v\n", msg)
 	blockCtx, err := k.GetVMBlockContext(ctx, gp)
 	if err != nil {
 		return nil, err

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -286,7 +286,6 @@ func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
 // EndBlock executes all ABCI EndBlock logic respective to the evm module. It
 // returns no validator updates.
 func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.ValidatorUpdate {
-	fmt.Println("JEREMYDEBUG: block gas used", req.BlockGasUsed, ", block height", ctx.BlockHeight())
 	newBaseFee := am.keeper.AdjustDynamicBaseFeePerGas(ctx, uint64(req.BlockGasUsed))
 	if newBaseFee != nil {
 		metrics.GaugeEvmBlockBaseFee(newBaseFee.TruncateInt().BigInt(), req.Height)

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -50,9 +50,9 @@ func (AppModuleBasic) Name() string {
 	return types.ModuleName
 }
 
-func (AppModuleBasic) RegisterCodec(*codec.LegacyAmino) {}
-
-func (AppModuleBasic) RegisterLegacyAminoCodec(*codec.LegacyAmino) {}
+func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+	types.RegisterCodec(cdc)
+}
 
 // RegisterInterfaces registers the module's interface types
 func (a AppModuleBasic) RegisterInterfaces(reg cdctypes.InterfaceRegistry) {

--- a/x/evm/module_test.go
+++ b/x/evm/module_test.go
@@ -51,7 +51,8 @@ func TestQuerierRoute(t *testing.T) {
 func TestModuleExportGenesis(t *testing.T) {
 	k, ctx := testkeeper.MockEVMKeeper()
 	module := evm.NewAppModule(nil, k)
-	jsonMsg := module.ExportGenesis(ctx, types.ModuleCdc)
+	cdc := app.MakeEncodingConfig().Marshaler
+	jsonMsg := module.ExportGenesis(ctx, cdc)
 	jsonStr := string(jsonMsg)
 	assert.Equal(t, "{\"params\":{\"priority_normalizer\":\"1.000000000000000000\",\"base_fee_per_gas\":\"0.000000000000000000\",\"minimum_fee_per_gas\":\"100000000000.000000000000000000\",\"whitelisted_cw_code_hashes_for_delegate_call\":[],\"deliver_tx_hook_wasm_gas_limit\":\"300000\",\"max_dynamic_base_fee_upward_adjustment\":\"0.000000000000000000\",\"max_dynamic_base_fee_downward_adjustment\":\"0.000000000000000000\",\"target_gas_used_per_block\":\"100000\"},\"address_associations\":[{\"sei_address\":\"sei17xpfvakm2amg962yls6f84z3kell8c5la4jkdu\",\"eth_address\":\"0x27F7B8B8B5A4e71E8E9aA671f4e4031E3773303F\"}],\"codes\":[],\"states\":[],\"nonces\":[],\"serialized\":[{\"prefix\":\"Fg==\",\"key\":\"AwAC\",\"value\":\"AAAAAAAAAAM=\"},{\"prefix\":\"Fg==\",\"key\":\"BAAG\",\"value\":\"AAAAAAAAAAQ=\"}]}", jsonStr)
 }

--- a/x/evm/types/codec.go
+++ b/x/evm/types/codec.go
@@ -18,17 +18,25 @@ import (
 
 var (
 	amino     = codec.NewLegacyAmino()
-	ModuleCdc = codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
-	AminoCdc  = codec.NewAminoCodec(amino)
+	ModuleCdc = codec.NewAminoCodec(amino)
 )
 
 func init() {
+	RegisterCodec(amino)
 	cryptocodec.RegisterCrypto(amino)
 	amino.Seal()
 }
 
 func GetAmino() *codec.LegacyAmino {
 	return amino
+}
+
+func RegisterCodec(cdc *codec.LegacyAmino) {
+	cdc.RegisterConcrete(&MsgAssociate{}, "evm/MsgAssociate", nil)
+	cdc.RegisterConcrete(&MsgEVMTransaction{}, "evm/MsgEVMTransaction", nil)
+	cdc.RegisterConcrete(&MsgSend{}, "evm/MsgSend", nil)
+	cdc.RegisterConcrete(&MsgRegisterPointer{}, "evm/MsgRegisterPointer", nil)
+	cdc.RegisterConcrete(&MsgAssociateContractAddress{}, "evm/MsgAssociateContractAddress", nil)
 }
 
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {

--- a/x/mint/types/codec.go
+++ b/x/mint/types/codec.go
@@ -7,9 +7,13 @@ import (
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 )
 
-var amino = codec.NewLegacyAmino()
+var (
+	amino     = codec.NewLegacyAmino()
+	ModuleCdc = codec.NewAminoCodec(amino)
+)
 
 func init() {
+	RegisterCodec(amino)
 	cryptocodec.RegisterCrypto(amino)
 	amino.Seal()
 }
@@ -23,5 +27,3 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 		&UpdateMinterProposal{},
 	)
 }
-
-var ModuleCdc = codec.NewProtoCodec(cdctypes.NewInterfaceRegistry())

--- a/x/oracle/keeper/test_utils.go
+++ b/x/oracle/keeper/test_utils.go
@@ -70,7 +70,7 @@ func MakeEncodingConfig(_ *testing.T) simparams.EncodingConfig {
 
 	ModuleBasics.RegisterLegacyAminoCodec(amino)
 	ModuleBasics.RegisterInterfaces(interfaceRegistry)
-	types.RegisterLegacyAminoCodec(amino)
+	types.RegisterCodec(amino)
 	types.RegisterInterfaces(interfaceRegistry)
 	return simparams.EncodingConfig{
 		InterfaceRegistry: interfaceRegistry,

--- a/x/oracle/module.go
+++ b/x/oracle/module.go
@@ -44,7 +44,7 @@ func (AppModuleBasic) Name() string {
 
 // RegisterLegacyAminoCodec registers the module's types on the given LegacyAmino codec.
 func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
-	types.RegisterLegacyAminoCodec(cdc)
+	types.RegisterCodec(cdc)
 }
 
 // RegisterInterfaces registers the module's interface types

--- a/x/oracle/types/codec.go
+++ b/x/oracle/types/codec.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
-func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func RegisterCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgAggregateExchangeRateVote{}, "oracle/MsgAggregateExchangeRateVote", nil)
 	cdc.RegisterConcrete(&MsgDelegateFeedConsent{}, "oracle/MsgDelegateFeedConsent", nil)
 }
@@ -24,6 +24,12 @@ func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 }
 
 var (
-	Amino     = codec.NewLegacyAmino()
-	ModuleCdc = codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
+	amino     = codec.NewLegacyAmino()
+	ModuleCdc = codec.NewAminoCodec(amino)
 )
+
+func init() {
+	RegisterCodec(amino)
+	sdk.RegisterLegacyAminoCodec(amino)
+	amino.Seal()
+}

--- a/x/tokenfactory/keeper/migrations_test.go
+++ b/x/tokenfactory/keeper/migrations_test.go
@@ -36,7 +36,7 @@ func TestMigrate2to3(t *testing.T) {
 	cdc := codec.NewProtoCodec(registry)
 
 	paramsSubspace := typesparams.NewSubspace(cdc,
-		types.Amino,
+		codec.NewLegacyAmino(),
 		storeKey,
 		memStoreKey,
 		"TokenfactoryParams",

--- a/x/tokenfactory/types/codec.go
+++ b/x/tokenfactory/types/codec.go
@@ -10,10 +10,10 @@ import (
 )
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
-	cdc.RegisterConcrete(&MsgCreateDenom{}, "tokenfactory/create-denom", nil)
-	cdc.RegisterConcrete(&MsgMint{}, "tokenfactory/mint", nil)
-	cdc.RegisterConcrete(&MsgBurn{}, "tokenfactory/burn", nil)
-	cdc.RegisterConcrete(&MsgChangeAdmin{}, "tokenfactory/change-admin", nil)
+	cdc.RegisterConcrete(&MsgCreateDenom{}, "tokenfactory/MsgCreateDenom", nil)
+	cdc.RegisterConcrete(&MsgMint{}, "tokenfactory/MsgMint", nil)
+	cdc.RegisterConcrete(&MsgBurn{}, "tokenfactory/MsgBurn", nil)
+	cdc.RegisterConcrete(&MsgChangeAdmin{}, "tokenfactory/MsgChangeAdmin", nil)
 }
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
@@ -34,6 +34,13 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 }
 
 var (
-	Amino     = codec.NewLegacyAmino()
-	ModuleCdc = codec.NewProtoCodec(cdctypes.NewInterfaceRegistry())
+	amino     = codec.NewLegacyAmino()
+	ModuleCdc = codec.NewAminoCodec(amino)
 )
+
+func init() {
+	RegisterCodec(amino)
+	sdk.RegisterLegacyAminoCodec(amino)
+
+	amino.Seal()
+}

--- a/x/tokenfactory/types/codec.go
+++ b/x/tokenfactory/types/codec.go
@@ -11,14 +11,19 @@ import (
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgCreateDenom{}, "tokenfactory/MsgCreateDenom", nil)
+	cdc.RegisterConcrete(&MsgUpdateDenom{}, "tokenfactory/MsgUpdateDenom", nil)
 	cdc.RegisterConcrete(&MsgMint{}, "tokenfactory/MsgMint", nil)
 	cdc.RegisterConcrete(&MsgBurn{}, "tokenfactory/MsgBurn", nil)
 	cdc.RegisterConcrete(&MsgChangeAdmin{}, "tokenfactory/MsgChangeAdmin", nil)
+	cdc.RegisterConcrete(&MsgSetDenomMetadata{}, "tokenfactory/MsgSetDenomMetadata", nil)
 }
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgCreateDenom{},
+	)
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgUpdateDenom{},
 	)
 	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgMint{},
@@ -28,6 +33,9 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	)
 	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgChangeAdmin{},
+	)
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgSetDenomMetadata{},
 	)
 
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)


### PR DESCRIPTION
## Describe your changes and provide context
This modifies the way the amino codec is used for custom modules to verify signatures. This will allow our custom modules to properly be amino signed and verified.

## Testing performed to validate your change
Local chain testing

