### PR TITLE
Fixed flaky p2p test

### DIFF
--- a/sei-tendermint/internal/p2p/conn/connection.go
+++ b/sei-tendermint/internal/p2p/conn/connection.go
@@ -344,12 +344,12 @@ func (c *MConnection) popSendQueue(ctx context.Context) (*pb.Packet, error) {
 			if err := utils.WithDeadline(ctx, q.flush, func(ctx context.Context) error {
 				return ctrl.Wait(ctx)
 			}); err != nil {
-				if ctx.Err() == nil {
-					// It is flush time!
-					q.flush = utils.None[time.Time]()
-					return nil, nil
+				if ctx.Err() != nil {
+					return nil, ctx.Err()
 				}
-				return nil, err
+				// It is flush time!
+				q.flush = utils.None[time.Time]()
+				return nil, nil
 			}
 		}
 	}

--- a/sei-tendermint/internal/p2p/conn/connection_test.go
+++ b/sei-tendermint/internal/p2p/conn/connection_test.go
@@ -192,8 +192,8 @@ func TestMConnectionReadErrorUnknownChannel(t *testing.T) {
 
 		s.SpawnBg(func() error { return utils.IgnoreCancel(mconnClient.Run(ctx)) })
 		s.Spawn(func() error {
-			if err, want := mconnServer.Run(ctx), (errBadChannel{}); !errors.As(err, &want) {
-				return fmt.Errorf("got %v, want %T", err, want)
+			if err := mconnServer.Run(ctx); !utils.ErrorAs[errBadChannel](err).IsPresent() {
+				return fmt.Errorf("got %v, want errBadChannel", err)
 			}
 			return nil
 		})


### PR DESCRIPTION
MConnection.sendRoutine() was incorrectly returning DeadlineExceeded in case flushing timer returned at the moment the context was cancelled (context error should be returned instead).