### PR TITLE
Recover panics from unmanaged goroutines

### DIFF
--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -239,6 +239,7 @@ func (a *BlockAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.Block
 		wg.Add(1)
 		go func(i int, hash common.Hash) {
 			defer wg.Done()
+			defer recoverAndLog()
 			receipt, err := a.keeper.GetReceipt(a.ctxProvider(height), hash)
 			if err != nil {
 				// When the transaction doesn't exist, skip it

--- a/evmrpc/filter.go
+++ b/evmrpc/filter.go
@@ -88,6 +88,7 @@ func NewFilterAPI(tmClient rpcclient.Client, k *keeper.Keeper, ctxProvider func(
 func (a *FilterAPI) timeoutLoop(timeout time.Duration) {
 	ticker := time.NewTicker(timeout)
 	defer ticker.Stop()
+	defer recoverAndLog()
 	for {
 		<-ticker.C
 		a.filtersMu.Lock()
@@ -306,6 +307,7 @@ func (f *LogFetcher) GetLogsByFilters(ctx context.Context, crit filters.FilterCr
 	}
 	close(runner.Queue)
 	go func() {
+		defer recoverAndLog()
 		runner.Done.Wait()
 		close(resultsChan)
 	}()
@@ -444,6 +446,7 @@ func (f *LogFetcher) fetchBlocksByCrit(ctx context.Context, crit filters.FilterC
 	}
 	close(runner.Queue)
 	go func() {
+		defer recoverAndLog()
 		wg.Wait()
 		close(res)
 		close(errChan)

--- a/evmrpc/subscribe.go
+++ b/evmrpc/subscribe.go
@@ -56,6 +56,7 @@ func NewSubscriptionAPI(tmClient rpcclient.Client, k *keeper.Keeper, ctxProvider
 		panic(err)
 	}
 	go func() {
+		defer recoverAndLog()
 		defer func() {
 			_ = api.subscriptionManager.Unsubscribe(context.Background(), id)
 		}()
@@ -116,6 +117,7 @@ func (a *SubscriptionAPI) NewHeads(ctx context.Context) (s *rpc.Subscription, er
 	a.newHeadListeners[rpcSub.ID] = listener
 
 	go func() {
+		defer recoverAndLog()
 	OUTER:
 		for {
 			select {
@@ -170,6 +172,7 @@ func (a *SubscriptionAPI) Logs(ctx context.Context, filter *filters.FilterCriter
 
 	if filter.BlockHash != nil {
 		go func() {
+			defer recoverAndLog()
 			logs, _, err := a.logFetcher.GetLogsByFilters(ctx, *filter, 0)
 			if err != nil {
 				_ = notifier.Notify(rpcSub.ID, err)
@@ -185,6 +188,7 @@ func (a *SubscriptionAPI) Logs(ctx context.Context, filter *filters.FilterCriter
 	}
 
 	go func() {
+		defer recoverAndLog()
 		begin := int64(0)
 		for {
 			logs, lastToHeight, err := a.logFetcher.GetLogsByFilters(ctx, *filter, begin)

--- a/evmrpc/utils.go
+++ b/evmrpc/utils.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -251,10 +252,18 @@ func NewParallelRunner(cnt int, capacity int) *ParallelRunner {
 	for i := 0; i < cnt; i++ {
 		go func() {
 			defer pr.Done.Done()
+			defer recoverAndLog()
 			for f := range pr.Queue {
 				f()
 			}
 		}()
 	}
 	return pr
+}
+
+func recoverAndLog() {
+	if e := recover(); e != nil {
+		fmt.Printf("Panic recovered: %s\n", e)
+		debug.PrintStack()
+	}
 }

--- a/evmrpc/utils_test.go
+++ b/evmrpc/utils_test.go
@@ -18,3 +18,12 @@ func TestCheckVersion(t *testing.T) {
 	ctx = ctx.WithBlockHeight(2)
 	require.NotNil(t, evmrpc.CheckVersion(ctx, k))
 }
+
+func TestParallelRunnerPanicRecovery(t *testing.T) {
+	r := evmrpc.NewParallelRunner(10, 10)
+	r.Queue <- func() {
+		panic("should be handled")
+	}
+	close(r.Queue)
+	require.NotPanics(t, r.Done.Wait)
+}


### PR DESCRIPTION
## Describe your changes and provide context
Panics from unmanaged goroutines could crash the entire process. This PR recovers such panics. The panics are also logged from further investigation because in general there shouldn't be any.

## Testing performed to validate your change
unit test
