### PR TITLE
Fix integration tests to run on release branch and clean up rules

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - seiv2
       - release/**
     paths:
       - "**.go"

--- a/.github/workflows/cross-arch-build.yml
+++ b/.github/workflows/cross-arch-build.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - release/**
 
 concurrency:
   cancel-in-progress: true

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - release/**
   push:
     branches:
       - main
+      - release/**
 
 jobs:
   sei-images:

--- a/.github/workflows/eth_blocktests.yml
+++ b/.github/workflows/eth_blocktests.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - main
-      - seiv2
+      - release/**
   pull_request:
     branches:
       - main
-      - seiv2
+      - release/**
 
 defaults:
  run:

--- a/.github/workflows/forge-test.yml
+++ b/.github/workflows/forge-test.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - evm
       - release/**
 
 env:

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -4,9 +4,8 @@ on:
     tags:
       - v*
     branches:
-      - master
       - main
-      - seiv2
+      - release/**
   pull_request:
 permissions:
   contents: read

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -7,12 +7,11 @@ on:
   push:
     branches:
       - main
-      - seiv2
+      - release/**
   pull_request:
     branches:
       - main
-      - seiv2
-      - evm
+      - release/**
 
 defaults:
   run:

--- a/.github/workflows/mock_balances_build.yml
+++ b/.github/workflows/mock_balances_build.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - release/**
   push:
     branches:
       - main
+      - release/**
 
 jobs:
   mock-balances-build:

--- a/.github/workflows/proto-registry.yml
+++ b/.github/workflows/proto-registry.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - seiv2
     paths:
       - "proto/**"
 

--- a/.github/workflows/uci-go-lint.yml
+++ b/.github/workflows/uci-go-lint.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - release/**
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Branch protection rules is enabled on `release/*` branches with the same CI requirements as `main`. But CI build flow is not configured to run for release branches correctly, specifically for integration tests.

Update the integration tests trigger events and while at it clean up all old CI branch rules for branches that no longer exist.
