### PR TITLE
fix linking with go 1.23+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,9 @@ build_tags_comma_sep := $(subst $(whitespace),$(comma),$(build_tags))
 
 # process linker flags
 
-ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=sei \
+# go 1.23+ needs a workaround (checklinkname=0) to link memsize (see https://github.com/fjl/memsize).
+ldflags = -checklinkname=0 \
+			-X github.com/cosmos/cosmos-sdk/version.Name=sei \
 			-X github.com/cosmos/cosmos-sdk/version.ServerName=seid \
 			-X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
 			-X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \

--- a/Makefile
+++ b/Makefile
@@ -46,14 +46,18 @@ build_tags_comma_sep := $(subst $(whitespace),$(comma),$(build_tags))
 
 # process linker flags
 
-# go 1.23+ needs a workaround (checklinkname=0) to link memsize (see https://github.com/fjl/memsize).
-ldflags = -checklinkname=0 \
-			-X github.com/cosmos/cosmos-sdk/version.Name=sei \
+ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=sei \
 			-X github.com/cosmos/cosmos-sdk/version.ServerName=seid \
 			-X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
 			-X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
 			-X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)"
 
+# go 1.23+ needs a workaround to link memsize (see https://github.com/fjl/memsize).
+# NOTE: this is a terribly ugly and unstable way of comparing version numbers,
+# but that's what you get when you do anything nontrivial in a Makefile.
+ifeq ($(firstword $(sort go1.23 $(shell go env GOVERSION))), go1.23)
+	ldflags += -checklinkname=0
+endif
 ifeq ($(LINK_STATICALLY),true)
 	ldflags += -linkmode=external -extldflags "-Wl,-z,muldefs -static"
 endif


### PR DESCRIPTION
To link https://github.com/fjl/memsize with go 1.23 a workaround is needed.