### PR TITLE
exclude transactions that failed ante from getTransaction

### DIFF
--- a/evmrpc/tests/tx_test.go
+++ b/evmrpc/tests/tx_test.go
@@ -19,3 +19,15 @@ func TestGetTransactionSkipSyntheticIndex(t *testing.T) {
 		},
 	)
 }
+
+func TestGetTransactionAnteFailed(t *testing.T) {
+	tx1Data := send(1) // incorrect nonce
+	signedTx1 := signTxWithMnemonic(tx1Data, mnemonic1)
+	tx1 := encodeEvmTx(tx1Data, signedTx1)
+	SetupTestServer([][][]byte{{tx1}}, mnemonicInitializer(mnemonic1)).Run(
+		func(port int) {
+			res := sendRequestWithNamespace("eth", port, "getTransactionByHash", signedTx1.Hash().Hex())
+			require.Equal(t, "not found", res["error"].(map[string]interface{})["message"].(string))
+		},
+	)
+}

--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -248,6 +248,9 @@ func (t *TransactionAPI) GetTransactionByHash(ctx context.Context, hash common.H
 		}
 		return nil, err
 	}
+	if isReceiptFromAnteError(receipt) {
+		return nil, errors.New("not found")
+	}
 	return t.GetTransactionByBlockNumberAndIndex(ctx, rpc.BlockNumber(receipt.BlockNumber), hexutil.Uint(receipt.TransactionIndex))
 }
 
@@ -307,6 +310,9 @@ func (t *TransactionAPI) getTransactionWithBlock(block *coretypes.ResultBlock, i
 	receipt, err := t.keeper.GetReceipt(t.ctxProvider(LatestCtxHeight), ethtx.Hash())
 	if err != nil {
 		return nil, err
+	}
+	if isReceiptFromAnteError(receipt) {
+		return nil, errors.New("not found")
 	}
 	height := int64(receipt.BlockNumber)
 	baseFeePerGas := t.keeper.GetBaseFee(t.ctxProvider(height))


### PR DESCRIPTION
## Describe your changes and provide context
Transactions that failed ante handler will change no state and thus should not be considered as "included in a block". So we should exclude them when querying `eth_getTransaction...` endpoints, which is consistent with `eth_getBlock...`

## Testing performed to validate your change
unit test
