### PR TITLE
Add back block tests removed from partial refund

### DIFF
--- a/run_blocktests.sh
+++ b/run_blocktests.sh
@@ -39,9 +39,6 @@ declare -a test_name_skip_list=(
     "tips" # failing after turning on eip-1559 and not burning base fee
     "burnVerify" # failing after turning on eip-1559 and not burning base fee
     "emptyPostTransfer" # failing after turning on eip-1559 and not burning base fee
-    "multimpleBalanceInstruction" # failing from 150% max gas refund change
-    "burnVerify" # failing from 150% max gas refund change
-    "refundReset" # failing from 150% max gas refund change
 
     # invalid block tests - state tests
     "gasLimitTooHigh" # block header gas limit doesn't apply to us


### PR DESCRIPTION
## Describe your changes and provide context

We originally removed some block tests because they were failing due to us removing the full refund of unused gas (https://github.com/sei-protocol/sei-chain/pull/1871/files#diff-0adc342d2882ffb81750cb8734fb7ab5c0a7393082b452370b3aacff3df49777R37-R39). However, we've reverted that change, so adding back these tests.

## Testing performed to validate your change
existing tests

