### PR TITLE
[SEI-9691] fix eth_feeHistory empty blocks

### DIFF
--- a/evmrpc/info.go
+++ b/evmrpc/info.go
@@ -298,6 +298,10 @@ func CalculatePercentiles(rewardPercentiles []float64, GasAndRewards []GasAndRew
 	})
 	res := []*hexutil.Big{}
 	if len(GasAndRewards) == 0 {
+		// Return array of zeros for each percentile when no transactions exist
+		for range rewardPercentiles {
+			res = append(res, (*hexutil.Big)(big.NewInt(0)))
+		}
 		return res
 	}
 	var txIndex int

--- a/evmrpc/info_test.go
+++ b/evmrpc/info_test.go
@@ -3,6 +3,7 @@ package evmrpc_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -130,9 +131,10 @@ func TestCalculatePercentiles(t *testing.T) {
 	result := evmrpc.CalculatePercentiles([]float64{}, []evmrpc.GasAndReward{}, 0)
 	require.Equal(t, 0, len(result))
 
-	// empty GasAndRewards
+	// empty GasAndRewards should return zeros for each percentile
 	result = evmrpc.CalculatePercentiles([]float64{1}, []evmrpc.GasAndReward{}, 0)
-	require.Equal(t, 0, len(result))
+	require.Equal(t, 1, len(result))
+	require.Equal(t, "0x0", result[0].String())
 
 	// empty percentiles
 	result = evmrpc.CalculatePercentiles([]float64{}, []evmrpc.GasAndReward{{Reward: big.NewInt(10), GasUsed: 1}}, 1)
@@ -213,4 +215,20 @@ func TestGasPriceLogic(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, test.expectedGasPrice, gasPrice.ToInt())
 	}
+}
+
+func TestCalculatePercentilesEmptyBlockWithMultiplePercentiles(t *testing.T) {
+	// Test with multiple percentiles and empty block
+	result := evmrpc.CalculatePercentiles([]float64{25, 50, 75}, []evmrpc.GasAndReward{}, 0)
+	require.Equal(t, 3, len(result))
+	for i, r := range result {
+		require.Equal(t, "0x0", r.String(), fmt.Sprintf("percentile %d should be zero", i))
+	}
+}
+
+func TestCalculatePercentilesEmptyBlockWithSinglePercentile(t *testing.T) {
+	// Test with single percentile and empty block
+	result := evmrpc.CalculatePercentiles([]float64{50}, []evmrpc.GasAndReward{}, 0)
+	require.Equal(t, 1, len(result))
+	require.Equal(t, "0x0", result[0].String())
 }


### PR DESCRIPTION
## Describe your changes and provide context

When eth_feeHistory is called on blocks that are empty, the endpoint returns an empty array instead of "0x0".

## Testing performed to validate your change
unit tests

