### PR TITLE
Remove prefill estimates scheduler code path

### DIFF
--- a/sei-cosmos/tasks/scheduler.go
+++ b/sei-cosmos/tasks/scheduler.go
@@ -256,18 +256,6 @@ func allValidated(tasks []*deliverTxTask) bool {
 	return true
 }
 
-func (s *scheduler) PrefillEstimates(reqs []*sdk.DeliverTxEntry) {
-	// iterate over TXs, update estimated writesets where applicable
-	for _, req := range reqs {
-		mappedWritesets := req.EstimatedWritesets
-		// order shouldnt matter for storeKeys because each storeKey partitioned MVS is independent
-		for storeKey, writeset := range mappedWritesets {
-			// we use `-1` to indicate a prefill incarnation
-			s.multiVersionStores[storeKey].SetEstimatedWriteset(req.AbsoluteIndex, -1, writeset)
-		}
-	}
-}
-
 // schedulerMetrics contains metrics for the scheduler
 type schedulerMetrics struct {
 	// maxIncarnation is the highest incarnation seen in this set
@@ -286,9 +274,6 @@ func (s *scheduler) ProcessAll(ctx sdk.Context, reqs []*sdk.DeliverTxEntry) ([]t
 	var iterations int
 	// initialize mutli-version stores if they haven't been initialized yet
 	s.tryInitMultiVersionStore(ctx)
-	// prefill estimates
-	// This "optimization" path is being disabled because we don't have a strong reason to have it given that it
-	// s.PrefillEstimates(reqs)
 	tasks, tasksMap := toTasks(reqs)
 	s.allTasks = tasks
 	s.allTasksMap = tasksMap

--- a/sei-cosmos/tasks/scheduler_test.go
+++ b/sei-cosmos/tasks/scheduler_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/cachekv"
 	"github.com/cosmos/cosmos-sdk/store/cachemulti"
 	"github.com/cosmos/cosmos-sdk/store/dbadapter"
-	"github.com/cosmos/cosmos-sdk/store/multiversion"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/occ"
 	"github.com/cosmos/cosmos-sdk/utils/tracing"
@@ -56,25 +55,6 @@ func abortRecoveryFunc(response *types.ResponseDeliverTx) {
 		// empty code and codespace
 		response.Info = "occ abort"
 	}
-}
-
-func requestListWithEstimatedWritesets(n int) []*sdk.DeliverTxEntry {
-	tasks := make([]*sdk.DeliverTxEntry, n)
-	for i := 0; i < n; i++ {
-		tasks[i] = &sdk.DeliverTxEntry{
-			Request: types.RequestDeliverTx{
-				Tx: []byte(fmt.Sprintf("%d", i)),
-			},
-			AbsoluteIndex: i,
-			EstimatedWritesets: sdk.MappedWritesets{
-				testStoreKey: multiversion.WriteSet{
-					string(itemKey): []byte("foo"),
-				},
-			},
-		}
-
-	}
-	return tasks
 }
 
 func initTestCtx(injectStores bool) sdk.Context {
@@ -242,42 +222,6 @@ func TestProcessAll(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			name:      "Test every tx accesses same key with estimated writesets",
-			workers:   50,
-			runs:      1,
-			addStores: true,
-			requests:  requestListWithEstimatedWritesets(1000),
-			deliverTxFunc: func(ctx sdk.Context, req types.RequestDeliverTx, tx sdk.Tx, checksum [32]byte) (res types.ResponseDeliverTx) {
-				defer abortRecoveryFunc(&res)
-				// all txs read and write to the same key to maximize conflicts
-				kv := ctx.MultiStore().GetKVStore(testStoreKey)
-				val := string(kv.Get(itemKey))
-
-				// write to the store with this tx's index
-				kv.Set(itemKey, req.Tx)
-
-				// return what was read from the store (final attempt should be index-1)
-				return types.ResponseDeliverTx{
-					Info: val,
-				}
-			},
-			assertions: func(t *testing.T, ctx sdk.Context, res []types.ResponseDeliverTx) {
-				for idx, response := range res {
-					if idx == 0 {
-						require.Equal(t, "", response.Info)
-					} else {
-						// the info is what was read from the kv store by the tx
-						// each tx writes its own index, so the info should be the index of the previous tx
-						require.Equal(t, fmt.Sprintf("%d", idx-1), response.Info)
-					}
-				}
-				// confirm last write made it to the parent store
-				latest := ctx.MultiStore().GetKVStore(testStoreKey).Get(itemKey)
-				require.Equal(t, []byte(fmt.Sprintf("%d", len(res)-1)), latest)
-			},
-			expectedErr: nil,
-		},
-		{
 			name:      "Test some tx accesses same key",
 			workers:   50,
 			runs:      1,
@@ -321,42 +265,6 @@ func TestProcessAll(t *testing.T) {
 				for idx, response := range res {
 					require.Equal(t, fmt.Sprintf("%d", idx), response.Info)
 				}
-			},
-			expectedErr: nil,
-		},
-		{
-			name:      "Test every tx accesses same key with estimated writesets",
-			workers:   50,
-			runs:      1,
-			addStores: true,
-			requests:  requestListWithEstimatedWritesets(1000),
-			deliverTxFunc: func(ctx sdk.Context, req types.RequestDeliverTx, tx sdk.Tx, checksum [32]byte) (res types.ResponseDeliverTx) {
-				defer abortRecoveryFunc(&res)
-				// all txs read and write to the same key to maximize conflicts
-				kv := ctx.MultiStore().GetKVStore(testStoreKey)
-				val := string(kv.Get(itemKey))
-
-				// write to the store with this tx's index
-				kv.Set(itemKey, req.Tx)
-
-				// return what was read from the store (final attempt should be index-1)
-				return types.ResponseDeliverTx{
-					Info: val,
-				}
-			},
-			assertions: func(t *testing.T, ctx sdk.Context, res []types.ResponseDeliverTx) {
-				for idx, response := range res {
-					if idx == 0 {
-						require.Equal(t, "", response.Info)
-					} else {
-						// the info is what was read from the kv store by the tx
-						// each tx writes its own index, so the info should be the index of the previous tx
-						require.Equal(t, fmt.Sprintf("%d", idx-1), response.Info)
-					}
-				}
-				// confirm last write made it to the parent store
-				latest := ctx.MultiStore().GetKVStore(testStoreKey).Get(itemKey)
-				require.Equal(t, []byte(fmt.Sprintf("%d", len(res)-1)), latest)
 			},
 			expectedErr: nil,
 		},

--- a/sei-cosmos/types/tx_batch.go
+++ b/sei-cosmos/types/tx_batch.go
@@ -1,23 +1,18 @@
 package types
 
 import (
-	"github.com/cosmos/cosmos-sdk/store/multiversion"
 	abci "github.com/tendermint/tendermint/abci/types"
 )
 
 // DeliverTxEntry represents an individual transaction's request within a batch.
 // This can be extended to include tx-level metadata
 type DeliverTxEntry struct {
-	Request            abci.RequestDeliverTx
-	SdkTx              Tx
-	Checksum           [32]byte
-	AbsoluteIndex      int
-	EstimatedWritesets MappedWritesets
-	TxTracer           TxTracer
+	Request       abci.RequestDeliverTx
+	SdkTx         Tx
+	Checksum      [32]byte
+	AbsoluteIndex int
+	TxTracer      TxTracer
 }
-
-// EstimatedWritesets represents an estimated writeset for a transaction mapped by storekey to the writeset estimate.
-type MappedWritesets map[StoreKey]multiversion.WriteSet
 
 // DeliverTxBatchRequest represents a request object for a batch of transactions.
 // This can be extended to include request-level tracing or metadata

--- a/sei-cosmos/x/accesscontrol/keeper/keeper.go
+++ b/sei-cosmos/x/accesscontrol/keeper/keeper.go
@@ -12,7 +12,6 @@ import (
 	"github.com/yourbasic/graph"
 
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/cosmos/cosmos-sdk/store/multiversion"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	acltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
@@ -503,53 +502,6 @@ func (k Keeper) GetStoreKeyMap(ctx sdk.Context) storeKeyMap {
 		storeKeyMap[storeKey.Name()] = storeKey
 	}
 	return storeKeyMap
-}
-
-func (k Keeper) UpdateWritesetsWithAccessOps(accessOps []acltypes.AccessOperation, mappedWritesets sdk.MappedWritesets, storeKeyMap storeKeyMap) sdk.MappedWritesets {
-	for _, accessOp := range accessOps {
-		// we only want writes and unknowns (assumed writes)
-		if accessOp.AccessType != acltypes.AccessType_WRITE && accessOp.AccessType != acltypes.AccessType_UNKNOWN {
-			continue
-		}
-		// the accessOps should only have SPECIFIC identifiers (we don't want wildcards)
-		if accessOp.IdentifierTemplate == "*" {
-			continue
-		}
-		// check the resource type to store key map for potential store key
-		if storeKeyStr, ok := k.ResourceTypeStoreKeyMapping[accessOp.ResourceType]; ok {
-			// check that we have a storekey corresponding to that string
-			if storeKey, ok2 := storeKeyMap[storeKeyStr]; ok2 {
-				// if we have a StoreKey, add it to the writeset - writing empty bytes is ok because it will be saved as EstimatedWriteset
-				if _, ok := mappedWritesets[storeKey]; !ok {
-					mappedWritesets[storeKey] = make(multiversion.WriteSet)
-				}
-				mappedWritesets[storeKey][accessOp.IdentifierTemplate] = []byte{}
-			}
-		}
-
-	}
-	return mappedWritesets
-}
-
-// GenerateEstimatedWritesets utilizes the existing patterns for access operation generation to estimate the writesets for a transaction
-func (k Keeper) GenerateEstimatedWritesets(ctx sdk.Context, anteDepGen sdk.AnteDepGenerator, txIndex int, tx sdk.Tx) (sdk.MappedWritesets, error) {
-	storeKeyMap := k.GetStoreKeyMap(ctx)
-	writesets := make(sdk.MappedWritesets)
-	// generate antedeps accessOps for tx
-	anteDeps, err := anteDepGen([]acltypes.AccessOperation{}, tx, txIndex)
-	if err != nil {
-		return nil, err
-	}
-	writesets = k.UpdateWritesetsWithAccessOps(anteDeps, writesets, storeKeyMap)
-
-	// generate accessOps for each message
-	msgs := tx.GetMsgs()
-	for _, msg := range msgs {
-		msgDependencies := k.GetMessageDependencies(ctx, msg)
-		// update estimated writeset for each message deps
-		writesets = k.UpdateWritesetsWithAccessOps(msgDependencies, writesets, storeKeyMap)
-	}
-	return writesets, nil
 }
 
 func (k Keeper) BuildDependencyDag(ctx sdk.Context, anteDepGen sdk.AnteDepGenerator, txs []sdk.Tx) (*types.Dag, error) {

--- a/sei-cosmos/x/accesscontrol/keeper/keeper_test.go
+++ b/sei-cosmos/x/accesscontrol/keeper/keeper_test.go
@@ -20,7 +20,6 @@ import (
 	aclkeeper "github.com/cosmos/cosmos-sdk/x/accesscontrol/keeper"
 	acltestutil "github.com/cosmos/cosmos-sdk/x/accesscontrol/testutil"
 	"github.com/cosmos/cosmos-sdk/x/accesscontrol/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -2638,40 +2637,6 @@ func (suite *KeeperTestSuite) TestBuildSelectorOps_AccessOperationSelectorType_C
 	_, err := app.AccessControlKeeper.BuildSelectorOps(
 		ctx, wasmContractAddresses[0], accessOps, wasmContractAddresses[0].String(), msgInfo, make(aclkeeper.ContractReferenceLookupMap))
 	req.NoError(err)
-}
-
-func TestGenerateEstimatedDependencies(t *testing.T) {
-	app := simapp.Setup(false)
-	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
-
-	accounts := simapp.AddTestAddrsIncremental(app, ctx, 2, sdk.NewInt(30000000))
-	// setup test txs
-	msgs := []sdk.Msg{
-		banktypes.NewMsgSend(accounts[0], accounts[1], sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(1)))),
-	}
-	// set up testing mapping
-	app.AccessControlKeeper.ResourceTypeStoreKeyMapping = map[acltypes.ResourceType]string{
-		acltypes.ResourceType_KV_BANK_BALANCES:      banktypes.StoreKey,
-		acltypes.ResourceType_KV_AUTH_ADDRESS_STORE: authtypes.StoreKey,
-	}
-
-	storeKeyMap := app.AccessControlKeeper.GetStoreKeyMap(ctx)
-
-	txBuilder := simapp.MakeTestEncodingConfig().TxConfig.NewTxBuilder()
-	err := txBuilder.SetMsgs(msgs...)
-	require.NoError(t, err)
-
-	writesets, err := app.AccessControlKeeper.GenerateEstimatedWritesets(ctx, app.GetAnteDepGenerator(), 0, txBuilder.GetTx())
-	require.NoError(t, err)
-
-	// check writesets
-	require.Equal(t, 2, len(writesets))
-	bankWritesets := writesets[storeKeyMap[banktypes.StoreKey]]
-	require.Equal(t, 3, len(bankWritesets))
-
-	authWritesets := writesets[storeKeyMap[authtypes.StoreKey]]
-	require.Equal(t, 1, len(authWritesets))
-
 }
 
 func TestKeeperTestSuite(t *testing.T) {


### PR DESCRIPTION
Port of the original work done by @udpatil in https://github.com/sei-protocol/sei-cosmos/pull/602

## Describe your changes and provide context
Because we established that prefilling estimates doesn't improve performance and have removed it from sei-chain, we can remove the prefillEstimates code path from occ scheduler since its no longer being used.

## Testing performed to validate your change
Updated unit tests to remove unnecessary tests.

