### PR TITLE
return error when log requested with too wide ranges

### DIFF
--- a/evmrpc/filter.go
+++ b/evmrpc/filter.go
@@ -319,8 +319,8 @@ func (f *LogFetcher) GetLogsByFilters(ctx context.Context, crit filters.FilterCr
 	})
 
 	// Apply rate limit
-	if applyOpenEndedLogLimit && int64(len(res)) >= f.filterConfig.maxLog {
-		res = res[:int(f.filterConfig.maxLog)]
+	if applyOpenEndedLogLimit && f.filterConfig.maxLog > 0 && int64(len(res)) > f.filterConfig.maxLog {
+		return nil, 0, fmt.Errorf("requested range has %d logs which is more than the maximum of %d", len(res), f.filterConfig.maxLog)
 	}
 
 	return res, end, err
@@ -397,7 +397,7 @@ func (f *LogFetcher) fetchBlocksByCrit(ctx context.Context, crit filters.FilterC
 		begin = lastToHeight
 	}
 	if !applyOpenEndedLogLimit && f.filterConfig.maxBlock > 0 && end >= (begin+f.filterConfig.maxBlock) {
-		end = begin + f.filterConfig.maxBlock - 1
+		return nil, 0, false, fmt.Errorf("a maximum of %d blocks worth of logs may be requested at a time", f.filterConfig.maxBlock)
 	}
 	// begin should always be <= end block at this point
 	if begin > end {

--- a/evmrpc/filter_test.go
+++ b/evmrpc/filter_test.go
@@ -317,7 +317,7 @@ func TestFilterGetFilterChanges(t *testing.T) {
 
 	resObj = sendRequest(t, TestPort, "getFilterChanges", filterId)
 	logs := resObj["result"].([]interface{})
-	require.Equal(t, 4, len(logs)) // limited by MaxLogNoBlock config to 4
+	require.Equal(t, 10, len(logs)) // limited by MaxLogNoBlock config to 4
 	logObj := logs[0].(map[string]interface{})
 	require.Equal(t, "0x2", logObj["blockNumber"].(string))
 

--- a/evmrpc/setup_test.go
+++ b/evmrpc/setup_test.go
@@ -548,7 +548,7 @@ func init() {
 	goodConfig.HTTPPort = TestPort
 	goodConfig.WSPort = TestWSPort
 	goodConfig.FilterTimeout = 500 * time.Millisecond
-	goodConfig.MaxLogNoBlock = 4
+	goodConfig.MaxLogNoBlock = 10
 	infoLog, err := log.NewDefaultLogger("text", "info")
 	if err != nil {
 		panic(err)

--- a/evmrpc/tests/log_test.go
+++ b/evmrpc/tests/log_test.go
@@ -19,3 +19,16 @@ func TestGetLogs(t *testing.T) {
 		},
 	)
 }
+
+func TestGetLogsRangeTooWide(t *testing.T) {
+	SetupTestServer([][][]byte{{}}, erc20Initializer()).Run(
+		func(port int) {
+			res := sendRequestWithNamespace("eth", port, "getLogs", map[string]interface{}{
+				"fromBlock": "0x1",
+				"toBlock":   "0x7D2",
+				"address":   erc20Addr.Hex(),
+			})
+			require.Equal(t, res["error"].(map[string]interface{})["message"].(string), "a maximum of 2000 blocks worth of logs may be requested at a time")
+		},
+	)
+}


### PR DESCRIPTION
## Describe your changes and provide context
Instead of silently returning a truncated list of logs, we will explicitly return an error when log requests are made with ranges that are too wide per RPC provider's config.

## Testing performed to validate your change
unit tests
