### PR TITLE
Fix volatile eth_gasPrice

### DIFF
--- a/evmrpc/info.go
+++ b/evmrpc/info.go
@@ -76,7 +76,7 @@ func (i *InfoAPI) GasPrice(ctx context.Context) (result *hexutil.Big, returnErr 
 	baseFee := i.keeper.GetDynamicBaseFeePerGas(i.ctxProvider(LatestCtxHeight)).TruncateInt().BigInt()
 	// increase base fee by 10% to get the gas price to get a tx included in a timely manner
 	// legacy txs will use this gas price to get included
-	// eip-1669 txs will use this as the max fee per gas to get included
+	// eip-1559 txs will use this as the max fee per gas to get included
 	gasPrice := new(big.Int).Mul(baseFee, big.NewInt(110))
 	gasPrice.Div(gasPrice, big.NewInt(100))
 	return (*hexutil.Big)(gasPrice), nil

--- a/evmrpc/info.go
+++ b/evmrpc/info.go
@@ -85,7 +85,12 @@ func (i *InfoAPI) GasPrice(ctx context.Context) (result *hexutil.Big, returnErr 
 	if err != nil {
 		return nil, err
 	}
-	medianRewardPrevBlock := feeHist.Reward[0][0].ToInt()
+	var medianRewardPrevBlock *big.Int
+	if len(feeHist.Reward) == 0 || len(feeHist.Reward[0]) == 0 {
+		medianRewardPrevBlock = big.NewInt(defaultPriorityFeePerGas)
+	} else {
+		medianRewardPrevBlock = feeHist.Reward[0][0].ToInt()
+	}
 	return i.GasPriceHelper(ctx, baseFee, totalGasUsed, medianRewardPrevBlock)
 }
 

--- a/evmrpc/info.go
+++ b/evmrpc/info.go
@@ -241,11 +241,6 @@ func (i *InfoAPI) getRewards(block *coretypes.ResultBlock, baseFee *big.Int, rew
 		if err != nil {
 			return nil, err
 		}
-		// We've had issues where is included in a block and fails but then is retried and included in a later block, overwriting the receipt.
-		// This is a temporary fix to ensure we only consider receipts that are included in the block we're querying.
-		if receipt.BlockNumber != uint64(block.Block.Height) {
-			continue
-		}
 		reward := new(big.Int).Sub(new(big.Int).SetUint64(receipt.EffectiveGasPrice), baseFee)
 		GasAndRewards = append(GasAndRewards, GasAndReward{GasUsed: receipt.GasUsed, Reward: reward})
 		totalEVMGasUsed += receipt.GasUsed

--- a/evmrpc/info_test.go
+++ b/evmrpc/info_test.go
@@ -166,5 +166,5 @@ func TestMaxPriorityFeePerGas(t *testing.T) {
 	Ctx = Ctx.WithBlockHeight(1)
 	// Mimic request sending and handle the response
 	resObj := sendRequestGood(t, "maxPriorityFeePerGas")
-	assert.Equal(t, "0x170cdc1e00", resObj["result"])
+	assert.Equal(t, "0x3b9aca00", resObj["result"])
 }

--- a/evmrpc/info_test.go
+++ b/evmrpc/info_test.go
@@ -61,8 +61,8 @@ func TestGasPrice(t *testing.T) {
 	resObj := sendRequestGood(t, "gasPrice")
 	Ctx = Ctx.WithBlockHeight(8)
 	result := resObj["result"].(string)
-	oneGwei := "0x3b9aca00"
-	require.Equal(t, oneGwei, result)
+	onePointOneGwei := "0x4190ab00"
+	require.Equal(t, onePointOneGwei, result)
 }
 
 func TestFeeHistory(t *testing.T) {


### PR DESCRIPTION
## Describe your changes and provide context

Our current eth_gasPrice uses the reward of the 50th percentile tx in the latest block as part of the calculation. This works decently well if the previous block is congested. However, if the previous block had only 1 tx where the user dramatically overpriced their tx, it will return a very high reward. This often causes our eth_gasPrice endpoint to jump around erratically.

This change uses the previous block's total gas used to determine if the block is congested. If the previous block is congested, we will use the previous logic of 50% of reward. Otherwise, eth_gasPrice now pulls the latest base fee and increases it by 10% to ensure the user's tx can be included in a timely manner without dramatically overpaying.

This also makes a similar adjustment to `eth_maxPriorityFeePerGas` where if the chain is not congested, a default priority fee of 1gwei is returned to the user.

## Testing performed to validate your change
existing unit testing + manually patched it onto an RPC node.

