### PR TITLE
always use block bloom for filtering

### DIFF
--- a/evmrpc/filter.go
+++ b/evmrpc/filter.go
@@ -1040,11 +1040,7 @@ func (f *LogFetcher) processBatch(ctx context.Context, start, end int64, crit fi
 		if len(crit.Addresses) != 0 || len(crit.Topics) != 0 {
 			// Bloom cache miss - read from database
 			providerCtx := f.ctxProvider(height)
-			if f.includeSyntheticReceipts {
-				blockBloom = f.k.GetBlockBloom(providerCtx)
-			} else {
-				blockBloom = f.k.GetEvmOnlyBlockBloom(providerCtx)
-			}
+			blockBloom = f.k.GetBlockBloom(providerCtx)
 
 			// When we cannot retrieve a bloom for the EVM-only view (all zeroes),
 			// skip the bloom pre-filter instead of short-circuiting the block.


### PR DESCRIPTION
## Describe your changes and provide context
evm-only block bloom could be incorrect

## Testing performed to validate your change

