### PR TITLE
[CON-153] fix: lightclient: divergence detector should return upon sending error

### DIFF
--- a/sei-tendermint/light/detector.go
+++ b/sei-tendermint/light/detector.go
@@ -204,12 +204,14 @@ func (c *Client) compareNewLightBlockWithWitness(ctx context.Context, errc chan 
 
 	if !bytes.Equal(l.Header.Hash(), lightBlock.Header.Hash()) {
 		errc <- ErrConflictingHeaders{Block: lightBlock, WitnessIndex: witnessIndex}
+		return
 	}
 
 	// ProposerPriorityHash is not part of the header hash, so we need to check it separately.
 	wanted, got := l.ValidatorSet.ProposerPriorityHash(), lightBlock.ValidatorSet.ProposerPriorityHash()
 	if !bytes.Equal(wanted, got) {
 		errc <- ErrProposerPrioritiesDiverge{WitnessHash: got, WitnessIndex: witnessIndex, PrimaryHash: wanted}
+		return
 	}
 
 	c.logger.Debug("matching header received by witness", "height", l.Height, "witness", witnessIndex)


### PR DESCRIPTION
If I'm understanding this code correctly, we should always return after adding an error to the channel. I think we're just missing two `return` statements.

Note: I wound up here investigating a flaky test failure, but I think this is an actual bug, not a test issue.