### PR TITLE
test to reproduce out of order nonce

### DIFF
--- a/sei-tendermint/abci/client/grpc_client.go
+++ b/sei-tendermint/abci/client/grpc_client.go
@@ -190,3 +190,12 @@ func (cli *grpcClient) LoadLatest(ctx context.Context, params *types.RequestLoad
 func (cli *grpcClient) GetTxPriorityHint(ctx context.Context, req *types.RequestGetTxPriorityHint) (*types.ResponseGetTxPriorityHint, error) {
 	return cli.client.GetTxPriorityHint(ctx, types.ToRequestGetTxPriorityHint(req).GetGetTxPriorityHint(), grpc.WaitForReady(true))
 }
+
+func (cli *grpcClient) CheckNonce(ctx context.Context, req any, index int) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
+func (cli *grpcClient) CheckTxWrapped(ctx context.Context, req *types.RequestCheckTx) (*types.ResponseCheckTxV2, any, error) {
+	res, err := cli.CheckTx(ctx, req)
+	return res, nil, err
+}

--- a/sei-tendermint/abci/client/mocks/client.go
+++ b/sei-tendermint/abci/client/mocks/client.go
@@ -601,6 +601,16 @@ func (_m *Client) VerifyVoteExtension(_a0 context.Context, _a1 *types.RequestVer
 	return r0, r1
 }
 
+func (_m *Client) CheckNonce(_a0 context.Context, _a1 any, _a2 int) (bool, error) {
+	ret := _m.Called(_a0, _a1, _a2)
+	return ret.Get(0).(bool), ret.Error(1)
+}
+
+func (_m *Client) CheckTxWrapped(_a0 context.Context, _a1 *types.RequestCheckTx) (*types.ResponseCheckTxV2, any, error) {
+	ret := _m.Called(_a0, _a1)
+	return ret.Get(0).(*types.ResponseCheckTxV2), ret.Get(1).(any), ret.Error(2)
+}
+
 // Wait provides a mock function with no fields
 func (_m *Client) Wait() {
 	_m.Called()

--- a/sei-tendermint/abci/client/socket_client.go
+++ b/sei-tendermint/abci/client/socket_client.go
@@ -377,6 +377,15 @@ func (cli *socketClient) GetTxPriorityHint(ctx context.Context, req *types.Reque
 	return res.GetGetTxPriorityHint(), nil
 }
 
+func (cli *socketClient) CheckNonce(ctx context.Context, req any, index int) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
+func (cli *socketClient) CheckTxWrapped(ctx context.Context, req *types.RequestCheckTx) (*types.ResponseCheckTxV2, any, error) {
+	res, err := cli.CheckTx(ctx, req)
+	return res, nil, err
+}
+
 //----------------------------------------
 
 func resMatchesReq(req *types.Request, res *types.Response) (ok bool) {

--- a/sei-tendermint/abci/example/kvstore/kvstore.go
+++ b/sei-tendermint/abci/example/kvstore/kvstore.go
@@ -209,6 +209,10 @@ func (*Application) CheckTx(_ context.Context, req *types.RequestCheckTx) (*type
 	return &types.ResponseCheckTxV2{ResponseCheckTx: &types.ResponseCheckTx{Code: code.CodeTypeOK, GasWanted: 1}}, nil
 }
 
+func (*Application) CheckTxWrapped(_ context.Context, req *types.RequestCheckTx) (*types.ResponseCheckTxV2, any, error) {
+	return &types.ResponseCheckTxV2{ResponseCheckTx: &types.ResponseCheckTx{Code: code.CodeTypeOK, GasWanted: 1}}, nil, nil
+}
+
 func (app *Application) Commit(_ context.Context) (*types.ResponseCommit, error) {
 	app.mu.Lock()
 	defer app.mu.Unlock()

--- a/sei-tendermint/abci/types/application.go
+++ b/sei-tendermint/abci/types/application.go
@@ -12,7 +12,9 @@ type Application interface {
 	Query(context.Context, *RequestQuery) (*ResponseQuery, error) // Query for state
 
 	// Mempool Connection
-	CheckTx(context.Context, *RequestCheckTx) (*ResponseCheckTxV2, error) // Validate a tx for the mempool
+	CheckTx(context.Context, *RequestCheckTx) (*ResponseCheckTxV2, error)             // Validate a tx for the mempool; deprecated
+	CheckTxWrapped(context.Context, *RequestCheckTx) (*ResponseCheckTxV2, any, error) // Validate a tx for the mempool
+	CheckNonce(context.Context, any, int) (bool, error)
 
 	// Consensus Connection
 	InitChain(context.Context, *RequestInitChain) (*ResponseInitChain, error) // Initialize blockchain w validators/other info from TendermintCore
@@ -54,6 +56,14 @@ func (BaseApplication) Info(_ context.Context, req *RequestInfo) (*ResponseInfo,
 
 func (BaseApplication) CheckTx(_ context.Context, req *RequestCheckTx) (*ResponseCheckTxV2, error) {
 	return &ResponseCheckTxV2{ResponseCheckTx: &ResponseCheckTx{Code: CodeTypeOK}}, nil
+}
+
+func (BaseApplication) CheckTxWrapped(_ context.Context, req *RequestCheckTx) (*ResponseCheckTxV2, any, error) {
+	return &ResponseCheckTxV2{ResponseCheckTx: &ResponseCheckTx{Code: CodeTypeOK}}, nil, nil
+}
+
+func (BaseApplication) CheckNonce(_ context.Context, req any, index int) (bool, error) {
+	return true, nil
 }
 
 func (BaseApplication) Commit(_ context.Context) (*ResponseCommit, error) {

--- a/sei-tendermint/abci/types/mocks/application.go
+++ b/sei-tendermint/abci/types/mocks/application.go
@@ -494,6 +494,16 @@ func (_m *Application) VerifyVoteExtension(_a0 context.Context, _a1 *types.Reque
 	return r0, r1
 }
 
+func (_m *Application) CheckNonce(_a0 context.Context, _a1 any, _a2 int) (bool, error) {
+	ret := _m.Called(_a0, _a1, _a2)
+	return ret.Get(0).(bool), ret.Error(1)
+}
+
+func (_m *Application) CheckTxWrapped(_a0 context.Context, _a1 *types.RequestCheckTx) (*types.ResponseCheckTxV2, any, error) {
+	ret := _m.Called(_a0, _a1)
+	return ret.Get(0).(*types.ResponseCheckTxV2), ret.Get(1).(any), ret.Error(2)
+}
+
 // NewApplication creates a new instance of Application. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewApplication(t interface {

--- a/sei-tendermint/config/config.go
+++ b/sei-tendermint/config/config.go
@@ -862,6 +862,10 @@ type MempoolConfig struct {
 	//
 	// See DropUtilisationThreshold and DropPriorityThreshold.
 	DropPriorityReservoirSize int `mapstructure:"drop-priority-reservoir-size"`
+
+	// Do a JIT check of nonce before proposing a block to make sure no transaction
+	// with invalid nonce is included in the block.
+	CheckNonceBeforePropose bool `mapstructure:"check-nonce-before-propose"`
 }
 
 // DefaultMempoolConfig returns a default configuration for the Tendermint mempool.
@@ -888,6 +892,7 @@ func DefaultMempoolConfig() *MempoolConfig {
 		DropPriorityThreshold:        0.1,
 		DropUtilisationThreshold:     1.0,
 		DropPriorityReservoirSize:    10_240,
+		CheckNonceBeforePropose:      false,
 	}
 }
 

--- a/sei-tendermint/config/toml.go
+++ b/sei-tendermint/config/toml.go
@@ -457,6 +457,8 @@ drop-utilisation-threshold = {{ .Mempool.DropUtilisationThreshold }}
 # See DropUtilisationThreshold and DropPriorityThreshold.
 drop-priority-reservoir-size = {{ .Mempool.DropPriorityReservoirSize }}
 
+check-nonce-before-propose = {{ .Mempool.CheckNonceBeforePropose }}
+
 #######################################################
 ###         State Sync Configuration Options        ###
 #######################################################

--- a/sei-tendermint/internal/consensus/mempool_test.go
+++ b/sei-tendermint/internal/consensus/mempool_test.go
@@ -236,7 +236,7 @@ func TestMempoolRmBadTx(t *testing.T) {
 
 		// check for the tx
 		for {
-			txs := assertMempool(t, cs.txNotifier).ReapMaxBytesMaxGas(int64(len(txBytes)), -1, -1)
+			txs := assertMempool(t, cs.txNotifier).ReapMaxBytesMaxGas(ctx, int64(len(txBytes)), -1, -1)
 			if len(txs) == 0 {
 				emptyMempoolCh <- struct{}{}
 				return
@@ -326,6 +326,15 @@ func (app *CounterApplication) CheckTx(_ context.Context, req *abci.RequestCheck
 	}
 	app.mempoolTxCount++
 	return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{Code: code.CodeTypeOK}}, nil
+}
+
+func (app *CounterApplication) CheckTxWrapped(ctx context.Context, req *abci.RequestCheckTx) (*abci.ResponseCheckTxV2, any, error) {
+	res, err := app.CheckTx(ctx, req)
+	return res, nil, err
+}
+
+func (app *CounterApplication) CheckNonce(ctx context.Context, req any, index int) (bool, error) {
+	return true, nil
 }
 
 func txAsUint64(tx []byte) uint64 {

--- a/sei-tendermint/internal/consensus/replay_stubs.go
+++ b/sei-tendermint/internal/consensus/replay_stubs.go
@@ -37,9 +37,11 @@ func (emptyMempool) Size() int                 { return 0 }
 func (emptyMempool) CheckTx(context.Context, types.Tx, func(*abci.ResponseCheckTx), mempool.TxInfo) error {
 	return nil
 }
-func (emptyMempool) RemoveTxByKey(txKey types.TxKey) error      { return nil }
-func (emptyMempool) ReapMaxBytesMaxGas(_, _, _ int64) types.Txs { return types.Txs{} }
-func (emptyMempool) ReapMaxTxs(n int) types.Txs                 { return types.Txs{} }
+func (emptyMempool) RemoveTxByKey(txKey types.TxKey) error { return nil }
+func (emptyMempool) ReapMaxBytesMaxGas(_ context.Context, _, _, _ int64) types.Txs {
+	return types.Txs{}
+}
+func (emptyMempool) ReapMaxTxs(n int) types.Txs { return types.Txs{} }
 func (emptyMempool) Update(
 	_ context.Context,
 	_ int64,

--- a/sei-tendermint/internal/mempool/mocks/mempool.go
+++ b/sei-tendermint/internal/mempool/mocks/mempool.go
@@ -109,8 +109,8 @@ func (_m *Mempool) Lock() {
 }
 
 // ReapMaxBytesMaxGas provides a mock function with given fields: maxBytes, maxGas, maxGasEstimated
-func (_m *Mempool) ReapMaxBytesMaxGas(maxBytes int64, maxGas int64, maxGasEstimated int64) types.Txs {
-	ret := _m.Called(maxBytes, maxGas, maxGasEstimated)
+func (_m *Mempool) ReapMaxBytesMaxGas(ctx context.Context, maxBytes int64, maxGas int64, maxGasEstimated int64) types.Txs {
+	ret := _m.Called(ctx, maxBytes, maxGas, maxGasEstimated)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ReapMaxBytesMaxGas")

--- a/sei-tendermint/internal/mempool/tx.go
+++ b/sei-tendermint/internal/mempool/tx.go
@@ -77,6 +77,7 @@ type WrappedTx struct {
 	evmAddress string
 	evmNonce   uint64
 	isEVM      bool
+	evmMessage any // *evmtypes.MsgEVMTransaction to avoid import cycle
 }
 
 // IsBefore returns true if the WrappedTx is before the given WrappedTx

--- a/sei-tendermint/internal/mempool/types.go
+++ b/sei-tendermint/internal/mempool/types.go
@@ -52,7 +52,7 @@ type Mempool interface {
 	//
 	// If all 3 maxes are negative, there is no cap on the size of all returned
 	// transactions (~ all available transactions).
-	ReapMaxBytesMaxGas(maxBytes, maxGas, maxGasEstimated int64) types.Txs
+	ReapMaxBytesMaxGas(ctx context.Context, maxBytes, maxGas, maxGasEstimated int64) types.Txs
 
 	// ReapMaxTxs reaps up to max transactions from the mempool. If max is
 	// negative, there is no cap on the size of all returned transactions

--- a/sei-tendermint/internal/proxy/client.go
+++ b/sei-tendermint/internal/proxy/client.go
@@ -214,6 +214,16 @@ func (app *proxyClient) ApplySnapshotChunk(ctx context.Context, req *types.Reque
 	return app.client.ApplySnapshotChunk(ctx, req)
 }
 
+func (app *proxyClient) CheckNonce(ctx context.Context, req any, index int) (bool, error) {
+	defer addTimeSample(app.metrics.MethodTiming.With("method", "check_nonce", "type", "sync"))()
+	return app.client.CheckNonce(ctx, req, index)
+}
+
+func (app *proxyClient) CheckTxWrapped(ctx context.Context, req *types.RequestCheckTx) (*types.ResponseCheckTxV2, any, error) {
+	defer addTimeSample(app.metrics.MethodTiming.With("method", "check_tx_wrapped", "type", "sync"))()
+	return app.client.CheckTxWrapped(ctx, req)
+}
+
 // addTimeSample returns a function that, when called, adds an observation to m.
 // The observation added to m is the number of seconds ellapsed since addTimeSample
 // was initially called. addTimeSample is meant to be called in a defer to calculate

--- a/sei-tendermint/internal/state/execution.go
+++ b/sei-tendermint/internal/state/execution.go
@@ -110,7 +110,7 @@ func (blockExec *BlockExecutor) CreateProposalBlock(
 	// Fetch a limited amount of valid txs
 	maxDataBytes := types.MaxDataBytes(maxBytes, evSize, state.Validators.Size())
 
-	txs := blockExec.mempool.ReapMaxBytesMaxGas(maxDataBytes, maxGasWanted, maxGas)
+	txs := blockExec.mempool.ReapMaxBytesMaxGas(ctx, maxDataBytes, maxGasWanted, maxGas)
 	block = state.MakeBlock(height, txs, lastCommit, evidence, proposerAddr)
 	rpp, err := blockExec.appClient.PrepareProposal(
 		ctx,

--- a/sei-tendermint/internal/state/execution_test.go
+++ b/sei-tendermint/internal/state/execution_test.go
@@ -967,7 +967,7 @@ func TestCreateProposalBlockPanicRecovery(t *testing.T) {
 
 	// Create mock mempool
 	mp := &mpmocks.Mempool{}
-	mp.On("ReapMaxBytesMaxGas", mock.Anything, mock.Anything, mock.Anything).Return(types.Txs{})
+	mp.On("ReapMaxBytesMaxGas", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(types.Txs{})
 
 	blockExec := sm.NewBlockExecutor(
 		stateStore,


### PR DESCRIPTION
## Describe your changes and provide context
This PR includes the following changes:
- Added a new `CheckTxWrapped` call which is the same as `CheckTx` but also returns the decoded transaction with all the derived fields to mempool
- Added a new `CheckNonce` call which is called per tx when proposer reaps from its mempool. Only transaction that passes `CheckNonce` will be accepted. Note that for an honest validator, this step will never happen when nonces in states are changing (i.e commit and propose are two disjoint steps)
- Implemented `CheckNonce` in EVM keeper

## Testing performed to validate your change
unit tests
TODO: test in cluster
