### PR TITLE
Add plugin-based MEV handler support

### DIFF
--- a/app/mev.go
+++ b/app/mev.go
@@ -1,0 +1,37 @@
+package app
+
+import (
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/spf13/cast"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+const pluginObjectName = "HandlerInstance"
+
+type MEVHandler interface {
+	Handle(ctx sdk.Context, req *abci.RequestPrepareProposal) (*abci.ResponsePrepareProposal, error)
+}
+
+const (
+	flagMevHandlerPluginPath = "mev.handler_plugin_path"
+)
+
+type MEVConfig struct {
+	HandlerPluginPath string `mapstructure:"handler_plugin_path"`
+}
+
+var DefaultMEVConfig = MEVConfig{
+	HandlerPluginPath: "",
+}
+
+func ReadMevConfig(opts servertypes.AppOptions) (MEVConfig, error) {
+	cfg := DefaultMEVConfig // copy
+	var err error
+	if v := opts.Get(flagMevHandlerPluginPath); v != nil {
+		if cfg.HandlerPluginPath, err = cast.ToStringE(v); err != nil {
+			return cfg, err
+		}
+	}
+	return cfg, nil
+}

--- a/app/utils.go
+++ b/app/utils.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"time"
 
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -23,4 +24,10 @@ type BlockProcessRequest interface {
 	GetByzantineValidators() []abci.Misbehavior
 	GetHeight() int64
 	GetTime() time.Time
+}
+
+func check(err error, event string) {
+	if err != nil {
+		panic(fmt.Sprintf("error %s for %s", err, event))
+	}
 }

--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -428,6 +428,8 @@ func initAppConfig() (string, interface{}) {
 		EvmQuery querier.Config `mapstructure:"evm_query"`
 
 		LightInvariance app.LightInvarianceConfig `mapstructure:"light_invariance"`
+
+		MEV app.MEVConfig `mapstructure:"mev"`
 	}
 
 	// Optionally allow the chain developer to overwrite the SDK's default
@@ -472,6 +474,7 @@ func initAppConfig() (string, interface{}) {
 		ETHBlockTest:    blocktest.DefaultConfig,
 		EvmQuery:        querier.DefaultConfig,
 		LightInvariance: app.DefaultLightInvarianceConfig,
+		MEV:             app.DefaultMEVConfig,
 	}
 
 	customAppTemplate := serverconfig.DefaultConfigTemplate + `
@@ -567,6 +570,9 @@ evm_query_gas_limit = {{ .EvmQuery.GasLimit }}
 
 [light_invariance]
 supply_enabled = {{ .LightInvariance.SupplyEnabled }}
+
+[mev]
+handler_plugin_path = "{{ .MEV.HandlerPluginPath }}"
 `
 
 	return customAppTemplate, customAppConfig


### PR DESCRIPTION
## Describe your changes and provide context
This PR implements logics to allow validators to dynamically load MEV handlers without having to fork sei-chain. Specifically a new section `mev` is added to `app.toml`. If a validator wishes to have custom MEV logic, they would need to compile encapsulate their logic in a library that follows the rules below:
- defines a custom struct that implements the MEVHandler interface introduced in this PR
- creates a singleton object of the custom struct that's named `HandlerInstance`
- build their library as a plugin.
An example can be found in https://github.com/sei-protocol/mev-demo, which can also be used as a template/starting point for validators to develop their own MEV plugins.

## Testing performed to validate your change
localnet with mev-demo
<img width="1057" alt="Screenshot 2025-03-25 at 12 51 20 PM" src="https://github.com/user-attachments/assets/865f92bd-9537-49e7-8494-dc8143879955" />


