### PR TITLE
Cache typed txs for RPC reads

### DIFF
--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -525,6 +525,9 @@ max_trace_lookback_blocks = {{ .EVM.MaxTraceLookbackBlocks }}
 # Timeout for each trace call
 trace_timeout = "{{ .EVM.TraceTimeout }}"
 
+# The max number of typed transactions to cache
+typed_tx_cache_limit = {{ .EVM.TypedTxCacheLimit }}
+
 [eth_replay]
 eth_replay_enabled = {{ .ETHReplay.Enabled }}
 eth_rpc = "{{ .ETHReplay.EthRPC }}"

--- a/evmrpc/config.go
+++ b/evmrpc/config.go
@@ -106,6 +106,9 @@ type Config struct {
 
 	// RPCStatsInterval for how often to report stats
 	RPCStatsInterval time.Duration `mapstructure:"rpc_stats_interval"`
+
+	// TypedTxCacheLimit sets the max number of typed transactions to cache
+	TypedTxCacheLimit int64 `mapstructure:"typed_tx_cache_limit"`
 }
 
 var DefaultConfig = Config{
@@ -136,6 +139,7 @@ var DefaultConfig = Config{
 	MaxTraceLookbackBlocks:       10000,
 	TraceTimeout:                 30 * time.Second,
 	RPCStatsInterval:             10 * time.Second,
+	TypedTxCacheLimit:            1000,
 }
 
 const (
@@ -166,6 +170,7 @@ const (
 	flagMaxTraceLookbackBlocks       = "evm.max_trace_lookback_blocks"
 	flagTraceTimeout                 = "evm.trace_timeout"
 	flagRPCStatsInterval             = "evm.rpc_stats_interval"
+	flagTypedTxCacheLimit            = "evm.typed_tx_cache_limit"
 )
 
 func ReadConfig(opts servertypes.AppOptions) (Config, error) {
@@ -306,6 +311,10 @@ func ReadConfig(opts servertypes.AppOptions) (Config, error) {
 			return cfg, err
 		}
 	}
-
+	if v := opts.Get(flagTypedTxCacheLimit); v != nil {
+		if cfg.TypedTxCacheLimit, err = cast.ToInt64E(v); err != nil {
+			return cfg, err
+		}
+	}
 	return cfg, nil
 }

--- a/evmrpc/config_test.go
+++ b/evmrpc/config_test.go
@@ -36,6 +36,7 @@ type opts struct {
 	maxTraceLookbackBlocks       interface{}
 	traceTimeout                 interface{}
 	rpcStatsInterval             interface{}
+	typedTxCacheLimit            interface{}
 }
 
 func (o *opts) Get(k string) interface{} {
@@ -120,6 +121,9 @@ func (o *opts) Get(k string) interface{} {
 	if k == "evm.rpc_stats_interval" {
 		return o.rpcStatsInterval
 	}
+	if k == "evm.typed_tx_cache_limit" {
+		return o.typedTxCacheLimit
+	}
 	panic("unknown key")
 }
 
@@ -152,6 +156,7 @@ func TestReadConfig(t *testing.T) {
 		int64(100),
 		30 * time.Second,
 		10 * time.Second,
+		1000,
 	}
 	_, err := evmrpc.ReadConfig(&goodOpts)
 	require.Nil(t, err)
@@ -243,6 +248,11 @@ func TestReadConfig(t *testing.T) {
 
 	badOpts = goodOpts
 	badOpts.traceTimeout = "bad"
+	_, err = evmrpc.ReadConfig(&badOpts)
+	require.NotNil(t, err)
+
+	badOpts = goodOpts
+	badOpts.typedTxCacheLimit = "bad"
 	_, err = evmrpc.ReadConfig(&badOpts)
 	require.NotNil(t, err)
 }

--- a/evmrpc/utils.go
+++ b/evmrpc/utils.go
@@ -220,10 +220,18 @@ func filterTransactions(
 	latestCtx := ctxProvider(LatestCtxHeight)
 	ctx := ctxProvider(block.Block.Height)
 	prevCtx := ctxProvider(block.Block.Height - 1)
+	typedTxs, typedTxCached := k.GetTypedTxs(block.Block.Height)
 	for i, tx := range block.Block.Txs {
-		sdkTx, err := txConfig.TxDecoder()(tx)
-		if err != nil {
-			continue
+		var sdkTx sdk.Tx
+		if typedTxCached {
+			sdkTx = typedTxs[i]
+		} else {
+			// only decode if the typed txs are not cached
+			typedTx, err := txConfig.TxDecoder()(tx)
+			if err != nil {
+				continue
+			}
+			sdkTx = typedTx
 		}
 		for _, msg := range sdkTx.GetMsgs() {
 			switch m := msg.(type) {

--- a/evmrpc/utils.go
+++ b/evmrpc/utils.go
@@ -233,6 +233,9 @@ func filterTransactions(
 			}
 			sdkTx = typedTx
 		}
+		if sdkTx == nil {
+			continue
+		}
 		for _, msg := range sdkTx.GetMsgs() {
 			switch m := msg.(type) {
 			case *types.MsgEVMTransaction:


### PR DESCRIPTION
## Describe your changes and provide context
Some RPC endpoints (e.g. `eth_getLogs`) spend a lot of CPU cycles on decoding transactions. This PR caches the decoded transaction in memory (up to a configurable limit) during the write path so that RPC requests for recent blocks don't need to spend on decoding. This cache doesn't participate in consensus in any way.

(cpu usage & breakdown before & after the change, under 200 eth_getLogs requests per second)
before:
<img width="785" height="483" alt="Screenshot 2025-10-13 at 7 22 01 PM" src="https://github.com/user-attachments/assets/75ca7961-63bf-4713-9e18-ee4e66296c45" />
<img width="1588" height="773" alt="Screenshot 2025-10-13 at 7 22 11 PM" src="https://github.com/user-attachments/assets/bf00036a-6f36-4759-bfd3-9810084ae444" />


after:
<img width="792" height="377" alt="Screenshot 2025-10-13 at 5 10 58 PM" src="https://github.com/user-attachments/assets/15c527d1-a37f-47d3-88b9-a0a98b5667fa" />
<img width="795" height="454" alt="Screenshot 2025-10-13 at 5 10 03 PM" src="https://github.com/user-attachments/assets/33758ece-b097-4b2a-90b1-0224ca8defca" />


## Testing performed to validate your change
^
unit tests
