### PR TITLE
[CON-143] fix: deflake TestRouter_dialPeer_Reject

### DIFF
--- a/sei-tendermint/internal/p2p/router_test.go
+++ b/sei-tendermint/internal/p2p/router_test.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/fortytw2/leaktest"
-	"github.com/gogo/protobuf/proto"
-	dbm "github.com/tendermint/tm-db"
-	"golang.org/x/time/rate"
-	"io"
 	"net"
 	"net/netip"
 	"strings"
 	"sync/atomic"
 	"testing"
+
+	"github.com/fortytw2/leaktest"
+	"github.com/gogo/protobuf/proto"
+	dbm "github.com/tendermint/tm-db"
+	"golang.org/x/time/rate"
 
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/internal/p2p/conn"
@@ -539,8 +539,8 @@ func TestRouter_dialPeer_Reject(t *testing.T) {
 				if err != nil {
 					return nil
 				}
-				if err := x.runConn(ctx, conn); !errors.Is(err, io.EOF) {
-					return fmt.Errorf("want EOF, got %w", err)
+				if err := x.runConn(ctx, conn); utils.IgnoreCancel(err) == nil {
+					return fmt.Errorf("want non-nil, non-cancellation error, got %w", err)
 				}
 				return nil
 			})
@@ -638,8 +638,8 @@ func TestRouter_EvictPeers(t *testing.T) {
 		t.Log("Report the peer as bad.")
 		r.Evict(peerID, errors.New("boom"))
 		t.Log("Wait for conn down")
-		if err := x.runConn(ctx, conn); !errors.Is(err, io.EOF) {
-			return fmt.Errorf("want EOF, got %w", err)
+		if err := x.runConn(ctx, conn); utils.IgnoreCancel(err) == nil {
+			return fmt.Errorf("want non-nil, non-cancellation error, got %w", err)
 		}
 		return nil
 	}); err != nil {


### PR DESCRIPTION
## Describe your changes and provide context

This test can flakily fail with the following error:

```
--- FAIL: TestRouter_dialPeer_Reject (0.14s)
    --- FAIL: TestRouter_dialPeer_Reject/incompatible_channels (0.02s)
        router_test.go:548: want EOF, got mconn.Run: recvRoutine: protoReader.ReadMsg(): read tcp 127.0.0.1:41769->127.0.0.1:44942: read: connection reset by peer
```

The issue is that the test only wants an EOF error to signal a connection being closed, but you can probably get a bunch of different errors. This PR weakens the fail condition to `utils.IgnoreCancel(err) == nil`, matching the pattern we already have in TestRouter_AcceptPeers (see [here](https://github.com/sei-protocol/sei-chain/blob/4bc58d5aee5cdf4ed02ed9228138b7960e82bc69/sei-tendermint/internal/p2p/router_test.go#L383)).

This PR also makes the same change to `TestRouter_EvictPeers`, which might flake in a similar way.

## Testing performed to validate your change

`make test` passes

