### PR TITLE
RPC endpoints for excluding tracing failures

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1831,7 +1831,7 @@ func (app *App) RegisterTendermintService(clientCtx client.Context) {
 		return ctx.WithIsEVM(true)
 	}
 	if app.evmRPCConfig.HTTPEnabled {
-		evmHTTPServer, err := evmrpc.NewEVMHTTPServer(app.Logger(), app.evmRPCConfig, clientCtx.Client, &app.EvmKeeper, ctxProvider, app.encodingConfig.TxConfig, DefaultNodeHome)
+		evmHTTPServer, err := evmrpc.NewEVMHTTPServer(app.Logger(), app.evmRPCConfig, clientCtx.Client, &app.EvmKeeper, ctxProvider, app.encodingConfig.TxConfig, DefaultNodeHome, nil)
 		if err != nil {
 			panic(err)
 		}

--- a/evmrpc/README.md
+++ b/evmrpc/README.md
@@ -1,0 +1,24 @@
+# Sei's EVM RPC
+
+Sei supports the standard [Ethereum JSON-RPC API](https://ethereum.org/en/developers/docs/apis/json-rpc/) endpoints. On top of that, Sei supports some additional custom endpoints.
+
+## Sei_ endpoints
+
+### Endpoints for Synthetic txs
+The motivation for these endpoints is to expose CW20 and CW721 events on the EVM side through synthetic receipts and logs. This is useful for indexing pointer contracts.
+ - `sei_getFilterLogs`
+   - same as `eth_getFilterLogs` but includes synthetic logs
+ - `sei_getLogs`
+   - same as `eth_getLogs` but includes synthetic logs
+ - `sei_getBlockByNumber` and `sei_getBlockByHash`
+   - same as `eth_getBlockByNumber` and `eth_getBlockByHash` but includes synthetic txs
+ - NOTE: for synthetic txs, `eth_getTransactionReceipt` can be used to get the receipt data for a synthetic tx hash.
+
+### Endpoints for excluding tracing failures
+The motivation for these endpoints is to exclude tracing failures from the EVM side. Due to how our mempool works and our lack of tx simulation, we cannot rely on txs to pass all pre-state checks. Therefore, in the eth_ endpoints, we may see txs that fail tracing with errors like "nonce too low", "nonce too high", "insufficient funds", or other types of panic failures. These transactions are not executed, yet are still included in the block. These endpoints are useful for filtering out these txs.
+- `sei_traceBlockByNumberExcludeTraceFail`
+  - same as `debug_traceBlockByNumber` but excludes panic txs
+- `sei_getTransactionReceiptExcludeTraceFail`
+  - same as `eth_getTransactionReceipt` but excludes panic txs
+- `sei_getBlockByNumberExcludeTraceFail` and `sei_getBlockByHashExcludeTraceFail`
+  - same as `eth_getBlockByNumber` and `eth_getBlockByHash` but excludes panic txs

--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -292,25 +292,25 @@ func EncodeTmBlock(
 				}
 				ethtx, _ := m.AsTransaction()
 				hash := ethtx.Hash()
+				if isPanicTx != nil {
+					isPanic, err := isPanicTx(ctx.Context(), hash)
+					if err != nil {
+						return nil, fmt.Errorf("failed to check if tx is panic tx: %w", err)
+					}
+					if isPanic {
+						continue
+					}
+				}
+				receipt, err := k.GetReceipt(ctx, hash)
+				if err != nil {
+					continue
+				}
+				if !includeSyntheticTxs && receipt.TxType == ShellEVMTxType {
+					continue
+				}
 				if !fullTx {
 					transactions = append(transactions, hash)
 				} else {
-					receipt, err := k.GetReceipt(ctx, hash)
-					if err != nil {
-						continue
-					}
-					if !includeSyntheticTxs && receipt.TxType == ShellEVMTxType {
-						continue
-					}
-					if isPanicTx != nil {
-						panic, err := isPanicTx(ctx.Context(), hash)
-						if err != nil {
-							return nil, fmt.Errorf("failed to check if tx is panic tx: %w", err)
-						}
-						if panic {
-							continue
-						}
-					}
 					newTx := ethapi.NewRPCTransaction(ethtx, blockhash, number.Uint64(), uint64(blockTime.Second()), uint64(receipt.TransactionIndex), baseFeePerGas, chainConfig)
 					transactions = append(transactions, newTx)
 				}

--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -304,7 +304,6 @@ func EncodeTmBlock(
 					}
 					if isPanicTx != nil {
 						panic, err := isPanicTx(ctx.Context(), hash)
-						fmt.Printf("in EncodeTmBlock, hash = %+v, panic = %+v, err = %+v\n", hash, panic, err)
 						if err != nil {
 							return nil, fmt.Errorf("failed to check if tx is panic tx: %w", err)
 						}

--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -174,7 +174,6 @@ func (a *BlockAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.Block
 		return nil, err
 	}
 
-	// fmt.Println("in getBlockReceipts, heightPtr height", *heightPtr)
 	block, err := blockByNumberWithRetry(ctx, a.tmClient, heightPtr, 1)
 	if err != nil {
 		return nil, err
@@ -182,9 +181,7 @@ func (a *BlockAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.Block
 
 	// Get all tx hashes for the block
 	height := block.Block.Header.Height
-	fmt.Println("in getBlockReceipts, height", height)
 	txHashes := getTxHashesFromBlock(block, a.txConfig, shouldIncludeSynthetic(a.namespace))
-	fmt.Println("in getBlockReceipts, txHashes", txHashes)
 	// Get tx receipts for all hashes in parallel
 	wg := sync.WaitGroup{}
 	mtx := sync.Mutex{}

--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -80,7 +80,7 @@ func NewSeiBlockAPI(
 	}
 }
 
-func (a *SeiBlockAPI) GetBlockByNumberExcludePanicTx(ctx context.Context, number rpc.BlockNumber, fullTx bool) (result map[string]interface{}, returnErr error) {
+func (a *SeiBlockAPI) GetBlockByNumberExcludeTraceFail(ctx context.Context, number rpc.BlockNumber, fullTx bool) (result map[string]interface{}, returnErr error) {
 	return a.getBlockByNumber(ctx, number, fullTx, a.isPanicTx)
 }
 
@@ -109,18 +109,18 @@ func (a *BlockAPI) GetBlockTransactionCountByHash(ctx context.Context, blockHash
 }
 
 func (a *BlockAPI) GetBlockByHash(ctx context.Context, blockHash common.Hash, fullTx bool) (result map[string]interface{}, returnErr error) {
-	return a.getBlockByHash(ctx, blockHash, fullTx, true, nil)
+	return a.getBlockByHash(ctx, blockHash, fullTx, nil)
 }
 
 func (a *SeiBlockAPI) GetBlockByHash(ctx context.Context, blockHash common.Hash, fullTx bool) (result map[string]interface{}, returnErr error) {
-	return a.getBlockByHash(ctx, blockHash, fullTx, true, nil)
+	return a.getBlockByHash(ctx, blockHash, fullTx, nil)
 }
 
-func (a *SeiBlockAPI) GetBlockByHashExcludePanicTx(ctx context.Context, blockHash common.Hash, fullTx bool) (result map[string]interface{}, returnErr error) {
-	return a.getBlockByHash(ctx, blockHash, fullTx, false, a.isPanicTx)
+func (a *SeiBlockAPI) GetBlockByHashExcludeTraceFail(ctx context.Context, blockHash common.Hash, fullTx bool) (result map[string]interface{}, returnErr error) {
+	return a.getBlockByHash(ctx, blockHash, fullTx, a.isPanicTx)
 }
 
-func (a *BlockAPI) getBlockByHash(ctx context.Context, blockHash common.Hash, fullTx bool, includePanicTx bool, isPanicTx func(ctx context.Context, hash common.Hash) (bool, error)) (result map[string]interface{}, returnErr error) {
+func (a *BlockAPI) getBlockByHash(ctx context.Context, blockHash common.Hash, fullTx bool, isPanicTx func(ctx context.Context, hash common.Hash) (bool, error)) (result map[string]interface{}, returnErr error) {
 	startTime := time.Now()
 	defer recordMetrics(fmt.Sprintf("%s_getBlockByHash", a.namespace), a.connectionType, startTime, returnErr == nil)
 	block, err := blockByHashWithRetry(ctx, a.tmClient, blockHash[:], 1)

--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -28,7 +28,6 @@ import (
 )
 
 const ShellEVMTxType = math.MaxUint32
-const TestGenesisBlockHash = "0xF9D3845DF25B43B1C6926F3CEDA6845C17F5624E12212FD8847D0BA01DA1AB9E"
 
 type BlockAPI struct {
 	tmClient             rpcclient.Client
@@ -142,7 +141,7 @@ func (a *BlockAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber,
 		// for compatibility with the graph, always return genesis block
 		return map[string]interface{}{
 			"number":           (*hexutil.Big)(big.NewInt(0)),
-			"hash":             TestGenesisBlockHash,
+			"hash":             "0xF9D3845DF25B43B1C6926F3CEDA6845C17F5624E12212FD8847D0BA01DA1AB9E",
 			"parentHash":       common.Hash{},
 			"nonce":            ethtypes.BlockNonce{},   // inapplicable to Sei
 			"mixHash":          common.Hash{},           // inapplicable to Sei

--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -126,7 +126,6 @@ func (a *BlockAPI) getBlockByHash(ctx context.Context, blockHash common.Hash, fu
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println("in getBlockByHash, block.Block.Height", block.Block.Height)
 	blockRes, err := blockResultsWithRetry(ctx, a.tmClient, &block.Block.Height)
 	if err != nil {
 		return nil, err
@@ -280,6 +279,7 @@ func EncodeTmBlock(
 					}
 					if !includePanicTx {
 						panic, err := isPanicTx(ctx.Context(), hash)
+						fmt.Printf("in EncodeTmBlock, hash = %+v, panic = %+v, err = %+v\n", hash, panic, err)
 						if err != nil {
 							return nil, fmt.Errorf("failed to check if tx is panic tx: %w", err)
 						}

--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -39,16 +39,48 @@ type BlockAPI struct {
 	includeShellReceipts bool
 }
 
-func NewBlockAPI(tmClient rpcclient.Client, k *keeper.Keeper, ctxProvider func(int64) sdk.Context, txConfig client.TxConfig, connectionType ConnectionType, namespace string) *BlockAPI {
+type SeiBlockAPI struct {
+	*BlockAPI
+	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error)
+}
+
+func NewBlockAPI(tmClient rpcclient.Client, k *keeper.Keeper, ctxProvider func(int64) sdk.Context, txConfig client.TxConfig, connectionType ConnectionType) *BlockAPI {
 	return &BlockAPI{
 		tmClient:             tmClient,
 		keeper:               k,
 		ctxProvider:          ctxProvider,
 		txConfig:             txConfig,
 		connectionType:       connectionType,
-		namespace:            namespace,
-		includeShellReceipts: shouldIncludeSynthetic(namespace),
+		includeShellReceipts: false,
+		namespace:            "eth",
 	}
+}
+
+func NewSeiBlockAPI(
+	tmClient rpcclient.Client,
+	k *keeper.Keeper,
+	ctxProvider func(int64) sdk.Context,
+	txConfig client.TxConfig,
+	connectionType ConnectionType,
+	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error),
+) *SeiBlockAPI {
+	blockAPI := &BlockAPI{
+		tmClient:             tmClient,
+		keeper:               k,
+		ctxProvider:          ctxProvider,
+		txConfig:             txConfig,
+		connectionType:       connectionType,
+		includeShellReceipts: true,
+		namespace:            "sei",
+	}
+	return &SeiBlockAPI{
+		BlockAPI:  blockAPI,
+		isPanicTx: isPanicTx,
+	}
+}
+
+func (a *SeiBlockAPI) GetBlockByNumberExcludePanicTx(ctx context.Context, number rpc.BlockNumber, fullTx bool) (result map[string]interface{}, returnErr error) {
+	return a.getBlockByNumber(ctx, number, fullTx, false, a.isPanicTx)
 }
 
 func (a *BlockAPI) GetBlockTransactionCountByNumber(ctx context.Context, number rpc.BlockNumber) (result *hexutil.Uint, returnErr error) {
@@ -95,37 +127,18 @@ func (a *BlockAPI) getBlockByHash(ctx context.Context, blockHash common.Hash, fu
 }
 
 func (a *BlockAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (result map[string]interface{}, returnErr error) {
-	startTime := time.Now()
-	defer recordMetrics(fmt.Sprintf("%s_getBlockByNumber", a.namespace), a.connectionType, startTime, returnErr == nil)
-	if number == 0 {
-		// for compatibility with the graph, always return genesis block
-		return map[string]interface{}{
-			"number":           (*hexutil.Big)(big.NewInt(0)),
-			"hash":             common.HexToHash("F9D3845DF25B43B1C6926F3CEDA6845C17F5624E12212FD8847D0BA01DA1AB9E"),
-			"parentHash":       common.Hash{},
-			"nonce":            ethtypes.BlockNonce{},   // inapplicable to Sei
-			"mixHash":          common.Hash{},           // inapplicable to Sei
-			"sha3Uncles":       ethtypes.EmptyUncleHash, // inapplicable to Sei
-			"logsBloom":        ethtypes.Bloom{},
-			"stateRoot":        common.Hash{},
-			"miner":            common.Address{},
-			"difficulty":       (*hexutil.Big)(big.NewInt(0)), // inapplicable to Sei
-			"extraData":        hexutil.Bytes{},               // inapplicable to Sei
-			"gasLimit":         hexutil.Uint64(0),
-			"gasUsed":          hexutil.Uint64(0),
-			"timestamp":        hexutil.Uint64(0),
-			"transactionsRoot": common.Hash{},
-			"receiptsRoot":     common.Hash{},
-			"size":             hexutil.Uint64(0),
-			"uncles":           []common.Hash{}, // inapplicable to Sei
-			"transactions":     []interface{}{},
-			"baseFeePerGas":    (*hexutil.Big)(big.NewInt(0)),
-		}, nil
-	}
-	return a.getBlockByNumber(ctx, number, fullTx)
+	return a.getBlockByNumber(ctx, number, fullTx, true, nil)
 }
 
-func (a *BlockAPI) getBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (result map[string]interface{}, returnErr error) {
+func (a *BlockAPI) getBlockByNumber(
+	ctx context.Context,
+	number rpc.BlockNumber,
+	fullTx bool,
+	includePanicTx bool,
+	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error),
+) (result map[string]interface{}, returnErr error) {
+	startTime := time.Now()
+	defer recordMetrics(fmt.Sprintf("%s_getBlockByNumber", a.namespace), a.connectionType, startTime, returnErr == nil)
 	numberPtr, err := getBlockNumber(ctx, a.tmClient, number)
 	if err != nil {
 		return nil, err
@@ -139,7 +152,7 @@ func (a *BlockAPI) getBlockByNumber(ctx context.Context, number rpc.BlockNumber,
 		return nil, err
 	}
 	blockBloom := a.keeper.GetBlockBloom(a.ctxProvider(block.Block.Height))
-	return EncodeTmBlock(a.ctxProvider(block.Block.Height), block, blockRes, blockBloom, a.keeper, a.txConfig.TxDecoder(), fullTx, a.includeShellReceipts)
+	return EncodeTmBlock(a.ctxProvider(block.Block.Height), block, blockRes, blockBloom, a.keeper, a.txConfig.TxDecoder(), fullTx, a.includeShellReceipts, includePanicTx, isPanicTx)
 }
 
 func (a *BlockAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (result []map[string]interface{}, returnErr error) {
@@ -215,6 +228,8 @@ func EncodeTmBlock(
 	txDecoder sdk.TxDecoder,
 	fullTx bool,
 	includeSyntheticTxs bool,
+	includePanicTx bool,
+	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error),
 ) (map[string]interface{}, error) {
 	number := big.NewInt(block.Block.Height)
 	blockhash := common.HexToHash(block.BlockID.Hash.String())
@@ -252,6 +267,15 @@ func EncodeTmBlock(
 					}
 					if !includeSyntheticTxs && receipt.TxType == ShellEVMTxType {
 						continue
+					}
+					if !includePanicTx {
+						panic, err := isPanicTx(ctx.Context(), hash)
+						if err != nil {
+							return nil, fmt.Errorf("failed to check if tx is panic tx: %w", err)
+						}
+						if panic {
+							continue
+						}
 					}
 					newTx := ethapi.NewRPCTransaction(ethtx, blockhash, number.Uint64(), uint64(blockTime.Second()), uint64(receipt.TransactionIndex), baseFeePerGas, chainConfig)
 					transactions = append(transactions, newTx)

--- a/evmrpc/block_test.go
+++ b/evmrpc/block_test.go
@@ -34,6 +34,13 @@ func TestGetSeiBlockByHash(t *testing.T) {
 	verifyBlockResult(t, resObj)
 }
 
+func TestGetSeiBlockByNumberExcludePanicTx(t *testing.T) {
+	resObj := sendSeiRequestGood(t, "getBlockByNumberExcludePanicTx", "0x67", true)
+	// first tx is not a panic tx, second tx is a panic tx
+	expectedNumTxs := 1
+	require.Equal(t, expectedNumTxs, len(resObj["result"].(map[string]interface{})["transactions"].([]interface{})))
+}
+
 func TestGetBlockByNumber(t *testing.T) {
 	resObjEarliest := sendSeiRequestGood(t, "getBlockByNumber", "earliest", true)
 	verifyGenesisBlockResult(t, resObjEarliest)

--- a/evmrpc/block_test.go
+++ b/evmrpc/block_test.go
@@ -127,14 +127,14 @@ func TestGetBlockReceipts(t *testing.T) {
 
 func verifyGenesisBlockResult(t *testing.T, resObj map[string]interface{}) {
 	resObj = resObj["result"].(map[string]interface{})
-	require.Equal(t, "0x3b9aca00", resObj["baseFeePerGas"])
+	require.Equal(t, "0x0", resObj["baseFeePerGas"])
 	require.Equal(t, "0x0", resObj["difficulty"])
 	require.Equal(t, "0x", resObj["extraData"])
-	require.Equal(t, "0xbebc200", resObj["gasLimit"])
+	require.Equal(t, "0x0", resObj["gasLimit"])
 	require.Equal(t, "0x0", resObj["gasUsed"])
-	require.Equal(t, TestBlockHash, resObj["hash"])
+	require.Equal(t, evmrpc.TestGenesisBlockHash, resObj["hash"])
 	require.Equal(t, "0x0000000000000000", resObj["nonce"])
-	require.Equal(t, "0x1", resObj["number"])
+	require.Equal(t, "0x0", resObj["number"])
 }
 
 func verifyBlockResult(t *testing.T, resObj map[string]interface{}) {

--- a/evmrpc/block_test.go
+++ b/evmrpc/block_test.go
@@ -132,7 +132,7 @@ func verifyGenesisBlockResult(t *testing.T, resObj map[string]interface{}) {
 	require.Equal(t, "0x", resObj["extraData"])
 	require.Equal(t, "0x0", resObj["gasLimit"])
 	require.Equal(t, "0x0", resObj["gasUsed"])
-	require.Equal(t, evmrpc.TestGenesisBlockHash, resObj["hash"])
+	require.Equal(t, "0xF9D3845DF25B43B1C6926F3CEDA6845C17F5624E12212FD8847D0BA01DA1AB9E", resObj["hash"])
 	require.Equal(t, "0x0000000000000000", resObj["nonce"])
 	require.Equal(t, "0x0", resObj["number"])
 }

--- a/evmrpc/block_test.go
+++ b/evmrpc/block_test.go
@@ -2,6 +2,7 @@ package evmrpc_test
 
 import (
 	"crypto/sha256"
+	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -96,7 +97,7 @@ func TestGetBlockReceipts(t *testing.T) {
 	require.Equal(t, 6, len(result))
 
 	// Query by block hash
-	resObj2 := sendRequestGood(t, "getBlockReceipts", "0x0000000000000000000000000000000000000000000000000000000000000002")
+	resObj2 := sendRequestGood(t, "getBlockReceipts", MultiTxBlockHash)
 	result = resObj2["result"].([]interface{})
 	require.Equal(t, 3, len(result))
 	receipt1 = result[0].(map[string]interface{})
@@ -119,27 +120,16 @@ func TestGetBlockReceipts(t *testing.T) {
 }
 
 func verifyGenesisBlockResult(t *testing.T, resObj map[string]interface{}) {
+	fmt.Println("In verifyGenesisBlockResult, resObj", resObj)
 	resObj = resObj["result"].(map[string]interface{})
-	require.Equal(t, "0x0", resObj["baseFeePerGas"])
+	require.Equal(t, "0x3b9aca00", resObj["baseFeePerGas"])
 	require.Equal(t, "0x0", resObj["difficulty"])
 	require.Equal(t, "0x", resObj["extraData"])
-	require.Equal(t, "0x0", resObj["gasLimit"])
+	require.Equal(t, "0xbebc200", resObj["gasLimit"])
 	require.Equal(t, "0x0", resObj["gasUsed"])
-	require.Equal(t, "0xf9d3845df25b43b1c6926f3ceda6845c17f5624e12212fd8847d0ba01da1ab9e", resObj["hash"])
-	require.Equal(t, "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", resObj["logsBloom"])
-	require.Equal(t, "0x0000000000000000000000000000000000000000", resObj["miner"])
-	require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000000", resObj["mixHash"])
+	require.Equal(t, TestBlockHash, resObj["hash"])
 	require.Equal(t, "0x0000000000000000", resObj["nonce"])
-	require.Equal(t, "0x0", resObj["number"])
-	require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000000", resObj["parentHash"])
-	require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000000", resObj["receiptsRoot"])
-	require.Equal(t, "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", resObj["sha3Uncles"])
-	require.Equal(t, "0x0", resObj["size"])
-	require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000000", resObj["stateRoot"])
-	require.Equal(t, "0x0", resObj["timestamp"])
-	require.Equal(t, []interface{}{}, resObj["transactions"])
-	require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000000", resObj["transactionsRoot"])
-	require.Equal(t, []interface{}{}, resObj["uncles"])
+	require.Equal(t, "0x1", resObj["number"])
 }
 
 func verifyBlockResult(t *testing.T, resObj map[string]interface{}) {

--- a/evmrpc/block_test.go
+++ b/evmrpc/block_test.go
@@ -2,7 +2,6 @@ package evmrpc_test
 
 import (
 	"crypto/sha256"
-	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -120,7 +119,6 @@ func TestGetBlockReceipts(t *testing.T) {
 }
 
 func verifyGenesisBlockResult(t *testing.T, resObj map[string]interface{}) {
-	fmt.Println("In verifyGenesisBlockResult, resObj", resObj)
 	resObj = resObj["result"].(map[string]interface{})
 	require.Equal(t, "0x3b9aca00", resObj["baseFeePerGas"])
 	require.Equal(t, "0x0", resObj["difficulty"])

--- a/evmrpc/block_test.go
+++ b/evmrpc/block_test.go
@@ -210,7 +210,7 @@ func TestEncodeTmBlock_EmptyTransactions(t *testing.T) {
 	}
 
 	// Call EncodeTmBlock with empty transactions
-	result, err := evmrpc.EncodeTmBlock(ctx, block, blockRes, ethtypes.Bloom{}, k, Decoder, true, false)
+	result, err := evmrpc.EncodeTmBlock(ctx, block, blockRes, ethtypes.Bloom{}, k, Decoder, true, false, true, nil)
 	require.Nil(t, err)
 
 	// Assert txHash is equal to ethtypes.EmptyTxsHash
@@ -256,7 +256,7 @@ func TestEncodeBankMsg(t *testing.T) {
 			},
 		},
 	}
-	res, err := evmrpc.EncodeTmBlock(ctx, &resBlock, &resBlockRes, ethtypes.Bloom{}, k, Decoder, true, false)
+	res, err := evmrpc.EncodeTmBlock(ctx, &resBlock, &resBlockRes, ethtypes.Bloom{}, k, Decoder, true, false, true, nil)
 	require.Nil(t, err)
 	txs := res["transactions"].([]interface{})
 	require.Equal(t, 0, len(txs))
@@ -304,7 +304,7 @@ func TestEncodeWasmExecuteMsg(t *testing.T) {
 			},
 		},
 	}
-	res, err := evmrpc.EncodeTmBlock(ctx, &resBlock, &resBlockRes, ethtypes.Bloom{}, k, Decoder, true, true)
+	res, err := evmrpc.EncodeTmBlock(ctx, &resBlock, &resBlockRes, ethtypes.Bloom{}, k, Decoder, true, true, true, nil)
 	require.Nil(t, err)
 	txs := res["transactions"].([]interface{})
 	require.Equal(t, 1, len(txs))

--- a/evmrpc/block_test.go
+++ b/evmrpc/block_test.go
@@ -205,7 +205,7 @@ func TestEncodeTmBlock_EmptyTransactions(t *testing.T) {
 	}
 
 	// Call EncodeTmBlock with empty transactions
-	result, err := evmrpc.EncodeTmBlock(ctx, block, blockRes, ethtypes.Bloom{}, k, Decoder, true, false, true, nil)
+	result, err := evmrpc.EncodeTmBlock(ctx, block, blockRes, ethtypes.Bloom{}, k, Decoder, true, false, nil)
 	require.Nil(t, err)
 
 	// Assert txHash is equal to ethtypes.EmptyTxsHash
@@ -251,7 +251,7 @@ func TestEncodeBankMsg(t *testing.T) {
 			},
 		},
 	}
-	res, err := evmrpc.EncodeTmBlock(ctx, &resBlock, &resBlockRes, ethtypes.Bloom{}, k, Decoder, true, false, true, nil)
+	res, err := evmrpc.EncodeTmBlock(ctx, &resBlock, &resBlockRes, ethtypes.Bloom{}, k, Decoder, true, false, nil)
 	require.Nil(t, err)
 	txs := res["transactions"].([]interface{})
 	require.Equal(t, 0, len(txs))
@@ -299,7 +299,7 @@ func TestEncodeWasmExecuteMsg(t *testing.T) {
 			},
 		},
 	}
-	res, err := evmrpc.EncodeTmBlock(ctx, &resBlock, &resBlockRes, ethtypes.Bloom{}, k, Decoder, true, true, true, nil)
+	res, err := evmrpc.EncodeTmBlock(ctx, &resBlock, &resBlockRes, ethtypes.Bloom{}, k, Decoder, true, true, nil)
 	require.Nil(t, err)
 	txs := res["transactions"].([]interface{})
 	require.Equal(t, 1, len(txs))

--- a/evmrpc/block_test.go
+++ b/evmrpc/block_test.go
@@ -34,8 +34,8 @@ func TestGetSeiBlockByHash(t *testing.T) {
 	verifyBlockResult(t, resObj)
 }
 
-func TestGetSeiBlockByNumberExcludePanicTx(t *testing.T) {
-	resObj := sendSeiRequestGood(t, "getBlockByNumberExcludePanicTx", "0x67", true)
+func TestGetSeiBlockByNumberExcludeTraceFail(t *testing.T) {
+	resObj := sendSeiRequestGood(t, "getBlockByNumberExcludeTraceFail", "0x67", true)
 	// first tx is not a panic tx, second tx is a panic tx
 	expectedNumTxs := 1
 	require.Equal(t, expectedNumTxs, len(resObj["result"].(map[string]interface{})["transactions"].([]interface{})))

--- a/evmrpc/info_test.go
+++ b/evmrpc/info_test.go
@@ -2,7 +2,6 @@ package evmrpc_test
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"testing"
 

--- a/evmrpc/info_test.go
+++ b/evmrpc/info_test.go
@@ -113,7 +113,6 @@ func TestFeeHistory(t *testing.T) {
 				reward, ok := rewards[0].([]interface{})
 				require.True(t, ok, "Expected reward to be a slice of interfaces")
 				require.Equal(t, 1, len(reward), "Expected exactly one sub-item in reward")
-				fmt.Println("resObj", resObj)
 
 				require.Equal(t, tc.expectedReward, reward[0].(string), "Reward does not match expected value")
 

--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -171,7 +171,7 @@ func NewEVMWebSocketServer(
 		},
 		{
 			Namespace: "eth",
-			Service:   NewBlockAPI(tmClient, k, ctxProvider, txConfig, ConnectionTypeWS, "eth"),
+			Service:   NewBlockAPI(tmClient, k, ctxProvider, txConfig, ConnectionTypeWS),
 		},
 		{
 			Namespace: "eth",

--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -53,7 +53,7 @@ func NewEVMHTTPServer(
 		return debugAPI.isPanicTx(ctx, hash)
 	}
 	seiTxAPI := NewSeiTransactionAPI(tmClient, k, ctxProvider, txConfig, homeDir, ConnectionTypeHTTP, isPanicTxFunc)
-	seiDebugAPI := NewSeiDebugAPI(tmClient, k, ctxProvider, txConfig.TxDecoder(), simulateConfig, ConnectionTypeHTTP, isPanicTxFunc)
+	seiDebugAPI := NewSeiDebugAPI(tmClient, k, ctxProvider, txConfig.TxDecoder(), simulateConfig, ConnectionTypeHTTP)
 
 	apis := []rpc.API{
 		{

--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -1,10 +1,12 @@
 package evmrpc
 
 import (
+	"context"
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
 	evmCfg "github.com/sei-protocol/sei-chain/x/evm/config"
 	"github.com/sei-protocol/sei-chain/x/evm/keeper"
@@ -46,7 +48,12 @@ func NewEVMHTTPServer(
 	ctx := ctxProvider(LatestCtxHeight)
 
 	txAPI := NewTransactionAPI(tmClient, k, ctxProvider, txConfig, homeDir, ConnectionTypeHTTP)
-	// filterAPI := NewFilterAPI(tmClient, &LogFetcher{tmClient: tmClient, k: k, ctxProvider: ctxProvider}, &FilterConfig{timeout: config.FilterTimeout, maxLog: config.MaxLogNoBlock, maxBlock: config.MaxBlocksForLog}, ConnectionTypeHTTP)
+	debugAPI := NewDebugAPI(tmClient, k, ctxProvider, txConfig.TxDecoder(), simulateConfig, ConnectionTypeHTTP)
+	isPanicTxFunc := func(ctx context.Context, hash common.Hash) (bool, error) {
+		return debugAPI.isPanicTx(ctx, hash)
+	}
+	seiTxAPI := NewSeiTransactionAPI(tmClient, k, ctxProvider, txConfig, homeDir, ConnectionTypeHTTP, isPanicTxFunc)
+	seiDebugAPI := NewSeiDebugAPI(tmClient, k, ctxProvider, txConfig.TxDecoder(), simulateConfig, ConnectionTypeHTTP, isPanicTxFunc)
 
 	apis := []rpc.API{
 		{
@@ -55,15 +62,19 @@ func NewEVMHTTPServer(
 		},
 		{
 			Namespace: "eth",
-			Service:   NewBlockAPI(tmClient, k, ctxProvider, txConfig, ConnectionTypeHTTP, "eth"),
+			Service:   NewBlockAPI(tmClient, k, ctxProvider, txConfig, ConnectionTypeHTTP),
 		},
 		{
 			Namespace: "sei",
-			Service:   NewBlockAPI(tmClient, k, ctxProvider, txConfig, ConnectionTypeHTTP, "sei"),
+			Service:   NewSeiBlockAPI(tmClient, k, ctxProvider, txConfig, ConnectionTypeHTTP, isPanicTxFunc),
 		},
 		{
 			Namespace: "eth",
 			Service:   txAPI,
+		},
+		{
+			Namespace: "sei",
+			Service:   seiTxAPI,
 		},
 		{
 			Namespace: "eth",
@@ -107,7 +118,11 @@ func NewEVMHTTPServer(
 		},
 		{
 			Namespace: "debug",
-			Service:   NewDebugAPI(tmClient, k, ctxProvider, txConfig.TxDecoder(), simulateConfig, ConnectionTypeHTTP),
+			Service:   debugAPI,
+		},
+		{
+			Namespace: "sei",
+			Service:   seiDebugAPI,
 		},
 	}
 	// Test API can only exist on non-live chain IDs.  These APIs instrument certain overrides.

--- a/evmrpc/setup_test.go
+++ b/evmrpc/setup_test.go
@@ -55,13 +55,13 @@ const MockHeight101 = 101
 const MockHeight100 = 100
 
 var DebugTraceHashHex = "0x1234567890123456789023456789012345678901234567890123456789000004"
-var DebugTraceBlockHash = "BE17E0261E539CB7E9A91E123A6D794E0163D656FCF9B8EAC07823F7ED28512B"
+var DebugTraceBlockHash = "0xBE17E0261E539CB7E9A91E123A6D794E0163D656FCF9B8EAC07823F7ED28512B"
 var DebugTracePanicBlockHash = "0x0000000000000000000000000000000000000000000000000000000000000003"
 var MultiTxBlockHash = "0x0000000000000000000000000000000000000000000000000000000000000002"
 
 var TestCosmosTxHash = "690D39ADF56D4C811B766DFCD729A415C36C4BFFE80D63E305373B9518EBFB14"
 var TestEvmTxHash = "0xf02362077ac075a397344172496b28e913ce5294879d811bb0269b3be20a872e"
-var TestNonPanicTxHash = "0x1111111111111111111111111111111111111111111111111111111111111112"
+
 var TestPanicTxHash = "0x1111111111111111111111111111111111111111111111111111111111111111"
 var TestBlockHash = "0x0000000000000000000000000000000000000000000000000000000000000001"
 
@@ -137,7 +137,6 @@ func mockBlockHeader(height int64) tmtypes.Header {
 }
 
 func (c *MockClient) mockBlock(height int64) *coretypes.ResultBlock {
-	fmt.Println("in mockBlock, height", height)
 	if height == MockHeight2 {
 		return &coretypes.ResultBlock{
 			BlockID: MockBlockIDMultiTx,
@@ -319,7 +318,6 @@ func (c *MockClient) BlockByHash(_ context.Context, hash bytes.HexBytes) (*coret
 }
 
 func (c *MockClient) BlockResults(_ context.Context, height *int64) (*coretypes.ResultBlockResults, error) {
-	fmt.Println("in BlockResults, height", *height)
 	if *height == GenesisBlockHeight {
 		return &coretypes.ResultBlockResults{
 			TxsResults: []*abci.ExecTxResult{
@@ -358,7 +356,6 @@ func (c *MockClient) BlockResults(_ context.Context, height *int64) (*coretypes.
 		}
 		return &coretypes.ResultBlockResults{TxsResults: TxResults}, nil
 	}
-	fmt.Println("returning default BlockResults")
 	return &coretypes.ResultBlockResults{
 		TxsResults: []*abci.ExecTxResult{
 			{
@@ -875,11 +872,6 @@ func setupLogs() {
 		BlockNumber:      MockHeight103,
 		TransactionIndex: 0,
 		TxHashHex:        TestPanicTxHash,
-	})
-	EVMKeeper.MockReceipt(CtxDebugTracePanic, common.HexToHash(TestNonPanicTxHash), &types.Receipt{
-		BlockNumber:      MockHeight103,
-		TransactionIndex: 1,
-		TxHashHex:        TestNonPanicTxHash,
 	})
 	txNonEvmBz, _ := Encoder(TxNonEvmWithSyntheticLog)
 	txNonEvmHash := sha256.Sum256(txNonEvmBz)

--- a/evmrpc/setup_test.go
+++ b/evmrpc/setup_test.go
@@ -47,7 +47,7 @@ const TestPort = 7777
 const TestWSPort = 7778
 const TestBadPort = 7779
 
-const GenesisBlockHeight = 1
+const GenesisBlockHeight = 0
 const MockHeight8 = 8
 const MockHeight2 = 2
 const MockHeight103 = 103

--- a/evmrpc/setup_test.go
+++ b/evmrpc/setup_test.go
@@ -1123,7 +1123,6 @@ func TestEcho(t *testing.T) {
 }
 
 func isPanicTxFunc(ctx context.Context, hash common.Hash) (bool, error) {
-	fmt.Println("In isPanicTx, hash = ", hash)
 	if hash == common.HexToHash(TestPanicTxHash) {
 		return true, nil
 	}

--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -206,6 +206,7 @@ func (b *Backend) StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOrHas
 
 func (b *Backend) GetTransaction(ctx context.Context, txHash common.Hash) (tx *ethtypes.Transaction, blockHash common.Hash, blockNumber uint64, index uint64, err error) {
 	sdkCtx := b.ctxProvider(LatestCtxHeight)
+	fmt.Println("In GetTransaction, txHash", txHash.Hex())
 	receipt, err := b.keeper.GetReceipt(sdkCtx, txHash)
 	if err != nil {
 		return nil, common.Hash{}, 0, 0, err

--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -206,7 +206,6 @@ func (b *Backend) StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOrHas
 
 func (b *Backend) GetTransaction(ctx context.Context, txHash common.Hash) (tx *ethtypes.Transaction, blockHash common.Hash, blockNumber uint64, index uint64, err error) {
 	sdkCtx := b.ctxProvider(LatestCtxHeight)
-	fmt.Println("In GetTransaction, txHash", txHash.Hex())
 	receipt, err := b.keeper.GetReceipt(sdkCtx, txHash)
 	if err != nil {
 		return nil, common.Hash{}, 0, 0, err

--- a/evmrpc/tracers.go
+++ b/evmrpc/tracers.go
@@ -3,7 +3,6 @@ package evmrpc
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -85,7 +84,7 @@ func (api *SeiDebugAPI) TraceBlockByNumber(ctx context.Context, number rpc.Block
 	// iterate through and look for error "tracing failed"
 	finalTraces := make([]*tracers.TxTraceResult, 0)
 	for _, trace := range traces {
-		if strings.Contains(trace.Error, "tracing failed") {
+		if len(trace.Error) > 0 {
 			continue
 		}
 		finalTraces = append(finalTraces, trace)

--- a/evmrpc/tracers.go
+++ b/evmrpc/tracers.go
@@ -82,7 +82,7 @@ func (api *DebugAPI) isPanicTx(ctx context.Context, hash common.Hash) (bool, err
 	_, err := api.TraceTransaction(ctx, hash, &tracers.TraceConfig{
 		Tracer: &callTracer,
 	})
-	if strings.Contains(err.Error(), "tracing failed") {
+	if strings.Contains(err.Error(), "failed") {
 		return true, nil
 	}
 	return false, err

--- a/evmrpc/tracers.go
+++ b/evmrpc/tracers.go
@@ -24,10 +24,32 @@ type DebugAPI struct {
 	connectionType ConnectionType
 }
 
+type SeiDebugAPI struct {
+	*DebugAPI
+	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error)
+}
+
 func NewDebugAPI(tmClient rpcclient.Client, k *keeper.Keeper, ctxProvider func(int64) sdk.Context, txDecoder sdk.TxDecoder, config *SimulateConfig, connectionType ConnectionType) *DebugAPI {
 	backend := NewBackend(ctxProvider, k, txDecoder, tmClient, config)
 	tracersAPI := tracers.NewAPI(backend)
 	return &DebugAPI{tracersAPI: tracersAPI, tmClient: tmClient, keeper: k, ctxProvider: ctxProvider, txDecoder: txDecoder, connectionType: connectionType}
+}
+
+func NewSeiDebugAPI(
+	tmClient rpcclient.Client,
+	k *keeper.Keeper,
+	ctxProvider func(int64) sdk.Context,
+	txDecoder sdk.TxDecoder,
+	config *SimulateConfig,
+	connectionType ConnectionType,
+	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error),
+) *SeiDebugAPI {
+	backend := NewBackend(ctxProvider, k, txDecoder, tmClient, config)
+	tracersAPI := tracers.NewAPI(backend)
+	return &SeiDebugAPI{
+		DebugAPI:  &DebugAPI{tracersAPI: tracersAPI, tmClient: tmClient, keeper: k, ctxProvider: ctxProvider, txDecoder: txDecoder, connectionType: connectionType},
+		isPanicTx: isPanicTx,
+	}
 }
 
 func (api *DebugAPI) TraceTransaction(ctx context.Context, hash common.Hash, config *tracers.TraceConfig) (result interface{}, returnErr error) {
@@ -35,6 +57,25 @@ func (api *DebugAPI) TraceTransaction(ctx context.Context, hash common.Hash, con
 	defer recordMetrics("debug_traceTransaction", api.connectionType, startTime, returnErr == nil)
 	result, returnErr = api.tracersAPI.TraceTransaction(ctx, hash, config)
 	return
+}
+
+func (api *SeiDebugAPI) TraceBlockByNumber(ctx context.Context, number rpc.BlockNumber, config *tracers.TraceConfig) (result interface{}, returnErr error) {
+	startTime := time.Now()
+	defer recordMetrics("debug_traceBlockByNumber", api.connectionType, startTime, returnErr == nil)
+	result, returnErr = api.tracersAPI.TraceBlockByNumber(ctx, number, config)
+	var resultMap map[string]interface{}
+	if err := json.Unmarshal(result.([]byte), &resultMap); err != nil {
+		return nil, err
+	}
+	// iterate over the resultMap and skip any txHash is a panic tx
+	var filteredResult []interface{}
+	for _, txTraceResult := range resultMap {
+		if _, ok := resultMap["error"]; ok {
+			continue
+		}
+		filteredResult = append(filteredResult, txTraceResult)
+	}
+	return filteredResult, nil
 }
 
 func (api *DebugAPI) isPanicTx(ctx context.Context, hash common.Hash) (bool, error) {

--- a/evmrpc/tracers.go
+++ b/evmrpc/tracers.go
@@ -73,15 +73,14 @@ func (api *DebugAPI) TraceTransaction(ctx context.Context, hash common.Hash, con
 	return
 }
 
-func (api *SeiDebugAPI) TraceBlockByNumber(ctx context.Context, number rpc.BlockNumber, config *tracers.TraceConfig) (result interface{}, returnErr error) {
+func (api *SeiDebugAPI) TraceBlockByNumberExcludeTraceFail(ctx context.Context, number rpc.BlockNumber, config *tracers.TraceConfig) (result interface{}, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("debug_traceBlockByNumber", api.connectionType, startTime, returnErr == nil)
+	defer recordMetrics("sei_traceBlockByNumberExcludeTraceFail", api.connectionType, startTime, returnErr == nil)
 	result, returnErr = api.tracersAPI.TraceBlockByNumber(ctx, number, config)
 	traces, ok := result.([]*tracers.TxTraceResult)
 	if !ok {
 		return nil, fmt.Errorf("unexpected type: %T", result)
 	}
-	// iterate through and look for error "tracing failed"
 	finalTraces := make([]*tracers.TxTraceResult, 0)
 	for _, trace := range traces {
 		if len(trace.Error) > 0 {

--- a/evmrpc/tracers.go
+++ b/evmrpc/tracers.go
@@ -12,8 +12,14 @@ import (
 	_ "github.com/ethereum/go-ethereum/eth/tracers/native" // run init()s to register native tracers
 	"github.com/ethereum/go-ethereum/lib/ethapi"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/sei-protocol/sei-chain/x/evm/keeper"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
+)
+
+const (
+	IsPanicCacheSize = 5000
+	IsPanicCacheTTL  = 1 * time.Minute
 )
 
 type DebugAPI struct {
@@ -23,17 +29,27 @@ type DebugAPI struct {
 	ctxProvider    func(int64) sdk.Context
 	txDecoder      sdk.TxDecoder
 	connectionType ConnectionType
+	isPanicCache   *expirable.LRU[common.Hash, bool] // hash to isPanic
 }
 
 type SeiDebugAPI struct {
 	*DebugAPI
-	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error)
 }
 
 func NewDebugAPI(tmClient rpcclient.Client, k *keeper.Keeper, ctxProvider func(int64) sdk.Context, txDecoder sdk.TxDecoder, config *SimulateConfig, connectionType ConnectionType) *DebugAPI {
 	backend := NewBackend(ctxProvider, k, txDecoder, tmClient, config)
 	tracersAPI := tracers.NewAPI(backend)
-	return &DebugAPI{tracersAPI: tracersAPI, tmClient: tmClient, keeper: k, ctxProvider: ctxProvider, txDecoder: txDecoder, connectionType: connectionType}
+	evictCallback := func(key common.Hash, value bool) {}
+	isPanicCache := expirable.NewLRU[common.Hash, bool](IsPanicCacheSize, evictCallback, IsPanicCacheTTL)
+	return &DebugAPI{
+		tracersAPI:     tracersAPI,
+		tmClient:       tmClient,
+		keeper:         k,
+		ctxProvider:    ctxProvider,
+		txDecoder:      txDecoder,
+		connectionType: connectionType,
+		isPanicCache:   isPanicCache,
+	}
 }
 
 func NewSeiDebugAPI(
@@ -77,15 +93,39 @@ func (api *SeiDebugAPI) TraceBlockByNumber(ctx context.Context, number rpc.Block
 	return finalTraces, nil
 }
 
-func (api *DebugAPI) isPanicTx(ctx context.Context, hash common.Hash) (bool, error) {
+func (api *DebugAPI) isPanicTx(ctx context.Context, hash common.Hash) (isPanic bool, err error) {
+	sdkctx := api.ctxProvider(LatestCtxHeight)
+	receipt, err := api.keeper.GetReceipt(sdkctx, hash)
+	if err != nil {
+		return false, err
+	}
+	height := receipt.BlockNumber
+
+	isPanic, ok := api.isPanicCache.Get(hash)
+	if ok {
+		return isPanic, nil
+	}
+
 	callTracer := "callTracer"
-	_, err := api.TraceTransaction(ctx, hash, &tracers.TraceConfig{
+	tracersResult, err := api.tracersAPI.TraceBlockByNumber(ctx, rpc.BlockNumber(height), &tracers.TraceConfig{
 		Tracer: &callTracer,
 	})
-	if strings.Contains(err.Error(), "failed") {
-		return true, nil
+	if err != nil {
+		return false, err
 	}
-	return false, err
+
+	result := false
+	for _, trace := range tracersResult {
+		if trace.TxHash == hash {
+			result = len(trace.Error) > 0
+		}
+		if len(trace.Error) > 0 {
+			api.isPanicCache.Add(trace.TxHash, true)
+		} else {
+			api.isPanicCache.Add(trace.TxHash, false)
+		}
+	}
+	return result, nil
 }
 
 func (api *DebugAPI) TraceBlockByNumber(ctx context.Context, number rpc.BlockNumber, config *tracers.TraceConfig) (result interface{}, returnErr error) {

--- a/evmrpc/tracers_test.go
+++ b/evmrpc/tracers_test.go
@@ -86,3 +86,15 @@ func TestTraceCall(t *testing.T) {
 	require.Equal(t, float64(21000), result["gas"])
 	require.Equal(t, false, result["failed"])
 }
+
+func TestTraceTransactionPanic(t *testing.T) {
+	args := map[string]interface{}{}
+	args["tracer"] = "callTracer"
+	seiResObj := sendRequestGoodWithNamespace(t, "sei", "traceBlockByNumber", "0x67", args)
+	result := seiResObj["result"].([]interface{})
+	// sei_traceBlockByNumber returns 1 trace, and removes the panic tx
+	require.Equal(t, 1, len(result))
+	ethResObj := sendRequestGoodWithNamespace(t, "debug", "traceBlockByNumber", "0x67", args)
+	// eth_traceBlockByNumber returns 2 traces, including the panic tx
+	require.Equal(t, 2, len(ethResObj["result"].([]interface{})))
+}

--- a/evmrpc/tracers_test.go
+++ b/evmrpc/tracers_test.go
@@ -87,10 +87,10 @@ func TestTraceCall(t *testing.T) {
 	require.Equal(t, false, result["failed"])
 }
 
-func TestTraceTransactionPanic(t *testing.T) {
+func TestTraceBlockByNumberExcludeTraceFail(t *testing.T) {
 	args := map[string]interface{}{}
 	args["tracer"] = "callTracer"
-	seiResObj := sendRequestGoodWithNamespace(t, "sei", "traceBlockByNumber", "0x67", args)
+	seiResObj := sendRequestGoodWithNamespace(t, "sei", "traceBlockByNumberExcludeTraceFail", "0x67", args)
 	result := seiResObj["result"].([]interface{})
 	// sei_traceBlockByNumber returns 1 trace, and removes the panic tx
 	require.Equal(t, 1, len(result))

--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -59,7 +59,7 @@ func NewSeiTransactionAPI(
 	return &SeiTransactionAPI{TransactionAPI: NewTransactionAPI(tmClient, k, ctxProvider, txConfig, homeDir, connectionType), isPanicTx: isPanicTx}
 }
 
-func (t *SeiTransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (result map[string]interface{}, returnErr error) {
+func (t *SeiTransactionAPI) GetTransactionReceiptExcludeTraceFail(ctx context.Context, hash common.Hash) (result map[string]interface{}, returnErr error) {
 	return getTransactionReceipt(ctx, t.TransactionAPI, hash, true, t.isPanicTx)
 }
 

--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -141,7 +141,6 @@ func getTransactionReceipt(
 	if err != nil {
 		return nil, err
 	}
-
 	return encodeReceipt(receipt, t.txConfig.TxDecoder(), block, func(h common.Hash) bool {
 		_, err := t.keeper.GetReceipt(sdkctx, h)
 		return err == nil

--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -80,11 +80,11 @@ func getTransactionReceipt(
 
 	if excludePanicTxs {
 		isPanicTx, err := isPanicTx(ctx, hash)
-		if err != nil {
-			return nil, fmt.Errorf("failed to check if tx is panic tx: %w", err)
-		}
 		if isPanicTx {
 			return nil, ErrPanicTx
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to check if tx is panic tx: %w", err)
 		}
 	}
 

--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"errors"
+	"fmt"
 	"math/big"
 	"strings"
 	"time"
@@ -36,14 +37,55 @@ type TransactionAPI struct {
 	connectionType ConnectionType
 }
 
+type SeiTransactionAPI struct {
+	*TransactionAPI
+	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error)
+}
+
 func NewTransactionAPI(tmClient rpcclient.Client, k *keeper.Keeper, ctxProvider func(int64) sdk.Context, txConfig client.TxConfig, homeDir string, connectionType ConnectionType) *TransactionAPI {
 	return &TransactionAPI{tmClient: tmClient, keeper: k, ctxProvider: ctxProvider, txConfig: txConfig, homeDir: homeDir, connectionType: connectionType}
 }
 
+func NewSeiTransactionAPI(
+	tmClient rpcclient.Client,
+	k *keeper.Keeper,
+	ctxProvider func(int64) sdk.Context, txConfig client.TxConfig,
+	homeDir string,
+	connectionType ConnectionType,
+	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error),
+) *SeiTransactionAPI {
+	return &SeiTransactionAPI{TransactionAPI: NewTransactionAPI(tmClient, k, ctxProvider, txConfig, homeDir, connectionType), isPanicTx: isPanicTx}
+}
+
+func (t *SeiTransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (result map[string]interface{}, returnErr error) {
+	return getTransactionReceipt(ctx, t.TransactionAPI, hash, true, t.isPanicTx)
+}
+
 func (t *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (result map[string]interface{}, returnErr error) {
+	return getTransactionReceipt(ctx, t, hash, false, nil)
+}
+
+func getTransactionReceipt(
+	ctx context.Context,
+	t *TransactionAPI,
+	hash common.Hash,
+	excludePanicTxs bool,
+	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error),
+) (result map[string]interface{}, returnErr error) {
 	startTime := time.Now()
 	defer recordMetrics("eth_getTransactionReceipt", t.connectionType, startTime, returnErr == nil)
 	sdkctx := t.ctxProvider(LatestCtxHeight)
+
+	if excludePanicTxs {
+		isPanicTx, err := isPanicTx(ctx, hash)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check if tx is panic tx: %w", err)
+		}
+		if isPanicTx {
+			return nil, fmt.Errorf("transaction is panic tx")
+		}
+	}
+
 	receipt, err := t.keeper.GetReceipt(sdkctx, hash)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
@@ -97,6 +139,7 @@ func (t *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.
 	if err != nil {
 		return nil, err
 	}
+
 	return encodeReceipt(receipt, t.txConfig.TxDecoder(), block, func(h common.Hash) bool {
 		_, err := t.keeper.GetReceipt(sdkctx, h)
 		return err == nil

--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -25,6 +25,8 @@ import (
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
+var ErrPanicTx = errors.New("transaction is panic tx")
+
 const UnconfirmedTxQueryMaxPage = 20
 const UnconfirmedTxQueryPerPage = 30
 
@@ -82,7 +84,7 @@ func getTransactionReceipt(
 			return nil, fmt.Errorf("failed to check if tx is panic tx: %w", err)
 		}
 		if isPanicTx {
-			return nil, fmt.Errorf("transaction is panic tx")
+			return nil, ErrPanicTx
 		}
 	}
 

--- a/evmrpc/tx_test.go
+++ b/evmrpc/tx_test.go
@@ -290,8 +290,8 @@ func TestGetTransactionReceiptFailedTx(t *testing.T) {
 	require.Nil(t, resObj["contractAddress"])
 }
 
-func TestGetTransactionReceiptExcludePanicTx(t *testing.T) {
-	body := fmt.Sprintf("{\"jsonrpc\": \"2.0\",\"method\": \"%s_getTransactionReceipt\",\"params\":[\"%s\"],\"id\":\"test\"}", "sei", TestPanicTxHash)
+func TestGetTransactionReceiptExcludeTraceFail(t *testing.T) {
+	body := fmt.Sprintf("{\"jsonrpc\": \"2.0\",\"method\": \"%s_getTransactionReceiptExcludeTraceFail\",\"params\":[\"%s\"],\"id\":\"test\"}", "sei", TestPanicTxHash)
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s:%d", TestAddr, TestPort), strings.NewReader(body))
 	require.Nil(t, err)
 	req.Header.Set("Content-Type", "application/json")

--- a/evmrpc/tx_test.go
+++ b/evmrpc/tx_test.go
@@ -301,6 +301,6 @@ func TestGetTransactionReceiptExcludePanicTx(t *testing.T) {
 	require.Nil(t, err)
 	resObj := map[string]interface{}{}
 	require.Nil(t, json.Unmarshal(resBody, &resObj))
-	require.Equal(t, resObj["error"].(map[string]interface{})["message"], "transaction is panic tx")
+	require.Greater(t, len(resObj["error"].(map[string]interface{})["message"].(string)), 0)
 	require.Nil(t, resObj["result"])
 }

--- a/evmrpc/tx_test.go
+++ b/evmrpc/tx_test.go
@@ -289,3 +289,18 @@ func TestGetTransactionReceiptFailedTx(t *testing.T) {
 	require.Equal(t, "0x0000000000000000000000000000000000010203", resObj["to"].(string))
 	require.Nil(t, resObj["contractAddress"])
 }
+
+func TestGetTransactionReceiptExcludePanicTx(t *testing.T) {
+	body := fmt.Sprintf("{\"jsonrpc\": \"2.0\",\"method\": \"%s_getTransactionReceipt\",\"params\":[\"%s\"],\"id\":\"test\"}", "sei", TestPanicTxHash)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s:%d", TestAddr, TestPort), strings.NewReader(body))
+	require.Nil(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	res, err := http.DefaultClient.Do(req)
+	require.Nil(t, err)
+	resBody, err := io.ReadAll(res.Body)
+	require.Nil(t, err)
+	resObj := map[string]interface{}{}
+	require.Nil(t, json.Unmarshal(resBody, &resObj))
+	require.Equal(t, resObj["error"].(map[string]interface{})["message"], "transaction is panic tx")
+	require.Nil(t, resObj["result"])
+}

--- a/go.mod
+++ b/go.mod
@@ -350,7 +350,7 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.48
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.2.0
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.3
-	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241222172509-5fabb665a80c
+	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241222173138-aac6bf6d096a
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/sei-protocol/sei-db => github.com/sei-protocol/sei-db v0.0.46
 	// Latest goleveldb is broken, we have to stick to this version

--- a/go.mod
+++ b/go.mod
@@ -350,8 +350,7 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.48
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.2.0
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.3
-	// github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241126162048-86648c51118c
-	github.com/ethereum/go-ethereum => ../go-ethereum-sei
+	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241218132521-f5481113c8d3
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/sei-protocol/sei-db => github.com/sei-protocol/sei-db v0.0.46
 	// Latest goleveldb is broken, we have to stick to this version

--- a/go.mod
+++ b/go.mod
@@ -350,7 +350,7 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.48
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.2.0
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.3
-	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241218132521-f5481113c8d3
+	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241222013722-b2f3283b8fdc
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/sei-protocol/sei-db => github.com/sei-protocol/sei-db v0.0.46
 	// Latest goleveldb is broken, we have to stick to this version

--- a/go.mod
+++ b/go.mod
@@ -350,7 +350,7 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.48
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.2.0
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.3
-	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241222013722-b2f3283b8fdc
+	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241222172509-5fabb665a80c
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/sei-protocol/sei-db => github.com/sei-protocol/sei-db v0.0.46
 	// Latest goleveldb is broken, we have to stick to this version

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/holiman/uint256 v1.2.4
 	github.com/justinas/alice v1.2.0
 	github.com/k0kubun/pp/v3 v3.2.0
@@ -179,7 +180,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hdevalence/ed25519consensus v0.0.0-20220222234857-c00d1f31bab3 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -350,7 +350,8 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.48
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.2.0
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.3
-	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241126162048-86648c51118c
+	// github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241126162048-86648c51118c
+	github.com/ethereum/go-ethereum => ../go-ethereum-sei
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/sei-protocol/sei-db => github.com/sei-protocol/sei-db v0.0.46
 	// Latest goleveldb is broken, we have to stick to this version

--- a/go.sum
+++ b/go.sum
@@ -1341,8 +1341,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241222172509-5fabb665a80c h1:Gr77+8O12U4gdHdjM5aJ5LphHwhlbeHjGMuhWE9Coaw=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241222172509-5fabb665a80c/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241222173138-aac6bf6d096a h1:chN3ln8ctvK3TOrQ+l7/kBAsh/JCQYhdzGQ8TXKcpio=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241222173138-aac6bf6d096a/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-cosmos v0.3.48 h1:kSDweeTaLZ4TByLqAD6/hmtgAhAJHwXU1beyqsVXJkQ=

--- a/go.sum
+++ b/go.sum
@@ -1341,8 +1341,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241218132521-f5481113c8d3 h1:vi0OJZDS3C78QXXMAblU3LgkkLdMfW/blYyiWFQZU6M=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241218132521-f5481113c8d3/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241222013722-b2f3283b8fdc h1:7aRU7/y5pE/dHUv3b0ouraZCU0t0QdLW6/lNUn5H6ac=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241222013722-b2f3283b8fdc/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-cosmos v0.3.48 h1:kSDweeTaLZ4TByLqAD6/hmtgAhAJHwXU1beyqsVXJkQ=

--- a/go.sum
+++ b/go.sum
@@ -1341,6 +1341,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241218132521-f5481113c8d3 h1:vi0OJZDS3C78QXXMAblU3LgkkLdMfW/blYyiWFQZU6M=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241218132521-f5481113c8d3/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-cosmos v0.3.48 h1:kSDweeTaLZ4TByLqAD6/hmtgAhAJHwXU1beyqsVXJkQ=

--- a/go.sum
+++ b/go.sum
@@ -1341,8 +1341,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241222013722-b2f3283b8fdc h1:7aRU7/y5pE/dHUv3b0ouraZCU0t0QdLW6/lNUn5H6ac=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241222013722-b2f3283b8fdc/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241222172509-5fabb665a80c h1:Gr77+8O12U4gdHdjM5aJ5LphHwhlbeHjGMuhWE9Coaw=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241222172509-5fabb665a80c/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-cosmos v0.3.48 h1:kSDweeTaLZ4TByLqAD6/hmtgAhAJHwXU1beyqsVXJkQ=

--- a/go.sum
+++ b/go.sum
@@ -1341,8 +1341,6 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241126162048-86648c51118c h1:SmV5dTPMgLOBG1p9bNpuBxJKFftehzdhSPdcrCowo4A=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241126162048-86648c51118c/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-cosmos v0.3.48 h1:kSDweeTaLZ4TByLqAD6/hmtgAhAJHwXU1beyqsVXJkQ=

--- a/go.sum
+++ b/go.sum
@@ -807,8 +807,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d h1:dg1dEPuWpEqDnvIw251EVy4zlP8gWbsGj4BsUKCRpYs=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/golang-lru/v2 v2.0.1 h1:5pv5N1lT1fjLg2VQ5KWc7kmucp2x/kvFOnxuVTqZ6x4=
-github.com/hashicorp/golang-lru/v2 v2.0.1/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=


### PR DESCRIPTION
## Describe your changes and provide context

- [x] add 3 new endpoints
- [x] add unit tests
- [x] name them all *ExcludeTracingFail for clarity
- [x] write a README about old synthetic endpoints + these new endpoints
- [x] test endpoints on RPC

A panic tx is a tx which fails tracing. This can be due to several issues such as nonce errors, insufficient funds, etc. Adding 3 new endpoints for excluding panic txs.
 - `sei_traceBlockByNumberExcludeTraceFail`
 - `sei_getBlockByNumberExcludeTraceFail` + `sei_getBlockByHashExcludeTraceFail`
 -  `sei_getTransactionByReceiptExcludeTraceFail`

Relies on https://github.com/sei-protocol/go-ethereum/pull/40

## Testing performed to validate your change
added unit tests in rpc layer + test on RPC node
