### PR TITLE
Do not take a new snapshot upon RevertToSnapshot

### DIFF
--- a/x/evm/state/state.go
+++ b/x/evm/state/state.go
@@ -115,7 +115,6 @@ func (s *DBImpl) RevertToSnapshot(rev int) {
 	s.snapshottedCtxs = s.snapshottedCtxs[:rev]
 	s.tempStateCurrent = s.tempStatesHist[rev]
 	s.tempStatesHist = s.tempStatesHist[:rev]
-	s.Snapshot()
 }
 
 func (s *DBImpl) handleResidualFundsInDestructedAccounts(st *TemporaryState) {


### PR DESCRIPTION
## Describe your changes and provide context
It was originally added to ensure snapshots immutability but it's not necessary since the contract within EVM is for the caller to be responsible for taking snapshots. 
This change is not supposed to cause any logical changes and may have some performance benefits

## Testing performed to validate your change
no logical change; existing tests should still pass
