### PR TITLE
Add custom query handling for unbonding balances

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -560,6 +560,7 @@ func New(
 			app.TransferKeeper,
 			app.AccessControlKeeper,
 			&app.EvmKeeper,
+			app.StakingKeeper,
 		),
 		wasmOpts...,
 	)

--- a/wasmbinding/query_plugin.go
+++ b/wasmbinding/query_plugin.go
@@ -13,6 +13,7 @@ const (
 	EpochRoute        = "epoch"
 	TokenFactoryRoute = "tokenfactory"
 	EVMRoute          = "evm"
+	StakingExtRoute   = "stakingext"
 )
 
 type SeiQueryWrapper struct {
@@ -37,6 +38,8 @@ func CustomQuerier(qp *QueryPlugin) func(ctx sdk.Context, request json.RawMessag
 			return qp.HandleTokenFactoryQuery(ctx, contractQuery.QueryData)
 		case EVMRoute:
 			return qp.HandleEVMQuery(ctx, contractQuery.QueryData)
+		case StakingExtRoute:
+			return qp.HandleStakingExtQuery(ctx, contractQuery.QueryData)
 		default:
 			return nil, wasmvmtypes.UnsupportedRequest{Kind: "Unknown Sei Query Route"}
 		}

--- a/wasmbinding/test/query_test.go
+++ b/wasmbinding/test/query_test.go
@@ -36,7 +36,7 @@ func SetupWasmbindingTest(t *testing.T) (*app.TestWrapper, func(ctx sdk.Context,
 	eh := epochwasm.NewEpochWasmQueryHandler(&testWrapper.App.EpochKeeper)
 	th := tokenfactorywasm.NewTokenFactoryWasmQueryHandler(&testWrapper.App.TokenFactoryKeeper)
 	evmh := evmwasm.NewEVMQueryHandler(&testWrapper.App.EvmKeeper)
-	qp := wasmbinding.NewQueryPlugin(oh, eh, th, evmh)
+	qp := wasmbinding.NewQueryPlugin(oh, eh, th, evmh, testWrapper.App.StakingKeeper)
 	return testWrapper, wasmbinding.CustomQuerier(qp)
 }
 

--- a/wasmbinding/wasm.go
+++ b/wasmbinding/wasm.go
@@ -7,6 +7,7 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	aclkeeper "github.com/cosmos/cosmos-sdk/x/accesscontrol/keeper"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	epochwasm "github.com/sei-protocol/sei-chain/x/epoch/client/wasm"
 	epochkeeper "github.com/sei-protocol/sei-chain/x/epoch/keeper"
 	evmwasm "github.com/sei-protocol/sei-chain/x/evm/client/wasm"
@@ -30,12 +31,13 @@ func RegisterCustomPlugins(
 	portSource wasmtypes.ICS20TransferPortSource,
 	aclKeeper aclkeeper.Keeper,
 	evmKeeper *evmkeeper.Keeper,
+	stakingKeeper stakingkeeper.Keeper,
 ) []wasmkeeper.Option {
 	oracleHandler := oraclewasm.NewOracleWasmQueryHandler(oracle)
 	epochHandler := epochwasm.NewEpochWasmQueryHandler(epoch)
 	tokenfactoryHandler := tokenfactorywasm.NewTokenFactoryWasmQueryHandler(tokenfactory)
 	evmHandler := evmwasm.NewEVMQueryHandler(evmKeeper)
-	wasmQueryPlugin := NewQueryPlugin(oracleHandler, epochHandler, tokenfactoryHandler, evmHandler)
+	wasmQueryPlugin := NewQueryPlugin(oracleHandler, epochHandler, tokenfactoryHandler, evmHandler, stakingKeeper)
 
 	queryPluginOpt := wasmkeeper.WithQueryPlugins(&wasmkeeper.QueryPlugins{
 		Custom: CustomQuerier(wasmQueryPlugin),


### PR DESCRIPTION
## Describe your changes and provide context
GetUnbondingDelegations is not part of the standard staking wasmbinding so to support it we either need to fork many additional repos or add it as a custom query. The former seems riskier in terms of blast radius so we are adding it as a custom query here.

## Testing performed to validate your change
integration test with gringotts contract
