### PR TITLE
reverted semantics of ParseAddressString

### DIFF
--- a/sei-tendermint/internal/p2p/transport.go
+++ b/sei-tendermint/internal/p2p/transport.go
@@ -143,8 +143,8 @@ func (c *Connection) Close() error {
 type Endpoint struct{ netip.AddrPort }
 
 // NewEndpoint constructs an Endpoint from a types.NetAddress structure.
-func NewEndpoint(addr string) (Endpoint, error) {
-	e, err := types.ParseAddressString(addr)
+func ResolveEndpoint(addr string) (Endpoint, error) {
+	e, err := types.ResolveAddressString(addr)
 	return Endpoint{e}, err
 }
 

--- a/sei-tendermint/node/setup.go
+++ b/sei-tendermint/node/setup.go
@@ -300,7 +300,7 @@ func createRouter(
 
 	p2pLogger := logger.With("module", "p2p")
 
-	ep, err := p2p.NewEndpoint(nodeKey.ID.AddressString(cfg.P2P.ListenAddress))
+	ep, err := p2p.ResolveEndpoint(nodeKey.ID.AddressString(cfg.P2P.ListenAddress))
 	if err != nil {
 		return nil, err
 	}

--- a/sei-tendermint/types/node_info_test.go
+++ b/sei-tendermint/types/node_info_test.go
@@ -178,7 +178,7 @@ func TestNodeInfoAddChannel(t *testing.T) {
 	require.Contains(t, nodeInfo.Channels, byte(0x02))
 }
 
-func TestParseAddressString(t *testing.T) {
+func TestResolveAddressString(t *testing.T) {
 	testCases := []struct {
 		name     string
 		addr     string
@@ -242,7 +242,7 @@ func TestParseAddressString(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			addr, err := ParseAddressString(tc.addr)
+			addr, err := ResolveAddressString(tc.addr)
 			if tc.correct {
 				require.NoError(t, err, tc.addr)
 				assert.Contains(t, tc.expected, addr.String())


### PR DESCRIPTION
https://github.com/sei-protocol/sei-tendermint/pull/308 has accidentally changed the semantics of ParseAddressString from resolving the tcp address to parsing tcp address. As a side effect, support for DNS names in the config has been removed.

This PR reverts to the original semantics to support DNS names again. Also renamed the functions to better describe what they do.