### PR TITLE
Use owner event to populate ERC721 transfer topic

### DIFF
--- a/app/receipt.go
+++ b/app/receipt.go
@@ -60,7 +60,7 @@ func (app *App) AddCosmosEventsToEVMReceiptIfApplicable(ctx sdk.Context, tx sdk.
 		// check if there is a ERC721 pointer to contract Addr
 		pointerAddr, _, exists = app.EvmKeeper.GetERC721CW721Pointer(wasmToEvmEventCtx, contractAddr)
 		if exists {
-			log, eligible := app.translateCW721Event(wasmToEvmEventCtx, wasmEvent, pointerAddr, contractAddr)
+			log, eligible := app.translateCW721Event(wasmToEvmEventCtx, wasmEvent, pointerAddr, contractAddr, response)
 			if eligible {
 				log.Index = uint(len(logs))
 				logs = append(logs, log)
@@ -173,7 +173,7 @@ func (app *App) translateCW20Event(ctx sdk.Context, wasmEvent abci.Event, pointe
 	return nil, false
 }
 
-func (app *App) translateCW721Event(ctx sdk.Context, wasmEvent abci.Event, pointerAddr common.Address, contractAddr string) (*ethtypes.Log, bool) {
+func (app *App) translateCW721Event(ctx sdk.Context, wasmEvent abci.Event, pointerAddr common.Address, contractAddr string, response sdk.DeliverTxHookInput) (*ethtypes.Log, bool) {
 	action, found := GetAttributeValue(wasmEvent, "action")
 	if !found {
 		return nil, false
@@ -185,9 +185,32 @@ func (app *App) translateCW721Event(ctx sdk.Context, wasmEvent abci.Event, point
 		if tokenID == nil {
 			return nil, false
 		}
+		sender := app.GetEvmAddressAttribute(ctx, wasmEvent, "sender")
+		ownerEvents := GetEventsOfType(response, wasmtypes.EventTypeCW721PreTransferOwner)
+		for _, ownerEvent := range ownerEvents {
+			if len(ownerEvent.Attributes) != 3 {
+				continue
+			}
+			if string(ownerEvent.Attributes[0].Key) != wasmtypes.AttributeKeyContractAddr || string(ownerEvent.Attributes[0].Value) != contractAddr {
+				continue
+			}
+			tokenIDStr, _ := GetAttributeValue(wasmEvent, "token_id")
+			if string(ownerEvent.Attributes[1].Key) != wasmtypes.AttributeKeyTokenId || string(ownerEvent.Attributes[1].Value) != tokenIDStr {
+				continue
+			}
+			if string(ownerEvent.Attributes[2].Key) != wasmtypes.AttributeKeyOwner {
+				continue
+			}
+			ownerAcc, err := sdk.AccAddressFromBech32(string(ownerEvent.Attributes[2].Value))
+			if err != nil {
+				continue
+			}
+			owner := app.EvmKeeper.GetEVMAddressOrDefault(ctx, ownerAcc)
+			sender = common.BytesToHash(owner[:])
+		}
 		topics = []common.Hash{
 			ERC721TransferTopic,
-			app.GetEvmAddressAttribute(ctx, wasmEvent, "sender"),
+			sender,
 			app.GetEvmAddressAttribute(ctx, wasmEvent, "recipient"),
 			common.BigToHash(tokenID),
 		}


### PR DESCRIPTION
## Describe your changes and provide context
PR https://github.com/sei-protocol/sei-wasmd/pull/67 introduces a new event type indicating the pre-transfer owner of a CW721 token. This PR leverages the new event type to populate the owner topic of synthetic ERC721 transfer event correctly (previously it's set to the sender, which may be the spender and not the actual owner, and is against ERC721 convention).

Since events and receipts are not part of consensus state, this PR shouldn't be breaking app hash.

## Testing performed to validate your change
unit test
