### PR TITLE
Fix log index on tx receipt

### DIFF
--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -261,9 +261,12 @@ func (a *BlockAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.Block
 				if receipt.BlockNumber != uint64(height) {
 					return
 				}
-				encodedReceipt, err := encodeReceipt(receipt, a.txConfig.TxDecoder(), block, func(h common.Hash) bool {
-					_, err := a.keeper.GetReceipt(a.ctxProvider(height), h)
-					return err == nil
+				encodedReceipt, err := encodeReceipt(receipt, a.txConfig.TxDecoder(), block, func(h common.Hash) *types.Receipt {
+					r, err := a.keeper.GetReceipt(a.ctxProvider(height), h)
+					if err != nil {
+						return nil
+					}
+					return r
 				}, a.includeShellReceipts, signer)
 				if err != nil {
 					mtx.Lock()

--- a/evmrpc/tests/receipt_test.go
+++ b/evmrpc/tests/receipt_test.go
@@ -1,0 +1,22 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReceiptLogIndex(t *testing.T) {
+	tx1Bz := signAndEncodeTx(depositErc20(1), erc20DeployerMnemonics)
+	tx2Data := sendErc20(2)
+	tx2 := signTxWithMnemonic(sendErc20(2), erc20DeployerMnemonics)
+	tx2Bz := encodeEvmTx(tx2Data, tx2)
+	SetupTestServer([][][]byte{{tx1Bz, tx2Bz}}, erc20Initializer()).Run(
+		func(port int) {
+			res := sendRequestWithNamespace("eth", port, "getTransactionReceipt", tx2.Hash().Hex())
+			// both tx 1 and tx2 have 1 log. Log of tx 1 will have log index 0x0 and
+			// log of tx 2 will have log index 0x1.
+			require.Equal(t, "0x1", res["result"].(map[string]interface{})["logs"].([]interface{})[0].(map[string]interface{})["logIndex"])
+		},
+	)
+}

--- a/evmrpc/tests/utils.go
+++ b/evmrpc/tests/utils.go
@@ -206,6 +206,10 @@ func formatParam(p interface{}) string {
 
 func signAndEncodeTx(txData ethtypes.TxData, mnemonic string) []byte {
 	signed := signTxWithMnemonic(txData, mnemonic)
+	return encodeEvmTx(txData, signed)
+}
+
+func encodeEvmTx(txData ethtypes.TxData, signed *ethtypes.Transaction) []byte {
 	var typedTx proto.Message
 	switch txData.(type) {
 	case *ethtypes.LegacyTx:

--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -155,9 +155,12 @@ func getTransactionReceipt(
 	if err != nil {
 		return nil, err
 	}
-	return encodeReceipt(receipt, t.txConfig.TxDecoder(), block, func(h common.Hash) bool {
-		_, err := t.keeper.GetReceipt(sdkctx, h)
-		return err == nil
+	return encodeReceipt(receipt, t.txConfig.TxDecoder(), block, func(h common.Hash) *types.Receipt {
+		r, err := t.keeper.GetReceipt(sdkctx, h)
+		if err != nil {
+			return nil
+		}
+		return r
 	}, includeSynthetic, signer)
 }
 
@@ -342,57 +345,70 @@ func getEthTxForTxBz(tx tmtypes.Tx, decoder sdk.TxDecoder) *ethtypes.Transaction
 
 // Gets the EVM tx index based on the tx index (typically from receipt.TransactionIndex
 // Essentially loops through and calculates the index if we ignore cosmos txs
-func GetEvmTxIndex(txs tmtypes.Txs, txIndex uint32, decoder sdk.TxDecoder, receiptChecker func(common.Hash) bool, includeSynthetic bool) (index int, found bool, etx *ethtypes.Transaction) {
-	var evmTxIndex int
+func GetEvmTxIndex(txs tmtypes.Txs, txIndex uint32, decoder sdk.TxDecoder, receiptChecker func(common.Hash) *types.Receipt, includeSynthetic bool) (index int, found bool, etx *ethtypes.Transaction, logIndexOffset int) {
+	var evmTxIndex, logIndex int
 	for i, tx := range txs {
 		etx = getEthTxForTxBz(tx, decoder)
 		isEVMTx := etx != nil
-		hasReceipt := receiptChecker(sha256.Sum256(tx))
+		var receipt *types.Receipt
+		if isEVMTx {
+			receipt = receiptChecker(etx.Hash())
+		} else {
+			receipt = receiptChecker(sha256.Sum256(tx))
+		}
+		hasReceipt := receipt != nil
 		if includeSynthetic {
 			if isEVMTx {
 				// must have receipt
 				if i == int(txIndex) {
-					return evmTxIndex, true, etx
+					return evmTxIndex, true, etx, logIndex
 				}
 				evmTxIndex++
+				if hasReceipt {
+					logIndex += len(receipt.Logs)
+				}
 			} else {
 				if hasReceipt {
 					if i == int(txIndex) {
-						return evmTxIndex, true, etx
+						return evmTxIndex, true, etx, logIndex
 					}
 					evmTxIndex++
+					logIndex += len(receipt.Logs)
 				}
 			}
 		} else {
 			if isEVMTx {
 				// must have receipt
 				if i == int(txIndex) {
-					return evmTxIndex, true, etx
+					return evmTxIndex, true, etx, logIndex
 				}
 				evmTxIndex++
+				if hasReceipt {
+					logIndex += len(receipt.Logs)
+				}
 			} else {
 				// would still find the tx, but not count it towards index
 				if hasReceipt {
 					if i == int(txIndex) {
-						return evmTxIndex, true, etx
+						return evmTxIndex, true, etx, logIndex
 					}
 				}
 			}
 		}
 	}
-	return -1, false, nil
+	return -1, false, nil, -1
 }
 
-func encodeReceipt(receipt *types.Receipt, decoder sdk.TxDecoder, block *coretypes.ResultBlock, receiptChecker func(common.Hash) bool, includeSynthetic bool, signer ethtypes.Signer) (map[string]interface{}, error) {
+func encodeReceipt(receipt *types.Receipt, decoder sdk.TxDecoder, block *coretypes.ResultBlock, receiptChecker func(common.Hash) *types.Receipt, includeSynthetic bool, signer ethtypes.Signer) (map[string]interface{}, error) {
 	blockHash := block.BlockID.Hash
 	bh := common.HexToHash(blockHash.String())
-	evmTxIndex, foundTx, etx := GetEvmTxIndex(block.Block.Txs, receipt.TransactionIndex, decoder, receiptChecker, includeSynthetic)
+	evmTxIndex, foundTx, etx, logIndexOffset := GetEvmTxIndex(block.Block.Txs, receipt.TransactionIndex, decoder, receiptChecker, includeSynthetic)
 	// convert tx index including cosmos txs to tx index excluding cosmos txs
 	if !foundTx {
 		return nil, errors.New("failed to find transaction in block")
 	}
 	receipt.TransactionIndex = uint32(evmTxIndex)
-	logs := keeper.GetLogsForTx(receipt, 0)
+	logs := keeper.GetLogsForTx(receipt, uint(logIndexOffset))
 	for _, log := range logs {
 		log.BlockHash = bh
 	}


### PR DESCRIPTION
## Describe your changes and provide context
Log index for transactions in a block should be cumulative: if tx 1 has 3 logs and tx 2 has 4 logs, then log index of tx 2 should be (3,4,5,6) instead of (0,1,2,3). This is the case for `eth_getLogs` and `eth_getBlockReceipts`, but not `eth_getTransactionReceipt`. This PR fixes that.

## Testing performed to validate your change
unit test

