### PR TITLE
Always set gas meter for every transaction

### DIFF
--- a/app/ante/cosmos_checktx.go
+++ b/app/ante/cosmos_checktx.go
@@ -73,7 +73,7 @@ func CosmosCheckTxAnte(
 ) (returnCtx sdk.Context, returnErr error) {
 	oracleVote, err := CosmosStatelessChecks(tx, ctx.BlockHeight(), ctx.ConsensusParams())
 	if err != nil {
-		return ctx, err
+		return SetGasMeter(ctx, 0, pk), err
 	}
 
 	defer func() {
@@ -81,11 +81,14 @@ func CosmosCheckTxAnte(
 			returnErr = HandleOutofGas(r, tx.(GasTx).GetGas(), ctx.GasMeter().GasConsumed())
 		}
 	}()
-	gasMeter, isGasless, err := GetGasMeter(ctx.WithGasMeter(storetypes.NewNoConsumptionInfiniteGasMeter()), tx, oraclek, ek, pk)
+	ctx = ctx.WithGasMeter(storetypes.NewNoConsumptionInfiniteGasMeter())
+	isGasless, err := antedecorators.IsTxGasless(tx, ctx, oraclek, ek)
 	if err != nil {
 		return ctx, err
 	}
-	ctx = ctx.WithGasMeter(gasMeter)
+	if !isGasless {
+		ctx = SetGasMeter(ctx, tx.(GasTx).GetGas(), pk)
+	}
 
 	authParams := accountKeeper.GetParams(ctx)
 
@@ -236,21 +239,14 @@ func CosmosStatelessChecks(tx sdk.Tx, height int64, consensusParams *tmproto.Con
 	return oracleVote, nil
 }
 
-func GetGasMeter(
-	ctx sdk.Context, tx sdk.Tx, oracleKeeper oraclekeeper.Keeper,
-	evmKeeper *evmkeeper.Keeper,
-	paramsKeeper paramskeeper.Keeper,
-) (sdk.GasMeter, bool, error) {
-	// TODO: may not be necessary for CheckTx
-	isGasless, err := antedecorators.IsTxGasless(tx, ctx, oracleKeeper, evmKeeper)
-	if err != nil {
-		return nil, false, err
+func SetGasMeter(ctx sdk.Context, gasLimit uint64, paramsKeeper paramskeeper.Keeper) sdk.Context {
+	cosmosGasParams := paramsKeeper.GetCosmosGasParams(ctx)
+
+	if ctx.BlockHeight() == 0 {
+		return ctx.WithGasMeter(storetypes.NewInfiniteMultiplierGasMeter(cosmosGasParams.CosmosGasMultiplierNumerator, cosmosGasParams.CosmosGasMultiplierDenominator))
 	}
-	if !isGasless {
-		cosmosGasParams := paramsKeeper.GetCosmosGasParams(ctx)
-		return storetypes.NewMultiplierGasMeter(tx.(GasTx).GetGas(), cosmosGasParams.CosmosGasMultiplierNumerator, cosmosGasParams.CosmosGasMultiplierDenominator), isGasless, nil
-	}
-	return ctx.GasMeter(), isGasless, nil
+
+	return ctx.WithGasMeter(storetypes.NewMultiplierGasMeter(gasLimit, cosmosGasParams.CosmosGasMultiplierNumerator, cosmosGasParams.CosmosGasMultiplierDenominator))
 }
 
 func CheckAndChargeFees(ctx sdk.Context, tx sdk.Tx, accountKeeper authkeeper.AccountKeeper, bankKeeper bankkeeper.Keeper, feegrantKeeper *feegrantkeeper.Keeper, paramsKeeper paramskeeper.Keeper, isGasless bool) (priority int64, err error) {


### PR DESCRIPTION
## Describe your changes and provide context
Setting gas meter should be the very first thing when handling a transaction. If that's not the case and the handler exits for whatever reason, the upstream logic will use the common gas meter set at the beginning of `FinalizeBlock` as the transaction's gas meter, which can cause unexpected results.

## Testing performed to validate your change
local cluster
