### PR TITLE
Integrate UCI automatic stale PR and issue closure

### DIFF
--- a/.github/workflows/uci-stale-check.yml
+++ b/.github/workflows/uci-stale-check.yml
@@ -19,3 +19,5 @@ jobs:
       issues: write
       pull-requests: write
     uses: sei-protocol/uci/.github/workflows/stale-check.yml@v0.0.3
+    with: 
+      days-before-pr-stale: '28'


### PR DESCRIPTION
Add UCI integration to automatically label stale PRs and close them if no update is made.

