### PR TITLE
Warn when sei-wasmd paths are t rimmed

### DIFF
--- a/cmd/seid/main.go
+++ b/cmd/seid/main.go
@@ -1,16 +1,22 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
-	"github.com/sei-protocol/sei-chain/app/params"
-	"github.com/sei-protocol/sei-chain/cmd/seid/cmd"
-
+	"github.com/CosmWasm/wasmd/check"
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 	"github.com/sei-protocol/sei-chain/app"
+	"github.com/sei-protocol/sei-chain/app/params"
+	"github.com/sei-protocol/sei-chain/cmd/seid/cmd"
 )
 
 func main() {
+
+	if trimmed, ok := check.RuntimePathTrimmed(); ok && trimmed {
+		_, _ = fmt.Fprintln(os.Stderr, "WARNING: paths are likely trimmed. This can result in inconsistent error stacktrace.")
+	}
+
 	params.SetAddressPrefixes()
 	rootCmd, _ := cmd.NewRootCmd()
 	if err := svrcmd.Execute(rootCmd, app.DefaultNodeHome); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -350,7 +350,7 @@ require (
 )
 
 replace (
-	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.3.11
+	github.com/CosmWasm/wasmd => github.com/sei-protocol/sei-wasmd v0.3.12-0.20251107122039-f0caf9fe384b
 	github.com/CosmWasm/wasmvm => github.com/sei-protocol/sei-wasmvm v1.5.4-sei.0.0.3
 	github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.23.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -2007,8 +2007,8 @@ github.com/sei-protocol/sei-tendermint v0.6.7 h1:76ElMtSi08p7oUbMBCFvd9qwXABwI+H
 github.com/sei-protocol/sei-tendermint v0.6.7/go.mod h1:SSZv0P1NBP/4uB3gZr5XJIan3ks3Ui8FJJzIap4r6uc=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
-github.com/sei-protocol/sei-wasmd v0.3.11 h1:Ldmge+XVm/8pxdNJhOjLNjZeT2oFiH5LEylwttKmmtc=
-github.com/sei-protocol/sei-wasmd v0.3.11/go.mod h1:C5TM6FIG7Nao2t1v5cdJYZEVXrRUswRNPdJ5XjCsCFk=
+github.com/sei-protocol/sei-wasmd v0.3.12-0.20251107122039-f0caf9fe384b h1:QoSQC8tsBg1hoOgIkTYFuNc7ymtJ+lJspOqI1IDOZMQ=
+github.com/sei-protocol/sei-wasmd v0.3.12-0.20251107122039-f0caf9fe384b/go.mod h1:C5TM6FIG7Nao2t1v5cdJYZEVXrRUswRNPdJ5XjCsCFk=
 github.com/sei-protocol/sei-wasmvm v1.5.4-sei.0.0.3 h1:hhZdZLR8g+6bxWBZiMflSnIuHgLcK/QEpzyjx0/yXYU=
 github.com/sei-protocol/sei-wasmvm v1.5.4-sei.0.0.3/go.mod h1:Q0bSEtlktzh7W2hhEaifrFp1Erx11ckQZmjq8FLCyys=
 github.com/sei-protocol/tm-db v0.0.4 h1:7Y4EU62Xzzg6wKAHEotm7SXQR0aPLcGhKHkh3qd0tnk=


### PR DESCRIPTION
Add a warning in `seid` main to warn if paths are trimmed

Example:

_Without `-trimpath`_
```
$  sei-chain % go build  -tags "netgo ledger" -ldflags '-X github.com/cosmos/cosmos-sdk/version.Name=sei -X github.com/cosmos/cosmos-sdk/version.ServerName=seid -X github.com/cosmos/cosmos-sdk/version.Version=v6.2.4 -X github.com/cosmos/cosmos-sdk/version.Commit=6e08a764b0b96980e785b45c284aed0c3015504d -X "github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger" -checklinkname=0' -o ./build/seid ./cmd/seid && ./build/seid version

v6.2.4
```

_With `-trimpath`_
```
 $ go build -trimpath -tags "netgo ledger" -ldflags '-X github.com/cosmos/cosmos-sdk/version.Name=sei -X github.com/cosmos/cosmos-sdk/version.ServerName=seid -X github.com/cosmos/cosmos-sdk/version.Version=v6.2.4 -X github.com/cosmos/cosmos-sdk/version.Commit=6e08a764b0b96980e785b45c284aed0c3015504d -X "github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger" -checklinkname=0' -o ./build/seid ./cmd/seid && ./build/seid version

WARNING: paths are likely trimmed. This can result in inconsistent error stacktrace.
v6.2.4
```
