### PR TITLE
perf(store): replace sync.Map with plain map in cachekv stores

### DIFF
--- a/sei-cosmos/store/cachekv/memiterator.go
+++ b/sei-cosmos/store/cachekv/memiterator.go
@@ -2,7 +2,6 @@ package cachekv
 
 import (
 	"bytes"
-	"sync"
 
 	dbm "github.com/tendermint/tm-db"
 
@@ -16,13 +15,13 @@ type memIterator struct {
 	types.Iterator
 
 	lastKey []byte
-	deleted *sync.Map
+	deleted map[string]struct{}
 }
 
 func newMemIterator(
 	start, end []byte,
 	items *dbm.MemDB,
-	deleted *sync.Map,
+	deleted map[string]struct{},
 	ascending bool,
 ) *memIterator {
 	var iter types.Iterator
@@ -56,7 +55,7 @@ func (mi *memIterator) Value() []byte {
 	// then we are calling value on the same thing as last time.
 	// Therefore we don't check the mi.deleted to see if this key is included in there.
 	reCallingOnOldLastKey := (mi.lastKey != nil) && bytes.Equal(key, mi.lastKey)
-	if _, ok := mi.deleted.Load(string(key)); ok && !reCallingOnOldLastKey {
+	if _, ok := mi.deleted[string(key)]; ok && !reCallingOnOldLastKey {
 		return nil
 	}
 	mi.lastKey = key


### PR DESCRIPTION
## Summary
- Replace `sync.Map` with plain `map` in cachekv stores for better performance

## Stack
8/19 — depends on perf/skip-redundant-snapshot (replaces auto-closed #2822)

🤖 Generated with [Claude Code](https://claude.com/claude-code)