### PR TITLE
chore(epoch): remove unused starport scaffolding comment

### DIFF
--- a/x/epoch/module.go
+++ b/x/epoch/module.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	// this line is used by starport scaffolding # 1
-
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"


### PR DESCRIPTION
Removes a leftover Starport scaffolding comment from the epoch module

