### PR TITLE
Fix log inclusion conditions

### DIFF
--- a/evmrpc/filter.go
+++ b/evmrpc/filter.go
@@ -796,7 +796,7 @@ func (f *LogFetcher) mergeSortedLogs(batches [][]*ethtypes.Log) []*ethtypes.Log 
 // Pooled version that reuses slice allocation
 func (f *LogFetcher) GetLogsForBlockPooled(block *coretypes.ResultBlock, crit filters.FilterCriteria, filters [][]bloomIndexes, result *[]*ethtypes.Log) {
 	collector := &pooledCollector{logs: result}
-	f.collectLogs(block, crit, filters, collector, true) // Apply exact matching
+	f.collectLogs(block, crit, filters, collector)
 }
 
 func (f *LogFetcher) IsLogExactMatch(log *ethtypes.Log, crit filters.FilterCriteria) bool {
@@ -811,7 +811,7 @@ func (f *LogFetcher) IsLogExactMatch(log *ethtypes.Log, crit filters.FilterCrite
 }
 
 // Unified log collection logic
-func (f *LogFetcher) collectLogs(block *coretypes.ResultBlock, crit filters.FilterCriteria, filters [][]bloomIndexes, collector logCollector, applyExactMatch bool) {
+func (f *LogFetcher) collectLogs(block *coretypes.ResultBlock, crit filters.FilterCriteria, filters [][]bloomIndexes, collector logCollector) {
 	ctx := f.ctxProvider(block.Block.Height)
 	totalLogs := uint(0)
 	evmTxIndex := 0
@@ -836,13 +836,29 @@ func (f *LogFetcher) collectLogs(block *coretypes.ResultBlock, crit filters.Filt
 			setCachedReceipt(block.Block.Height, block, hash, receipt)
 		}
 
+		// no need to include receipts with status 0
+		if receipt.Status == 0 {
+			continue
+		}
+
+		// TODO: simplify this logic once we are confident that the unexpected
+		//       case would not happen.
 		if int64(receipt.BlockNumber) != block.Block.Height {
+			// we never want to include non-synthetic receipts with a block number mismatch
+			if receipt.TxType != evmtypes.ShellEVMTxType {
+				continue
+			}
 			if !f.includeSyntheticReceipts {
 				ctx.Logger().Error(fmt.Sprintf("collectLogs: receipt %s blockNumber=%d != iterHeight=%d; skipping", hash.Hex(), receipt.BlockNumber, block.Block.Height))
 				continue
 			}
+			// this condition corresponds to the case where we have a synthetic receipt
+			// and a block number mismatch, which should never happen, so we log an error
+			ctx.Logger().Error(fmt.Sprintf("collectLogs: synthetic receipt %s blockNumber=%d != iterHeight=%d; skipping", hash.Hex(), receipt.BlockNumber, block.Block.Height))
+			continue
 		}
 
+		// Todo: this may also be simplifiable given the previous conditions.
 		if !f.includeSyntheticReceipts && (receipt.TxType == evmtypes.ShellEVMTxType || receipt.EffectiveGasPrice == 0) {
 			continue
 		}
@@ -856,20 +872,11 @@ func (f *LogFetcher) collectLogs(block *coretypes.ResultBlock, crit filters.Filt
 
 		if len(crit.Addresses) != 0 || len(crit.Topics) != 0 {
 			if len(receipt.LogsBloom) == 0 || MatchFilters(ethtypes.Bloom(receipt.LogsBloom), filters) {
-				if applyExactMatch {
-					for _, log := range txLogs {
-						log.TxIndex = uint(evmTxIndex)
-						log.BlockNumber = uint64(block.Block.Height)
-						log.BlockHash = common.BytesToHash(block.BlockID.Hash)
-						if f.IsLogExactMatch(log, crit) {
-							collector.Append(log)
-						}
-					}
-				} else {
-					for _, log := range txLogs {
-						log.TxIndex = uint(evmTxIndex)
-						log.BlockNumber = uint64(block.Block.Height)
-						log.BlockHash = common.BytesToHash(block.BlockID.Hash)
+				for _, log := range txLogs {
+					log.TxIndex = uint(evmTxIndex)
+					log.BlockNumber = uint64(block.Block.Height)
+					log.BlockHash = common.BytesToHash(block.BlockID.Hash)
+					if f.IsLogExactMatch(log, crit) {
 						collector.Append(log)
 					}
 				}

--- a/evmrpc/tests/log_test.go
+++ b/evmrpc/tests/log_test.go
@@ -50,3 +50,43 @@ func TestGetLogIndex(t *testing.T) {
 		},
 	)
 }
+
+// This tests a scenario where two transactions from the same sender got included
+// in blocks with ordering opposite to the order of their nonce:
+// tx with nonce 2 is included in block 2 but failed because the expected nonce is 1.
+// tx with nonce i is included in block 3 and succeeded, bumping expected nonce to 2.
+// the same tx with nonce 2 is included in block 4 again and succeeded.
+// In this case, there should be no log in block 2 but there should be one in block 4.
+func TestGetLogWithDuplicateTxHash(t *testing.T) {
+	tx1Bz := signAndEncodeTx(sendErc20(2), erc20DeployerMnemonics)
+	tx2Bz := signAndEncodeTx(send(1), erc20DeployerMnemonics)
+	SetupTestServer([][][]byte{{tx1Bz}, {tx2Bz}, {tx1Bz}}, erc20Initializer()).Run(
+		func(port int) {
+			res := sendRequestWithNamespace("eth", port, "getLogs", map[string]interface{}{
+				"fromBlock": "0x2",
+				"toBlock":   "0x2",
+				"address":   erc20Addr.Hex(),
+			})
+			require.Len(t, res["result"], 0)
+			res = sendRequestWithNamespace("eth", port, "getLogs", map[string]interface{}{
+				"fromBlock": "0x4",
+				"toBlock":   "0x4",
+				"address":   erc20Addr.Hex(),
+			})
+			require.Len(t, res["result"], 1)
+
+			res = sendRequestWithNamespace("sei", port, "getLogs", map[string]interface{}{
+				"fromBlock": "0x2",
+				"toBlock":   "0x2",
+				"address":   erc20Addr.Hex(),
+			})
+			require.Len(t, res["result"], 0)
+			res = sendRequestWithNamespace("sei", port, "getLogs", map[string]interface{}{
+				"fromBlock": "0x4",
+				"toBlock":   "0x4",
+				"address":   erc20Addr.Hex(),
+			})
+			require.Len(t, res["result"], 1)
+		},
+	)
+}


### PR DESCRIPTION
## Describe your changes and provide context
This adds two conditions to determine whether a log should be included:
- if the receipt has status failed (0), it should never be included
- if the receipt's block number doesn't match the block's block number (e.g. in the case of a failed tx with higher nonce), it should never be included.

The conditions right now are explicitly listed out so looks lengthy. Eventually we can simplify it once we are confident with the logic.
## Testing performed to validate your change
unit test & test on node
