### PR TITLE
refactor: use wasm-to-evm gas limit for all interop operations

### DIFF
--- a/app/receipt.go
+++ b/app/receipt.go
@@ -39,6 +39,8 @@ func (app *App) AddCosmosEventsToEVMReceiptIfApplicable(ctx sdk.Context, tx sdk.
 		return
 	}
 	logs := []*ethtypes.Log{}
+	// Note: txs with a very large number of WASM events may run out of gas due to
+	// additional gas consumption from EVM receipt generation and event translation
 	wasmToEvmEventGasLimit := app.EvmKeeper.GetDeliverTxHookWasmGasLimit(ctx.WithGasMeter(sdk.NewInfiniteGasMeter(1, 1)))
 	wasmToEvmEventCtx := ctx.WithGasMeter(sdk.NewGasMeterWithMultiplier(ctx, wasmToEvmEventGasLimit))
 	for _, wasmEvent := range wasmEvents {
@@ -46,7 +48,6 @@ func (app *App) AddCosmosEventsToEVMReceiptIfApplicable(ctx sdk.Context, tx sdk.
 		if !found {
 			continue
 		}
-		// check if there is a ERC20 pointer to contractAddr
 		pointerAddr, _, exists := app.EvmKeeper.GetERC20CW20Pointer(wasmToEvmEventCtx, contractAddr)
 		if exists {
 			log, eligible := app.translateCW20Event(wasmToEvmEventCtx, wasmEvent, pointerAddr, contractAddr)

--- a/app/seidb.go
+++ b/app/seidb.go
@@ -56,7 +56,7 @@ func SetupSeiDB(
 
 	// cms must be overridden before the other options, because they may use the cms,
 	// make sure the cms aren't be overridden by the other options later on.
-	cms := rootmulti.NewStore(homePath, logger, scConfig, ssConfig)
+	cms := rootmulti.NewStore(homePath, logger, scConfig, ssConfig, false)
 	baseAppOptions = append([]func(*baseapp.BaseApp){
 		func(baseApp *baseapp.BaseApp) {
 			baseApp.SetCMS(cms)

--- a/go.mod
+++ b/go.mod
@@ -346,7 +346,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.2.4
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.39
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.41
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.2.0
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.2
 	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-23

--- a/go.sum
+++ b/go.sum
@@ -1347,8 +1347,8 @@ github.com/sei-protocol/go-ethereum v1.13.5-sei-23 h1:rkgeOHC56QTco4mIyGd6cZHtlo
 github.com/sei-protocol/go-ethereum v1.13.5-sei-23/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.3.39 h1:EaAoJNyN11MJCkgZG5D92UGXLy0X2NAPz0HltOHEBxk=
-github.com/sei-protocol/sei-cosmos v0.3.39/go.mod h1:ZwWxF/69WlcLEn4BzVjPPToTFkE2sjPanU8PNNyKoOk=
+github.com/sei-protocol/sei-cosmos v0.3.41 h1:w5ekTGC5J/7kxJhRkfdHk2KWOqi1zhic0gOXNm6W5vI=
+github.com/sei-protocol/sei-cosmos v0.3.41/go.mod h1:ZwWxF/69WlcLEn4BzVjPPToTFkE2sjPanU8PNNyKoOk=
 github.com/sei-protocol/sei-db v0.0.44 h1:HMgcyDTQlmXdJysHJxmIo66EKeXn1CSQT9qXDnxjJgI=
 github.com/sei-protocol/sei-db v0.0.44/go.mod h1:F/ZKZA8HJPcUzSZPA8yt6pfwlGriJ4RDR4eHKSGLStI=
 github.com/sei-protocol/sei-iavl v0.2.0 h1:OisPjXiDT+oe+aeckzDEFgkZCYuUjHgs/PP8DPicN+I=

--- a/tools/migration/sc/migrator.go
+++ b/tools/migration/sc/migrator.go
@@ -77,7 +77,7 @@ func NewMigrator(homeDir string, db dbm.DB) *Migrator {
 	scConfig.Enable = true
 	ssConfig := config.DefaultStateStoreConfig()
 	ssConfig.Enable = false
-	cmsV2 := rootmulti2.NewStore(homeDir, logger, scConfig, ssConfig)
+	cmsV2 := rootmulti2.NewStore(homeDir, logger, scConfig, ssConfig, false)
 	for _, key := range Keys {
 		cmsV2.MountStoreWithDB(key, sdk.StoreTypeIAVL, db)
 	}


### PR DESCRIPTION
## Describe your changes and provide context
- Make the lookup of GetDeliverTxHookWasmGasLimit use an infinite gas meter (10k gas)
- Use the DeliverTxHookWasmGasLimit parameter to govern the whole method, including
  -   Setting Transient Receipt
  -   Lookups like translating CW20 events
  -   GetEVMAddressOrDefault
  -   AppendToEvmTxDeferredInfo

## Testing performed to validate your change

