### PR TITLE
Configure self-hosted runners for Go tests

### DIFF
--- a/.github/workflows/go-test-coverage.yml
+++ b/.github/workflows/go-test-coverage.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       GO_TEST_TIMEOUT: 30m
     name: "Test ${{ matrix.modules.name }}"
-    runs-on: ubuntu-latest
+    runs-on: uci-default
     strategy:
       fail-fast: false
       matrix:
@@ -41,15 +41,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Remove unnecessary tooling
-        run: |
-          # Remove unrelated tooling to open up more space. Without doing 
-          # this ~80% of the available 15GiB space is already occupied.
-          sudo rm -rf \
-            /usr/share/dotnet \
-            /usr/local/lib/android \
-            /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force
       - name: Go test with coverage
         working-directory: '${{ matrix.modules.path }}'
         run: go test -tags='${{ matrix.modules.tags }}' -timeout='${{env.GO_TEST_TIMEOUT}}' -covermode=atomic -coverprofile=coverage.out -coverpkg=./... ./...

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       GO_TEST_TIMEOUT: 30m
     name: "Test ${{ matrix.modules.name }}"
-    runs-on: ubuntu-latest
+    runs-on: uci-default
     strategy:
       fail-fast: false
       matrix:
@@ -43,17 +43,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Remove unnecessary tooling
-        run: |
-          # Remove unrelated tooling to open up more space. Without doing 
-          # this ~80% of the available 15GiB space is already occupied.
-          sudo rm -rf \
-            /usr/share/dotnet \
-            /usr/local/lib/android \
-            /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force
-
       - name: Determine test packages
         id: test-packages
         run: |


### PR DESCRIPTION
Configure go tests to use the self hosted runners set up as part of Platform. This change reduces the time it takes to run the test by at least 2X, down to 11m for the longest running job. We can further optimise the time by spending more on resources. See [before](https://github.com/sei-protocol/sei-chain/actions/runs/21406131444) (current head of main) and [after](https://github.com/sei-protocol/sei-chain/actions/runs/21415926870?pr=2715) (current head of this branch).

The runner is only applied to go tests for now. Eventually they will also be used for integration tests in a separate body of work. The reason for the separation is to also optimise the testing and containerisation logic of integration tests themselves, not just the runner.

Fixes PLT-51