### PR TITLE
perf(store): sync.Pool for cachekv stores + clear() in Write

### DIFF
--- a/sei-cosmos/store/cachekv/store.go
+++ b/sei-cosmos/store/cachekv/store.go
@@ -27,17 +27,36 @@ type Store struct {
 
 var _ types.CacheKVStore = (*Store)(nil)
 
+var storePool = sync.Pool{
+	New: func() any {
+		return &Store{
+			cache:         make(map[string]*types.CValue),
+			deleted:       make(map[string]struct{}),
+			unsortedCache: make(map[string]struct{}),
+		}
+	},
+}
+
 // NewStore creates a new Store object
 func NewStore(parent types.KVStore, storeKey types.StoreKey, cacheSize int) *Store {
-	return &Store{
-		cache:         make(map[string]*types.CValue),
-		deleted:       make(map[string]struct{}),
-		unsortedCache: make(map[string]struct{}),
-		sortedCache:   nil,
-		parent:        parent,
-		storeKey:      storeKey,
-		cacheSize:     cacheSize,
-	}
+	s := storePool.Get().(*Store)
+	s.parent = parent
+	s.storeKey = storeKey
+	s.cacheSize = cacheSize
+	return s
+}
+
+// Release clears all state and returns the store to the pool for reuse.
+func (store *Store) Release() {
+	store.mtx.Lock()
+	clear(store.cache)
+	clear(store.deleted)
+	clear(store.unsortedCache)
+	store.sortedCache = nil
+	store.parent = nil
+	store.storeKey = nil
+	store.mtx.Unlock()
+	storePool.Put(store)
 }
 
 func (store *Store) GetWorkingHash() ([]byte, error) {
@@ -116,9 +135,9 @@ func (store *Store) Write() {
 		}
 	}
 
-	store.cache = make(map[string]*types.CValue)
-	store.deleted = make(map[string]struct{})
-	store.unsortedCache = make(map[string]struct{})
+	clear(store.cache)
+	clear(store.deleted)
+	clear(store.unsortedCache)
 	store.sortedCache = nil
 }
 

--- a/sei-cosmos/store/cachemulti/store.go
+++ b/sei-cosmos/store/cachemulti/store.go
@@ -408,6 +408,27 @@ func (cms Store) Close() {
 	}
 }
 
+// Release returns all pooled child stores back to their sync.Pools.
+func (cms Store) Release() {
+	cms.mu.Lock()
+	for _, s := range cms.stores {
+		if ckv, ok := s.(*cachekv.Store); ok {
+			ckv.Release()
+		}
+	}
+	if cms.db != nil {
+		if ckv, ok := cms.db.(*cachekv.Store); ok {
+			ckv.Release()
+		}
+	}
+	for _, s := range cms.gigaStores {
+		if gkv, ok := s.(*gigacachekv.Store); ok {
+			gkv.Release()
+		}
+	}
+	cms.mu.Unlock()
+}
+
 func (cms Store) GetEarliestVersion() int64 {
 	panic("not implemented")
 }


### PR DESCRIPTION
## Summary
- Use `sync.Pool` to reuse cachekv store instances and clear maps on Write to reduce allocations

## Stack
5/13 — depends on perf/skip-force-materialize-child-cms

🤖 Generated with [Claude Code](https://claude.com/claude-code)