### PR TITLE
[giga] abstract occ scheduler into interfaces

### DIFF
--- a/giga/executor/types/common.go
+++ b/giga/executor/types/common.go
@@ -1,0 +1,5 @@
+package types
+
+type Hash [32]byte
+
+type Address [20]byte

--- a/giga/executor/types/interfaces.go
+++ b/giga/executor/types/interfaces.go
@@ -1,0 +1,21 @@
+package types
+
+// The interface defines the entrypoints of a transaction execution.
+type VM interface {
+	Create(sender Address, code []byte, gas uint64, value Hash) (ret []byte, contractAddr Address, gasLeft uint64, err error)
+	Call(sender Address, to Address, input []byte, gas uint64, value Hash) (ret []byte, gasLeft uint64, err error)
+}
+
+// The interface defines access to states. These are needed mainly
+// for the preprocessing before the VM entrypoints are called (
+// e.g. nonce checking/setting, fee charging, value transfer, etc.)
+type Storage interface {
+	GetCode(addr Address) ([]byte, error)
+	GetState(addr Address, key Hash) (Hash, error)
+	SetState(addr Address, key Hash, value Hash) error
+	GetBalance(addr Address) (Hash, error)
+	SetBalance(addr Address, value Hash) error
+	GetNonce(addr Address) (uint64, error)
+	SetNonce(addr Address, nonce uint64) error
+	// TODO: accesslist setting
+}

--- a/giga/executor/vm/evmc/vm.go
+++ b/giga/executor/vm/evmc/vm.go
@@ -1,0 +1,32 @@
+package evmc
+
+import (
+	"math"
+
+	"github.com/ethereum/evmc/v12/bindings/go/evmc"
+	"github.com/sei-protocol/sei-chain/giga/executor/types"
+)
+
+type VMImpl struct {
+	hostContext evmc.HostContext
+}
+
+func NewVM(hostContext evmc.HostContext) types.VM {
+	return &VMImpl{hostContext: hostContext}
+}
+
+func (v *VMImpl) Create(sender types.Address, code []byte, gas uint64, value types.Hash) (ret []byte, contractAddr types.Address, gasLeft uint64, err error) {
+	if gas > math.MaxInt64 {
+		panic("gas overflow")
+	}
+	ret, left, _, addr, err := v.hostContext.Call(evmc.Create, evmc.Address{}, evmc.Address(sender), evmc.Hash(value), code, int64(gas), 0, false, evmc.Hash{}, evmc.Address{})
+	return ret, types.Address(addr), uint64(left), err //nolint:gosec
+}
+
+func (v *VMImpl) Call(sender types.Address, to types.Address, input []byte, gas uint64, value types.Hash) (ret []byte, gasLeft uint64, err error) {
+	if gas > math.MaxInt64 {
+		panic("gas overflow")
+	}
+	ret, left, _, _, err := v.hostContext.Call(evmc.Call, evmc.Address(to), evmc.Address(sender), evmc.Hash(value), input, int64(gas), 0, false, evmc.Hash{}, evmc.Address(to))
+	return ret, uint64(left), err //nolint:gosec
+}

--- a/giga/executor/vm/geth/vm.go
+++ b/giga/executor/vm/geth/vm.go
@@ -1,0 +1,28 @@
+package geth
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/holiman/uint256"
+	"github.com/sei-protocol/sei-chain/giga/executor/types"
+)
+
+var _ types.VM = &VMImpl{}
+
+type VMImpl struct {
+	evm *vm.EVM
+}
+
+func NewVM(evm *vm.EVM) types.VM {
+	return &VMImpl{evm: evm}
+}
+
+func (v *VMImpl) Create(sender types.Address, code []byte, gas uint64, value types.Hash) (ret []byte, contractAddr types.Address, gasLeft uint64, err error) {
+	ret, addr, gasLeft, err := v.evm.Create(common.Address(sender), code, gas, new(uint256.Int).SetBytes(value[:]))
+	return ret, types.Address(addr), gasLeft, err
+}
+
+func (v *VMImpl) Call(sender types.Address, to types.Address, input []byte, gas uint64, value types.Hash) (ret []byte, gasLeft uint64, err error) {
+	ret, gasLeft, err = v.evm.Call(common.Address(sender), common.Address(to), input, gas, new(uint256.Int).SetBytes(value[:]))
+	return ret, gasLeft, err
+}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/iavl v0.21.0-alpha.1.0.20230904092046-df3db2d96583
 	github.com/cosmos/ibc-go/v3 v3.0.0
+	github.com/ethereum/evmc/v12 v12.1.0
 	github.com/ethereum/go-ethereum v1.16.1
 	github.com/go-playground/validator/v10 v10.11.1
 	github.com/gogo/protobuf v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -971,6 +971,8 @@ github.com/esimonov/ifshort v1.0.4 h1:6SID4yGWfRae/M7hkVDVVyppy8q/v9OuxNdmjLQStB
 github.com/esimonov/ifshort v1.0.4/go.mod h1:Pe8zjlRrJ80+q2CxHLfEOfTwxCZ4O+MuhcHcfgNWTk0=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=
 github.com/ethereum/c-kzg-4844 v1.0.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
+github.com/ethereum/evmc/v12 v12.1.0 h1:fUIzJNnXa9VPYx253lDS7L9iBZtP+tlpTdZst5e6Pks=
+github.com/ethereum/evmc/v12 v12.1.0/go.mod h1:80jmft01io35nSmrX70bKFR/lncwFuqE90iLLSMyMAE=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=
 github.com/ethereum/go-verkle v0.2.2/go.mod h1:M3b90YRnzqKyyzBEWJGqj8Qff4IDeXnzFw0P9bFw3uk=
 github.com/ettle/strcase v0.1.1 h1:htFueZyVeE1XNnMEfbqp5r67qAN/4r6ya1ysq8Q+Zcw=


### PR DESCRIPTION
## Describe your changes and provide context
The existing OCC scheduler is somewhat coupled with Cosmos specific logics like `sdk.Context` and stores. This PR refactors the scheduler to be generic and not dependent on any Cosmos specific types, so that it can later be used for giga execution. Specifically this PR yields the following two interfaces for giga to implement and use:
```
type Scheduler[Response any]
type SchedulerTask[Response any]
```

## Testing performed to validate your change
refactor - existing tests should still hold
