### PR TITLE
disallow future block number to be passed to balance queries

### DIFF
--- a/evmrpc/state.go
+++ b/evmrpc/state.go
@@ -43,6 +43,9 @@ func (a *StateAPI) GetBalance(ctx context.Context, address common.Address, block
 	}
 	sdkCtx := a.ctxProvider(LatestCtxHeight)
 	if block != nil {
+		if sdkCtx.BlockHeight() < *block {
+			return nil, errors.New("cannot query future blocks")
+		}
 		sdkCtx = a.ctxProvider(*block)
 		if err := CheckVersion(sdkCtx, a.keeper); err != nil {
 			return nil, err
@@ -61,6 +64,9 @@ func (a *StateAPI) GetCode(ctx context.Context, address common.Address, blockNrO
 	}
 	sdkCtx := a.ctxProvider(LatestCtxHeight)
 	if block != nil {
+		if sdkCtx.BlockHeight() < *block {
+			return nil, errors.New("cannot query future blocks")
+		}
 		sdkCtx = a.ctxProvider(*block)
 		if err := CheckVersion(sdkCtx, a.keeper); err != nil {
 			return nil, err
@@ -79,6 +85,9 @@ func (a *StateAPI) GetStorageAt(ctx context.Context, address common.Address, hex
 	}
 	sdkCtx := a.ctxProvider(LatestCtxHeight)
 	if block != nil {
+		if sdkCtx.BlockHeight() < *block {
+			return nil, errors.New("cannot query future blocks")
+		}
 		sdkCtx = a.ctxProvider(*block)
 		if err := CheckVersion(sdkCtx, a.keeper); err != nil {
 			return nil, err

--- a/evmrpc/tests/state_test.go
+++ b/evmrpc/tests/state_test.go
@@ -1,0 +1,26 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetBalance(t *testing.T) {
+	txBz := signAndEncodeTx(send(0), mnemonic1)
+	SetupTestServer([][][]byte{{txBz}}, mnemonicInitializer(mnemonic1)).Run(
+		func(port int) {
+			res := sendRequestWithNamespace("eth", port, "getBalance", getAddrWithMnemonic(mnemonic1).Hex(), "0x1")
+			balance := res["result"].(string)
+			require.Equal(t, "0x21e19e0c9bab2400000", balance)
+			res = sendRequestWithNamespace("eth", port, "getBalance", getAddrWithMnemonic(mnemonic1).Hex(), "0x2")
+			balance = res["result"].(string)
+			require.Equal(t, "0x21e19e0b6a140b5a830", balance)
+			res = sendRequestWithNamespace("eth", port, "getBalance", getAddrWithMnemonic(mnemonic1).Hex(), "0x3")
+			fmt.Println(res)
+			err := res["error"].(map[string]interface{})
+			require.Equal(t, "cannot query future blocks", err["message"].(string))
+		},
+	)
+}


### PR DESCRIPTION
## Describe your changes and provide context
When users query balances (or other states) with a future block height, the expected behavior is an error instead of returning the latest state.

## Testing performed to validate your change
unit test
