### PR TITLE
[CON-76] fix: sei-tendermint: include all fields in CommitHash

### DIFF
--- a/sei-tendermint/types/block.go
+++ b/sei-tendermint/types/block.go
@@ -845,21 +845,34 @@ func (commit *Commit) ValidateBasic() error {
 	return nil
 }
 
-// Hash returns the hash of the commit
+// Hash returns the hash of the commit.
+// It computes a Merkle tree from all commit fields: Height, Round, BlockID, and Signatures.
 func (commit *Commit) Hash() tmbytes.HexBytes {
 	if commit == nil {
 		return nil
 	}
 	if commit.hash == nil {
-		bs := make([][]byte, len(commit.Signatures))
+		// Encode BlockID
+		pbbi := commit.BlockID.ToProto()
+		bzbi, err := pbbi.Marshal()
+		if err != nil {
+			panic(err)
+		}
+
+		// Build slice with metadata fields first, then signatures
+		// Fields: Height, Round, BlockID, followed by each CommitSig
+		bs := make([][]byte, 3+len(commit.Signatures))
+		bs[0] = cdcEncode(commit.Height)
+		bs[1] = cdcEncode(int64(commit.Round)) // Cast to int64 for cdcEncode
+		bs[2] = bzbi
+
 		for i, commitSig := range commit.Signatures {
 			pbcs := commitSig.ToProto()
 			bz, err := pbcs.Marshal()
 			if err != nil {
 				panic(err)
 			}
-
-			bs[i] = bz
+			bs[3+i] = bz
 		}
 		commit.hash = merkle.HashFromByteSlices(bs)
 	}

--- a/sei-tendermint/types/block_test.go
+++ b/sei-tendermint/types/block_test.go
@@ -272,6 +272,93 @@ func TestCommit(t *testing.T) {
 	assert.True(t, commit.IsCommit())
 }
 
+func TestCommitHash(t *testing.T) {
+	// Create a base commit for comparison
+	blockID := makeBlockIDRandom()
+	sig := CommitSig{
+		BlockIDFlag:      BlockIDFlagCommit,
+		ValidatorAddress: crypto.AddressHash([]byte("validator1")),
+		Timestamp:        time.Now(),
+		Signature:        crypto.CRandBytes(64),
+	}
+
+	baseCommit := &Commit{
+		Height:     100,
+		Round:      1,
+		BlockID:    blockID,
+		Signatures: []CommitSig{sig},
+	}
+	baseHash := baseCommit.Hash()
+	require.NotNil(t, baseHash, "base commit hash should not be nil")
+
+	t.Run("same commit produces same hash", func(t *testing.T) {
+		// Create identical commit
+		sameCommit := &Commit{
+			Height:     100,
+			Round:      1,
+			BlockID:    blockID,
+			Signatures: []CommitSig{sig},
+		}
+		assert.Equal(t, baseHash, sameCommit.Hash(), "identical commits should have identical hashes")
+	})
+
+	t.Run("different height produces different hash", func(t *testing.T) {
+		differentHeightCommit := &Commit{
+			Height:     101, // Different height
+			Round:      1,
+			BlockID:    blockID,
+			Signatures: []CommitSig{sig},
+		}
+		assert.NotEqual(t, baseHash, differentHeightCommit.Hash(),
+			"commit with different height should have different hash")
+	})
+
+	t.Run("different round produces different hash", func(t *testing.T) {
+		differentRoundCommit := &Commit{
+			Height:     100,
+			Round:      2, // Different round
+			BlockID:    blockID,
+			Signatures: []CommitSig{sig},
+		}
+		assert.NotEqual(t, baseHash, differentRoundCommit.Hash(),
+			"commit with different round should have different hash")
+	})
+
+	t.Run("different blockID produces different hash", func(t *testing.T) {
+		differentBlockID := makeBlockIDRandom()
+		differentBlockIDCommit := &Commit{
+			Height:     100,
+			Round:      1,
+			BlockID:    differentBlockID, // Different blockID
+			Signatures: []CommitSig{sig},
+		}
+		assert.NotEqual(t, baseHash, differentBlockIDCommit.Hash(),
+			"commit with different blockID should have different hash")
+	})
+
+	t.Run("different signature produces different hash", func(t *testing.T) {
+		differentSig := CommitSig{
+			BlockIDFlag:      BlockIDFlagCommit,
+			ValidatorAddress: crypto.AddressHash([]byte("validator2")), // Different validator
+			Timestamp:        time.Now(),
+			Signature:        crypto.CRandBytes(64),
+		}
+		differentSigCommit := &Commit{
+			Height:     100,
+			Round:      1,
+			BlockID:    blockID,
+			Signatures: []CommitSig{differentSig},
+		}
+		assert.NotEqual(t, baseHash, differentSigCommit.Hash(),
+			"commit with different signatures should have different hash")
+	})
+
+	t.Run("nil commit has nil hash", func(t *testing.T) {
+		var nilCommit *Commit
+		assert.Nil(t, nilCommit.Hash(), "nil commit should have nil hash")
+	})
+}
+
 func TestCommitValidateBasic(t *testing.T) {
 	testCases := []struct {
 		testName       string


### PR DESCRIPTION
## Describe your changes and provide context

Pretty much as in the title -- the CommitHash now covers all fields.

## Testing performed to validate your change

Added a few new tests, `make test` passes.
