### PR TITLE
add debug_traceStateAccess endpoint

### DIFF
--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -37,6 +37,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 	"github.com/tendermint/tendermint/rpc/coretypes"
+	tmtypes "github.com/tendermint/tendermint/types"
 )
 
 type CtxIsWasmdPrecompileCallKeyType string
@@ -364,19 +365,57 @@ func (b *Backend) HeaderByNumber(ctx context.Context, bn rpc.BlockNumber) (*etht
 
 func (b *Backend) StateAtTransaction(ctx context.Context, block *ethtypes.Block, txIndex int, reexec uint64) (*ethtypes.Transaction, vm.BlockContext, vm.StateDB, tracers.StateReleaseFunc, error) {
 	emptyRelease := func() {}
+	stateDB, txs, err := b.ReplayTransactionTillIndex(ctx, block, txIndex-1)
+	if err != nil {
+		return nil, vm.BlockContext{}, nil, emptyRelease, err
+	}
+	blockContext, err := b.keeper.GetVMBlockContext(stateDB.(*state.DBImpl).Ctx(), core.GasPool(b.RPCGasCap()))
+	if err != nil {
+		return nil, vm.BlockContext{}, nil, emptyRelease, err
+	}
+	if txIndex > len(txs)-1 {
+		return nil, vm.BlockContext{}, nil, emptyRelease, errors.New("transaction not found")
+	}
+	tx := txs[txIndex]
+	sdkTx, err := b.txConfig.TxDecoder()(tx)
+	if err != nil {
+		panic(err)
+	}
+	if utils.IsTxPrioritized(sdkTx) {
+		return nil, vm.BlockContext{}, nil, emptyRelease, errors.New("cannot trace oracle tx")
+	}
+	var evmMsg *types.MsgEVMTransaction
+	if msgs := sdkTx.GetMsgs(); len(msgs) != 1 {
+		return nil, vm.BlockContext{}, nil, emptyRelease, fmt.Errorf("cannot replay non-EVM transaction %d at block %d", txIndex, block.Number().Int64())
+	} else if msg, ok := msgs[0].(*types.MsgEVMTransaction); !ok {
+		return nil, vm.BlockContext{}, nil, emptyRelease, fmt.Errorf("cannot replay non-EVM transaction %d at block %d", txIndex, block.Number().Int64())
+	} else {
+		evmMsg = msg
+	}
+	ethTx, _ := evmMsg.AsTransaction()
+	return ethTx, *blockContext, stateDB, emptyRelease, nil
+}
+
+func (b *Backend) ReplayTransactionTillIndex(ctx context.Context, block *ethtypes.Block, txIndex int) (vm.StateDB, tmtypes.Txs, error) {
 	// Short circuit if it's genesis block.
 	if block.Number().Int64() == 0 {
-		return nil, vm.BlockContext{}, nil, emptyRelease, errors.New("no transaction in genesis")
+		return nil, nil, errors.New("no transaction in genesis")
 	}
 	sdkCtx, tmBlock, err := b.initializeBlock(ctx, block)
 	if err != nil {
-		return nil, vm.BlockContext{}, nil, emptyRelease, err
+		return nil, nil, err
 	}
-	blockContext, err := b.keeper.GetVMBlockContext(sdkCtx, core.GasPool(b.RPCGasCap()))
-	if err != nil {
-		return nil, vm.BlockContext{}, nil, emptyRelease, err
+	if txIndex > len(tmBlock.Block.Txs)-1 {
+		return nil, nil, errors.New("did not find transaction")
 	}
+	if txIndex < 0 {
+		return state.NewDBImpl(sdkCtx.WithIsEVM(true), b.keeper, true), tmBlock.Block.Txs, nil
+	}
+	sdkCtx.StoreTracer().Clear()
 	for idx, tx := range tmBlock.Block.Txs {
+		if idx > txIndex {
+			break
+		}
 		sdkTx, err := b.txConfig.TxDecoder()(tx)
 		if err != nil {
 			panic(err)
@@ -384,21 +423,10 @@ func (b *Backend) StateAtTransaction(ctx context.Context, block *ethtypes.Block,
 		if utils.IsTxPrioritized(sdkTx) {
 			continue
 		}
-		if idx == txIndex {
-			var evmMsg *types.MsgEVMTransaction
-			if msgs := sdkTx.GetMsgs(); len(msgs) != 1 {
-				return nil, vm.BlockContext{}, nil, emptyRelease, fmt.Errorf("cannot replay non-EVM transaction %d at block %d", idx, block.Number().Int64())
-			} else if msg, ok := msgs[0].(*types.MsgEVMTransaction); !ok {
-				return nil, vm.BlockContext{}, nil, emptyRelease, fmt.Errorf("cannot replay non-EVM transaction %d at block %d", idx, block.Number().Int64())
-			} else {
-				evmMsg = msg
-			}
-			ethTx, _ := evmMsg.AsTransaction()
-			return ethTx, *blockContext, state.NewDBImpl(sdkCtx.WithIsEVM(true), b.keeper, true), emptyRelease, nil
-		}
-		_ = b.app.DeliverTx(sdkCtx, abci.RequestDeliverTx{}, sdkTx, sha256.Sum256(tx))
+		sdkCtx.StoreTracer().Clear()
+		_ = b.app.DeliverTx(sdkCtx, abci.RequestDeliverTx{Tx: tx}, sdkTx, sha256.Sum256(tx))
 	}
-	return nil, vm.BlockContext{}, nil, nil, fmt.Errorf("transaction index %d out of range for block %#x", txIndex, block.Hash())
+	return state.NewDBImpl(sdkCtx.WithIsEVM(true), b.keeper, true), tmBlock.Block.Txs, nil
 }
 
 func (b *Backend) StateAtBlock(ctx context.Context, block *ethtypes.Block, reexec uint64, base vm.StateDB, readOnly bool, preferDisk bool) (vm.StateDB, tracers.StateReleaseFunc, error) {
@@ -505,7 +533,9 @@ func (b *Backend) GetCustomPrecompiles(h int64) map[common.Address]vm.Precompile
 func (b *Backend) PrepareTx(statedb vm.StateDB, tx *ethtypes.Transaction) error {
 	typedStateDB := statedb.(*state.DBImpl)
 	typedStateDB.CleanupForTracer()
-	ctx, _ := b.keeper.PrepareCtxForEVMTransaction(typedStateDB.Ctx(), tx)
+	ctx := typedStateDB.Ctx()
+	ctx.StoreTracer().Clear()
+	ctx, _ = b.keeper.PrepareCtxForEVMTransaction(typedStateDB.Ctx(), tx)
 	ctx = ctx.WithIsEVM(true)
 	if noSignatureSet(tx) {
 		// skip ante if no signature is set

--- a/evmrpc/tests/tracers_test.go
+++ b/evmrpc/tests/tracers_test.go
@@ -3,8 +3,11 @@ package tests
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/sei-protocol/sei-chain/app"
 	"testing"
+
+	"github.com/sei-protocol/sei-chain/app"
+	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/x/evm/types"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -21,7 +24,7 @@ func TestTraceBlockByNumber(t *testing.T) {
 			})
 			blockHash := res["result"].([]interface{})[0].(map[string]interface{})["result"].([]interface{})[0].(map[string]interface{})["blockHash"]
 			// assert that the block hash has been overwritten instead of the RLP hash.
-			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000002", blockHash.(string))
+			require.Equal(t, "0x6f2168eb453152b1f68874fe32cea6fcb199bfd63836acb72a8eb33e666613fe", blockHash.(string))
 		},
 	)
 }
@@ -39,7 +42,7 @@ func TestTraceBlockByNumberExcludeTraceFail(t *testing.T) {
 			require.Len(t, txs, 1)
 			blockHash := txs[0].(map[string]interface{})["result"].([]interface{})[0].(map[string]interface{})["blockHash"]
 			// assert that the block hash has been overwritten instead of the RLP hash.
-			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000002", blockHash.(string))
+			require.Equal(t, "0x6f2168eb453152b1f68874fe32cea6fcb199bfd63836acb72a8eb33e666613fe", blockHash.(string))
 		},
 	)
 }
@@ -48,12 +51,12 @@ func TestTraceBlockByHash(t *testing.T) {
 	txBz := signAndEncodeTx(send(0), mnemonic1)
 	SetupTestServer([][][]byte{{txBz}}, mnemonicInitializer(mnemonic1)).Run(
 		func(port int) {
-			res := sendRequestWithNamespace("debug", port, "traceBlockByHash", "0x0000000000000000000000000000000000000000000000000000000000000002", map[string]interface{}{
+			res := sendRequestWithNamespace("debug", port, "traceBlockByHash", "0x6f2168eb453152b1f68874fe32cea6fcb199bfd63836acb72a8eb33e666613fe", map[string]interface{}{
 				"timeout": "60s", "tracer": "flatCallTracer",
 			})
 			blockHash := res["result"].([]interface{})[0].(map[string]interface{})["result"].([]interface{})[0].(map[string]interface{})["blockHash"]
 			// assert that the block hash has been overwritten instead of the RLP hash.
-			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000002", blockHash.(string))
+			require.Equal(t, "0x6f2168eb453152b1f68874fe32cea6fcb199bfd63836acb72a8eb33e666613fe", blockHash.(string))
 		},
 	)
 }
@@ -63,7 +66,7 @@ func TestTraceBlockByHashExcludeTraceFail(t *testing.T) {
 	panicTxBz := signAndEncodeTx(send(100), mnemonic1)
 	SetupTestServer([][][]byte{{txBz, panicTxBz}}, mnemonicInitializer(mnemonic1)).Run(
 		func(port int) {
-			res := sendRequestWithNamespace("sei", port, "traceBlockByHashExcludeTraceFail", "0x0000000000000000000000000000000000000000000000000000000000000002", map[string]interface{}{
+			res := sendRequestWithNamespace("sei", port, "traceBlockByHashExcludeTraceFail", "0x6f2168eb453152b1f68874fe32cea6fcb199bfd63836acb72a8eb33e666613fe", map[string]interface{}{
 				"timeout": "60s", "tracer": "flatCallTracer",
 			})
 			fmt.Println(res)
@@ -71,7 +74,7 @@ func TestTraceBlockByHashExcludeTraceFail(t *testing.T) {
 			require.Len(t, txs, 1)
 			blockHash := txs[0].(map[string]interface{})["result"].([]interface{})[0].(map[string]interface{})["blockHash"]
 			// assert that the block hash has been overwritten instead of the RLP hash.
-			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000002", blockHash.(string))
+			require.Equal(t, "0x6f2168eb453152b1f68874fe32cea6fcb199bfd63836acb72a8eb33e666613fe", blockHash.(string))
 		},
 	)
 }
@@ -117,12 +120,29 @@ func TestTraceMultipleTransactionsShouldNotHang(t *testing.T) {
 	txBzList = append(txBzList, signAndEncodeTx(callWasmIter(0, cwIter), mnemonic1))
 	SetupTestServer([][][]byte{txBzList}, mnemonicInitializer(mnemonic1), multiCoinInitializer(mnemonic1), cwIterInitializer(mnemonic1), erc20Initializer()).Run(
 		func(port int) {
-			res := sendRequestWithNamespace("debug", port, "traceBlockByHash", "0x0000000000000000000000000000000000000000000000000000000000000002", map[string]interface{}{
+			res := sendRequestWithNamespace("debug", port, "traceBlockByHash", "0x6f2168eb453152b1f68874fe32cea6fcb199bfd63836acb72a8eb33e666613fe", map[string]interface{}{
 				"timeout": "60s", "tracer": "flatCallTracer",
 			})
 			blockHash := res["result"].([]interface{})[0].(map[string]interface{})["result"].([]interface{})[0].(map[string]interface{})["blockHash"]
 			// assert that the block hash has been overwritten instead of the RLP hash.
-			require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000002", blockHash.(string))
+			require.Equal(t, "0x6f2168eb453152b1f68874fe32cea6fcb199bfd63836acb72a8eb33e666613fe", blockHash.(string))
+		},
+	)
+}
+
+func TestTraceStateAccess(t *testing.T) {
+	txBz := signAndEncodeTx(send(0), mnemonic1)
+	sdkTx, _ := testkeeper.EVMTestApp.GetTxConfig().TxDecoder()(txBz)
+	evmTx, _ := sdkTx.GetMsgs()[0].(*types.MsgEVMTransaction).AsTransaction()
+	hash := evmTx.Hash()
+	SetupTestServer([][][]byte{{txBz}}, mnemonicInitializer(mnemonic1)).Run(
+		func(port int) {
+			res := sendRequestWithNamespace("debug", port, "traceStateAccess", hash.Hex())
+			result := res["result"].(map[string]interface{})["modules"].(map[string]interface{})
+			require.Contains(t, result, "acc")
+			require.Contains(t, result, "bank")
+			require.Contains(t, result, "evm")
+			require.Contains(t, result, "params")
 		},
 	)
 }

--- a/evmrpc/tracers.go
+++ b/evmrpc/tracers.go
@@ -2,7 +2,10 @@ package evmrpc
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"runtime/debug"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
@@ -16,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/sei-protocol/sei-chain/x/evm/keeper"
+	"github.com/sei-protocol/sei-chain/x/evm/state"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 )
 
@@ -32,6 +36,7 @@ type DebugAPI struct {
 	txDecoder      sdk.TxDecoder
 	connectionType ConnectionType
 	isPanicCache   *expirable.LRU[common.Hash, bool] // hash to isPanic
+	backend        *Backend
 }
 
 type SeiDebugAPI struct {
@@ -52,6 +57,7 @@ func NewDebugAPI(tmClient rpcclient.Client, k *keeper.Keeper, ctxProvider func(i
 		txDecoder:      txConfig.TxDecoder(),
 		connectionType: connectionType,
 		isPanicCache:   isPanicCache,
+		backend:        backend,
 	}
 }
 
@@ -178,4 +184,35 @@ func (api *DebugAPI) TraceCall(ctx context.Context, args ethapi.TransactionArgs,
 	defer recordMetrics("debug_traceCall", api.connectionType, startTime, returnErr == nil)
 	result, returnErr = api.tracersAPI.TraceCall(ctx, args, blockNrOrHash, config)
 	return
+}
+
+func (api *DebugAPI) TraceStateAccess(ctx context.Context, hash common.Hash) (result interface{}, returnErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			result = nil
+			debug.PrintStack()
+			returnErr = fmt.Errorf("panic occurred: %v, could not trace tx state: %s", r, hash.Hex())
+		}
+	}()
+	tx, blockHash, blockNumber, index, err := api.backend.GetTransaction(ctx, hash)
+	if err != nil {
+		return nil, err
+	}
+	// Only mined txes are supported
+	if tx == nil {
+		return nil, errors.New("transaction not found")
+	}
+	// It shouldn't happen in practice.
+	if blockNumber == 0 {
+		return nil, errors.New("genesis is not traceable")
+	}
+	block, _, err := api.backend.BlockByHash(ctx, blockHash)
+	if err != nil {
+		return nil, err
+	}
+	stateDB, _, err := api.backend.ReplayTransactionTillIndex(ctx, block, int(index))
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(stateDB.(*state.DBImpl).Ctx().StoreTracer().DerivePrestateToJson()), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -351,7 +351,7 @@ replace (
 	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.3.5
 	github.com/CosmWasm/wasmvm => github.com/sei-protocol/sei-wasmvm v1.5.4-sei.0.0.3
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.60
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.61
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.2.0
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.6
 	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.13.5-sei-38

--- a/go.sum
+++ b/go.sum
@@ -1348,8 +1348,8 @@ github.com/sei-protocol/go-ethereum v1.13.5-sei-38 h1:QmgqsnzhP/lGOuKHtsSB9FwKc+
 github.com/sei-protocol/go-ethereum v1.13.5-sei-38/go.mod h1:kcRZmuzRn1lVejiFNTz4l4W7imnpq1bDAnuKS/RyhbQ=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.3.60 h1:ARhS0anE+oz2x8GmmqFCuHKTPV/DxtwxDQ6RkAskisM=
-github.com/sei-protocol/sei-cosmos v0.3.60/go.mod h1:Z+0XynKuhMu9m2XHIvUBwk4A+iLPc4YnzFlabpMOWqw=
+github.com/sei-protocol/sei-cosmos v0.3.61 h1:FIDre4De5RX3+iA4Qrl/ETUTTmRstOhFSBUEZw2B0jI=
+github.com/sei-protocol/sei-cosmos v0.3.61/go.mod h1:Z+0XynKuhMu9m2XHIvUBwk4A+iLPc4YnzFlabpMOWqw=
 github.com/sei-protocol/sei-db v0.0.49 h1:31q5SzqzSrk1BiYUZK2A5Zcn8j6lD/ToIB3ham6bDho=
 github.com/sei-protocol/sei-db v0.0.49/go.mod h1:m5g7p0QeAS3dNJHIl28zQpzOgxQmvYqPb7t4hwgIOCA=
 github.com/sei-protocol/sei-iavl v0.2.0 h1:OisPjXiDT+oe+aeckzDEFgkZCYuUjHgs/PP8DPicN+I=


### PR DESCRIPTION
## Describe your changes and provide context
Add a new `debug_traceStateAccess` endpoint that returns pre-transaction states in terms of underlying KV. Example response:
```json
map[id:test jsonrpc:2.0 result:map[modules:map[acc:map[has:[] reads:map[0165d13fca4130e23eb89438e223906384cd80f572: 01ea93f70ca3388866470baf58dc527be485e1b9b3:0a202f636f736d6f732e617574682e763162657461312e426173654163636f756e74122e0a2a736569316132666c77723972387a7978763363743461766463356e6d756a7a377277646e3868657070781807]] bank:map[has:[] reads:map[021465766d5f636f696e62617365000000000000000075736569: 021465d13fca4130e23eb89438e223906384cd80f57275736569: 0214ea93f70ca3388866470baf58dc527be485e1b9b375736569:0a0475736569120a39393939393939393739 0465d13fca4130e23eb89438e223906384cd80f572: 04ea93f70ca3388866470baf58dc527be485e1b9b3:]] evm:map[has:[] reads:map[015b4eba929f3811980f5ae0c5d04fa200f837df4e:ea93f70ca3388866470baf58dc527be485e1b9b3 0165766d5f636f696e626173650000000000000000: 0165d13fca4130e23eb89438e223906384cd80f572: 02ea93f70ca3388866470baf58dc527be485e1b9b3:5b4eba929f3811980f5ae0c5d04fa200f837df4e 0765d13fca4130e23eb89438e223906384cd80f572: 085b4eba929f3811980f5ae0c5d04fa200f837df4e: 0865d13fca4130e23eb89438e223906384cd80f572: 0a5b4eba929f3811980f5ae0c5d04fa200f837df4e:0000000000000001 0a65d13fca4130e23eb89438e223906384cd80f572: 1b:22313030303030303030302e30303030303030303030303030303030303022]] params:map[has:[] reads:map[65766d2f4b657942617365466565506572476173:22302e30303030303030303030303030303030303022 65766d2f4b657944656c697665725478486f6f6b5761736d4761734c696d6974:2233303030303022 65766d2f4b65794d617844796e616d696342617365466565446f776e7761726441646a7573746d656e74:22302e30303339303030303030303030303030303022 65766d2f4b65794d617844796e616d69634261736546656555707761726441646a7573746d656e74:22302e30313839303030303030303030303030303022 65766d2f4b65794d6178696d756d466565506572476173:22313030303030303030303030302e30303030303030303030303030303030303022 65766d2f4b65794d696e466565506572476173:22313030303030303030302e30303030303030303030303030303030303022 65766d2f4b65795072696f726974794e6f726d616c697a6572:22312e30303030303030303030303030303030303022 65766d2f4b657954617267657447617355736564506572426c6f636b:2232353030303022 65766d2f4b657957686974656c69737465644377436f6465486173686573466f7244656c656761746543616c6c:5b5d]] upgrade:map[has:[] reads:map[0176352e352e32: 0176352e352e35: 0176352e362e32: 0176352e372e35: 0176352e382e30: 0176362e302e30: 0176362e302e31: 0176362e302e33: 0176362e302e35: 0176362e302e36:]]]]]
```

## Testing performed to validate your change
unit test
