### PR TITLE
Fix compile error in sei-wasmd

### DIFF
--- a/sei-wasmd/x/wasm/ibctesting/chain.go
+++ b/sei-wasmd/x/wasm/ibctesting/chain.go
@@ -483,7 +483,7 @@ func (chain *TestChain) CreateTMClientHeader(chainID string, blockHeight int64, 
 		voteSet.AddVote(vote)
 	}
 
-	commit := voteSet.MakeExtendedCommit().ToCommit()
+	commit := voteSet.MakeCommit()
 
 	signedHeader := &tmproto.SignedHeader{
 		Header: tmHeader.ToProto(),


### PR DESCRIPTION
The support for extended commits was removed as it was an unused feature of tendermint at Sei. This happened before move to mono repo. As a result we never got around updating the breaking changes in wasmd.

The changes here resolve this breaking change.

See:
 - https://github.com/sei-protocol/sei-tendermint/pull/312
