### PR TITLE
Add features & knobs to benchmark.sh

### DIFF
--- a/app/abci.go
+++ b/app/abci.go
@@ -195,5 +195,10 @@ func (app *App) DeliverTxBatch(ctx sdk.Context, req sdk.DeliverTxBatchRequest) (
 func (app *App) Commit(ctx context.Context) (res *abci.ResponseCommit, err error) {
 	_, span := app.GetBaseApp().TracingInfo.StartWithContext("Commit", ctx)
 	defer span.End()
-	return app.BaseApp.Commit(ctx)
+	start := time.Now()
+	res, err = app.BaseApp.Commit(ctx)
+	if app.benchmarkLogger != nil {
+		app.benchmarkLogger.RecordCommitTime(time.Since(start))
+	}
+	return res, err
 }

--- a/app/app.go
+++ b/app/app.go
@@ -1167,6 +1167,11 @@ func (app *App) ClearOptimisticProcessingInfo() {
 }
 
 func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcessProposal) (resp *abci.ResponseProcessProposal, err error) {
+	// Start block processing timing (ends at FinalizeBlock)
+	if app.benchmarkLogger != nil {
+		app.benchmarkLogger.StartBlockProcessing()
+	}
+
 	// TODO: this check decodes transactions which is redone in subsequent processing. We might be able to optimize performance
 	// by recording the decoding results and avoid decoding again later on.
 
@@ -1242,6 +1247,10 @@ func (app *App) FinalizeBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock)
 		app.ClearOptimisticProcessingInfo()
 		duration := time.Since(startTime)
 		ctx.Logger().Info(fmt.Sprintf("FinalizeBlock took %dms", duration/time.Millisecond))
+		// End block processing timing (started at ProcessProposal)
+		if app.benchmarkLogger != nil {
+			app.benchmarkLogger.EndBlockProcessing()
+		}
 	}()
 
 	// Get all optimistic processing info atomically

--- a/app/benchmark.go
+++ b/app/benchmark.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -27,7 +29,16 @@ type benchmarkLogger struct {
 	blockTimeCount int64         // Number of block time differences calculated
 	prevBlockTime  time.Time     // Previous block time for calculating differences
 	lastFlushTime  time.Time     // When we last flushed (for TPS calculation)
-	logger         log.Logger
+	// Commit time tracking
+	maxCommitTime   time.Duration // Maximum commit time in the window
+	totalCommitTime time.Duration // Sum of all commit times in the window
+	commitCount     int64         // Number of commits in the window
+	// Block processing time tracking (ProcessProposal start to FinalizeBlock end)
+	blockProcessStartTime time.Time     // Start time of current block processing
+	maxBlockProcessTime   time.Duration // Maximum block processing time in the window
+	totalBlockProcessTime time.Duration // Sum of all block processing times in the window
+	blockProcessCount     int64         // Number of block processing times recorded
+	logger                log.Logger
 }
 
 func (l *benchmarkLogger) Increment(count int64, blocktime time.Time, height int64) {
@@ -57,6 +68,43 @@ func (l *benchmarkLogger) Increment(count int64, blocktime time.Time, height int
 	l.prevBlockTime = blocktime
 }
 
+// RecordCommitTime records the duration of a commit operation
+func (l *benchmarkLogger) RecordCommitTime(duration time.Duration) {
+	l.mx.Lock()
+	defer l.mx.Unlock()
+
+	if duration > l.maxCommitTime {
+		l.maxCommitTime = duration
+	}
+	l.totalCommitTime += duration
+	l.commitCount++
+}
+
+// StartBlockProcessing marks the start of block processing (at ProcessProposal)
+func (l *benchmarkLogger) StartBlockProcessing() {
+	l.mx.Lock()
+	defer l.mx.Unlock()
+	l.blockProcessStartTime = time.Now()
+}
+
+// EndBlockProcessing marks the end of block processing (at FinalizeBlock end) and records the duration
+func (l *benchmarkLogger) EndBlockProcessing() {
+	l.mx.Lock()
+	defer l.mx.Unlock()
+
+	if l.blockProcessStartTime.IsZero() {
+		return
+	}
+
+	duration := time.Since(l.blockProcessStartTime)
+	if duration > l.maxBlockProcessTime {
+		l.maxBlockProcessTime = duration
+	}
+	l.totalBlockProcessTime += duration
+	l.blockProcessCount++
+	l.blockProcessStartTime = time.Time{} // Reset for next block
+}
+
 // calculateTPS computes transactions per second based on transaction count and duration
 func calculateTPS(txCount int64, duration time.Duration) float64 {
 	if duration <= 0 {
@@ -76,12 +124,16 @@ func calculateAvgBlockTime(totalBlockTime time.Duration, blockTimeCount int64) i
 
 // flushStats holds the statistics for a flush window
 type flushStats struct {
-	txCount        int64
-	blockCount     int64
-	latestHeight   int64
-	maxBlockTimeMs int64
-	avgBlockTimeMs int64
-	tps            float64
+	txCount           int64
+	blockCount        int64
+	latestHeight      int64
+	maxBlockTimeMs    int64
+	avgBlockTimeMs    int64
+	maxCommitTimeMs   int64
+	avgCommitTimeMs   int64
+	maxBlockProcessMs int64
+	avgBlockProcessMs int64
+	tps               float64
 }
 
 // getAndResetStats atomically reads current stats and resets counters for next window
@@ -90,23 +142,35 @@ func (l *benchmarkLogger) getAndResetStats(now time.Time) (flushStats, time.Time
 	defer l.mx.Unlock()
 
 	stats := flushStats{
-		txCount:        l.txCount,
-		blockCount:     l.blockCount,
-		latestHeight:   l.latestHeight,
-		maxBlockTimeMs: l.maxBlockTime.Milliseconds(),
+		txCount:           l.txCount,
+		blockCount:        l.blockCount,
+		latestHeight:      l.latestHeight,
+		maxBlockTimeMs:    l.maxBlockTime.Milliseconds(),
+		maxCommitTimeMs:   l.maxCommitTime.Milliseconds(),
+		maxBlockProcessMs: l.maxBlockProcessTime.Milliseconds(),
 	}
 
 	prevTime := l.lastFlushTime
 	totalBlockTime := l.totalBlockTime
 	blockTimeCount := l.blockTimeCount
+	totalCommitTime := l.totalCommitTime
+	commitCount := l.commitCount
+	totalBlockProcessTime := l.totalBlockProcessTime
+	blockProcessCount := l.blockProcessCount
 
-	// Reset counters for next window (but keep prevBlockTime for continuity)
+	// Reset counters for next window (but keep prevBlockTime and blockProcessStartTime for continuity)
 	l.txCount = 0
 	l.blockCount = 0
 	l.latestHeight = 0
 	l.maxBlockTime = 0
 	l.totalBlockTime = 0
 	l.blockTimeCount = 0
+	l.maxCommitTime = 0
+	l.totalCommitTime = 0
+	l.commitCount = 0
+	l.maxBlockProcessTime = 0
+	l.totalBlockProcessTime = 0
+	l.blockProcessCount = 0
 	l.lastFlushTime = now
 
 	// Calculate TPS
@@ -117,6 +181,16 @@ func (l *benchmarkLogger) getAndResetStats(now time.Time) (flushStats, time.Time
 
 	// Calculate average block time
 	stats.avgBlockTimeMs = calculateAvgBlockTime(totalBlockTime, blockTimeCount)
+
+	// Calculate average commit time
+	if commitCount > 0 {
+		stats.avgCommitTimeMs = (totalCommitTime / time.Duration(commitCount)).Milliseconds()
+	}
+
+	// Calculate average block processing time
+	if blockProcessCount > 0 {
+		stats.avgBlockProcessMs = (totalBlockProcessTime / time.Duration(blockProcessCount)).Milliseconds()
+	}
 
 	return stats, prevTime
 }
@@ -131,6 +205,10 @@ func (l *benchmarkLogger) FlushLog() {
 		"height", stats.latestHeight,
 		"blockTimeMax", stats.maxBlockTimeMs,
 		"blockTimeAvg", stats.avgBlockTimeMs,
+		"commitTimeMax", stats.maxCommitTimeMs,
+		"commitTimeAvg", stats.avgCommitTimeMs,
+		"blockProcessMax", stats.maxBlockProcessMs,
+		"blockProcessAvg", stats.avgBlockProcessMs,
 		"tps", stats.tps,
 	)
 }
@@ -149,6 +227,15 @@ func (l *benchmarkLogger) Start(ctx context.Context) {
 }
 
 func NewGeneratorCh(ctx context.Context, txConfig client.TxConfig, chainID string, evmChainID int64, logger log.Logger) <-chan *abci.ResponsePrepareProposal {
+	// Read number of transactions per batch from environment variable, default to 1000
+	txsPerBatch := 1000
+	if envVal := os.Getenv("BENCHMARK_TXS_PER_BATCH"); envVal != "" {
+		if parsed, err := strconv.Atoi(envVal); err == nil && parsed > 0 {
+			txsPerBatch = parsed
+		}
+	}
+	logger.Info("benchmark generator config", "txsPerBatch", txsPerBatch)
+
 	gen, err := generator.NewConfigBasedGenerator(&config.LoadConfig{
 		ChainID:    evmChainID,
 		SeiChainID: chainID,
@@ -170,8 +257,8 @@ func NewGeneratorCh(ctx context.Context, txConfig client.TxConfig, chainID strin
 			if ctx.Err() != nil {
 				return
 			}
-			// generate txs like: txs := gen.GenerateN(1000)
-			loadTxs := gen.GenerateN(1000)
+			// generate txs
+			loadTxs := gen.GenerateN(txsPerBatch)
 			if len(loadTxs) == 0 {
 				continue
 			}


### PR DESCRIPTION
## Describe your changes and provide context
Add finer-grained metrics that track commit latency and execution latency, which excludes time spent on the tendermint side.
Also added a flag to turn off tx indexer and a flag to specify block size.

## Testing performed to validate your change
./scripts/benchmark.sh

