### PR TITLE
Update golangci.yml

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.21
+          cache: true
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
Enabled Go module caching in the golangci-lint workflow so future runs can reuse previously downloaded dependencies, improving lint job performance

Testing
⚠️ actionlint .github/workflows/golangci.yml (command not found)

⚠️ go test ./... (failed: fetching modules returned 403 Forbidden)

✅ go version

## Describe your changes and provide context

## Testing performed to validate your change

