### PR TITLE
fix(benchmark): auto-claim port offset in benchmark.sh

### DIFF
--- a/benchmark/CLAUDE.md
+++ b/benchmark/CLAUDE.md
@@ -30,8 +30,8 @@ BENCHMARK_CONFIG=benchmark/scenarios/erc20.json benchmark/benchmark.sh
 | Var | Default | Purpose |
 |-----|---------|---------|
 | `BENCHMARK_PHASE` | `all` | `init` (build+init+configure), `start` (run node), `all` (both) |
-| `SEI_HOME` | `$HOME/.sei` | Final chain data dir. Init uses a temp staging dir, then moves here |
-| `PORT_OFFSET` | `0` | Added to all ports (RPC, P2P, pprof, gRPC, etc.) |
+| `SEI_HOME` | `$HOME/.sei` (or `$HOME/.sei-bench-<offset>` when auto-claimed) | Final chain data dir. Init uses a temp staging dir, then moves here |
+| `PORT_OFFSET` | auto-claimed | Added to all ports (RPC, P2P, pprof, gRPC, etc.). Auto-claimed via atomic `mkdir` slots when not set, same mechanism as benchmark-compare.sh |
 | `SEID_BIN` | `""` | Pre-built binary path. If set, skip build step |
 | `LOG_FILE` | `""` | Redirect seid output to file |
 | `BENCHMARK_CONFIG` | `$SCRIPT_DIR/scenarios/evm.json` | Scenario config file (absolute path resolved from script location) |


### PR DESCRIPTION
## Summary

- `benchmark.sh` now auto-claims a port offset slot (same atomic `mkdir` mechanism as `benchmark-compare.sh`) when `PORT_OFFSET` is not explicitly set
- Prevents port collisions between concurrent standalone `benchmark.sh` runs and stale `seid` processes from crashed runs
- When auto-claiming, `SEI_HOME` is also isolated to `$HOME/.sei-bench-<offset>` to avoid data directory collisions
- Port slot is released in all exit paths (staging cleanup, seid cleanup trap, and normal exit)
- When `PORT_OFFSET` is explicitly set by the caller (e.g., from `benchmark-compare.sh`), behavior is unchanged

## Test plan

- [x] Run two concurrent `benchmark.sh` invocations — both should auto-claim different port slots and run without collisions
- [x] Run `benchmark-compare.sh` (which passes explicit `PORT_OFFSET`) — should still work as before
- [x] Kill a `benchmark.sh` mid-run — port slot should be released by the trap handler
- [x] Syntax check: `bash -n benchmark/benchmark.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)