### PR TITLE
Use wire and wire-json to check for proto breaking changes

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -26,4 +26,5 @@ lint:
 
 breaking:
   use:
-    - FILE
+    - WIRE
+    - WIRE_JSON


### PR DESCRIPTION
With the ongoing removal of unused code across the repo on the way we hit false negative cases where Buf breacking check fails for fields that are removed having been reserved.

What we really care about when it comes to breaking changes is wire-breaking changes since everyone uses the software we ship. Therefore, there is no concern about SDK level breaking changes.

The changes here change the breaking check rule to WIRE and WIRE_JSON from the default FILE.
