### PR TITLE
optimize getLog endpoint memory usage

### DIFF
--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -552,6 +552,15 @@ max_blocks_for_log = {{ .EVM.MaxBlocksForLog }}
 # max number of concurrent NewHead subscriptions
 max_subscriptions_new_head = {{ .EVM.MaxSubscriptionsNewHead }}
 
+# max number of workers for log query handling
+max_num_of_log_workers = {{ .EVM.MaxNumOfLogWorkers }}
+
+# max number of queue size for log query jobs
+max_get_log_job_queue_size = {{ .EVM.MaxGetLogJobQueueSize }}
+
+# max number of log response channel size
+max_get_log_response_chan_size = {{ .EVM.MaxGetLogResponseChanSize }}
+
 [eth_replay]
 eth_replay_enabled = {{ .ETHReplay.Enabled }}
 eth_rpc = "{{ .ETHReplay.EthRPC }}"

--- a/evmrpc/config.go
+++ b/evmrpc/config.go
@@ -85,54 +85,69 @@ type Config struct {
 
 	// test api enables certain override apis for integration test situations
 	EnableTestAPI bool `mapstructure:"enable_test_api"`
+
+	// max number of workers for log query handling
+	MaxNumOfLogWorkers int `mapstructure:"max_num_of_log_workers"`
+
+	// max number of queue size for log query jobs
+	MaxGetLogJobQueueSize int `mapstructure:"max_get_log_job_queue_size"`
+
+	// max number of log response channel size
+	MaxGetLogResponseChanSize int `mapstructure:"max_get_log_response_chan_size"`
 }
 
 var DefaultConfig = Config{
-	HTTPEnabled:             true,
-	HTTPPort:                8545,
-	WSEnabled:               true,
-	WSPort:                  8546,
-	ReadTimeout:             rpc.DefaultHTTPTimeouts.ReadTimeout,
-	ReadHeaderTimeout:       rpc.DefaultHTTPTimeouts.ReadHeaderTimeout,
-	WriteTimeout:            rpc.DefaultHTTPTimeouts.WriteTimeout,
-	IdleTimeout:             rpc.DefaultHTTPTimeouts.IdleTimeout,
-	SimulationGasLimit:      10_000_000, // 10M
-	SimulationEVMTimeout:    60 * time.Second,
-	CORSOrigins:             "*",
-	WSOrigins:               "*",
-	FilterTimeout:           120 * time.Second,
-	CheckTxTimeout:          5 * time.Second,
-	MaxTxPoolTxs:            1000,
-	Slow:                    false,
-	DenyList:                make([]string, 0),
-	MaxLogNoBlock:           10000,
-	MaxBlocksForLog:         2000,
-	MaxSubscriptionsNewHead: 10000,
-	EnableTestAPI:           false,
+	HTTPEnabled:               true,
+	HTTPPort:                  8545,
+	WSEnabled:                 true,
+	WSPort:                    8546,
+	ReadTimeout:               rpc.DefaultHTTPTimeouts.ReadTimeout,
+	ReadHeaderTimeout:         rpc.DefaultHTTPTimeouts.ReadHeaderTimeout,
+	WriteTimeout:              rpc.DefaultHTTPTimeouts.WriteTimeout,
+	IdleTimeout:               rpc.DefaultHTTPTimeouts.IdleTimeout,
+	SimulationGasLimit:        10_000_000, // 10M
+	SimulationEVMTimeout:      60 * time.Second,
+	CORSOrigins:               "*",
+	WSOrigins:                 "*",
+	FilterTimeout:             120 * time.Second,
+	CheckTxTimeout:            5 * time.Second,
+	MaxTxPoolTxs:              1000,
+	Slow:                      false,
+	DenyList:                  make([]string, 0),
+	MaxLogNoBlock:             10000,
+	MaxBlocksForLog:           2000,
+	MaxSubscriptionsNewHead:   10000,
+	EnableTestAPI:             false,
+	MaxNumOfLogWorkers:        500,
+	MaxGetLogJobQueueSize:     1000,
+	MaxGetLogResponseChanSize: 1000,
 }
 
 const (
-	flagHTTPEnabled             = "evm.http_enabled"
-	flagHTTPPort                = "evm.http_port"
-	flagWSEnabled               = "evm.ws_enabled"
-	flagWSPort                  = "evm.ws_port"
-	flagReadTimeout             = "evm.read_timeout"
-	flagReadHeaderTimeout       = "evm.read_header_timeout"
-	flagWriteTimeout            = "evm.write_timeout"
-	flagIdleTimeout             = "evm.idle_timeout"
-	flagSimulationGasLimit      = "evm.simulation_gas_limit"
-	flagSimulationEVMTimeout    = "evm.simulation_evm_timeout"
-	flagCORSOrigins             = "evm.cors_origins"
-	flagWSOrigins               = "evm.ws_origins"
-	flagFilterTimeout           = "evm.filter_timeout"
-	flagMaxTxPoolTxs            = "evm.max_tx_pool_txs"
-	flagCheckTxTimeout          = "evm.checktx_timeout"
-	flagSlow                    = "evm.slow"
-	flagDenyList                = "evm.deny_list"
-	flagMaxLogNoBlock           = "evm.max_log_no_block"
-	flagMaxBlocksForLog         = "evm.max_blocks_for_log"
-	flagMaxSubscriptionsNewHead = "evm.max_subscriptions_new_head"
-	flagEnableTestAPI           = "evm.enable_test_api"
+	flagHTTPEnabled               = "evm.http_enabled"
+	flagHTTPPort                  = "evm.http_port"
+	flagWSEnabled                 = "evm.ws_enabled"
+	flagWSPort                    = "evm.ws_port"
+	flagReadTimeout               = "evm.read_timeout"
+	flagReadHeaderTimeout         = "evm.read_header_timeout"
+	flagWriteTimeout              = "evm.write_timeout"
+	flagIdleTimeout               = "evm.idle_timeout"
+	flagSimulationGasLimit        = "evm.simulation_gas_limit"
+	flagSimulationEVMTimeout      = "evm.simulation_evm_timeout"
+	flagCORSOrigins               = "evm.cors_origins"
+	flagWSOrigins                 = "evm.ws_origins"
+	flagFilterTimeout             = "evm.filter_timeout"
+	flagMaxTxPoolTxs              = "evm.max_tx_pool_txs"
+	flagCheckTxTimeout            = "evm.checktx_timeout"
+	flagSlow                      = "evm.slow"
+	flagDenyList                  = "evm.deny_list"
+	flagMaxLogNoBlock             = "evm.max_log_no_block"
+	flagMaxBlocksForLog           = "evm.max_blocks_for_log"
+	flagMaxSubscriptionsNewHead   = "evm.max_subscriptions_new_head"
+	flagEnableTestAPI             = "evm.enable_test_api"
+	flagMaxNumOfLogWorkers        = "evm.max_num_of_log_workers"
+	flagMaxGetLogJobQueueSize     = "evm.max_get_log_job_queue_size"
+	flagMaxGetLogResponseChanSize = "evm.max_get_log_response_chan_size"
 )
 
 func ReadConfig(opts servertypes.AppOptions) (Config, error) {
@@ -240,6 +255,21 @@ func ReadConfig(opts servertypes.AppOptions) (Config, error) {
 	}
 	if v := opts.Get(flagEnableTestAPI); v != nil {
 		if cfg.EnableTestAPI, err = cast.ToBoolE(v); err != nil {
+			return cfg, err
+		}
+	}
+	if v := opts.Get(flagMaxNumOfLogWorkers); v != nil {
+		if cfg.MaxNumOfLogWorkers, err = cast.ToIntE(v); err != nil {
+			return cfg, err
+		}
+	}
+	if v := opts.Get(flagMaxGetLogJobQueueSize); v != nil {
+		if cfg.MaxGetLogJobQueueSize, err = cast.ToIntE(v); err != nil {
+			return cfg, err
+		}
+	}
+	if v := opts.Get(flagMaxGetLogResponseChanSize); v != nil {
+		if cfg.MaxGetLogResponseChanSize, err = cast.ToIntE(v); err != nil {
 			return cfg, err
 		}
 	}

--- a/evmrpc/config_test.go
+++ b/evmrpc/config_test.go
@@ -9,27 +9,30 @@ import (
 )
 
 type opts struct {
-	httpEnabled             interface{}
-	httpPort                interface{}
-	wsEnabled               interface{}
-	wsPort                  interface{}
-	readTimeout             interface{}
-	readHeaderTimeout       interface{}
-	writeTimeout            interface{}
-	idleTimeout             interface{}
-	simulationGasLimit      interface{}
-	simulationEVMTimeout    interface{}
-	corsOrigins             interface{}
-	wsOrigins               interface{}
-	filterTimeout           interface{}
-	checkTxTimeout          interface{}
-	maxTxPoolTxs            interface{}
-	slow                    interface{}
-	denyList                interface{}
-	maxLogNoBlock           interface{}
-	maxBlocksForLog         interface{}
-	maxSubscriptionsNewHead interface{}
-	enableTestAPI           interface{}
+	httpEnabled               interface{}
+	httpPort                  interface{}
+	wsEnabled                 interface{}
+	wsPort                    interface{}
+	readTimeout               interface{}
+	readHeaderTimeout         interface{}
+	writeTimeout              interface{}
+	idleTimeout               interface{}
+	simulationGasLimit        interface{}
+	simulationEVMTimeout      interface{}
+	corsOrigins               interface{}
+	wsOrigins                 interface{}
+	filterTimeout             interface{}
+	checkTxTimeout            interface{}
+	maxTxPoolTxs              interface{}
+	slow                      interface{}
+	denyList                  interface{}
+	maxLogNoBlock             interface{}
+	maxBlocksForLog           interface{}
+	maxSubscriptionsNewHead   interface{}
+	enableTestAPI             interface{}
+	maxNumOfLogWorkers        interface{}
+	maxGetLogJobQueueSize     interface{}
+	maxGetLogResponseChanSize interface{}
 }
 
 func (o *opts) Get(k string) interface{} {
@@ -96,6 +99,15 @@ func (o *opts) Get(k string) interface{} {
 	if k == "evm.enable_test_api" {
 		return o.enableTestAPI
 	}
+	if k == "evm.max_num_of_log_workers" {
+		return o.maxNumOfLogWorkers
+	}
+	if k == "evm.max_get_log_job_queue_size" {
+		return o.maxGetLogJobQueueSize
+	}
+	if k == "evm.max_get_log_response_chan_size" {
+		return o.maxGetLogResponseChanSize
+	}
 	panic("unknown key")
 }
 
@@ -122,6 +134,9 @@ func TestReadConfig(t *testing.T) {
 		1000,
 		10000,
 		false,
+		500,
+		1000,
+		1000,
 	}
 	_, err := evmrpc.ReadConfig(&goodOpts)
 	require.Nil(t, err)

--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -109,11 +109,11 @@ func NewEVMHTTPServer(
 		},
 		{
 			Namespace: "eth",
-			Service:   NewFilterAPI(tmClient, k, ctxProvider, txConfig, &FilterConfig{timeout: config.FilterTimeout, maxLog: config.MaxLogNoBlock, maxBlock: config.MaxBlocksForLog}, ConnectionTypeHTTP, "eth"),
+			Service:   NewFilterAPI(tmClient, k, ctxProvider, txConfig, &FilterConfig{timeout: config.FilterTimeout, maxLog: config.MaxLogNoBlock, maxBlock: config.MaxBlocksForLog, maxNumOfLogWorkers: config.MaxGetLogJobQueueSize, maxGetLogJobQueueSize: config.MaxGetLogJobQueueSize, maxGetLogResponseChanSize: config.MaxGetLogResponseChanSize}, ConnectionTypeHTTP, "eth"),
 		},
 		{
 			Namespace: "sei",
-			Service:   NewFilterAPI(tmClient, k, ctxProvider, txConfig, &FilterConfig{timeout: config.FilterTimeout, maxLog: config.MaxLogNoBlock, maxBlock: config.MaxBlocksForLog}, ConnectionTypeHTTP, "sei"),
+			Service:   NewFilterAPI(tmClient, k, ctxProvider, txConfig, &FilterConfig{timeout: config.FilterTimeout, maxLog: config.MaxLogNoBlock, maxBlock: config.MaxBlocksForLog, maxNumOfLogWorkers: config.MaxGetLogJobQueueSize, maxGetLogJobQueueSize: config.MaxGetLogJobQueueSize, maxGetLogResponseChanSize: config.MaxGetLogResponseChanSize}, ConnectionTypeHTTP, "sei"),
 		},
 		{
 			Namespace: "sei",
@@ -212,7 +212,7 @@ func NewEVMWebSocketServer(
 		},
 		{
 			Namespace: "eth",
-			Service:   NewSubscriptionAPI(tmClient, k, ctxProvider, &LogFetcher{tmClient: tmClient, k: k, ctxProvider: ctxProvider, txConfig: txConfig}, &SubscriptionConfig{subscriptionCapacity: 100, newHeadLimit: config.MaxSubscriptionsNewHead}, &FilterConfig{timeout: config.FilterTimeout, maxLog: config.MaxLogNoBlock, maxBlock: config.MaxBlocksForLog}, ConnectionTypeWS),
+			Service:   NewSubscriptionAPI(tmClient, k, ctxProvider, &LogFetcher{tmClient: tmClient, k: k, ctxProvider: ctxProvider, txConfig: txConfig}, &SubscriptionConfig{subscriptionCapacity: 100, newHeadLimit: config.MaxSubscriptionsNewHead}, &FilterConfig{timeout: config.FilterTimeout, maxLog: config.MaxLogNoBlock, maxBlock: config.MaxBlocksForLog, maxNumOfLogWorkers: config.MaxGetLogJobQueueSize, maxGetLogJobQueueSize: config.MaxGetLogJobQueueSize, maxGetLogResponseChanSize: config.MaxGetLogResponseChanSize}, ConnectionTypeWS),
 		},
 		{
 			Namespace: "web3",


### PR DESCRIPTION
## Describe your changes and provide context
Previously we hardcode the number of goroutines and buffer sizes to a large number for every getLog request, even if the request is just for 1 block. This PR changes the provision to be based on number of blocks, up to a configurable limit.

## Testing performed to validate your change
unit test

