### PR TITLE
Allow safe/latest/final to be passed as block number to trace/simulate endpoints

### DIFF
--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -233,8 +233,17 @@ func (b *Backend) ChainDb() ethdb.Database {
 	panic("implement me")
 }
 
-func (b Backend) BlockByNumber(ctx context.Context, bn rpc.BlockNumber) (*ethtypes.Block, error) {
+func (b Backend) ConvertBlockNumber(bn rpc.BlockNumber) int64 {
 	blockNum := bn.Int64()
+	switch blockNum {
+	case rpc.SafeBlockNumber.Int64(), rpc.FinalizedBlockNumber.Int64(), rpc.LatestBlockNumber.Int64():
+		blockNum = b.ctxProvider(LatestCtxHeight).BlockHeight()
+	}
+	return blockNum
+}
+
+func (b Backend) BlockByNumber(ctx context.Context, bn rpc.BlockNumber) (*ethtypes.Block, error) {
+	blockNum := b.ConvertBlockNumber(bn)
 	tmBlock, err := blockByNumber(ctx, b.tmClient, &blockNum)
 	if err != nil {
 		return nil, err

--- a/evmrpc/simulate_test.go
+++ b/evmrpc/simulate_test.go
@@ -203,3 +203,17 @@ func TestNewRevertError(t *testing.T) {
 	require.Equal(t, 3, err.ErrorCode())
 	require.Equal(t, "0x", err.ErrorData())
 }
+
+func TestConvertBlockNumber(t *testing.T) {
+	backend := evmrpc.NewBackend(func(i int64) sdk.Context {
+		if i == evmrpc.LatestCtxHeight {
+			return sdk.Context{}.WithBlockHeight(1000)
+		}
+		return sdk.Context{}
+	}, nil, nil, nil, nil, nil, nil)
+	require.Equal(t, int64(10), backend.ConvertBlockNumber(10))
+	require.Equal(t, int64(0), backend.ConvertBlockNumber(0))
+	require.Equal(t, int64(1000), backend.ConvertBlockNumber(-2))
+	require.Equal(t, int64(1000), backend.ConvertBlockNumber(-3))
+	require.Equal(t, int64(1000), backend.ConvertBlockNumber(-4))
+}


### PR DESCRIPTION
## Describe your changes and provide context
Currently if one calls `trace_` or gas simulation endpoints with block number parameter being `safe` or `latest`, it would fail with a message like `height must be greater than zero (requested height: -4)`. This PR makes such keywords acceptable for these endpoints.

## Testing performed to validate your change
unit test
