### PR TITLE
fix loadtest for erc20s

### DIFF
--- a/loadtest/contracts/deploy_erc20.sh
+++ b/loadtest/contracts/deploy_erc20.sh
@@ -15,8 +15,8 @@ if (( $(echo "$BALANCE < $THRESHOLD" | bc -l) )); then
 fi
 cd loadtest/contracts/evm || exit 1
 
-./setup.sh > /dev/null
+./setup.sh > /dev/null 2>&1
 
-git submodule update --init --recursive > /dev/null
+git submodule update --init --recursive > /dev/null 2>&1
 
-/root/.foundry/bin/forge create -r "$evm_endpoint" --private-key 57acb95d82739866a5c29e40b0aa2590742ae50425b7dd5b5d279a986370189e src/NoopToken.sol:NoopToken --json --constructor-args "NoopToken" "NT" | jq -r '.deployedTo'
+/root/.foundry/bin/forge create --broadcast -r "$evm_endpoint" --private-key 57acb95d82739866a5c29e40b0aa2590742ae50425b7dd5b5d279a986370189e src/NoopToken.sol:NoopToken --json --constructor-args "NoopToken" "NT"  |jq -r '.deployedTo'

--- a/loadtest/contracts/deploy_erc721.sh
+++ b/loadtest/contracts/deploy_erc721.sh
@@ -16,8 +16,8 @@ fi
 
 cd loadtest/contracts/evm || exit 1
 
-./setup.sh > /dev/null
+./setup.sh > /dev/null 2>&1
 
-git submodule update --init --recursive > /dev/null
+git submodule update --init --recursive > /dev/null 2>&1
 
-/root/.foundry/bin/forge create -r "$evm_endpoint" --private-key 57acb95d82739866a5c29e40b0aa2590742ae50425b7dd5b5d279a986370189e src/ERC721.sol:MyNFT --json | jq -r '.deployedTo'
+/root/.foundry/bin/forge create --broadcast -r "$evm_endpoint" --private-key 57acb95d82739866a5c29e40b0aa2590742ae50425b7dd5b5d279a986370189e src/ERC721.sol:MyNFT --json | jq -r '.deployedTo'

--- a/loadtest/contracts/evm/remappings.txt
+++ b/loadtest/contracts/evm/remappings.txt
@@ -1,4 +1,4 @@
-@openzeppelin=lib/openzeppelin-contracts/contracts/
+@openzeppelin/=lib/openzeppelin-contracts/
 ds-test/=lib/forge-std/lib/ds-test/src/
 erc4626-tests/=lib/openzeppelin-contracts/lib/erc4626-tests/
 forge-std/=lib/forge-std/src/

--- a/loadtest/types.go
+++ b/loadtest/types.go
@@ -81,8 +81,8 @@ func (c *Config) EVMRpcEndpoint() string {
 	endpoints := strings.Split(c.EvmRpcEndpoints, ",")
 	return endpoints[0]
 }
-
 func (c *Config) ContainsAnyMessageTypes(types ...string) bool {
+
 	for _, t := range types {
 		for _, mt := range c.MessageTypes {
 			if mt == t {


### PR DESCRIPTION
## Describe your changes and provide context
- script outputs the address of the deployed contract, but needed trim
- lower level invocations were emitting warnings which messed up address parsing
- forge now requires --broadcast for the deploy (create) command
- uniswap deploy was clearing out all previously-deployed addresses from the config

## Testing performed to validate your change
- loadtesting env

