### PR TITLE
Fix inconsistent pb.go relative to default zero field in `Asset`

### DIFF
--- a/x/evm/types/tx.pb.go
+++ b/x/evm/types/tx.pb.go
@@ -833,7 +833,7 @@ func (m *Asset) GetAssetType() AssetType {
 	if m != nil {
 		return m.AssetType
 	}
-	return AssetType_TYPECW20
+	return AssetType_TYPEUNKNOWN
 }
 
 func (m *Asset) GetContractAddress() string {


### PR DESCRIPTION
`GetAssetType` should return unknown if no asset is set, consistent with the generated go code from proto.

