### PR TITLE
Pull request security

### DIFF
--- a/integration_test/dapp_tests/uniswap/uniswapTest.js
+++ b/integration_test/dapp_tests/uniswap/uniswapTest.js
@@ -28,6 +28,9 @@ describe("Uniswap Test", function () {
     let originalSeidConfig;
     before(async function () {
         const accounts = hre.config.networks[testChain].accounts
+        if (!accounts || !accounts.mnemonic) {
+            throw new Error("DAPP_TESTS_MNEMONIC environment variable is not set. Please export it before running tests.");
+        }
         const deployerWallet = hre.ethers.Wallet.fromMnemonic(accounts.mnemonic, accounts.path);
         deployer = deployerWallet.connect(hre.ethers.provider);
 
@@ -298,8 +301,10 @@ describe("Uniswap Test", function () {
     after(async function () {
         // Set the chain back to regular state
         console.log("Resetting")
-        await execute(`seid config chain-id ${originalSeidConfig["chain-id"]}`)
-        await execute(`seid config node ${originalSeidConfig["node"]}`)
-        await execute(`seid config keyring-backend ${originalSeidConfig["keyring-backend"]}`)
+        if (originalSeidConfig) {
+            await execute(`seid config chain-id ${originalSeidConfig["chain-id"]}`)
+            await execute(`seid config node ${originalSeidConfig["node"]}`)
+            await execute(`seid config keyring-backend ${originalSeidConfig["keyring-backend"]}`)
+        }
     })
 })


### PR DESCRIPTION
## Describe your changes and provide context

This PR addresses two test failures (`invalid mnemonic` and `Cannot read properties of undefined (reading 'chain-id')`) in `uniswapTest.js` that occur when the `DAPP_TESTS_MNEMONIC` environment variable is not set.

The changes include:
- Adding an explicit check for the `DAPP_TESTS_MNEMONIC` environment variable in the `before` hook, providing a clear error message if it's missing.
- Guarding the `after` hook with a check for `originalSeidConfig` to prevent a cascading `TypeError` if the `before` hook fails.

## Testing performed to validate your change

The changes were validated by identifying the root cause of the test failures (missing `DAPP_TESTS_MNEMONIC`) and implementing checks to provide clearer error messages and prevent cascading failures. The fix ensures that tests fail gracefully and informatively when the mnemonic is not provided.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-0c1703bb-bae7-4daa-b1f6-b73a96cfd1dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0c1703bb-bae7-4daa-b1f6-b73a96cfd1dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

