### PR TITLE
Fix tx index in getTransactionByHash response

### DIFF
--- a/evmrpc/tests/mock_client.go
+++ b/evmrpc/tests/mock_client.go
@@ -180,6 +180,10 @@ func (c *MockClient) Events(_ context.Context, req *coretypes.RequestEvents) (*c
 	}
 }
 
+func (c *MockClient) UnconfirmedTxs(context.Context, *int, *int) (*coretypes.ResultUnconfirmedTxs, error) {
+	return &coretypes.ResultUnconfirmedTxs{}, nil
+}
+
 func mockHash(height int64, prefix int64) tmbytes.HexBytes {
 	heightBz, prefixBz := make([]byte, 8), make([]byte, 8)
 	binary.BigEndian.PutUint64(heightBz, uint64(height))

--- a/evmrpc/tests/tx_test.go
+++ b/evmrpc/tests/tx_test.go
@@ -1,0 +1,21 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTransactionSkipSyntheticIndex(t *testing.T) {
+	tx1 := signAndEncodeCosmosTx(bankSendMsg(mnemonic1), mnemonic1, 7, 0)
+	tx2Data := send(0)
+	signedTx2 := signTxWithMnemonic(tx2Data, mnemonic1)
+	tx2 := encodeEvmTx(tx2Data, signedTx2)
+	SetupTestServer([][][]byte{{tx1, tx2}}, mnemonicInitializer(mnemonic1)).Run(
+		func(port int) {
+			res := sendRequestWithNamespace("eth", port, "getTransactionByHash", signedTx2.Hash().Hex())
+			txIdx := res["result"].(map[string]any)["transactionIndex"].(string)
+			require.Equal(t, "0x0", txIdx) // should skip the first tx as it's not EVM
+		},
+	)
+}


### PR DESCRIPTION
## Describe your changes and provide context
Non-EVM transactions should be skipped when counting for transaction index in `eth_getTransactionByHash|Number` calls

## Testing performed to validate your change
unit tests
