### PR TITLE
stop flushing deferred info into receipt store

### DIFF
--- a/x/evm/keeper/receipt.go
+++ b/x/evm/keeper/receipt.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/iavl"
 	"github.com/ethereum/go-ethereum/common"
@@ -91,12 +92,12 @@ func (k *Keeper) MockReceipt(ctx sdk.Context, txHash common.Hash, receipt *types
 }
 
 func (k *Keeper) FlushTransientReceipts(ctx sdk.Context) error {
-	iter := ctx.TransientStore(k.transientStoreKey).Iterator(nil, nil)
+	iter := prefix.NewStore(ctx.TransientStore(k.transientStoreKey), types.ReceiptKeyPrefix).Iterator(nil, nil)
 	defer iter.Close()
 	var pairs []*iavl.KVPair
 	var changesets []*proto.NamedChangeSet
 	for ; iter.Valid(); iter.Next() {
-		kvPair := &iavl.KVPair{Key: iter.Key(), Value: iter.Value()}
+		kvPair := &iavl.KVPair{Key: types.ReceiptKey(common.Hash(iter.Key())), Value: iter.Value()}
 		pairs = append(pairs, kvPair)
 	}
 	if len(pairs) == 0 {

--- a/x/evm/keeper/receipt_test.go
+++ b/x/evm/keeper/receipt_test.go
@@ -3,7 +3,9 @@ package keeper_test
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 	"github.com/stretchr/testify/require"
@@ -16,7 +18,10 @@ func TestReceipt(t *testing.T) {
 	_, err := k.GetReceipt(ctx, txHash)
 	require.NotNil(t, err)
 	k.MockReceipt(ctx, txHash, &types.Receipt{TxHashHex: txHash.Hex()})
+	k.AppendToEvmTxDeferredInfo(ctx, ethtypes.Bloom{}, common.Hash{1}, sdk.NewInt(1)) // make sure this isn't flushed into receipt store
 	r, err := k.GetReceipt(ctx, txHash)
 	require.Nil(t, err)
 	require.Equal(t, txHash.Hex(), r.TxHashHex)
+	_, err = k.GetReceipt(ctx, common.Hash{1})
+	require.Equal(t, "not found", err.Error())
 }


### PR DESCRIPTION
## Describe your changes and provide context
Iterating through the whole transient store would fetch things (e.g. deferred info) other than receipt and flush them into the receipt store. This would not cause issue correctness wise but would make receipt store grow faster in size and increase time to flush receipts.

## Testing performed to validate your change
unit test
