### PR TITLE
Support query latest state when SS disabled

### DIFF
--- a/sei-cosmos/storev2/rootmulti/store.go
+++ b/sei-cosmos/storev2/rootmulti/store.go
@@ -246,6 +246,9 @@ func (rs *Store) CacheMultiStoreWithVersion(version int64) (types.CacheMultiStor
 	stores := make(map[types.StoreKey]types.CacheWrapper)
 	// Serve from SS stores for ALL historical queries
 	if rs.ssStore != nil {
+		if version <= 0 {
+			version = rs.ssStore.GetLatestVersion()
+		}
 		// add the transient/mem stores registered in current app.
 		for k, store := range rs.ckvStores {
 			if store.GetStoreType() != types.StoreTypeIAVL {

--- a/sei-cosmos/storev2/rootmulti/store_test.go
+++ b/sei-cosmos/storev2/rootmulti/store_test.go
@@ -1,6 +1,7 @@
 package rootmulti
 
 import (
+	"github.com/cosmos/cosmos-sdk/storev2/state"
 	"testing"
 
 	"time"
@@ -92,4 +93,100 @@ func TestSCSS_WriteAndHistoricalRead(t *testing.T) {
 	})
 	require.EqualValues(t, 0, resp.Code)
 	require.Equal(t, valV1, resp.Value)
+}
+
+// TestCacheMultiStoreWithVersion_OnlyUsesSSStores verifies that CacheMultiStoreWithVersion
+// serves SS stores when enabled, and falls back to SC when SS is disabled, for
+// height=0 (latest) and explicit latest height.
+func TestCacheMultiStoreWithVersion_OnlyUsesSSStores(t *testing.T) {
+	testCases := []struct {
+		name      string
+		ssEnabled bool
+	}{
+		{"ss-enabled", true},
+		{"ss-disabled", false},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			scCfg := config.DefaultStateCommitConfig()
+			scCfg.Enable = true
+			scCfg.AsyncCommitBuffer = 0
+			ssCfg := config.DefaultStateStoreConfig()
+			ssCfg.Enable = tc.ssEnabled
+			ssCfg.AsyncWriteBuffer = 0
+
+			store := NewStore(home, log.NewNopLogger(), scCfg, ssCfg, false, []string{})
+			defer func() { _ = store.Close() }()
+
+			iavlKey1 := types.NewKVStoreKey("iavl_store1")
+			iavlKey2 := types.NewKVStoreKey("iavl_store2")
+			transientKey := types.NewTransientStoreKey("transient_store")
+			memKey := types.NewMemoryStoreKey("mem_store")
+
+			store.MountStoreWithDB(iavlKey1, types.StoreTypeIAVL, nil)
+			store.MountStoreWithDB(iavlKey2, types.StoreTypeIAVL, nil)
+			store.MountStoreWithDB(transientKey, types.StoreTypeTransient, nil)
+			store.MountStoreWithDB(memKey, types.StoreTypeMemory, nil)
+			require.NoError(t, store.LoadLatestVersion())
+
+			iavl1KV := store.GetStoreByName("iavl_store1").(types.KVStore)
+			iavl2KV := store.GetStoreByName("iavl_store2").(types.KVStore)
+			iavl1KV.Set([]byte("k1"), []byte("v1"))
+			iavl2KV.Set([]byte("k2"), []byte("v2"))
+			c1 := store.Commit(true)
+			require.Equal(t, int64(1), c1.Version)
+
+			iavl1KV = store.GetStoreByName("iavl_store1").(types.KVStore)
+			iavl2KV = store.GetStoreByName("iavl_store2").(types.KVStore)
+			iavl1KV.Set([]byte("k1"), []byte("v1_updated"))
+			iavl2KV.Set([]byte("k2"), []byte("v2_updated"))
+			c2 := store.Commit(true)
+			require.Equal(t, int64(2), c2.Version)
+
+			if tc.ssEnabled {
+				waitUntilSSVersion(t, store, c2.Version)
+			}
+
+			queryVersions := []int64{0, c2.Version}
+			for _, v := range queryVersions {
+				cms, err := store.CacheMultiStoreWithVersion(v)
+				require.NoError(t, err)
+
+				iavl1Store := cms.GetKVStore(iavlKey1)
+				iavl2Store := cms.GetKVStore(iavlKey2)
+				require.NotNil(t, iavl1Store)
+				require.NotNil(t, iavl2Store)
+
+				if tc.ssEnabled {
+					require.Equal(t, types.StoreType(state.StoreTypeSSStore), iavl1Store.GetStoreType())
+					require.Equal(t, types.StoreType(state.StoreTypeSSStore), iavl2Store.GetStoreType())
+				} else {
+					require.Equal(t, types.StoreTypeIAVL, iavl1Store.GetStoreType())
+					require.Equal(t, types.StoreTypeIAVL, iavl2Store.GetStoreType())
+				}
+
+				transientStore := cms.GetKVStore(transientKey)
+				memStore := cms.GetKVStore(memKey)
+				require.NotNil(t, transientStore)
+				require.NotNil(t, memStore)
+				require.Equal(t, types.StoreTypeTransient, transientStore.GetStoreType())
+				require.Equal(t, types.StoreTypeMemory, memStore.GetStoreType())
+
+				if v != 0 {
+					require.Equal(t, []byte("v1_updated"), iavl1Store.Get([]byte("k1")))
+					require.Equal(t, []byte("v2_updated"), iavl2Store.Get([]byte("k2")))
+				}
+			}
+
+			if !tc.ssEnabled {
+				cmsHistorical, err := store.CacheMultiStoreWithVersion(c1.Version)
+				require.NoError(t, err)
+				require.Panics(t, func() { _ = cmsHistorical.GetKVStore(iavlKey1) })
+				require.Panics(t, func() { _ = cmsHistorical.GetKVStore(iavlKey2) })
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Describe your changes and provide context
In previous PR, we removed completely to serve any historical query from SC, because that could cause data inconsistency issues (SC data is not in sync with SS)

However that introduced a bug for validator nodes, since validator nodes have SS disabled, and it still need to be able to serve query with height=latestHeight

This PR fixed both issues by adding the SC back, but only serve from SC when SS is disabled to keep the data still consistent for RPC node.

## Testing performed to validate your change
Added unit test
