### PR TITLE
fix: cosmos: protect coin denom regexp with a lock

### DIFF
--- a/sei-cosmos/types/dec_coin.go
+++ b/sei-cosmos/types/dec_coin.go
@@ -625,7 +625,11 @@ func (coins DecCoins) Sort() DecCoins {
 func ParseDecCoin(coinStr string) (coin DecCoin, err error) {
 	coinStr = strings.TrimSpace(coinStr)
 
-	matches := reDecCoin.FindStringSubmatch(coinStr)
+	denomRegexMu.RLock()
+	re := reDecCoin
+	denomRegexMu.RUnlock()
+
+	matches := re.FindStringSubmatch(coinStr)
 	if matches == nil {
 		return DecCoin{}, fmt.Errorf("invalid decimal coin expression: %s", coinStr)
 	}


### PR DESCRIPTION
Should fix the racy CI failure seen [here](https://github.com/sei-protocol/sei-chain/actions/runs/20720010312/job/59480948722).

We could also just prevent the conflicting tests from running in parallel, but I think an actual change to source code is slightly better here.