### PR TITLE
Log into dockerhub with RO credentials to avoid pull rate limiting

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -23,6 +23,11 @@ jobs:
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -21,6 +21,11 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Login Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -34,6 +34,11 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.25.6'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Remove unnecessary tooling
         run: |
           # Remove unrelated tooling to open up more space. Without doing 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -146,7 +146,11 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: '1.25.6'
-
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Start 4 node docker cluster
         run: make clean && DOCKER_DETACH=true INVARIANT_CHECK_INTERVAL=10 ${{matrix.test.env}} make docker-cluster-start
 


### PR DESCRIPTION
Set up and integrate dockerhub credentials for all jobs that may pull images from dockerhub to avoid hitting the unauthenticated tier rate limiting.

Fixes PLT-93

