### PR TITLE
disallow cancelled integration test to pass CI

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -202,6 +202,10 @@ jobs:
                   echo "Some or all tests have failed!"
                   exit 1
                 fi
+                if [[ "$status" == "cancelled" ]]; then
+                  echo "Some or all tests have been cancelled!"
+                  exit 1
+                fi
               done
 
               echo "All tests have passed!"


### PR DESCRIPTION
## Describe your changes and provide context
If a test times out after 30m it'd have a status of cancelled, which is not caught by our check and thus would allow the PR to be merged

## Testing performed to validate your change

