### PR TITLE
fix: mempool: enforce txBlacklisting for stupidly big txs

### DIFF
--- a/sei-tendermint/config/config.go
+++ b/sei-tendermint/config/config.go
@@ -876,8 +876,8 @@ func DefaultMempoolConfig() *MempoolConfig {
 		TTLDuration:                  5 * time.Second, // prevent stale txs from filling mempool
 		TTLNumBlocks:                 10,              // remove txs after 10 blocks
 		TxNotifyThreshold:            0,
-		CheckTxErrorBlacklistEnabled: false,
-		CheckTxErrorThreshold:        0,
+		CheckTxErrorBlacklistEnabled: true,
+		CheckTxErrorThreshold:        50,
 		PendingSize:                  5000,
 		MaxPendingTxsBytes:           1024 * 1024 * 1024, // 1GB
 		PendingTTLDuration:           0 * time.Second,


### PR DESCRIPTION
## Describe your changes and provide context

This PR:
- changes mempool config to have `CheckTxErrorBlacklistEnabled` true by default
- weakens blacklist protection to apply to only  oversized transactions.

Future PRs will expand blacklist protection to cover other forms of "clearly bad" transactions, such as:
- undecodeable transactions
- incorrect signatures
- ludicrous params (more gas than a block has)
- etc.

## Testing performed to validate your change

`make test` passes

