### PR TITLE
Add EVM state store interface with separate sub-DBs

### DIFF
--- a/sei-db/config/config.go
+++ b/sei-db/config/config.go
@@ -110,6 +110,24 @@ type StateStoreConfig struct {
 	UseDefaultComparer bool `mapstructure:"use-default-comparer"`
 }
 
+// EVMStateStoreConfig defines configuration for the separate EVM state stores.
+// EVM stores use default comparer and separate PebbleDBs for storage, balance, nonce, and code.
+type EVMStateStoreConfig struct {
+	// Enable defines if the EVM state stores should be enabled.
+	// When enabled, EVM data is stored in separate optimized databases.
+	// defaults to false
+	Enable bool `mapstructure:"enable"`
+
+	// DBDirectory defines the directory to store the EVM state store db files
+	// If not explicitly set, defaults to <home>/data/evm_ss
+	DBDirectory string `mapstructure:"db-directory"`
+
+	// KeepRecent defines the number of versions to keep in EVM state stores
+	// Setting it to 0 means keep everything.
+	// Default to keep the last 100,000 blocks
+	KeepRecent int `mapstructure:"keep-recent"`
+}
+
 // ReceiptStoreConfig defines configuration for the receipt store database.
 type ReceiptStoreConfig struct {
 	// DBDirectory defines the directory to store the receipt store db files
@@ -174,5 +192,12 @@ func DefaultReceiptStoreConfig() ReceiptStoreConfig {
 		KeepRecent:           DefaultSSKeepRecent,
 		PruneIntervalSeconds: DefaultSSPruneInterval,
 		UseDefaultComparer:   false, // TODO: flip to true once MVCCComparer is deprecated
+	}
+}
+
+func DefaultEVMStateStoreConfig() EVMStateStoreConfig {
+	return EVMStateStoreConfig{
+		Enable:     false, // Disabled by default, enable for optimized EVM storage
+		KeepRecent: DefaultSSKeepRecent,
 	}
 }

--- a/sei-db/state_db/ss/evm/config.go
+++ b/sei-db/state_db/ss/evm/config.go
@@ -1,0 +1,28 @@
+package evm
+
+import (
+	"github.com/sei-protocol/sei-chain/sei-db/config"
+)
+
+// EVMStoreType represents different EVM data stores
+type EVMStoreType string
+
+const (
+	StorageStore EVMStoreType = "storage"
+	BalanceStore EVMStoreType = "balance"
+	NonceStore   EVMStoreType = "nonce"
+	CodeStore    EVMStoreType = "code"
+)
+
+// EVMStoreConfig is an alias to the main config
+type EVMStoreConfig = config.EVMStateStoreConfig
+
+// DefaultEVMStoreConfig returns default configuration
+func DefaultEVMStoreConfig() EVMStoreConfig {
+	return config.DefaultEVMStateStoreConfig()
+}
+
+// AllEVMStoreTypes returns all EVM store types
+func AllEVMStoreTypes() []EVMStoreType {
+	return []EVMStoreType{StorageStore, BalanceStore, NonceStore, CodeStore}
+}

--- a/sei-db/state_db/ss/evm/db.go
+++ b/sei-db/state_db/ss/evm/db.go
@@ -1,0 +1,645 @@
+package evm
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/cockroachdb/pebble/v2/bloom"
+	"github.com/cockroachdb/pebble/v2/sstable"
+	"golang.org/x/exp/slices"
+
+	iavl "github.com/sei-protocol/sei-chain/sei-iavl"
+	"github.com/sei-protocol/sei-chain/sei-db/state_db/ss/types"
+)
+
+const (
+	VersionSize        = 8
+	latestVersionKey   = "_latest"
+	earliestVersionKey = "_earliest"
+)
+
+var defaultWriteOpts = pebble.NoSync
+
+// EVMDatabase is a single PebbleDB for one EVM store type using default comparer
+type EVMDatabase struct {
+	storage         *pebble.DB
+	storeType       EVMStoreType
+	latestVersion   atomic.Int64
+	earliestVersion atomic.Int64
+	mu              sync.RWMutex
+}
+
+// OpenEVMDB opens a PebbleDB with default comparer for EVM data
+func OpenEVMDB(dataDir string, storeType EVMStoreType) (*EVMDatabase, error) {
+	cache := pebble.NewCache(1024 * 1024 * 16) // 16MB cache per EVM DB
+	defer cache.Unref()
+
+	opts := &pebble.Options{
+		Cache:                       cache,
+		Comparer:                    pebble.DefaultComparer, // Use default comparer for EVM stores
+		FormatMajorVersion:          pebble.FormatVirtualSSTables,
+		L0CompactionThreshold:       2,
+		L0StopWritesThreshold:       1000,
+		LBaseMaxBytes:               64 << 20,
+		MemTableSize:                64 << 20,
+		MemTableStopWritesThreshold: 4,
+	}
+
+	// Configure levels
+	for i := 0; i < len(opts.Levels); i++ {
+		l := &opts.Levels[i]
+		l.BlockSize = 32 << 10
+		l.IndexBlockSize = 256 << 10
+		l.FilterPolicy = bloom.FilterPolicy(10)
+		l.FilterType = pebble.TableFilter
+		l.Compression = func() *sstable.CompressionProfile { return sstable.ZstdCompression }
+		if i == 0 {
+			l.EnsureL0Defaults()
+		} else {
+			l.EnsureL1PlusDefaults(&opts.Levels[i-1])
+		}
+	}
+	opts.Levels[6].FilterPolicy = nil
+
+	db, err := pebble.Open(dataDir, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open EVM PebbleDB for %s: %w", storeType, err)
+	}
+
+	earliestVersion, err := retrieveVersion(db, earliestVersionKey)
+	if err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+
+	latestVersion, err := retrieveVersion(db, latestVersionKey)
+	if err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+
+	database := &EVMDatabase{
+		storage:   db,
+		storeType: storeType,
+	}
+	database.latestVersion.Store(latestVersion)
+	database.earliestVersion.Store(earliestVersion)
+
+	return database, nil
+}
+
+func (db *EVMDatabase) Close() error {
+	if db.storage == nil {
+		return nil
+	}
+	err := db.storage.Close()
+	db.storage = nil
+	return err
+}
+
+// encodeKey creates key with version suffix: key + version (big-endian)
+func encodeKey(key []byte, version int64) []byte {
+	result := make([]byte, len(key)+VersionSize)
+	copy(result, key)
+	binary.BigEndian.PutUint64(result[len(key):], uint64(version))
+	return result
+}
+
+// decodeKey extracts key and version from encoded key
+func decodeKey(encoded []byte) (key []byte, version int64, ok bool) {
+	if len(encoded) < VersionSize {
+		return nil, 0, false
+	}
+	keyLen := len(encoded) - VersionSize
+	key = encoded[:keyLen]
+	version = int64(binary.BigEndian.Uint64(encoded[keyLen:]))
+	return key, version, true
+}
+
+func (db *EVMDatabase) Get(key []byte, targetVersion int64) ([]byte, error) {
+	if targetVersion < db.earliestVersion.Load() {
+		return nil, nil
+	}
+
+	// Scan for the latest version <= targetVersion
+	upperBound := encodeKey(key, targetVersion+1)
+	lowerBound := encodeKey(key, 0)
+
+	itr, err := db.storage.NewIter(&pebble.IterOptions{
+		LowerBound: lowerBound,
+		UpperBound: upperBound,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer itr.Close()
+
+	if !itr.Last() {
+		return nil, nil
+	}
+
+	// Verify it's the same key
+	foundKey, _, ok := decodeKey(itr.Key())
+	if !ok || !slices.Equal(foundKey, key) {
+		return nil, nil
+	}
+
+	value := slices.Clone(itr.Value())
+	// Check for tombstone (empty value means deleted)
+	if len(value) == 0 {
+		return nil, nil
+	}
+	return value, nil
+}
+
+func (db *EVMDatabase) Has(key []byte, version int64) (bool, error) {
+	val, err := db.Get(key, version)
+	return val != nil, err
+}
+
+func (db *EVMDatabase) Set(key, value []byte, version int64) error {
+	encodedKey := encodeKey(key, version)
+	return db.storage.Set(encodedKey, value, defaultWriteOpts)
+}
+
+func (db *EVMDatabase) Delete(key []byte, version int64) error {
+	// Write tombstone (empty value)
+	encodedKey := encodeKey(key, version)
+	return db.storage.Set(encodedKey, nil, defaultWriteOpts)
+}
+
+// ApplyBatch applies multiple key-value pairs in a single batch for efficiency
+func (db *EVMDatabase) ApplyBatch(pairs []*iavl.KVPair, version int64) error {
+	if len(pairs) == 0 {
+		return nil
+	}
+
+	batch := db.storage.NewBatch()
+	defer batch.Close()
+
+	for _, pair := range pairs {
+		encodedKey := encodeKey(pair.Key, version)
+		if pair.Value == nil || pair.Delete {
+			// Tombstone
+			if err := batch.Set(encodedKey, nil, nil); err != nil {
+				return err
+			}
+		} else {
+			if err := batch.Set(encodedKey, pair.Value, nil); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := batch.Commit(defaultWriteOpts); err != nil {
+		return err
+	}
+
+	return db.SetLatestVersion(version)
+}
+
+func (db *EVMDatabase) SetLatestVersion(version int64) error {
+	db.latestVersion.Store(version)
+	var ts [VersionSize]byte
+	binary.LittleEndian.PutUint64(ts[:], uint64(version))
+	return db.storage.Set([]byte(latestVersionKey), ts[:], defaultWriteOpts)
+}
+
+func (db *EVMDatabase) GetLatestVersion() int64 {
+	return db.latestVersion.Load()
+}
+
+func (db *EVMDatabase) SetEarliestVersion(version int64) error {
+	db.earliestVersion.Store(version)
+	var ts [VersionSize]byte
+	binary.LittleEndian.PutUint64(ts[:], uint64(version))
+	return db.storage.Set([]byte(earliestVersionKey), ts[:], defaultWriteOpts)
+}
+
+func (db *EVMDatabase) GetEarliestVersion() int64 {
+	return db.earliestVersion.Load()
+}
+
+func retrieveVersion(db *pebble.DB, key string) (int64, error) {
+	bz, closer, err := db.Get([]byte(key))
+	if err != nil {
+		if errors.Is(err, pebble.ErrNotFound) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	defer closer.Close()
+
+	if len(bz) == 0 {
+		return 0, nil
+	}
+	uz := binary.LittleEndian.Uint64(bz)
+	if uz > math.MaxInt64 {
+		return 0, fmt.Errorf("version overflows int64: %d", uz)
+	}
+	return int64(uz), nil
+}
+
+// Iterator returns an iterator over the EVM database
+func (db *EVMDatabase) Iterator(start, end []byte, version int64) (types.DBIterator, error) {
+	return newEVMIterator(db.storage, start, end, version, db.earliestVersion.Load(), false)
+}
+
+// ReverseIterator returns a reverse iterator over the EVM database
+func (db *EVMDatabase) ReverseIterator(start, end []byte, version int64) (types.DBIterator, error) {
+	return newEVMIterator(db.storage, start, end, version, db.earliestVersion.Load(), true)
+}
+
+// EVMStateStore manages multiple EVM databases (storage, balance, nonce, code)
+type EVMStateStore struct {
+	dbs     map[EVMStoreType]*EVMDatabase
+	baseDir string
+	mu      sync.RWMutex
+}
+
+// NewEVMStateStore creates a new EVM state store with separate DBs
+func NewEVMStateStore(baseDir string) (*EVMStateStore, error) {
+	store := &EVMStateStore{
+		dbs:     make(map[EVMStoreType]*EVMDatabase),
+		baseDir: baseDir,
+	}
+
+	for _, storeType := range AllEVMStoreTypes() {
+		dbPath := filepath.Join(baseDir, string(storeType))
+		db, err := OpenEVMDB(dbPath, storeType)
+		if err != nil {
+			store.Close()
+			return nil, fmt.Errorf("failed to open %s db: %w", storeType, err)
+		}
+		store.dbs[storeType] = db
+	}
+
+	return store, nil
+}
+
+func (s *EVMStateStore) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var lastErr error
+	for _, db := range s.dbs {
+		if err := db.Close(); err != nil {
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+// GetDB returns the database for a specific store type
+func (s *EVMStateStore) GetDB(storeType EVMStoreType) *EVMDatabase {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.dbs[storeType]
+}
+
+// Get retrieves a value from the appropriate EVM database
+func (s *EVMStateStore) Get(storeType EVMStoreType, key []byte, version int64) ([]byte, error) {
+	db := s.GetDB(storeType)
+	if db == nil {
+		return nil, fmt.Errorf("unknown EVM store type: %s", storeType)
+	}
+	return db.Get(key, version)
+}
+
+// Set stores a value in the appropriate EVM database
+func (s *EVMStateStore) Set(storeType EVMStoreType, key, value []byte, version int64) error {
+	db := s.GetDB(storeType)
+	if db == nil {
+		return fmt.Errorf("unknown EVM store type: %s", storeType)
+	}
+	return db.Set(key, value, version)
+}
+
+// Delete removes a key from the appropriate EVM database
+func (s *EVMStateStore) Delete(storeType EVMStoreType, key []byte, version int64) error {
+	db := s.GetDB(storeType)
+	if db == nil {
+		return fmt.Errorf("unknown EVM store type: %s", storeType)
+	}
+	return db.Delete(key, version)
+}
+
+// ApplyChangeset applies a changeset to all relevant EVM databases sequentially
+func (s *EVMStateStore) ApplyChangeset(version int64, changes map[EVMStoreType][]*iavl.KVPair) error {
+	for storeType, pairs := range changes {
+		db := s.GetDB(storeType)
+		if db == nil {
+			continue
+		}
+		if err := db.ApplyBatch(pairs, version); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ApplyChangesetParallel applies changesets to different EVM DBs in parallel
+func (s *EVMStateStore) ApplyChangesetParallel(version int64, changes map[EVMStoreType][]*iavl.KVPair) error {
+	if len(changes) == 0 {
+		return nil
+	}
+
+	// If only one store type, no need for parallelism
+	if len(changes) == 1 {
+		return s.ApplyChangeset(version, changes)
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(changes))
+
+	for storeType, pairs := range changes {
+		db := s.GetDB(storeType)
+		if db == nil {
+			continue
+		}
+
+		wg.Add(1)
+		go func(db *EVMDatabase, pairs []*iavl.KVPair) {
+			defer wg.Done()
+			if err := db.ApplyBatch(pairs, version); err != nil {
+				errCh <- err
+			}
+		}(db, pairs)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	// Return first error if any
+	for err := range errCh {
+		return err
+	}
+	return nil
+}
+
+// GetLatestVersion returns the latest version across all EVM databases
+func (s *EVMStateStore) GetLatestVersion() int64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var maxVersion int64
+	for _, db := range s.dbs {
+		if v := db.GetLatestVersion(); v > maxVersion {
+			maxVersion = v
+		}
+	}
+	return maxVersion
+}
+
+// SetLatestVersion sets the latest version for all EVM databases
+func (s *EVMStateStore) SetLatestVersion(version int64) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, db := range s.dbs {
+		if err := db.SetLatestVersion(version); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Prune removes old versions from all EVM databases
+func (s *EVMStateStore) Prune(version int64) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for storeType, db := range s.dbs {
+		if err := pruneEVMDB(db, version); err != nil {
+			return fmt.Errorf("failed to prune %s: %w", storeType, err)
+		}
+	}
+	return nil
+}
+
+func pruneEVMDB(db *EVMDatabase, version int64) error {
+	itr, err := db.storage.NewIter(nil)
+	if err != nil {
+		return err
+	}
+	defer itr.Close()
+
+	batch := db.storage.NewBatch()
+	defer batch.Close()
+
+	var (
+		prevKey        []byte
+		prevVersion    int64
+		prevKeyEncoded []byte
+		counter        int
+	)
+
+	for itr.First(); itr.Valid(); itr.Next() {
+		// Skip metadata keys
+		if isMetadataKey(itr.Key()) {
+			continue
+		}
+
+		currKey, currVersion, ok := decodeKey(itr.Key())
+		if !ok {
+			continue
+		}
+
+		// Delete previous version if same key and version <= prune target
+		if slices.Equal(prevKey, currKey) && prevVersion <= version {
+			if err := batch.Delete(prevKeyEncoded, nil); err != nil {
+				return err
+			}
+			counter++
+			if counter >= 50 {
+				if err := batch.Commit(defaultWriteOpts); err != nil {
+					return err
+				}
+				batch.Reset()
+				counter = 0
+			}
+		}
+
+		prevKey = slices.Clone(currKey)
+		prevVersion = currVersion
+		prevKeyEncoded = slices.Clone(itr.Key())
+	}
+
+	if counter > 0 {
+		if err := batch.Commit(defaultWriteOpts); err != nil {
+			return err
+		}
+	}
+
+	return db.SetEarliestVersion(version + 1)
+}
+
+func isMetadataKey(key []byte) bool {
+	return len(key) > 0 && key[0] == '_'
+}
+
+// EVMIterator implements types.DBIterator for EVM database
+type EVMIterator struct {
+	itr             *pebble.Iterator
+	start, end      []byte
+	version         int64
+	earliestVersion int64
+	reverse         bool
+	valid           bool
+	currentKey      []byte
+	currentValue    []byte
+	err             error
+}
+
+func newEVMIterator(db *pebble.DB, start, end []byte, version, earliestVersion int64, reverse bool) (*EVMIterator, error) {
+	var lowerBound, upperBound []byte
+	if start != nil {
+		lowerBound = encodeKey(start, 0)
+	}
+	if end != nil {
+		upperBound = encodeKey(end, 0)
+	}
+
+	itr, err := db.NewIter(&pebble.IterOptions{
+		LowerBound: lowerBound,
+		UpperBound: upperBound,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	it := &EVMIterator{
+		itr:             itr,
+		start:           start,
+		end:             end,
+		version:         version,
+		earliestVersion: earliestVersion,
+		reverse:         reverse,
+	}
+
+	// Position at first entry
+	if reverse {
+		it.valid = itr.Last()
+	} else {
+		it.valid = itr.First()
+	}
+
+	// Find first valid entry
+	if it.valid {
+		it.findValidEntry()
+	}
+
+	return it, nil
+}
+
+// findValidEntry scans from current position to find a valid entry for iteration
+func (it *EVMIterator) findValidEntry() {
+	for it.itr.Valid() {
+		key, keyVersion, ok := decodeKey(it.itr.Key())
+		if !ok {
+			it.moveNext()
+			continue
+		}
+
+		// Skip versions that are too new or too old
+		if keyVersion > it.version || keyVersion < it.earliestVersion {
+			it.moveNext()
+			continue
+		}
+
+		// Check for tombstone (empty value)
+		value := it.itr.Value()
+		if len(value) == 0 {
+			// Skip all versions of this tombstoned key
+			it.skipPastKey(key)
+			continue
+		}
+
+		// Found valid entry - store it
+		it.currentKey = slices.Clone(key)
+		it.currentValue = slices.Clone(value)
+		it.valid = true
+		return
+	}
+
+	it.valid = false
+}
+
+func (it *EVMIterator) moveNext() {
+	if it.reverse {
+		it.itr.Prev()
+	} else {
+		it.itr.Next()
+	}
+}
+
+// skipPastKey moves the iterator past all versions of the given key
+func (it *EVMIterator) skipPastKey(currentKey []byte) {
+	for it.itr.Valid() {
+		it.moveNext()
+		if !it.itr.Valid() {
+			return
+		}
+		key, _, ok := decodeKey(it.itr.Key())
+		if !ok || !slices.Equal(key, currentKey) {
+			return
+		}
+	}
+}
+
+func (it *EVMIterator) Domain() ([]byte, []byte) {
+	return it.start, it.end
+}
+
+func (it *EVMIterator) Valid() bool {
+	return it.valid && it.err == nil
+}
+
+func (it *EVMIterator) Next() {
+	if !it.valid {
+		return
+	}
+
+	// Skip past all versions of current key
+	it.skipPastKey(it.currentKey)
+
+	// Find the next valid entry
+	if it.itr.Valid() {
+		it.findValidEntry()
+	} else {
+		it.valid = false
+	}
+}
+
+func (it *EVMIterator) Key() []byte {
+	if !it.valid {
+		return nil
+	}
+	return it.currentKey
+}
+
+func (it *EVMIterator) Value() []byte {
+	if !it.valid {
+		return nil
+	}
+	return it.currentValue
+}
+
+func (it *EVMIterator) Error() error {
+	if it.err != nil {
+		return it.err
+	}
+	return it.itr.Error()
+}
+
+func (it *EVMIterator) Close() error {
+	return it.itr.Close()
+}
+
+var _ types.DBIterator = (*EVMIterator)(nil)

--- a/sei-db/state_db/ss/evm/db_test.go
+++ b/sei-db/state_db/ss/evm/db_test.go
@@ -1,0 +1,492 @@
+package evm
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	iavl "github.com/sei-protocol/sei-chain/sei-iavl"
+)
+
+func TestEVMDatabase(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "evm_db_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	db, err := OpenEVMDB(tmpDir, StorageStore)
+	require.NoError(t, err)
+	defer db.Close()
+
+	t.Run("Set and Get", func(t *testing.T) {
+		key := []byte("test_key")
+		value := []byte("test_value")
+
+		err := db.Set(key, value, 1)
+		require.NoError(t, err)
+
+		got, err := db.Get(key, 1)
+		require.NoError(t, err)
+		require.Equal(t, value, got)
+	})
+
+	t.Run("Version handling", func(t *testing.T) {
+		key := []byte("versioned_key")
+
+		// Write at version 1
+		err := db.Set(key, []byte("v1"), 1)
+		require.NoError(t, err)
+
+		// Write at version 5
+		err = db.Set(key, []byte("v5"), 5)
+		require.NoError(t, err)
+
+		// Read at version 3 should return v1
+		val, err := db.Get(key, 3)
+		require.NoError(t, err)
+		require.Equal(t, []byte("v1"), val)
+
+		// Read at version 5 should return v5
+		val, err = db.Get(key, 5)
+		require.NoError(t, err)
+		require.Equal(t, []byte("v5"), val)
+
+		// Read at version 10 should return v5
+		val, err = db.Get(key, 10)
+		require.NoError(t, err)
+		require.Equal(t, []byte("v5"), val)
+	})
+
+	t.Run("Delete (tombstone)", func(t *testing.T) {
+		key := []byte("delete_key")
+
+		err := db.Set(key, []byte("exists"), 1)
+		require.NoError(t, err)
+
+		err = db.Delete(key, 2)
+		require.NoError(t, err)
+
+		// At version 1, key should exist
+		val, err := db.Get(key, 1)
+		require.NoError(t, err)
+		require.Equal(t, []byte("exists"), val)
+
+		// At version 2, key should be deleted
+		val, err = db.Get(key, 2)
+		require.NoError(t, err)
+		require.Nil(t, val)
+	})
+
+	t.Run("Has", func(t *testing.T) {
+		key := []byte("has_key")
+
+		has, err := db.Has(key, 1)
+		require.NoError(t, err)
+		require.False(t, has)
+
+		err = db.Set(key, []byte("value"), 1)
+		require.NoError(t, err)
+
+		has, err = db.Has(key, 1)
+		require.NoError(t, err)
+		require.True(t, has)
+	})
+}
+
+func TestEVMStateStore(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "evm_state_store_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewEVMStateStore(tmpDir)
+	require.NoError(t, err)
+	defer store.Close()
+
+	t.Run("Multiple store types", func(t *testing.T) {
+		// Storage
+		err := store.Set(StorageStore, []byte("storage_key"), []byte("storage_val"), 1)
+		require.NoError(t, err)
+
+		// Code
+		err = store.Set(CodeStore, []byte("code_key"), []byte("bytecode"), 1)
+		require.NoError(t, err)
+
+		// Nonce
+		err = store.Set(NonceStore, []byte("nonce_key"), []byte{5}, 1)
+		require.NoError(t, err)
+
+		// Verify
+		val, err := store.Get(StorageStore, []byte("storage_key"), 1)
+		require.NoError(t, err)
+		require.Equal(t, []byte("storage_val"), val)
+
+		val, err = store.Get(CodeStore, []byte("code_key"), 1)
+		require.NoError(t, err)
+		require.Equal(t, []byte("bytecode"), val)
+
+		val, err = store.Get(NonceStore, []byte("nonce_key"), 1)
+		require.NoError(t, err)
+		require.Equal(t, []byte{5}, val)
+	})
+
+	t.Run("ApplyChangeset", func(t *testing.T) {
+		changes := map[EVMStoreType][]*iavl.KVPair{
+			StorageStore: {
+				{Key: []byte("addr1"), Value: []byte("slot_value")},
+			},
+			CodeStore: {
+				{Key: []byte("addr2"), Value: []byte("contract_code")},
+			},
+		}
+
+		err := store.ApplyChangeset(2, changes)
+		require.NoError(t, err)
+
+		val, err := store.Get(StorageStore, []byte("addr1"), 2)
+		require.NoError(t, err)
+		require.Equal(t, []byte("slot_value"), val)
+
+		val, err = store.Get(CodeStore, []byte("addr2"), 2)
+		require.NoError(t, err)
+		require.Equal(t, []byte("contract_code"), val)
+	})
+}
+
+func TestKeyRouter(t *testing.T) {
+	router := NewKeyRouter()
+
+	t.Run("Routes EVM storage keys", func(t *testing.T) {
+		key := append([]byte{0x03}, []byte("address_storage")...)
+		storeType, strippedKey, isEVM := router.RouteKey(EVMStoreKey, key)
+
+		require.True(t, isEVM)
+		require.Equal(t, StorageStore, storeType)
+		require.Equal(t, []byte("address_storage"), strippedKey)
+	})
+
+	t.Run("Routes EVM code keys", func(t *testing.T) {
+		key := append([]byte{0x07}, []byte("contract_addr")...)
+		storeType, strippedKey, isEVM := router.RouteKey(EVMStoreKey, key)
+
+		require.True(t, isEVM)
+		require.Equal(t, CodeStore, storeType)
+		require.Equal(t, []byte("contract_addr"), strippedKey)
+	})
+
+	t.Run("Routes EVM nonce keys", func(t *testing.T) {
+		key := append([]byte{0x0a}, []byte("account_addr")...)
+		storeType, strippedKey, isEVM := router.RouteKey(EVMStoreKey, key)
+
+		require.True(t, isEVM)
+		require.Equal(t, NonceStore, storeType)
+		require.Equal(t, []byte("account_addr"), strippedKey)
+	})
+
+	t.Run("Non-routed EVM keys", func(t *testing.T) {
+		// Other EVM key prefix
+		key := []byte{0x01, 'a', 'b', 'c'}
+		_, _, isEVM := router.RouteKey(EVMStoreKey, key)
+		require.False(t, isEVM)
+	})
+
+	t.Run("Non-EVM store", func(t *testing.T) {
+		key := []byte("some_key")
+		_, _, isEVM := router.RouteKey("bank", key)
+		require.False(t, isEVM)
+	})
+
+	t.Run("RestoreKey", func(t *testing.T) {
+		strippedKey := []byte("test_data")
+
+		restored := router.RestoreKey(StorageStore, strippedKey)
+		require.Equal(t, append([]byte{0x03}, strippedKey...), restored)
+
+		restored = router.RestoreKey(CodeStore, strippedKey)
+		require.Equal(t, append([]byte{0x07}, strippedKey...), restored)
+
+		restored = router.RestoreKey(NonceStore, strippedKey)
+		require.Equal(t, append([]byte{0x0a}, strippedKey...), restored)
+	})
+}
+
+func TestEVMDatabaseBatch(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "evm_batch_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	db, err := OpenEVMDB(tmpDir, StorageStore)
+	require.NoError(t, err)
+	defer db.Close()
+
+	t.Run("ApplyBatch multiple keys", func(t *testing.T) {
+		pairs := []*iavl.KVPair{
+			{Key: []byte("key1"), Value: []byte("val1")},
+			{Key: []byte("key2"), Value: []byte("val2")},
+			{Key: []byte("key3"), Value: []byte("val3")},
+		}
+
+		err := db.ApplyBatch(pairs, 1)
+		require.NoError(t, err)
+
+		for _, pair := range pairs {
+			val, err := db.Get(pair.Key, 1)
+			require.NoError(t, err)
+			require.Equal(t, pair.Value, val)
+		}
+	})
+
+	t.Run("ApplyBatch with deletes", func(t *testing.T) {
+		// First set some values
+		pairs := []*iavl.KVPair{
+			{Key: []byte("del_key1"), Value: []byte("val1")},
+			{Key: []byte("del_key2"), Value: []byte("val2")},
+		}
+		err := db.ApplyBatch(pairs, 2)
+		require.NoError(t, err)
+
+		// Now delete one
+		deletePairs := []*iavl.KVPair{
+			{Key: []byte("del_key1"), Delete: true},
+			{Key: []byte("del_key2"), Value: []byte("updated")},
+		}
+		err = db.ApplyBatch(deletePairs, 3)
+		require.NoError(t, err)
+
+		// Check del_key1 is deleted at version 3
+		val, err := db.Get([]byte("del_key1"), 3)
+		require.NoError(t, err)
+		require.Nil(t, val)
+
+		// Check del_key1 still exists at version 2
+		val, err = db.Get([]byte("del_key1"), 2)
+		require.NoError(t, err)
+		require.Equal(t, []byte("val1"), val)
+
+		// Check del_key2 is updated
+		val, err = db.Get([]byte("del_key2"), 3)
+		require.NoError(t, err)
+		require.Equal(t, []byte("updated"), val)
+	})
+
+	t.Run("ApplyBatch empty", func(t *testing.T) {
+		err := db.ApplyBatch([]*iavl.KVPair{}, 4)
+		require.NoError(t, err)
+	})
+}
+
+func TestEVMStateStoreParallel(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "evm_parallel_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewEVMStateStore(tmpDir)
+	require.NoError(t, err)
+	defer store.Close()
+
+	t.Run("ApplyChangesetParallel", func(t *testing.T) {
+		changes := map[EVMStoreType][]*iavl.KVPair{
+			StorageStore: {
+				{Key: []byte("storage1"), Value: []byte("s1")},
+				{Key: []byte("storage2"), Value: []byte("s2")},
+			},
+			CodeStore: {
+				{Key: []byte("code1"), Value: []byte("bytecode1")},
+			},
+			NonceStore: {
+				{Key: []byte("nonce1"), Value: []byte{1}},
+			},
+		}
+
+		err := store.ApplyChangesetParallel(1, changes)
+		require.NoError(t, err)
+
+		// Verify all writes
+		val, err := store.Get(StorageStore, []byte("storage1"), 1)
+		require.NoError(t, err)
+		require.Equal(t, []byte("s1"), val)
+
+		val, err = store.Get(CodeStore, []byte("code1"), 1)
+		require.NoError(t, err)
+		require.Equal(t, []byte("bytecode1"), val)
+
+		val, err = store.Get(NonceStore, []byte("nonce1"), 1)
+		require.NoError(t, err)
+		require.Equal(t, []byte{1}, val)
+	})
+}
+
+func TestEVMDatabaseConcurrent(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "evm_concurrent_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	db, err := OpenEVMDB(tmpDir, StorageStore)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Pre-populate some data
+	for i := 0; i < 100; i++ {
+		key := []byte(fmt.Sprintf("key%d", i))
+		val := []byte(fmt.Sprintf("val%d", i))
+		require.NoError(t, db.Set(key, val, 1))
+	}
+
+	t.Run("Concurrent reads", func(t *testing.T) {
+		var wg sync.WaitGroup
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				for j := 0; j < 100; j++ {
+					key := []byte(fmt.Sprintf("key%d", j))
+					_, err := db.Get(key, 1)
+					require.NoError(t, err)
+				}
+			}(i)
+		}
+		wg.Wait()
+	})
+
+	t.Run("Concurrent reads and writes", func(t *testing.T) {
+		var wg sync.WaitGroup
+
+		// Readers
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 50; j++ {
+					key := []byte(fmt.Sprintf("key%d", j))
+					_, _ = db.Get(key, 1)
+				}
+			}()
+		}
+
+		// Writers
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				for j := 0; j < 20; j++ {
+					key := []byte(fmt.Sprintf("concurrent_key_%d_%d", idx, j))
+					val := []byte(fmt.Sprintf("val_%d_%d", idx, j))
+					_ = db.Set(key, val, int64(2+idx))
+				}
+			}(i)
+		}
+
+		wg.Wait()
+	})
+}
+
+func TestEVMDatabaseIterator(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "evm_iter_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	db, err := OpenEVMDB(tmpDir, StorageStore)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Add data
+	keys := []string{"aaa", "bbb", "ccc", "ddd"}
+	for i, k := range keys {
+		require.NoError(t, db.Set([]byte(k), []byte(fmt.Sprintf("val%d", i)), 1))
+	}
+
+	t.Run("Forward iteration", func(t *testing.T) {
+		itr, err := db.Iterator(nil, nil, 1)
+		require.NoError(t, err)
+		defer itr.Close()
+
+		var found []string
+		for ; itr.Valid(); itr.Next() {
+			found = append(found, string(itr.Key()))
+		}
+		require.Equal(t, keys, found)
+	})
+
+	t.Run("Reverse iteration", func(t *testing.T) {
+		itr, err := db.ReverseIterator(nil, nil, 1)
+		require.NoError(t, err)
+		defer itr.Close()
+
+		var found []string
+		for ; itr.Valid(); itr.Next() {
+			found = append(found, string(itr.Key()))
+		}
+
+		// Should be reversed
+		expected := []string{"ddd", "ccc", "bbb", "aaa"}
+		require.Equal(t, expected, found)
+	})
+
+	t.Run("Bounded iteration", func(t *testing.T) {
+		itr, err := db.Iterator([]byte("bbb"), []byte("ddd"), 1)
+		require.NoError(t, err)
+		defer itr.Close()
+
+		var found []string
+		for ; itr.Valid(); itr.Next() {
+			found = append(found, string(itr.Key()))
+		}
+		require.Equal(t, []string{"bbb", "ccc"}, found)
+	})
+}
+
+func TestEVMDatabaseVersionEdgeCases(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "evm_version_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	db, err := OpenEVMDB(tmpDir, StorageStore)
+	require.NoError(t, err)
+	defer db.Close()
+
+	t.Run("Version 0 read", func(t *testing.T) {
+		require.NoError(t, db.Set([]byte("key"), []byte("val"), 1))
+
+		// Version 0 should not find the key (written at version 1)
+		val, err := db.Get([]byte("key"), 0)
+		require.NoError(t, err)
+		require.Nil(t, val)
+	})
+
+	t.Run("Large version gap", func(t *testing.T) {
+		require.NoError(t, db.Set([]byte("gapkey"), []byte("v1"), 1))
+		require.NoError(t, db.Set([]byte("gapkey"), []byte("v1000"), 1000))
+
+		// Version 500 should return v1
+		val, err := db.Get([]byte("gapkey"), 500)
+		require.NoError(t, err)
+		require.Equal(t, []byte("v1"), val)
+
+		// Version 1000 should return v1000
+		val, err = db.Get([]byte("gapkey"), 1000)
+		require.NoError(t, err)
+		require.Equal(t, []byte("v1000"), val)
+	})
+
+	t.Run("Overwrite same version", func(t *testing.T) {
+		// This shouldn't happen in practice, but let's be safe
+		require.NoError(t, db.Set([]byte("owkey"), []byte("first"), 5))
+		require.NoError(t, db.Set([]byte("owkey"), []byte("second"), 5))
+
+		// Should return the last written value
+		val, err := db.Get([]byte("owkey"), 5)
+		require.NoError(t, err)
+		require.Equal(t, []byte("second"), val)
+	})
+
+	t.Run("Empty value vs tombstone", func(t *testing.T) {
+		// Set with empty value (should be treated as tombstone)
+		require.NoError(t, db.Set([]byte("emptykey"), []byte{}, 1))
+
+		// Get should return nil (empty is tombstone)
+		val, err := db.Get([]byte("emptykey"), 1)
+		require.NoError(t, err)
+		require.Nil(t, val)
+	})
+}

--- a/sei-db/state_db/ss/evm/router.go
+++ b/sei-db/state_db/ss/evm/router.go
@@ -1,0 +1,74 @@
+package evm
+
+import (
+	"bytes"
+)
+
+// EVM key prefixes from x/evm/types/keys.go
+var (
+	StateKeyPrefix = []byte{0x03} // Storage
+	CodeKeyPrefix  = []byte{0x07}
+	NonceKeyPrefix = []byte{0x0a}
+)
+
+// EVMStoreKey is the cosmos store key for EVM module
+const EVMStoreKey = "evm"
+
+// BankStoreKey is the cosmos store key for bank module (for balances)
+const BankStoreKey = "bank"
+
+// KeyRouter determines which EVM database should handle a given key
+type KeyRouter struct{}
+
+// NewKeyRouter creates a new key router
+func NewKeyRouter() *KeyRouter {
+	return &KeyRouter{}
+}
+
+// RouteKey determines the EVM store type for a given store key and data key
+// Returns (storeType, strippedKey, isEVM)
+// strippedKey has the prefix removed for EVM stores
+func (r *KeyRouter) RouteKey(storeKey string, key []byte) (EVMStoreType, []byte, bool) {
+	if storeKey == EVMStoreKey && len(key) > 0 {
+		switch {
+		case bytes.HasPrefix(key, StateKeyPrefix):
+			return StorageStore, key[len(StateKeyPrefix):], true
+		case bytes.HasPrefix(key, CodeKeyPrefix):
+			return CodeStore, key[len(CodeKeyPrefix):], true
+		case bytes.HasPrefix(key, NonceKeyPrefix):
+			return NonceStore, key[len(NonceKeyPrefix):], true
+		}
+	}
+
+	// Balance routing: bank module balance keys
+	// Bank balance keys are typically: prefix + address
+	if storeKey == BankStoreKey && len(key) > 0 {
+		// We can route specific bank prefixes to BalanceStore if needed
+		// For now, leave bank in Cosmos_SS to avoid complexity
+	}
+
+	return "", nil, false
+}
+
+// IsEVMStore checks if a store key is routed to EVM stores
+func (r *KeyRouter) IsEVMStore(storeKey string) bool {
+	return storeKey == EVMStoreKey
+}
+
+// RestoreKey prepends the original prefix back to the key
+func (r *KeyRouter) RestoreKey(storeType EVMStoreType, key []byte) []byte {
+	var prefix []byte
+	switch storeType {
+	case StorageStore:
+		prefix = StateKeyPrefix
+	case CodeStore:
+		prefix = CodeKeyPrefix
+	case NonceStore:
+		prefix = NonceKeyPrefix
+	case BalanceStore:
+		return key // No prefix for balance (different store)
+	default:
+		return key
+	}
+	return append(prefix, key...)
+}


### PR DESCRIPTION
Implements EVMStateStore with separate PebbleDB databases for different EVM data types (storage, balance, nonce, code) using default comparer.

- EVMDatabase: Single PebbleDB with default comparer for one EVM store type
- EVMStateStore: Manages all 4 separate EVM databases
- KeyRouter: Routes keys based on EVM prefixes (0x03, 0x07, 0x0a)
- EVMStateStoreConfig: Configuration for EVM state stores
- Supports versioned key-value storage with batch writes and parallel operations

This provides the foundation for the composite state store that will route between Cosmos_SS (MVCC) and EVM_SS (default comparer).

## Describe your changes and provide context

## Testing performed to validate your change

