### PR TITLE
Fix RPC read race

### DIFF
--- a/sei-cosmos/storev2/rootmulti/store.go
+++ b/sei-cosmos/storev2/rootmulti/store.go
@@ -249,9 +249,6 @@ func (rs *Store) CacheMultiStore() types.CacheMultiStore {
 // CacheMultiStoreWithVersion Implements interface MultiStore
 // used to createQueryContext, abci_query or grpc query service.
 func (rs *Store) CacheMultiStoreWithVersion(version int64) (types.CacheMultiStore, error) {
-	if version <= 0 || (rs.lastCommitInfo != nil && version == rs.lastCommitInfo.Version) {
-		return rs.CacheMultiStore(), nil
-	}
 	rs.mtx.RLock()
 	defer rs.mtx.RUnlock()
 	stores := make(map[types.StoreKey]types.CacheWrapper)


### PR DESCRIPTION
## Describe your changes and provide context

### Intro

[This](https://github.com/sei-protocol/sei-chain/blob/6a5c937fa9737b1e3aa2288b9349d5a9f51c9d79/sei-cosmos/baseapp/abci.go#L385-L387) is the sequence of events during block commitment.
[app.WriteState()](https://github.com/sei-protocol/sei-chain/blob/6a5c937fa9737b1e3aa2288b9349d5a9f51c9d79/sei-cosmos/baseapp/abci.go#L385) writes latest state to memiavl (among other things).
[app.cms.Commit(true)](https://github.com/sei-protocol/sei-chain/blob/6a5c937fa9737b1e3aa2288b9349d5a9f51c9d79/sei-cosmos/baseapp/abci.go#L387) updates lastCommitInfo (among other things).

### Effect on RPC reads

[GetTransactionCount](https://github.com/sei-protocol/sei-chain/blob/5188d672c53db123530a4a591738de75cfd787bb/evmrpc/tx.go#L275) resolves stores to use on the following call path: [GetTransactionCount](https://github.com/sei-protocol/sei-chain/blob/5188d672c53db123530a4a591738de75cfd787bb/evmrpc/tx.go#L275) ->  [RPCContextProvider](https://github.com/sei-protocol/sei-chain/blob/23848322a96b90550cfdd5f6cbe987dc3dcefbde/app/app.go#L1933) -> [CreateQueryContext](https://github.com/sei-protocol/sei-chain/blob/6a5c937fa9737b1e3aa2288b9349d5a9f51c9d79/sei-cosmos/baseapp/abci.go#L712) -> [CacheMultiStoreWithVersion](https://github.com/sei-protocol/sei-chain/blob/06a4e242bf80fff303be607734e121bd2f0f6916/sei-cosmos/storev2/rootmulti/store.go#L251).

Stores can be resolved in two ways dependent on whether `blockNumber` from the RPC query is equal to [rs.lastCommitInfo.Version](https://github.com/sei-protocol/sei-chain/blob/06a4e242bf80fff303be607734e121bd2f0f6916/sei-cosmos/storev2/rootmulti/store.go#L252):
https://github.com/sei-protocol/sei-chain/blob/06a4e242bf80fff303be607734e121bd2f0f6916/sei-cosmos/storev2/rootmulti/store.go#L253
https://github.com/sei-protocol/sei-chain/blob/06a4e242bf80fff303be607734e121bd2f0f6916/sei-cosmos/storev2/rootmulti/store.go#L257-L275

If it is equal we allow reading from `memiavl` (which holds only latest data if I understood correctly) and if it is different we allow reading from snapshot stores exclusively.

Because of the sequence of events outlined in the intro the following can happen:

1. State from block X+1 (block that's currently executing) was written into `memiavl` via [app.WriteState()](https://github.com/sei-protocol/sei-chain/blob/6a5c937fa9737b1e3aa2288b9349d5a9f51c9d79/sei-cosmos/baseapp/abci.go#L385).
2. `eth_getTransactionCount` on block X is querried and during execution evaluates [this](https://github.com/sei-protocol/sei-chain/blob/06a4e242bf80fff303be607734e121bd2f0f6916/sei-cosmos/storev2/rootmulti/store.go#L252) `if` - since [app.cms.Commit(true)](https://github.com/sei-protocol/sei-chain/blob/6a5c937fa9737b1e3aa2288b9349d5a9f51c9d79/sei-cosmos/baseapp/abci.go#L387) has not yet executed and updated [lastCommitInfo](https://github.com/sei-protocol/sei-chain/blob/06a4e242bf80fff303be607734e121bd2f0f6916/sei-cosmos/storev2/rootmulti/store.go#L48) we think that `blockNumber` from the RPC query is equal to [rs.lastCommitInfo.Version](https://github.com/sei-protocol/sei-chain/blob/06a4e242bf80fff303be607734e121bd2f0f6916/sei-cosmos/storev2/rootmulti/store.go#L252) - as `true` and serves [rs.CacheMultiStore()](https://github.com/sei-protocol/sei-chain/blob/06a4e242bf80fff303be607734e121bd2f0f6916/sei-cosmos/storev2/rootmulti/store.go#L253).
3. We read the nonce from `memiavl` which serves the latest nonce instead of the nonce at block X.

### Impact

The corruption window lasts from when the state was written to memiavl via [app.WriteState()](https://github.com/sei-protocol/sei-chain/blob/6a5c937fa9737b1e3aa2288b9349d5a9f51c9d79/sei-cosmos/baseapp/abci.go#L385) until [app.cms.Commit(true)](https://github.com/sei-protocol/sei-chain/blob/6a5c937fa9737b1e3aa2288b9349d5a9f51c9d79/sei-cosmos/baseapp/abci.go#L387) executes.

Issue affects all RPC data that can be served from `memiavl` during the window outlined above (e.g. `eth_getBalance`, `eth_getTransactionCount`, etc.).

### Solution

We should never serve `memiavl` on the RPC read path (or any non-execution read path) and [this](https://github.com/sei-protocol/sei-chain/blob/06a4e242bf80fff303be607734e121bd2f0f6916/sei-cosmos/storev2/rootmulti/store.go#L252-L254) block of code should be removed entirely.

Logically it does not make sense to serve `memiavl` as a store on the RPC read path seeing as it only contains the latest state and the read path does not get a clone/must not lock it meaning it can get modified on the fly which leads to inconsistencies.

## Testing performed to validate your change

I had a repro of the issue locally so I validated that the issue goes away when this change is introduced.