### PR TITLE
Enable Queries to Iavl for Non-Migrating Nodes

### DIFF
--- a/app/seidb.go
+++ b/app/seidb.go
@@ -64,7 +64,7 @@ func SetupSeiDB(
 	migrationHeight := cast.ToInt64(appOpts.Get(FlagMigrateHeight))
 	baseAppOptions = append([]func(*baseapp.BaseApp){
 		func(baseApp *baseapp.BaseApp) {
-			if migrationEnabled {
+			if migrationEnabled || migrationHeight > 0 {
 				originalCMS := baseApp.CommitMultiStore()
 				baseApp.SetQueryMultiStore(originalCMS)
 				baseApp.SetMigrationHeight(migrationHeight)


### PR DESCRIPTION
## Describe your changes and provide context
- Allows running sc-migration and setting `--migrate-height` on a node
- Queries before migrate height will be routed to iavl and after to seidb

## Testing performed to validate your change
- Tested and verified on a rpc node that ran sc migration and migrate height
