### PR TITLE
perf(store): replace sync.Map with plain map in cachekv stores

### DIFF
--- a/sei-cosmos/store/cachekv/memiterator.go
+++ b/sei-cosmos/store/cachekv/memiterator.go
@@ -2,7 +2,6 @@ package cachekv
 
 import (
 	"bytes"
-	"sync"
 
 	dbm "github.com/tendermint/tm-db"
 
@@ -16,13 +15,13 @@ type memIterator struct {
 	types.Iterator
 
 	lastKey []byte
-	deleted *sync.Map
+	deleted map[string]struct{}
 }
 
 func newMemIterator(
 	start, end []byte,
 	items *dbm.MemDB,
-	deleted *sync.Map,
+	deleted map[string]struct{},
 	ascending bool,
 ) *memIterator {
 	var iter types.Iterator
@@ -56,7 +55,7 @@ func (mi *memIterator) Value() []byte {
 	// then we are calling value on the same thing as last time.
 	// Therefore we don't check the mi.deleted to see if this key is included in there.
 	reCallingOnOldLastKey := (mi.lastKey != nil) && bytes.Equal(key, mi.lastKey)
-	if _, ok := mi.deleted.Load(string(key)); ok && !reCallingOnOldLastKey {
+	if _, ok := mi.deleted[string(key)]; ok && !reCallingOnOldLastKey {
 		return nil
 	}
 	mi.lastKey = key

--- a/sei-cosmos/store/cachekv/store.go
+++ b/sei-cosmos/store/cachekv/store.go
@@ -16,9 +16,9 @@ import (
 // Store wraps an in-memory cache around an underlying types.KVStore.
 type Store struct {
 	mtx           sync.RWMutex
-	cache         *sync.Map
-	deleted       *sync.Map
-	unsortedCache *sync.Map
+	cache         map[string]*types.CValue
+	deleted       map[string]struct{}
+	unsortedCache map[string]struct{}
 	sortedCache   *dbm.MemDB // always ascending sorted
 	parent        types.KVStore
 	storeKey      types.StoreKey
@@ -30,9 +30,9 @@ var _ types.CacheKVStore = (*Store)(nil)
 // NewStore creates a new Store object
 func NewStore(parent types.KVStore, storeKey types.StoreKey, cacheSize int) *Store {
 	return &Store{
-		cache:         &sync.Map{},
-		deleted:       &sync.Map{},
-		unsortedCache: &sync.Map{},
+		cache:         make(map[string]*types.CValue),
+		deleted:       make(map[string]struct{}),
+		unsortedCache: make(map[string]struct{}),
 		sortedCache:   nil,
 		parent:        parent,
 		storeKey:      storeKey,
@@ -51,8 +51,8 @@ func (store *Store) GetStoreType() types.StoreType {
 
 // getFromCache queries the write-through cache for a value by key.
 func (store *Store) getFromCache(key []byte) []byte {
-	if cv, ok := store.cache.Load(conv.UnsafeBytesToStr(key)); ok {
-		return cv.(*types.CValue).Value()
+	if cv, ok := store.cache[conv.UnsafeBytesToStr(key)]; ok {
+		return cv.Value()
 	}
 	return store.parent.Get(key)
 }
@@ -91,12 +91,11 @@ func (store *Store) Write() {
 	// Not the best, but probably not a bottleneck depending.
 	keys := []string{}
 
-	store.cache.Range(func(key, value any) bool {
-		if value.(*types.CValue).Dirty() {
-			keys = append(keys, key.(string))
+	for key, value := range store.cache {
+		if value.Dirty() {
+			keys = append(keys, key)
 		}
-		return true
-	})
+	}
 	sort.Strings(keys)
 	// TODO: Consider allowing usage of Batch, which would allow the write to
 	// at least happen atomically.
@@ -110,16 +109,16 @@ func (store *Store) Write() {
 			continue
 		}
 
-		cacheValue, ok := store.cache.Load(key)
-		if ok && cacheValue.(*types.CValue).Value() != nil {
+		cacheValue, ok := store.cache[key]
+		if ok && cacheValue.Value() != nil {
 			// It already exists in the parent, hence delete it.
-			store.parent.Set([]byte(key), cacheValue.(*types.CValue).Value())
+			store.parent.Set([]byte(key), cacheValue.Value())
 		}
 	}
 
-	store.cache = &sync.Map{}
-	store.deleted = &sync.Map{}
-	store.unsortedCache = &sync.Map{}
+	store.cache = make(map[string]*types.CValue)
+	store.deleted = make(map[string]struct{})
+	store.unsortedCache = make(map[string]struct{})
 	store.sortedCache = nil
 }
 
@@ -281,16 +280,13 @@ func (store *Store) dirtyItems(start, end []byte) {
 	// Even without that, too many range checks eventually becomes more expensive
 	// than just not having the cache.
 	// store.emitUnsortedCacheSizeMetric()
-	store.unsortedCache.Range(func(key, value any) bool {
-		cKey := key.(string)
+	for cKey := range store.unsortedCache {
 		if dbm.IsKeyInDomain(conv.UnsafeStrToBytes(cKey), start, end) {
-			cacheValue, ok := store.cache.Load(key)
-			if ok {
-				unsorted = append(unsorted, &kv.Pair{Key: []byte(cKey), Value: cacheValue.(*types.CValue).Value()})
+			if cacheValue, ok := store.cache[cKey]; ok {
+				unsorted = append(unsorted, &kv.Pair{Key: []byte(cKey), Value: cacheValue.Value()})
 			}
 		}
-		return true
-	})
+	}
 	store.clearUnsortedCacheSubset(unsorted, stateUnsorted)
 	return
 }
@@ -323,7 +319,7 @@ func (store *Store) clearUnsortedCacheSubset(unsorted []*kv.Pair, sortState sort
 func (store *Store) deleteKeysFromUnsortedCache(unsorted []*kv.Pair) {
 	for _, kv := range unsorted {
 		keyStr := conv.UnsafeBytesToStr(kv.Key)
-		store.unsortedCache.Delete(keyStr)
+		delete(store.unsortedCache, keyStr)
 	}
 }
 
@@ -335,19 +331,19 @@ func (store *Store) setCacheValue(key, value []byte, deleted bool, dirty bool) {
 	types.AssertValidKey(key)
 
 	keyStr := conv.UnsafeBytesToStr(key)
-	store.cache.Store(keyStr, types.NewCValue(value, dirty))
+	store.cache[keyStr] = types.NewCValue(value, dirty)
 	if deleted {
-		store.deleted.Store(keyStr, struct{}{})
+		store.deleted[keyStr] = struct{}{}
 	} else {
-		store.deleted.Delete(keyStr)
+		delete(store.deleted, keyStr)
 	}
 	if dirty {
-		store.unsortedCache.Store(keyStr, struct{}{})
+		store.unsortedCache[keyStr] = struct{}{}
 	}
 }
 
 func (store *Store) isDeleted(key string) bool {
-	_, ok := store.deleted.Load(key)
+	_, ok := store.deleted[key]
 	return ok
 }
 
@@ -367,20 +363,18 @@ func (store *Store) GetAllKeyStrsInRange(start, end []byte) (res []string) {
 	for _, pk := range store.parent.GetAllKeyStrsInRange(start, end) {
 		keyStrs[pk] = struct{}{}
 	}
-	store.cache.Range(func(key, value any) bool {
-		kbz := []byte(key.(string))
+	for key, cv := range store.cache {
+		kbz := []byte(key)
 		if bytes.Compare(kbz, start) < 0 || bytes.Compare(kbz, end) >= 0 {
 			// we don't want to break out of the iteration since cache isn't sorted
-			return true
+			continue
 		}
-		cv := value.(*types.CValue)
 		if cv.Value() == nil {
-			delete(keyStrs, key.(string))
+			delete(keyStrs, key)
 		} else {
-			keyStrs[key.(string)] = struct{}{}
+			keyStrs[key] = struct{}{}
 		}
-		return true
-	})
+	}
 	for k := range keyStrs {
 		res = append(res, k)
 	}


### PR DESCRIPTION
## Summary

- Replace `*sync.Map` with typed Go maps (`map[string]*types.CValue`, `map[string]struct{}`) in both sei-cosmos and giga cachekv implementations
- Within OCC, each worker gets its own cachekv.Store — zero concurrent access makes sync.Map thread-safety pure overhead
- Eliminates ~27.5 GB allocation and 370M objects per profiling window from sync.Map internal nodes (`newIndirectNode`, `newEntryNode`)
- Keeps `sync.RWMutex` for defense-in-depth (uncontested, <20ns)

**Files changed:** `sei-cosmos/store/cachekv/store.go`, `sei-cosmos/store/cachekv/memiterator.go`, `giga/deps/store/cachekv.go`

## Micro-benchmarks (cachekv, 3 runs)

| Benchmark | Before (sync.Map) | After (map) | Speedup | Allocs |
|---|---|---|---|---|
| BlankParentAppend (Set) | 868 ns/op | 383 ns/op | **56% faster** | 5 → **1** |
| GetKeyFound | 252.6 ns/op | 123.3 ns/op | **51% faster** | 1 → 1 |
| SetKeySize32 (Set+Iter) | 2545 ns/op | 1525 ns/op | **40% faster** | 9 → **5** |
| IteratorNext | 1970 ns/op | 1180 ns/op | **40% faster** | 4 → 4 |
| IteratorOnParent1MDeletes | 2670 ns/op | 1599 ns/op | **40% faster** | 5 → 5 |
| GetNoKeyFound | 53.8 ns/op | 36.7 ns/op | **32% faster** | 2 → 2 |

4 allocs/op eliminated from Set paths — exactly the sync.Map internal node allocations.

## TPS benchmark (GIGA+OCC, EVMTransfer 1000 txs/batch)

| Metric | Before (after #2820) | After this PR | Delta |
|---|---|---|---|
| TPS (avg, 2300+ blocks) | ~8,400 | **~8,936** | **+536 TPS (+6.4%)** |
| TPS (range) | 8,000–8,800 | 7,800–9,602 | |
| Block process avg | ~82ms | ~77ms | -6% |
| Block time avg | ~118ms | ~112ms | -5% |

### Cumulative from origin/main

| Metric | Origin/main | This PR | Cumulative |
|---|---|---|---|
| TPS (avg) | ~7,800 | **~8,936** | **+14.6%** |

## Test plan

- [x] `sei-cosmos/store/cachekv` tests (11 tests pass)
- [x] `sei-cosmos/store/...` full suite (15 packages pass)
- [x] `giga/tests` (all pass)
- [x] `gofmt -s -l` clean
- [x] Cachekv micro-benchmarks (32-56% faster, 4 allocs/op eliminated)
- [x] TPS benchmark 2300+ blocks steady state

🤖 Generated with [Claude Code](https://claude.com/claude-code)