### PR TITLE
Harden oracle tx spam prevention

### DIFF
--- a/x/oracle/ante.go
+++ b/x/oracle/ante.go
@@ -2,7 +2,6 @@ package oracle
 
 import (
 	"encoding/hex"
-	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
@@ -82,7 +81,6 @@ func (spd SpammingPreventionDecorator) AnteDeps(txDeps []sdkacltypes.AccessOpera
 
 // CheckOracleSpamming check whether the msgs are spamming purpose or not
 func (spd SpammingPreventionDecorator) CheckOracleSpamming(ctx sdk.Context, msgs []sdk.Msg) error {
-	curHeight := ctx.BlockHeight()
 	for _, msg := range msgs {
 		switch msg := msg.(type) {
 		case *types.MsgAggregateExchangeRateVote:
@@ -101,11 +99,9 @@ func (spd SpammingPreventionDecorator) CheckOracleSpamming(ctx sdk.Context, msgs
 				return err
 			}
 
-			spamPreventionCounterHeight := spd.oracleKeeper.GetSpamPreventionCounter(ctx, valAddr)
-			if spamPreventionCounterHeight == curHeight {
-				return sdkerrors.Wrap(sdkerrors.ErrAlreadyExists, fmt.Sprintf("the validator has already submitted a vote at the current height=%d", curHeight))
+			if err := spd.oracleKeeper.CheckAndSetSpamPreventionCounter(ctx, valAddr); err != nil {
+				return err
 			}
-			spd.oracleKeeper.SetSpamPreventionCounter(ctx, valAddr)
 			continue
 		default:
 			return nil

--- a/x/oracle/keeper/keeper_test.go
+++ b/x/oracle/keeper/keeper_test.go
@@ -817,14 +817,11 @@ func TestCalculateTwapsWithUnsupportedDenom(t *testing.T) {
 func TestSpamPreventionCounter(t *testing.T) {
 	input := CreateTestInput(t)
 
-	// verify value == -1 when not set
-	require.Equal(t, int64(-1), input.OracleKeeper.GetSpamPreventionCounter(input.Ctx, sdk.ValAddress(Addrs[0])))
+	require.NoError(t, input.OracleKeeper.CheckAndSetSpamPreventionCounter(input.Ctx, sdk.ValAddress(Addrs[0])))
+	require.Error(t, input.OracleKeeper.CheckAndSetSpamPreventionCounter(input.Ctx, sdk.ValAddress(Addrs[0])))
 
 	input.Ctx = input.Ctx.WithBlockHeight(3)
 
-	input.OracleKeeper.SetSpamPreventionCounter(input.Ctx, sdk.ValAddress(Addrs[0]))
-	// verify counter value correct when set
-	require.Equal(t, int64(3), input.OracleKeeper.GetSpamPreventionCounter(input.Ctx, sdk.ValAddress(Addrs[0])))
-	// verify value == -1 for a different address
-	require.Equal(t, int64(-1), input.OracleKeeper.GetSpamPreventionCounter(input.Ctx, sdk.ValAddress(Addrs[1])))
+	require.NoError(t, input.OracleKeeper.CheckAndSetSpamPreventionCounter(input.Ctx, sdk.ValAddress(Addrs[0])))
+	require.NoError(t, input.OracleKeeper.CheckAndSetSpamPreventionCounter(input.Ctx, sdk.ValAddress(Addrs[1])))
 }


### PR DESCRIPTION
## Describe your changes and provide context
Multiple concurrent CheckTx calls can break through the previous oracle spam prevention implementation because getting and setting are not atomic. This PR makes the check-and-set operation atomic.

## Testing performed to validate your change
unit test

