### PR TITLE
Require MsgClaim sender to match signer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ COPY . /code/
 # force it to use static lib (from above) not standard libgo_cosmwasm.so file
 # then log output of file /code/build/seid
 # then ensure static linking
-RUN LEDGER_ENABLED=false BUILD_TAGS=muslc LINK_STATICALLY=true make build -B \
+RUN LEDGER_ENABLED=false BUILD_TAGS=muslc LINK_STATICALLY=true make build-verbose -B \
   && file /code/build/seid \
   && echo "Ensuring binary is statically linked ..." \
   && (file /code/build/seid | grep "statically linked")

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,9 @@ lint:
 build:
 	go build $(BUILD_FLAGS) -o ./build/seid ./cmd/seid
 
+build-verbose:
+	go build -x -v $(BUILD_FLAGS) -o ./build/seid ./cmd/seid
+
 build-price-feeder:
 	go build $(BUILD_FLAGS) -o ./build/price-feeder ./oracle/price-feeder
 

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -506,6 +506,12 @@ async function printClaimMsg(sender, claimer) {
     catch(e) { console.log(e); }
 }
 
+async function printClaimMsgBySender(sender, claimer, senderAddr) {
+    const command = `seid tx evm print-claim-by-sender ${claimer} ${senderAddr} --from ${sender} -y`;
+    try { return await execute(command); }
+    catch(e) { console.log(e); }
+}
+
 async function printClaimSpecificMsg(sender, claimer, ...assets) {
     const command = `seid tx evm print-claim-specific ${claimer} ${assets.join(' ')} --from ${sender} -y`;
     try { return await execute(command); }
@@ -656,6 +662,7 @@ module.exports = {
     associateWasm,
     generateWallet,
     printClaimMsg,
+    printClaimMsgBySender,
     printClaimSpecificMsg,
     addKey,
     getKeySeiAddress,

--- a/precompiles/solo/solo.go
+++ b/precompiles/solo/solo.go
@@ -1,6 +1,7 @@
 package solo
 
 import (
+	"bytes"
 	"embed"
 	"encoding/json"
 	"errors"
@@ -241,6 +242,10 @@ func (p PrecompileExecutor) sigverify(ctx sdk.Context, tx sdk.Tx, claimMsg claim
 		if pubkey == nil {
 			return errors.New("must provide pubkey from accounts that have never sent transactions")
 		}
+	}
+	pubkeyAddr := sdk.AccAddress(pubkey.Address())
+	if !bytes.Equal(pubkeyAddr, sender) {
+		return fmt.Errorf("claim message is for %s but was signed by %s", sender.String(), pubkeyAddr.String())
 	}
 	sigs, err := sigTx.GetSignaturesV2()
 	if err != nil {

--- a/precompiles/solo/solo_test.go
+++ b/precompiles/solo/solo_test.go
@@ -69,6 +69,13 @@ func TestClaim(t *testing.T) {
 	_, remainingGas, err = p.Claim(ctx, imposter, &method, []interface{}{signClaimMsg(t, evmtypes.NewMsgClaim(claimee, claimer), claimee, claimer, acc, claimeeKey)}, false)
 	require.Error(t, err, "claim tx is meant for")
 	require.Equal(t, uint64(0), remainingGas)
+	// imposter on ClaimMsg
+	ctx, _ = origCtx.CacheContext()
+	ctx = ctx.WithGasMeter(sdk.NewGasMeter(1000000, 1, 1))
+	imposterKey := testkeeper.MockPrivateKey()
+	_, remainingGas, err = p.Claim(ctx, imposter, &method, []interface{}{signClaimMsg(t, evmtypes.NewMsgClaim(claimee, imposter), claimee, imposter, acc, imposterKey)}, false)
+	require.Error(t, err, "claim message is for")
+	require.Equal(t, uint64(0), remainingGas)
 	// account does not exist
 	ctx, _ = origCtx.CacheContext()
 	ctx = ctx.WithGasMeter(sdk.NewGasMeter(1000000, 1, 1))

--- a/x/evm/client/cli/native_tx.go
+++ b/x/evm/client/cli/native_tx.go
@@ -232,6 +232,32 @@ func PrintClaimTxPayloadCmd() *cobra.Command {
 	return cmd
 }
 
+func PrintClaimTxBySenderPayloadCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "print-claim-by-sender [claimer] [sender] --from=<sender>",
+		Short: `Print hex-encoded claim message payload for Sei Solo migration.`,
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgClaim(sdk.MustAccAddressFromBech32(args[1]), common.HexToAddress(args[0]))
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			clientCtx.PrintSignedOnly = true
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}
+
 func PrintClaimSpecificTxPayloadCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "print-claim-specific [claimer] [[CW20|CW721] [contract addr]]... --from=<sender>",

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -69,6 +69,7 @@ func GetTxCmd() *cobra.Command {
 	cmd.AddCommand(AssociateContractAddressCmd())
 	cmd.AddCommand(NativeAssociateCmd())
 	cmd.AddCommand(PrintClaimTxPayloadCmd())
+	cmd.AddCommand(PrintClaimTxBySenderPayloadCmd())
 	cmd.AddCommand(PrintClaimSpecificTxPayloadCmd())
 
 	return cmd


### PR DESCRIPTION
## Describe your changes and provide context
Instead of only requiring MsgClaim to be properly signed, we also need to enforce that it's signed by the specified sender.

## Testing performed to validate your change
unit/integration tests

