### PR TITLE
Avoid panics in getLogs

### DIFF
--- a/evmrpc/filter.go
+++ b/evmrpc/filter.go
@@ -356,7 +356,7 @@ func (f *LogFetcher) GetLogsByFilters(ctx context.Context, crit filters.FilterCr
 			h := height
 			block, berr := blockByNumberWithRetry(ctx, f.tmClient, &h, 1)
 			if berr != nil {
-				panic(berr)
+				err = berr
 			}
 			matchedLogs := f.GetLogsForBlock(block, crit, bloomIndexes)
 			for _, log := range matchedLogs {


### PR DESCRIPTION
## Describe your changes and provide context
This PR fix the problem of panic, we should not panic in EVM getLogs, instead we can just update the error.

## Testing performed to validate your change

