### PR TITLE
perf: per-index slots, EVM pool, select→range workers

### DIFF
--- a/giga/deps/tasks/scheduler.go
+++ b/giga/deps/tasks/scheduler.go
@@ -1,7 +1,6 @@
 package tasks
 
 import (
-	"context"
 	"crypto/sha256"
 	"fmt"
 	"sort"
@@ -132,16 +131,11 @@ func (s *scheduler) invalidateTask(task *deliverTxTask) {
 	}
 }
 
-func start(ctx context.Context, ch chan func(), workers int) {
+func start(ch chan func(), workers int) {
 	for i := 0; i < workers; i++ {
 		go func() {
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case work := <-ch:
-					work()
-				}
+			for work := range ch {
+				work()
 			}
 		}()
 	}
@@ -214,7 +208,7 @@ func (s *scheduler) collectResponses(tasks []*deliverTxTask) []types.ResponseDel
 	return res
 }
 
-func (s *scheduler) tryInitMultiVersionStore(ctx sdk.Context) {
+func (s *scheduler) tryInitMultiVersionStore(ctx sdk.Context, numTxSlots int) {
 	if s.multiVersionStores != nil {
 		return
 	}
@@ -222,9 +216,9 @@ func (s *scheduler) tryInitMultiVersionStore(ctx sdk.Context) {
 	keys := ctx.MultiStore().StoreKeys()
 	for _, sk := range keys {
 		if ctx.GigaMultiStore().IsStoreGiga(sk) {
-			mvs[sk] = multiversion.NewMultiVersionStore(ctx.GigaKVStore(sk))
+			mvs[sk] = multiversion.NewMultiVersionStoreWithSize(ctx.GigaKVStore(sk), numTxSlots)
 		} else {
-			mvs[sk] = multiversion.NewMultiVersionStore(ctx.MultiStore().GetKVStore(sk))
+			mvs[sk] = multiversion.NewMultiVersionStoreWithSize(ctx.MultiStore().GetKVStore(sk), numTxSlots)
 		}
 	}
 	s.multiVersionStores = mvs
@@ -277,7 +271,13 @@ func (s *scheduler) ProcessAll(ctx sdk.Context, reqs []*sdk.DeliverTxEntry) ([]t
 	startTime := time.Now()
 	var iterations int
 	// initialize mutli-version stores if they haven't been initialized yet
-	s.tryInitMultiVersionStore(ctx)
+	numTxSlots := len(reqs)
+	for _, r := range reqs {
+		if r.AbsoluteIndex+1 > numTxSlots {
+			numTxSlots = r.AbsoluteIndex + 1
+		}
+	}
+	s.tryInitMultiVersionStore(ctx, numTxSlots)
 	tasks, tasksMap := toTasks(reqs)
 	s.allTasks = tasks
 	s.allTasksMap = tasksMap
@@ -291,14 +291,13 @@ func (s *scheduler) ProcessAll(ctx sdk.Context, reqs []*sdk.DeliverTxEntry) ([]t
 		workers = len(tasks)
 	}
 
-	workerCtx, cancel := context.WithCancel(ctx.Context())
-	defer cancel()
-
 	// execution tasks are limited by workers
-	start(workerCtx, s.executeCh, workers)
+	start(s.executeCh, workers)
+	defer close(s.executeCh)
 
 	// validation tasks uses length of tasks to avoid blocking on validation
-	start(workerCtx, s.validateCh, len(tasks))
+	start(s.validateCh, len(tasks))
+	defer close(s.validateCh)
 
 	toExecute := tasks
 	for !allValidated(tasks) {

--- a/giga/executor/executor.go
+++ b/giga/executor/executor.go
@@ -34,6 +34,11 @@ func NewGethExecutor(blockCtx vm.BlockContext, stateDB vm.StateDB, chainConfig *
 	}
 }
 
+// Reset reuses the executor for a new transaction by resetting per-tx EVM state.
+func (e *Executor) Reset(stateDB vm.StateDB) {
+	e.evm.Reset(stateDB)
+}
+
 func (e *Executor) ExecuteTransaction(tx *types.Transaction, sender common.Address, baseFee *big.Int, gasPool *core.GasPool) (*core.ExecutionResult, error) {
 	message, err := core.TransactionToMessage(tx, &internal.Signer{From: sender}, baseFee)
 	if err != nil {

--- a/go.sum
+++ b/go.sum
@@ -1943,8 +1943,6 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/securego/gosec/v2 v2.13.1 h1:7mU32qn2dyC81MH9L2kefnQyRMUarfDER3iQyMHcjYM=
 github.com/securego/gosec/v2 v2.13.1/go.mod h1:EO1sImBMBWFjOTFzMWfTRrZW6M15gm60ljzrmy/wtHo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/go-ethereum v1.15.7-sei-16 h1:MUvhmn5acNwS/9smQ19gdl6Qh3cNjukTQzz4u8GiUHs=
-github.com/sei-protocol/go-ethereum v1.15.7-sei-16/go.mod h1:+S9k+jFzlyVTNcYGvqFhzN/SFhI6vA+aOY4T5tLSPL0=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-load v0.0.0-20251007135253-78fbdc141082 h1:f2sY8OcN60UL1/6POx+HDMZ4w04FTZtSScnrFSnGZHg=

--- a/sei-cosmos/store/multiversion/store_test.go
+++ b/sei-cosmos/store/multiversion/store_test.go
@@ -165,7 +165,7 @@ func TestMultiVersionStoreWritesetSetAndInvalidate(t *testing.T) {
 	require.Equal(t, 3, len(writesetKeys))
 	require.Equal(t, []string{"key1"}, writesetKeys[1])
 	require.Equal(t, []string{"key1"}, writesetKeys[2])
-	require.Equal(t, []string{"key4", "key5"}, writesetKeys[3])
+	require.ElementsMatch(t, []string{"key4", "key5"}, writesetKeys[3])
 
 }
 


### PR DESCRIPTION
## Summary
- Use per-index slots, pool EVM instances, and replace select with range-based worker dispatch

## Stack
8/13 — depends on docs/occ-store-layer-analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)