### PR TITLE
[giga] Add UseRegularStore flag to GigaEvmKeeper for testing fallback

### DIFF
--- a/giga/deps/xevm/keeper/address.go
+++ b/giga/deps/xevm/keeper/address.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (k *Keeper) SetAddressMapping(ctx sdk.Context, seiAddress sdk.AccAddress, evmAddress common.Address) {
-	store := ctx.GigaKVStore(k.storeKey)
+	store := k.GetKVStore(ctx)
 	store.Set(types.EVMAddressToSeiAddressKey(evmAddress), seiAddress)
 	store.Set(types.SeiAddressToEVMAddressKey(seiAddress), evmAddress[:])
 	if !k.accountKeeper.HasAccount(ctx, seiAddress) {
@@ -22,13 +22,13 @@ func (k *Keeper) SetAddressMapping(ctx sdk.Context, seiAddress sdk.AccAddress, e
 }
 
 func (k *Keeper) DeleteAddressMapping(ctx sdk.Context, seiAddress sdk.AccAddress, evmAddress common.Address) {
-	store := ctx.GigaKVStore(k.storeKey)
+	store := k.GetKVStore(ctx)
 	store.Delete(types.EVMAddressToSeiAddressKey(evmAddress))
 	store.Delete(types.SeiAddressToEVMAddressKey(seiAddress))
 }
 
 func (k *Keeper) GetEVMAddress(ctx sdk.Context, seiAddress sdk.AccAddress) (common.Address, bool) {
-	store := ctx.GigaKVStore(k.storeKey)
+	store := k.GetKVStore(ctx)
 	bz := store.Get(types.SeiAddressToEVMAddressKey(seiAddress))
 	addr := common.Address{}
 	if bz == nil {
@@ -47,7 +47,7 @@ func (k *Keeper) GetEVMAddressOrDefault(ctx sdk.Context, seiAddress sdk.AccAddre
 }
 
 func (k *Keeper) GetSeiAddress(ctx sdk.Context, evmAddress common.Address) (sdk.AccAddress, bool) {
-	store := ctx.GigaKVStore(k.storeKey)
+	store := k.GetKVStore(ctx)
 	bz := store.Get(types.EVMAddressToSeiAddressKey(evmAddress))
 	if bz == nil {
 		return []byte{}, false
@@ -64,7 +64,7 @@ func (k *Keeper) GetSeiAddressOrDefault(ctx sdk.Context, evmAddress common.Addre
 }
 
 func (k *Keeper) IterateSeiAddressMapping(ctx sdk.Context, cb func(evmAddr common.Address, seiAddr sdk.AccAddress) bool) {
-	iter := prefix.NewStore(ctx.GigaKVStore(k.storeKey), types.EVMAddressToSeiAddressKeyPrefix).Iterator(nil, nil)
+	iter := prefix.NewStore(k.GetKVStore(ctx), types.EVMAddressToSeiAddressKeyPrefix).Iterator(nil, nil)
 	defer func() { _ = iter.Close() }()
 	for ; iter.Valid(); iter.Next() {
 		evmAddr := common.BytesToAddress(iter.Key())

--- a/giga/deps/xevm/keeper/code.go
+++ b/giga/deps/xevm/keeper/code.go
@@ -59,7 +59,7 @@ func (k *Keeper) GetCodeSize(ctx sdk.Context, addr common.Address) int {
 }
 
 func (k *Keeper) IterateAllCode(ctx sdk.Context, cb func(addr common.Address, code []byte) bool) {
-	iter := prefix.NewStore(ctx.GigaKVStore(k.storeKey), types.CodeKeyPrefix).Iterator(nil, nil)
+	iter := prefix.NewStore(k.GetKVStore(ctx), types.CodeKeyPrefix).Iterator(nil, nil)
 	defer func() { _ = iter.Close() }()
 	for ; iter.Valid(); iter.Next() {
 		evmAddr := common.BytesToAddress(iter.Key())

--- a/giga/deps/xevm/keeper/fee.go
+++ b/giga/deps/xevm/keeper/fee.go
@@ -61,7 +61,7 @@ func (k *Keeper) AdjustDynamicBaseFeePerGas(ctx sdk.Context, blockGasUsed uint64
 // NOTE: this is only used in migrate_base_fee_off_by_one migration. This is deprecated.
 // dont have height be a prefix, just store the current base fee directly
 func (k *Keeper) GetCurrBaseFeePerGas(ctx sdk.Context) sdk.Dec {
-	store := ctx.GigaKVStore(k.storeKey)
+	store := k.GetKVStore(ctx)
 	bz := store.Get(types.BaseFeePerGasPrefix)
 	if bz == nil {
 		minFeePerGas := k.GetMinimumFeePerGas(ctx)
@@ -80,7 +80,7 @@ func (k *Keeper) GetCurrBaseFeePerGas(ctx sdk.Context) sdk.Dec {
 
 // NOTE: this is only used in migrate_base_fee_off_by_one migration. This is deprecated.
 func (k *Keeper) SetCurrBaseFeePerGas(ctx sdk.Context, baseFeePerGas sdk.Dec) {
-	store := ctx.GigaKVStore(k.storeKey)
+	store := k.GetKVStore(ctx)
 	bz, err := baseFeePerGas.MarshalJSON()
 	if err != nil {
 		panic(err)
@@ -89,7 +89,7 @@ func (k *Keeper) SetCurrBaseFeePerGas(ctx sdk.Context, baseFeePerGas sdk.Dec) {
 }
 
 func (k *Keeper) SetNextBaseFeePerGas(ctx sdk.Context, baseFeePerGas sdk.Dec) {
-	store := ctx.GigaKVStore(k.storeKey)
+	store := k.GetKVStore(ctx)
 	bz, err := baseFeePerGas.MarshalJSON()
 	if err != nil {
 		panic(err)
@@ -98,7 +98,7 @@ func (k *Keeper) SetNextBaseFeePerGas(ctx sdk.Context, baseFeePerGas sdk.Dec) {
 }
 
 func (k *Keeper) GetNextBaseFeePerGas(ctx sdk.Context) sdk.Dec {
-	store := ctx.GigaKVStore(k.storeKey)
+	store := k.GetKVStore(ctx)
 	bz := store.Get(types.NextBaseFeePerGasPrefix)
 	if bz == nil {
 		minFeePerGas := k.GetMinimumFeePerGas(ctx)

--- a/giga/deps/xevm/keeper/log.go
+++ b/giga/deps/xevm/keeper/log.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (k *Keeper) GetBlockBloom(ctx sdk.Context) (res ethtypes.Bloom) {
-	store := ctx.GigaKVStore(k.storeKey)
+	store := k.GetKVStore(ctx)
 	bz := store.Get(types.BlockBloomPrefix)
 	if bz != nil {
 		res.SetBytes(bz)
@@ -26,7 +26,7 @@ func (k *Keeper) GetBlockBloom(ctx sdk.Context) (res ethtypes.Bloom) {
 }
 
 func (k *Keeper) GetEvmOnlyBlockBloom(ctx sdk.Context) (res ethtypes.Bloom) {
-	store := ctx.GigaKVStore(k.storeKey)
+	store := k.GetKVStore(ctx)
 	bz := store.Get(types.EvmOnlyBlockBloomPrefix)
 	if bz != nil {
 		res.SetBytes(bz)
@@ -40,7 +40,7 @@ func (k *Keeper) GetEvmOnlyBlockBloom(ctx sdk.Context) (res ethtypes.Bloom) {
 }
 
 func (k *Keeper) GetLegacyBlockBloom(ctx sdk.Context, height int64) (res ethtypes.Bloom) {
-	store := ctx.GigaKVStore(k.storeKey)
+	store := k.GetKVStore(ctx)
 	bz := store.Get(types.BlockBloomKey(height))
 	if bz != nil {
 		res.SetBytes(bz)
@@ -55,7 +55,7 @@ func (k *Keeper) SetEvmOnlyBlockBloom(ctx sdk.Context, blooms []ethtypes.Bloom) 
 		bitutil.ORBytes(or, blockBloom, bloom[:])
 		blockBloom = or
 	}
-	store := ctx.GigaKVStore(k.storeKey)
+	store := k.GetKVStore(ctx)
 	store.Set(types.EvmOnlyBlockBloomPrefix, blockBloom)
 }
 
@@ -66,19 +66,19 @@ func (k *Keeper) SetBlockBloom(ctx sdk.Context, blooms []ethtypes.Bloom) {
 		bitutil.ORBytes(or, blockBloom, bloom[:])
 		blockBloom = or
 	}
-	store := ctx.GigaKVStore(k.storeKey)
+	store := k.GetKVStore(ctx)
 	store.Set(types.BlockBloomPrefix, blockBloom)
 }
 
 func (k *Keeper) SetLegacyBlockBloomCutoffHeight(ctx sdk.Context) {
-	store := ctx.GigaKVStore(k.storeKey)
+	store := k.GetKVStore(ctx)
 	bz := make([]byte, 8)
 	binary.BigEndian.PutUint64(bz, uint64(ctx.BlockHeight())) //nolint:gosec
 	store.Set(types.LegacyBlockBloomCutoffHeightKey, bz)
 }
 
 func (k *Keeper) GetLegacyBlockBloomCutoffHeight(ctx sdk.Context) int64 {
-	store := ctx.GigaKVStore(k.storeKey)
+	store := k.GetKVStore(ctx)
 	bz := store.Get(types.LegacyBlockBloomCutoffHeightKey)
 	if len(bz) == 0 {
 		return 0

--- a/giga/deps/xevm/keeper/nonce.go
+++ b/giga/deps/xevm/keeper/nonce.go
@@ -24,7 +24,7 @@ func (k *Keeper) SetNonce(ctx sdk.Context, addr common.Address, nonce uint64) {
 }
 
 func (k *Keeper) IterateAllNonces(ctx sdk.Context, cb func(addr common.Address, nonce uint64) bool) {
-	iter := prefix.NewStore(ctx.GigaKVStore(k.storeKey), types.NonceKeyPrefix).Iterator(nil, nil)
+	iter := prefix.NewStore(k.GetKVStore(ctx), types.NonceKeyPrefix).Iterator(nil, nil)
 	defer func() { _ = iter.Close() }()
 	for ; iter.Valid(); iter.Next() {
 		evmAddr := common.BytesToAddress(iter.Key())

--- a/giga/deps/xevm/keeper/receipt.go
+++ b/giga/deps/xevm/keeper/receipt.go
@@ -70,7 +70,7 @@ func (k *Keeper) GetReceipt(ctx sdk.Context, txHash common.Hash) (*types.Receipt
 	}
 
 	// try legacy store for older receipts
-	store := ctx.GigaKVStore(k.storeKey)
+	store := k.GetKVStore(ctx)
 	bz := store.Get(types.ReceiptKey(txHash))
 	if bz == nil {
 		return nil, receipts.ErrNotFound

--- a/giga/deps/xevm/keeper/state.go
+++ b/giga/deps/xevm/keeper/state.go
@@ -25,7 +25,7 @@ func (k *Keeper) SetState(ctx sdk.Context, addr common.Address, key common.Hash,
 }
 
 func (k *Keeper) IterateState(ctx sdk.Context, cb func(addr common.Address, key common.Hash, val common.Hash) bool) {
-	iter := prefix.NewStore(ctx.GigaKVStore(k.storeKey), types.StateKeyPrefix).Iterator(nil, nil)
+	iter := prefix.NewStore(k.GetKVStore(ctx), types.StateKeyPrefix).Iterator(nil, nil)
 	defer func() { _ = iter.Close() }()
 	for ; iter.Valid(); iter.Next() {
 		k := iter.Key()


### PR DESCRIPTION
## Summary

- Add `UseRegularStore` flag to `GigaEvmKeeper` that allows using regular `KVStore` instead of `GigaKVStore`
- Add `GetKVStore()` helper method that returns the appropriate store based on the flag
- Update all keeper files to use `k.GetKVStore(ctx)` instead of `ctx.GigaKVStore(k.storeKey)` directly

This enables testing Giga executor logic in isolation from the GigaKVStore layer. When `UseRegularStore` is set to `true`, the keeper operations write to/read from the regular KVStore, which is useful for debugging and verifying that the executor logic is correct independent of the GigaKVStore integration.

## Test plan

- [x] Verify existing tests still pass
- [x] Used in conjunction with `pd/giga-state-tests` branch which adds `ModeGigaWithRegularStore` test mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)