### PR TITLE
[SEI-9449] Make distr module invariant less strict

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -353,7 +353,7 @@ replace (
 	github.com/CosmWasm/wasmvm => github.com/sei-protocol/sei-wasmvm v1.5.4-sei.0.0.3
 	github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.23.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.65
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.65-0.20250731171927-1ed860fbc84c
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.2.0
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.6
 	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.15.7-sei-3

--- a/go.mod
+++ b/go.mod
@@ -353,7 +353,7 @@ replace (
 	github.com/CosmWasm/wasmvm => github.com/sei-protocol/sei-wasmvm v1.5.4-sei.0.0.3
 	github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.23.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.65-0.20250731171927-1ed860fbc84c
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.65-0.20250731172952-13be9af34c41
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.2.0
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.3.6
 	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.15.7-sei-3

--- a/go.sum
+++ b/go.sum
@@ -1991,8 +1991,8 @@ github.com/sei-protocol/go-ethereum v1.15.7-sei-3 h1:Xf6qYewZK8+534cXOZI6iDVGYkN
 github.com/sei-protocol/go-ethereum v1.15.7-sei-3/go.mod h1:+S9k+jFzlyVTNcYGvqFhzN/SFhI6vA+aOY4T5tLSPL0=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.3.65 h1:tV2+OvWpRWHD9ts1JyA/d4fmXHxFIGJTkCLLcws1B1g=
-github.com/sei-protocol/sei-cosmos v0.3.65/go.mod h1:xckXRG0A8Fxr69YNYTE8/aqSprVui3Byt5iJEiSrEQ4=
+github.com/sei-protocol/sei-cosmos v0.3.65-0.20250731171927-1ed860fbc84c h1:jqjnPQINXGsqkQ04ncVq19d5nDM4E+bTw/JQjrdESOE=
+github.com/sei-protocol/sei-cosmos v0.3.65-0.20250731171927-1ed860fbc84c/go.mod h1:xckXRG0A8Fxr69YNYTE8/aqSprVui3Byt5iJEiSrEQ4=
 github.com/sei-protocol/sei-db v0.0.51 h1:jK6Ps+jDbGdWIPZttaWk7VIsq8aLWWlkTp9axIraL/U=
 github.com/sei-protocol/sei-db v0.0.51/go.mod h1:m5g7p0QeAS3dNJHIl28zQpzOgxQmvYqPb7t4hwgIOCA=
 github.com/sei-protocol/sei-iavl v0.2.0 h1:OisPjXiDT+oe+aeckzDEFgkZCYuUjHgs/PP8DPicN+I=

--- a/go.sum
+++ b/go.sum
@@ -1991,8 +1991,8 @@ github.com/sei-protocol/go-ethereum v1.15.7-sei-3 h1:Xf6qYewZK8+534cXOZI6iDVGYkN
 github.com/sei-protocol/go-ethereum v1.15.7-sei-3/go.mod h1:+S9k+jFzlyVTNcYGvqFhzN/SFhI6vA+aOY4T5tLSPL0=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
-github.com/sei-protocol/sei-cosmos v0.3.65-0.20250731171927-1ed860fbc84c h1:jqjnPQINXGsqkQ04ncVq19d5nDM4E+bTw/JQjrdESOE=
-github.com/sei-protocol/sei-cosmos v0.3.65-0.20250731171927-1ed860fbc84c/go.mod h1:xckXRG0A8Fxr69YNYTE8/aqSprVui3Byt5iJEiSrEQ4=
+github.com/sei-protocol/sei-cosmos v0.3.65-0.20250731172952-13be9af34c41 h1:iTz7dAzfe2S6dF4l9E2hkZ6RBte41SwwYlBeas/lKr4=
+github.com/sei-protocol/sei-cosmos v0.3.65-0.20250731172952-13be9af34c41/go.mod h1:xckXRG0A8Fxr69YNYTE8/aqSprVui3Byt5iJEiSrEQ4=
 github.com/sei-protocol/sei-db v0.0.51 h1:jK6Ps+jDbGdWIPZttaWk7VIsq8aLWWlkTp9axIraL/U=
 github.com/sei-protocol/sei-db v0.0.51/go.mod h1:m5g7p0QeAS3dNJHIl28zQpzOgxQmvYqPb7t4hwgIOCA=
 github.com/sei-protocol/sei-iavl v0.2.0 h1:OisPjXiDT+oe+aeckzDEFgkZCYuUjHgs/PP8DPicN+I=


### PR DESCRIPTION
## Describe your changes and provide context

Make a crisis invariant check in the distribution and gov module less strict. So instead of checking that the expected and actual balances are actually equal, we will check that the actual balance is at least the expected balance.

cosmos PR: https://github.com/sei-protocol/sei-cosmos/pull/592

## Testing performed to validate your change
existing tests

