### PR TITLE
Add periodic rpc stats logs

### DIFF
--- a/evmrpc/association.go
+++ b/evmrpc/association.go
@@ -41,7 +41,7 @@ type AssociateRequest struct {
 
 func (t *AssociationAPI) Associate(ctx context.Context, req *AssociateRequest) (returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("sei_associate", t.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("sei_associate", t.connectionType, startTime, returnErr)
 	rBytes, err := decodeHexString(req.R)
 	if err != nil {
 		return err
@@ -89,7 +89,7 @@ func (t *AssociationAPI) Associate(ctx context.Context, req *AssociateRequest) (
 
 func (t *AssociationAPI) GetSeiAddress(_ context.Context, ethAddress common.Address) (result string, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("sei_getSeiAddress", t.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("sei_getSeiAddress", t.connectionType, startTime, returnErr)
 	seiAddress, found := t.keeper.GetSeiAddress(t.ctxProvider(LatestCtxHeight), ethAddress)
 	if !found {
 		return "", fmt.Errorf("failed to find Sei address for %s", ethAddress.Hex())
@@ -100,7 +100,7 @@ func (t *AssociationAPI) GetSeiAddress(_ context.Context, ethAddress common.Addr
 
 func (t *AssociationAPI) GetEVMAddress(_ context.Context, seiAddress string) (result string, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("sei_getEVMAddress", t.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("sei_getEVMAddress", t.connectionType, startTime, returnErr)
 	seiAddr, err := sdk.AccAddressFromBech32(seiAddress)
 	if err != nil {
 		return "", err
@@ -123,7 +123,7 @@ func decodeHexString(hexString string) ([]byte, error) {
 
 func (t *AssociationAPI) GetCosmosTx(ctx context.Context, ethHash common.Hash) (result string, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("sei_getCosmosTx", t.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("sei_getCosmosTx", t.connectionType, startTime, returnErr)
 	receipt, err := t.keeper.GetReceipt(t.ctxProvider(LatestCtxHeight), ethHash)
 	if err != nil {
 		return "", err
@@ -164,7 +164,7 @@ func (t *AssociationAPI) GetCosmosTx(ctx context.Context, ethHash common.Hash) (
 
 func (t *AssociationAPI) GetEvmTx(ctx context.Context, cosmosHash string) (result string, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("sei_getEvmTx", t.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("sei_getEvmTx", t.connectionType, startTime, returnErr)
 	hashBytes, err := hex.DecodeString(cosmosHash)
 	if err != nil {
 		return "", fmt.Errorf("failed to decode cosmosHash: %w", err)

--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -113,7 +113,7 @@ func (a *SeiBlockAPI) GetBlockByHashExcludeTraceFail(ctx context.Context, blockH
 
 func (a *BlockAPI) GetBlockTransactionCountByNumber(ctx context.Context, number rpc.BlockNumber) (result *hexutil.Uint, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics(fmt.Sprintf("%s_getBlockTransactionCountByNumber", a.namespace), a.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError(fmt.Sprintf("%s_getBlockTransactionCountByNumber", a.namespace), a.connectionType, startTime, returnErr)
 	numberPtr, err := getBlockNumber(ctx, a.tmClient, number)
 	if err != nil {
 		return nil, err
@@ -127,7 +127,7 @@ func (a *BlockAPI) GetBlockTransactionCountByNumber(ctx context.Context, number 
 
 func (a *BlockAPI) GetBlockTransactionCountByHash(ctx context.Context, blockHash common.Hash) (result *hexutil.Uint, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics(fmt.Sprintf("%s_getBlockTransactionCountByHash", a.namespace), a.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError(fmt.Sprintf("%s_getBlockTransactionCountByHash", a.namespace), a.connectionType, startTime, returnErr)
 	block, err := blockByHashWithRetry(ctx, a.tmClient, blockHash[:], 1)
 	if err != nil {
 		return nil, err
@@ -142,7 +142,7 @@ func (a *BlockAPI) GetBlockByHash(ctx context.Context, blockHash common.Hash, fu
 
 func (a *BlockAPI) getBlockByHash(ctx context.Context, blockHash common.Hash, fullTx bool, includeSyntheticTxs bool, isPanicTx func(ctx context.Context, hash common.Hash) (bool, error)) (result map[string]interface{}, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics(fmt.Sprintf("%s_getBlockByHash", a.namespace), a.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError(fmt.Sprintf("%s_getBlockByHash", a.namespace), a.connectionType, startTime, returnErr)
 	block, err := blockByHashWithRetry(ctx, a.tmClient, blockHash[:], 1)
 	if err != nil {
 		return nil, err
@@ -163,7 +163,7 @@ func (a *BlockAPI) getBlockByHash(ctx context.Context, blockHash common.Hash, fu
 
 func (a *BlockAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (result map[string]interface{}, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics(fmt.Sprintf("%s_getBlockByNumber", a.namespace), a.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError(fmt.Sprintf("%s_getBlockByNumber", a.namespace), a.connectionType, startTime, returnErr)
 	if number == 0 {
 		// for compatibility with the graph, always return genesis block
 		return map[string]interface{}{
@@ -199,8 +199,6 @@ func (a *BlockAPI) getBlockByNumber(
 	includeSyntheticTxs bool,
 	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error),
 ) (result map[string]interface{}, returnErr error) {
-	startTime := time.Now()
-	defer recordMetrics(fmt.Sprintf("%s_getBlockByNumber", a.namespace), a.connectionType, startTime, returnErr == nil)
 	numberPtr, err := getBlockNumber(ctx, a.tmClient, number)
 	if err != nil {
 		return nil, err
@@ -225,7 +223,7 @@ func (a *BlockAPI) getBlockByNumber(
 
 func (a *BlockAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (result []map[string]interface{}, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics(fmt.Sprintf("%s_getBlockReceipts", a.namespace), a.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError(fmt.Sprintf("%s_getBlockReceipts", a.namespace), a.connectionType, startTime, returnErr)
 	// Get height from params
 	heightPtr, err := GetBlockNumberByNrOrHash(ctx, a.tmClient, blockNrOrHash)
 	if err != nil {

--- a/evmrpc/config.go
+++ b/evmrpc/config.go
@@ -103,6 +103,9 @@ type Config struct {
 
 	// Timeout for each trace call
 	TraceTimeout time.Duration `mapstructure:"trace_timeout"`
+
+	// RPCStatsInterval for how often to report stats
+	RPCStatsInterval time.Duration `mapstructure:"rpc_stats_interval"`
 }
 
 var DefaultConfig = Config{
@@ -132,6 +135,7 @@ var DefaultConfig = Config{
 	MaxConcurrentSimulationCalls: runtime.NumCPU(),
 	MaxTraceLookbackBlocks:       10000,
 	TraceTimeout:                 30 * time.Second,
+	RPCStatsInterval:             10 * time.Second,
 }
 
 const (
@@ -161,6 +165,7 @@ const (
 	flagMaxConcurrentSimulationCalls = "evm.max_concurrent_simulation_calls"
 	flagMaxTraceLookbackBlocks       = "evm.max_trace_lookback_blocks"
 	flagTraceTimeout                 = "evm.trace_timeout"
+	flagRPCStatsInterval             = "evm.rpc_stats_interval"
 )
 
 func ReadConfig(opts servertypes.AppOptions) (Config, error) {
@@ -293,6 +298,11 @@ func ReadConfig(opts servertypes.AppOptions) (Config, error) {
 	}
 	if v := opts.Get(flagTraceTimeout); v != nil {
 		if cfg.TraceTimeout, err = cast.ToDurationE(v); err != nil {
+			return cfg, err
+		}
+	}
+	if v := opts.Get(flagRPCStatsInterval); v != nil {
+		if cfg.RPCStatsInterval, err = cast.ToDurationE(v); err != nil {
 			return cfg, err
 		}
 	}

--- a/evmrpc/config_test.go
+++ b/evmrpc/config_test.go
@@ -35,6 +35,7 @@ type opts struct {
 	maxConcurrentSimulationCalls interface{}
 	maxTraceLookbackBlocks       interface{}
 	traceTimeout                 interface{}
+	rpcStatsInterval             interface{}
 }
 
 func (o *opts) Get(k string) interface{} {
@@ -116,6 +117,9 @@ func (o *opts) Get(k string) interface{} {
 	if k == "evm.trace_timeout" {
 		return o.traceTimeout
 	}
+	if k == "evm.rpc_stats_interval" {
+		return o.rpcStatsInterval
+	}
 	panic("unknown key")
 }
 
@@ -147,6 +151,7 @@ func TestReadConfig(t *testing.T) {
 		uint64(10),
 		int64(100),
 		30 * time.Second,
+		10 * time.Second,
 	}
 	_, err := evmrpc.ReadConfig(&goodOpts)
 	require.Nil(t, err)

--- a/evmrpc/filter.go
+++ b/evmrpc/filter.go
@@ -369,7 +369,7 @@ func (a *FilterAPI) NewFilter(
 	ctx context.Context,
 	crit filters.FilterCriteria,
 ) (id ethrpc.ID, err error) {
-	defer recordMetrics(fmt.Sprintf("%s_newFilter", a.namespace), a.connectionType, time.Now(), err == nil)
+	defer recordMetricsWithError(fmt.Sprintf("%s_newFilter", a.namespace), a.connectionType, time.Now(), err)
 
 	_, cancel := context.WithCancel(a.shutdownCtx)
 
@@ -390,7 +390,7 @@ func (a *FilterAPI) NewFilter(
 func (a *FilterAPI) NewBlockFilter(
 	ctx context.Context,
 ) (id ethrpc.ID, err error) {
-	defer recordMetrics(fmt.Sprintf("%s_newBlockFilter", a.namespace), a.connectionType, time.Now(), err == nil)
+	defer recordMetricsWithError(fmt.Sprintf("%s_newBlockFilter", a.namespace), a.connectionType, time.Now(), err)
 
 	_, cancel := context.WithCancel(a.shutdownCtx)
 
@@ -411,7 +411,7 @@ func (a *FilterAPI) GetFilterChanges(
 	ctx context.Context,
 	filterID ethrpc.ID,
 ) (res interface{}, err error) {
-	defer recordMetrics(fmt.Sprintf("%s_getFilterChanges", a.namespace), a.connectionType, time.Now(), err == nil)
+	defer recordMetricsWithError(fmt.Sprintf("%s_getFilterChanges", a.namespace), a.connectionType, time.Now(), err)
 
 	// Read filter with read lock
 	a.filtersMu.RLock()
@@ -473,7 +473,7 @@ func (a *FilterAPI) GetFilterLogs(
 	ctx context.Context,
 	filterID ethrpc.ID,
 ) (res []*ethtypes.Log, err error) {
-	defer recordMetrics(fmt.Sprintf("%s_getFilterLogs", a.namespace), a.connectionType, time.Now(), err == nil)
+	defer recordMetricsWithError(fmt.Sprintf("%s_getFilterLogs", a.namespace), a.connectionType, time.Now(), err)
 
 	// Read filter with read lock
 	a.filtersMu.RLock()
@@ -504,7 +504,7 @@ func (a *FilterAPI) GetFilterLogs(
 }
 
 func (a *FilterAPI) GetLogs(ctx context.Context, crit filters.FilterCriteria) (res []*ethtypes.Log, err error) {
-	defer recordMetrics(fmt.Sprintf("%s_getLogs", a.namespace), a.connectionType, time.Now(), err == nil)
+	defer recordMetricsWithError(fmt.Sprintf("%s_getLogs", a.namespace), a.connectionType, time.Now(), err)
 	// Calculate block range
 	latest := a.logFetcher.ctxProvider(LatestCtxHeight).BlockHeight()
 	begin, end := latest, latest
@@ -585,7 +585,7 @@ func (a *FilterAPI) UninstallFilter(
 	_ context.Context,
 	filterID ethrpc.ID,
 ) (res bool) {
-	defer recordMetrics(fmt.Sprintf("%s_uninstallFilter", a.namespace), a.connectionType, time.Now(), res)
+	defer recordMetrics(fmt.Sprintf("%s_uninstallFilter", a.namespace), a.connectionType, time.Now())
 
 	// Check if filter exists
 	a.filtersMu.RLock()

--- a/evmrpc/info.go
+++ b/evmrpc/info.go
@@ -57,11 +57,6 @@ func (i *InfoAPI) ChainId() *hexutil.Big {
 	return (*hexutil.Big)(i.keeper.ChainID(i.ctxProvider(LatestCtxHeight)))
 }
 
-// nolint:revive
-func (i *InfoAPI) Panic() *hexutil.Big {
-	panic("panic intentionally")
-}
-
 func (i *InfoAPI) Coinbase() (addr common.Address, err error) {
 	startTime := time.Now()
 	defer recordMetricsWithError("eth_Coinbase", i.connectionType, startTime, err)

--- a/evmrpc/info.go
+++ b/evmrpc/info.go
@@ -46,26 +46,31 @@ type FeeHistoryResult struct {
 
 func (i *InfoAPI) BlockNumber() hexutil.Uint64 {
 	startTime := time.Now()
-	defer recordMetrics("eth_BlockNumber", i.connectionType, startTime, true)
+	defer recordMetrics("eth_BlockNumber", i.connectionType, startTime)
 	return hexutil.Uint64(i.ctxProvider(LatestCtxHeight).BlockHeight())
 }
 
 //nolint:revive
 func (i *InfoAPI) ChainId() *hexutil.Big {
 	startTime := time.Now()
-	defer recordMetrics("eth_ChainId", i.connectionType, startTime, true)
+	defer recordMetrics("eth_ChainId", i.connectionType, startTime)
 	return (*hexutil.Big)(i.keeper.ChainID(i.ctxProvider(LatestCtxHeight)))
 }
 
-func (i *InfoAPI) Coinbase() (common.Address, error) {
+// nolint:revive
+func (i *InfoAPI) Panic() *hexutil.Big {
+	panic("panic intentionally")
+}
+
+func (i *InfoAPI) Coinbase() (addr common.Address, err error) {
 	startTime := time.Now()
-	defer recordMetrics("eth_Coinbase", i.connectionType, startTime, true)
+	defer recordMetricsWithError("eth_Coinbase", i.connectionType, startTime, err)
 	return i.keeper.GetFeeCollectorAddress(i.ctxProvider(LatestCtxHeight))
 }
 
 func (i *InfoAPI) Accounts() (result []common.Address, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("eth_Accounts", i.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("eth_Accounts", i.connectionType, startTime, returnErr)
 	kb, err := getTestKeyring(i.homeDir)
 	if err != nil {
 		return []common.Address{}, err
@@ -78,7 +83,7 @@ func (i *InfoAPI) Accounts() (result []common.Address, returnErr error) {
 
 func (i *InfoAPI) GasPrice(ctx context.Context) (result *hexutil.Big, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("eth_GasPrice", i.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("eth_GasPrice", i.connectionType, startTime, returnErr)
 	baseFee := i.keeper.GetNextBaseFeePerGas(i.ctxProvider(LatestCtxHeight)).TruncateInt().BigInt()
 	totalGasUsed, err := i.getCongestionData(ctx, nil)
 	if err != nil {
@@ -115,7 +120,7 @@ func (i *InfoAPI) GasPriceHelper(ctx context.Context, baseFee *big.Int, totalGas
 // lastBlock is inclusive
 func (i *InfoAPI) FeeHistory(ctx context.Context, blockCount gmath.HexOrDecimal64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (result *FeeHistoryResult, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("eth_feeHistory", i.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("eth_feeHistory", i.connectionType, startTime, returnErr)
 	result = &FeeHistoryResult{}
 
 	// logic consistent with go-ethereum's validation (block < 1 means no block)
@@ -219,12 +224,12 @@ func (i *InfoAPI) FeeHistory(ctx context.Context, blockCount gmath.HexOrDecimal6
 	return result, nil
 }
 
-func (i *InfoAPI) MaxPriorityFeePerGas(ctx context.Context) (*hexutil.Big, error) {
+func (i *InfoAPI) MaxPriorityFeePerGas(ctx context.Context) (fee *hexutil.Big, returnErr error) {
 	// Checks the most recent block. If it has high gas used, it will return the reward of the 50% percentile.
 	// Otherwise, since the previous block has low gas used, a user shouldn't need to tip a high amount to get included,
 	// so a default value is returned.
 	startTime := time.Now()
-	defer recordMetrics("eth_maxPriorityFeePerGas", i.connectionType, startTime, true)
+	defer recordMetricsWithError("eth_maxPriorityFeePerGas", i.connectionType, startTime, returnErr)
 	totalGasUsed, err := i.getCongestionData(ctx, nil)
 	if err != nil {
 		return nil, err

--- a/evmrpc/net.go
+++ b/evmrpc/net.go
@@ -22,6 +22,6 @@ func NewNetAPI(tmClient rpcclient.Client, k *keeper.Keeper, ctxProvider func(int
 
 func (i *NetAPI) Version() string {
 	startTime := time.Now()
-	defer recordMetrics("net_version", i.connectionType, startTime, true)
+	defer recordMetrics("net_version", i.connectionType, startTime)
 	return fmt.Sprintf("%d", i.keeper.ChainID(i.ctxProvider(LatestCtxHeight)).Uint64())
 }

--- a/evmrpc/send.go
+++ b/evmrpc/send.go
@@ -54,7 +54,7 @@ func NewSendAPI(tmClient rpcclient.Client, txConfigProvider func(int64) client.T
 
 func (s *SendAPI) SendRawTransaction(ctx context.Context, input hexutil.Bytes) (hash common.Hash, err error) {
 	startTime := time.Now()
-	defer recordMetrics("eth_sendRawTransaction", s.connectionType, startTime, err == nil)
+	defer recordMetricsWithError("eth_sendRawTransaction", s.connectionType, startTime, err)
 	tx := new(ethtypes.Transaction)
 	if err = tx.UnmarshalBinary(input); err != nil {
 		return
@@ -167,7 +167,7 @@ func (s *SendAPI) simulateTx(ctx context.Context, tx *ethtypes.Transaction) (est
 
 func (s *SendAPI) SignTransaction(_ context.Context, args apitypes.SendTxArgs, _ *string) (result *export.SignTransactionResult, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("eth_signTransaction", s.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("eth_signTransaction", s.connectionType, startTime, returnErr)
 	unsignedTx, err := args.ToTransaction()
 	if err != nil {
 		return nil, err
@@ -185,7 +185,7 @@ func (s *SendAPI) SignTransaction(_ context.Context, args apitypes.SendTxArgs, _
 
 func (s *SendAPI) SendTransaction(ctx context.Context, args export.TransactionArgs) (result common.Hash, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("eth_sendTransaction", s.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("eth_sendTransaction", s.connectionType, startTime, returnErr)
 	if err := args.SetDefaults(ctx, s.backend, false); err != nil {
 		return common.Hash{}, err
 	}

--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -2,6 +2,8 @@ package evmrpc
 
 import (
 	"context"
+	"strings"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -12,7 +14,6 @@ import (
 	"github.com/sei-protocol/sei-chain/x/evm/keeper"
 	"github.com/tendermint/tendermint/libs/log"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
-	"strings"
 )
 
 type ConnectionType string

--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -13,7 +13,6 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 	"strings"
-	"time"
 )
 
 type ConnectionType string
@@ -44,7 +43,7 @@ func NewEVMHTTPServer(
 	logger = logger.With("module", "evmrpc")
 
 	// Initialize RPC tracker
-	stats.InitRPCTracker(ctxProvider(LatestCtxHeight).Context(), logger, 10*time.Second)
+	stats.InitRPCTracker(ctxProvider(LatestCtxHeight).Context(), logger, config.RPCStatsInterval)
 
 	httpServer := NewHTTPServer(logger, rpc.HTTPTimeouts{
 		ReadTimeout:       config.ReadTimeout,
@@ -184,7 +183,7 @@ func NewEVMWebSocketServer(
 	logger = logger.With("module", "evmrpc")
 
 	// Initialize WebSocket tracker.
-	stats.InitWSTracker(ctxProvider(LatestCtxHeight).Context(), logger, 10*time.Second)
+	stats.InitWSTracker(ctxProvider(LatestCtxHeight).Context(), logger, config.RPCStatsInterval)
 
 	httpServer := NewHTTPServer(logger, rpc.HTTPTimeouts{
 		ReadTimeout:       config.ReadTimeout,

--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -79,7 +79,7 @@ type AccessListResult struct {
 
 func (s *SimulationAPI) CreateAccessList(ctx context.Context, args export.TransactionArgs, blockNrOrHash *rpc.BlockNumberOrHash) (result *AccessListResult, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("eth_createAccessList", s.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("eth_createAccessList", s.connectionType, startTime, returnErr)
 	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
 	if blockNrOrHash != nil {
 		bNrOrHash = *blockNrOrHash
@@ -138,7 +138,7 @@ func (s *SimulationAPI) EstimateGasAfterCalls(ctx context.Context, args export.T
 
 func (s *SimulationAPI) Call(ctx context.Context, args export.TransactionArgs, blockNrOrHash *rpc.BlockNumberOrHash, overrides *export.StateOverride, blockOverrides *export.BlockOverrides) (result hexutil.Bytes, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("eth_call", s.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("eth_call", s.connectionType, startTime, returnErr)
 	/* ---------- fail‑fast limiter ---------- */
 	if s.requestLimiter != nil {
 		if !s.requestLimiter.TryAcquire(1) {

--- a/evmrpc/state.go
+++ b/evmrpc/state.go
@@ -36,7 +36,7 @@ func NewStateAPI(tmClient rpcclient.Client, k *keeper.Keeper, ctxProvider func(i
 
 func (a *StateAPI) GetBalance(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (result *hexutil.Big, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("eth_getBalance", a.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("eth_getBalance", a.connectionType, startTime, returnErr)
 	block, err := GetBlockNumberByNrOrHash(ctx, a.tmClient, blockNrOrHash)
 	if err != nil {
 		return nil, err
@@ -57,7 +57,7 @@ func (a *StateAPI) GetBalance(ctx context.Context, address common.Address, block
 
 func (a *StateAPI) GetCode(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (result hexutil.Bytes, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("eth_getCode", a.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("eth_getCode", a.connectionType, startTime, returnErr)
 	block, err := GetBlockNumberByNrOrHash(ctx, a.tmClient, blockNrOrHash)
 	if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (a *StateAPI) GetCode(ctx context.Context, address common.Address, blockNrO
 
 func (a *StateAPI) GetStorageAt(ctx context.Context, address common.Address, hexKey string, blockNrOrHash rpc.BlockNumberOrHash) (result hexutil.Bytes, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("eth_getStorageAt", a.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("eth_getStorageAt", a.connectionType, startTime, returnErr)
 	block, err := GetBlockNumberByNrOrHash(ctx, a.tmClient, blockNrOrHash)
 	if err != nil {
 		return nil, err
@@ -113,7 +113,7 @@ type ProofResult struct {
 
 func (a *StateAPI) GetProof(ctx context.Context, address common.Address, storageKeys []string, blockNrOrHash rpc.BlockNumberOrHash) (result *ProofResult, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("eth_getProof", a.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("eth_getProof", a.connectionType, startTime, returnErr)
 	var block *coretypes.ResultBlock
 	var err error
 	if blockNr, ok := blockNrOrHash.Number(); ok {
@@ -168,7 +168,7 @@ OUTER:
 
 func (a *StateAPI) GetNonce(_ context.Context, address common.Address) uint64 {
 	startTime := time.Now()
-	defer recordMetrics("eth_getNonce", a.connectionType, startTime, true)
+	defer recordMetrics("eth_getNonce", a.connectionType, startTime)
 	return a.keeper.GetNonce(a.ctxProvider(LatestCtxHeight), address)
 }
 

--- a/evmrpc/stats/tracker.go
+++ b/evmrpc/stats/tracker.go
@@ -41,12 +41,12 @@ type methodStats struct {
 
 // InitRPCTracker initializes the HTTP/RPC tracker.
 func InitRPCTracker(ctx context.Context, logger log.Logger, interval time.Duration) {
-	httpTracker = initTracker(ctx, logger, "http", interval)
+	httpTracker = newTracker(ctx, logger, "http", interval)
 }
 
 // InitWSTracker initializes the WebSocket tracker.
 func InitWSTracker(ctx context.Context, logger log.Logger, interval time.Duration) {
-	wsTracker = initTracker(ctx, logger, "ws", interval)
+	wsTracker = newTracker(ctx, logger, "ws", interval)
 }
 
 type tracker struct {
@@ -62,8 +62,8 @@ type tracker struct {
 	currentPeriod *periodStats
 }
 
-// NewTracker creates a new stats tracker.
-func initTracker(ctx context.Context, logger log.Logger,
+// newTracker creates a new stats tracker.
+func newTracker(ctx context.Context, logger log.Logger,
 	connType string, interval time.Duration) *tracker {
 	logger = logger.With("conn_type", connType)
 	trackerCtx, cancel := context.WithCancel(ctx)

--- a/evmrpc/stats/tracker.go
+++ b/evmrpc/stats/tracker.go
@@ -1,0 +1,330 @@
+package stats
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+type Event struct {
+	Method     string
+	Connection string
+	Duration   time.Duration
+	Success    bool
+	Timestamp  time.Time
+}
+
+// periodStats holds aggregated stats for a time period
+type periodStats struct {
+	periodStart  time.Time
+	connType     string
+	totalEvents  int
+	totalSuccess int
+	methodData   map[string]*methodStats
+}
+
+// methodStats holds per-method aggregated stats
+type methodStats struct {
+	count        int
+	successCount int
+	totalLatency time.Duration
+	maxLatency   time.Duration
+}
+
+type Tracker struct {
+	logger   log.Logger
+	ch       chan Event
+	interval time.Duration
+	ctx      context.Context
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+
+	// Simple current period tracking
+	mu            sync.RWMutex
+	currentPeriod *periodStats
+}
+
+func NewTracker(ctx context.Context, logger log.Logger, interval time.Duration) *Tracker {
+	trackerCtx, cancel := context.WithCancel(ctx)
+
+	t := &Tracker{
+		logger:   logger,
+		ch:       make(chan Event, 10000),
+		interval: interval,
+		ctx:      trackerCtx,
+		cancel:   cancel,
+	}
+
+	t.wg.Add(1)
+	go t.run()
+	return t
+}
+
+func (t *Tracker) Middleware(next http.Handler, connType string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		// Read body for method extraction with error handling
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.logger.Debug("failed to read request body", "error", err)
+		}
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		method := extractMethod(body)
+
+		rw := &responseCapture{ResponseWriter: w, status: 200, captureBody: true}
+
+		// Track panics as failures
+		var panicOccurred bool
+		var panicValue interface{}
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				panicOccurred = true
+				panicValue = recovered
+				// Log the panic for debugging
+				t.logger.Error("panic occurred in RPC handler",
+					"method", method,
+					"connection", connType,
+					"panic", recovered)
+			}
+
+			// Check if response indicates a panic (JSON-RPC error -32603 "method handler crashed")
+			isPanicResponse := rw.isPanicResponse()
+			if isPanicResponse {
+				t.logger.Error("panic detected from response",
+					"method", method,
+					"connection", connType,
+					"response_body", string(rw.body))
+			}
+
+			// Create event and try to send non-blocking
+			event := Event{
+				Method:     method,
+				Connection: connType,
+				Duration:   time.Since(start),
+				Success:    !panicOccurred && !isPanicResponse && rw.status < 400,
+				Timestamp:  start, // Use request start time for bucketing
+			}
+
+			select {
+			case t.ch <- event:
+			default:
+				// Drop on overflow to not block RPC - log at debug level to avoid spam
+				t.logger.Debug("event channel full, dropping event",
+					"method", method,
+					"connection", connType)
+			}
+
+			// Re-panic to maintain original behavior
+			if panicOccurred {
+				panic(panicValue)
+			}
+		}()
+		next.ServeHTTP(rw, r)
+	})
+}
+
+// run processes events continuously and reports periods on interval
+func (t *Tracker) run() {
+	defer t.wg.Done()
+
+	// Report stats every interval
+	ticker := time.NewTicker(t.interval)
+	defer ticker.Stop()
+
+	t.logger.Info("stats tracker started", "interval", t.interval)
+
+	for {
+		select {
+		case <-t.ctx.Done():
+			t.logger.Info("stats tracker stopping", "reason", t.ctx.Err())
+			// Report current period before stopping
+			t.reportCurrentPeriod()
+			return
+		case event := <-t.ch:
+			// Process event immediately
+			t.processEvent(event)
+		case <-ticker.C:
+			// Report current period and start fresh
+			t.reportCurrentPeriod()
+		}
+	}
+}
+
+// processEvent aggregates an event into the current period
+func (t *Tracker) processEvent(event Event) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Initialize current period if needed
+	if t.currentPeriod == nil {
+		t.currentPeriod = &periodStats{
+			periodStart:  time.Now().Truncate(t.interval),
+			connType:     event.Connection,
+			methodData:   make(map[string]*methodStats),
+			totalEvents:  0,
+			totalSuccess: 0,
+		}
+	}
+
+	// Update overall stats
+	t.currentPeriod.totalEvents++
+	if event.Success {
+		t.currentPeriod.totalSuccess++
+	}
+
+	// Get or create method stats
+	method := t.currentPeriod.methodData[event.Method]
+	if method == nil {
+		method = &methodStats{}
+		t.currentPeriod.methodData[event.Method] = method
+	}
+
+	// Update method stats
+	method.count++
+	method.totalLatency += event.Duration
+	if event.Success {
+		method.successCount++
+	}
+	if event.Duration > method.maxLatency {
+		method.maxLatency = event.Duration
+	}
+}
+
+// reportCurrentPeriod reports the current period and starts a new one
+func (t *Tracker) reportCurrentPeriod() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// If no current period, create an empty one for this interval
+	if t.currentPeriod == nil {
+		t.currentPeriod = &periodStats{
+			periodStart:  time.Now().Truncate(t.interval),
+			connType:     "http", // default connection type
+			methodData:   make(map[string]*methodStats),
+			totalEvents:  0,
+			totalSuccess: 0,
+		}
+	}
+
+	// Report the current period
+	t.reportPeriod(t.currentPeriod)
+
+	// Start a new period
+	t.currentPeriod = nil
+}
+
+// reportPeriod logs the stats for a completed period
+func (t *Tracker) reportPeriod(period *periodStats) {
+	// Always log overall stats, even for periods with no events
+	if period.totalEvents == 0 {
+		// Log overall stats for periods with no requests
+		t.logger.Info("stats",
+			"period", period.periodStart.Format("2006-01-02T15:04:05Z"),
+			"count", 0,
+			"conn_type", period.connType,
+			"connections", 0,
+			"interval_ms", t.interval.Milliseconds(),
+		)
+		return // No method stats to report
+	}
+
+	// Calculate overall success rate
+	overallSuccessRate := float64(period.totalSuccess) / float64(period.totalEvents) * 100
+
+	// Log overall stats for this period
+	t.logger.Info("stats",
+		"period", period.periodStart.Format("2006-01-02T15:04:05Z"),
+		"count", period.totalEvents,
+		"success_rate_pct", overallSuccessRate,
+		"conn_type", period.connType,
+		"connections", period.totalEvents,
+		"interval_ms", t.interval.Milliseconds(),
+	)
+
+	// Log per-method stats for this period
+	for method, stats := range period.methodData {
+
+		// Calculate average latency in milliseconds with 2 decimal places
+		avgLatencyMs := float64(stats.totalLatency.Nanoseconds()) / float64(stats.count) / 1000000.0
+		maxLatencyMs := float64(stats.maxLatency.Nanoseconds()) / 1000000.0
+
+		t.logger.Info("method stats",
+			"period", period.periodStart.Format("2006-01-02T15:04:05Z"),
+			"method", method,
+			"count", stats.count,
+			"success", stats.successCount,
+			"fails", stats.count-stats.successCount,
+			"latency_avg", avgLatencyMs,
+			"latency_max", maxLatencyMs,
+		)
+	}
+}
+
+func (t *Tracker) Stop() {
+	t.cancel()  // Cancel context to stop the goroutine
+	t.wg.Wait() // Wait for goroutine to finish
+	t.logger.Info("stats tracker stopped")
+}
+
+type responseCapture struct {
+	http.ResponseWriter
+	status      int
+	body        []byte
+	captureBody bool
+}
+
+// WriteHeader captures status code.
+func (r *responseCapture) WriteHeader(code int) {
+	r.status = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+// Write captures response body if captureBody is enabled.
+func (r *responseCapture) Write(data []byte) (int, error) {
+	if r.captureBody {
+		r.body = append(r.body, data...)
+	}
+	return r.ResponseWriter.Write(data)
+}
+
+// isPanicResponse checks if the response indicates a panic occurred.
+func (r *responseCapture) isPanicResponse() bool {
+	if !r.captureBody || len(r.body) == 0 {
+		return false
+	}
+
+	// Check for JSON-RPC error response with code -32603 and "method handler crashed"
+	bodyStr := string(r.body)
+	return strings.Contains(bodyStr, `"code":-32603`) &&
+		strings.Contains(bodyStr, `"method handler crashed"`)
+}
+
+// minInt returns the minimum of two integers.
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// extractMethod extracts method from JSON payload.
+func extractMethod(body []byte) string {
+	var tmp struct {
+		Method string `json:"method"`
+	}
+	if err := json.Unmarshal(body, &tmp); err == nil {
+		if tmp.Method == "" {
+			return "unknown"
+		}
+		return tmp.Method
+	}
+	return "unknown"
+}

--- a/evmrpc/stats/tracker.go
+++ b/evmrpc/stats/tracker.go
@@ -41,12 +41,16 @@ type methodStats struct {
 
 // InitRPCTracker initializes the HTTP/RPC tracker.
 func InitRPCTracker(ctx context.Context, logger log.Logger, interval time.Duration) {
-	httpTracker = newTracker(ctx, logger, "http", interval)
+	if interval > 0 {
+		httpTracker = newTracker(ctx, logger, "http", interval)
+	}
 }
 
 // InitWSTracker initializes the WebSocket tracker.
 func InitWSTracker(ctx context.Context, logger log.Logger, interval time.Duration) {
-	wsTracker = newTracker(ctx, logger, "ws", interval)
+	if interval > 0 {
+		wsTracker = newTracker(ctx, logger, "ws", interval)
+	}
 }
 
 type tracker struct {

--- a/evmrpc/stats/tracker_test.go
+++ b/evmrpc/stats/tracker_test.go
@@ -93,7 +93,7 @@ func TestTracker(t *testing.T) {
 			setup: func() (*tracker, *mockLogger, context.CancelFunc) {
 				logger := newMockLogger()
 				ctx, cancel := context.WithCancel(context.Background())
-				tracker := NewTracker(ctx, logger, 100*time.Millisecond)
+				tracker := newTracker(ctx, logger, "http", 100*time.Millisecond)
 				return tracker, logger, cancel
 			},
 			test: func(t *testing.T, tracker *tracker, logger *mockLogger) {
@@ -114,7 +114,7 @@ func TestTracker(t *testing.T) {
 			setup: func() (*tracker, *mockLogger, context.CancelFunc) {
 				logger := newMockLogger()
 				ctx, cancel := context.WithCancel(context.Background())
-				tracker := NewTracker(ctx, logger, 100*time.Millisecond)
+				tracker := newTracker(ctx, logger, "http", 100*time.Millisecond)
 				return tracker, logger, cancel
 			},
 			test: func(t *testing.T, tracker *tracker, logger *mockLogger) {
@@ -136,7 +136,7 @@ func TestTracker(t *testing.T) {
 			setup: func() (*tracker, *mockLogger, context.CancelFunc) {
 				logger := newMockLogger()
 				ctx, cancel := context.WithCancel(context.Background())
-				tracker := NewTracker(ctx, logger, 50*time.Millisecond)
+				tracker := newTracker(ctx, logger, "http", 50*time.Millisecond)
 				return tracker, logger, cancel
 			},
 			test: func(t *testing.T, tracker *tracker, logger *mockLogger) {
@@ -173,7 +173,7 @@ func TestTracker(t *testing.T) {
 			setup: func() (*tracker, *mockLogger, context.CancelFunc) {
 				logger := newMockLogger()
 				ctx, cancel := context.WithCancel(context.Background())
-				tracker := NewTracker(ctx, logger, 100*time.Millisecond)
+				tracker := newTracker(ctx, logger, "http", 100*time.Millisecond)
 				return tracker, logger, cancel
 			},
 			test: func(t *testing.T, tracker *tracker, logger *mockLogger) {
@@ -219,7 +219,7 @@ func TestTracker(t *testing.T) {
 			setup: func() (*tracker, *mockLogger, context.CancelFunc) {
 				logger := newMockLogger()
 				ctx, cancel := context.WithCancel(context.Background())
-				tracker := NewTracker(ctx, logger, 1*time.Second) // Longer interval to prevent flushing
+				tracker := newTracker(ctx, logger, "http", 1*time.Second) // Longer interval to prevent flushing
 				return tracker, logger, cancel
 			},
 			test: func(t *testing.T, tracker *tracker, logger *mockLogger) {
@@ -245,7 +245,7 @@ func TestTracker(t *testing.T) {
 			setup: func() (*tracker, *mockLogger, context.CancelFunc) {
 				logger := newMockLogger()
 				ctx, cancel := context.WithCancel(context.Background())
-				tracker := NewTracker(ctx, logger, 200*time.Millisecond)
+				tracker := newTracker(ctx, logger, "http", 200*time.Millisecond)
 				return tracker, logger, cancel
 			},
 			test: func(t *testing.T, tracker *tracker, logger *mockLogger) {
@@ -306,7 +306,7 @@ func TestTracker(t *testing.T) {
 				logger := newMockLogger()
 				ctx, cancel := context.WithCancel(context.Background())
 				// Use very short interval for faster testing
-				tracker := NewTracker(ctx, logger, 50*time.Millisecond)
+				tracker := newTracker(ctx, logger, "http", 50*time.Millisecond)
 				return tracker, logger, cancel
 			},
 			test: func(t *testing.T, tracker *tracker, logger *mockLogger) {
@@ -431,7 +431,7 @@ func TestTrackMessage(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	tracker := NewTracker(ctx, logger, 100*time.Millisecond)
+	tracker := newTracker(ctx, logger, "http", 100*time.Millisecond)
 	defer tracker.Stop()
 
 	// Test tracking different connection types

--- a/evmrpc/stats/tracker_test.go
+++ b/evmrpc/stats/tracker_test.go
@@ -1,0 +1,667 @@
+package stats
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+// mockLogger implements log.Logger for testing
+type mockLogger struct {
+	logs []logEntry
+	mu   sync.Mutex
+}
+
+type logEntry struct {
+	level   string
+	msg     string
+	keyvals []interface{}
+}
+
+func newMockLogger() *mockLogger {
+	return &mockLogger{
+		logs: make([]logEntry, 0),
+	}
+}
+
+func (m *mockLogger) Debug(msg string, keyvals ...interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.logs = append(m.logs, logEntry{level: "debug", msg: msg, keyvals: keyvals})
+}
+
+func (m *mockLogger) Info(msg string, keyvals ...interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.logs = append(m.logs, logEntry{level: "info", msg: msg, keyvals: keyvals})
+}
+
+func (m *mockLogger) Error(msg string, keyvals ...interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.logs = append(m.logs, logEntry{level: "error", msg: msg, keyvals: keyvals})
+}
+
+func (m *mockLogger) With(keyvals ...interface{}) log.Logger {
+	return m // Simple implementation for testing
+}
+
+func (m *mockLogger) getLogs() []logEntry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]logEntry(nil), m.logs...)
+}
+
+func (m *mockLogger) getLogsByLevel(level string) []logEntry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var filtered []logEntry
+	for _, entry := range m.logs {
+		if entry.level == level {
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered
+}
+
+func (m *mockLogger) hasLogWithMessage(msg string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, entry := range m.logs {
+		if entry.msg == msg {
+			return true
+		}
+	}
+	return false
+}
+
+// Test scenarios using struct-based approach
+func TestTracker(t *testing.T) {
+	scenarios := []struct {
+		name        string
+		setup       func() (*Tracker, *mockLogger, context.CancelFunc)
+		test        func(t *testing.T, tracker *Tracker, logger *mockLogger)
+		cleanup     func(*Tracker, context.CancelFunc)
+		expectError bool
+	}{
+		{
+			name: "basic_tracker_creation",
+			setup: func() (*Tracker, *mockLogger, context.CancelFunc) {
+				logger := newMockLogger()
+				ctx, cancel := context.WithCancel(context.Background())
+				tracker := NewTracker(ctx, logger, 100*time.Millisecond)
+				return tracker, logger, cancel
+			},
+			test: func(t *testing.T, tracker *Tracker, logger *mockLogger) {
+				require.NotNil(t, tracker)
+				require.NotNil(t, tracker.ch)
+				require.Equal(t, 100*time.Millisecond, tracker.interval)
+
+				// Wait a bit for startup log
+				time.Sleep(50 * time.Millisecond)
+				require.True(t, logger.hasLogWithMessage("stats tracker started"))
+			},
+			cleanup: func(tracker *Tracker, cancel context.CancelFunc) {
+				tracker.Stop()
+			},
+		},
+		{
+			name: "tracker_stop_lifecycle",
+			setup: func() (*Tracker, *mockLogger, context.CancelFunc) {
+				logger := newMockLogger()
+				ctx, cancel := context.WithCancel(context.Background())
+				tracker := NewTracker(ctx, logger, 100*time.Millisecond)
+				return tracker, logger, cancel
+			},
+			test: func(t *testing.T, tracker *Tracker, logger *mockLogger) {
+				// Let it run briefly
+				time.Sleep(50 * time.Millisecond)
+
+				tracker.Stop()
+
+				// Check stop log appears
+				time.Sleep(50 * time.Millisecond)
+				require.True(t, logger.hasLogWithMessage("stats tracker stopped"))
+			},
+			cleanup: func(tracker *Tracker, cancel context.CancelFunc) {
+				// Already stopped in test
+			},
+		},
+		{
+			name: "middleware_successful_request",
+			setup: func() (*Tracker, *mockLogger, context.CancelFunc) {
+				logger := newMockLogger()
+				ctx, cancel := context.WithCancel(context.Background())
+				tracker := NewTracker(ctx, logger, 50*time.Millisecond)
+				return tracker, logger, cancel
+			},
+			test: func(t *testing.T, tracker *Tracker, logger *mockLogger) {
+				// Create test handler
+				handler := tracker.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte("success"))
+				}), "http")
+
+				// Create test request with JSON-RPC payload
+				payload := `{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x123"],"id":1}`
+				req := httptest.NewRequest("POST", "/", strings.NewReader(payload))
+				req.Header.Set("Content-Type", "application/json")
+
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+
+				require.Equal(t, http.StatusOK, rr.Code)
+				require.Equal(t, "success", rr.Body.String())
+
+				// Give enough time for the event to be processed from the channel
+				time.Sleep(50 * time.Millisecond)
+
+				// Stop the tracker to force reporting of all remaining periods
+				tracker.Stop()
+
+				// Check that stats were logged during shutdown
+				infoLogs := logger.getLogsByLevel("info")
+				var foundOverallStats, foundMethodStats bool
+				for _, log := range infoLogs {
+					if log.msg == "stats" {
+						foundOverallStats = true
+					}
+					if log.msg == "method stats" {
+						foundMethodStats = true
+					}
+				}
+				require.True(t, foundOverallStats, "Expected to find overall stats log")
+				require.True(t, foundMethodStats, "Expected to find method stats log")
+			},
+			cleanup: func(tracker *Tracker, cancel context.CancelFunc) {
+				// Already stopped in test
+			},
+		},
+		{
+			name: "middleware_error_request",
+			setup: func() (*Tracker, *mockLogger, context.CancelFunc) {
+				logger := newMockLogger()
+				ctx, cancel := context.WithCancel(context.Background())
+				tracker := NewTracker(ctx, logger, 100*time.Millisecond)
+				return tracker, logger, cancel
+			},
+			test: func(t *testing.T, tracker *Tracker, logger *mockLogger) {
+				// Create test handler that returns error
+				handler := tracker.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusInternalServerError)
+					w.Write([]byte("error"))
+				}), "websocket")
+
+				payload := `{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[],"id":1}`
+				req := httptest.NewRequest("POST", "/", strings.NewReader(payload))
+
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+
+				require.Equal(t, http.StatusInternalServerError, rr.Code)
+
+				// Give enough time for the event to be processed from the channel
+				time.Sleep(50 * time.Millisecond)
+
+				// Stop the tracker to force reporting of all remaining periods
+				tracker.Stop()
+
+				// Verify error was tracked
+				infoLogs := logger.getLogsByLevel("info")
+				var foundOverallStats, foundMethodStats bool
+				var overallSuccessRate, methodSuccessRate float64
+
+				for _, log := range infoLogs {
+					if log.msg == "stats" {
+						foundOverallStats = true
+						// Check that overall success rate reflects the error
+						for i := 0; i < len(log.keyvals); i += 2 {
+							if log.keyvals[i] == "success_rate_pct" {
+								overallSuccessRate = log.keyvals[i+1].(float64)
+							}
+						}
+					}
+					if log.msg == "method stats" {
+						foundMethodStats = true
+						// Check that method success rate reflects the error
+						for i := 0; i < len(log.keyvals); i += 2 {
+							if log.keyvals[i] == "success_rate_pct" {
+								methodSuccessRate = log.keyvals[i+1].(float64)
+							}
+						}
+					}
+				}
+				require.True(t, foundOverallStats, "Expected to find overall stats log")
+				require.True(t, foundMethodStats, "Expected to find method stats log")
+				require.Equal(t, 0.0, overallSuccessRate, "Expected 0% overall success rate for error request")
+				require.Equal(t, 0.0, methodSuccessRate, "Expected 0% method success rate for error request")
+			},
+			cleanup: func(tracker *Tracker, cancel context.CancelFunc) {
+				// Already stopped in test
+			},
+		},
+		{
+			name: "channel_overflow_handling",
+			setup: func() (*Tracker, *mockLogger, context.CancelFunc) {
+				logger := newMockLogger()
+				ctx, cancel := context.WithCancel(context.Background())
+				tracker := NewTracker(ctx, logger, 1*time.Second) // Longer interval to prevent flushing
+				return tracker, logger, cancel
+			},
+			test: func(t *testing.T, tracker *Tracker, logger *mockLogger) {
+				handler := tracker.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}), "http")
+
+				// Fill the channel beyond capacity (10000 events)
+				// We'll send a reasonable number to test overflow without taking too long
+				for i := 0; i < 100; i++ {
+					req := httptest.NewRequest("POST", "/", strings.NewReader(`{"method":"test"}`))
+					rr := httptest.NewRecorder()
+					handler.ServeHTTP(rr, req)
+				}
+
+				// Check for potential overflow debug logs
+				time.Sleep(50 * time.Millisecond)
+				debugLogs := logger.getLogsByLevel("debug")
+
+				// We might not hit overflow with just 100 requests, but the test verifies the structure works
+				require.True(t, len(debugLogs) >= 0, "Debug logs should be accessible")
+			},
+			cleanup: func(tracker *Tracker, cancel context.CancelFunc) {
+				// Already stopped in test
+			},
+		},
+		{
+			name: "malformed_json_handling",
+			setup: func() (*Tracker, *mockLogger, context.CancelFunc) {
+				logger := newMockLogger()
+				ctx, cancel := context.WithCancel(context.Background())
+				tracker := NewTracker(ctx, logger, 100*time.Millisecond)
+				return tracker, logger, cancel
+			},
+			test: func(t *testing.T, tracker *Tracker, logger *mockLogger) {
+				handler := tracker.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}), "http")
+
+				// Send malformed JSON
+				req := httptest.NewRequest("POST", "/", strings.NewReader(`{invalid json`))
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+
+				require.Equal(t, http.StatusOK, rr.Code)
+
+				// Give a small delay to ensure event is processed
+				time.Sleep(10 * time.Millisecond)
+
+				// Stop the tracker to force reporting of all remaining periods
+				tracker.Stop()
+
+				// Should still log stats with "unknown" method
+				infoLogs := logger.getLogsByLevel("info")
+				var foundOverallStats, foundMethodStats bool
+				for _, log := range infoLogs {
+					if log.msg == "stats" {
+						foundOverallStats = true
+					}
+					if log.msg == "method stats" {
+						foundMethodStats = true
+					}
+				}
+				require.True(t, foundOverallStats, "Expected overall stats log even with malformed JSON")
+				require.True(t, foundMethodStats, "Expected method stats log even with malformed JSON")
+			},
+			cleanup: func(tracker *Tracker, cancel context.CancelFunc) {
+				// Already stopped in test
+			},
+		},
+		{
+			name: "concurrent_requests",
+			setup: func() (*Tracker, *mockLogger, context.CancelFunc) {
+				logger := newMockLogger()
+				ctx, cancel := context.WithCancel(context.Background())
+				tracker := NewTracker(ctx, logger, 200*time.Millisecond)
+				return tracker, logger, cancel
+			},
+			test: func(t *testing.T, tracker *Tracker, logger *mockLogger) {
+				handler := tracker.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// Simulate some processing time
+					time.Sleep(10 * time.Millisecond)
+					w.WriteHeader(http.StatusOK)
+				}), "http")
+
+				// Run concurrent requests
+				var wg sync.WaitGroup
+				numRequests := 50
+
+				for i := 0; i < numRequests; i++ {
+					wg.Add(1)
+					go func(id int) {
+						defer wg.Done()
+						payload := `{"jsonrpc":"2.0","method":"eth_call","params":[],"id":` +
+							string(rune('0'+id%10)) + `}`
+						req := httptest.NewRequest("POST", "/", strings.NewReader(payload))
+						rr := httptest.NewRecorder()
+						handler.ServeHTTP(rr, req)
+						require.Equal(t, http.StatusOK, rr.Code)
+					}(i)
+				}
+
+				wg.Wait()
+
+				// Give enough time for all events to be processed from the channel
+				time.Sleep(100 * time.Millisecond)
+
+				// Stop the tracker to force reporting of all remaining periods
+				tracker.Stop()
+
+				// Verify stats were collected
+				infoLogs := logger.getLogsByLevel("info")
+				var foundOverallStats, foundMethodStats bool
+				var totalEvents int
+				for _, log := range infoLogs {
+					if log.msg == "stats" {
+						foundOverallStats = true
+						for i := 0; i < len(log.keyvals); i += 2 {
+							if log.keyvals[i] == "count" {
+								totalEvents = log.keyvals[i+1].(int)
+								break
+							}
+						}
+					}
+					if log.msg == "method stats" {
+						foundMethodStats = true
+					}
+				}
+				require.True(t, foundOverallStats, "Expected to find overall stats log")
+				require.True(t, foundMethodStats, "Expected to find method stats log")
+				require.Equal(t, numRequests, totalEvents, "Expected all requests to be tracked")
+			},
+			cleanup: func(tracker *Tracker, cancel context.CancelFunc) {
+				tracker.Stop()
+			},
+		},
+		{
+			name: "period_completion_reporting",
+			setup: func() (*Tracker, *mockLogger, context.CancelFunc) {
+				logger := newMockLogger()
+				ctx, cancel := context.WithCancel(context.Background())
+				// Use very short interval for faster testing
+				tracker := NewTracker(ctx, logger, 50*time.Millisecond)
+				return tracker, logger, cancel
+			},
+			test: func(t *testing.T, tracker *Tracker, logger *mockLogger) {
+				handler := tracker.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}), "http")
+
+				// Make a request in the first period
+				payload1 := `{"jsonrpc":"2.0","method":"eth_getBalance","params":[],"id":1}`
+				req1 := httptest.NewRequest("POST", "/", strings.NewReader(payload1))
+				rr1 := httptest.NewRecorder()
+				handler.ServeHTTP(rr1, req1)
+				require.Equal(t, http.StatusOK, rr1.Code)
+
+				// Wait for event to be processed
+				time.Sleep(10 * time.Millisecond)
+
+				// Wait long enough for the period to complete AND for the ticker to trigger reportCompletedPeriods
+				// The ticker runs every 1 second, and we need the period (50ms) + interval (50ms) + ticker time
+				time.Sleep(1200 * time.Millisecond)
+
+				// Check if the first period was automatically reported by reportCompletedPeriods
+				infoLogs := logger.getLogsByLevel("info")
+				var foundAutoReportedPeriod bool
+
+				for _, log := range infoLogs {
+					if log.msg == "stats" {
+						// This should be from automatic period completion, not from Stop()
+						foundAutoReportedPeriod = true
+						break
+					}
+				}
+
+				require.True(t, foundAutoReportedPeriod, "Expected reportCompletedPeriods to automatically report the completed period")
+
+				// Stop tracker
+				tracker.Stop()
+			},
+			cleanup: func(tracker *Tracker, cancel context.CancelFunc) {
+				// Already stopped in test
+			},
+		},
+		{
+			name: "panic_tracking",
+			setup: func() (*Tracker, *mockLogger, context.CancelFunc) {
+				logger := newMockLogger()
+				ctx, cancel := context.WithCancel(context.Background())
+				tracker := NewTracker(ctx, logger, 50*time.Millisecond)
+				return tracker, logger, cancel
+			},
+			test: func(t *testing.T, tracker *Tracker, logger *mockLogger) {
+				handler := tracker.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// Simulate a panic like the eth_panic endpoint
+					panic("test panic")
+				}), "http")
+
+				// Make request that will panic
+				payload := `{"jsonrpc":"2.0","method":"eth_panic","params":[],"id":1}`
+				req := httptest.NewRequest("POST", "/", strings.NewReader(payload))
+
+				// Capture the panic
+				var panicValue interface{}
+				func() {
+					defer func() {
+						panicValue = recover()
+					}()
+					rr := httptest.NewRecorder()
+					handler.ServeHTTP(rr, req)
+				}()
+
+				// Verify panic was re-thrown
+				require.NotNil(t, panicValue, "Expected panic to be re-thrown")
+				require.Equal(t, "test panic", panicValue, "Expected panic value to match")
+
+				// Give time for event to be processed
+				time.Sleep(50 * time.Millisecond)
+
+				// Stop tracker to force reporting
+				tracker.Stop()
+
+				// Verify panic was tracked as failure
+				infoLogs := logger.getLogsByLevel("info")
+				var foundOverallStats, foundMethodStats bool
+				var overallSuccessRate float64
+
+				for _, log := range infoLogs {
+					if log.msg == "stats" {
+						foundOverallStats = true
+						for i := 0; i < len(log.keyvals); i += 2 {
+							if log.keyvals[i] == "success_rate_pct" {
+								overallSuccessRate = log.keyvals[i+1].(float64)
+							}
+						}
+					}
+					if log.msg == "method stats" {
+						foundMethodStats = true
+					}
+				}
+
+				require.True(t, foundOverallStats, "Expected to find overall stats log")
+				require.True(t, foundMethodStats, "Expected to find method stats log")
+				require.Equal(t, 0.0, overallSuccessRate, "Expected 0% success rate for panic")
+
+				// Verify panic was logged as error
+				errorLogs := logger.getLogsByLevel("error")
+				var foundPanicLog bool
+				for _, log := range errorLogs {
+					if log.msg == "panic occurred in RPC handler" {
+						foundPanicLog = true
+						break
+					}
+				}
+				require.True(t, foundPanicLog, "Expected to find panic error log")
+			},
+			cleanup: func(tracker *Tracker, cancel context.CancelFunc) {
+				// Already stopped in test
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			tracker, logger, cancel := scenario.setup()
+
+			// Run the test
+			scenario.test(t, tracker, logger)
+
+			// Cleanup
+			scenario.cleanup(tracker, cancel)
+		})
+	}
+}
+
+func TestExtractMethod(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    []byte
+		expected string
+	}{
+		{
+			name:     "valid_json_rpc",
+			input:    []byte(`{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x123"],"id":1}`),
+			expected: "eth_getBalance",
+		},
+		{
+			name:     "minimal_valid_json",
+			input:    []byte(`{"method":"test_method"}`),
+			expected: "test_method",
+		},
+		{
+			name:     "empty_method",
+			input:    []byte(`{"method":""}`),
+			expected: "unknown",
+		},
+		{
+			name:     "malformed_json",
+			input:    []byte(`{invalid json`),
+			expected: "unknown",
+		},
+		{
+			name:     "missing_method",
+			input:    []byte(`{"jsonrpc":"2.0","params":[],"id":1}`),
+			expected: "unknown",
+		},
+		{
+			name:     "empty_input",
+			input:    []byte(``),
+			expected: "unknown",
+		},
+		{
+			name:     "null_input",
+			input:    nil,
+			expected: "unknown",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := extractMethod(tc.input)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestMinInt(t *testing.T) {
+	testCases := []struct {
+		name     string
+		a, b     int
+		expected int
+	}{
+		{
+			name:     "a_smaller",
+			a:        5,
+			b:        10,
+			expected: 5,
+		},
+		{
+			name:     "b_smaller",
+			a:        10,
+			b:        5,
+			expected: 5,
+		},
+		{
+			name:     "equal",
+			a:        7,
+			b:        7,
+			expected: 7,
+		},
+		{
+			name:     "negative_numbers",
+			a:        -5,
+			b:        -10,
+			expected: -10,
+		},
+		{
+			name:     "zero_and_positive",
+			a:        0,
+			b:        5,
+			expected: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := minInt(tc.a, tc.b)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestResponseCapture(t *testing.T) {
+	testCases := []struct {
+		name           string
+		writeHeader    bool
+		statusCode     int
+		expectedStatus int
+	}{
+		{
+			name:           "default_status_200",
+			writeHeader:    false,
+			expectedStatus: 200,
+		},
+		{
+			name:           "explicit_status_404",
+			writeHeader:    true,
+			statusCode:     404,
+			expectedStatus: 404,
+		},
+		{
+			name:           "explicit_status_500",
+			writeHeader:    true,
+			statusCode:     500,
+			expectedStatus: 500,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			capture := &responseCapture{ResponseWriter: rr, status: 200}
+
+			if tc.writeHeader {
+				capture.WriteHeader(tc.statusCode)
+			}
+
+			require.Equal(t, tc.expectedStatus, capture.status)
+		})
+	}
+}

--- a/evmrpc/subscribe.go
+++ b/evmrpc/subscribe.go
@@ -101,7 +101,7 @@ func handleListener(c chan map[string]interface{}, ethHeader map[string]interfac
 }
 
 func (a *SubscriptionAPI) NewHeads(ctx context.Context) (s *rpc.Subscription, err error) {
-	defer recordMetrics("eth_newHeads", a.connectionType, time.Now(), err == nil)
+	defer recordMetricsWithError("eth_newHeads", a.connectionType, time.Now(), err)
 	notifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {
 		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
@@ -143,7 +143,7 @@ func (a *SubscriptionAPI) NewHeads(ctx context.Context) (s *rpc.Subscription, er
 }
 
 func (a *SubscriptionAPI) Logs(ctx context.Context, filter *filters.FilterCriteria) (s *rpc.Subscription, err error) {
-	defer recordMetrics("eth_logs", a.connectionType, time.Now(), err == nil)
+	defer recordMetricsWithError("eth_logs", a.connectionType, time.Now(), err)
 	notifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {
 		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported

--- a/evmrpc/tests/utils.go
+++ b/evmrpc/tests/utils.go
@@ -123,7 +123,6 @@ func setupTestServer(
 		func(ctx context.Context, hash common.Hash) (bool, error) {
 			return false, nil
 		},
-		nil,
 	)
 	if err != nil {
 		panic(err)

--- a/evmrpc/tests/utils.go
+++ b/evmrpc/tests/utils.go
@@ -123,6 +123,7 @@ func setupTestServer(
 		func(ctx context.Context, hash common.Hash) (bool, error) {
 			return false, nil
 		},
+		nil,
 	)
 	if err != nil {
 		panic(err)

--- a/evmrpc/tracers.go
+++ b/evmrpc/tracers.go
@@ -140,7 +140,7 @@ func (api *DebugAPI) TraceTransaction(ctx context.Context, hash common.Hash, con
 	defer cancel()
 
 	startTime := time.Now()
-	defer recordMetrics("debug_traceTransaction", api.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("debug_traceTransaction", api.connectionType, startTime, returnErr)
 	result, returnErr = api.tracersAPI.TraceTransaction(ctx, hash, config)
 	return
 }
@@ -158,7 +158,7 @@ func (api *SeiDebugAPI) TraceBlockByNumberExcludeTraceFail(ctx context.Context, 
 	}
 
 	startTime := time.Now()
-	defer recordMetrics("sei_traceBlockByNumberExcludeTraceFail", api.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("sei_traceBlockByNumberExcludeTraceFail", api.connectionType, startTime, returnErr)
 	// Accessing tracersAPI from the embedded DebugAPI
 	result, returnErr = api.DebugAPI.tracersAPI.TraceBlockByNumber(ctx, number, config)
 	if returnErr != nil {
@@ -186,7 +186,7 @@ func (api *SeiDebugAPI) TraceBlockByHashExcludeTraceFail(ctx context.Context, ha
 	defer cancel()
 
 	startTime := time.Now()
-	defer recordMetrics("sei_traceBlockByHashExcludeTraceFail", api.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("sei_traceBlockByHashExcludeTraceFail", api.connectionType, startTime, returnErr)
 	// Accessing tracersAPI from the embedded DebugAPI
 	result, returnErr = api.DebugAPI.tracersAPI.TraceBlockByHash(ctx, hash, config)
 	if returnErr != nil {
@@ -272,7 +272,7 @@ func (api *DebugAPI) TraceBlockByNumber(ctx context.Context, number rpc.BlockNum
 	}
 
 	startTime := time.Now()
-	defer recordMetrics("debug_traceBlockByNumber", api.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("debug_traceBlockByNumber", api.connectionType, startTime, returnErr)
 	result, returnErr = api.tracersAPI.TraceBlockByNumber(ctx, number, config)
 	return
 }
@@ -285,7 +285,7 @@ func (api *DebugAPI) TraceBlockByHash(ctx context.Context, hash common.Hash, con
 	defer cancel()
 
 	startTime := time.Now()
-	defer recordMetrics("debug_traceBlockByHash", api.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("debug_traceBlockByHash", api.connectionType, startTime, returnErr)
 	result, returnErr = api.tracersAPI.TraceBlockByHash(ctx, hash, config)
 	return
 }
@@ -298,7 +298,7 @@ func (api *DebugAPI) TraceCall(ctx context.Context, args export.TransactionArgs,
 	defer cancel()
 
 	startTime := time.Now()
-	defer recordMetrics("debug_traceCall", api.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("debug_traceCall", api.connectionType, startTime, returnErr)
 	result, returnErr = api.tracersAPI.TraceCall(ctx, args, blockNrOrHash, config)
 	return
 }

--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -93,7 +93,7 @@ func getTransactionReceipt(
 	signer ethtypes.Signer,
 ) (result map[string]interface{}, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("eth_getTransactionReceipt", t.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("eth_getTransactionReceipt", t.connectionType, startTime, returnErr)
 	sdkctx := t.ctxProvider(LatestCtxHeight)
 
 	if excludePanicTxs {
@@ -170,7 +170,7 @@ func getTransactionReceipt(
 
 func (t *TransactionAPI) GetVMError(hash common.Hash) (result string, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("eth_getVMError", t.connectionType, startTime, true)
+	defer recordMetricsWithError("eth_getVMError", t.connectionType, startTime, returnErr)
 	receipt, err := t.keeper.GetReceipt(t.ctxProvider(LatestCtxHeight), hash)
 	if err != nil {
 		return "", err
@@ -180,7 +180,7 @@ func (t *TransactionAPI) GetVMError(hash common.Hash) (result string, returnErr 
 
 func (t *TransactionAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, txIndex hexutil.Uint) (result *export.RPCTransaction, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("eth_getTransactionByBlockNumberAndIndex", t.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("eth_getTransactionByBlockNumberAndIndex", t.connectionType, startTime, returnErr)
 	return t.getTransactionByBlockNumberAndIndex(ctx, blockNr, NewTransactionIndexFromEVMIndex(uint32(txIndex)))
 }
 
@@ -198,7 +198,7 @@ func (t *TransactionAPI) getTransactionByBlockNumberAndIndex(ctx context.Context
 
 func (t *TransactionAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, txIndex hexutil.Uint) (result *export.RPCTransaction, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("eth_getTransactionByBlockHashAndIndex", t.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("eth_getTransactionByBlockHashAndIndex", t.connectionType, startTime, returnErr)
 	block, err := blockByHash(ctx, t.tmClient, blockHash[:])
 	if err != nil {
 		return nil, err
@@ -208,7 +208,7 @@ func (t *TransactionAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, 
 
 func (t *TransactionAPI) GetTransactionByHash(ctx context.Context, hash common.Hash) (result *export.RPCTransaction, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("eth_getTransactionByHash", t.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("eth_getTransactionByHash", t.connectionType, startTime, returnErr)
 	sdkCtx := t.ctxProvider(LatestCtxHeight)
 	// first try get from mempool
 	for page := 1; page <= UnconfirmedTxQueryMaxPage; page++ {
@@ -261,7 +261,7 @@ func (t *TransactionAPI) GetTransactionByHash(ctx context.Context, hash common.H
 
 func (t *TransactionAPI) GetTransactionErrorByHash(_ context.Context, hash common.Hash) (result string, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("eth_getTransactionErrorByHash", t.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("eth_getTransactionErrorByHash", t.connectionType, startTime, returnErr)
 	receipt, err := t.keeper.GetReceipt(t.ctxProvider(LatestCtxHeight), hash)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
@@ -274,7 +274,7 @@ func (t *TransactionAPI) GetTransactionErrorByHash(_ context.Context, hash commo
 
 func (t *TransactionAPI) GetTransactionCount(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (result *hexutil.Uint64, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("eth_getTransactionCount", t.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("eth_getTransactionCount", t.connectionType, startTime, returnErr)
 	sdkCtx := t.ctxProvider(LatestCtxHeight)
 
 	var pending bool
@@ -348,7 +348,7 @@ func (t *TransactionAPI) getTransactionWithBlock(block *coretypes.ResultBlock, t
 
 func (t *TransactionAPI) Sign(addr common.Address, data hexutil.Bytes) (result hexutil.Bytes, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("eth_sign", t.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("eth_sign", t.connectionType, startTime, returnErr)
 	kb, err := getTestKeyring(t.homeDir)
 	if err != nil {
 		return nil, err

--- a/evmrpc/txpool.go
+++ b/evmrpc/txpool.go
@@ -35,7 +35,7 @@ func NewTxPoolAPI(tmClient rpcclient.Client, k *keeper.Keeper, ctxProvider func(
 // For now, we put all unconfirmed txs in pending and none in queued
 func (t *TxPoolAPI) Content(ctx context.Context) (result map[string]map[string]map[string]*export.RPCTransaction, returnErr error) {
 	startTime := time.Now()
-	defer recordMetrics("sei_content", t.connectionType, startTime, returnErr == nil)
+	defer recordMetricsWithError("sei_content", t.connectionType, startTime, returnErr)
 	content := map[string]map[string]map[string]*export.RPCTransaction{
 		"pending": make(map[string]map[string]*export.RPCTransaction),
 		"queued":  make(map[string]map[string]*export.RPCTransaction),

--- a/evmrpc/utils.go
+++ b/evmrpc/utils.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/sei-protocol/sei-chain/evmrpc/stats"
 	"github.com/sei-protocol/sei-chain/utils/metrics"
 	"github.com/sei-protocol/sei-chain/x/evm/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
@@ -31,6 +32,7 @@ import (
 
 const LatestCtxHeight int64 = -1
 
+// GetBlockNumberByNrOrHash returns the height of the block with the given number or hash.
 func GetBlockNumberByNrOrHash(ctx context.Context, tmClient rpcclient.Client, blockNrOrHash rpc.BlockNumberOrHash) (*int64, error) {
 	if blockNrOrHash.BlockHash != nil {
 		res, err := blockByHash(ctx, tmClient, blockNrOrHash.BlockHash[:])
@@ -172,14 +174,38 @@ func blockByHashWithRetry(ctx context.Context, client rpcclient.Client, hash byt
 	return blockRes, err
 }
 
-func recordMetrics(apiMethod string, connectionType ConnectionType, startTime time.Time, success bool) {
+func recordMetrics(apiMethod string, connectionType ConnectionType, startTime time.Time) {
+	// Automatically detect success/failure based on panic state
+	panicValue := recover()
+	success := panicValue == nil
+
+	// Keep existing metrics for backward compatibility
 	metrics.IncrementRpcRequestCounter(apiMethod, string(connectionType), success)
 	metrics.MeasureRpcRequestLatency(apiMethod, string(connectionType), startTime)
+	stats.RecordAPIInvocation(apiMethod, string(connectionType), startTime, success)
+
+	// If there was a panic, re-panic to preserve the original behavior
+	if !success {
+		panic(panicValue)
+	}
 }
 
 func recordMetricsWithError(apiMethod string, connectionType ConnectionType, startTime time.Time, err error) {
-	metrics.IncrementErrorMetrics(apiMethod, err)
-	recordMetrics(apiMethod, connectionType, startTime, err == nil)
+	// Automatically detect success/failure based on panic state
+	panicValue := recover()
+	success := panicValue == nil || err != nil
+
+	if err != nil {
+		metrics.IncrementErrorMetrics(apiMethod, err)
+	}
+
+	metrics.IncrementRpcRequestCounter(apiMethod, string(connectionType), success)
+	metrics.MeasureRpcRequestLatency(apiMethod, string(connectionType), startTime)
+	stats.RecordAPIInvocation(apiMethod, string(connectionType), startTime, success)
+
+	if panicValue != nil {
+		panic(panicValue)
+	}
 }
 
 func CheckVersion(ctx sdk.Context, k *keeper.Keeper) error {


### PR DESCRIPTION
## Describe your changes and provide context
- every interval (default = 10s)
  - can be overridden with `rpc_stats_interval` setting
- logs success/fail, avg & max duration, count, by method, by connection type (ws | http)
- requests are bucketed by a truncated interval (to 10s interval)
  - requests are bucketed by _completion_ time to simplify bucketing 
- summarizes success/fail and count across methods
- bug fixes
  - fixed double-metric-reporting of get-block-by-number
  - fixed capturing panic as errors
  - fixed capturing certain errors as errors

<img width="1823" height="137" alt="image" src="https://github.com/user-attachments/assets/2a50fda1-8546-490d-a406-853336d21d1a" />


## Notes
- Initially I implemented this with middleware, but that doesn't work for websockets
  - For now, left the `recordMetrics` pattern 
- avg and max are preferred to limit performance issues of bookkeeping
- if the channel is full (should never be), we drop events for safety (and log)

## Testing performed to validate your change
- added unit tests
- ran locally
