### PR TITLE
[giga] Fix gigacachekv.Store.Write() to preserve cache for reads

### DIFF
--- a/giga/deps/store/cachekv.go
+++ b/giga/deps/store/cachekv.go
@@ -110,7 +110,18 @@ func (store *Store) Write() {
 		}
 	}
 
-	store.cache = &sync.Map{}
+	// Mark all entries as clean (not dirty) instead of clearing the cache.
+	// This is important because the parent store (commitment.Store) doesn't make
+	// writes immediately visible until Commit(). By keeping the cache populated
+	// with clean entries, subsequent reads will still hit the cache instead of
+	// falling through to the parent which can't read uncommitted data.
+	store.cache.Range(func(key, value any) bool {
+		cv := value.(*types.CValue)
+		// Replace with a clean (non-dirty) version of the same value
+		store.cache.Store(key, types.NewCValue(cv.Value(), false))
+		return true
+	})
+	// Clear the deleted map since those deletes have been sent to parent
 	store.deleted = &sync.Map{}
 }
 


### PR DESCRIPTION
## Summary
The `Write()` method was clearing the cache after writing dirty entries to the parent store. This caused issues because:

1. The parent store (`commitment.Store`) writes to a changeSet buffer
2. `commitment.Store.Get()` reads from the tree, not the changeSet
3. After clearing the cache, reads fell through to parent which couldn't return uncommitted data

**Fix:** Mark cache entries as clean (non-dirty) instead of clearing them. This preserves readability while still flushing data to parent for eventual commit.

This fixes state test failures where pre-state data was lost after `ProcessBlock` called `WriteGiga()`.

## Test plan
- [x] Existing state tests pass with this fix
- [ ] Verify cache behavior after multiple Write() calls