### PR TITLE
fix: state: safely handle access list reverts

### DIFF
--- a/x/evm/state/accesslist.go
+++ b/x/evm/state/accesslist.go
@@ -58,11 +58,12 @@ func (s *DBImpl) AddSlotToAccessList(addr common.Address, slot common.Hash) {
 		s.journal = append(s.journal, &accessListAddSlotChange{address: addr, slot: slot})
 		return
 	}
-	// There is already an (address,slot) mapping
 	slotmap := al.Slots[idx]
-	if _, ok := slotmap[slot]; !ok {
-		slotmap[slot] = struct{}{}
+	if _, ok := slotmap[slot]; ok {
+		// Slot already present, nothing to do (no journal entry needed)
+		return
 	}
+	slotmap[slot] = struct{}{}
 	s.journal = append(s.journal, &accessListAddSlotChange{address: addr, slot: slot})
 }
 

--- a/x/evm/state/accesslist_test.go
+++ b/x/evm/state/accesslist_test.go
@@ -115,3 +115,39 @@ func addAndCheckSlot(t *testing.T, statedb *state.DBImpl, addr common.Address, a
 	require.Nil(t, statedb.Err())
 	require.True(t, slotOk)
 }
+
+func TestDuplicateSlotsInAccessListRevert(t *testing.T) {
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	statedb := state.NewDBImpl(ctx, k, false)
+
+	_, sender := testkeeper.MockAddressPair()
+	_, coinbase := testkeeper.MockAddressPair()
+	_, dest := testkeeper.MockAddressPair()
+	_, accessAddr := testkeeper.MockAddressPair()
+
+	duplicateSlot := common.BytesToHash([]byte("duplicate"))
+	txaccesses := []ethtypes.AccessTuple{
+		{
+			Address: accessAddr,
+			StorageKeys: []common.Hash{
+				duplicateSlot,
+				duplicateSlot,
+				duplicateSlot,
+			},
+		},
+	}
+
+	shanghai := params.Rules{ChainID: k.ChainID(ctx), IsShanghai: true}
+
+	statedb.Prepare(shanghai, sender, coinbase, &dest, []common.Address{}, txaccesses)
+
+	addrOk, slotOk := statedb.SlotInAccessList(accessAddr, duplicateSlot)
+	require.True(t, addrOk)
+	require.True(t, slotOk)
+
+	// Reverting to snapshot 0 (initial) should NOT panic
+	require.NotPanics(t, func() {
+		statedb.RevertToSnapshot(0)
+	})
+}

--- a/x/evm/state/journal.go
+++ b/x/evm/state/journal.go
@@ -56,8 +56,17 @@ func (e *accessListAddSlotChange) revert(s *DBImpl) {
 	// since slot change always comes after address change, and revert
 	// happens in reverse order, the address access list hasn't been
 	// cleared at this point.
-	idx := s.tempState.transientAccessLists.Addresses[e.address]
+	idx, ok := s.tempState.transientAccessLists.Addresses[e.address]
+	// If the address was already removed or has no slots (idx == -1),
+	// there is nothing to revert.
+	if !ok || idx == -1 {
+		return
+	}
 	slotsList := s.tempState.transientAccessLists.Slots
+	// Bounds check in case a prior revert already modified the slots slice.
+	if idx >= len(slotsList) {
+		return
+	}
 	slots := slotsList[idx]
 	delete(slots, e.slot)
 	if len(slots) == 0 {


### PR DESCRIPTION
## Describe your changes and provide context

Similar to #2626, we should handle potential duplicates safely in access list changes.

## Testing performed to validate your change

Added a new test.