### PR TITLE
Remove duplicate panic recovery in process proposal

### DIFF
--- a/sei-cosmos/baseapp/abci.go
+++ b/sei-cosmos/baseapp/abci.go
@@ -1117,20 +1117,6 @@ func (app *BaseApp) ProcessProposal(ctx context.Context, req *abci.RequestProces
 		}
 	}()
 
-	defer func() {
-		if err := recover(); err != nil {
-			app.logger.Error(
-				"panic recovered in ProcessProposal",
-				"height", req.Height,
-				"time", req.Time,
-				"hash", fmt.Sprintf("%X", req.Hash),
-				"panic", err,
-			)
-
-			resp = &abci.ResponseProcessProposal{Status: abci.ResponseProcessProposal_REJECT}
-		}
-	}()
-
 	if app.processProposalHandler != nil {
 		resp, err = app.processProposalHandler(app.processProposalState.ctx, req)
 		if err != nil {


### PR DESCRIPTION
Port of original work in https://github.com/sei-protocol/sei-cosmos/pull/601

The panic recovery block seems to be repeated twice. This might have been an error rebasing or found its way in by accident?
