### PR TITLE
[giga] Fix commitment.Store to read from changeSet for uncommitted data

### DIFF
--- a/giga/deps/store/cachekv.go
+++ b/giga/deps/store/cachekv.go
@@ -110,6 +110,9 @@ func (store *Store) Write() {
 		}
 	}
 
+	// Clear the cache and deleted map after writing to parent.
+	// The parent store (commitment.Store) now makes writes immediately visible
+	// via Get() by checking its changeSet buffer.
 	store.cache = &sync.Map{}
 	store.deleted = &sync.Map{}
 }

--- a/sei-cosmos/storev2/commitment/store_test.go
+++ b/sei-cosmos/storev2/commitment/store_test.go
@@ -14,3 +14,70 @@ func TestLastCommitID(t *testing.T) {
 	store := NewStore(tree, log.NewNopLogger())
 	require.Equal(t, types.CommitID{Hash: tree.RootHash()}, store.LastCommitID())
 }
+
+func TestGetReadsFromChangeSet(t *testing.T) {
+	tree := memiavl.New(100)
+	store := NewStore(tree, log.NewNopLogger())
+
+	// Initially key doesn't exist
+	require.Nil(t, store.Get([]byte("key")))
+	require.False(t, store.Has([]byte("key")))
+
+	// Set without commit - should be visible via Get/Has
+	store.Set([]byte("key"), []byte("value"))
+	require.Equal(t, []byte("value"), store.Get([]byte("key")))
+	require.True(t, store.Has([]byte("key")))
+
+	// Update the same key - should see the latest value
+	store.Set([]byte("key"), []byte("updated"))
+	require.Equal(t, []byte("updated"), store.Get([]byte("key")))
+	require.True(t, store.Has([]byte("key")))
+
+	// Delete without commit - should appear deleted
+	store.Delete([]byte("key"))
+	require.Nil(t, store.Get([]byte("key")))
+	require.False(t, store.Has([]byte("key")))
+
+	// Set again after delete - should be visible
+	store.Set([]byte("key"), []byte("resurrected"))
+	require.Equal(t, []byte("resurrected"), store.Get([]byte("key")))
+	require.True(t, store.Has([]byte("key")))
+}
+
+func TestGetReadsFromChangeSetMultipleKeys(t *testing.T) {
+	tree := memiavl.New(100)
+	store := NewStore(tree, log.NewNopLogger())
+
+	// Set multiple keys
+	store.Set([]byte("key1"), []byte("value1"))
+	store.Set([]byte("key2"), []byte("value2"))
+	store.Set([]byte("key3"), []byte("value3"))
+
+	// All should be visible
+	require.Equal(t, []byte("value1"), store.Get([]byte("key1")))
+	require.Equal(t, []byte("value2"), store.Get([]byte("key2")))
+	require.Equal(t, []byte("value3"), store.Get([]byte("key3")))
+
+	// Delete one key
+	store.Delete([]byte("key2"))
+	require.Equal(t, []byte("value1"), store.Get([]byte("key1")))
+	require.Nil(t, store.Get([]byte("key2")))
+	require.Equal(t, []byte("value3"), store.Get([]byte("key3")))
+}
+
+func TestPopChangeSetClearsBuffer(t *testing.T) {
+	tree := memiavl.New(100)
+	store := NewStore(tree, log.NewNopLogger())
+
+	// Set a key
+	store.Set([]byte("key"), []byte("value"))
+	require.Equal(t, []byte("value"), store.Get([]byte("key")))
+
+	// Pop the changeset
+	cs := store.PopChangeSet()
+	require.Len(t, cs.Pairs, 1)
+
+	// After pop, key should not be visible (not in changeSet anymore, not in tree)
+	require.Nil(t, store.Get([]byte("key")))
+	require.False(t, store.Has([]byte("key")))
+}


### PR DESCRIPTION
## Summary

Fixes the root cause of the issue that PR #2772 worked around. After block processing in state tests, querying Giga state returned empty results because `commitment.Store.Get()` reads from the committed tree, not from the pending `changeSet` buffer that `Set()` writes to.

### Root Cause

The `commitment.Store` in `sei-cosmos/storev2/commitment/store.go` was designed with the assumption (see old comment on line 84-85: *"we assume Set is only called in `Commit`"*) that `Set()` only happens during `Commit()`. However, Giga violates this by calling `Set()` during block processing via `WriteGiga()`, expecting data to be readable before `Commit()`.

```go
// Old behavior:
func (st *Store) Set(key, value []byte) {
    st.changeSet.Pairs = append(...)  // Writes to buffer
}

func (st *Store) Get(key []byte) []byte {
    return st.tree.Get(key)  // Reads from committed tree, NOT changeSet!
}
```

### Solution

Modified `Get()` and `Has()` to check the pending `changeSet` before falling back to the tree:

```go
func (st *Store) Get(key []byte) []byte {
    if value, found := st.getFromChangeSet(key); found {
        return value
    }
    return st.tree.Get(key)
}
```

### Why This is Better Than PR #2772's Workaround

| Aspect | PR #2772 Workaround | This Fix |
|--------|---------------------|----------|
| Memory | Cache grows unbounded | changeSet bounded per block |
| Semantics | Cache acts as read-through | Clean layering |
| Location | Wrong layer (gigacachekv) | Correct layer (commitment) |
| Scope | Only Giga path | All callers benefit |

## Test plan
- [x] Added unit tests for `commitment.Store` reading from changeSet
- [x] Existing commitment store tests pass
- [x] Giga tests pass (TestGigaVsGeth_*, TestAllModes_*)
- [x] storev2 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)