### PR TITLE
perf(evm): skip redundant initial Snapshot in OCC executor path

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1844,7 +1844,7 @@ func (app *App) executeEVMTxWithGigaExecutor(ctx sdk.Context, msg *evmtypes.MsgE
 	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeterWithMultiplier(ctx))
 
 	// Create state DB for this transaction
-	stateDB := gigaevmstate.NewDBImpl(ctx, &app.GigaEvmKeeper, false)
+	stateDB := gigaevmstate.NewDBImplWithoutSnapshot(ctx, &app.GigaEvmKeeper, false)
 	defer stateDB.Cleanup()
 
 	// Get gas pool

--- a/giga/deps/xevm/state/state.go
+++ b/giga/deps/xevm/state/state.go
@@ -23,6 +23,9 @@ func (s *DBImpl) CreateAccount(acc common.Address) {
 }
 
 func (s *DBImpl) GetCommittedState(addr common.Address, hash common.Hash) common.Hash {
+	if len(s.snapshottedCtxs) == 0 {
+		return s.getState(s.ctx, addr, hash)
+	}
 	return s.getState(s.snapshottedCtxs[0], addr, hash)
 }
 


### PR DESCRIPTION
## Summary
- Skip the redundant initial `Snapshot()` call in the OCC executor path

## Stack
7/19 — depends on perf/cache-gaskv-context (replaces auto-closed #2819)

🤖 Generated with [Claude Code](https://claude.com/claude-code)