### PR TITLE
perf(evm): skip redundant initial Snapshot in OCC executor path

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1846,7 +1846,7 @@ func (app *App) executeEVMTxWithGigaExecutor(ctx sdk.Context, msg *evmtypes.MsgE
 	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeterWithMultiplier(ctx))
 
 	// Create state DB for this transaction
-	stateDB := gigaevmstate.NewDBImpl(ctx, &app.GigaEvmKeeper, false)
+	stateDB := gigaevmstate.NewDBImplWithoutSnapshot(ctx, &app.GigaEvmKeeper, false)
 	defer stateDB.Cleanup()
 
 	// Get gas pool

--- a/giga/deps/xevm/state/state.go
+++ b/giga/deps/xevm/state/state.go
@@ -23,6 +23,9 @@ func (s *DBImpl) CreateAccount(acc common.Address) {
 }
 
 func (s *DBImpl) GetCommittedState(addr common.Address, hash common.Hash) common.Hash {
+	if len(s.snapshottedCtxs) == 0 {
+		return s.getState(s.ctx, addr, hash)
+	}
 	return s.getState(s.snapshottedCtxs[0], addr, hash)
 }
 


### PR DESCRIPTION
## Summary

- Skip the redundant initial `Snapshot()` call in `NewDBImpl` for the OCC executor hot path
- Add `NewDBImplWithoutSnapshot()` used only by `executeEVMTxWithGigaExecutor`
- Original `NewDBImpl` preserved for all other callers (tests, RPC, ante handlers)

## Problem

In the OCC executor path, each EVM transaction creates 3 CacheMultiStore layers:

```
prepareTask:   CMS1 (VIS-wrapped)       ← needed for OCC isolation
NewDBImpl:     CMS2 (wrapping CMS1)     ← REDUNDANT
Prepare:       CMS3 (wrapping CMS2)     ← needed for EVM revert support
```

CMS2 exists to provide a `GetCommittedState` baseline via `snapshottedCtxs[0]`. But no state changes occur between `NewDBImpl` and `Prepare` (called by go-ethereum's `StateTransition.Execute`), so Prepare's Snapshot provides the same baseline.

Profiling after #2808 (30s, M4 Max, 1000 EVM transfers/block):

| Metric | Value |
|--------|-------|
| `DBImpl.Snapshot` alloc_space (cum) | 44.8 GB |
| `cachemulti.newStoreWithoutGiga` alloc_space | 22.5 GB |
| CMS layers per tx | 3 (only 2 needed) |

## Changes

- **`giga/deps/xevm/state/statedb.go`**: Add `NewDBImplWithoutSnapshot()` constructor + defensive guard on `flushEvents`
- **`giga/deps/xevm/state/state.go`**: Defensive guard on `GetCommittedState` for empty `snapshottedCtxs`
- **`app/app.go`**: Hot path uses `NewDBImplWithoutSnapshot`

## Benchmark Results (M4 Max, 1000 EVM transfers/block, 30s profile)

| Metric | Before (after #2808) | After | Delta |
|--------|----------------------|-------|-------|
| TPS (steady-state range) | 7,800–9,000 | 7,200–8,600 | median ~8,000 |
| `DBImpl.Snapshot` alloc_space | 44.8 GB cum | 19.5 GB cum | **-9.8 GB flat** |
| `cachemulti.newStoreWithoutGiga` alloc | 22.5 GB | 12.0 GB | **-10.5 GB** |
| `newCacheMultiStoreFromCMS` alloc (cum) | 38.8 GB | 14.2 GB cum | **-17.9 GB cum** |
| Total alloc_space | 457 GB | 313 GB | **-144 GB (-31%)** |
| Idle CPU (usleep+kevent+pthread_cond_wait) | 42.9s | 30.1s | **-30% idle** |
| `memclrNoHeapPointers` CPU | 2.1s | 10.7s | +8.6s (more fresh spans) |

Note: TPS is flat despite -31% alloc because freed CPU shifts from idle to allocation overhead (`memclrNoHeapPointers`). Workers complete faster but the GC/allocator remains the bottleneck.

### `pprof -alloc_space -diff_base` highlights

```
 -9,840 MB  DBImpl.Snapshot              (direct savings — one fewer CMS per tx)
-10,482 MB  cachemulti.newStoreWithoutGiga (cascading)
 -5,807 MB  btree.NewFreeListG            (cascading)
 -6,992 MB  sync.newIndirectNode          (cascading)
 -4,622 MB  sync.newEntryNode             (cascading)
 -4,194 MB  sei-db utils.Clone            (cascading)
```

### `pprof -top -diff_base` highlights (CPU)

```
 +8.60s  runtime.memclrNoHeapPointers  (more fresh spans allocated)
 -8.07s  runtime.usleep                (less idle — workers busier)
 -2.51s  runtime.kevent                (less idle)
 -2.22s  runtime.pthread_cond_wait     (less contention)
 +2.50s  runtime.heapBitsSmallForAddr  (more heap metadata tracking)
```

## Why safe

- In the OCC path, `core.ApplyMessage` → `StateTransition.Execute` always calls `Prepare()` → `Snapshot()` before any EVM state reads/writes
- `GetCommittedState` uses `snapshottedCtxs[0]` which is set by `Prepare`'s `Snapshot()` — same committed state baseline
- All other `NewDBImpl` callers (tests, RPC, ante) keep the initial `Snapshot()` for isolation
- Defensive guards prevent panics if `snapshottedCtxs` is empty

## Test plan

- [x] `go test ./giga/deps/xevm/state/... -count=1` — pass (including TestSnapshot)
- [x] `go test ./giga/tests/... -count=1` — pass (all 14 giga tests)
- [x] `gofmt -s -w` clean
- [x] Benchmark 2000+ blocks with heap profiling

🤖 Generated with [Claude Code](https://claude.com/claude-code)