### PR TITLE
Fix github action codex check (updated CLI)

### DIFF
--- a/.github/workflows/pr-to-slack-codex.yml
+++ b/.github/workflows/pr-to-slack-codex.yml
@@ -34,7 +34,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -euo pipefail
-          codex login --api-key "$OPENAI_API_KEY"
+          printenv "$OPENAI_API_KEY" | codex login --with-api-key
 
       - name: Compute merge-base diff (compact)
         run: |

--- a/.github/workflows/pr-to-slack-codex.yml
+++ b/.github/workflows/pr-to-slack-codex.yml
@@ -2,7 +2,7 @@ name: PR → Codex review → Slack
 
 on:
   pull_request:
-    #types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review]
 
 jobs:
   codex_review:

--- a/.github/workflows/pr-to-slack-codex.yml
+++ b/.github/workflows/pr-to-slack-codex.yml
@@ -34,7 +34,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -euo pipefail
-          printenv "$OPENAI_API_KEY" | codex login --with-api-key
+          printenv ${{ secrets.OPENAI_API_KEY }} | codex login --with-api-key
 
       - name: Compute merge-base diff (compact)
         run: |

--- a/.github/workflows/pr-to-slack-codex.yml
+++ b/.github/workflows/pr-to-slack-codex.yml
@@ -2,7 +2,7 @@ name: PR → Codex review → Slack
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    #types: [opened, reopened, ready_for_review]
 
 jobs:
   codex_review:
@@ -34,7 +34,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -euo pipefail
-          printenv ${{ secrets.OPENAI_API_KEY }} | codex login --with-api-key
+          echo ${{ secrets.OPENAI_API_KEY }} | codex login --with-api-key
 
       - name: Compute merge-base diff (compact)
         run: |


### PR DESCRIPTION
## Describe your changes and provide context
- fixes this error on codex github check
```
The --api-key flag is no longer supported. Pipe the key instead, e.g. `printenv OPENAI_API_KEY | codex login --with-api-key`.
```

## Testing performed to validate your change
- this pr execution
