### PR TITLE
Fix RPC subscription fields

### DIFF
--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -212,7 +212,7 @@ func NewEVMWebSocketServer(
 		},
 		{
 			Namespace: "eth",
-			Service:   NewSubscriptionAPI(tmClient, &LogFetcher{tmClient: tmClient, k: k, ctxProvider: ctxProvider, txConfig: txConfig}, &SubscriptionConfig{subscriptionCapacity: 100, newHeadLimit: config.MaxSubscriptionsNewHead}, &FilterConfig{timeout: config.FilterTimeout, maxLog: config.MaxLogNoBlock, maxBlock: config.MaxBlocksForLog}, ConnectionTypeWS),
+			Service:   NewSubscriptionAPI(tmClient, k, ctxProvider, &LogFetcher{tmClient: tmClient, k: k, ctxProvider: ctxProvider, txConfig: txConfig}, &SubscriptionConfig{subscriptionCapacity: 100, newHeadLimit: config.MaxSubscriptionsNewHead}, &FilterConfig{timeout: config.FilterTimeout, maxLog: config.MaxLogNoBlock, maxBlock: config.MaxBlocksForLog}, ConnectionTypeWS),
 		},
 		{
 			Namespace: "web3",

--- a/evmrpc/setup_test.go
+++ b/evmrpc/setup_test.go
@@ -280,6 +280,9 @@ func (c *MockClient) mockEventDataNewBlockHeader(mockHeight uint64) *tmtypes.Eve
 		ResultFinalizeBlock: abci.ResponseFinalizeBlock{
 			TxResults: mockTxResult(),
 			AppHash:   bytes.HexBytes(mustHexToBytes("0000000000000000000000000000000000000000000000000000000000000006")),
+			ConsensusParamUpdates: &types2.ConsensusParams{
+				Block: &types2.BlockParams{MaxGas: 100000},
+			},
 		},
 	}
 }

--- a/evmrpc/subscribe_test.go
+++ b/evmrpc/subscribe_test.go
@@ -32,7 +32,7 @@ func TestSubscribeNewHeads(t *testing.T) {
 	inapplicableKeys := make(map[string]struct{})
 	for _, key := range []string{
 		"difficulty", "extraData", "logsBloom", "nonce", "sha3Uncles", "mixHash",
-		"excessBlobGas", "parentBeaconBlockRoot", "withdrawlsRoot", "baseFeePerGas",
+		"excessBlobGas", "parentBeaconBlockRoot", "withdrawlsRoot",
 		"withdrawalsRoot", "blobGasUsed",
 	} {
 		inapplicableKeys[key] = struct{}{}


### PR DESCRIPTION
## Describe your changes and provide context
Fixed the following:
- use block gas limit instead of the sum of all txs gas limit for the `gasLimit` field in new header subscription response
- populate base fee per gas now that we've implemented EIP1559

## Testing performed to validate your change
unit test

