### PR TITLE
bug fix: Be resilient to failing txs in debug trace block [main]

### DIFF
--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -380,7 +380,7 @@ func (b *Backend) StateAtBlock(ctx context.Context, block *ethtypes.Block, reexe
 			if !associatedNow {
 				err := types.NewAssociationMissingErr(msg.From.Hex())
 				metrics.IncrementAssociationError("state_at_block", err)
-				return nil, emptyRelease, err
+				continue // don't return error, just continue bc we want to process the rest of the txs and return the statedb
 			}
 			if err := helpers.NewAssociationHelper(b.keeper, b.keeper.BankKeeper(), b.keeper.AccountKeeper()).AssociateAddresses(statedb.Ctx(), seiAddr, msg.From, nil); err != nil {
 				return nil, emptyRelease, err

--- a/go.mod
+++ b/go.mod
@@ -349,7 +349,7 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.44
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.2.0
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.2
-	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-23
+	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241119210153-2fbfc549fcbb
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/sei-protocol/sei-db => github.com/sei-protocol/sei-db v0.0.45
 	// Latest goleveldb is broken, we have to stick to this version

--- a/go.mod
+++ b/go.mod
@@ -349,7 +349,7 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.44
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.2.0
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.2
-	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241119210153-2fbfc549fcbb
+	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241120141252-bf6b5923d7d7
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/sei-protocol/sei-db => github.com/sei-protocol/sei-db v0.0.45
 	// Latest goleveldb is broken, we have to stick to this version

--- a/go.sum
+++ b/go.sum
@@ -1343,8 +1343,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241119210153-2fbfc549fcbb h1:D1zfAWe2RfQ67th/Hajy4r1R6atwjiX1a3dFHnasXvU=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241119210153-2fbfc549fcbb/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241120141252-bf6b5923d7d7 h1:5G1wqz9+1lDKQIpnoaP/oXneLfuhJozPd1/BDNCtaxw=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241120141252-bf6b5923d7d7/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-cosmos v0.3.44 h1:7wLuJguQBhQ1ljU92lEDrZDLcNt+JbUcX7r1Y7V1qws=

--- a/go.sum
+++ b/go.sum
@@ -1343,8 +1343,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-23 h1:rkgeOHC56QTco4mIyGd6cZHtlonulLsaPLZCaMY6TAw=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-23/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241119210153-2fbfc549fcbb h1:D1zfAWe2RfQ67th/Hajy4r1R6atwjiX1a3dFHnasXvU=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241119210153-2fbfc549fcbb/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-cosmos v0.3.44 h1:7wLuJguQBhQ1ljU92lEDrZDLcNt+JbUcX7r1Y7V1qws=


### PR DESCRIPTION
## Describe your changes and provide context
geth changes: https://github.com/sei-protocol/go-ethereum/pull/36
fixes:
 - https://github.com/sei-protocol/sei-chain/issues/1944
 - https://github.com/sei-protocol/sei-chain/issues/1943

The https://github.com/sei-protocol/sei-chain/issues/1943 "address 0xxxx is not linked" issue is caused by not being able to retrieve the previous/parent block's statedb due to an association error. Instead of just erroring out completely, we want to still try our best to return a statedb for the parent block to run debug trace blocks on the current block.

The https://github.com/sei-protocol/sei-chain/issues/1944 "Nonce too low" issue is caused when a tx in the current block is not able to be traced. In this situation, we want to just skip over this tx and continue to trace other txs in the same block instead of erroring out completely.

## Testing performed to validate your change
existing tests + manual testing on archive node

