### PR TITLE
Reject pending transactions if sender doesn't have sufficient funds

### DIFF
--- a/x/evm/ante/sig.go
+++ b/x/evm/ante/sig.go
@@ -44,6 +44,9 @@ func (svd *EVMSigVerifyDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulat
 	txChainID := ethTx.ChainId()
 
 	fee := new(big.Int).Mul(ethTx.GasPrice(), new(big.Int).SetUint64(ethTx.Gas()))
+	if ethTx.Value() != nil {
+		fee = new(big.Int).Add(fee, ethTx.Value())
+	}
 
 	// validate chain ID on the transaction
 	switch ethTx.Type() {

--- a/x/evm/ante/sig.go
+++ b/x/evm/ante/sig.go
@@ -9,7 +9,6 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmtypes "github.com/tendermint/tendermint/types"
 
-	"github.com/sei-protocol/sei-chain/x/evm/keeper"
 	evmkeeper "github.com/sei-protocol/sei-chain/x/evm/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
@@ -101,10 +100,10 @@ func (svd *EVMSigVerifyDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulat
 					return abci.Rejected
 				} else if txNonce < nextPendingNonce {
 					// check if the sender still has enough funds to pay for gas
-					balance := svd.evmKeeper.BankKeeper().GetBalance(latestCtx, types.MustGetEVMTransactionMessage(tx).Derived.SenderSeiAddr, keeper.BaseDenom).Amount
+					balance := svd.evmKeeper.BankKeeper().GetBalance(latestCtx, types.MustGetEVMTransactionMessage(tx).Derived.SenderSeiAddr, evmkeeper.BaseDenom).Amount
 					if balance.LT(sdk.NewIntFromBigInt(fee)) {
-						// not enough funds
-						return abci.Rejected
+						// not enough funds. Go back to pending as it may obtain sufficient funds later.
+						return abci.Pending
 					}
 					// this nonce is allowed to process as it is part of the
 					// consecutive nonces from nextNonceToBeMined to nextPendingNonce

--- a/x/evm/ante/sig_test.go
+++ b/x/evm/ante/sig_test.go
@@ -149,7 +149,7 @@ func TestSigVerifyPendingTransaction(t *testing.T) {
 	require.Equal(t, abci.Pending, newCtx.PendingTxChecker()())
 	k.SetNonce(ctx, evmAddr, 1)
 	// not enough fund
-	require.Equal(t, abci.Rejected, newCtx.PendingTxChecker()())
+	require.Equal(t, abci.Pending, newCtx.PendingTxChecker()())
 	fee := sdk.NewIntFromUint64(tx.Gas()).Mul(sdk.NewIntFromBigInt(tx.GasPrice())).Add(sdk.NewIntFromBigInt(tx.Value()))
 	_ = k.BankKeeper().AddCoins(ctx, msg.Derived.SenderSeiAddr, sdk.NewCoins(sdk.NewCoin("usei", fee)), false)
 	require.Equal(t, abci.Accepted, newCtx.PendingTxChecker()())

--- a/x/evm/ante/sig_test.go
+++ b/x/evm/ante/sig_test.go
@@ -148,7 +148,12 @@ func TestSigVerifyPendingTransaction(t *testing.T) {
 	// test checker
 	require.Equal(t, abci.Pending, newCtx.PendingTxChecker()())
 	k.SetNonce(ctx, evmAddr, 1)
+	// not enough fund
+	require.Equal(t, abci.Rejected, newCtx.PendingTxChecker()())
+	fee := sdk.NewIntFromUint64(tx.Gas()).Mul(sdk.NewIntFromBigInt(tx.GasPrice())).Add(sdk.NewIntFromBigInt(tx.Value()))
+	_ = k.BankKeeper().AddCoins(ctx, msg.Derived.SenderSeiAddr, sdk.NewCoins(sdk.NewCoin("usei", fee)), false)
 	require.Equal(t, abci.Accepted, newCtx.PendingTxChecker()())
+	// incorrect nonce
 	k.SetNonce(ctx, evmAddr, 2)
 	require.Equal(t, abci.Rejected, newCtx.PendingTxChecker()())
 


### PR DESCRIPTION
## Describe your changes and provide context
Pending transactions may become invalid if the state that they run CheckTx on became invalid, which is especially common with balances.

## Testing performed to validate your change
unit test & local sei cluster
