### PR TITLE
Fix account not found error code

### DIFF
--- a/integration_test/confidential_transfers_module/apply_pending_balance_test.yaml
+++ b/integration_test/confidential_transfers_module/apply_pending_balance_test.yaml
@@ -43,7 +43,7 @@
   verifiers:
     # Verify that the setup was successful
     - type: eval
-      expr: INIT_ACCOUNT_CODE == 0 or INIT_ACCOUNT_CODE == 38
+      expr: INIT_ACCOUNT_CODE == 0 or INIT_ACCOUNT_CODE == 18
 
     # Verify that the setup deposit was successful
     - type: eval
@@ -153,7 +153,7 @@
   verifiers:
     # Verify that the account exists after the instruction is executed.
     - type: eval
-      expr: INIT_ACCOUNT_CODE == 0 or INIT_ACCOUNT_CODE == 38
+      expr: INIT_ACCOUNT_CODE == 0 or INIT_ACCOUNT_CODE == 18
 
     # Verify that the deposit was successful
     - type: eval

--- a/integration_test/confidential_transfers_module/close_account_test.yaml
+++ b/integration_test/confidential_transfers_module/close_account_test.yaml
@@ -122,7 +122,7 @@
   verifiers:
     # Verify that the account exists after the instruction is executed.
     - type: eval
-      expr: INIT_ACCOUNT_CODE == 0 or INIT_ACCOUNT_CODE == 38
+      expr: INIT_ACCOUNT_CODE == 0 or INIT_ACCOUNT_CODE == 18
 
     # Verify that closing the account was successful
     - type: eval

--- a/integration_test/confidential_transfers_module/ct_precompile_queries.yaml
+++ b/integration_test/confidential_transfers_module/ct_precompile_queries.yaml
@@ -36,7 +36,7 @@
   verifiers:
     # Verify that the account exists after the instruction is executed.
     - type: eval
-      expr: INIT_ACCOUNT_CODE == 0 or INIT_ACCOUNT_CODE == 38
+      expr: INIT_ACCOUNT_CODE == 0 or INIT_ACCOUNT_CODE == 18
 
     # Verify that the deposit was successful
     - type: eval

--- a/integration_test/confidential_transfers_module/deposit_test.yaml
+++ b/integration_test/confidential_transfers_module/deposit_test.yaml
@@ -49,7 +49,7 @@
   verifiers:
     # Verify that the account exists after the instruction is executed.
     - type: eval
-      expr: INIT_ACCOUNT_CODE == 0 or INIT_ACCOUNT_CODE == 38
+      expr: INIT_ACCOUNT_CODE == 0 or INIT_ACCOUNT_CODE == 18
 
     # Verify that the deposit was successful
     - type: eval
@@ -135,7 +135,7 @@
   verifiers:
     # Verify that the account exists after the instruction is executed.
     - type: eval
-      expr: INIT_ACCOUNT_CODE_USDC == 0 or INIT_ACCOUNT_CODE_USDC == 38
+      expr: INIT_ACCOUNT_CODE_USDC == 0 or INIT_ACCOUNT_CODE_USDC == 18
 
     # Verify that the deposit was unsuccessful
     - type: eval
@@ -201,7 +201,7 @@
   verifiers:
     # Verify that the account exists after the instruction is executed.
     - type: eval
-      expr: INIT_ACCOUNT_CODE == 0 or INIT_ACCOUNT_CODE == 38
+      expr: INIT_ACCOUNT_CODE == 0 or INIT_ACCOUNT_CODE == 18
 
     # Verify that the deposit was successful
     - type: eval

--- a/integration_test/confidential_transfers_module/initialize_account_test.yaml
+++ b/integration_test/confidential_transfers_module/initialize_account_test.yaml
@@ -39,7 +39,7 @@
 
     # Verify that the account initialization was successful
     - type: eval
-      expr: INIT_ACCOUNT_CODE_REPEAT == 38
+      expr: INIT_ACCOUNT_CODE_REPEAT == 18
 
     # Verify that the account initialization for a different denom was successful
     - type: eval

--- a/integration_test/confidential_transfers_module/transfer_test.yaml
+++ b/integration_test/confidential_transfers_module/transfer_test.yaml
@@ -74,9 +74,9 @@
   verifiers:
     # Verify that the account exists after the instruction is executed.
     - type: eval
-      expr: INIT_SENDER_ACCOUNT_CODE == 0 or INIT_SENDER_ACCOUNT_CODE == 38
+      expr: INIT_SENDER_ACCOUNT_CODE == 0 or INIT_SENDER_ACCOUNT_CODE == 18
     - type: eval
-      expr: INIT_RECIPIENT_ACCOUNT_CODE == 0 or INIT_RECIPIENT_ACCOUNT_CODE == 38
+      expr: INIT_RECIPIENT_ACCOUNT_CODE == 0 or INIT_RECIPIENT_ACCOUNT_CODE == 18
 
     # Verify that the deposit was successful
     - type: eval
@@ -183,7 +183,7 @@
   verifiers:
     # Verify that the account exists after the instruction is executed.
     - type: eval
-      expr: INIT_SENDER_ACCOUNT_CODE == 0 or INIT_SENDER_ACCOUNT_CODE == 38
+      expr: INIT_SENDER_ACCOUNT_CODE == 0 or INIT_SENDER_ACCOUNT_CODE == 18
 
     # Verify that the deposit was successful
     - type: eval
@@ -282,9 +282,9 @@
   verifiers:
     # Verify that the account exists after the instruction is executed.
     - type: eval
-      expr: INIT_SENDER_ACCOUNT_CODE == 0 or INIT_SENDER_ACCOUNT_CODE == 38
+      expr: INIT_SENDER_ACCOUNT_CODE == 0 or INIT_SENDER_ACCOUNT_CODE == 18
     - type: eval
-      expr: INIT_RECIPIENT_ACCOUNT_CODE == 0 or INIT_RECIPIENT_ACCOUNT_CODE == 38
+      expr: INIT_RECIPIENT_ACCOUNT_CODE == 0 or INIT_RECIPIENT_ACCOUNT_CODE == 18
 
     # Verify that the deposit was successful
     - type: eval

--- a/integration_test/confidential_transfers_module/withdraw_test.yaml
+++ b/integration_test/confidential_transfers_module/withdraw_test.yaml
@@ -55,7 +55,7 @@
   verifiers:
     # Verify that the account exists after the instruction is executed.
     - type: eval
-      expr: INIT_ACCOUNT_CODE == 0 or INIT_ACCOUNT_CODE == 38
+      expr: INIT_ACCOUNT_CODE == 0 or INIT_ACCOUNT_CODE == 18
 
     # Verify that the deposit was successful
     - type: eval
@@ -182,7 +182,7 @@
   verifiers:
     # Verify that the account exists after the instruction is executed.
     - type: eval
-      expr: INIT_ACCOUNT_CODE == 0 or INIT_ACCOUNT_CODE == 38
+      expr: INIT_ACCOUNT_CODE == 0 or INIT_ACCOUNT_CODE == 18
 
     # Verify that the deposit was successful
     - type: eval

--- a/x/confidentialtransfers/keeper/msg_server.go
+++ b/x/confidentialtransfers/keeper/msg_server.go
@@ -45,7 +45,7 @@ func (m msgServer) InitializeAccount(goCtx context.Context, req *types.MsgInitia
 	// Check if the account already exists
 	_, exists := m.Keeper.GetAccount(ctx, req.FromAddress, instruction.Denom)
 	if exists {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrNotFound, "account already exists")
+		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "account already exists")
 	}
 
 	// Check if denom already exists.

--- a/x/confidentialtransfers/keeper/msg_server_test.go
+++ b/x/confidentialtransfers/keeper/msg_server_test.go
@@ -59,8 +59,7 @@ func (suite *KeeperTestSuite) TestMsgServer_InitializeAccountBasic() {
 
 	// Try to initialize the account again - this should produce an error
 	_, err = suite.msgServer.InitializeAccount(sdk.WrapSDKContext(suite.Ctx), req)
-	suite.Require().Error(err, "Should have error initializing account that already exists")
-	suite.Require().ErrorContains(err, "account already exists")
+	suite.Require().EqualError(err, "account already exists: invalid request")
 
 	// Try to initialize another account for a different denom
 	otherDenom := DefaultOtherDenom


### PR DESCRIPTION
## Describe your changes and provide context
We return error code `38` not found for case when account found and exists (on account initialization).
Changing this to be `18` invalid request

## Testing performed to validate your change
- unit test
- integration test