### PR TITLE
perf(types): cache gaskv.Store wrappers in Context

### DIFF
--- a/sei-cosmos/types/context.go
+++ b/sei-cosmos/types/context.go
@@ -495,6 +495,11 @@ func (c Context) WithIsTracing(it bool) Context {
 	if it {
 		c.storeTracer = NewStoreTracer()
 	}
+	// Invalidate gaskv cache — tracing state affects store wrapping.
+	if c.gaskvStoresMu != nil {
+		c.gaskvStores = make(map[StoreKey]KVStore)
+		c.gaskvStoresMu = &sync.RWMutex{}
+	}
 	return c
 }
 


### PR DESCRIPTION
## Summary
- Cache `gaskv.Store` wrappers in Context to avoid repeated allocations
- Includes thread-safety fix (RWMutex) and tracing invalidation fix

## Stack
6/19 — depends on perf/optimize-updatereadset-alloc (replaces auto-closed #2808)

🤖 Generated with [Claude Code](https://claude.com/claude-code)