### PR TITLE
overwrite block hash in tracer response with tendermint block hash

### DIFF
--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -282,6 +282,7 @@ func (b Backend) BlockByNumber(ctx context.Context, bn rpc.BlockNumber) (*ethtyp
 		Header_: header,
 		Txs:     txs,
 	}
+	block.OverwriteHash(common.BytesToHash(tmBlock.BlockID.Hash))
 	return block, nil
 }
 

--- a/evmrpc/tests/tracers_test.go
+++ b/evmrpc/tests/tracers_test.go
@@ -1,0 +1,21 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTraceBlockByNumber(t *testing.T) {
+	txBz := signAndEncodeTx(send(0), mnemonic1)
+	SetupTestServer([][][]byte{{txBz}}, mnemonicInitializer(mnemonic1)).Run(
+		func(port int) {
+			res := sendRequestWithNamespace("debug", port, "traceBlockByNumber", "0x2", map[string]interface{}{
+				"timeout": "60s", "tracer": "flatCallTracer",
+			})
+			blockHash := res["result"].([]interface{})[0].(map[string]interface{})["result"].([]interface{})[0].(map[string]interface{})["blockHash"]
+			// assert that the block hash has been overwritten instead of the RLP hash.
+			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000002", blockHash.(string))
+		},
+	)
+}

--- a/go.mod
+++ b/go.mod
@@ -354,7 +354,7 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.56-0.20250313190228-9fb9a4fd8636
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.2.0
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.5
-	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-27
+	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-28
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/sei-protocol/sei-db => github.com/sei-protocol/sei-db v0.0.48
 	// Latest goleveldb is broken, we have to stick to this version

--- a/go.sum
+++ b/go.sum
@@ -1344,8 +1344,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod
 github.com/securego/gosec/v2 v2.11.0 h1:+PDkpzR41OI2jrw1q6AdXZCbsNGNGT7pQjal0H0cArI=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-27 h1:TYZLAoKSfE2N/63sFTTWh3djH59L9BxtQRSm2Q/8bLY=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-27/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-28 h1:V+NAzqD74lL+j57u57oGv9g7gmr4VzbZStYnh5THXvI=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-28/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-cosmos v0.3.56-0.20250313190228-9fb9a4fd8636 h1:9RMstipSzuAgpwz8IcM+LvZB2frXSBolu8CRj660fI4=


### PR DESCRIPTION
## Describe your changes and provide context
related issue: https://github.com/sei-protocol/sei-chain/issues/2116
tracer endpoints were incorrectly using the RLP hash as the block hash in responses. This PR changes the logic so that the tendermint block hash is used to overwrite the block hash in responses.

## Testing performed to validate your change
unit test

