### PR TITLE
[giga] avoid double signature decoding

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -2093,7 +2093,7 @@ func (app *App) DecodeTransactionsConcurrently(ctx sdk.Context, txs [][]byte) []
 				ctx.Logger().Error(fmt.Sprintf("error decoding transaction at index %d due to %s", idx, err))
 				typedTxs[idx] = nil
 			} else {
-				if isEVM, _ := evmante.IsEVMMessage(typedTx); isEVM {
+				if isEVM, _ := evmante.IsEVMMessage(typedTx); isEVM && !app.GigaExecutorEnabled {
 					msg := evmtypes.MustGetEVMTransactionMessage(typedTx)
 					if err := evmante.Preprocess(ctx, msg, app.EvmKeeper.ChainID(ctx), app.EvmKeeper.EthBlockTestConfig.Enabled); err != nil {
 						ctx.Logger().Error(fmt.Sprintf("error preprocessing EVM tx due to %s", err))


### PR DESCRIPTION
## Describe your changes and provide context
In giga signatures are explicitly decoded here https://github.com/sei-protocol/sei-chain/blob/main/app/app.go#L1723 so the previous decoding (that's skipped by this PR) is not necessary. For the fallback scenario, signature decoding will be handled by the ante handler's lazy decoding logic: https://github.com/sei-protocol/sei-chain/blob/main/x/evm/ante/preprocess.go#L59

## Testing performed to validate your change
existing tests
