### PR TITLE
Backport `release/v6.3`: Update dockerfile for caching efficiency and better libwasmvm handling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,14 @@
 build/
+.github
+assets
+docker
+**/*.md
+**/README*
+**/LICENSE*
+
+# Ignore all go test files as no tests are run during docker build.
+**/*_test.go
+
 # The .git folder must be transferred to Docker context since the Makefile
 # uses git commands to get the current commit hash and tag for versioning.
 # .git/

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -32,5 +32,5 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Validate Docker build (amd64)
-        run: docker build --platform=linux/amd64 --target=go-builder .
+        run: docker build --platform=linux/amd64 .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,19 @@
-# ---------- Builder ----------
-FROM docker.io/golang:1.24.5 AS go-builder
-WORKDIR /app/sei-chain
+FROM docker.io/golang:1.24-bookworm@sha256:fc58bb98c4b7ebc8211c94df9dee40489e48363c69071bceca91aa59023b0dee AS builder
+WORKDIR /go/src/sei-chain
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && \
-    rm -rf /var/lib/apt/lists/*
+COPY sei-wasmd/x/wasm/artifacts/v152/api/*.so /tmp/wasmd-libs/
+COPY sei-wasmd/x/wasm/artifacts/v155/api/*.so /tmp/wasmd-libs/
+COPY sei-wasmvm/internal/api/*.so /tmp/wasmvm-libs/
+ARG TARGETARCH
+RUN mkdir -p /go/lib && \
+    case "${TARGETARCH}" in \
+      amd64) ARCH_SUFFIX="x86_64" ;; \
+      arm64) ARCH_SUFFIX="aarch64" ;; \
+      *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    cp /tmp/wasmd-libs/libwasmvm152.${ARCH_SUFFIX}.so /go/lib/ && \
+    cp /tmp/wasmd-libs/libwasmvm155.${ARCH_SUFFIX}.so /go/lib/ && \
+    cp /tmp/wasmvm-libs/libwasmvm.${ARCH_SUFFIX}.so /go/lib/
 
 # Cache Go modules
 COPY go.work go.work.sum ./
@@ -16,56 +26,27 @@ COPY sei-ibc-go/go.mod sei-ibc-go/go.sum ./sei-ibc-go/
 COPY sei-db/go.mod sei-db/go.sum ./sei-db/
 RUN go mod download
 
-# Copy source and build (CGO enabled for libwasmvm)
 COPY . .
 ENV CGO_ENABLED=1
-RUN make build build-price-feeder
+ARG SEI_CHAIN_REF=""
+ARG GO_BUILD_TAGS=""
+ARG GO_BUILD_ARGS=""
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    BUILD_TAGS="netgo ledger ${GO_BUILD_TAGS}" && \
+    VERSION_PKG="github.com/cosmos/cosmos-sdk/version" && \
+    LDFLAGS="\
+      -X ${VERSION_PKG}.Name=sei \
+      -X ${VERSION_PKG}.AppName=seid \
+      -X ${VERSION_PKG}.Version=$(git describe --tags || echo "${SEI_CHAIN_REF}") \
+      -X ${VERSION_PKG}.Commit=$(git log -1 --format='%H') \
+      -X '${VERSION_PKG}.BuildTags=${BUILD_TAGS}'" && \
+    go build -tags "${BUILD_TAGS}" -ldflags "${LDFLAGS}" ${GO_BUILD_ARGS} -o /go/bin/seid ./cmd/seid && \
+    go build -tags "${BUILD_TAGS}" -ldflags "${LDFLAGS}" ${GO_BUILD_ARGS} -o /go/bin/price-feeder ./oracle/price-feeder
 
-# Collect libwasmvm*.so: try ./seiwasmd; else auto-derive version and download glibc .so
-ARG WASMVM_VERSION=""
-RUN set -eux; \
-    mkdir -p /build/deps; \
-    LIBWASM_DIR="./sei-wasmd"; \
-    found=0; \
-    # Copy from module cache if present
-    FILES="$(find "$LIBWASM_DIR" -type f -name 'libwasmvm*.so' -print || true)"; \
-    if [ -n "$FILES" ]; then \
-        echo "$FILES" | xargs -r -n1 -I{} cp -v "{}" /build/deps/; \
-        found=1; \
-    fi; \
-    # If not found, derive version (or use provided WASMVM_VERSION) and download
-    if [ "$found" -eq 0 ]; then \
-        if [ -z "$WASMVM_VERSION" ]; then \
-            WASMVM_VERSION="$(go list -f '{{if .Replace}}{{.Replace.Version}}{{else}}{{.Version}}{{end}}' -m github.com/CosmWasm/wasmvm 2>/dev/null | sed 's/^v//' | sed 's/-.*//')"; \
-            [ -n "$WASMVM_VERSION" ] || { echo "wasmvm version not found in go.mod; set --build-arg WASMVM_VERSION=vX.Y.Z"; exit 1; }; \
-            WASMVM_VERSION="v${WASMVM_VERSION}"; \
-        fi; \
-        case "${TARGETARCH:-$(go env GOARCH)}" in \
-            amd64) ARCH=x86_64 ;; \
-            arm64) ARCH=aarch64 ;; \
-            *) echo "unsupported arch: ${TARGETARCH:-$(go env GOARCH)}"; exit 1 ;; \
-        esac; \
-        wget -O /build/deps/libwasmvm.${ARCH}.so \
-            "https://github.com/CosmWasm/wasmvm/releases/download/${WASMVM_VERSION}/libwasmvm.${ARCH}.so"; \
-        found=1; \
-    fi; \
-    ls -l /build/deps
+FROM docker.io/ubuntu:24.04@sha256:104ae83764a5119017b8e8d6218fa0832b09df65aae7d5a6de29a85d813da2fb
 
-# ---------- Runtime ----------
-FROM ubuntu:24.04
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
+COPY --from=builder /go/bin/seid /go/bin/price-feeder /usr/bin/
+COPY --from=builder /go/lib/*.so /usr/lib/
 
-COPY --from=go-builder /app/sei-chain/build/seid /bin/seid
-COPY --from=go-builder /app/sei-chain/build/price-feeder /bin/price-feeder
-COPY --from=go-builder /build/deps/libwasmvm*.so /usr/lib/
-
-# Ensure generic symlink exists and refresh linker cache
-RUN bash -lc '\
-    set -eux; \
-    arch=$(uname -m); case "$arch" in x86_64|amd64) a=x86_64 ;; aarch64|arm64) a=aarch64 ;; *) a="" ;; esac; \
-    if [ -n "$a" ] && [ -f "/usr/lib/libwasmvm.${a}.so" ]; then ln -sf "/usr/lib/libwasmvm.${a}.so" /usr/lib/libwasmvm.so; fi; \
-    ldconfig'
-
-EXPOSE 1317 26656 26657 8545 9090
-ENTRYPOINT ["/bin/seid"]
+ENTRYPOINT ["/usr/bin/seid"]


### PR DESCRIPTION
Backport of #2598 to `release/v6.3`.