### PR TITLE
Fix log inclusion conditions

### DIFF
--- a/evmrpc/block_test.go
+++ b/evmrpc/block_test.go
@@ -430,30 +430,32 @@ func TestEthBloom_ExcludesSyntheticTopics(t *testing.T) {
 	require.True(t, ethtypes.BloomLookup(bloomSei, evmTopic), "sei bloom should include real EVM topic")
 }
 
-func TestGetLogs_SyntheticTopic_EthVsSei(t *testing.T) {
-	// Synthetic-only topic
-	synthTopic := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000234")
+// REMOVED BECAUSE THE SETUP IS WRONG (WITH INCONSISTENT BLOCK NUMBER). REPLACED BY TESTS
+// UNDER /tests.
+// func TestGetLogs_SyntheticTopic_EthVsSei(t *testing.T) {
+// 	// Synthetic-only topic
+// 	synthTopic := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000234")
 
-	// Query a small range that has bloom + synthetic activity
-	crit := map[string]interface{}{
-		"fromBlock": "0x8",
-		"toBlock":   "0x8",
-		"topics":    [][]common.Hash{{synthTopic}},
-	}
+// 	// Query a small range that has bloom + synthetic activity
+// 	crit := map[string]interface{}{
+// 		"fromBlock": "0x8",
+// 		"toBlock":   "0x8",
+// 		"topics":    [][]common.Hash{{synthTopic}},
+// 	}
 
-	// eth_: should exclude synthetic logs completely
-	resEth := sendRequestGood(t, "getLogs", crit)
-	logsEth, ok := resEth["result"].([]interface{})
-	require.True(t, ok, "eth_getLogs: result should be an array")
-	require.Equal(t, 0, len(logsEth), "eth_getLogs should NOT return synthetic-only logs")
+// 	// eth_: should exclude synthetic logs completely
+// 	resEth := sendRequestGood(t, "getLogs", crit)
+// 	logsEth, ok := resEth["result"].([]interface{})
+// 	require.True(t, ok, "eth_getLogs: result should be an array")
+// 	require.Equal(t, 0, len(logsEth), "eth_getLogs should NOT return synthetic-only logs")
 
-	// sei_: should include synthetic logs
-	resSei := sendSeiRequestGood(t, "getLogs", crit)
-	logsSei, ok := resSei["result"].([]interface{})
-	require.True(t, ok, "sei_getLogs: result should be an array")
-	require.GreaterOrEqual(t, len(logsSei), 1, "sei_getLogs should include synthetic logs")
+// 	// sei_: should include synthetic logs
+// 	resSei := sendSeiRequestGood(t, "getLogs", crit)
+// 	logsSei, ok := resSei["result"].([]interface{})
+// 	require.True(t, ok, "sei_getLogs: result should be an array")
+// 	require.GreaterOrEqual(t, len(logsSei), 1, "sei_getLogs should include synthetic logs")
 
-	first := logsSei[0].(map[string]interface{})
-	topics := first["topics"].([]interface{})
-	require.Equal(t, synthTopic.Hex(), topics[0].(string))
-}
+// 	first := logsSei[0].(map[string]interface{})
+// 	topics := first["topics"].([]interface{})
+// 	require.Equal(t, synthTopic.Hex(), topics[0].(string))
+// }

--- a/evmrpc/filter.go
+++ b/evmrpc/filter.go
@@ -836,11 +836,8 @@ func (f *LogFetcher) collectLogs(block *coretypes.ResultBlock, crit filters.Filt
 			setCachedReceipt(block.Block.Height, block, hash, receipt)
 		}
 
-		if int64(receipt.BlockNumber) != block.Block.Height {
-			if !f.includeSyntheticReceipts {
-				ctx.Logger().Error(fmt.Sprintf("collectLogs: receipt %s blockNumber=%d != iterHeight=%d; skipping", hash.Hex(), receipt.BlockNumber, block.Block.Height))
-				continue
-			}
+		if receipt.BlockNumber != uint64(block.Block.Height) {
+			continue
 		}
 
 		if !f.includeSyntheticReceipts && (receipt.TxType == evmtypes.ShellEVMTxType || receipt.EffectiveGasPrice == 0) {

--- a/evmrpc/filter_test.go
+++ b/evmrpc/filter_test.go
@@ -196,45 +196,47 @@ func TestFilterGetLogs(t *testing.T) {
 	testFilterGetLogs(t, "eth", getCommonFilterLogTests())
 }
 
-func TestFilterSeiGetLogs(t *testing.T) {
-	// make sure we pass all the eth_ namespace tests
-	testFilterGetLogs(t, "sei", getCommonFilterLogTests())
+// REMOVED BECAUSE THE SETUP IS WRONG (WITH INCONSISTENT BLOCK NUMBER). REPLACED BY TESTS
+// UNDER /tests.
+// func TestFilterSeiGetLogs(t *testing.T) {
+// 	// make sure we pass all the eth_ namespace tests
+// 	testFilterGetLogs(t, "sei", getCommonFilterLogTests())
 
-	// test where we get a synthetic log
-	testFilterGetLogs(t, "sei", []GetFilterLogTests{
-		{
-			name:      "filter by single synthetic address",
-			fromBlock: "0x64",
-			toBlock:   "0x64",
-			addrs:     []common.Address{common.HexToAddress("0x1111111111111111111111111111111111111116")},
-			wantErr:   false,
-			check: func(t *testing.T, log map[string]interface{}) {
-				require.Equal(t, "0x1111111111111111111111111111111111111116", log["address"].(string))
-			},
-			wantLen: 1,
-		},
-		{
-			name:      "filter by single topic, include synethetic logs",
-			topics:    [][]common.Hash{{common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000234")}},
-			wantErr:   false,
-			fromBlock: "0x64",
-			toBlock:   "0x64",
-			check: func(t *testing.T, log map[string]interface{}) {
-				require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000234", log["topics"].([]interface{})[0].(string))
-			},
-			wantLen: 1,
-		},
-		{
-			name:    "filter by single topic with default range, include synethetic logs",
-			topics:  [][]common.Hash{{common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000234")}},
-			wantErr: false,
-			check: func(t *testing.T, log map[string]interface{}) {
-				require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000234", log["topics"].([]interface{})[0].(string))
-			},
-			wantLen: 1,
-		},
-	})
-}
+// 	// test where we get a synthetic log
+// 	testFilterGetLogs(t, "sei", []GetFilterLogTests{
+// 		{
+// 			name:      "filter by single synthetic address",
+// 			fromBlock: "0x64",
+// 			toBlock:   "0x64",
+// 			addrs:     []common.Address{common.HexToAddress("0x1111111111111111111111111111111111111116")},
+// 			wantErr:   false,
+// 			check: func(t *testing.T, log map[string]interface{}) {
+// 				require.Equal(t, "0x1111111111111111111111111111111111111116", log["address"].(string))
+// 			},
+// 			wantLen: 1,
+// 		},
+// 		{
+// 			name:      "filter by single topic, include synethetic logs",
+// 			topics:    [][]common.Hash{{common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000234")}},
+// 			wantErr:   false,
+// 			fromBlock: "0x64",
+// 			toBlock:   "0x64",
+// 			check: func(t *testing.T, log map[string]interface{}) {
+// 				require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000234", log["topics"].([]interface{})[0].(string))
+// 			},
+// 			wantLen: 1,
+// 		},
+// 		{
+// 			name:    "filter by single topic with default range, include synethetic logs",
+// 			topics:  [][]common.Hash{{common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000234")}},
+// 			wantErr: false,
+// 			check: func(t *testing.T, log map[string]interface{}) {
+// 				require.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000234", log["topics"].([]interface{})[0].(string))
+// 			},
+// 			wantLen: 1,
+// 		},
+// 	})
+// }
 
 func TestFilterEthEndpointReturnsNormalEvmLogEvenIfSyntheticLogIsInSameBlock(t *testing.T) {
 	testFilterGetLogs(t, "eth", []GetFilterLogTests{

--- a/evmrpc/tests/log_test.go
+++ b/evmrpc/tests/log_test.go
@@ -50,3 +50,17 @@ func TestGetLogIndex(t *testing.T) {
 		},
 	)
 }
+
+func TestGetLogsAnteError(t *testing.T) {
+	txBz1 := signAndEncodeTx(depositErc20(2), erc20DeployerMnemonics)
+	txBz2 := signAndEncodeTx(send(1), erc20DeployerMnemonics)
+	SetupTestServer([][][]byte{{txBz1}, {txBz2}, {txBz1}}, erc20Initializer()).Run(
+		func(port int) {
+			res := sendRequestWithNamespace("eth", port, "getLogs", map[string]interface{}{
+				"toBlock": "latest",
+				"address": erc20Addr.Hex(),
+			})
+			require.Len(t, res["result"], 1)
+		},
+	)
+}


### PR DESCRIPTION
## Describe your changes and provide context
This adds two conditions to determine whether a log should be included:

if the receipt's block number doesn't match the block's block number (e.g. in the case of a failed tx with higher nonce), it should never be included.

The conditions right now are explicitly listed out so looks lengthy. Eventually we can simplify it once we are confident with the logic.

## Testing performed to validate your change
unit test & test on node
