### PR TITLE
fix(giga): bail on wrong nonce as v2 does

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1849,6 +1849,28 @@ func (app *App) executeEVMTxWithGigaExecutor(ctx sdk.Context, msg *evmtypes.MsgE
 	}
 
 	// ============================================================================
+	// Nonce validation (mirrors V2's ante handler check in x/evm/ante/sig.go)
+	// V2 rejects with ErrWrongSequence if txNonce != expectedNonce, with NO state changes.
+	// ============================================================================
+	expectedNonce := app.GigaEvmKeeper.GetNonce(ctx, sender)
+	txNonce := ethTx.Nonce()
+	if txNonce != expectedNonce {
+		// Calculate intrinsic gas for reporting (V2 reports this as gasUsed)
+		intrinsicGas, _ := core.IntrinsicGas(ethTx.Data(), ethTx.AccessList(), ethTx.SetCodeAuthorizations(), ethTx.To() == nil, true, true, true)
+
+		nonceDirection := "too high"
+		if txNonce < expectedNonce {
+			nonceDirection = "too low"
+		}
+		return &abci.ExecTxResult{
+			Code:      sdkerrors.ErrWrongSequence.ABCICode(),
+			GasUsed:   int64(intrinsicGas), //nolint:gosec
+			GasWanted: int64(ethTx.Gas()),  //nolint:gosec
+			Log:       fmt.Sprintf("nonce %s: address %s, tx: %d state: %d: %s", nonceDirection, sender.Hex(), txNonce, expectedNonce, sdkerrors.ErrWrongSequence.Error()),
+		}, nil
+	}
+
+	// ============================================================================
 	// Fee validation (mirrors V2's ante handler checks in evm_checktx.go)
 	// NOTE: In V2, failed transactions still increment nonce and charge gas.
 	// We track validation errors here but don't return early - we still need to


### PR DESCRIPTION
## Describe your changes and provide context

fixes mismatch of [this block](https://seiscan.io/txs?block=193119398). there are 2 txs (don't show up on seiscan) that have invalid nonces:
```
V2's log: "nonce too high: address 0x6a9dE37D180C56b7E9362d7688ACa8B7acEb425C, tx: 23213 state: 23211"

V2's log: "nonce too high: address 0x4A7d9e41340d1dba4d157fdE37Ed1697E42CBC7b, tx: 7423188 state: 7423187"
```

In this case we just bail WITHOUT bumping the nonce.

## Testing performed to validate your change

tests pass, get us past the block in question.

