### PR TITLE
Upgrade to latest UCI workflows

### DIFF
--- a/.github/workflows/uci-backport.yml
+++ b/.github/workflows/uci-backport.yml
@@ -1,4 +1,5 @@
-name: UCI / Backport
+name: UCI
+run-name: UCI / Backport
 
 on:
   pull_request_target:

--- a/.github/workflows/uci-go-lint.yml
+++ b/.github/workflows/uci-go-lint.yml
@@ -1,4 +1,5 @@
-name: UCI / Go Lint
+name: UCI
+run-name: UCI / Go Lint
 
 on:
   pull_request:

--- a/.github/workflows/uci-release-check.yml
+++ b/.github/workflows/uci-release-check.yml
@@ -1,4 +1,5 @@
-name: UCI / Release Check
+name: UCI
+run-name: UCI / Release Check
 
 on:
   pull_request_target:

--- a/.github/workflows/uci-release-publish.yml
+++ b/.github/workflows/uci-release-publish.yml
@@ -1,4 +1,5 @@
-name: UCI / Release Publish
+name: UCI
+run-name: UCI / Release Publish
 
 on:
   push:

--- a/.github/workflows/uci-stale-check.yml
+++ b/.github/workflows/uci-stale-check.yml
@@ -1,4 +1,5 @@
-name: UCI / Stale Check
+name: UCI
+run-name: UCI / Stale Check
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Upgrade uniformly to the latest UCI release. Most notable changes:

* Backporting triggers regular CI flow, now performed via `seidrod`
* On conflict backport PRs are drafted regardless.
* Various dependency upgrades.

Additionally, the workflow names are refined to be unique across the
repo for easier interaction via GitHub UI.

Fixes PLT-101
