### PR TITLE
Set log index across all transactions in a block

### DIFF
--- a/app/receipt.go
+++ b/app/receipt.go
@@ -118,7 +118,7 @@ func (app *App) AddCosmosEventsToEVMReceiptIfApplicable(ctx sdk.Context, tx sdk.
 		for i, l := range r.Logs {
 			l.Index = uint32(i)
 		}
-		bloom = ethtypes.CreateBloom(ethtypes.Receipts{&ethtypes.Receipt{Logs: evmkeeper.GetLogsForTx(r)}})
+		bloom = ethtypes.CreateBloom(ethtypes.Receipts{&ethtypes.Receipt{Logs: evmkeeper.GetLogsForTx(r, 0)}})
 		r.LogsBloom = bloom[:]
 		_ = app.EvmKeeper.SetTransientReceipt(wasmToEvmEventCtx, txHash, r)
 	} else {

--- a/evmrpc/filter.go
+++ b/evmrpc/filter.go
@@ -423,6 +423,7 @@ func (f *LogFetcher) GetLogsForBlock(block *coretypes.ResultBlock, crit filters.
 
 func (f *LogFetcher) FindLogsByBloom(block *coretypes.ResultBlock, filters [][]bloomIndexes) (res []*ethtypes.Log) {
 	ctx := f.ctxProvider(LatestCtxHeight)
+	totalLogs := uint(0)
 	for _, hash := range getTxHashesFromBlock(block, f.txConfig, f.includeSyntheticReceipts) {
 		receipt, err := f.k.GetReceipt(ctx, hash)
 		if err != nil {
@@ -436,8 +437,9 @@ func (f *LogFetcher) FindLogsByBloom(block *coretypes.ResultBlock, filters [][]b
 			continue
 		}
 		if len(receipt.LogsBloom) > 0 && MatchFilters(ethtypes.Bloom(receipt.LogsBloom), filters) {
-			res = append(res, keeper.GetLogsForTx(receipt)...)
+			res = append(res, keeper.GetLogsForTx(receipt, totalLogs)...)
 		}
+		totalLogs += uint(len(receipt.Logs))
 	}
 	return
 }

--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -350,7 +350,7 @@ func GetEvmTxIndex(txs tmtypes.Txs, txIndex uint32, decoder sdk.TxDecoder, recei
 func encodeReceipt(receipt *types.Receipt, decoder sdk.TxDecoder, block *coretypes.ResultBlock, receiptChecker func(common.Hash) bool) (map[string]interface{}, error) {
 	blockHash := block.BlockID.Hash
 	bh := common.HexToHash(blockHash.String())
-	logs := keeper.GetLogsForTx(receipt)
+	logs := keeper.GetLogsForTx(receipt, 0)
 	for _, log := range logs {
 		log.BlockHash = bh
 	}

--- a/x/evm/keeper/log.go
+++ b/x/evm/keeper/log.go
@@ -61,11 +61,11 @@ func (k *Keeper) GetLegacyBlockBloomCutoffHeight(ctx sdk.Context) int64 {
 	return int64(binary.BigEndian.Uint64(bz))
 }
 
-func GetLogsForTx(receipt *types.Receipt) []*ethtypes.Log {
-	return utils.Map(receipt.Logs, func(l *types.Log) *ethtypes.Log { return convertLog(l, receipt) })
+func GetLogsForTx(receipt *types.Receipt, logStartIndex uint) []*ethtypes.Log {
+	return utils.Map(receipt.Logs, func(l *types.Log) *ethtypes.Log { return convertLog(l, receipt, logStartIndex) })
 }
 
-func convertLog(l *types.Log, receipt *types.Receipt) *ethtypes.Log {
+func convertLog(l *types.Log, receipt *types.Receipt, logStartIndex uint) *ethtypes.Log {
 	return &ethtypes.Log{
 		Address:     common.HexToAddress(l.Address),
 		Topics:      utils.Map(l.Topics, common.HexToHash),
@@ -73,7 +73,7 @@ func convertLog(l *types.Log, receipt *types.Receipt) *ethtypes.Log {
 		BlockNumber: receipt.BlockNumber,
 		TxHash:      common.HexToHash(receipt.TxHashHex),
 		TxIndex:     uint(receipt.TransactionIndex),
-		Index:       uint(l.Index)}
+		Index:       uint(l.Index) + logStartIndex}
 }
 
 func ConvertEthLog(l *ethtypes.Log) *types.Log {

--- a/x/evm/keeper/log_test.go
+++ b/x/evm/keeper/log_test.go
@@ -69,7 +69,7 @@ func TestGetLogsForTx(t *testing.T) {
 	}
 
 	// Convert the types.Receipt to a list of ethtypes.Log objects
-	logs := keeper.GetLogsForTx(receipt)
+	logs := keeper.GetLogsForTx(receipt, 0)
 
 	// Check that the fields match
 	require.Equal(t, len(receipt.Logs), len(logs))
@@ -81,6 +81,13 @@ func TestGetLogsForTx(t *testing.T) {
 		}
 		require.Equal(t, receipt.Logs[i].Data, log.Data)
 		require.Equal(t, uint(receipt.Logs[i].Index), log.Index)
+	}
+
+	// non-zero starting index
+	logs = keeper.GetLogsForTx(receipt, 5)
+	require.Equal(t, len(receipt.Logs), len(logs))
+	for i, log := range logs {
+		require.Equal(t, uint(receipt.Logs[i].Index+5), log.Index)
 	}
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
Previously if we have two EVM transactions in the same block, each with 1 log, both logs will have log index of 0, because log index was set relative to each transaction. The expected behavior is for log index to be set across transactions in a block (i.e. the log of the first tx would have index 0, whereas the log of the second would have index 1).

It is not quite feasible to set log index as such during execution though, because transactions may be processed in parallel, so this PR adds backfill log on the read path instead.

## Testing performed to validate your change
unit test

