### PR TITLE
Investigate Go test run time on ubuntu-large

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Remove unnecessary tooling
         run: |
           # Remove unrelated tooling to open up more space. Without doing 
-          # this ~80% of the available 15GiB space is already occupied.
+          # this ~80% of the available 15 GiB space is already occupied.
           sudo rm -rf \
             /usr/share/dotnet \
             /usr/local/lib/android \


### PR DESCRIPTION
Bump instance type to see if go tests can run faster
