### PR TITLE
Refactor RPC tests

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -258,6 +258,7 @@ func TestProcessOracleAndOtherTxsSuccess(t *testing.T) {
 		txs,
 		req,
 		req.DecidedLastCommit,
+		false,
 	)
 	fmt.Println("txResults1", txResults)
 
@@ -280,6 +281,7 @@ func TestProcessOracleAndOtherTxsSuccess(t *testing.T) {
 		diffOrderTxs,
 		req,
 		req.DecidedLastCommit,
+		false,
 	)
 	fmt.Println("txResults2", txResults2)
 

--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -24,6 +24,7 @@ const LocalAddress = "0.0.0.0"
 
 type EVMServer interface {
 	Start() error
+	Stop()
 }
 
 func NewEVMHTTPServer(

--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -269,7 +269,7 @@ func (b Backend) BlockByNumber(ctx context.Context, bn rpc.BlockNumber) (*ethtyp
 			}
 		}
 	}
-	header := b.getHeader(big.NewInt(bn.Int64()))
+	header := b.getHeader(big.NewInt(blockNum))
 	block := &ethtypes.Block{
 		Header_: header,
 		Txs:     txs,
@@ -331,7 +331,7 @@ func (b *Backend) StateAtTransaction(ctx context.Context, block *ethtypes.Block,
 	}
 	reqBeginBlock := tmBlock.Block.ToReqBeginBlock(res.Validators)
 	reqBeginBlock.Simulate = true
-	sdkCtx := b.ctxProvider(prevBlockHeight)
+	sdkCtx := b.ctxProvider(prevBlockHeight).WithBlockHeight(blockNumber).WithBlockTime(tmBlock.Block.Time)
 	_ = b.app.BeginBlock(sdkCtx, reqBeginBlock)
 	blockContext, err := b.keeper.GetVMBlockContext(sdkCtx, core.GasPool(b.RPCGasCap()))
 	if err != nil {

--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -377,7 +377,7 @@ func (b *Backend) GetEVM(_ context.Context, msg *core.Message, stateDB vm.StateD
 	if blockCtx == nil {
 		blockCtx, _ = b.keeper.GetVMBlockContext(b.ctxProvider(LatestCtxHeight).WithIsEVM(true).WithEVMEntryViaWasmdPrecompile(wasmd.IsWasmdCall(msg.To)), core.GasPool(b.RPCGasCap()))
 	}
-	return vm.NewEVM(*blockCtx, txContext, stateDB, b.ChainConfig(), *vmConfig, nil)
+	return vm.NewEVM(*blockCtx, txContext, stateDB, b.ChainConfig(), *vmConfig, b.keeper.CustomPrecompiles())
 }
 
 func (b *Backend) CurrentHeader() *ethtypes.Header {
@@ -431,6 +431,10 @@ func (b *Backend) getHeader(blockNumber *big.Int) *ethtypes.Header {
 		header.Time = uint64(block.Block.Header.Time.Unix())
 	}
 	return header
+}
+
+func (b *Backend) GetCustomPrecompiles() map[common.Address]vm.PrecompiledContract {
+	return b.keeper.CustomPrecompiles()
 }
 
 type Engine struct {

--- a/evmrpc/tests/block_test.go
+++ b/evmrpc/tests/block_test.go
@@ -1,0 +1,92 @@
+package tests
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/sei-protocol/sei-chain/precompiles"
+	"github.com/sei-protocol/sei-chain/precompiles/pointer"
+	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetBlockByHash(t *testing.T) {
+	port := 7777
+	txBz := signAndEncodeTx(send(0), mnemonic1)
+	RunWithServer(
+		SetupTestServer(port, [][][]byte{{txBz}}, mnemonicInitializer(mnemonic1)),
+		func() {
+			res := sendRequestWithNamespace("eth", port, "getBlockByHash", common.HexToHash("0x1").Hex(), true)
+			blockHash := res["result"].(map[string]interface{})["hash"]
+			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000001", blockHash.(string))
+		},
+	)
+}
+
+func TestGetSeiBlockByHash(t *testing.T) {
+	port := 7779
+	pInfo := precompiles.GetPrecompileInfo(pointer.PrecompileName)
+	input, err := pInfo.ABI.Pack("addCW20Pointer", "sei18cszlvm6pze0x9sz32qnjq4vtd45xehqs8dq7cwy8yhq35wfnn3quh5sau")
+	require.Nil(t, err)
+	pointer := common.HexToAddress(pointer.PointerAddress)
+	txData := &ethtypes.DynamicFeeTx{
+		Nonce:     0,
+		GasFeeCap: big.NewInt(1000000000),
+		Gas:       4000000,
+		To:        &pointer,
+		Value:     big.NewInt(0),
+		Data:      input,
+		ChainID:   chainId,
+	}
+	tx1 := signAndEncodeTx(txData, mnemonic1)
+	recipient, _ := testkeeper.MockAddressPair()
+	msg := &wasmtypes.MsgExecuteContract{
+		Sender:   getSeiAddrWithMnemonic(mnemonic1).String(),
+		Contract: "sei18cszlvm6pze0x9sz32qnjq4vtd45xehqs8dq7cwy8yhq35wfnn3quh5sau",
+		Msg:      []byte(fmt.Sprintf("{\"transfer\":{\"recipient\":\"%s\",\"amount\":\"100\"}}", recipient.String())),
+	}
+	tx := signCosmosTxWithMnemonic(msg, mnemonic1, 7, 0)
+	txBz, _ := testkeeper.EVMTestApp.GetTxConfig().TxEncoder()(tx)
+	RunWithServer(
+		SetupTestServer(port, [][][]byte{{tx1}, {txBz}}, mnemonicInitializer(mnemonic1), cw20Initializer(mnemonic1)),
+		func() {
+			res := sendRequestWithNamespace("sei", port, "getBlockByHash", common.HexToHash("0x2").Hex(), true)
+			txs := res["result"].(map[string]interface{})["transactions"]
+			require.Len(t, txs.([]interface{}), 1)
+		},
+	)
+}
+
+func TestGetBlockByNumber(t *testing.T) {
+	port := 7778
+	txBz1 := signAndEncodeTx(send(0), mnemonic1)
+	txBz2 := signAndEncodeTx(send(1), mnemonic1)
+	txBz3 := signAndEncodeTx(send(2), mnemonic1)
+	RunWithServer(
+		SetupTestServer(port, [][][]byte{{txBz1}, {txBz2}, {txBz3}}, mnemonicInitializer(mnemonic1)),
+		func() {
+			res := sendRequestWithNamespace("eth", port, "getBlockByNumber", "earliest", true)
+			blockHash := res["result"].(map[string]interface{})["hash"]
+			require.Equal(t, "0xF9D3845DF25B43B1C6926F3CEDA6845C17F5624E12212FD8847D0BA01DA1AB9E", blockHash.(string))
+			res = sendRequestWithNamespace("eth", port, "getBlockByNumber", "safe", true)
+			blockHash = res["result"].(map[string]interface{})["hash"]
+			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000003", blockHash.(string))
+			res = sendRequestWithNamespace("eth", port, "getBlockByNumber", "latest", true)
+			blockHash = res["result"].(map[string]interface{})["hash"]
+			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000003", blockHash.(string))
+			res = sendRequestWithNamespace("eth", port, "getBlockByNumber", "finalized", true)
+			blockHash = res["result"].(map[string]interface{})["hash"]
+			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000003", blockHash.(string))
+			res = sendRequestWithNamespace("eth", port, "getBlockByNumber", "pending", true)
+			blockHash = res["result"].(map[string]interface{})["hash"]
+			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000003", blockHash.(string))
+			res = sendRequestWithNamespace("eth", port, "getBlockByNumber", "0x2", true)
+			blockHash = res["result"].(map[string]interface{})["hash"]
+			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000002", blockHash.(string))
+		},
+	)
+}

--- a/evmrpc/tests/block_test.go
+++ b/evmrpc/tests/block_test.go
@@ -1,25 +1,16 @@
 package tests
 
 import (
-	"fmt"
-	"math/big"
 	"testing"
 
-	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/ethereum/go-ethereum/common"
-	ethtypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/sei-protocol/sei-chain/precompiles"
-	"github.com/sei-protocol/sei-chain/precompiles/pointer"
-	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGetBlockByHash(t *testing.T) {
-	port := 7777
 	txBz := signAndEncodeTx(send(0), mnemonic1)
-	RunWithServer(
-		SetupTestServer(port, [][][]byte{{txBz}}, mnemonicInitializer(mnemonic1)),
-		func() {
+	SetupTestServer([][][]byte{{txBz}}, mnemonicInitializer(mnemonic1)).Run(
+		func(port int) {
 			res := sendRequestWithNamespace("eth", port, "getBlockByHash", common.HexToHash("0x1").Hex(), true)
 			blockHash := res["result"].(map[string]interface{})["hash"]
 			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000001", blockHash.(string))
@@ -28,33 +19,12 @@ func TestGetBlockByHash(t *testing.T) {
 }
 
 func TestGetSeiBlockByHash(t *testing.T) {
-	port := 7779
-	pInfo := precompiles.GetPrecompileInfo(pointer.PrecompileName)
-	input, err := pInfo.ABI.Pack("addCW20Pointer", "sei18cszlvm6pze0x9sz32qnjq4vtd45xehqs8dq7cwy8yhq35wfnn3quh5sau")
-	require.Nil(t, err)
-	pointer := common.HexToAddress(pointer.PointerAddress)
-	txData := &ethtypes.DynamicFeeTx{
-		Nonce:     0,
-		GasFeeCap: big.NewInt(1000000000),
-		Gas:       4000000,
-		To:        &pointer,
-		Value:     big.NewInt(0),
-		Data:      input,
-		ChainID:   chainId,
-	}
-	tx1 := signAndEncodeTx(txData, mnemonic1)
-	recipient, _ := testkeeper.MockAddressPair()
-	msg := &wasmtypes.MsgExecuteContract{
-		Sender:   getSeiAddrWithMnemonic(mnemonic1).String(),
-		Contract: "sei18cszlvm6pze0x9sz32qnjq4vtd45xehqs8dq7cwy8yhq35wfnn3quh5sau",
-		Msg:      []byte(fmt.Sprintf("{\"transfer\":{\"recipient\":\"%s\",\"amount\":\"100\"}}", recipient.String())),
-	}
-	tx := signCosmosTxWithMnemonic(msg, mnemonic1, 7, 0)
-	txBz, _ := testkeeper.EVMTestApp.GetTxConfig().TxEncoder()(tx)
-	RunWithServer(
-		SetupTestServer(port, [][][]byte{{tx1}, {txBz}}, mnemonicInitializer(mnemonic1), cw20Initializer(mnemonic1)),
-		func() {
-			res := sendRequestWithNamespace("sei", port, "getBlockByHash", common.HexToHash("0x2").Hex(), true)
+	cw20 := "sei18cszlvm6pze0x9sz32qnjq4vtd45xehqs8dq7cwy8yhq35wfnn3quh5sau" // hardcoded
+	tx1 := signAndEncodeTx(registerCW20Pointer(0, cw20), mnemonic1)
+	tx2 := signAndEncodeCosmosTx(transferCW20Msg(mnemonic1, cw20), mnemonic1, 7, 0)
+	SetupTestServer([][][]byte{{tx1}, {tx2}}, mnemonicInitializer(mnemonic1), cw20Initializer(mnemonic1)).Run(
+		func(port int) {
+			res := sendRequestWithNamespace("sei", port, "getBlockByHash", common.HexToHash("0x3").Hex(), true)
 			txs := res["result"].(map[string]interface{})["transactions"]
 			require.Len(t, txs.([]interface{}), 1)
 		},
@@ -62,28 +32,26 @@ func TestGetSeiBlockByHash(t *testing.T) {
 }
 
 func TestGetBlockByNumber(t *testing.T) {
-	port := 7778
 	txBz1 := signAndEncodeTx(send(0), mnemonic1)
 	txBz2 := signAndEncodeTx(send(1), mnemonic1)
 	txBz3 := signAndEncodeTx(send(2), mnemonic1)
-	RunWithServer(
-		SetupTestServer(port, [][][]byte{{txBz1}, {txBz2}, {txBz3}}, mnemonicInitializer(mnemonic1)),
-		func() {
+	SetupTestServer([][][]byte{{txBz1}, {txBz2}, {txBz3}}, mnemonicInitializer(mnemonic1)).Run(
+		func(port int) {
 			res := sendRequestWithNamespace("eth", port, "getBlockByNumber", "earliest", true)
 			blockHash := res["result"].(map[string]interface{})["hash"]
 			require.Equal(t, "0xF9D3845DF25B43B1C6926F3CEDA6845C17F5624E12212FD8847D0BA01DA1AB9E", blockHash.(string))
 			res = sendRequestWithNamespace("eth", port, "getBlockByNumber", "safe", true)
 			blockHash = res["result"].(map[string]interface{})["hash"]
-			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000003", blockHash.(string))
+			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000004", blockHash.(string))
 			res = sendRequestWithNamespace("eth", port, "getBlockByNumber", "latest", true)
 			blockHash = res["result"].(map[string]interface{})["hash"]
-			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000003", blockHash.(string))
+			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000004", blockHash.(string))
 			res = sendRequestWithNamespace("eth", port, "getBlockByNumber", "finalized", true)
 			blockHash = res["result"].(map[string]interface{})["hash"]
-			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000003", blockHash.(string))
+			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000004", blockHash.(string))
 			res = sendRequestWithNamespace("eth", port, "getBlockByNumber", "pending", true)
 			blockHash = res["result"].(map[string]interface{})["hash"]
-			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000003", blockHash.(string))
+			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000004", blockHash.(string))
 			res = sendRequestWithNamespace("eth", port, "getBlockByNumber", "0x2", true)
 			blockHash = res["result"].(map[string]interface{})["hash"]
 			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000002", blockHash.(string))

--- a/evmrpc/tests/mock_accounts.go
+++ b/evmrpc/tests/mock_accounts.go
@@ -1,0 +1,123 @@
+package tests
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"os"
+
+	clienttx "github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	xauthsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/sei-protocol/sei-chain/app"
+	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/x/evm/config"
+	"github.com/sei-protocol/sei-chain/x/evm/types"
+)
+
+var chainId = big.NewInt(config.DefaultChainID)
+var mnemonic1 = "fish mention unlock february marble dove vintage sand hub ordinary fade found inject room embark supply fabric improve spike stem give current similar glimpse"
+
+func signTxWithMnemonic(txData ethtypes.TxData, mnemonic string) *ethtypes.Transaction {
+	derivedPriv, _ := hd.Secp256k1.Derive()(mnemonic, "", "")
+	privKey := hd.Secp256k1.Generate()(derivedPriv)
+	testPrivHex := hex.EncodeToString(privKey.Bytes())
+	key, _ := crypto.HexToECDSA(testPrivHex)
+	ethCfg := types.DefaultChainConfig().EthereumConfig(chainId)
+	signer := ethtypes.MakeSigner(ethCfg, big.NewInt(1), 1)
+	tx := ethtypes.NewTx(txData)
+	tx, err := ethtypes.SignTx(tx, signer, key)
+	if err != nil {
+		panic(err)
+	}
+	return tx
+}
+
+func signCosmosTxWithMnemonic(msg sdk.Msg, mnemonic string, accountNumber uint64, sequenceNumber uint64) sdk.Tx {
+	derivedPriv, _ := hd.Secp256k1.Derive()(mnemonic, "", "")
+	privKey := hd.Secp256k1.Generate()(derivedPriv)
+	txBuilder := testkeeper.EVMTestApp.GetTxConfig().NewTxBuilder()
+	txBuilder.SetMsgs(msg)
+	txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(1000000))))
+	txBuilder.SetGasLimit(300000)
+	var sigsV2 []signing.SignatureV2
+	sigV2 := signing.SignatureV2{
+		PubKey: privKey.PubKey(),
+		Data: &signing.SingleSignatureData{
+			SignMode:  testkeeper.EVMTestApp.GetTxConfig().SignModeHandler().DefaultMode(),
+			Signature: nil,
+		},
+		Sequence: sequenceNumber,
+	}
+	sigsV2 = append(sigsV2, sigV2)
+	_ = txBuilder.SetSignatures(sigsV2...)
+	sigsV2 = []signing.SignatureV2{}
+	signerData := xauthsigning.SignerData{
+		ChainID:       "sei-test",
+		AccountNumber: accountNumber,
+		Sequence:      sequenceNumber,
+	}
+	sigV2, _ = clienttx.SignWithPrivKey(
+		testkeeper.EVMTestApp.GetTxConfig().SignModeHandler().DefaultMode(),
+		signerData,
+		txBuilder,
+		privKey,
+		testkeeper.EVMTestApp.GetTxConfig(),
+		sequenceNumber,
+	)
+	sigsV2 = append(sigsV2, sigV2)
+	_ = txBuilder.SetSignatures(sigsV2...)
+	return txBuilder.GetTx()
+}
+
+func getAddrWithMnemonic(mnemonic string) common.Address {
+	derivedPriv, _ := hd.Secp256k1.Derive()(mnemonic, "", "")
+	privKey := hd.Secp256k1.Generate()(derivedPriv)
+	_, evmAddr := testkeeper.PrivateKeyToAddresses(privKey)
+	return evmAddr
+}
+
+func getSeiAddrWithMnemonic(mnemonic string) sdk.AccAddress {
+	derivedPriv, _ := hd.Secp256k1.Derive()(mnemonic, "", "")
+	privKey := hd.Secp256k1.Generate()(derivedPriv)
+	seiAddr, _ := testkeeper.PrivateKeyToAddresses(privKey)
+	return seiAddr
+}
+
+func mnemonicInitializer(mnemonic string) func(ctx sdk.Context, a *app.App) {
+	return func(ctx sdk.Context, a *app.App) {
+		seiAddr := getSeiAddrWithMnemonic(mnemonic)
+		evmAddr := getAddrWithMnemonic(mnemonic)
+		a.EvmKeeper.SetAddressMapping(ctx, seiAddr, evmAddr)
+		amt := sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(10000000000)))
+		a.BankKeeper.MintCoins(ctx, types.ModuleName, amt)
+		a.BankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, seiAddr, amt)
+	}
+}
+
+func cw20Initializer(mnemonic string) func(ctx sdk.Context, a *app.App) {
+	return func(ctx sdk.Context, a *app.App) {
+		code, err := os.ReadFile("../../contracts/wasm/cw20_base.wasm")
+		if err != nil {
+			panic(err)
+		}
+		creator := getSeiAddrWithMnemonic(mnemonic)
+		codeID, err := a.EvmKeeper.WasmKeeper().Create(ctx, creator, code, nil)
+		if err != nil {
+			panic(err)
+		}
+		contractAddr, _, err := a.EvmKeeper.WasmKeeper().Instantiate(ctx, codeID, creator, creator,
+			[]byte(fmt.Sprintf("{\"name\":\"test\",\"symbol\":\"test\",\"decimals\":6,\"initial_balances\":[{\"address\":\"%s\",\"amount\":\"1000000000\"}]}",
+				creator.String())), "test", sdk.NewCoins())
+		if err != nil {
+			panic(err)
+		}
+		evmAddr := common.BytesToAddress(contractAddr)
+		a.EvmKeeper.SetAddressMapping(ctx, contractAddr, evmAddr)
+	}
+}

--- a/evmrpc/tests/mock_accounts.go
+++ b/evmrpc/tests/mock_accounts.go
@@ -40,7 +40,7 @@ func signCosmosTxWithMnemonic(msg sdk.Msg, mnemonic string, accountNumber uint64
 	derivedPriv, _ := hd.Secp256k1.Derive()(mnemonic, "", "")
 	privKey := hd.Secp256k1.Generate()(derivedPriv)
 	txBuilder := testkeeper.EVMTestApp.GetTxConfig().NewTxBuilder()
-	txBuilder.SetMsgs(msg)
+	_ = txBuilder.SetMsgs(msg)
 	txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(1000000))))
 	txBuilder.SetGasLimit(300000)
 	var sigsV2 []signing.SignatureV2
@@ -93,7 +93,7 @@ func mnemonicInitializer(mnemonic string) func(ctx sdk.Context, a *app.App) {
 		evmAddr := getAddrWithMnemonic(mnemonic)
 		a.EvmKeeper.SetAddressMapping(ctx, seiAddr, evmAddr)
 		amt := sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(10000000000)))
-		a.BankKeeper.MintCoins(ctx, types.ModuleName, amt)
-		a.BankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, seiAddr, amt)
+		_ = a.BankKeeper.MintCoins(ctx, types.ModuleName, amt)
+		_ = a.BankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, seiAddr, amt)
 	}
 }

--- a/evmrpc/tests/mock_accounts.go
+++ b/evmrpc/tests/mock_accounts.go
@@ -2,9 +2,7 @@ package tests
 
 import (
 	"encoding/hex"
-	"fmt"
 	"math/big"
-	"os"
 
 	clienttx "github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
@@ -97,27 +95,5 @@ func mnemonicInitializer(mnemonic string) func(ctx sdk.Context, a *app.App) {
 		amt := sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(10000000000)))
 		a.BankKeeper.MintCoins(ctx, types.ModuleName, amt)
 		a.BankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, seiAddr, amt)
-	}
-}
-
-func cw20Initializer(mnemonic string) func(ctx sdk.Context, a *app.App) {
-	return func(ctx sdk.Context, a *app.App) {
-		code, err := os.ReadFile("../../contracts/wasm/cw20_base.wasm")
-		if err != nil {
-			panic(err)
-		}
-		creator := getSeiAddrWithMnemonic(mnemonic)
-		codeID, err := a.EvmKeeper.WasmKeeper().Create(ctx, creator, code, nil)
-		if err != nil {
-			panic(err)
-		}
-		contractAddr, _, err := a.EvmKeeper.WasmKeeper().Instantiate(ctx, codeID, creator, creator,
-			[]byte(fmt.Sprintf("{\"name\":\"test\",\"symbol\":\"test\",\"decimals\":6,\"initial_balances\":[{\"address\":\"%s\",\"amount\":\"1000000000\"}]}",
-				creator.String())), "test", sdk.NewCoins())
-		if err != nil {
-			panic(err)
-		}
-		evmAddr := common.BytesToAddress(contractAddr)
-		a.EvmKeeper.SetAddressMapping(ctx, contractAddr, evmAddr)
 	}
 }

--- a/evmrpc/tests/mock_client.go
+++ b/evmrpc/tests/mock_client.go
@@ -1,0 +1,111 @@
+package tests
+
+import (
+	"context"
+	"encoding/binary"
+	"time"
+
+	seiutils "github.com/sei-protocol/sei-chain/utils"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/bytes"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	"github.com/tendermint/tendermint/rpc/client/mock"
+	"github.com/tendermint/tendermint/rpc/coretypes"
+	tmtypes "github.com/tendermint/tendermint/types"
+)
+
+type MockClient struct {
+	mock.Client
+	blocks           [][][]byte
+	txResults        [][]*abci.ExecTxResult
+	consParamUpdates []*tmproto.ConsensusParams
+	events           [][]abci.Event
+}
+
+func (c *MockClient) Block(_ context.Context, h *int64) (*coretypes.ResultBlock, error) {
+	if h == nil {
+		return c.getBlock(int64(len(c.blocks))), nil
+	}
+	return c.getBlock(*h), nil
+}
+
+func (c *MockClient) BlockByHash(_ context.Context, hash bytes.HexBytes) (*coretypes.ResultBlock, error) {
+	bz := make([]byte, 8)
+	if len(hash) < 8 {
+		copy(bz, hash)
+	} else {
+		copy(bz, hash[len(hash)-8:])
+	}
+	return c.getBlock(int64(binary.BigEndian.Uint64(bz))), nil
+}
+
+func (c *MockClient) getBlock(i int64) *coretypes.ResultBlock {
+	return &coretypes.ResultBlock{
+		BlockID: tmtypes.BlockID{Hash: mockHash(i, 0)},
+		Block: &tmtypes.Block{
+			Data:       tmtypes.Data{Txs: seiutils.Map(c.blocks[i-1], func(tx []byte) tmtypes.Tx { return tmtypes.Tx(tx) })},
+			Header:     mockBlockHeader(i),
+			LastCommit: &tmtypes.Commit{Height: i},
+		},
+	}
+}
+
+func (c *MockClient) Genesis(context.Context) (*coretypes.ResultGenesis, error) {
+	return &coretypes.ResultGenesis{Genesis: &tmtypes.GenesisDoc{InitialHeight: 1}}, nil
+}
+
+func (c *MockClient) BlockResults(_ context.Context, height *int64) (*coretypes.ResultBlockResults, error) {
+	return &coretypes.ResultBlockResults{
+		TxsResults:            c.txResults[*height-1],
+		ConsensusParamUpdates: c.consParamUpdates[*height-1],
+	}, nil
+}
+
+func (c *MockClient) recordBlockResult(txResults []*abci.ExecTxResult, consParamUpdates *abci.ConsensusParams, events []abci.Event) {
+	c.txResults = append(c.txResults, txResults)
+	cp := &tmproto.ConsensusParams{
+		Evidence:  consParamUpdates.Evidence,
+		Validator: consParamUpdates.Validator,
+		Version:   consParamUpdates.Version,
+	}
+	if consParamUpdates.Block != nil {
+		cp.Block = &tmproto.BlockParams{
+			MaxBytes:      consParamUpdates.Block.MaxBytes,
+			MaxGas:        consParamUpdates.Block.MaxGas,
+			MinTxsInBlock: consParamUpdates.Block.MinTxsInBlock,
+		}
+	}
+	c.consParamUpdates = append(c.consParamUpdates, cp)
+	c.events = append(c.events, events)
+}
+
+func (c *MockClient) Validators(ctx context.Context, height *int64, page, perPage *int) (*coretypes.ResultValidators, error) {
+	return &coretypes.ResultValidators{}, nil
+}
+
+func mockHash(height int64, prefix int64) bytes.HexBytes {
+	heightBz, prefixBz := make([]byte, 8), make([]byte, 8)
+	binary.BigEndian.PutUint64(heightBz, uint64(height))
+	binary.BigEndian.PutUint64(prefixBz, uint64(prefix))
+	return bytes.HexBytes(append(prefixBz, heightBz...))
+}
+
+func mockBlockHeader(height int64) tmtypes.Header {
+	return tmtypes.Header{
+		ChainID:         "test",
+		Height:          height,
+		Time:            time.Unix(1696941649+height, 0),
+		DataHash:        mockHash(height, 1),
+		AppHash:         mockHash(height, 2),
+		LastResultsHash: mockHash(height, 3),
+		ProposerAddress: mockHash(height, 4),
+		LastBlockID: tmtypes.BlockID{
+			Hash: mockHash(height-1, 0),
+		},
+		LastCommitHash:     mockHash(height, 5),
+		ValidatorsHash:     mockHash(height, 6),
+		NextValidatorsHash: mockHash(height, 7),
+		ConsensusHash:      mockHash(height, 8),
+		EvidenceHash:       mockHash(height, 9),
+	}
+}

--- a/evmrpc/tests/mock_contracts.go
+++ b/evmrpc/tests/mock_contracts.go
@@ -1,0 +1,32 @@
+package tests
+
+import (
+	"fmt"
+	"os"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/sei-protocol/sei-chain/app"
+)
+
+func cw20Initializer(mnemonic string) func(ctx sdk.Context, a *app.App) {
+	return func(ctx sdk.Context, a *app.App) {
+		code, err := os.ReadFile("../../contracts/wasm/cw20_base.wasm")
+		if err != nil {
+			panic(err)
+		}
+		creator := getSeiAddrWithMnemonic(mnemonic)
+		codeID, err := a.EvmKeeper.WasmKeeper().Create(ctx, creator, code, nil)
+		if err != nil {
+			panic(err)
+		}
+		contractAddr, _, err := a.EvmKeeper.WasmKeeper().Instantiate(ctx, codeID, creator, creator,
+			[]byte(fmt.Sprintf("{\"name\":\"test\",\"symbol\":\"test\",\"decimals\":6,\"initial_balances\":[{\"address\":\"%s\",\"amount\":\"1000000000\"}]}",
+				creator.String())), "test", sdk.NewCoins())
+		if err != nil {
+			panic(err)
+		}
+		evmAddr := common.BytesToAddress(contractAddr)
+		a.EvmKeeper.SetAddressMapping(ctx, contractAddr, evmAddr)
+	}
+}

--- a/evmrpc/tests/tx.go
+++ b/evmrpc/tests/tx.go
@@ -1,9 +1,15 @@
 package tests
 
 import (
+	"fmt"
 	"math/big"
 
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/sei-protocol/sei-chain/precompiles"
+	"github.com/sei-protocol/sei-chain/precompiles/pointer"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 )
 
@@ -17,5 +23,29 @@ func send(nonce uint64) ethtypes.TxData {
 		Value:     big.NewInt(2000),
 		Data:      []byte{},
 		ChainID:   chainId,
+	}
+}
+
+func registerCW20Pointer(nonce uint64, cw20Addr string) ethtypes.TxData {
+	pInfo := precompiles.GetPrecompileInfo(pointer.PrecompileName)
+	input, _ := pInfo.ABI.Pack("addCW20Pointer", cw20Addr)
+	pointer := common.HexToAddress(pointer.PointerAddress)
+	return &ethtypes.DynamicFeeTx{
+		Nonce:     0,
+		GasFeeCap: big.NewInt(1000000000),
+		Gas:       4000000,
+		To:        &pointer,
+		Value:     big.NewInt(0),
+		Data:      input,
+		ChainID:   chainId,
+	}
+}
+
+func transferCW20Msg(mnemonic string, cw20Addr string) sdk.Msg {
+	recipient, _ := testkeeper.MockAddressPair()
+	return &wasmtypes.MsgExecuteContract{
+		Sender:   getSeiAddrWithMnemonic(mnemonic).String(),
+		Contract: cw20Addr,
+		Msg:      []byte(fmt.Sprintf("{\"transfer\":{\"recipient\":\"%s\",\"amount\":\"100\"}}", recipient.String())),
 	}
 }

--- a/evmrpc/tests/tx.go
+++ b/evmrpc/tests/tx.go
@@ -1,0 +1,21 @@
+package tests
+
+import (
+	"math/big"
+
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
+)
+
+func send(nonce uint64) ethtypes.TxData {
+	_, recipient := testkeeper.MockAddressPair()
+	return &ethtypes.DynamicFeeTx{
+		Nonce:     nonce,
+		GasFeeCap: big.NewInt(1000000000),
+		Gas:       21000,
+		To:        &recipient,
+		Value:     big.NewInt(2000),
+		Data:      []byte{},
+		ChainID:   chainId,
+	}
+}

--- a/evmrpc/tests/utils.go
+++ b/evmrpc/tests/utils.go
@@ -1,0 +1,186 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/gogo/protobuf/proto"
+	"github.com/sei-protocol/sei-chain/app"
+	"github.com/sei-protocol/sei-chain/evmrpc"
+	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
+	seiutils "github.com/sei-protocol/sei-chain/utils"
+	"github.com/sei-protocol/sei-chain/x/evm/types"
+	"github.com/sei-protocol/sei-chain/x/evm/types/ethtx"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+const testAddr = "127.0.0.1"
+
+func RunWithServer(s evmrpc.EVMServer, r func()) {
+	s.Start()
+	defer s.Stop()
+	r()
+}
+
+func forkCtx(ctx sdk.Context) sdk.Context {
+	ms := ctx.MultiStore()
+	msCache := ms.CacheMultiStore()
+	return ctx.WithMultiStore(msCache)
+}
+
+func SetupTestServer(
+	port int,
+	blocks [][][]byte,
+	initializer ...func(sdk.Context, *app.App),
+) evmrpc.EVMServer {
+	mockClient := MockClient{blocks: blocks}
+	a := testkeeper.EVMTestApp
+	ctx := forkCtx(a.GetContextForDeliverTx(nil)).WithBlockTime(time.Now()).WithChainID("sei-test")
+	for _, i := range initializer {
+		i(ctx, a)
+	}
+	ctxList := []sdk.Context{}
+	for i, block := range blocks {
+		ctxList = append(ctxList, ctx)
+		ctx = forkCtx(ctx).WithBlockHeight(int64(i + 1)).WithBlockTime(time.Now()).WithChainID("sei-test")
+		e, t, c, err := a.ProcessBlock(ctx, block, &abci.RequestProcessProposal{
+			Height: int64(i + 1),
+		}, abci.CommitInfo{}, true)
+		// fmt.Println(t)
+		if err != nil {
+			panic(err)
+		}
+		a.EvmKeeper.FlushTransientReceipts(ctx)
+		mockClient.recordBlockResult(t, c.ConsensusParamUpdates, e)
+	}
+	cfg := evmrpc.DefaultConfig
+	cfg.HTTPEnabled = true
+	cfg.HTTPPort = port
+	s, err := evmrpc.NewEVMHTTPServer(
+		log.NewNopLogger(),
+		cfg,
+		&mockClient,
+		&a.EvmKeeper,
+		a.BaseApp,
+		a.AnteHandler,
+		func(i int64) sdk.Context {
+			if i == evmrpc.LatestCtxHeight {
+				return ctxList[len(ctxList)-1]
+			}
+			return ctxList[i-1]
+		},
+		a.GetTxConfig(),
+		"",
+		func(ctx context.Context, hash common.Hash) (bool, error) {
+			return false, nil
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+func sendRequestWithNamespace(namespace string, port int, method string, params ...interface{}) map[string]interface{} {
+	paramsFormatted := ""
+	if len(params) > 0 {
+		paramsFormatted = strings.Join(seiutils.Map(params, formatParam), ",")
+	}
+	body := fmt.Sprintf("{\"jsonrpc\": \"2.0\",\"method\": \"%s_%s\",\"params\":[%s],\"id\":\"test\"}", namespace, method, paramsFormatted)
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s:%d", testAddr, port), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	res, _ := http.DefaultClient.Do(req)
+	defer res.Body.Close()
+	resBody, _ := io.ReadAll(res.Body)
+	resObj := map[string]interface{}{}
+	_ = json.Unmarshal(resBody, &resObj)
+	return resObj
+}
+
+func formatParam(p interface{}) string {
+	if p == nil {
+		return "null"
+	}
+	switch v := p.(type) {
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	case int:
+		return fmt.Sprintf("%d", v)
+	case float64:
+		return fmt.Sprintf("%f", v)
+	case string:
+		return fmt.Sprintf("\"%s\"", v)
+	case common.Address:
+		return fmt.Sprintf("\"%s\"", v)
+	case []common.Address:
+		wrapper := func(i common.Address) string {
+			return formatParam(i)
+		}
+		return fmt.Sprintf("[%s]", strings.Join(seiutils.Map(v, wrapper), ","))
+	case common.Hash:
+		return fmt.Sprintf("\"%s\"", v)
+	case []common.Hash:
+		wrapper := func(i common.Hash) string {
+			return formatParam(i)
+		}
+		return fmt.Sprintf("[%s]", strings.Join(seiutils.Map(v, wrapper), ","))
+	case [][]common.Hash:
+		wrapper := func(i []common.Hash) string {
+			return formatParam(i)
+		}
+		return fmt.Sprintf("[%s]", strings.Join(seiutils.Map(v, wrapper), ","))
+	case []string:
+		return fmt.Sprintf("[%s]", strings.Join(v, ","))
+	case []interface{}:
+		return fmt.Sprintf("[%s]", strings.Join(seiutils.Map(v, formatParam), ","))
+	case map[string]interface{}:
+		kvs := []string{}
+		for k, v := range v {
+			kvs = append(kvs, fmt.Sprintf("\"%s\":%s", k, formatParam(v)))
+		}
+		return fmt.Sprintf("{%s}", strings.Join(kvs, ","))
+	case map[string]map[string]interface{}:
+		kvs := []string{}
+		for k, v := range v {
+			kvs = append(kvs, fmt.Sprintf("\"%s\":%s", k, formatParam(v)))
+		}
+		return fmt.Sprintf("{%s}", strings.Join(kvs, ","))
+	default:
+		panic("did not match on type")
+	}
+}
+
+func signAndEncodeTx(txData ethtypes.TxData, mnemonic string) []byte {
+	signed := signTxWithMnemonic(txData, mnemonic1)
+	var typedTx proto.Message
+	switch txData.(type) {
+	case *ethtypes.LegacyTx:
+		typedTx, _ = ethtx.NewLegacyTx(signed)
+	case *ethtypes.AccessListTx:
+		typedTx, _ = ethtx.NewAccessListTx(signed)
+	case *ethtypes.DynamicFeeTx:
+		typedTx, _ = ethtx.NewDynamicFeeTx(signed)
+	case *ethtypes.BlobTx:
+		typedTx, _ = ethtx.NewBlobTx(signed)
+	default:
+		panic("invalid tx type")
+	}
+	msg, _ := types.NewMsgEVMTransaction(typedTx)
+	builder := testkeeper.EVMTestApp.GetTxConfig().NewTxBuilder()
+	builder.SetMsgs(msg)
+	tx := builder.GetTx()
+	txBz, _ := testkeeper.EVMTestApp.GetTxConfig().TxEncoder()(tx)
+	return txBz
+}

--- a/evmrpc/tests/utils.go
+++ b/evmrpc/tests/utils.go
@@ -38,7 +38,7 @@ type TestServer struct {
 }
 
 func (ts TestServer) Run(r func(port int)) {
-	ts.Start()
+	_ = ts.Start()
 	defer ts.Stop()
 	r(ts.port)
 }
@@ -64,7 +64,7 @@ func SetupTestServer(
 	for _, i := range initializer {
 		i(ctx, a)
 	}
-	a.Commit(context.Background())
+	_, _ = a.Commit(context.Background())
 	mockClient.recordBlockResult(res.TxResults, res.ConsensusParamUpdates, res.Events)
 	for i, block := range blocks {
 		height := int64(i + 2)
@@ -78,7 +78,7 @@ func SetupTestServer(
 		if err != nil {
 			panic(err)
 		}
-		a.Commit(context.Background())
+		_, _ = a.Commit(context.Background())
 		mockClient.recordBlockResult(res.TxResults, res.ConsensusParamUpdates, res.Events)
 	}
 	cfg := evmrpc.DefaultConfig
@@ -196,7 +196,7 @@ func signAndEncodeTx(txData ethtypes.TxData, mnemonic string) []byte {
 	}
 	msg, _ := types.NewMsgEVMTransaction(typedTx)
 	builder := testkeeper.EVMTestApp.GetTxConfig().NewTxBuilder()
-	builder.SetMsgs(msg)
+	_ = builder.SetMsgs(msg)
 	tx := builder.GetTx()
 	txBz, _ := testkeeper.EVMTestApp.GetTxConfig().TxEncoder()(tx)
 	return txBz

--- a/go.mod
+++ b/go.mod
@@ -359,7 +359,7 @@ replace (
 	github.com/sei-protocol/sei-db => github.com/sei-protocol/sei-db v0.0.47
 	// Latest goleveldb is broken, we have to stick to this version
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
-	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.5.2-0.20250303201904-d6900b1190ff
+	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.5.1
 	github.com/tendermint/tm-db => github.com/sei-protocol/tm-db v0.0.4
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.mod
+++ b/go.mod
@@ -354,7 +354,7 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.54-0.20250303201913-2ce1c3d9c189
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.2.0
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.5
-	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-26
+	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-27
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/sei-protocol/sei-db => github.com/sei-protocol/sei-db v0.0.47
 	// Latest goleveldb is broken, we have to stick to this version

--- a/go.mod
+++ b/go.mod
@@ -359,7 +359,7 @@ replace (
 	github.com/sei-protocol/sei-db => github.com/sei-protocol/sei-db v0.0.47
 	// Latest goleveldb is broken, we have to stick to this version
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
-	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.5.1
+	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.5.2
 	github.com/tendermint/tm-db => github.com/sei-protocol/tm-db v0.0.4
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1356,8 +1356,8 @@ github.com/sei-protocol/sei-iavl v0.2.0 h1:OisPjXiDT+oe+aeckzDEFgkZCYuUjHgs/PP8D
 github.com/sei-protocol/sei-iavl v0.2.0/go.mod h1:qRf8QYUPfrAO7K6VDB2B2l/N7K5L76OorioGBcJBIbw=
 github.com/sei-protocol/sei-ibc-go/v3 v3.3.5 h1:SQRzWi9KSMuGNGd3f5RWAmsGGk7yeY1zhnEnrr/nqug=
 github.com/sei-protocol/sei-ibc-go/v3 v3.3.5/go.mod h1:VwB/vWu4ysT5DN2aF78d17LYmx3omSAdq6gpKvM7XRA=
-github.com/sei-protocol/sei-tendermint v0.5.1 h1:0mSzSlM1irROkOUF2o2mXqZk8n0qrMWbSM9KsVVST5M=
-github.com/sei-protocol/sei-tendermint v0.5.1/go.mod h1:4LSlJdhl3nf3OmohliwRNUFLOB1XWlrmSodrIP7fLh4=
+github.com/sei-protocol/sei-tendermint v0.5.2 h1:NygOo5CN1Otzn+H5Bx1U4wEKx2PSKtGGubh7d+ADrF8=
+github.com/sei-protocol/sei-tendermint v0.5.2/go.mod h1:4LSlJdhl3nf3OmohliwRNUFLOB1XWlrmSodrIP7fLh4=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
 github.com/sei-protocol/sei-wasmd v0.3.0 h1:IJabKisvmsstAPsVAk37HxVyQwAe36g1CNYM/QcPisc=

--- a/go.sum
+++ b/go.sum
@@ -1344,8 +1344,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-26 h1:I+ruPtAeHW89y0aN0iStKrl7V1+GurVjPo6l4VdOQlI=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-26/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-27 h1:TYZLAoKSfE2N/63sFTTWh3djH59L9BxtQRSm2Q/8bLY=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-27/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-cosmos v0.3.54-0.20250303201913-2ce1c3d9c189 h1:WkRKxW93rCleS3rxe3HnqFZ6AtKCSgVXK4HmUuJrhWg=

--- a/go.sum
+++ b/go.sum
@@ -1356,8 +1356,8 @@ github.com/sei-protocol/sei-iavl v0.2.0 h1:OisPjXiDT+oe+aeckzDEFgkZCYuUjHgs/PP8D
 github.com/sei-protocol/sei-iavl v0.2.0/go.mod h1:qRf8QYUPfrAO7K6VDB2B2l/N7K5L76OorioGBcJBIbw=
 github.com/sei-protocol/sei-ibc-go/v3 v3.3.5 h1:SQRzWi9KSMuGNGd3f5RWAmsGGk7yeY1zhnEnrr/nqug=
 github.com/sei-protocol/sei-ibc-go/v3 v3.3.5/go.mod h1:VwB/vWu4ysT5DN2aF78d17LYmx3omSAdq6gpKvM7XRA=
-github.com/sei-protocol/sei-tendermint v0.5.2-0.20250303201904-d6900b1190ff h1:9rG3Voc+gb5e3cIsOVueuxyRazQD1EXfX/WOSyOF6SI=
-github.com/sei-protocol/sei-tendermint v0.5.2-0.20250303201904-d6900b1190ff/go.mod h1:4LSlJdhl3nf3OmohliwRNUFLOB1XWlrmSodrIP7fLh4=
+github.com/sei-protocol/sei-tendermint v0.5.1 h1:0mSzSlM1irROkOUF2o2mXqZk8n0qrMWbSM9KsVVST5M=
+github.com/sei-protocol/sei-tendermint v0.5.1/go.mod h1:4LSlJdhl3nf3OmohliwRNUFLOB1XWlrmSodrIP7fLh4=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
 github.com/sei-protocol/sei-wasmd v0.3.0 h1:IJabKisvmsstAPsVAk37HxVyQwAe36g1CNYM/QcPisc=

--- a/occ_tests/utils/utils.go
+++ b/occ_tests/utils/utils.go
@@ -262,7 +262,7 @@ func runTxs(testCtx *TestContext, msgs []*TestMessage, occ bool) ([]types.Event,
 		Height: testCtx.Ctx.BlockHeader().Height,
 	}
 
-	return testCtx.TestApp.ProcessBlock(testCtx.Ctx, txs, req, req.DecidedLastCommit)
+	return testCtx.TestApp.ProcessBlock(testCtx.Ctx, txs, req, req.DecidedLastCommit, false)
 }
 
 func JoinMsgs(msgsList ...[]*TestMessage) []*TestMessage {

--- a/precompiles/pointer/pointer_test.go
+++ b/precompiles/pointer/pointer_test.go
@@ -34,7 +34,11 @@ func TestAddNative(t *testing.T) {
 	require.Nil(t, err)
 	statedb := state.NewDBImpl(ctx, &testApp.EvmKeeper, true)
 	blockCtx, _ := testApp.EvmKeeper.GetVMBlockContext(ctx, core.GasPool(suppliedGas))
+<<<<<<< HEAD
 	evm := vm.NewEVM(*blockCtx, vm.TxContext{}, statedb, cfg, vm.Config{}, nil)
+=======
+	evm := vm.NewEVM(*blockCtx, vm.TxContext{}, statedb, cfg, vm.Config{}, testApp.EvmKeeper.CustomPrecompiles())
+>>>>>>> d6cbdbd2 (refactor RPC tests)
 	_, g, err := p.RunAndCalculateGas(evm, caller, caller, append(p.GetExecutor().(*pointer.PrecompileExecutor).AddNativePointerID, args...), suppliedGas, nil, nil, false, false)
 	require.NotNil(t, err)
 	require.NotNil(t, statedb.GetPrecompileError())
@@ -54,7 +58,11 @@ func TestAddNative(t *testing.T) {
 		}},
 	})
 	statedb = state.NewDBImpl(ctx, &testApp.EvmKeeper, false)
+<<<<<<< HEAD
 	evm = vm.NewEVM(*blockCtx, vm.TxContext{}, statedb, cfg, vm.Config{}, nil)
+=======
+	evm = vm.NewEVM(*blockCtx, vm.TxContext{}, statedb, cfg, vm.Config{}, testApp.EvmKeeper.CustomPrecompiles())
+>>>>>>> d6cbdbd2 (refactor RPC tests)
 	ret, g, err := p.RunAndCalculateGas(evm, caller, caller, append(p.GetExecutor().(*pointer.PrecompileExecutor).AddNativePointerID, args...), suppliedGas, nil, nil, false, false)
 	require.Nil(t, err)
 	require.Equal(t, uint64(8889527), g)
@@ -83,7 +91,7 @@ func TestAddNative(t *testing.T) {
 	testApp.EvmKeeper.DeleteERC20NativePointer(statedb.Ctx(), "test", version)
 	testApp.EvmKeeper.SetERC20NativePointerWithVersion(statedb.Ctx(), "test", pointerAddr, version-1)
 	statedb = state.NewDBImpl(statedb.Ctx(), &testApp.EvmKeeper, true)
-	evm = vm.NewEVM(*blockCtx, vm.TxContext{}, statedb, cfg, vm.Config{}, nil)
+	evm = vm.NewEVM(*blockCtx, vm.TxContext{}, statedb, cfg, vm.Config{}, testApp.EvmKeeper.CustomPrecompiles())
 	_, _, err = p.RunAndCalculateGas(evm, caller, caller, append(p.GetExecutor().(*pointer.PrecompileExecutor).AddNativePointerID, args...), suppliedGas, nil, nil, false, false)
 	require.Nil(t, err)
 	require.Nil(t, statedb.GetPrecompileError())

--- a/precompiles/pointer/pointer_test.go
+++ b/precompiles/pointer/pointer_test.go
@@ -34,11 +34,7 @@ func TestAddNative(t *testing.T) {
 	require.Nil(t, err)
 	statedb := state.NewDBImpl(ctx, &testApp.EvmKeeper, true)
 	blockCtx, _ := testApp.EvmKeeper.GetVMBlockContext(ctx, core.GasPool(suppliedGas))
-<<<<<<< HEAD
-	evm := vm.NewEVM(*blockCtx, vm.TxContext{}, statedb, cfg, vm.Config{}, nil)
-=======
 	evm := vm.NewEVM(*blockCtx, vm.TxContext{}, statedb, cfg, vm.Config{}, testApp.EvmKeeper.CustomPrecompiles())
->>>>>>> d6cbdbd2 (refactor RPC tests)
 	_, g, err := p.RunAndCalculateGas(evm, caller, caller, append(p.GetExecutor().(*pointer.PrecompileExecutor).AddNativePointerID, args...), suppliedGas, nil, nil, false, false)
 	require.NotNil(t, err)
 	require.NotNil(t, statedb.GetPrecompileError())
@@ -58,11 +54,7 @@ func TestAddNative(t *testing.T) {
 		}},
 	})
 	statedb = state.NewDBImpl(ctx, &testApp.EvmKeeper, false)
-<<<<<<< HEAD
-	evm = vm.NewEVM(*blockCtx, vm.TxContext{}, statedb, cfg, vm.Config{}, nil)
-=======
 	evm = vm.NewEVM(*blockCtx, vm.TxContext{}, statedb, cfg, vm.Config{}, testApp.EvmKeeper.CustomPrecompiles())
->>>>>>> d6cbdbd2 (refactor RPC tests)
 	ret, g, err := p.RunAndCalculateGas(evm, caller, caller, append(p.GetExecutor().(*pointer.PrecompileExecutor).AddNativePointerID, args...), suppliedGas, nil, nil, false, false)
 	require.Nil(t, err)
 	require.Equal(t, uint64(8889527), g)

--- a/precompiles/setup.go
+++ b/precompiles/setup.go
@@ -38,6 +38,82 @@ type IPrecompile interface {
 	Address() ecommon.Address
 }
 
+func GetCustomPrecompiles(
+	evmKeeper common.EVMKeeper,
+	bankKeeper common.BankKeeper,
+	bankSender common.BankMsgServer,
+	wasmdKeeper common.WasmdKeeper,
+	wasmdViewKeeper common.WasmdViewKeeper,
+	stakingKeeper common.StakingKeeper,
+	stakingQuerier common.StakingQuerier,
+	govKeeper common.GovKeeper,
+	distrKeeper common.DistributionKeeper,
+	oracleKeeper common.OracleKeeper,
+	transferKeeper common.TransferKeeper,
+	clientKeeper common.ClientKeeper,
+	connectionKeeper common.ConnectionKeeper,
+	channelKeeper common.ChannelKeeper,
+	accountKeeper common.AccountKeeper,
+) map[ecommon.Address]vm.PrecompiledContract {
+	bankp, err := bank.NewPrecompile(bankKeeper, bankSender, evmKeeper, accountKeeper)
+	if err != nil {
+		panic(err)
+	}
+	wasmdp, err := wasmd.NewPrecompile(evmKeeper, wasmdKeeper, wasmdViewKeeper, bankKeeper)
+	if err != nil {
+		panic(err)
+	}
+	jsonp, err := json.NewPrecompile()
+	if err != nil {
+		panic(err)
+	}
+	addrp, err := addr.NewPrecompile(evmKeeper, bankKeeper, accountKeeper)
+	if err != nil {
+		panic(err)
+	}
+	stakingp, err := staking.NewPrecompile(stakingKeeper, stakingQuerier, evmKeeper, bankKeeper)
+	if err != nil {
+		panic(err)
+	}
+	govp, err := gov.NewPrecompile(govKeeper, evmKeeper, bankKeeper)
+	if err != nil {
+		panic(err)
+	}
+	distrp, err := distribution.NewPrecompile(distrKeeper, evmKeeper)
+	if err != nil {
+		panic(err)
+	}
+	oraclep, err := oracle.NewPrecompile(oracleKeeper, evmKeeper)
+	if err != nil {
+		panic(err)
+	}
+	ibcp, err := ibc.NewPrecompile(transferKeeper, evmKeeper, clientKeeper, connectionKeeper, channelKeeper)
+	if err != nil {
+		panic(err)
+	}
+	pointerp, err := pointer.NewPrecompile(evmKeeper, bankKeeper, wasmdViewKeeper)
+	if err != nil {
+		panic(err)
+	}
+	pointerviewp, err := pointerview.NewPrecompile(evmKeeper)
+	if err != nil {
+		panic(err)
+	}
+	return map[ecommon.Address]vm.PrecompiledContract{
+		bankp.Address():        bankp,
+		wasmdp.Address():       wasmdp,
+		jsonp.Address():        jsonp,
+		addrp.Address():        addrp,
+		stakingp.Address():     stakingp,
+		govp.Address():         govp,
+		distrp.Address():       distrp,
+		oraclep.Address():      oraclep,
+		ibcp.Address():         ibcp,
+		pointerp.Address():     pointerp,
+		pointerviewp.Address(): pointerviewp,
+	}
+}
+
 func InitializePrecompiles(
 	dryRun bool,
 	evmKeeper common.EVMKeeper,

--- a/x/evm/ante/fee.go
+++ b/x/evm/ante/fee.go
@@ -72,7 +72,7 @@ func (fc EVMFeeCheckDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 	}
 	cfg := evmtypes.DefaultChainConfig().EthereumConfig(fc.evmKeeper.ChainID(ctx))
 	txCtx := core.NewEVMTxContext(emsg)
-	evmInstance := vm.NewEVM(*blockCtx, txCtx, stateDB, cfg, vm.Config{}, nil)
+	evmInstance := vm.NewEVM(*blockCtx, txCtx, stateDB, cfg, vm.Config{}, fc.evmKeeper.CustomPrecompiles())
 	st := core.NewStateTransition(evmInstance, emsg, &gp, true)
 	// run stateless checks before charging gas (mimicking Geth behavior)
 	if !ctx.IsCheckTx() && !ctx.IsReCheckTx() {

--- a/x/evm/keeper/evm.go
+++ b/x/evm/keeper/evm.go
@@ -181,7 +181,7 @@ func (k *Keeper) createReadOnlyEVM(ctx sdk.Context, from sdk.AccAddress) (*vm.EV
 	}
 	cfg := types.DefaultChainConfig().EthereumConfig(k.ChainID(ctx))
 	txCtx := vm.TxContext{Origin: k.GetEVMAddressOrDefault(ctx, from)}
-	return vm.NewEVM(*blockCtx, txCtx, stateDB, cfg, vm.Config{}, nil), nil
+	return vm.NewEVM(*blockCtx, txCtx, stateDB, cfg, vm.Config{}, k.customPrecompiles), nil
 }
 
 func (k *Keeper) getEvmGasLimitFromCtx(ctx sdk.Context) uint64 {

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -80,6 +80,8 @@ type Keeper struct {
 	ReplayBlock *ethtypes.Block
 
 	receiptStore seidbtypes.StateStore
+
+	customPrecompiles map[common.Address]vm.PrecompiledContract
 }
 
 type AddressNoncePair struct {
@@ -134,6 +136,14 @@ func NewKeeper(
 		receiptStore:                 receiptStateStore,
 	}
 	return k
+}
+
+func (k *Keeper) SetCustomPrecompiles(cp map[common.Address]vm.PrecompiledContract) {
+	k.customPrecompiles = cp
+}
+
+func (k *Keeper) CustomPrecompiles() map[common.Address]vm.PrecompiledContract {
+	return k.customPrecompiles
 }
 
 func (k *Keeper) AccountKeeper() *authkeeper.AccountKeeper {

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -241,7 +241,7 @@ func (k Keeper) applyEVMMessage(ctx sdk.Context, msg *core.Message, stateDB *sta
 	}
 	cfg := types.DefaultChainConfig().EthereumConfig(k.ChainID(ctx))
 	txCtx := core.NewEVMTxContext(msg)
-	evmInstance := vm.NewEVM(*blockCtx, txCtx, stateDB, cfg, vm.Config{}, nil)
+	evmInstance := vm.NewEVM(*blockCtx, txCtx, stateDB, cfg, vm.Config{}, k.customPrecompiles)
 	st := core.NewStateTransition(evmInstance, msg, &gp, true) // fee already charged in ante handler
 	return st.TransitionDb()
 }

--- a/x/evm/keeper/pointer_upgrade.go
+++ b/x/evm/keeper/pointer_upgrade.go
@@ -26,7 +26,7 @@ func (k *Keeper) RunWithOneOffEVMInstance(
 	}
 	cfg := types.DefaultChainConfig().EthereumConfig(k.ChainID(ctx))
 	txCtx := core.NewEVMTxContext(&core.Message{From: evmModuleAddress, GasPrice: utils.Big0})
-	evmInstance := vm.NewEVM(*blockCtx, txCtx, stateDB, cfg, vm.Config{}, nil)
+	evmInstance := vm.NewEVM(*blockCtx, txCtx, stateDB, cfg, vm.Config{}, k.customPrecompiles)
 	err = runner(evmInstance)
 	if err != nil {
 		logger("upserting pointer", err.Error())

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -292,7 +292,7 @@ func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
 				panic(err)
 			}
 			statedb := state.NewDBImpl(ctx, am.keeper, false)
-			vmenv := vm.NewEVM(*blockCtx, vm.TxContext{}, statedb, types.DefaultChainConfig().EthereumConfig(am.keeper.ChainID(ctx)), vm.Config{}, nil)
+			vmenv := vm.NewEVM(*blockCtx, vm.TxContext{}, statedb, types.DefaultChainConfig().EthereumConfig(am.keeper.ChainID(ctx)), vm.Config{}, am.keeper.CustomPrecompiles())
 			core.ProcessBeaconBlockRoot(*beaconRoot, vmenv, statedb)
 			_, err = statedb.Finalize()
 			if err != nil {


### PR DESCRIPTION
## Describe your changes and provide context
It's becoming difficult to add new RPC tests due to the way old tests are set up. This PR creates a new framework for adding RPC unit tests where it allows spinning up independent server threads and more authentic data mocking.

One thing to call out is that this refactor requires our custom precompiles to be loaded dynamically rather than through a global variable (so that it's possible to have independent concurrent servers across multiple tests)

## Testing performed to validate your change
unit test

