### PR TITLE
fix: app: defensively check for nil tx

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1836,6 +1836,10 @@ func (app *App) checkTotalBlockGas(ctx sdk.Context, txs [][]byte) (result bool) 
 // Returns false only if DEFINITELY not gasless.
 // False negatives are unacceptable as they cause incorrect gas metrics.
 func (app *App) couldBeGaslessTransaction(tx sdk.Tx) bool {
+	if tx == nil {
+		return false
+	}
+
 	msgs := tx.GetMsgs()
 	if len(msgs) == 0 {
 		// Empty transactions are definitely not gasless

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -797,3 +797,15 @@ func TestProcessBlockUpgradePanicLogic(t *testing.T) {
 		})
 	}
 }
+
+func TestDeliverTxWithNilTypedTxDoesNotPanic(t *testing.T) {
+	sei := app.Setup(t, false, false, false)
+	ctx := sei.BaseApp.NewContext(false, types.Header{})
+
+	malformedTxBytes := []byte("invalid tx bytes that cannot be decoded")
+
+	require.NotPanics(t, func() {
+		result := sei.DeliverTxWithResult(ctx, malformedTxBytes, nil)
+		require.NotNil(t, result)
+	})
+}


### PR DESCRIPTION
Just adding a defensive check in case something funky happens here.

