### PR TITLE
Fix broken link to Cosmos SDK telemetry documentation

### DIFF
--- a/utils/metrics/README.md
+++ b/utils/metrics/README.md
@@ -1,5 +1,5 @@
 # Sei Metrics
 
-This is intended to be an utility library to expose additional metrics that's useful for monitoring a given Sei chain. It buils ontop of the existing [Cosmos SDK telemetry library](https://docs.cosmos.network/master/core/telemetry.html)
+This is intended to be an utility library to expose additional metrics that's useful for monitoring a given Sei chain. It buils ontop of the existing [Cosmos SDK telemetry library](https://docs.cosmos.network/main/learn/advanced/telemetry)
 
 Note: In-memory sink is always attached (when the telemetry is enabled) with 10 second interval and 1 minute retention. This means that metrics will be aggregated over 10 seconds, and metrics will be kept alive for 1 minute.


### PR DESCRIPTION
Replaced the outdated link to the Cosmos SDK telemetry documentation in utils/metrics/README.md with the current official URL: https://docs.cosmos.network/main/learn/advanced/telemetry. This ensures that users are directed to the latest and correct resource for telemetry setup and usage.
