### PR TITLE
[giga] pipelining skeleton

### DIFF
--- a/giga/executor/executor.go
+++ b/giga/executor/executor.go
@@ -1,0 +1,35 @@
+package executor
+
+import "github.com/sei-protocol/sei-chain/giga/executor/tracks"
+
+type Config struct {
+	StatelessWorkerCount   int
+	ReceiptSinkWorkerCount int
+	blocksBuffer           int
+	receiptsBuffer         int
+	changeSetsBuffer       int
+}
+
+func RunExecutor[RawBlock, Block tracks.Identifiable, Receipt, ChangeSet any](
+	config Config,
+	rawBlocks <-chan RawBlock, // channel where the consensus layer produces to
+	statelessFn func(RawBlock) Block, // TODO: function that checks sig, nonce, etc.
+	schedulerFn func(Block, chan<- Receipt) ChangeSet, // TODO: main processing logic
+	commitFn func(ChangeSet), // TODO: commit to working set after a block is fully done
+	receiptSinkFn func(Receipt), // TODO: persist receipts to disk
+	historicalStateSinkFn func(ChangeSet), // TODO: persist historical state to disk
+	prevBlock uint64, // TODO: the last executed block id,
+) {
+	blocks := make(chan Block, config.blocksBuffer)
+	receipts := make(chan Receipt, config.receiptsBuffer)
+	changeSets := make(chan ChangeSet, config.changeSetsBuffer)
+
+	// spins off `StatelessWorkerCount` goroutines.
+	tracks.StartStatelessTrack(rawBlocks, blocks, statelessFn, config.StatelessWorkerCount, prevBlock)
+	// spins off 1 goroutine.
+	tracks.StartExecutionTrack(blocks, receipts, changeSets, schedulerFn, commitFn)
+	// spins off `ReceiptSinkWorkerCount` goroutines.
+	tracks.StartReceiptSinkTrack(receipts, receiptSinkFn, config.ReceiptSinkWorkerCount)
+	// spins off 1 goroutine.
+	tracks.StartHistoricalStateSinkTrack(changeSets, historicalStateSinkFn)
+}

--- a/giga/executor/tracks/execution.go
+++ b/giga/executor/tracks/execution.go
@@ -1,18 +1,34 @@
 package tracks
 
-// Execution track is not parallelizable since it requires the previous block to be executed.
-func StartExecutionTrack[Block, Receipt, ChangeSet any](
+type ExecutionTrack[Block, Receipt, ChangeSet any] struct {
+	blocks      <-chan Block
+	receipts    chan<- Receipt
+	changeSets  chan<- ChangeSet
+	schedulerFn func(Block, chan<- Receipt) ChangeSet
+	commitFn    func(ChangeSet)
+}
+
+func NewExecutionTrack[Block, Receipt, ChangeSet any](
 	blocks <-chan Block,
 	receipts chan<- Receipt,
 	changeSets chan<- ChangeSet,
 	schedulerFn func(Block, chan<- Receipt) ChangeSet,
 	commitFn func(ChangeSet),
-) {
+) *ExecutionTrack[Block, Receipt, ChangeSet] {
+	return &ExecutionTrack[Block, Receipt, ChangeSet]{blocks, receipts, changeSets, schedulerFn, commitFn}
+}
+
+func (t *ExecutionTrack[Block, Receipt, ChangeSet]) Start() {
 	go func() {
-		for block := range blocks {
-			rcs := schedulerFn(block, receipts)
-			commitFn(rcs)
-			changeSets <- rcs
+		for block := range t.blocks {
+			rcs := t.schedulerFn(block, t.receipts)
+			t.commitFn(rcs)
+			t.changeSets <- rcs
 		}
 	}()
+}
+
+func (t *ExecutionTrack[Block, Receipt, ChangeSet]) Stop() {
+	close(t.receipts)
+	close(t.changeSets)
 }

--- a/giga/executor/tracks/execution.go
+++ b/giga/executor/tracks/execution.go
@@ -1,0 +1,18 @@
+package tracks
+
+// Execution track is not parallelizable since it requires the previous block to be executed.
+func StartExecutionTrack[Block, Receipt, ChangeSet any](
+	blocks <-chan Block,
+	receipts chan<- Receipt,
+	changeSets chan<- ChangeSet,
+	schedulerFn func(Block, chan<- Receipt) ChangeSet,
+	commitFn func(ChangeSet),
+) {
+	go func() {
+		for block := range blocks {
+			rcs := schedulerFn(block, receipts)
+			commitFn(rcs)
+			changeSets <- rcs
+		}
+	}()
+}

--- a/giga/executor/tracks/sinks.go
+++ b/giga/executor/tracks/sinks.go
@@ -1,0 +1,28 @@
+package tracks
+
+// Receipt sink can be fully parallelized since each receipt is independent of each other.
+func StartReceiptSinkTrack[Receipt any](
+	receipts <-chan Receipt,
+	sinkFn func(Receipt),
+	workerCount int,
+) {
+	for range workerCount {
+		go func() {
+			for receipt := range receipts {
+				sinkFn(receipt)
+			}
+		}()
+	}
+}
+
+// Historical state sink is not parallelizable since it requires the previous state to be committed.
+func StartHistoricalStateSinkTrack[ChangeSet any](
+	changeSets <-chan ChangeSet,
+	sinkFn func(ChangeSet),
+) {
+	go func() {
+		for changeSet := range changeSets {
+			sinkFn(changeSet)
+		}
+	}()
+}

--- a/giga/executor/tracks/stateless.go
+++ b/giga/executor/tracks/stateless.go
@@ -1,0 +1,46 @@
+package tracks
+
+import (
+	"sync"
+	"time"
+)
+
+type Identifiable interface {
+	GetID() uint64
+}
+
+// Stateless track is parallelizable since the processing is stateless.
+// However, the output order must be in the same order as the input, hence
+// the involved signaling logic.
+func StartStatelessTrack[RawBlock, Block Identifiable](
+	inputs <-chan RawBlock,
+	outputs chan<- Block,
+	processFn func(RawBlock) Block,
+	workerCount int,
+	prevBlock uint64,
+) {
+	// completion signals are used to ensure outputs are in order.
+	completionSignals := sync.Map{}
+	lastBlockSignal := make(chan struct{}, 1)
+	lastBlockSignal <- struct{}{}
+	completionSignals.Store(prevBlock, lastBlockSignal)
+	for range workerCount {
+		go func() {
+			for input := range inputs {
+				completionSignal := make(chan struct{}, 1)
+				completionSignals.Store(input.GetID(), completionSignal)
+				output := processFn(input)
+				prevCompletionSignal, ok := completionSignals.Load(input.GetID() - 1)
+				// in practice it's almost impossible for ok == false, but we'll handle it anyway
+				for !ok {
+					time.Sleep(10 * time.Millisecond)
+					prevCompletionSignal, ok = completionSignals.Load(input.GetID() - 1)
+				}
+				<-prevCompletionSignal.(chan struct{})
+				outputs <- output
+				completionSignal <- struct{}{}
+				completionSignals.Delete(input.GetID() - 1)
+			}
+		}()
+	}
+}

--- a/giga/executor/tracks/stateless_test.go
+++ b/giga/executor/tracks/stateless_test.go
@@ -23,7 +23,9 @@ func TestStatelessTrack(t *testing.T) {
 	}
 	workerCount := 10
 	lastBlock := uint64(100)
-	tracks.StartStatelessTrack(inputs, outputs, processFn, workerCount, lastBlock)
+	statelessTrack := tracks.NewStatelessTrack(inputs, outputs, processFn, workerCount, lastBlock)
+	statelessTrack.Start()
+	defer statelessTrack.Stop()
 	for i := range 100 {
 		inputs <- &testBlock{id: uint64(i) + 1 + lastBlock}
 	}

--- a/giga/executor/tracks/stateless_test.go
+++ b/giga/executor/tracks/stateless_test.go
@@ -1,0 +1,34 @@
+package tracks_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/sei-protocol/sei-chain/giga/executor/tracks"
+	"github.com/tendermint/tendermint/libs/utils/require"
+)
+
+type testBlock struct{ id uint64 }
+
+func (b *testBlock) GetID() uint64 { return b.id }
+
+func TestStatelessTrack(t *testing.T) {
+	inputs := make(chan *testBlock, 100)
+	outputs := make(chan *testBlock, 100)
+	processFn := func(input *testBlock) *testBlock {
+		sleepDuration := time.Duration(rand.Intn(100)) * time.Millisecond
+		time.Sleep(sleepDuration)
+		return &testBlock{id: input.GetID()}
+	}
+	workerCount := 10
+	lastBlock := uint64(100)
+	tracks.StartStatelessTrack(inputs, outputs, processFn, workerCount, lastBlock)
+	for i := range 100 {
+		inputs <- &testBlock{id: uint64(i) + 1 + lastBlock}
+	}
+	for i := range 100 {
+		output := <-outputs
+		require.Equal(t, uint64(i)+1+lastBlock, output.GetID())
+	}
+}


### PR DESCRIPTION
## Describe your changes and provide context
Create skeleton code and concurrency control for the following model:
```
1st train: decode (unnecessary if the block fed by consensus is already decoded) and stateless checks
this is not exactly a "train", because the processing of the next block can start even before the current block finishes. However it still needs to send finished blocks to the next train in order
2nd train: I'll just call this ExecuteBlock. It's all stateful (anything stateless should happen in the 1st train) so blocks must be executed one after the other (unless we can establish a dependency graph among blocks)
1. wrap each transaction in the block into a task. A task includes:
a. PreprocessTx - includes fee charging, nonce bumping, value transfer, etc.
b. VMCall/VMCreate - [executes](https://github.com/sei-protocol/sei-chain/pull/2610/files#diff-a3fcc02b6a90cd9324dc5c0aec2f6994195165d9674c7a09e1955499e830837fR5-R6) the contract. Note that this is just the entrypoint into the VM. When VM makes its internal calls, it will use whatever functions it has internally and never calls back to these interfaces
c. PostprocessTx - includes gas refund, and send receipt info to the next train
2. feed the tasks into a [scheduler](https://github.com/sei-protocol/sei-chain/pull/2610/files#diff-5ffdd3eea7ab02b10dc36af3d59ae6d8ee3cf03aeae71d8bad25baf14bf3123bR202-R206)
3. wait for the tasks to finish and commit the changeset
3rd train: writes receipt to disk
also not exactly a "train" and can be as parallelized as resources allow
```
## Testing performed to validate your change
unit test for concurrency control
