### PR TITLE
backfill from/to on receipts for failed txs

### DIFF
--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -60,11 +60,23 @@ func NewSeiTransactionAPI(
 }
 
 func (t *SeiTransactionAPI) GetTransactionReceiptExcludeTraceFail(ctx context.Context, hash common.Hash) (result map[string]interface{}, returnErr error) {
-	return getTransactionReceipt(ctx, t.TransactionAPI, hash, true, t.isPanicTx, true)
+	sdkCtx := t.ctxProvider(LatestCtxHeight)
+	signer := ethtypes.MakeSigner(
+		types.DefaultChainConfig().EthereumConfig(t.keeper.ChainID(sdkCtx)),
+		big.NewInt(sdkCtx.BlockHeight()),
+		uint64(sdkCtx.BlockTime().Unix()),
+	)
+	return getTransactionReceipt(ctx, t.TransactionAPI, hash, true, t.isPanicTx, true, signer)
 }
 
 func (t *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (result map[string]interface{}, returnErr error) {
-	return getTransactionReceipt(ctx, t, hash, false, nil, false)
+	sdkCtx := t.ctxProvider(LatestCtxHeight)
+	signer := ethtypes.MakeSigner(
+		types.DefaultChainConfig().EthereumConfig(t.keeper.ChainID(sdkCtx)),
+		big.NewInt(sdkCtx.BlockHeight()),
+		uint64(sdkCtx.BlockTime().Unix()),
+	)
+	return getTransactionReceipt(ctx, t, hash, false, nil, false, signer)
 }
 
 func getTransactionReceipt(
@@ -74,6 +86,7 @@ func getTransactionReceipt(
 	excludePanicTxs bool,
 	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error),
 	includeSynthetic bool,
+	signer ethtypes.Signer,
 ) (result map[string]interface{}, returnErr error) {
 	startTime := time.Now()
 	defer recordMetrics("eth_getTransactionReceipt", t.connectionType, startTime, returnErr == nil)
@@ -145,7 +158,7 @@ func getTransactionReceipt(
 	return encodeReceipt(receipt, t.txConfig.TxDecoder(), block, func(h common.Hash) bool {
 		_, err := t.keeper.GetReceipt(sdkctx, h)
 		return err == nil
-	}, includeSynthetic)
+	}, includeSynthetic, signer)
 }
 
 func (t *TransactionAPI) GetVMError(hash common.Hash) (result string, returnErr error) {
@@ -329,22 +342,23 @@ func getEthTxForTxBz(tx tmtypes.Tx, decoder sdk.TxDecoder) *ethtypes.Transaction
 
 // Gets the EVM tx index based on the tx index (typically from receipt.TransactionIndex
 // Essentially loops through and calculates the index if we ignore cosmos txs
-func GetEvmTxIndex(txs tmtypes.Txs, txIndex uint32, decoder sdk.TxDecoder, receiptChecker func(common.Hash) bool, includeSynthetic bool) (index int, found bool) {
+func GetEvmTxIndex(txs tmtypes.Txs, txIndex uint32, decoder sdk.TxDecoder, receiptChecker func(common.Hash) bool, includeSynthetic bool) (index int, found bool, etx *ethtypes.Transaction) {
 	var evmTxIndex int
 	for i, tx := range txs {
-		isEVMTx := getEthTxForTxBz(tx, decoder) != nil
+		etx = getEthTxForTxBz(tx, decoder)
+		isEVMTx := etx != nil
 		hasReceipt := receiptChecker(sha256.Sum256(tx))
 		if includeSynthetic {
 			if isEVMTx {
 				// must have receipt
 				if i == int(txIndex) {
-					return evmTxIndex, true
+					return evmTxIndex, true, etx
 				}
 				evmTxIndex++
 			} else {
 				if hasReceipt {
 					if i == int(txIndex) {
-						return evmTxIndex, true
+						return evmTxIndex, true, etx
 					}
 					evmTxIndex++
 				}
@@ -353,26 +367,26 @@ func GetEvmTxIndex(txs tmtypes.Txs, txIndex uint32, decoder sdk.TxDecoder, recei
 			if isEVMTx {
 				// must have receipt
 				if i == int(txIndex) {
-					return evmTxIndex, true
+					return evmTxIndex, true, etx
 				}
 				evmTxIndex++
 			} else {
 				// would still find the tx, but not count it towards index
 				if hasReceipt {
 					if i == int(txIndex) {
-						return evmTxIndex, true
+						return evmTxIndex, true, etx
 					}
 				}
 			}
 		}
 	}
-	return -1, false
+	return -1, false, nil
 }
 
-func encodeReceipt(receipt *types.Receipt, decoder sdk.TxDecoder, block *coretypes.ResultBlock, receiptChecker func(common.Hash) bool, includeSynthetic bool) (map[string]interface{}, error) {
+func encodeReceipt(receipt *types.Receipt, decoder sdk.TxDecoder, block *coretypes.ResultBlock, receiptChecker func(common.Hash) bool, includeSynthetic bool, signer ethtypes.Signer) (map[string]interface{}, error) {
 	blockHash := block.BlockID.Hash
 	bh := common.HexToHash(blockHash.String())
-	evmTxIndex, foundTx := GetEvmTxIndex(block.Block.Txs, receipt.TransactionIndex, decoder, receiptChecker, includeSynthetic)
+	evmTxIndex, foundTx, etx := GetEvmTxIndex(block.Block.Txs, receipt.TransactionIndex, decoder, receiptChecker, includeSynthetic)
 	// convert tx index including cosmos txs to tx index excluding cosmos txs
 	if !foundTx {
 		return nil, errors.New("failed to find transaction in block")
@@ -397,6 +411,16 @@ func encodeReceipt(receipt *types.Receipt, decoder sdk.TxDecoder, block *coretyp
 		"type":              hexutil.Uint(receipt.TxType),
 		"effectiveGasPrice": (*hexutil.Big)(big.NewInt(int64(receipt.EffectiveGasPrice))),
 		"status":            hexutil.Uint(receipt.Status),
+	}
+	if etx != nil && receipt.From == "" {
+		from, err := ethtypes.Sender(signer, etx)
+		if err != nil {
+			fields["from"] = from
+		}
+		to := etx.To()
+		if to != nil {
+			fields["to"] = *to
+		}
 	}
 	if receipt.ContractAddress != "" && receipt.To == "" {
 		fields["contractAddress"] = common.HexToAddress(receipt.ContractAddress)


### PR DESCRIPTION
## Describe your changes and provide context
if tx failed to process, it will have a receipt without from/to. This PR would backfill those addresses by parsing the original tx body upon request.

## Testing performed to validate your change
patched on node
