### PR TITLE
fix: 2 giga changes to match v2 behaviour

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -31,6 +31,7 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/cosmos/cosmos-sdk/tasks"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	genesistypes "github.com/cosmos/cosmos-sdk/types/genesis"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/types/occ"
@@ -1805,7 +1806,7 @@ func (app *App) executeEVMTxWithGigaExecutor(ctx sdk.Context, msg *evmtypes.MsgE
 	// Determine result code based on VM error
 	code := uint32(0)
 	if execResult.Err != nil {
-		code = 1
+		code = sdkerrors.ErrEVMVMError.ABCICode()
 	}
 
 	// GasWanted should be set to the transaction's gas limit to match standard executor behavior.


### PR DESCRIPTION
- Set the txIndex correctly (ProcessBlock already does this)
- Return ABCI codes