### PR TITLE
bug fix: eth_getLogs missing events from early return

### DIFF
--- a/evmrpc/block_test.go
+++ b/evmrpc/block_test.go
@@ -80,7 +80,7 @@ func TestGetBlockReceipts(t *testing.T) {
 	// Query by block height
 	resObj := sendRequestGood(t, "getBlockReceipts", "0x2")
 	result := resObj["result"].([]interface{})
-	require.Equal(t, 6, len(result))
+	require.Equal(t, 5, len(result))
 	receipt1 := result[0].(map[string]interface{})
 	require.Equal(t, "0x2", receipt1["blockNumber"])
 	require.Equal(t, "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", receipt1["transactionHash"])
@@ -91,10 +91,14 @@ func TestGetBlockReceipts(t *testing.T) {
 	require.Equal(t, "0x2", receipt3["blockNumber"])
 	require.Equal(t, "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", receipt3["transactionHash"])
 
+	resObjSei := sendSeiRequestGood(t, "getBlockReceipts", "0x2")
+	result = resObjSei["result"].([]interface{})
+	require.Equal(t, 6, len(result))
+
 	// Query by block hash
 	resObj2 := sendRequestGood(t, "getBlockReceipts", "0x0000000000000000000000000000000000000000000000000000000000000002")
 	result = resObj2["result"].([]interface{})
-	require.Equal(t, 6, len(result))
+	require.Equal(t, 5, len(result))
 	receipt1 = result[0].(map[string]interface{})
 	require.Equal(t, "0x2", receipt1["blockNumber"])
 	require.Equal(t, "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", receipt1["transactionHash"])

--- a/evmrpc/filter.go
+++ b/evmrpc/filter.go
@@ -372,11 +372,7 @@ func (f *LogFetcher) FindLogsByBloom(height int64, filters [][]bloomIndexes) (re
 			ctx.Logger().Error(fmt.Sprintf("FindLogsByBloom: unable to find receipt for hash %s", hash.Hex()))
 			continue
 		}
-		// if includeShellReceipts is false, include receipts with synthetic logs but exclude shell tx receipts
-		if !f.includeSyntheticReceipts && receipt.TxType == ShellEVMTxType {
-			continue
-		}
-		if !f.includeSyntheticReceipts && receipt.EffectiveGasPrice == 0 {
+		if !f.includeSyntheticReceipts && (receipt.TxType == ShellEVMTxType || receipt.EffectiveGasPrice == 0) {
 			continue
 		}
 		if len(receipt.LogsBloom) > 0 && MatchFilters(ethtypes.Bloom(receipt.LogsBloom), filters) {

--- a/evmrpc/filter.go
+++ b/evmrpc/filter.go
@@ -377,7 +377,7 @@ func (f *LogFetcher) FindLogsByBloom(height int64, filters [][]bloomIndexes) (re
 			continue
 		}
 		if !f.includeSyntheticReceipts && receipt.EffectiveGasPrice == 0 {
-			return
+			continue
 		}
 		if len(receipt.LogsBloom) > 0 && MatchFilters(ethtypes.Bloom(receipt.LogsBloom), filters) {
 			res = append(res, keeper.GetLogsForTx(receipt)...)

--- a/evmrpc/filter.go
+++ b/evmrpc/filter.go
@@ -216,6 +216,7 @@ func (a *FilterAPI) GetLogs(
 	ctx context.Context,
 	crit filters.FilterCriteria,
 ) (res []*ethtypes.Log, err error) {
+	fmt.Println("In GetLogs", "crit", crit)
 	defer recordMetrics(fmt.Sprintf("%s_getLogs", a.namespace), a.connectionType, time.Now(), err == nil)
 	logs, _, err := a.logFetcher.GetLogsByFilters(ctx, crit, 0)
 	return logs, err
@@ -311,6 +312,7 @@ func (f *LogFetcher) GetLogsByFilters(ctx context.Context, crit filters.FilterCr
 	if !applyOpenEndedLogLimit && f.filterConfig.maxBlock > 0 && end >= (begin+f.filterConfig.maxBlock) {
 		end = begin + f.filterConfig.maxBlock - 1
 	}
+	fmt.Println("In GetLogsByFilters", "begin", begin, "end", end)
 	// begin should always be <= end block at this point
 	if begin > end {
 		return nil, 0, fmt.Errorf("fromBlock %d is after toBlock %d", begin, end)
@@ -372,11 +374,17 @@ func (f *LogFetcher) FindLogsByBloom(height int64, filters [][]bloomIndexes) (re
 			ctx.Logger().Error(fmt.Sprintf("FindLogsByBloom: unable to find receipt for hash %s", hash.Hex()))
 			continue
 		}
+		fmt.Println("In FindLogsByBloom", "considering hash", hash.Hex())
+		fmt.Println("In FindLogsByBloom", "includeSyntheticReceipts", f.includeSyntheticReceipts, "receipt.TxType", receipt.TxType, "receipt.EffectiveGasPrice", receipt.EffectiveGasPrice)
 		if !f.includeSyntheticReceipts && (receipt.TxType == ShellEVMTxType || receipt.EffectiveGasPrice == 0) {
+			fmt.Println("In FindLogsByBloom", "skipping hash", hash.Hex())
 			continue
 		}
+		fmt.Println("In FindLogsByBloom", "no skipping hash", hash.Hex())
 		if len(receipt.LogsBloom) > 0 && MatchFilters(ethtypes.Bloom(receipt.LogsBloom), filters) {
-			res = append(res, keeper.GetLogsForTx(receipt)...)
+			logs := keeper.GetLogsForTx(receipt)
+			fmt.Println("Adding", len(logs), "logs")
+			res = append(res, logs...)
 		}
 	}
 	return

--- a/evmrpc/filter_test.go
+++ b/evmrpc/filter_test.go
@@ -130,9 +130,11 @@ func getCommonFilterLogTests() []GetFilterLogTests {
 			wantLen: 4,
 		},
 		{
-			name:    "filter by single topic with default range",
-			topics:  [][]common.Hash{{common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")}},
-			wantErr: false,
+			name:      "filter by single topic with block range",
+			fromBlock: "0x8",
+			toBlock:   "0x8",
+			topics:    [][]common.Hash{{common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")}},
+			wantErr:   false,
 			check: func(t *testing.T, log map[string]interface{}) {
 				require.Equal(t, "0x1111111111111111111111111111111111111111111111111111111111111111", log["topics"].([]interface{})[0].(string))
 			},
@@ -192,7 +194,7 @@ func TestFilterGetLogs(t *testing.T) {
 	testFilterGetLogs(t, "eth", getCommonFilterLogTests())
 }
 
-func TestSeiFilterGetLogs(t *testing.T) {
+func TestFilterSeiGetLogs(t *testing.T) {
 	// make sure we pass all the eth_ namespace tests
 	testFilterGetLogs(t, "sei", getCommonFilterLogTests())
 
@@ -221,16 +223,33 @@ func TestSeiFilterGetLogs(t *testing.T) {
 	})
 }
 
-func TestEthEndpointCanReturnSyntheticLogs(t *testing.T) {
+func TestFilterEthEndpointCanReturnSyntheticLogs(t *testing.T) {
 	testFilterGetLogs(t, "eth", []GetFilterLogTests{
 		{
-			name:    "filter by single topic with default range, exclude synethetic logs",
+			name:    "filter by single topic with default range, still include synthetic logs",
 			topics:  [][]common.Hash{{common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000234")}},
 			wantErr: false,
 			check: func(t *testing.T, log map[string]interface{}) {
 				require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000234", log["topics"].([]interface{})[0].(string))
 			},
 			wantLen: 1,
+		},
+	})
+}
+
+func TestFilterEthEndpointReturnsNormalEvmLogEvenIfSyntheticLogIsInSameBlock(t *testing.T) {
+	testFilterGetLogs(t, "eth", []GetFilterLogTests{
+		{
+			name:      "normal evm log is returned even if synthetic log is in the same block",
+			fromBlock: "0x64", // 100
+			toBlock:   "0x64",
+			wantErr:   false,
+			check: func(t *testing.T, log map[string]interface{}) {
+				// check that none of the events have the synthetic hash
+				syntheticHash := multiTxBlockSynthTx.Hash()
+				require.NotEqual(t, syntheticHash.Hex(), log["transactionHash"].(string))
+			},
+			wantLen: 2,
 		},
 	})
 }
@@ -283,7 +302,7 @@ func TestFilterGetFilterLogs(t *testing.T) {
 
 	resObj = sendRequest(t, TestPort, "getFilterLogs", filterId)
 	logs := resObj["result"].([]interface{})
-	require.Equal(t, 7, len(logs))
+	require.Equal(t, 6, len(logs))
 	for _, log := range logs {
 		logObj := log.(map[string]interface{})
 		require.Equal(t, "0x2", logObj["blockNumber"].(string))

--- a/evmrpc/info.go
+++ b/evmrpc/info.go
@@ -3,6 +3,7 @@ package evmrpc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"slices"
 	"time"
@@ -41,6 +42,7 @@ type FeeHistoryResult struct {
 func (i *InfoAPI) BlockNumber() hexutil.Uint64 {
 	startTime := time.Now()
 	defer recordMetrics("eth_BlockNumber", i.connectionType, startTime, true)
+	fmt.Println("In BlockNumber", "i.ctxProvider(LatestCtxHeight).BlockHeight() = ", i.ctxProvider(LatestCtxHeight).BlockHeight())
 	return hexutil.Uint64(i.ctxProvider(LatestCtxHeight).BlockHeight())
 }
 

--- a/evmrpc/info.go
+++ b/evmrpc/info.go
@@ -3,7 +3,6 @@ package evmrpc
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math/big"
 	"slices"
 	"time"

--- a/evmrpc/info.go
+++ b/evmrpc/info.go
@@ -42,7 +42,6 @@ type FeeHistoryResult struct {
 func (i *InfoAPI) BlockNumber() hexutil.Uint64 {
 	startTime := time.Now()
 	defer recordMetrics("eth_BlockNumber", i.connectionType, startTime, true)
-	fmt.Println("In BlockNumber", "i.ctxProvider(LatestCtxHeight).BlockHeight() = ", i.ctxProvider(LatestCtxHeight).BlockHeight())
 	return hexutil.Uint64(i.ctxProvider(LatestCtxHeight).BlockHeight())
 }
 

--- a/evmrpc/setup_test.go
+++ b/evmrpc/setup_test.go
@@ -779,6 +779,7 @@ func setupLogs() {
 		},
 	}}}})
 	EVMKeeper.MockReceipt(CtxMock, multiTxBlockSynthTx.Hash(), &types.Receipt{
+		TxType:           evmrpc.ShellEVMTxType,
 		BlockNumber:      MockHeight,
 		TransactionIndex: 0,
 		TxHashHex:        multiTxBlockSynthTx.Hash().Hex(),

--- a/evmrpc/setup_test.go
+++ b/evmrpc/setup_test.go
@@ -778,7 +778,6 @@ func setupLogs() {
 			common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000456"),
 		},
 	}}}})
-	fmt.Println("multiTxBlockSynthTx.Hash()", multiTxBlockSynthTx.Hash().Hex())
 	EVMKeeper.MockReceipt(CtxMock, multiTxBlockSynthTx.Hash(), &types.Receipt{
 		BlockNumber:      MockHeight,
 		TransactionIndex: 0,
@@ -819,7 +818,6 @@ func setupLogs() {
 		multiTxBlockTx3.Hash(),
 	})
 	EVMKeeper.SetBlockBloom(MultiTxCtx, []ethtypes.Bloom{bloom1, bloom2, bloom3})
-	fmt.Println("Should be on block 8", multiTxBlockTx1.Hash(), multiTxBlockTx2.Hash(), multiTxBlockTx3.Hash())
 
 	// block 2
 	EVMKeeper.SetTxHashesOnHeight(Ctx, MockHeight, []common.Hash{
@@ -832,7 +830,6 @@ func setupLogs() {
 			common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111112")},
 	}}}})
 	EVMKeeper.SetBlockBloom(Ctx, []ethtypes.Bloom{bloomSynth, bloom4, bloomTx1})
-	fmt.Println("Should be on block 2", multiTxBlockSynthTx.Hash(), multiTxBlockTx4.Hash())
 }
 
 //nolint:deadcode

--- a/evmrpc/setup_test.go
+++ b/evmrpc/setup_test.go
@@ -50,6 +50,7 @@ const TestBadPort = 7779
 const MockHeight = 8
 const MultiTxBlockHeight = 2
 const DebugTraceMockHeight = 101
+const SyntheticBlockHeight = 100
 
 var DebugTraceHashHex = "0x1234567890123456789023456789012345678901234567890123456789000004"
 var DebugTraceBlockHash = "BE17E0261E539CB7E9A91E123A6D794E0163D656FCF9B8EAC07823F7ED28512B"
@@ -163,6 +164,26 @@ func (c *MockClient) mockBlock(height int64) *coretypes.ResultBlock {
 				},
 				LastCommit: &tmtypes.Commit{
 					Height: height,
+				},
+			},
+		}
+	}
+	if height == SyntheticBlockHeight {
+		return &coretypes.ResultBlock{
+			BlockID: MockBlockID,
+			Block: &tmtypes.Block{
+				Header: mockBlockHeader(height),
+				Data: tmtypes.Data{
+					Txs: []tmtypes.Tx{
+						func() []byte {
+							bz, _ := Encoder(MultiTxBlockSynthTx)
+							return bz
+						}(),
+						func() []byte {
+							bz, _ := Encoder(MultiTxBlockTx1)
+							return bz
+						}(),
+					},
 				},
 			},
 		}
@@ -576,7 +597,7 @@ func generateTxData() {
 		From:              "0x1234567890123456789012345678901234567890",
 		To:                "0x1234567890123456789012345678901234567890",
 		TransactionIndex:  0,
-		BlockNumber:       8,
+		BlockNumber:       MockHeight,
 		TxType:            1,
 		ContractAddress:   "0x1234567890123456789012345678901234567890",
 		CumulativeGasUsed: 123,
@@ -679,7 +700,8 @@ func setupLogs() {
 			common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000123"),
 		},
 	}}}})
-	EVMKeeper.MockReceipt(Ctx, multiTxBlockTx1.Hash(), &types.Receipt{
+	CtxMultiTx := Ctx.WithBlockHeight(MultiTxBlockHeight)
+	EVMKeeper.MockReceipt(CtxMultiTx, multiTxBlockTx1.Hash(), &types.Receipt{
 		BlockNumber:      MultiTxBlockHeight,
 		TransactionIndex: 1, // start at 1 bc 0 is the non-evm tx
 		TxHashHex:        multiTxBlockTx1.Hash().Hex(),
@@ -700,7 +722,7 @@ func setupLogs() {
 			common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000456"),
 		},
 	}}}})
-	EVMKeeper.MockReceipt(Ctx, multiTxBlockTx2.Hash(), &types.Receipt{
+	EVMKeeper.MockReceipt(CtxMultiTx, multiTxBlockTx2.Hash(), &types.Receipt{
 		BlockNumber:      MultiTxBlockHeight,
 		TransactionIndex: 3,
 		TxHashHex:        multiTxBlockTx2.Hash().Hex(),
@@ -718,7 +740,7 @@ func setupLogs() {
 			common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000456"),
 		},
 	}}}})
-	EVMKeeper.MockReceipt(Ctx, multiTxBlockTx3.Hash(), &types.Receipt{
+	EVMKeeper.MockReceipt(CtxMultiTx, multiTxBlockTx3.Hash(), &types.Receipt{
 		BlockNumber:      MultiTxBlockHeight,
 		TransactionIndex: 4,
 		TxHashHex:        multiTxBlockTx3.Hash().Hex(),
@@ -736,9 +758,10 @@ func setupLogs() {
 			common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000456"),
 		},
 	}}}})
-	EVMKeeper.MockReceipt(Ctx, multiTxBlockTx4.Hash(), &types.Receipt{
+	CtxMock := Ctx.WithBlockHeight(MockHeight)
+	EVMKeeper.MockReceipt(CtxMock, multiTxBlockTx4.Hash(), &types.Receipt{
 		BlockNumber:      MockHeight,
-		TransactionIndex: 0,
+		TransactionIndex: 1,
 		TxHashHex:        multiTxBlockTx4.Hash().Hex(),
 		LogsBloom:        bloom4[:],
 		Logs: []*types.Log{{
@@ -755,9 +778,10 @@ func setupLogs() {
 			common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000456"),
 		},
 	}}}})
-	EVMKeeper.MockReceipt(Ctx, multiTxBlockSynthTx.Hash(), &types.Receipt{
-		BlockNumber:      MultiTxBlockHeight,
-		TransactionIndex: 5,
+	fmt.Println("multiTxBlockSynthTx.Hash()", multiTxBlockSynthTx.Hash().Hex())
+	EVMKeeper.MockReceipt(CtxMock, multiTxBlockSynthTx.Hash(), &types.Receipt{
+		BlockNumber:      MockHeight,
+		TransactionIndex: 0,
 		TxHashHex:        multiTxBlockSynthTx.Hash().Hex(),
 		LogsBloom:        bloomSynth[:],
 		Logs: []*types.Log{{
@@ -765,16 +789,17 @@ func setupLogs() {
 			Topics:    []string{"0x0000000000000000000000000000000000000000000000000000000000000234", "0x0000000000000000000000000000000000000000000000000000000000000789"},
 			Synthetic: true,
 		}},
-		EffectiveGasPrice: 100,
+		EffectiveGasPrice: 0,
 	})
-	EVMKeeper.MockReceipt(Ctx, common.HexToHash(DebugTraceHashHex), &types.Receipt{
+	CtxDebugTrace := Ctx.WithBlockHeight(DebugTraceMockHeight)
+	EVMKeeper.MockReceipt(CtxDebugTrace, common.HexToHash(DebugTraceHashHex), &types.Receipt{
 		BlockNumber:      DebugTraceMockHeight,
 		TransactionIndex: 0,
 		TxHashHex:        DebugTraceHashHex,
 	})
 	txNonEvmBz, _ := Encoder(TxNonEvmWithSyntheticLog)
 	txNonEvmHash := sha256.Sum256(txNonEvmBz)
-	EVMKeeper.MockReceipt(Ctx, txNonEvmHash, &types.Receipt{
+	EVMKeeper.MockReceipt(CtxMultiTx, txNonEvmHash, &types.Receipt{
 		BlockNumber:      MultiTxBlockHeight,
 		TransactionIndex: 1,
 		TxHashHex:        common.Hash(txNonEvmHash).Hex(),
@@ -786,22 +811,28 @@ func setupLogs() {
 		}},
 		EffectiveGasPrice: 100,
 	})
+
+	// block 8
 	EVMKeeper.SetTxHashesOnHeight(Ctx, MultiTxBlockHeight, []common.Hash{
 		multiTxBlockTx1.Hash(),
 		multiTxBlockTx2.Hash(),
 		multiTxBlockTx3.Hash(),
 	})
+	EVMKeeper.SetBlockBloom(MultiTxCtx, []ethtypes.Bloom{bloom1, bloom2, bloom3})
+	fmt.Println("Should be on block 8", multiTxBlockTx1.Hash(), multiTxBlockTx2.Hash(), multiTxBlockTx3.Hash())
+
+	// block 2
 	EVMKeeper.SetTxHashesOnHeight(Ctx, MockHeight, []common.Hash{
-		multiTxBlockTx4.Hash(),
 		multiTxBlockSynthTx.Hash(),
+		multiTxBlockTx4.Hash(),
 	})
 	bloomTx1 := ethtypes.CreateBloom(ethtypes.Receipts{&ethtypes.Receipt{Logs: []*ethtypes.Log{{
 		Address: common.HexToAddress("0x1111111111111111111111111111111111111111"),
 		Topics: []common.Hash{common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111"),
 			common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111112")},
 	}}}})
-	EVMKeeper.SetBlockBloom(MultiTxCtx, []ethtypes.Bloom{bloom1, bloom2, bloom3})
-	EVMKeeper.SetBlockBloom(Ctx, []ethtypes.Bloom{bloom4, bloomSynth, bloomTx1})
+	EVMKeeper.SetBlockBloom(Ctx, []ethtypes.Bloom{bloomSynth, bloom4, bloomTx1})
+	fmt.Println("Should be on block 2", multiTxBlockSynthTx.Hash(), multiTxBlockTx4.Hash())
 }
 
 //nolint:deadcode


### PR DESCRIPTION
## Describe your changes and provide context
Fixes this issue: https://github.com/sei-protocol/sei-chain/issues/1934

This PR fixes the case where there's a block with a synthetic tx followed by a normal evm tx, we would do an early return and skip the normal evm tx logs in the eth_getLogs endpoint. Instead, what we should do is simply skip the synthetic tx and return any normal evm logs later on in the block.

## Testing performed to validate your change
unit tests.


