### PR TITLE
fix: isolate benchmark-compare.sh for parallel invocations

### DIFF
--- a/benchmark/benchmark.sh
+++ b/benchmark/benchmark.sh
@@ -19,11 +19,11 @@ DEBUG=${DEBUG:-false}
 DB_BACKEND=${DB_BACKEND:-goleveldb}
 
 # --- New env vars for phase gating / multi-instance support ---
-# Final chain data dir. If != ~/.sei, init in ~/.sei then mv.
+# Final chain data dir. Init is done in a temp staging dir then moved here.
 SEI_HOME=${SEI_HOME:-"$HOME/.sei"}
 # Added to all ports (RPC, P2P, pprof, gRPC, etc.)
 PORT_OFFSET=${PORT_OFFSET:-0}
-# Pre-built binary path. If set, skip build + copy to ~/go/bin/seid.
+# Pre-built binary path. If set, skip build.
 SEID_BIN=${SEID_BIN:-""}
 # Phase control: "init" (build+init+configure), "start" (run node), "all" (both)
 BENCHMARK_PHASE=${BENCHMARK_PHASE:-all}
@@ -81,15 +81,17 @@ echo "Available scenarios in $SCRIPT_DIR/scenarios/:"
 ls -1 "$SCRIPT_DIR"/scenarios/*.json 2>/dev/null | sed 's/^/    /' || echo "    (none found)"
 echo "================================"
 
-# clean up old sei directory
-rm -rf ~/.sei
+# Create isolated staging directory for chain init
+STAGING_DIR=$(mktemp -d "${TMPDIR:-/tmp}/sei-bench-init.XXXXXX")
+staging_cleanup() {
+  rm -rf "$STAGING_DIR" 2>/dev/null || true
+}
+trap staging_cleanup EXIT
+
 echo "Building..."
 
 if [ -n "$SEID_BIN" ]; then
-  # Use pre-built binary: copy to ~/go/bin/seid so downstream tools find it
   echo "Using pre-built binary: $SEID_BIN"
-  mkdir -p ~/go/bin
-  cp "$SEID_BIN" ~/go/bin/seid
 else
   # Determine build options based on DB_BACKEND
   BUILD_TAGS=""
@@ -121,50 +123,50 @@ else
 fi
 
 # initialize chain with chain ID and add the first key
-"$SEID" init demo --chain-id sei-chain
-"$SEID" keys add $keyname --keyring-backend test
+"$SEID" init demo --chain-id sei-chain --home "$STAGING_DIR"
+"$SEID" keys add $keyname --keyring-backend test --home "$STAGING_DIR"
 # add the key as a genesis account with massive balances of several different tokens
-"$SEID" add-genesis-account $("$SEID" keys show $keyname -a --keyring-backend test) 100000000000000000000usei,100000000000000000000uusdc,100000000000000000000uatom --keyring-backend test
+"$SEID" add-genesis-account $("$SEID" keys show $keyname -a --keyring-backend test --home "$STAGING_DIR") 100000000000000000000usei,100000000000000000000uusdc,100000000000000000000uatom --keyring-backend test --home "$STAGING_DIR"
 # gentx for account
-"$SEID" gentx $keyname 7000000000000000usei --chain-id sei-chain --keyring-backend test
+"$SEID" gentx $keyname 7000000000000000usei --chain-id sei-chain --keyring-backend test --home "$STAGING_DIR"
 # add validator information to genesis file
-KEY=$(jq '.pub_key' ~/.sei/config/priv_validator_key.json -c)
-jq '.validators = [{}]' ~/.sei/config/genesis.json > ~/.sei/config/tmp_genesis.json
-jq '.validators[0] += {"power":"7000000000"}' ~/.sei/config/tmp_genesis.json > ~/.sei/config/tmp_genesis_2.json
-jq '.validators[0] += {"pub_key":'$KEY'}' ~/.sei/config/tmp_genesis_2.json > ~/.sei/config/tmp_genesis_3.json
-mv ~/.sei/config/tmp_genesis_3.json ~/.sei/config/genesis.json && rm ~/.sei/config/tmp_genesis.json && rm ~/.sei/config/tmp_genesis_2.json
+KEY=$(jq '.pub_key' "$STAGING_DIR/config/priv_validator_key.json" -c)
+jq '.validators = [{}]' "$STAGING_DIR/config/genesis.json" > "$STAGING_DIR/config/tmp_genesis.json"
+jq '.validators[0] += {"power":"7000000000"}' "$STAGING_DIR/config/tmp_genesis.json" > "$STAGING_DIR/config/tmp_genesis_2.json"
+jq '.validators[0] += {"pub_key":'$KEY'}' "$STAGING_DIR/config/tmp_genesis_2.json" > "$STAGING_DIR/config/tmp_genesis_3.json"
+mv "$STAGING_DIR/config/tmp_genesis_3.json" "$STAGING_DIR/config/genesis.json" && rm "$STAGING_DIR/config/tmp_genesis.json" && rm "$STAGING_DIR/config/tmp_genesis_2.json"
 
 echo "Creating Accounts"
 # create 10 test accounts + fund them
-python3  "$REPO_ROOT/loadtest/scripts/populate_genesis_accounts.py" 20 loc
+SEI_HOME_DIR="$STAGING_DIR" SEID_BIN="$SEID" python3 "$REPO_ROOT/loadtest/scripts/populate_genesis_accounts.py" 20 loc
 
-"$SEID" collect-gentxs
+"$SEID" collect-gentxs --home "$STAGING_DIR"
 # update some params in genesis file for easier use of the chain localls (make gov props faster)
-cat ~/.sei/config/genesis.json | jq '.app_state["gov"]["deposit_params"]["max_deposit_period"]="60s"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
-cat ~/.sei/config/genesis.json | jq '.app_state["gov"]["voting_params"]["voting_period"]="30s"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
-cat ~/.sei/config/genesis.json | jq '.app_state["gov"]["voting_params"]["expedited_voting_period"]="10s"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
-cat ~/.sei/config/genesis.json | jq '.app_state["oracle"]["params"]["vote_period"]="2"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
-cat ~/.sei/config/genesis.json | jq '.app_state["evm"]["params"]["target_gas_used_per_block"]="1000000000000"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
-cat ~/.sei/config/genesis.json | jq '.app_state["oracle"]["params"]["whitelist"]=[{"name": "ueth"},{"name": "ubtc"},{"name": "uusdc"},{"name": "uusdt"},{"name": "uosmo"},{"name": "uatom"},{"name": "usei"}]' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
-cat ~/.sei/config/genesis.json | jq '.app_state["distribution"]["params"]["community_tax"]="0.000000000000000000"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
-cat ~/.sei/config/genesis.json | jq '.consensus_params["block"]["max_gas"]="100000000"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
-cat ~/.sei/config/genesis.json | jq '.consensus_params["block"]["min_txs_in_block"]="2"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
-cat ~/.sei/config/genesis.json | jq '.consensus_params["block"]["max_gas_wanted"]="150000000"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
-cat ~/.sei/config/genesis.json | jq '.app_state["staking"]["params"]["max_voting_power_ratio"]="1.000000000000000000"' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
-cat ~/.sei/config/genesis.json | jq '.app_state["bank"]["denom_metadata"]=[{"denom_units":[{"denom":"usei","exponent":0,"aliases":["USEI"]}],"base":"usei","display":"usei","name":"USEI","symbol":"USEI"}]' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
+cat "$STAGING_DIR/config/genesis.json" | jq '.app_state["gov"]["deposit_params"]["max_deposit_period"]="60s"' > "$STAGING_DIR/config/tmp_genesis.json" && mv "$STAGING_DIR/config/tmp_genesis.json" "$STAGING_DIR/config/genesis.json"
+cat "$STAGING_DIR/config/genesis.json" | jq '.app_state["gov"]["voting_params"]["voting_period"]="30s"' > "$STAGING_DIR/config/tmp_genesis.json" && mv "$STAGING_DIR/config/tmp_genesis.json" "$STAGING_DIR/config/genesis.json"
+cat "$STAGING_DIR/config/genesis.json" | jq '.app_state["gov"]["voting_params"]["expedited_voting_period"]="10s"' > "$STAGING_DIR/config/tmp_genesis.json" && mv "$STAGING_DIR/config/tmp_genesis.json" "$STAGING_DIR/config/genesis.json"
+cat "$STAGING_DIR/config/genesis.json" | jq '.app_state["oracle"]["params"]["vote_period"]="2"' > "$STAGING_DIR/config/tmp_genesis.json" && mv "$STAGING_DIR/config/tmp_genesis.json" "$STAGING_DIR/config/genesis.json"
+cat "$STAGING_DIR/config/genesis.json" | jq '.app_state["evm"]["params"]["target_gas_used_per_block"]="1000000000000"' > "$STAGING_DIR/config/tmp_genesis.json" && mv "$STAGING_DIR/config/tmp_genesis.json" "$STAGING_DIR/config/genesis.json"
+cat "$STAGING_DIR/config/genesis.json" | jq '.app_state["oracle"]["params"]["whitelist"]=[{"name": "ueth"},{"name": "ubtc"},{"name": "uusdc"},{"name": "uusdt"},{"name": "uosmo"},{"name": "uatom"},{"name": "usei"}]' > "$STAGING_DIR/config/tmp_genesis.json" && mv "$STAGING_DIR/config/tmp_genesis.json" "$STAGING_DIR/config/genesis.json"
+cat "$STAGING_DIR/config/genesis.json" | jq '.app_state["distribution"]["params"]["community_tax"]="0.000000000000000000"' > "$STAGING_DIR/config/tmp_genesis.json" && mv "$STAGING_DIR/config/tmp_genesis.json" "$STAGING_DIR/config/genesis.json"
+cat "$STAGING_DIR/config/genesis.json" | jq '.consensus_params["block"]["max_gas"]="100000000"' > "$STAGING_DIR/config/tmp_genesis.json" && mv "$STAGING_DIR/config/tmp_genesis.json" "$STAGING_DIR/config/genesis.json"
+cat "$STAGING_DIR/config/genesis.json" | jq '.consensus_params["block"]["min_txs_in_block"]="2"' > "$STAGING_DIR/config/tmp_genesis.json" && mv "$STAGING_DIR/config/tmp_genesis.json" "$STAGING_DIR/config/genesis.json"
+cat "$STAGING_DIR/config/genesis.json" | jq '.consensus_params["block"]["max_gas_wanted"]="150000000"' > "$STAGING_DIR/config/tmp_genesis.json" && mv "$STAGING_DIR/config/tmp_genesis.json" "$STAGING_DIR/config/genesis.json"
+cat "$STAGING_DIR/config/genesis.json" | jq '.app_state["staking"]["params"]["max_voting_power_ratio"]="1.000000000000000000"' > "$STAGING_DIR/config/tmp_genesis.json" && mv "$STAGING_DIR/config/tmp_genesis.json" "$STAGING_DIR/config/genesis.json"
+cat "$STAGING_DIR/config/genesis.json" | jq '.app_state["bank"]["denom_metadata"]=[{"denom_units":[{"denom":"usei","exponent":0,"aliases":["USEI"]}],"base":"usei","display":"usei","name":"USEI","symbol":"USEI"}]' > "$STAGING_DIR/config/tmp_genesis.json" && mv "$STAGING_DIR/config/tmp_genesis.json" "$STAGING_DIR/config/genesis.json"
 
 # Use the Python command to get the dates
 START_DATE=$($PYTHON_CMD -c "from datetime import datetime; print(datetime.now().strftime('%Y-%m-%d'))")
 END_DATE_3DAYS=$($PYTHON_CMD -c "from datetime import datetime, timedelta; print((datetime.now() + timedelta(days=3)).strftime('%Y-%m-%d'))")
 END_DATE_5DAYS=$($PYTHON_CMD -c "from datetime import datetime, timedelta; print((datetime.now() + timedelta(days=5)).strftime('%Y-%m-%d'))")
 
-cat ~/.sei/config/genesis.json | jq --arg start_date "$START_DATE" --arg end_date "$END_DATE_3DAYS" '.app_state["mint"]["params"]["token_release_schedule"]=[{"start_date": $start_date, "end_date": $end_date, "token_release_amount": "999999999999"}]' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
-cat ~/.sei/config/genesis.json | jq --arg start_date "$END_DATE_3DAYS" --arg end_date "$END_DATE_5DAYS" '.app_state["mint"]["params"]["token_release_schedule"] += [{"start_date": $start_date, "end_date": $end_date, "token_release_amount": "999999999999"}]' > ~/.sei/config/tmp_genesis.json && mv ~/.sei/config/tmp_genesis.json ~/.sei/config/genesis.json
+cat "$STAGING_DIR/config/genesis.json" | jq --arg start_date "$START_DATE" --arg end_date "$END_DATE_3DAYS" '.app_state["mint"]["params"]["token_release_schedule"]=[{"start_date": $start_date, "end_date": $end_date, "token_release_amount": "999999999999"}]' > "$STAGING_DIR/config/tmp_genesis.json" && mv "$STAGING_DIR/config/tmp_genesis.json" "$STAGING_DIR/config/genesis.json"
+cat "$STAGING_DIR/config/genesis.json" | jq --arg start_date "$END_DATE_3DAYS" --arg end_date "$END_DATE_5DAYS" '.app_state["mint"]["params"]["token_release_schedule"] += [{"start_date": $start_date, "end_date": $end_date, "token_release_amount": "999999999999"}]' > "$STAGING_DIR/config/tmp_genesis.json" && mv "$STAGING_DIR/config/tmp_genesis.json" "$STAGING_DIR/config/genesis.json"
 
 if [ ! -z "$2" ]; then
   APP_TOML_PATH="$2"
 else
-  APP_TOML_PATH="$HOME/.sei/config/app.toml"
+  APP_TOML_PATH="$STAGING_DIR/config/app.toml"
 fi
 # Enable OCC and SeiDB
 sed -i.bak -e 's/# concurrency-workers = .*/concurrency-workers = 500/' "$APP_TOML_PATH"
@@ -212,13 +214,13 @@ fi
 if [ ! -z "$1" ]; then
   CONFIG_PATH="$1"
 else
-  CONFIG_PATH="$HOME/.sei/config/config.toml"
+  CONFIG_PATH="$STAGING_DIR/config/config.toml"
 fi
 
 if [ ! -z "$2" ]; then
   APP_PATH="$2"
 else
-  APP_PATH="$HOME/.sei/config/app.toml"
+  APP_PATH="$STAGING_DIR/config/app.toml"
 fi
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
@@ -287,13 +289,13 @@ if [ "$PORT_OFFSET" -ne 0 ] 2>/dev/null; then
   fi
 fi
 
-"$SEID" config keyring-backend test
+"$SEID" config keyring-backend test --home "$STAGING_DIR"
 
-# If SEI_HOME is not ~/.sei, move the data dir
-if [ "$SEI_HOME" != "$HOME/.sei" ]; then
-  mkdir -p "$(dirname "$SEI_HOME")"
-  mv ~/.sei "$SEI_HOME"
-fi
+# Move staging dir to final SEI_HOME
+rm -rf "$SEI_HOME"
+mkdir -p "$(dirname "$SEI_HOME")"
+mv "$STAGING_DIR" "$SEI_HOME"
+trap - EXIT
 
 fi # end BENCHMARK_PHASE=init
 

--- a/loadtest/scripts/populate_genesis_accounts.py
+++ b/loadtest/scripts/populate_genesis_accounts.py
@@ -13,12 +13,14 @@ PARALLEISM=64
 # Does not need to be thread safe, each thread should only be writing to its own index
 global_accounts_mapping = {}
 home_path = os.path.expanduser('~')
+seid_bin = os.environ.get('SEID_BIN', os.path.join(home_path, 'go', 'bin', 'seid'))
+sei_home_dir = os.environ.get('SEI_HOME_DIR', os.path.join(home_path, '.sei'))
 
 def add_key(account_name, local=False):
     if local:
-        add_key_cmd = f"yes | ~/go/bin/seid keys add {account_name} --keyring-backend test"
+        add_key_cmd = f"yes | {seid_bin} keys add {account_name} --keyring-backend test --home {sei_home_dir}"
     else:
-        add_key_cmd = f"printf '12345678\n' | ~/go/bin/seid keys add {account_name}"
+        add_key_cmd = f"printf '12345678\n' | {seid_bin} keys add {account_name} --home {sei_home_dir}"
     add_key_output = subprocess.check_output(
         [add_key_cmd],
         stderr=subprocess.STDOUT,
@@ -94,7 +96,7 @@ def main():
     if len(args) > 1 and args[1] == "loc":
         is_local = True
 
-    genesis_json_file_path = f"{home_path}/.sei/config/genesis.json"
+    genesis_json_file_path = os.path.join(sei_home_dir, 'config', 'genesis.json')
     genesis_file = read_genesis_file(genesis_json_file_path)
 
     num_threads = max(1, number_of_accounts // PARALLEISM)


### PR DESCRIPTION
## Summary

- Namespace `BASE_DIR` per run via `RUN_ID` (defaults to PID): `/tmp/sei-bench-${RUN_ID}/`
- Auto-claim port offset slots via atomic `mkdir` (supports 30 concurrent runs, zero coordination)
- Replace `git checkout` with git worktrees for isolated builds (no working tree collisions)
- Replace `~/go/bin/seid` with `GOBIN`-based builds per label (no binary collisions)
- Replace `~/.sei` staging with `mktemp` + `--home` on all `seid` commands (no init collisions)
- Pass `SEI_HOME_DIR`/`SEID_BIN` env vars to `populate_genesis_accounts.py` (backward-compatible defaults)
- Fix pre-existing double lifecycle bug by passing `DURATION=0` to child start-phase

## Test plan

- [x] Syntax check: `bash -n` on both shell scripts, `py_compile` on Python
- [x] Two concurrent `benchmark-compare.sh` runs with `DURATION=120` — both completed, separate `BASE_DIR`s, no port conflicts
- [x] All 6 profile types captured for all 4 nodes (CPU ~145KB, fgprof ~115KB, heap ~248KB, etc.)
- [x] TPS data collected (36-37 readings per node)
- [x] `pprof -diff_base` produces valid analyzable output from both runs
- [x] Port slot locks cleaned up after exit
- [x] Git worktrees cleaned up after exit
- [x] Backward compatible — no env vars needed for single-instance usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)