### PR TITLE
Add make target for mock balances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ all: lint install
 install: go.sum
 		go install $(BUILD_FLAGS) ./cmd/seid
 
+install-mock-balances: go.sum
+	go install -tags "$(build_tags)" -ldflags '$(ldflags) -X github.com/sei-protocol/sei-chain/x/evm/state.mockBalanceTesting=enabled' ./cmd/seid
+
 install-with-race-detector: go.sum
 		go install -race $(BUILD_FLAGS) ./cmd/seid
 

--- a/scripts/initialize_local_chain.sh
+++ b/scripts/initialize_local_chain.sh
@@ -35,7 +35,7 @@ echo "Building..."
 # install seid -- conditionally build with mock balance function
 if [ "$MOCK_BALANCES" = true ]; then
     echo "Building with mock balances enabled..."
-    make install LDFLAGS="-X github.com/sei-protocol/sei-chain/x/evm/state.mockBalanceTesting=enabled"
+    make install-mock-balances
 else
     echo "Building with standard configuration..."
     make install


### PR DESCRIPTION
## Describe your changes and provide context
This adds a makefile target to build with the testing mode for mocking balances. Just a QoL change to improve dev workflow.

## Testing performed to validate your change
Verified with local env scripts