### PR TITLE
Set Earliest Version After SS Migration

### DIFF
--- a/tools/migration/ss/migrator.go
+++ b/tools/migration/ss/migrator.go
@@ -67,7 +67,12 @@ func (m *Migrator) Migrate(version int64, homeDir string) error {
 		}
 	}
 
-	// Set latest version in the database
+	// Set earliest and latest version in the database
+	err = m.stateStore.SetEarliestVersion(1)
+	if err != nil {
+		return err
+	}
+
 	return m.stateStore.SetLatestVersion(version)
 }
 
@@ -93,6 +98,7 @@ func (m *Migrator) Verify(version int64) error {
 			}
 			if !bytes.Equal(val, value) {
 				verifyErr = fmt.Errorf("verification error: value doesn't match for key %s. Expected %s, got %s", string(key), string(value), string(val))
+				return true
 			}
 			count++
 			if count%1000000 == 0 {


### PR DESCRIPTION
## Describe your changes and provide context
- Sets the earliest version for SS after migration to height 1 for archive nodes 

## Testing performed to validate your change
- Verifying on node running migration
