### PR TITLE
fix: eth_gasPrice not found

### DIFF
--- a/evmrpc/info.go
+++ b/evmrpc/info.go
@@ -274,7 +274,7 @@ func (i *InfoAPI) getCongestionData(ctx context.Context, height *int64) (blockGa
 			continue
 		}
 		// okay to get from latest since receipt is immutable
-		receipt, err := i.keeper.GetReceipt(i.ctxProvider(LatestCtxHeight), ethtx.Hash())
+		receipt, err := i.keeper.GetReceiptWithRetry(i.ctxProvider(LatestCtxHeight), ethtx.Hash(), 3)
 		if err != nil {
 			return 0, err
 		}

--- a/x/evm/keeper/receipt_test.go
+++ b/x/evm/keeper/receipt_test.go
@@ -32,26 +32,19 @@ func TestGetReceiptWithRetry(t *testing.T) {
 	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{})
 	txHash := common.HexToHash("0x0750333eac0be1203864220893d8080dd8a8fd7a2ed098dfd92a718c99d437f2")
 
-	// Test initial failure
-	_, err := k.GetReceiptWithRetry(ctx, txHash, 3)
+	// Test max retries exceeded first
+	nonExistentHash := common.Hash{1}
+	_, err := k.GetReceiptWithRetry(ctx, nonExistentHash, 2)
 	require.NotNil(t, err)
 	require.Equal(t, "not found", err.Error())
 
-	// Test successful retry
-	// Simulate async receipt creation after a delay
+	// Then test successful retry
 	go func() {
-		time.Sleep(300 * time.Millisecond) // Wait for first retry to fail
+		time.Sleep(300 * time.Millisecond)
 		k.MockReceipt(ctx, txHash, &types.Receipt{TxHashHex: txHash.Hex()})
 	}()
 
-	// This should succeed after retry
 	r, err := k.GetReceiptWithRetry(ctx, txHash, 3)
 	require.Nil(t, err)
 	require.Equal(t, txHash.Hex(), r.TxHashHex)
-
-	// Test max retries exceeded
-	nonExistentHash := common.Hash{1}
-	_, err = k.GetReceiptWithRetry(ctx, nonExistentHash, 2)
-	require.NotNil(t, err)
-	require.Equal(t, "not found", err.Error())
 }


### PR DESCRIPTION
## Describe your changes and provide context

Add GetReceiptWithRetry to imrove conditions where receipts may not be immediately available after transaction execution. This improves reliability of receipt retrieval by implementing a retry mechanism(3 by default) with linear backoff. 

NOTICE this may not 100% eliminating the `not found` error as we do 3 max retries.

## Testing performed to validate your change

1. Added unit test TestGetReceiptWithRetry 
2. Confirmed `ab -n 100000 -c 100 -T "application/json" -p request.json <endpoint>` got 100% successful rate.

