### PR TITLE
Disable Pruning during SC migration + Bump Sei-cosmos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -346,7 +346,7 @@ require (
 replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.2.4
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.41
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.43
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.2.0
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.2
 	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-23

--- a/go.sum
+++ b/go.sum
@@ -1347,8 +1347,8 @@ github.com/sei-protocol/go-ethereum v1.13.5-sei-23 h1:rkgeOHC56QTco4mIyGd6cZHtlo
 github.com/sei-protocol/go-ethereum v1.13.5-sei-23/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.3.41 h1:w5ekTGC5J/7kxJhRkfdHk2KWOqi1zhic0gOXNm6W5vI=
-github.com/sei-protocol/sei-cosmos v0.3.41/go.mod h1:ZwWxF/69WlcLEn4BzVjPPToTFkE2sjPanU8PNNyKoOk=
+github.com/sei-protocol/sei-cosmos v0.3.43 h1:H3F6wHze6Td0bdrOgV6uGzbMV9H699AA5w2sVgscKEA=
+github.com/sei-protocol/sei-cosmos v0.3.43/go.mod h1:ZwWxF/69WlcLEn4BzVjPPToTFkE2sjPanU8PNNyKoOk=
 github.com/sei-protocol/sei-db v0.0.45 h1:95ygzGFMyvaGwEUmzlKi8MxwXfbluoNzbaIjy9zOG6o=
 github.com/sei-protocol/sei-db v0.0.45/go.mod h1:m5g7p0QeAS3dNJHIl28zQpzOgxQmvYqPb7t4hwgIOCA=
 github.com/sei-protocol/sei-iavl v0.2.0 h1:OisPjXiDT+oe+aeckzDEFgkZCYuUjHgs/PP8DPicN+I=

--- a/tools/migration/sc/migrator.go
+++ b/tools/migration/sc/migrator.go
@@ -77,6 +77,7 @@ func NewMigrator(homeDir string, db dbm.DB) *Migrator {
 	scConfig.Enable = true
 	ssConfig := config.DefaultStateStoreConfig()
 	ssConfig.Enable = true
+	ssConfig.KeepRecent = 0
 	cmsV2 := rootmulti2.NewStore(homeDir, logger, scConfig, ssConfig, true)
 	for _, key := range Keys {
 		cmsV2.MountStoreWithDB(key, sdk.StoreTypeIAVL, db)


### PR DESCRIPTION
## Describe your changes and provide context
- Disables pruning of state store during sc migration
- Pruning previously didn't have an effect though since there is only 1 version for each key stored which won't get removed
- bump sei-cosmos to v0.3.43

## Testing performed to validate your change
- Tested on rpc nodes for sc migration
- 
