### PR TITLE
Enable occ and slow=true in docker cluster

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,6 +36,7 @@ services:
     ports:
       - "26659-26661:26656-26658"
       - "9092-9093:9090-9091"
+      - "8547-8548:8545-8546"
     environment:
       - ID=1
       - CLUSTER_SIZE=4
@@ -70,6 +71,7 @@ services:
     ports:
       - "26662-26664:26656-26658"
       - "9094-9095:9090-9091"
+      - "8549-8550:8545-8546"
     volumes:
       - "${PROJECT_HOME}:/sei-protocol/sei-chain:Z"
       - "${PROJECT_HOME}/../sei-tendermint:/sei-protocol/sei-tendermint:Z"
@@ -97,6 +99,7 @@ services:
     ports:
       - "26665-26667:26656-26658"
       - "9096-9097:9090-9091"
+      - "8551-8552:8545-8546"
     volumes:
       - "${PROJECT_HOME}:/sei-protocol/sei-chain:Z"
       - "${PROJECT_HOME}/../sei-tendermint:/sei-protocol/sei-tendermint:Z"

--- a/docker/localnode/config/app.toml
+++ b/docker/localnode/config/app.toml
@@ -64,6 +64,12 @@ index-events = []
 # Default cache size is 50mb.
 iavl-cache-size = 781250
 
+# concurrency-workers defines how many workers to run for concurrent transaction execution
+concurrency-workers = 4
+
+# occ-enabled defines whether OCC is enabled or not for transaction execution
+occ-enabled = true
+
 ###############################################################################
 ###                         Telemetry Configuration                         ###
 ###############################################################################

--- a/docker/localnode/scripts/step4_config_override.sh
+++ b/docker/localnode/scripts/step4_config_override.sh
@@ -15,3 +15,6 @@ sed -i'' -e 's/persistent-peers = ""/persistent-peers = "'$PEERS'"/g' ~/.sei/con
 
 # Override snapshot directory
 sed -i.bak -e "s|^snapshot-directory *=.*|snapshot-directory = \"./build/generated/node_$NODE_ID/snapshots\"|" ~/.sei/config/app.toml
+
+# Enable slow mode
+sed -i.bak -e 's/slow = .*/slow = true/' ~/.sei/config/app.toml


### PR DESCRIPTION
## Describe your changes and provide context
This enables OCC execution by default for local docker cluster, and also enables slow=true for better ability to test loadtesting tooling

## Testing performed to validate your change

