### PR TITLE
[SEI-10041] Add compile flagged mock balance testing functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ docker-cluster-start: docker-cluster-stop build-docker-node
 	@rm -rf $(PROJECT_HOME)/build/generated
 	@mkdir -p $(shell go env GOPATH)/pkg/mod
 	@mkdir -p $(shell go env GOCACHE)
-	@cd docker && USERID=$(shell id -u) GROUPID=$(shell id -g) GOCACHE=$(shell go env GOCACHE) NUM_ACCOUNTS=10 INVARIANT_CHECK_INTERVAL=${INVARIANT_CHECK_INTERVAL} UPGRADE_VERSION_LIST=${UPGRADE_VERSION_LIST} docker compose up
+	@cd docker && USERID=$(shell id -u) GROUPID=$(shell id -g) GOCACHE=$(shell go env GOCACHE) NUM_ACCOUNTS=10 INVARIANT_CHECK_INTERVAL=${INVARIANT_CHECK_INTERVAL} UPGRADE_VERSION_LIST=${UPGRADE_VERSION_LIST} MOCK_BALANCES=${MOCK_BALANCES} docker compose up
 
 .PHONY: localnet-start
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - SKIP_BUILD
       - INVARIANT_CHECK_INTERVAL
       - UPGRADE_VERSION_LIST
+      - MOCK_BALANCES
     volumes:
       - "${PROJECT_HOME}:/sei-protocol/sei-chain:Z"
       - "${PROJECT_HOME}/../sei-tendermint:/sei-protocol/sei-tendermint:Z"

--- a/docker/localnode/scripts/deploy.sh
+++ b/docker/localnode/scripts/deploy.sh
@@ -17,7 +17,7 @@ mkdir -p $GOBIN
 # Step 0: Build on node 0
 if [ "$NODE_ID" = 0 ] && [ -z "$SKIP_BUILD" ]
 then
-  /usr/bin/build.sh
+  /usr/bin/build.sh $MOCK_BALANCES
 fi
 
 if ! [ "$SKIP_BUILD" ]

--- a/docker/localnode/scripts/step0_build.sh
+++ b/docker/localnode/scripts/step0_build.sh
@@ -9,7 +9,8 @@ echo "Building seid from local branch"
 git config --global --add safe.directory /sei-protocol/sei-chain
 export LEDGER_ENABLED=false
 make clean
-make build-linux
+# build seid with the mock balance function enabled
+make build-linux LDFLAGS="-X github.com/sei-protocol/sei-chain/x/evm/state.mockBalanceTesting=enabled"
 make build-price-feeder-linux
 mkdir -p build/generated
 echo "DONE" > build/generated/build.complete

--- a/docker/localnode/scripts/step0_build.sh
+++ b/docker/localnode/scripts/step0_build.sh
@@ -3,6 +3,7 @@
 # Input parameters
 NODE_ID=${ID:-0}
 ARCH=$(uname -m)
+MOCK_BALANCES=${MOCK_BALANCES:-false}
 
 # Build seid
 echo "Building seid from local branch"
@@ -10,7 +11,13 @@ git config --global --add safe.directory /sei-protocol/sei-chain
 export LEDGER_ENABLED=false
 make clean
 # build seid with the mock balance function enabled
-make build-linux LDFLAGS="-X github.com/sei-protocol/sei-chain/x/evm/state.mockBalanceTesting=enabled"
+if [ "$MOCK_BALANCES" = true ]; then
+    echo "Building with mock balances enabled..."
+    make build-linux LDFLAGS="-X github.com/sei-protocol/sei-chain/x/evm/state.mockBalanceTesting=enabled"
+else
+    echo "Building with standard configuration..."
+    make build-linux
+fi
 make build-price-feeder-linux
 mkdir -p build/generated
 echo "DONE" > build/generated/build.complete

--- a/scripts/initialize_local_chain.sh
+++ b/scripts/initialize_local_chain.sh
@@ -2,6 +2,8 @@
 # require success for commands
 set -e
 
+# Parse command line arguments
+MOCK_BALANCES=${MOCK_BALANCES:-false}
 
 # Use python3 as default, but fall back to python if python3 doesn't exist
 PYTHON_CMD=python3
@@ -30,8 +32,14 @@ keyname=admin
 # clean up old sei directory
 rm -rf ~/.sei
 echo "Building..."
-# install seid -- build it with the mock balance function enabled
-make install LDFLAGS="-X github.com/sei-protocol/sei-chain/x/evm/state.mockBalanceTesting=enabled"
+# install seid -- conditionally build with mock balance function
+if [ "$MOCK_BALANCES" = true ]; then
+    echo "Building with mock balances enabled..."
+    make install LDFLAGS="-X github.com/sei-protocol/sei-chain/x/evm/state.mockBalanceTesting=enabled"
+else
+    echo "Building with standard configuration..."
+    make install
+fi
 # initialize chain with chain ID and add the first key
 ~/go/bin/seid init demo --chain-id sei-chain
 ~/go/bin/seid keys add $keyname --keyring-backend test

--- a/scripts/initialize_local_chain.sh
+++ b/scripts/initialize_local_chain.sh
@@ -30,8 +30,8 @@ keyname=admin
 # clean up old sei directory
 rm -rf ~/.sei
 echo "Building..."
-#install seid
-make install
+# install seid -- build it with the mock balance function enabled
+make install LDFLAGS="-X github.com/sei-protocol/sei-chain/x/evm/state.mockBalanceTesting=enabled"
 # initialize chain with chain ID and add the first key
 ~/go/bin/seid init demo --chain-id sei-chain
 ~/go/bin/seid keys add $keyname --keyring-backend test

--- a/x/evm/state/balance.go
+++ b/x/evm/state/balance.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/holiman/uint256"
+	"github.com/sei-protocol/sei-chain/x/evm/config"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
 
@@ -106,6 +107,10 @@ func (s *DBImpl) AddBalance(evmAddr common.Address, amtUint256 *uint256.Int, rea
 func (s *DBImpl) mockBalance(evmAddr common.Address) *uint256.Int {
 	if mockBalanceTesting != "enabled" {
 		panic("mockBalance is only intended for use in TESTING")
+	}
+	// Prevent calling mockBalance on sei mainnet
+	if config.GetEVMChainID(s.ctx.ChainID()) == big.NewInt(1329) {
+		panic("Prevent mock balance from ever being called on mainnet")
 	}
 
 	// Mint enough for many gas operations (10 ETH worth)

--- a/x/evm/state/balance.go
+++ b/x/evm/state/balance.go
@@ -3,12 +3,19 @@ package state
 import (
 	"math/big"
 
+	"github.com/tendermint/tendermint/libs/log"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/holiman/uint256"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
+
+// This is a compile time flag to enable/disable the mock balance function.
+// It is only intended for use in TESTING.
+// go build -X github.com/sei-protocol/sei-chain/x/evm/state.MockBalanceTesting=true
+var mockBalanceTesting string = ""
 
 var ZeroInt = uint256.NewInt(0)
 
@@ -95,12 +102,52 @@ func (s *DBImpl) AddBalance(evmAddr common.Address, amtUint256 *uint256.Int, rea
 	return *ZeroInt
 }
 
+// This function is used to mock balance, and is only intended for use in TESTING. The access to this function will be gated by a compile time flag.
+func (s *DBImpl) mockBalance(evmAddr common.Address) *uint256.Int {
+	if mockBalanceTesting != "enabled" {
+		panic("mockBalance is only intended for use in TESTING")
+	}
+
+	// Mint enough for many gas operations (10 ETH worth)
+	bal := uint256.NewInt(10_000_000_000_000_000_000) // 10 ETH in wei
+
+	amt := bal.ToBig()
+	seiAddr := s.getSeiAddress(evmAddr)
+
+	// Check if account exists, create if needed
+	if !s.k.AccountKeeper().HasAccount(s.ctx, seiAddr) {
+		s.k.AccountKeeper().SetAccount(s.ctx, s.k.AccountKeeper().NewAccountWithAddress(s.ctx, seiAddr))
+	}
+
+	moduleAddr := s.k.AccountKeeper().GetModuleAddress(types.ModuleName)
+	usei, _ := SplitUseiWeiAmount(amt)
+	coinsAmt := sdk.NewCoins(sdk.NewCoin(s.k.GetBaseDenom(s.ctx), usei.Add(sdk.OneInt())))
+
+	// avoids flooding logs
+	if err := s.k.BankKeeper().MintCoins(s.ctx.WithLogger(log.NewNopLogger()), types.ModuleName, coinsAmt); err != nil {
+		panic(err)
+	}
+	s.send(moduleAddr, seiAddr, amt)
+	if s.err != nil {
+		panic(s.err)
+	}
+	return bal
+}
+
 func (s *DBImpl) GetBalance(evmAddr common.Address) *uint256.Int {
 	s.k.PrepareReplayedAddr(s.ctx, evmAddr)
 	seiAddr := s.getSeiAddress(evmAddr)
 	res, overflow := uint256.FromBig(s.k.GetBalance(s.ctx, seiAddr))
 	if overflow {
 		panic("balance overflow")
+	}
+	if mockBalanceTesting == "enabled" {
+		// Lazy initialization: if balance is insufficient for gas operations, mint more
+		minRequiredBalance := uint256.NewInt(1_000_000_000_000_000_000) // 1 ETH worth of wei for gas
+		if res == nil || res.Cmp(minRequiredBalance) < 0 {
+			mockBal := s.mockBalance(evmAddr)
+			return mockBal
+		}
 	}
 	if res == nil {
 		return uint256.NewInt(0)


### PR DESCRIPTION
## Describe your changes and provide context
This allows for mocking EVM balances using a compile-time flag for testing purposes. 

## Testing performed to validate your change
Tested using the intiialize_local_chain script
