### PR TITLE
flush cached contexts after tracing each transaction

### DIFF
--- a/evmrpc/send.go
+++ b/evmrpc/send.go
@@ -47,7 +47,7 @@ func NewSendAPI(tmClient rpcclient.Client, txConfig client.TxConfig, sendConfig 
 		keeper:         k,
 		ctxProvider:    ctxProvider,
 		homeDir:        homeDir,
-		backend:        NewBackend(ctxProvider, k, txConfig.TxDecoder(), tmClient, simulateConfig, app, antehandler),
+		backend:        NewBackend(ctxProvider, k, txConfig, tmClient, simulateConfig, app, antehandler),
 		connectionType: connectionType,
 	}
 }

--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -53,14 +53,14 @@ func NewEVMHTTPServer(
 	ctx := ctxProvider(LatestCtxHeight)
 
 	txAPI := NewTransactionAPI(tmClient, k, ctxProvider, txConfig, homeDir, ConnectionTypeHTTP)
-	debugAPI := NewDebugAPI(tmClient, k, ctxProvider, txConfig.TxDecoder(), simulateConfig, app, antehandler, ConnectionTypeHTTP)
+	debugAPI := NewDebugAPI(tmClient, k, ctxProvider, txConfig, simulateConfig, app, antehandler, ConnectionTypeHTTP)
 	if isPanicOrSyntheticTxFunc == nil {
 		isPanicOrSyntheticTxFunc = func(ctx context.Context, hash common.Hash) (bool, error) {
 			return debugAPI.isPanicOrSyntheticTx(ctx, hash)
 		}
 	}
 	seiTxAPI := NewSeiTransactionAPI(tmClient, k, ctxProvider, txConfig, homeDir, ConnectionTypeHTTP, isPanicOrSyntheticTxFunc)
-	seiDebugAPI := NewSeiDebugAPI(tmClient, k, ctxProvider, txConfig.TxDecoder(), simulateConfig, app, antehandler, ConnectionTypeHTTP)
+	seiDebugAPI := NewSeiDebugAPI(tmClient, k, ctxProvider, txConfig, simulateConfig, app, antehandler, ConnectionTypeHTTP)
 
 	apis := []rpc.API{
 		{
@@ -101,7 +101,7 @@ func NewEVMHTTPServer(
 		},
 		{
 			Namespace: "eth",
-			Service:   NewSimulationAPI(ctxProvider, k, txConfig.TxDecoder(), tmClient, simulateConfig, app, antehandler, ConnectionTypeHTTP),
+			Service:   NewSimulationAPI(ctxProvider, k, txConfig, tmClient, simulateConfig, app, antehandler, ConnectionTypeHTTP),
 		},
 		{
 			Namespace: "net",
@@ -204,7 +204,7 @@ func NewEVMWebSocketServer(
 		},
 		{
 			Namespace: "eth",
-			Service:   NewSimulationAPI(ctxProvider, k, txConfig.TxDecoder(), tmClient, simulateConfig, app, antehandler, ConnectionTypeWS),
+			Service:   NewSimulationAPI(ctxProvider, k, txConfig, tmClient, simulateConfig, app, antehandler, ConnectionTypeWS),
 		},
 		{
 			Namespace: "net",

--- a/evmrpc/tracers.go
+++ b/evmrpc/tracers.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/eth/tracers"
@@ -37,9 +38,9 @@ type SeiDebugAPI struct {
 	*DebugAPI
 }
 
-func NewDebugAPI(tmClient rpcclient.Client, k *keeper.Keeper, ctxProvider func(int64) sdk.Context, txDecoder sdk.TxDecoder, config *SimulateConfig, app *baseapp.BaseApp,
+func NewDebugAPI(tmClient rpcclient.Client, k *keeper.Keeper, ctxProvider func(int64) sdk.Context, txConfig client.TxConfig, config *SimulateConfig, app *baseapp.BaseApp,
 	antehandler sdk.AnteHandler, connectionType ConnectionType) *DebugAPI {
-	backend := NewBackend(ctxProvider, k, txDecoder, tmClient, config, app, antehandler)
+	backend := NewBackend(ctxProvider, k, txConfig, tmClient, config, app, antehandler)
 	tracersAPI := tracers.NewAPI(backend)
 	evictCallback := func(key common.Hash, value bool) {}
 	isPanicCache := expirable.NewLRU[common.Hash, bool](IsPanicCacheSize, evictCallback, IsPanicCacheTTL)
@@ -48,7 +49,7 @@ func NewDebugAPI(tmClient rpcclient.Client, k *keeper.Keeper, ctxProvider func(i
 		tmClient:       tmClient,
 		keeper:         k,
 		ctxProvider:    ctxProvider,
-		txDecoder:      txDecoder,
+		txDecoder:      txConfig.TxDecoder(),
 		connectionType: connectionType,
 		isPanicCache:   isPanicCache,
 	}
@@ -58,16 +59,16 @@ func NewSeiDebugAPI(
 	tmClient rpcclient.Client,
 	k *keeper.Keeper,
 	ctxProvider func(int64) sdk.Context,
-	txDecoder sdk.TxDecoder,
+	txConfig client.TxConfig,
 	config *SimulateConfig,
 	app *baseapp.BaseApp,
 	antehandler sdk.AnteHandler,
 	connectionType ConnectionType,
 ) *SeiDebugAPI {
-	backend := NewBackend(ctxProvider, k, txDecoder, tmClient, config, app, antehandler)
+	backend := NewBackend(ctxProvider, k, txConfig, tmClient, config, app, antehandler)
 	tracersAPI := tracers.NewAPI(backend)
 	return &SeiDebugAPI{
-		DebugAPI: &DebugAPI{tracersAPI: tracersAPI, tmClient: tmClient, keeper: k, ctxProvider: ctxProvider, txDecoder: txDecoder, connectionType: connectionType},
+		DebugAPI: &DebugAPI{tracersAPI: tracersAPI, tmClient: tmClient, keeper: k, ctxProvider: ctxProvider, txDecoder: txConfig.TxDecoder(), connectionType: connectionType},
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -360,7 +360,7 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.57
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.2.0
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.6
-	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-32
+	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-34
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/sei-protocol/sei-db => github.com/sei-protocol/sei-db v0.0.48
 	// Latest goleveldb is broken, we have to stick to this version

--- a/go.sum
+++ b/go.sum
@@ -1354,8 +1354,8 @@ github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+f
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sei-protocol/coinbase-kryptology v0.0.0-20241210171554-278d19024e41 h1:J68EXEY5o6eKFx0/8tD4hvZT3PJN6tabomwaBfx/sXg=
 github.com/sei-protocol/coinbase-kryptology v0.0.0-20241210171554-278d19024e41/go.mod h1:vAKKp7/qgfMtPXMseamOlZMqK7BytjfOm0rFKWph5c4=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-32 h1:FmbTqDZwBI+dU9OTHdODAVBbA/SYHiaiImvMMm++J1Y=
-github.com/sei-protocol/go-ethereum v1.13.5-sei-32/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-34 h1:7g8EwfEK/XwOEuYXQJZNY0iZ+lCimSAvQ/efWpPVEJc=
+github.com/sei-protocol/go-ethereum v1.13.5-sei-34/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-cosmos v0.3.57 h1:1VbBZ6I6YTHUUmonW6YgSvPyCyfFLv+5St9MBrqfk4E=


### PR DESCRIPTION
## Describe your changes and provide context
An EVM transaction may take "snapshots" during its execution, which is implemented as branching out another layer of cachekv under sei's store structure. During normal chain execution, these branched cachekvs will be flushed to the base cachekv/context at the end of a transaction. However during `traceBlock` calls, such flushing doesn't happen, and subsequent transaction's "base" context is its predecessor's multilayer cached context. Although this would not cause correctness issue, it may make certain store operations (e.g. iterator) slow. This PR makes sure any outstanding contexts are flushed to the base context before tracer starts on each transaction.

## Testing performed to validate your change
unit test wip
