### PR TITLE
giga allocation optimizations

### DIFF
--- a/giga/deps/tasks/scheduler.go
+++ b/giga/deps/tasks/scheduler.go
@@ -163,9 +163,22 @@ func (s *scheduler) DoExecute(work func()) {
 	s.executeCh <- work
 }
 
+// Pool for reusing conflict dedup maps
+var conflictMapPool = sync.Pool{
+	New: func() interface{} {
+		return make(map[int]struct{})
+	},
+}
+
 func (s *scheduler) findConflicts(task *deliverTxTask) (bool, []int) {
 	var conflicts []int
-	uniq := make(map[int]struct{})
+	uniq := conflictMapPool.Get().(map[int]struct{})
+	// Clear the map for reuse
+	for k := range uniq {
+		delete(uniq, k)
+	}
+	defer conflictMapPool.Put(uniq)
+
 	valid := true
 	for _, mv := range s.multiVersionStores {
 		ok, mvConflicts := mv.ValidateTransactionState(task.AbsoluteIndex)
@@ -183,7 +196,7 @@ func (s *scheduler) findConflicts(task *deliverTxTask) (bool, []int) {
 }
 
 func toTasks(reqs []*sdk.DeliverTxEntry) ([]*deliverTxTask, map[int]*deliverTxTask) {
-	tasksMap := make(map[int]*deliverTxTask)
+	tasksMap := make(map[int]*deliverTxTask, len(reqs))
 	allTasks := make([]*deliverTxTask, 0, len(reqs))
 	for _, r := range reqs {
 		task := &deliverTxTask{
@@ -192,7 +205,7 @@ func toTasks(reqs []*sdk.DeliverTxEntry) ([]*deliverTxTask, map[int]*deliverTxTa
 			Checksum:      r.Checksum,
 			AbsoluteIndex: r.AbsoluteIndex,
 			Status:        statusPending,
-			Dependencies:  map[int]struct{}{},
+			Dependencies:  make(map[int]struct{}, 4), // Pre-allocate with small capacity
 			TxTracer:      r.TxTracer,
 		}
 
@@ -239,16 +252,6 @@ func dependenciesValidated(tasksMap map[int]*deliverTxTask, deps map[int]struct{
 		}
 	}
 	return true
-}
-
-func filterTasks(tasks []*deliverTxTask, filter func(*deliverTxTask) bool) []*deliverTxTask {
-	var res []*deliverTxTask
-	for _, t := range tasks {
-		if filter(t) {
-			res = append(res, t)
-		}
-	}
-	return res
 }
 
 func allValidated(tasks []*deliverTxTask) bool {
@@ -485,16 +488,18 @@ func (s *scheduler) prepareTask(task *deliverTxTask) {
 	_, span := s.traceSpan(ctx, "SchedulerPrepare", task)
 	defer span.End()
 
+	numStores := len(s.multiVersionStores)
+
 	// initialize the context
-	abortCh := make(chan occ.Abort, len(s.multiVersionStores))
+	abortCh := make(chan occ.Abort, numStores)
 
 	// if there are no stores, don't try to wrap, because there's nothing to wrap
-	if len(s.multiVersionStores) > 0 {
+	if numStores > 0 {
 		// non-blocking
 		cms := ctx.MultiStore().CacheMultiStore()
 
-		// init version stores by store key
-		vs := make(map[store.StoreKey]*multiversion.VersionIndexedStore)
+		// init version stores by store key with pre-allocated capacity
+		vs := make(map[store.StoreKey]*multiversion.VersionIndexedStore, numStores)
 		for storeKey, mvs := range s.multiVersionStores {
 			vs[storeKey] = mvs.VersionedIndexedStore(task.AbsoluteIndex, task.Incarnation, abortCh)
 		}

--- a/giga/deps/tasks/scheduler.go
+++ b/giga/deps/tasks/scheduler.go
@@ -174,9 +174,7 @@ func (s *scheduler) findConflicts(task *deliverTxTask) (bool, []int) {
 	var conflicts []int
 	uniq := conflictMapPool.Get().(map[int]struct{})
 	// Clear the map for reuse
-	for k := range uniq {
-		delete(uniq, k)
-	}
+	clear(uniq)
 	defer conflictMapPool.Put(uniq)
 
 	valid := true

--- a/giga/deps/xevm/state/journal.go
+++ b/giga/deps/xevm/state/journal.go
@@ -90,25 +90,25 @@ func (e *refundChange) revert(s *DBImpl) {
 }
 
 func (e *transientStorageChange) revert(s *DBImpl) {
-	states := s.tempState.transientStates[e.account.Hex()]
+	states := s.tempState.transientStates[e.account]
 	if e.prevalue.Cmp(common.Hash{}) == 0 {
 		// If the per-account transient map was already removed by a later revert,
 		// there is nothing to delete.
 		if states == nil {
 			return
 		}
-		delete(states, e.key.Hex())
+		delete(states, e.key)
 		if len(states) == 0 {
-			delete(s.tempState.transientStates, e.account.Hex())
+			delete(s.tempState.transientStates, e.account)
 		}
 	} else {
 		// A prior revert may have deleted the per-account map when it became empty.
 		// Re-create it so we can restore a non-zero prevalue.
 		if states == nil {
-			states = make(map[string]common.Hash)
-			s.tempState.transientStates[e.account.Hex()] = states
+			states = make(map[common.Hash]common.Hash, 4)
+			s.tempState.transientStates[e.account] = states
 		}
-		states[e.key.Hex()] = e.prevalue
+		states[e.key] = e.prevalue
 	}
 }
 
@@ -117,8 +117,8 @@ func (e *watermark) revert(s *DBImpl) {}
 func (e *accountStatusChange) revert(s *DBImpl) {
 	accts := s.tempState.transientAccounts
 	if e.prev == nil {
-		delete(accts, e.account.Hex())
+		delete(accts, e.account)
 	} else {
-		accts[e.account.Hex()] = e.prev
+		accts[e.account] = e.prev
 	}
 }

--- a/giga/deps/xevm/state/journal_test.go
+++ b/giga/deps/xevm/state/journal_test.go
@@ -63,11 +63,11 @@ func TestTransientStorageChangeRevert_Delete(t *testing.T) {
 	db := &DBImpl{tempState: NewTemporaryState()}
 	addr := common.Address{4}
 	key := common.Hash{5}
-	states := map[string]common.Hash{key.Hex(): {6}}
-	db.tempState.transientStates[addr.Hex()] = states
+	states := map[common.Hash]common.Hash{key: {6}}
+	db.tempState.transientStates[addr] = states
 	change := &transientStorageChange{account: addr, key: key, prevalue: common.Hash{}}
 	change.revert(db)
-	_, ok := db.tempState.transientStates[addr.Hex()]
+	_, ok := db.tempState.transientStates[addr]
 	require.False(t, ok)
 }
 
@@ -75,12 +75,12 @@ func TestTransientStorageChangeRevert_Update(t *testing.T) {
 	db := &DBImpl{tempState: NewTemporaryState()}
 	addr := common.Address{7}
 	key := common.Hash{8}
-	states := map[string]common.Hash{}
-	db.tempState.transientStates[addr.Hex()] = states
+	states := map[common.Hash]common.Hash{}
+	db.tempState.transientStates[addr] = states
 	prevalue := common.Hash{9}
 	change := &transientStorageChange{account: addr, key: key, prevalue: prevalue}
 	change.revert(db)
-	require.Equal(t, prevalue, db.tempState.transientStates[addr.Hex()][key.Hex()])
+	require.Equal(t, prevalue, db.tempState.transientStates[addr][key])
 }
 
 func TestWatermarkRevert(t *testing.T) {
@@ -92,10 +92,10 @@ func TestWatermarkRevert(t *testing.T) {
 func TestAccountStatusChangeRevert_Delete(t *testing.T) {
 	db := &DBImpl{tempState: NewTemporaryState()}
 	addr := common.Address{10}
-	db.tempState.transientAccounts[addr.Hex()] = []byte{1, 2, 3}
+	db.tempState.transientAccounts[addr] = []byte{1, 2, 3}
 	change := &accountStatusChange{account: addr, prev: nil}
 	change.revert(db)
-	_, ok := db.tempState.transientAccounts[addr.Hex()]
+	_, ok := db.tempState.transientAccounts[addr]
 	require.False(t, ok)
 }
 
@@ -105,5 +105,5 @@ func TestAccountStatusChangeRevert_Update(t *testing.T) {
 	prev := []byte{4, 5, 6}
 	change := &accountStatusChange{account: addr, prev: prev}
 	change.revert(db)
-	require.Equal(t, prev, db.tempState.transientAccounts[addr.Hex()])
+	require.Equal(t, prev, db.tempState.transientAccounts[addr])
 }


### PR DESCRIPTION
## Describe your changes and provide context
- optimize allocation in scheduler.go
- use byte array instead of calling Hex() every time for map keys in state/

## Testing performed to validate your change
refactor - existing tests should hold

