### PR TITLE
Revert evm migration for RemoveTxHashes

### DIFF
--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -229,10 +229,6 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	_ = cfg.RegisterMigration(types.ModuleName, 15, func(ctx sdk.Context) error {
 		return migrations.StoreCWPointerCode(ctx, am.keeper, false, false, true)
 	})
-
-	_ = cfg.RegisterMigration(types.ModuleName, 16, func(ctx sdk.Context) error {
-		return migrations.RemoveTxHashes(ctx, am.keeper)
-	})
 }
 
 // RegisterInvariants registers the capability module's invariants.
@@ -270,7 +266,7 @@ func (am AppModule) ExportGenesisStream(ctx sdk.Context, cdc codec.JSONCodec) <-
 }
 
 // ConsensusVersion implements ConsensusVersion.
-func (AppModule) ConsensusVersion() uint64 { return 16 }
+func (AppModule) ConsensusVersion() uint64 { return 15 }
 
 // BeginBlock executes all ABCI BeginBlock logic respective to the capability module.
 func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {

--- a/x/evm/module_test.go
+++ b/x/evm/module_test.go
@@ -60,7 +60,7 @@ func TestModuleExportGenesis(t *testing.T) {
 func TestConsensusVersion(t *testing.T) {
 	k, _ := testkeeper.MockEVMKeeper()
 	module := evm.NewAppModule(nil, k)
-	assert.Equal(t, uint64(16), module.ConsensusVersion())
+	assert.Equal(t, uint64(15), module.ConsensusVersion())
 }
 
 func TestABCI(t *testing.T) {


### PR DESCRIPTION
## Describe your changes and provide context
This PR reverts the migration handler for RemoveTxHashes.
## Testing performed to validate your change

