### PR TITLE
Fix getLog&getReceipt txIndex mismatch

### DIFF
--- a/evmrpc/filter.go
+++ b/evmrpc/filter.go
@@ -340,6 +340,7 @@ func (f *LogFetcher) GetLogsForBlock(block *coretypes.ResultBlock, crit filters.
 func (f *LogFetcher) FindLogsByBloom(block *coretypes.ResultBlock, filters [][]bloomIndexes) (res []*ethtypes.Log) {
 	ctx := f.ctxProvider(LatestCtxHeight)
 	totalLogs := uint(0)
+	txCount := 0
 	for _, hash := range getTxHashesFromBlock(block, f.txConfig, f.includeSyntheticReceipts) {
 		receipt, err := f.k.GetReceipt(ctx, hash)
 		if err != nil {
@@ -352,10 +353,15 @@ func (f *LogFetcher) FindLogsByBloom(block *coretypes.ResultBlock, filters [][]b
 		if !f.includeSyntheticReceipts && (receipt.TxType == ShellEVMTxType || receipt.EffectiveGasPrice == 0) {
 			continue
 		}
+		logs := keeper.GetLogsForTx(receipt, totalLogs)
+		for _, log := range logs {
+			log.TxIndex = uint(txCount)
+		}
 		if len(receipt.LogsBloom) > 0 && MatchFilters(ethtypes.Bloom(receipt.LogsBloom), filters) {
-			res = append(res, keeper.GetLogsForTx(receipt, totalLogs)...)
+			res = append(res, logs...)
 		}
 		totalLogs += uint(len(receipt.Logs))
+		txCount++
 	}
 	return
 }

--- a/evmrpc/tests/log_test.go
+++ b/evmrpc/tests/log_test.go
@@ -32,3 +32,21 @@ func TestGetLogsRangeTooWide(t *testing.T) {
 		},
 	)
 }
+
+func TestGetLogIndex(t *testing.T) {
+	cw20 := "sei18cszlvm6pze0x9sz32qnjq4vtd45xehqs8dq7cwy8yhq35wfnn3quh5sau" // hardcoded
+	tx0 := signAndEncodeCosmosTx(transferCW20Msg(mnemonic1, cw20), mnemonic1, 7, 0)
+	tx1Bz := signAndEncodeTx(depositErc20(1), erc20DeployerMnemonics)
+	tx2Bz := signAndEncodeTx(sendErc20(2), erc20DeployerMnemonics)
+	SetupTestServer([][][]byte{{tx0, tx1Bz, tx2Bz}}, mnemonicInitializer(mnemonic1), cw20Initializer(mnemonic1), erc20Initializer()).Run(
+		func(port int) {
+			res := sendRequestWithNamespace("eth", port, "getLogs", map[string]interface{}{
+				"toBlock": "latest",
+				"address": erc20Addr.Hex(),
+			})
+			require.Len(t, res["result"], 2)
+			require.Equal(t, "0x0", res["result"].([]interface{})[0].(map[string]interface{})["transactionIndex"])
+			require.Equal(t, "0x1", res["result"].([]interface{})[1].(map[string]interface{})["transactionIndex"])
+		},
+	)
+}


### PR DESCRIPTION
## Describe your changes and provide context
overwrite txIndex on logs in getLogs response based on the number of txs that are relevant

## Testing performed to validate your change
unit test
