### PR TITLE
[CON-152] fix: state: safely set per-account maps when handling reverts

### DIFF
--- a/x/evm/state/journal.go
+++ b/x/evm/state/journal.go
@@ -92,11 +92,22 @@ func (e *refundChange) revert(s *DBImpl) {
 func (e *transientStorageChange) revert(s *DBImpl) {
 	states := s.tempState.transientStates[e.account.Hex()]
 	if e.prevalue.Cmp(common.Hash{}) == 0 {
+		// If the per-account transient map was already removed by a later revert,
+		// there is nothing to delete.
+		if states == nil {
+			return
+		}
 		delete(states, e.key.Hex())
 		if len(states) == 0 {
 			delete(s.tempState.transientStates, e.account.Hex())
 		}
 	} else {
+		// A prior revert may have deleted the per-account map when it became empty.
+		// Re-create it so we can restore a non-zero prevalue.
+		if states == nil {
+			states = make(map[string]common.Hash)
+			s.tempState.transientStates[e.account.Hex()] = states
+		}
 		states[e.key.Hex()] = e.prevalue
 	}
 }

--- a/x/evm/state/state_test.go
+++ b/x/evm/state/state_test.go
@@ -231,3 +231,43 @@ func TestSnapshot(t *testing.T) {
 	require.Equal(t, val, newStateDB.GetState(evmAddr, key))
 	require.Equal(t, eventCount+1, len(ctx.EventManager().Events()))
 }
+
+// TestTransientStorageRevertNilMapPanic tests that reverting multiple transient storage
+// changes does not panic when a prior revert deletes the account's transient state map.
+func TestTransientStorageRevertNilMapPanic(t *testing.T) {
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	_, evmAddr := testkeeper.MockAddressPair()
+	statedb := state.NewDBImpl(ctx, k, false)
+	statedb.CreateAccount(evmAddr)
+
+	tkey := common.BytesToHash([]byte("transient_key"))
+	value1 := common.BytesToHash([]byte("value1"))
+	value2 := common.BytesToHash([]byte("value2"))
+
+	// Step 1: TSTORE(key, value1) - creates map, journal entry with prevalue=0
+	statedb.SetTransientState(evmAddr, tkey, value1)
+	require.Equal(t, value1, statedb.GetTransientState(evmAddr, tkey))
+
+	// Step 2: Take first snapshot
+	firstSnapshot := statedb.Snapshot()
+
+	// Step 3: TSTORE(key, 0) - deletes value, journal entry with prevalue=value1
+	statedb.SetTransientState(evmAddr, tkey, common.Hash{})
+	require.Equal(t, common.Hash{}, statedb.GetTransientState(evmAddr, tkey))
+
+	// Step 4: Take second snapshot (not used, but part of the sequence)
+	_ = statedb.Snapshot()
+
+	// Step 5: TSTORE(key, value2) - sets value, journal entry with prevalue=0
+	statedb.SetTransientState(evmAddr, tkey, value2)
+	require.Equal(t, value2, statedb.GetTransientState(evmAddr, tkey))
+
+	// Step 6: RevertToSnapshot(first), this should NOT panic.
+	require.NotPanics(t, func() {
+		statedb.RevertToSnapshot(firstSnapshot)
+	})
+
+	// After revert, the transient state should be restored to value1
+	require.Equal(t, value1, statedb.GetTransientState(evmAddr, tkey))
+}


### PR DESCRIPTION
## Describe your changes and provide context

Fixes an edge-case where two reverts could be unsafe.

## Testing performed to validate your change

Added a new test
