### PR TITLE
[giga] clear up cache after Write

### DIFF
--- a/giga/deps/store/cachekv.go
+++ b/giga/deps/store/cachekv.go
@@ -110,18 +110,7 @@ func (store *Store) Write() {
 		}
 	}
 
-	// Mark all entries as clean (not dirty) instead of clearing the cache.
-	// This is important because the parent store (commitment.Store) doesn't make
-	// writes immediately visible until Commit(). By keeping the cache populated
-	// with clean entries, subsequent reads will still hit the cache instead of
-	// falling through to the parent which can't read uncommitted data.
-	store.cache.Range(func(key, value any) bool {
-		cv := value.(*types.CValue)
-		// Replace with a clean (non-dirty) version of the same value
-		store.cache.Store(key, types.NewCValue(cv.Value(), false))
-		return true
-	})
-	// Clear the deleted map since those deletes have been sent to parent
+	store.cache = &sync.Map{}
 	store.deleted = &sync.Map{}
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
The logic to preserve cache entries was added to circumvent the visibility issue with base store. This PR removes it because:
1. it's no longer needed as https://github.com/sei-protocol/sei-chain/pull/2780 has addressed the visibility issue
2. it causes stale cache reads if some balance is modified in giga, the tx falls back, and v2 modifies the balance to a different value, then subsequent txs will see incorrect balance when processed in giga

## Testing performed to validate your change

