### PR TITLE
fix usages in mock balances build path

### DIFF
--- a/.github/workflows/mock_balances_build.yml
+++ b/.github/workflows/mock_balances_build.yml
@@ -1,0 +1,22 @@
+name: Mock Balances Build Check
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  mock-balances-build:
+    name: Compile with Mock Balances
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.21
+
+      - name: Build with Mock Balances
+        run: make install-mock-balances

--- a/x/evm/state/mock_balances.go
+++ b/x/evm/state/mock_balances.go
@@ -2,18 +2,20 @@
 
 package state
 
-// ==============================================================================
-// ============================= !!! WARNING !!! ================================
-// ==============================================================================
-// == This file is ONLY for TESTING PURPOSES.                                  ==
-// == It enables MOCK BALANCES for EVM accounts.                               ==
-// == DO NOT USE IN PRODUCTION OR MAINNET BUILDS.                              ==
-// == This file is included only when the 'mock_balances' build tag is set,    ==
-// == and replaces the existing balance.go file.                               ==
-// == It is used to mock balances for accounts that don't have any balances    ==
-// == yet, and to top off balances when attempting to spend with insufficient  ==
-// == funds.                                                                   ==
-// ==============================================================================
+/*
+==============================================================================
+============================= !!! WARNING !!! ================================
+==============================================================================
+== This file is ONLY for TESTING PURPOSES.                                  ==
+== It enables MOCK BALANCES for EVM accounts.                               ==
+== DO NOT USE IN PRODUCTION OR MAINNET BUILDS.                              ==
+== This file is included only when the 'mock_balances' build tag is set,    ==
+== and replaces the existing balance.go file.                               ==
+== It is used to mock balances for accounts that don't have any balances    ==
+== yet, and to top off balances when attempting to spend with insufficient  ==
+== funds.                                                                   ==
+==============================================================================
+*/
 
 import (
 	"math/big"
@@ -68,7 +70,7 @@ func (s *DBImpl) SubBalance(evmAddr common.Address, amtUint256 *uint256.Int, rea
 		s.logger.OnBalanceChange(evmAddr, oldBalance, newBalance, reason)
 	}
 
-	s.tempStateCurrent.surplus = s.tempStateCurrent.surplus.Add(sdk.NewIntFromBigInt(amt))
+	s.tempState.surplus = s.tempState.surplus.Add(sdk.NewIntFromBigInt(amt))
 	return *ZeroInt
 }
 
@@ -109,7 +111,7 @@ func (s *DBImpl) AddBalance(evmAddr common.Address, amtUint256 *uint256.Int, rea
 		s.logger.OnBalanceChange(evmAddr, oldBalance, newBalance, reason)
 	}
 
-	s.tempStateCurrent.surplus = s.tempStateCurrent.surplus.Sub(sdk.NewIntFromBigInt(amt))
+	s.tempState.surplus = s.tempState.surplus.Sub(sdk.NewIntFromBigInt(amt))
 	return *ZeroInt
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
This fixes some references to struct values that were refactored previously. It also adds a build CI check for the mock balances build tag to verify that new changes don't break the build path like we recently did.

## Testing performed to validate your change
Testing build + new CI check