### PR TITLE
Catch panic in trace transaction / trace call

### DIFF
--- a/evmrpc/tracers_test.go
+++ b/evmrpc/tracers_test.go
@@ -86,3 +86,8 @@ func TestTraceCall(t *testing.T) {
 	require.Equal(t, float64(21000), result["gas"])
 	require.Equal(t, false, result["failed"])
 }
+
+func TestTraceTransactionPanic(t *testing.T) {
+	// try to make a NewDebugAPI here and just call that
+	
+}

--- a/evmrpc/tracers_test.go
+++ b/evmrpc/tracers_test.go
@@ -86,8 +86,3 @@ func TestTraceCall(t *testing.T) {
 	require.Equal(t, float64(21000), result["gas"])
 	require.Equal(t, false, result["failed"])
 }
-
-func TestTraceTransactionPanic(t *testing.T) {
-	// try to make a NewDebugAPI here and just call that
-	
-}

--- a/go.mod
+++ b/go.mod
@@ -350,7 +350,8 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.48
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.2.0
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.3
-	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-25
+	// github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-25
+	github.com/ethereum/go-ethereum => ../go-ethereum-sei
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/sei-protocol/sei-db => github.com/sei-protocol/sei-db v0.0.46
 	// Latest goleveldb is broken, we have to stick to this version

--- a/go.mod
+++ b/go.mod
@@ -350,7 +350,7 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.48
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.2.0
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.3
-	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241222235830-661f1cf0a9eb
+	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241224143343-21ee50facc96
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/sei-protocol/sei-db => github.com/sei-protocol/sei-db v0.0.46
 	// Latest goleveldb is broken, we have to stick to this version

--- a/go.mod
+++ b/go.mod
@@ -350,8 +350,7 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.48
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.2.0
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.3
-	// github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-25
-	github.com/ethereum/go-ethereum => ../go-ethereum-sei
+	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241222235830-661f1cf0a9eb
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/sei-protocol/sei-db => github.com/sei-protocol/sei-db v0.0.46
 	// Latest goleveldb is broken, we have to stick to this version

--- a/go.sum
+++ b/go.sum
@@ -1341,8 +1341,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241222235830-661f1cf0a9eb h1:eisbYeW8oL8LsFMo7IL9qvTxUA6QUCFOQGFYUDFsCN0=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241222235830-661f1cf0a9eb/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241224143343-21ee50facc96 h1:q3c27XE7bRDg1PUood5H5urkBFd6qNxySpAuKUlcWxE=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241224143343-21ee50facc96/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-cosmos v0.3.48 h1:kSDweeTaLZ4TByLqAD6/hmtgAhAJHwXU1beyqsVXJkQ=

--- a/go.sum
+++ b/go.sum
@@ -1341,8 +1341,6 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-25 h1:qj+AbDeIDMFiRdlOzJJZJVdTJoKA2uvyznhs6l9c5LE=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-25/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-cosmos v0.3.48 h1:kSDweeTaLZ4TByLqAD6/hmtgAhAJHwXU1beyqsVXJkQ=

--- a/go.sum
+++ b/go.sum
@@ -1341,6 +1341,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241222235830-661f1cf0a9eb h1:eisbYeW8oL8LsFMo7IL9qvTxUA6QUCFOQGFYUDFsCN0=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-9.0.20241222235830-661f1cf0a9eb/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-cosmos v0.3.48 h1:kSDweeTaLZ4TByLqAD6/hmtgAhAJHwXU1beyqsVXJkQ=


### PR DESCRIPTION
## Describe your changes and provide context
Small change to catch the panic at the top level of TraceTransaction and TraceCall. This way, if one of these panics, it will return more gracefully fail and print out a panic error message instead of "method handler crashed".

## Testing performed to validate your change
existing unit tests

