### PR TITLE
Use golang base image with version matching go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # docker build . -t sei-protocol/sei:latest
 # docker run --rm -it sei-protocol/sei:latest /bin/sh
-FROM golang:1.23.0-alpine AS go-builder
+FROM golang:1.24.5-alpine AS go-builder
 
 # this comes from standard alpine nightly file
 #  https://github.com/rust-lang/docker-rust-nightly/blob/master/alpine3.12/Dockerfile


### PR DESCRIPTION
The go mod was updated in this branch to 1.24.5 but looks like Dockerfile base image version bump was missed which results in container build failure.

Fixed by using the base image with version matching go.mod

