### PR TITLE
Add capability for MEV plugin to accept submission via RPC

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -114,6 +114,7 @@ import (
 	"github.com/sei-protocol/sei-chain/app/upgrades"
 	v0upgrade "github.com/sei-protocol/sei-chain/app/upgrades/v0"
 	"github.com/sei-protocol/sei-chain/evmrpc"
+	"github.com/sei-protocol/sei-chain/mev"
 	"github.com/sei-protocol/sei-chain/precompiles"
 	"github.com/sei-protocol/sei-chain/utils"
 	"github.com/sei-protocol/sei-chain/utils/metrics"
@@ -380,7 +381,7 @@ type App struct {
 
 	forkInitializer func(sdk.Context)
 
-	mevHandler MEVHandler
+	mevHandler mev.MEVHandler
 }
 
 type AppOption func(*App)
@@ -652,14 +653,14 @@ func New(
 	check(err, "reading genesis import config")
 	app.genesisImportConfig = genesisImportConfig
 
-	mevConfig, err := ReadMevConfig(appOpts)
+	mevConfig, err := mev.ReadMevConfig(appOpts)
 	check(err, "reading mev config")
 	if mevConfig.HandlerPluginPath != "" {
 		p, err := plugin.Open(mevConfig.HandlerPluginPath)
 		check(err, "loading mev plugin")
-		h, err := p.Lookup(pluginObjectName)
+		h, err := p.Lookup(mev.PluginObjectName)
 		check(err, "looking up mev handler")
-		typedHandler, ok := h.(MEVHandler)
+		typedHandler, ok := h.(mev.MEVHandler)
 		if !ok {
 			panic("MEV handler does not implement MEVHandler interface")
 		}
@@ -1865,7 +1866,7 @@ func (app *App) RegisterTendermintService(clientCtx client.Context) {
 	tmservice.RegisterTendermintService(app.BaseApp.GRPCQueryRouter(), clientCtx, app.interfaceRegistry)
 
 	if app.evmRPCConfig.HTTPEnabled {
-		evmHTTPServer, err := evmrpc.NewEVMHTTPServer(app.Logger(), app.evmRPCConfig, clientCtx.Client, &app.EvmKeeper, app.BaseApp, app.AnteHandler, app.RPCContextProvider, app.encodingConfig.TxConfig, DefaultNodeHome, nil)
+		evmHTTPServer, err := evmrpc.NewEVMHTTPServer(app.Logger(), app.evmRPCConfig, clientCtx.Client, &app.EvmKeeper, app.BaseApp, app.AnteHandler, app.RPCContextProvider, app.encodingConfig.TxConfig, DefaultNodeHome, nil, app.mevHandler)
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -37,6 +37,7 @@ import (
 	"github.com/sei-protocol/sei-chain/app"
 	"github.com/sei-protocol/sei-chain/app/params"
 	"github.com/sei-protocol/sei-chain/evmrpc"
+	"github.com/sei-protocol/sei-chain/mev"
 	"github.com/sei-protocol/sei-chain/tools"
 	"github.com/sei-protocol/sei-chain/tools/migration/ss"
 	"github.com/sei-protocol/sei-chain/x/evm/blocktest"
@@ -429,7 +430,7 @@ func initAppConfig() (string, interface{}) {
 
 		LightInvariance app.LightInvarianceConfig `mapstructure:"light_invariance"`
 
-		MEV app.MEVConfig `mapstructure:"mev"`
+		MEV mev.MEVConfig `mapstructure:"mev"`
 	}
 
 	// Optionally allow the chain developer to overwrite the SDK's default
@@ -474,7 +475,7 @@ func initAppConfig() (string, interface{}) {
 		ETHBlockTest:    blocktest.DefaultConfig,
 		EvmQuery:        querier.DefaultConfig,
 		LightInvariance: app.DefaultLightInvarianceConfig,
-		MEV:             app.DefaultMEVConfig,
+		MEV:             mev.DefaultMEVConfig,
 	}
 
 	customAppTemplate := serverconfig.DefaultConfigTemplate + `

--- a/evmrpc/mev.go
+++ b/evmrpc/mev.go
@@ -1,0 +1,24 @@
+package evmrpc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/sei-protocol/sei-chain/mev"
+)
+
+type MevAPI struct {
+	handler mev.MEVHandler
+}
+
+func NewMevAPI(handler mev.MEVHandler) *MevAPI {
+	return &MevAPI{handler: handler}
+}
+
+func (i *MevAPI) Submission(ctx context.Context, req json.RawMessage) (res json.RawMessage, err error) {
+	if i.handler == nil {
+		return nil, errors.New("this node does not support MEV submission")
+	}
+	return i.handler.RPCSubmission(ctx, req)
+}

--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -9,6 +9,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/sei-protocol/sei-chain/mev"
 	evmCfg "github.com/sei-protocol/sei-chain/x/evm/config"
 	"github.com/sei-protocol/sei-chain/x/evm/keeper"
 	"github.com/tendermint/tendermint/libs/log"
@@ -38,6 +39,7 @@ func NewEVMHTTPServer(
 	txConfig client.TxConfig,
 	homeDir string,
 	isPanicOrSyntheticTxFunc func(ctx context.Context, hash common.Hash) (bool, error), // used in *ExcludeTraceFail endpoints
+	mevHandler mev.MEVHandler,
 ) (EVMServer, error) {
 	httpServer := NewHTTPServer(logger, rpc.HTTPTimeouts{
 		ReadTimeout:       config.ReadTimeout,
@@ -134,6 +136,10 @@ func NewEVMHTTPServer(
 		{
 			Namespace: "sei",
 			Service:   seiDebugAPI,
+		},
+		{
+			Namespace: "mev",
+			Service:   NewMevAPI(mevHandler),
 		},
 	}
 	// Test API can only exist on non-live chain IDs.  These APIs instrument certain overrides.

--- a/evmrpc/setup_test.go
+++ b/evmrpc/setup_test.go
@@ -553,7 +553,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	HttpServer, err := evmrpc.NewEVMHTTPServer(infoLog, goodConfig, &MockClient{}, EVMKeeper, testApp.BaseApp, testApp.AnteHandler, ctxProvider, TxConfig, "", isPanicTxFunc)
+	HttpServer, err := evmrpc.NewEVMHTTPServer(infoLog, goodConfig, &MockClient{}, EVMKeeper, testApp.BaseApp, testApp.AnteHandler, ctxProvider, TxConfig, "", isPanicTxFunc, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -565,7 +565,7 @@ func init() {
 	badConfig := evmrpc.DefaultConfig
 	badConfig.HTTPPort = TestBadPort
 	badConfig.FilterTimeout = 500 * time.Millisecond
-	badHTTPServer, err := evmrpc.NewEVMHTTPServer(infoLog, badConfig, &MockBadClient{}, EVMKeeper, testApp.BaseApp, testApp.AnteHandler, ctxProvider, TxConfig, "", nil)
+	badHTTPServer, err := evmrpc.NewEVMHTTPServer(infoLog, badConfig, &MockBadClient{}, EVMKeeper, testApp.BaseApp, testApp.AnteHandler, ctxProvider, TxConfig, "", nil, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/evmrpc/tests/utils.go
+++ b/evmrpc/tests/utils.go
@@ -97,6 +97,7 @@ func SetupTestServer(
 		func(ctx context.Context, hash common.Hash) (bool, error) {
 			return false, nil
 		},
+		nil,
 	)
 	if err != nil {
 		panic(err)

--- a/mev/mev.go
+++ b/mev/mev.go
@@ -1,16 +1,20 @@
-package app
+package mev
 
 import (
+	"context"
+	"encoding/json"
+
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cast"
 	abci "github.com/tendermint/tendermint/abci/types"
 )
 
-const pluginObjectName = "HandlerInstance"
+const PluginObjectName = "HandlerInstance"
 
 type MEVHandler interface {
 	Handle(ctx sdk.Context, req *abci.RequestPrepareProposal) (*abci.ResponsePrepareProposal, error)
+	RPCSubmission(ctx context.Context, req json.RawMessage) (res json.RawMessage, err error)
 }
 
 const (


### PR DESCRIPTION
## Describe your changes and provide context
This PR adds an additional functionality to the MEV plugin interface to allow custom logic for MEV submission via rpc. A new RPC endpoint `mev_submission` is added (which will return error if called on a node without any MEV plugins). An example implementation of the new interface method can be found in https://github.com/sei-protocol/mev-demo/blob/main/plugin.go#L28

## Testing performed to validate your change
localnet with mev-demo
<img width="897" alt="Screenshot 2025-03-25 at 11 04 43 PM" src="https://github.com/user-attachments/assets/b36c5b9c-d555-4f50-914a-1d59baee8606" />
<img width="1367" alt="Screenshot 2025-03-25 at 11 04 54 PM" src="https://github.com/user-attachments/assets/cc5b5a5b-bc05-4d45-bed2-94ff87191295" />


