### PR TITLE
[giga] Add EvmKeeper mode to Giga Executor

### DIFF
--- a/giga/deps/xevm/keeper/giga_executor_keeper.go
+++ b/giga/deps/xevm/keeper/giga_executor_keeper.go
@@ -1,0 +1,95 @@
+package keeper
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/sei-protocol/sei-chain/giga/deps/xevm/state"
+	"github.com/sei-protocol/sei-chain/giga/deps/xevm/types"
+	"github.com/sei-protocol/sei-chain/utils"
+)
+
+// StateDBWithFinalize is the interface that state.DBImpl implements.
+// This allows the GigaExecutorKeeper interface to work with both
+// giga/deps/xevm/state.DBImpl and x/evm/state.DBImpl.
+type StateDBWithFinalize interface {
+	vm.StateDB
+
+	// Finalize commits the state changes and returns any surplus.
+	Finalize() (sdk.Int, error)
+
+	// Cleanup releases resources held by the state DB.
+	Cleanup()
+
+	// GetAllLogs returns all logs emitted during execution.
+	GetAllLogs() []*ethtypes.Log
+
+	// GetPrecompileError returns any error from precompile execution.
+	GetPrecompileError() error
+}
+
+// NewStateDB creates a new state DB for transaction execution.
+// This method allows GigaEvmKeeper to satisfy the GigaExecutorKeeper interface.
+func (k *Keeper) NewStateDB(ctx sdk.Context, simulation bool) StateDBWithFinalize {
+	return state.NewDBImpl(ctx, k, simulation)
+}
+
+// WriteReceiptFromInterface writes a transaction receipt using the StateDBWithFinalize interface.
+// This method allows GigaEvmKeeper to satisfy the GigaExecutorKeeper interface.
+func (k *Keeper) WriteReceiptFromInterface(
+	ctx sdk.Context,
+	stateDB StateDBWithFinalize,
+	msg *core.Message,
+	txType uint32,
+	txHash common.Hash,
+	gasUsed uint64,
+	vmError string,
+) (*types.Receipt, error) {
+	ethLogs := stateDB.GetAllLogs()
+	bloom := ethtypes.CreateBloom(&ethtypes.Receipt{Logs: ethLogs})
+	receipt := &types.Receipt{
+		TxType:            txType,
+		CumulativeGasUsed: uint64(0),
+		TxHashHex:         txHash.Hex(),
+		GasUsed:           gasUsed,
+		BlockNumber:       uint64(ctx.BlockHeight()), // nolint:gosec
+		TransactionIndex:  uint32(ctx.TxIndex()),     //nolint:gosec
+		EffectiveGasPrice: msg.GasPrice.Uint64(),
+		VmError:           vmError,
+		Logs:              utils.Map(ethLogs, ConvertEthLog),
+		LogsBloom:         bloom[:],
+	}
+
+	if msg.To == nil {
+		receipt.ContractAddress = crypto.CreateAddress(msg.From, msg.Nonce).Hex()
+	} else {
+		receipt.To = msg.To.Hex()
+		if len(msg.Data) > 0 {
+			receipt.ContractAddress = msg.To.Hex()
+		}
+	}
+
+	if vmError == "" {
+		receipt.Status = uint32(ethtypes.ReceiptStatusSuccessful)
+	} else {
+		receipt.Status = uint32(ethtypes.ReceiptStatusFailed)
+	}
+
+	if perr := stateDB.GetPrecompileError(); perr != nil {
+		if receipt.Status > 0 {
+			ctx.Logger().Error(fmt.Sprintf("Transaction %s succeeded in execution but has precompile error %s", receipt.TxHashHex, perr.Error()))
+		} else {
+			// append precompile error to VM error
+			receipt.VmError = fmt.Sprintf("%s|%s", receipt.VmError, perr.Error())
+		}
+	}
+
+	receipt.From = msg.From.Hex()
+
+	return receipt, k.SetTransientReceipt(ctx, txHash, receipt)
+}

--- a/giga/executor/config/config.go
+++ b/giga/executor/config/config.go
@@ -11,16 +11,22 @@ type Config struct {
 	Enabled bool `mapstructure:"enabled"`
 	// OCCEnabled controls whether to use OCC (Optimistic Concurrency Control) with the Giga executor
 	OCCEnabled bool `mapstructure:"occ_enabled"`
+	// UseEvmKeeper controls whether to use the original EvmKeeper (x/evm/keeper) instead of
+	// GigaEvmKeeper (giga/deps/xevm/keeper). This is useful for comparing behavior between keepers.
+	// When true, the executor uses ctx.KVStore() instead of ctx.GigaKVStore().
+	UseEvmKeeper bool `mapstructure:"use_evm_keeper"`
 }
 
 var DefaultConfig = Config{
-	Enabled:    false, // disabled by default, opt-in
-	OCCEnabled: false, // OCC disabled by default
+	Enabled:      false, // disabled by default, opt-in
+	OCCEnabled:   false, // OCC disabled by default
+	UseEvmKeeper: false, // use GigaEvmKeeper by default
 }
 
 const (
-	FlagEnabled    = "giga_executor.enabled"
-	FlagOCCEnabled = "giga_executor.occ_enabled"
+	FlagEnabled      = "giga_executor.enabled"
+	FlagOCCEnabled   = "giga_executor.occ_enabled"
+	FlagUseEvmKeeper = "giga_executor.use_evm_keeper"
 )
 
 func ReadConfig(opts servertypes.AppOptions) (Config, error) {
@@ -33,6 +39,11 @@ func ReadConfig(opts servertypes.AppOptions) (Config, error) {
 	}
 	if v := opts.Get(FlagOCCEnabled); v != nil {
 		if cfg.OCCEnabled, err = cast.ToBoolE(v); err != nil {
+			return cfg, err
+		}
+	}
+	if v := opts.Get(FlagUseEvmKeeper); v != nil {
+		if cfg.UseEvmKeeper, err = cast.ToBoolE(v); err != nil {
 			return cfg, err
 		}
 	}
@@ -55,4 +66,10 @@ enabled = {{ .GigaExecutor.Enabled }}
 # When true, transactions are executed in parallel with conflict detection and retry.
 # Default: false
 occ_enabled = {{ .GigaExecutor.OCCEnabled }}
+
+# use_evm_keeper controls whether to use the original EvmKeeper (x/evm/keeper) instead of
+# GigaEvmKeeper (giga/deps/xevm/keeper). This is useful for comparing behavior between keepers.
+# When true, the executor uses ctx.KVStore() instead of ctx.GigaKVStore().
+# Default: false
+use_evm_keeper = {{ .GigaExecutor.UseEvmKeeper }}
 `

--- a/giga/executor/evmkeeper_adapter.go
+++ b/giga/executor/evmkeeper_adapter.go
@@ -1,0 +1,116 @@
+package executor
+
+import (
+	"fmt"
+	"math/big"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	"github.com/ethereum/evmc/v12/bindings/go/evmc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+	evmkeeper "github.com/sei-protocol/sei-chain/x/evm/keeper"
+	evmstate "github.com/sei-protocol/sei-chain/x/evm/state"
+	evmtypes "github.com/sei-protocol/sei-chain/x/evm/types"
+)
+
+// EvmKeeperAdapter wraps the original EvmKeeper to satisfy GigaExecutorKeeper.
+// This allows the Giga executor to use either the GigaEvmKeeper or the original
+// EvmKeeper for comparison testing.
+type EvmKeeperAdapter struct {
+	keeper   *evmkeeper.Keeper
+	evmoneVM *evmc.VM
+}
+
+// NewEvmKeeperAdapter creates a new adapter wrapping the original EvmKeeper.
+// The evmoneVM is passed separately since the original EvmKeeper doesn't have it.
+func NewEvmKeeperAdapter(k *evmkeeper.Keeper, vm *evmc.VM) *EvmKeeperAdapter {
+	return &EvmKeeperAdapter{keeper: k, evmoneVM: vm}
+}
+
+// EvmoneVM returns the evmone VM instance for use by the executor.
+func (a *EvmKeeperAdapter) EvmoneVM() *evmc.VM {
+	return a.evmoneVM
+}
+
+// GetVMBlockContext returns the VM block context for transaction execution.
+func (a *EvmKeeperAdapter) GetVMBlockContext(ctx sdk.Context, gp core.GasPool) (*vm.BlockContext, error) {
+	return a.keeper.GetVMBlockContext(ctx, gp)
+}
+
+// GetGasPool returns the gas pool for the block.
+func (a *EvmKeeperAdapter) GetGasPool() core.GasPool {
+	return a.keeper.GetGasPool()
+}
+
+// GetBaseFee returns the base fee for EIP-1559 transactions.
+func (a *EvmKeeperAdapter) GetBaseFee(ctx sdk.Context) *big.Int {
+	return a.keeper.GetBaseFee(ctx)
+}
+
+// ChainID returns the EVM chain ID.
+func (a *EvmKeeperAdapter) ChainID(ctx sdk.Context) *big.Int {
+	return a.keeper.ChainID(ctx)
+}
+
+// GetChainConfig returns the Ethereum chain config for EVM execution.
+func (a *EvmKeeperAdapter) GetChainConfig(ctx sdk.Context) *params.ChainConfig {
+	sstore := a.keeper.GetParams(ctx).SeiSstoreSetGasEip2200
+	return evmtypes.DefaultChainConfig().EthereumConfigWithSstore(a.keeper.ChainID(ctx), &sstore)
+}
+
+// CustomPrecompiles returns the custom precompiled contracts.
+func (a *EvmKeeperAdapter) CustomPrecompiles(ctx sdk.Context) map[common.Address]vm.PrecompiledContract {
+	return a.keeper.CustomPrecompiles(ctx)
+}
+
+// GetEVMAddress returns the EVM address for a given Sei address.
+func (a *EvmKeeperAdapter) GetEVMAddress(ctx sdk.Context, seiAddr sdk.AccAddress) (common.Address, bool) {
+	return a.keeper.GetEVMAddress(ctx, seiAddr)
+}
+
+// SetAddressMapping sets the bidirectional mapping between Sei and EVM addresses.
+func (a *EvmKeeperAdapter) SetAddressMapping(ctx sdk.Context, seiAddr sdk.AccAddress, evmAddr common.Address) {
+	a.keeper.SetAddressMapping(ctx, seiAddr, evmAddr)
+}
+
+// BankKeeper returns the bank keeper.
+func (a *EvmKeeperAdapter) BankKeeper() bankkeeper.Keeper {
+	return a.keeper.BankKeeper()
+}
+
+// AccountKeeper returns the account keeper.
+func (a *EvmKeeperAdapter) AccountKeeper() *authkeeper.AccountKeeper {
+	return a.keeper.AccountKeeper()
+}
+
+// NewStateDB creates a new state DB using the original x/evm/state package.
+// This uses ctx.KVStore() instead of ctx.GigaKVStore().
+func (a *EvmKeeperAdapter) NewStateDB(ctx sdk.Context, simulation bool) StateDBWithFinalize {
+	return evmstate.NewDBImpl(ctx, a.keeper, simulation)
+}
+
+// WriteReceipt writes the transaction receipt using the original EvmKeeper.
+// Returns ReceiptResult containing the bloom and serialized receipt.
+func (a *EvmKeeperAdapter) WriteReceipt(ctx sdk.Context, stateDB StateDBWithFinalize, msg *core.Message, txType uint32, txHash common.Hash, gasUsed uint64, vmError string) (*ReceiptResult, error) {
+	// Cast to the concrete type expected by the original keeper
+	dbImpl, ok := stateDB.(*evmstate.DBImpl)
+	if !ok {
+		return nil, fmt.Errorf("expected *evmstate.DBImpl, got %T", stateDB)
+	}
+	receipt, err := a.keeper.WriteReceipt(ctx, dbImpl, msg, txType, txHash, gasUsed, vmError)
+	if err != nil {
+		return nil, err
+	}
+	receiptBytes, _ := receipt.Marshal()
+	return &ReceiptResult{
+		LogsBloom:    receipt.LogsBloom,
+		ReceiptBytes: receiptBytes,
+	}, nil
+}
+
+// Verify EvmKeeperAdapter implements GigaExecutorKeeper at compile time
+var _ GigaExecutorKeeper = (*EvmKeeperAdapter)(nil)

--- a/giga/executor/gigaevmkeeper_wrapper.go
+++ b/giga/executor/gigaevmkeeper_wrapper.go
@@ -1,0 +1,106 @@
+package executor
+
+import (
+	"math/big"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	"github.com/ethereum/evmc/v12/bindings/go/evmc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+	gigaevmkeeper "github.com/sei-protocol/sei-chain/giga/deps/xevm/keeper"
+	gigatypes "github.com/sei-protocol/sei-chain/giga/deps/xevm/types"
+)
+
+// GigaEvmKeeperWrapper wraps the GigaEvmKeeper to satisfy GigaExecutorKeeper.
+// This allows the executor to use a unified interface for both keeper implementations.
+type GigaEvmKeeperWrapper struct {
+	keeper *gigaevmkeeper.Keeper
+}
+
+// NewGigaEvmKeeperWrapper creates a new wrapper around the GigaEvmKeeper.
+func NewGigaEvmKeeperWrapper(k *gigaevmkeeper.Keeper) *GigaEvmKeeperWrapper {
+	return &GigaEvmKeeperWrapper{keeper: k}
+}
+
+// EvmoneVM returns the evmone VM instance for use by the executor.
+func (w *GigaEvmKeeperWrapper) EvmoneVM() *evmc.VM {
+	return w.keeper.EvmoneVM
+}
+
+// GetVMBlockContext returns the VM block context for transaction execution.
+func (w *GigaEvmKeeperWrapper) GetVMBlockContext(ctx sdk.Context, gp core.GasPool) (*vm.BlockContext, error) {
+	return w.keeper.GetVMBlockContext(ctx, gp)
+}
+
+// GetGasPool returns the gas pool for the block.
+func (w *GigaEvmKeeperWrapper) GetGasPool() core.GasPool {
+	return w.keeper.GetGasPool()
+}
+
+// GetBaseFee returns the base fee for EIP-1559 transactions.
+func (w *GigaEvmKeeperWrapper) GetBaseFee(ctx sdk.Context) *big.Int {
+	return w.keeper.GetBaseFee(ctx)
+}
+
+// ChainID returns the EVM chain ID.
+func (w *GigaEvmKeeperWrapper) ChainID(ctx sdk.Context) *big.Int {
+	return w.keeper.ChainID(ctx)
+}
+
+// GetChainConfig returns the Ethereum chain config for EVM execution.
+func (w *GigaEvmKeeperWrapper) GetChainConfig(ctx sdk.Context) *params.ChainConfig {
+	sstore := w.keeper.GetParams(ctx).SeiSstoreSetGasEip2200
+	return gigatypes.DefaultChainConfig().EthereumConfigWithSstore(w.keeper.ChainID(ctx), &sstore)
+}
+
+// CustomPrecompiles returns the custom precompiled contracts.
+func (w *GigaEvmKeeperWrapper) CustomPrecompiles(ctx sdk.Context) map[common.Address]vm.PrecompiledContract {
+	return w.keeper.CustomPrecompiles(ctx)
+}
+
+// GetEVMAddress returns the EVM address for a given Sei address.
+func (w *GigaEvmKeeperWrapper) GetEVMAddress(ctx sdk.Context, seiAddr sdk.AccAddress) (common.Address, bool) {
+	return w.keeper.GetEVMAddress(ctx, seiAddr)
+}
+
+// SetAddressMapping sets the bidirectional mapping between Sei and EVM addresses.
+func (w *GigaEvmKeeperWrapper) SetAddressMapping(ctx sdk.Context, seiAddr sdk.AccAddress, evmAddr common.Address) {
+	w.keeper.SetAddressMapping(ctx, seiAddr, evmAddr)
+}
+
+// BankKeeper returns the bank keeper.
+func (w *GigaEvmKeeperWrapper) BankKeeper() bankkeeper.Keeper {
+	return w.keeper.BankKeeper()
+}
+
+// AccountKeeper returns the account keeper.
+func (w *GigaEvmKeeperWrapper) AccountKeeper() *authkeeper.AccountKeeper {
+	return w.keeper.AccountKeeper()
+}
+
+// NewStateDB creates a new state DB using the giga/deps/xevm/state package.
+// This uses ctx.GigaKVStore() instead of ctx.KVStore().
+func (w *GigaEvmKeeperWrapper) NewStateDB(ctx sdk.Context, simulation bool) StateDBWithFinalize {
+	return w.keeper.NewStateDB(ctx, simulation)
+}
+
+// WriteReceipt writes the transaction receipt using the GigaEvmKeeper.
+// Returns ReceiptResult containing the bloom and serialized receipt.
+func (w *GigaEvmKeeperWrapper) WriteReceipt(ctx sdk.Context, stateDB StateDBWithFinalize, msg *core.Message, txType uint32, txHash common.Hash, gasUsed uint64, vmError string) (*ReceiptResult, error) {
+	receipt, err := w.keeper.WriteReceiptFromInterface(ctx, stateDB, msg, txType, txHash, gasUsed, vmError)
+	if err != nil {
+		return nil, err
+	}
+	receiptBytes, _ := receipt.Marshal()
+	return &ReceiptResult{
+		LogsBloom:    receipt.LogsBloom,
+		ReceiptBytes: receiptBytes,
+	}, nil
+}
+
+// Verify GigaEvmKeeperWrapper implements GigaExecutorKeeper at compile time
+var _ GigaExecutorKeeper = (*GigaEvmKeeperWrapper)(nil)

--- a/giga/executor/keeper.go
+++ b/giga/executor/keeper.go
@@ -1,0 +1,73 @@
+package executor
+
+import (
+	"math/big"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	"github.com/ethereum/evmc/v12/bindings/go/evmc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// GigaExecutorKeeper defines what the Giga executor needs from a keeper.
+// Both GigaEvmKeeper and EvmKeeper (via adapter) can satisfy this interface.
+type GigaExecutorKeeper interface {
+	// Block context
+	GetVMBlockContext(ctx sdk.Context, gp core.GasPool) (*vm.BlockContext, error)
+	GetGasPool() core.GasPool
+	GetBaseFee(ctx sdk.Context) *big.Int
+	ChainID(ctx sdk.Context) *big.Int
+	CustomPrecompiles(ctx sdk.Context) map[common.Address]vm.PrecompiledContract
+
+	// Chain config - returns the Ethereum chain config for EVM execution.
+	// Uses keeper's params (SeiSstoreSetGasEip2200) to configure the chain.
+	GetChainConfig(ctx sdk.Context) *params.ChainConfig
+
+	// Address operations
+	GetEVMAddress(ctx sdk.Context, seiAddr sdk.AccAddress) (common.Address, bool)
+	SetAddressMapping(ctx sdk.Context, seiAddr sdk.AccAddress, evmAddr common.Address)
+
+	// Accessor keepers (for association helper)
+	BankKeeper() bankkeeper.Keeper
+	AccountKeeper() *authkeeper.AccountKeeper
+
+	// EvmoneVM returns the evmone VM instance for EVM execution.
+	EvmoneVM() *evmc.VM
+
+	// StateDB creation - returns the appropriate StateDB for this keeper
+	NewStateDB(ctx sdk.Context, simulation bool) StateDBWithFinalize
+
+	// Receipt operations - writes transaction receipt and returns receipt data for response construction
+	WriteReceipt(ctx sdk.Context, stateDB StateDBWithFinalize, msg *core.Message, txType uint32, txHash common.Hash, gasUsed uint64, vmError string) (*ReceiptResult, error)
+}
+
+// ReceiptResult contains the receipt data needed for constructing the transaction response.
+// This allows the interface to be type-agnostic while still providing all necessary data.
+type ReceiptResult struct {
+	// LogsBloom is the bloom filter for the logs
+	LogsBloom []byte
+	// ReceiptBytes is the serialized receipt for including in response Data field
+	ReceiptBytes []byte
+}
+
+// StateDBWithFinalize extends vm.StateDB with additional methods needed by the executor.
+type StateDBWithFinalize interface {
+	vm.StateDB
+
+	// Finalize commits the state changes and returns any surplus.
+	Finalize() (sdk.Int, error)
+
+	// Cleanup releases resources held by the state DB.
+	Cleanup()
+
+	// GetAllLogs returns all logs emitted during execution.
+	GetAllLogs() []*ethtypes.Log
+
+	// GetPrecompileError returns any error from precompile execution.
+	GetPrecompileError() error
+}


### PR DESCRIPTION
## Summary

- Add an alternative mode where the Giga executor uses the original EvmKeeper (`x/evm/keeper`) instead of GigaEvmKeeper (`giga/deps/xevm/keeper`)
- This enables comparing behavior between the two keepers for debugging and validation
- Complements PR #2745 (store-switching within GigaEvmKeeper) by providing full keeper comparison

## Changes

- **`giga/executor/keeper.go`**: Define `GigaExecutorKeeper` interface that abstracts over both keeper implementations
- **`giga/executor/evmkeeper_adapter.go`**: Adapter wrapping original EvmKeeper to satisfy the interface (uses `ctx.KVStore()`)
- **`giga/executor/gigaevmkeeper_wrapper.go`**: Wrapper for GigaEvmKeeper to satisfy the interface (uses `ctx.GigaKVStore()`)
- **`giga/deps/xevm/keeper/giga_executor_keeper.go`**: Add `NewStateDB()` and `WriteReceiptFromInterface()` methods
- **`giga/executor/config/config.go`**: Add `use_evm_keeper` config flag
- **`app/app.go`**: Add keeper selection logic and update `executeEVMTxWithGigaExecutor()` to use the interface

## Configuration

```toml
[giga_executor]
enabled = true
use_evm_keeper = true  # Use original EvmKeeper instead of GigaEvmKeeper
```

## Key Differences Between Modes

| Aspect | GigaEvmKeeper (default) | EvmKeeper (use_evm_keeper=true) |
|--------|-------------------------|----------------------------------|
| Store access | `ctx.GigaKVStore()` | `ctx.KVStore()` |
| StateDB | `giga/deps/xevm/state` | `x/evm/state` |
| StateDB flush | MultiStore + GigaMultiStore | MultiStore only |

## Test plan

- [x] All existing giga tests pass
- [x] Code compiles successfully
- [ ] Manual testing with both keeper modes
- [ ] Compare receipts and state between modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)