### PR TITLE
refactor: remove obsolete // +build tag

### DIFF
--- a/app/params/amino.go
+++ b/app/params/amino.go
@@ -1,5 +1,4 @@
 //go:build test_amino
-// +build test_amino
 
 package params
 

--- a/app/params/proto.go
+++ b/app/params/proto.go
@@ -1,5 +1,4 @@
 //go:build !test_amino
-// +build !test_amino
 
 package params
 

--- a/x/mint/client/rest/grpc_query_test.go
+++ b/x/mint/client/rest/grpc_query_test.go
@@ -1,5 +1,4 @@
 //go:build norace
-// +build norace
 
 package rest_test
 


### PR DESCRIPTION
## Describe your changes and provide context

From Go 1.17, the preferred syntax for build constraints is `//go:build`,
which replaces the old `// +build` form. The old style is now considered
deprecated but still supported for backward compatibility.

This change removes the obsolete `// +build xxx` line, keeping only the
modern `//go:build xxx` directive.

More info: https://github.com/golang/go/issues/41184 and https://go.dev/doc/go1.17#build-lines

Design Doc / Proposal：
https://go.dev/design/draft-gobuild

## Testing performed to validate your change

