### PR TITLE
perf: event in-place marking, VIS map reuse, EventManager pool, snapshot release

### DIFF
--- a/sei-cosmos/store/multiversion/store.go
+++ b/sei-cosmos/store/multiversion/store.go
@@ -249,9 +249,14 @@ func (s *Store) GetAllWritesetKeys() map[int][]string {
 }
 
 func (s *Store) SetReadset(index int, readset ReadSet) {
+	// Clone the readset so the caller (VIS) can reuse its map via clear().
+	clone := make(ReadSet, len(readset))
+	for k, v := range readset {
+		clone[k] = v
+	}
 	sl := s.slot(index)
 	sl.mu.Lock()
-	sl.readset = readset
+	sl.readset = clone
 	sl.mu.Unlock()
 }
 
@@ -264,9 +269,12 @@ func (s *Store) GetReadset(index int) ReadSet {
 }
 
 func (s *Store) SetIterateset(index int, iterateset Iterateset) {
+	// Clone the iterateset so the caller (VIS) can reuse its slice via [:0].
+	clone := make(Iterateset, len(iterateset))
+	copy(clone, iterateset)
 	sl := s.slot(index)
 	sl.mu.Lock()
-	sl.iterateset = iterateset
+	sl.iterateset = clone
 	sl.mu.Unlock()
 }
 

--- a/sei-cosmos/types/events_test.go
+++ b/sei-cosmos/types/events_test.go
@@ -131,30 +131,31 @@ func (s *eventsTestSuite) TestStringifyEvents() {
 }
 
 func (s *eventsTestSuite) TestMarkEventsToIndex() {
-	events := []abci.Event{
-		{
-			Type: "message",
-			Attributes: []abci.EventAttribute{
-				{Key: []byte("sender"), Value: []byte("foo")},
-				{Key: []byte("recipient"), Value: []byte("bar")},
+	// Helper to create fresh events for each subtest since MarkEventsToIndex modifies in-place.
+	newEvents := func() []abci.Event {
+		return []abci.Event{
+			{
+				Type: "message",
+				Attributes: []abci.EventAttribute{
+					{Key: []byte("sender"), Value: []byte("foo")},
+					{Key: []byte("recipient"), Value: []byte("bar")},
+				},
 			},
-		},
-		{
-			Type: "staking",
-			Attributes: []abci.EventAttribute{
-				{Key: []byte("deposit"), Value: []byte("5")},
-				{Key: []byte("unbond"), Value: []byte("10")},
+			{
+				Type: "staking",
+				Attributes: []abci.EventAttribute{
+					{Key: []byte("deposit"), Value: []byte("5")},
+					{Key: []byte("unbond"), Value: []byte("10")},
+				},
 			},
-		},
+		}
 	}
 
 	testCases := map[string]struct {
-		events   []abci.Event
 		indexSet map[string]struct{}
 		expected []abci.Event
 	}{
 		"empty index set": {
-			events: events,
 			expected: []abci.Event{
 				{
 					Type: "message",
@@ -174,7 +175,6 @@ func (s *eventsTestSuite) TestMarkEventsToIndex() {
 			indexSet: map[string]struct{}{},
 		},
 		"index some events": {
-			events: events,
 			expected: []abci.Event{
 				{
 					Type: "message",
@@ -197,7 +197,6 @@ func (s *eventsTestSuite) TestMarkEventsToIndex() {
 			},
 		},
 		"index all events": {
-			events: events,
 			expected: []abci.Event{
 				{
 					Type: "message",
@@ -226,7 +225,8 @@ func (s *eventsTestSuite) TestMarkEventsToIndex() {
 	for name, tc := range testCases {
 		tc := tc
 		s.T().Run(name, func(_ *testing.T) {
-			legacyEvents := sdk.MarkEventsToIndex(tc.events, tc.indexSet)
+			events := newEvents()
+			legacyEvents := sdk.MarkEventsToIndex(events, tc.indexSet)
 			s.Require().Equal(tc.expected, legacyEvents)
 		})
 	}


### PR DESCRIPTION
## Summary
- Mark events in-place, reuse VIS maps, pool EventManager instances, and release snapshots eagerly

## Stack
10/13 — depends on perf/pool-vis-occ-cms-fastpath

🤖 Generated with [Claude Code](https://claude.com/claude-code)