### PR TITLE
Add EVM execution microbenchmarks via go test -bench

### DIFF
--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -121,12 +121,12 @@ func NewTestWrapper(tb testing.TB, tm time.Time, valPub cryptotypes.PubKey, enab
 	return newTestWrapper(tb, tm, valPub, enableEVMCustomPrecompiles, false, TestAppOpts{}, baseAppOptions...)
 }
 
-func NewTestWrapperWithSc(t *testing.T, tm time.Time, valPub cryptotypes.PubKey, enableEVMCustomPrecompiles bool, baseAppOptions ...func(*bam.BaseApp)) *TestWrapper {
-	return newTestWrapper(t, tm, valPub, enableEVMCustomPrecompiles, true, TestAppOpts{UseSc: true}, baseAppOptions...)
+func NewTestWrapperWithSc(tb testing.TB, tm time.Time, valPub cryptotypes.PubKey, enableEVMCustomPrecompiles bool, baseAppOptions ...func(*bam.BaseApp)) *TestWrapper {
+	return newTestWrapper(tb, tm, valPub, enableEVMCustomPrecompiles, true, TestAppOpts{UseSc: true}, baseAppOptions...)
 }
 
-func NewGigaTestWrapper(t *testing.T, tm time.Time, valPub cryptotypes.PubKey, enableEVMCustomPrecompiles bool, useOcc bool, baseAppOptions ...func(*bam.BaseApp)) *TestWrapper {
-	wrapper := newTestWrapper(t, tm, valPub, enableEVMCustomPrecompiles, true, TestAppOpts{UseSc: true, EnableGiga: true, EnableGigaOCC: useOcc}, baseAppOptions...)
+func NewGigaTestWrapper(tb testing.TB, tm time.Time, valPub cryptotypes.PubKey, enableEVMCustomPrecompiles bool, useOcc bool, baseAppOptions ...func(*bam.BaseApp)) *TestWrapper {
+	wrapper := newTestWrapper(tb, tm, valPub, enableEVMCustomPrecompiles, true, TestAppOpts{UseSc: true, EnableGiga: true, EnableGigaOCC: useOcc}, baseAppOptions...)
 	genState := evmtypes.DefaultGenesis()
 	wrapper.App.EvmKeeper.InitGenesis(wrapper.Ctx, *genState)
 	return wrapper
@@ -140,9 +140,9 @@ func NewGigaTestWrapper(t *testing.T, tm time.Time, valPub cryptotypes.PubKey, e
 // - Creates app with UseSc=true but EnableGiga=false (so GigaKVStore is NOT registered)
 // - Manually enables Giga executor flags on the app
 // - Sets GigaEvmKeeper.UseRegularStore=true so it uses ctx.KVStore instead of ctx.GigaKVStore
-func NewGigaTestWrapperWithRegularStore(t *testing.T, tm time.Time, valPub cryptotypes.PubKey, enableEVMCustomPrecompiles bool, useOcc bool, baseAppOptions ...func(*bam.BaseApp)) *TestWrapper {
+func NewGigaTestWrapperWithRegularStore(tb testing.TB, tm time.Time, valPub cryptotypes.PubKey, enableEVMCustomPrecompiles bool, useOcc bool, baseAppOptions ...func(*bam.BaseApp)) *TestWrapper {
 	// Create wrapper with Sc but WITHOUT EnableGiga - this means GigaKVStore won't be registered
-	wrapper := newTestWrapper(t, tm, valPub, enableEVMCustomPrecompiles, true, TestAppOpts{UseSc: true, EnableGiga: false, EnableGigaOCC: false}, baseAppOptions...)
+	wrapper := newTestWrapper(tb, tm, valPub, enableEVMCustomPrecompiles, true, TestAppOpts{UseSc: true, EnableGiga: false, EnableGigaOCC: false}, baseAppOptions...)
 
 	// Manually enable Giga executor on the app
 	wrapper.App.GigaExecutorEnabled = true
@@ -179,11 +179,7 @@ func newTestWrapper(tb testing.TB, tm time.Time, valPub cryptotypes.PubKey, enab
 		DefaultNodeHome = originalHome
 	})
 	if UseSc {
-		if testT, ok := tb.(*testing.T); ok {
-			appPtr = SetupWithSc(testT, false, enableEVMCustomPrecompiles, testAppOpts, baseAppOptions...)
-		} else {
-			panic("SetupWithSc requires *testing.T, cannot use with *testing.B")
-		}
+		appPtr = SetupWithSc(tb, false, enableEVMCustomPrecompiles, testAppOpts, baseAppOptions...)
 	} else {
 		appPtr = Setup(tb, false, enableEVMCustomPrecompiles, false, baseAppOptions...)
 	}
@@ -471,7 +467,7 @@ func SetupWithDB(tb testing.TB, db dbm.DB, isCheckTx bool, enableEVMCustomPrecom
 	return res
 }
 
-func SetupWithSc(t *testing.T, isCheckTx bool, enableEVMCustomPrecompiles bool, testAppOpts TestAppOpts, baseAppOptions ...func(*bam.BaseApp)) (res *App) {
+func SetupWithSc(tb testing.TB, isCheckTx bool, enableEVMCustomPrecompiles bool, testAppOpts TestAppOpts, baseAppOptions ...func(*bam.BaseApp)) (res *App) {
 	db := dbm.NewMemDB()
 	encodingConfig := MakeEncodingConfig()
 	cdc := encodingConfig.Marshaler
@@ -492,7 +488,7 @@ func SetupWithSc(t *testing.T, isCheckTx bool, enableEVMCustomPrecompiles bool, 
 		nil,
 		true,
 		map[int64]bool{},
-		t.TempDir(),
+		tb.TempDir(),
 		1,
 		enableEVMCustomPrecompiles,
 		config.TestConfig(),

--- a/occ_tests/evm_benchmark_test.go
+++ b/occ_tests/evm_benchmark_test.go
@@ -1,0 +1,131 @@
+package occ
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/server/config"
+	"github.com/sei-protocol/sei-chain/occ_tests/messages"
+	"github.com/sei-protocol/sei-chain/occ_tests/utils"
+)
+
+type benchConfig struct {
+	name       string
+	workers    int
+	occEnabled bool
+}
+
+var occConfigs = []benchConfig{
+	{name: "occ", workers: config.DefaultConcurrencyWorkers, occEnabled: true},
+	{name: "sequential", workers: 1, occEnabled: false},
+}
+
+func runEVMBenchmark(b *testing.B, txCount int, cfg benchConfig, genTxs func(tCtx *utils.TestContext) []*utils.TestMessage) {
+	b.Helper()
+	blockTime := time.Now()
+	accts := utils.NewTestAccounts(5)
+
+	var totalGasUsed int64
+	var totalTimedDuration time.Duration
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		iterCtx := utils.NewTestContext(b, accts, blockTime, cfg.workers, cfg.occEnabled)
+		txMsgs := genTxs(iterCtx)
+		txs := utils.ToTxBytes(iterCtx, txMsgs)
+		b.StartTimer()
+
+		startTime := time.Now()
+		_, txResults, _, err := utils.ProcessBlockDirect(iterCtx, txs, cfg.occEnabled)
+		timedDuration := time.Since(startTime)
+		totalTimedDuration += timedDuration
+
+		if err != nil {
+			b.Fatalf("ProcessBlock error: %v", err)
+		}
+		if len(txResults) != len(txs) {
+			b.Fatalf("expected %d tx results, got %d", len(txs), len(txResults))
+		}
+
+		for _, result := range txResults {
+			totalGasUsed += result.GasUsed
+		}
+	}
+
+	b.ReportMetric(float64(txCount), "txns/op")
+	avgGasPerOp := float64(totalGasUsed) / float64(b.N)
+	b.ReportMetric(avgGasPerOp, "gas/op")
+	avgTimeSeconds := totalTimedDuration.Seconds() / float64(b.N)
+	if avgTimeSeconds > 0 {
+		b.ReportMetric(avgGasPerOp/avgTimeSeconds, "gas/sec")
+		b.ReportMetric(float64(txCount)/avgTimeSeconds, "tps")
+		b.ReportMetric(avgTimeSeconds/float64(txCount)*1e9, "ns/tx")
+	}
+}
+
+func BenchmarkEVMTransfer(b *testing.B) {
+	txCounts := []int{100, 500, 1000, 5000}
+	for _, tc := range txCounts {
+		for _, cfg := range occConfigs {
+			tc := tc
+			cfg := cfg
+			b.Run(benchName(tc, cfg.name), func(b *testing.B) {
+				runEVMBenchmark(b, tc, cfg, func(tCtx *utils.TestContext) []*utils.TestMessage {
+					return utils.JoinMsgs(messages.EVMTransferNonConflicting(tCtx, tc))
+				})
+			})
+		}
+	}
+}
+
+func BenchmarkEVMTransferConflicting(b *testing.B) {
+	txCounts := []int{100, 1000}
+	for _, tc := range txCounts {
+		for _, cfg := range occConfigs {
+			tc := tc
+			cfg := cfg
+			b.Run(benchName(tc, cfg.name), func(b *testing.B) {
+				runEVMBenchmark(b, tc, cfg, func(tCtx *utils.TestContext) []*utils.TestMessage {
+					return utils.JoinMsgs(messages.EVMTransferConflicting(tCtx, tc))
+				})
+			})
+		}
+	}
+}
+
+func BenchmarkEVMTransferMixed(b *testing.B) {
+	txCounts := []int{1000}
+	for _, tc := range txCounts {
+		for _, cfg := range occConfigs {
+			tc := tc
+			cfg := cfg
+			half := tc / 2
+			b.Run(benchName(tc, cfg.name), func(b *testing.B) {
+				runEVMBenchmark(b, tc, cfg, func(tCtx *utils.TestContext) []*utils.TestMessage {
+					conflicting := messages.EVMTransferConflicting(tCtx, half)
+					nonConflicting := messages.EVMTransferNonConflicting(tCtx, tc-half)
+					return utils.Shuffle(utils.JoinMsgs(conflicting, nonConflicting))
+				})
+			})
+		}
+	}
+}
+
+func benchName(txCount int, mode string) string {
+	return "txs_" + itoa(txCount) + "/" + mode
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	buf := [20]byte{}
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}


### PR DESCRIPTION
## Summary
- Widen `SetupWithSc`, `NewTestWrapperWithSc`, `NewGigaTestWrapper`, and `NewGigaTestWrapperWithRegularStore` to accept `testing.TB` instead of `*testing.T`, enabling benchmarks to use the SC code path
- Add table-driven EVM microbenchmarks in `occ_tests/evm_benchmark_test.go` covering non-conflicting, conflicting, and mixed transfer workloads at 100-5000 tx scales
- Each benchmark has OCC and sequential sub-variants and reports `txns/op`, `tps`, `gas/op`, `gas/sec`, `ns/tx`

## Initial Results (`benchtime=3s`)

### Non-Conflicting EVM Transfers

| Txs | Mode | ns/op | TPS | gas/sec |
|-----|------|------:|----:|--------:|
| 100 | occ | 14.7M | **6,820** | 143M |
| 100 | sequential | 39.9M | 2,509 | 52.7M |
| 500 | occ | 92.0M | **5,433** | 114M |
| 500 | sequential | 224.7M | 2,225 | 46.7M |
| 1000 | occ | 388.5M | **2,574** | 54.1M |
| 1000 | sequential | 525.1M | 1,904 | 40.0M |
| 5000 | occ | 6.72B | 744 | 15.6M |
| 5000 | sequential | 4.82B | **1,037** | 21.8M |

### Conflicting EVM Transfers

| Txs | Mode | ns/op | TPS | gas/sec |
|-----|------|------:|----:|--------:|
| 100 | occ | 91.2M | 1,096 | 23.0M |
| 100 | sequential | 41.1M | **2,435** | 51.1M |
| 1000 | occ | 3.46B | 289 | 6.1M |
| 1000 | sequential | 519.3M | **1,926** | 40.4M |

### Mixed (50/50 conflicting + non-conflicting)

| Txs | Mode | ns/op | TPS | gas/sec |
|-----|------|------:|----:|--------:|
| 1000 | occ | 3.96B | 253 | 5.3M |
| 1000 | sequential | 510.0M | **1,961** | 41.2M |

### Key Observations
- OCC provides ~2.5-2.7x speedup for non-conflicting txs at smaller batch sizes (100-500)
- OCC degrades with conflicts due to retry overhead (4-7x slower than sequential)
- At 5000 txs, even non-conflicting OCC is slower than sequential (memory/contention overhead)
- Sequential is consistently ~1,900-2,500 TPS regardless of conflict patterns

## Usage

```bash
# Run all EVM benchmarks (~30s-2min depending on scale)
go test -bench=BenchmarkEVM -benchtime=3s -count=1 ./occ_tests/

# Run specific scale
go test -bench=BenchmarkEVMTransfer/txs_1000 -benchtime=5s -count=3 ./occ_tests/

# Compare before/after with benchstat
go test -bench=BenchmarkEVM -benchtime=5s -count=5 ./occ_tests/ > old.txt
# ... make changes ...
go test -bench=BenchmarkEVM -benchtime=5s -count=5 ./occ_tests/ > new.txt
benchstat old.txt new.txt
```

## Test plan
- [x] `go test -bench=BenchmarkEVM -benchtime=1x -count=1 ./occ_tests/` — all benchmarks run without error
- [x] `go test ./occ_tests/ -run TestParallelTransactionsEvmTransfer` — existing OCC tests still pass
- [x] `go vet ./occ_tests/` — no errors
- [x] `gofmt -s -l app/test_helpers.go occ_tests/evm_benchmark_test.go` — no output

🤖 Generated with [Claude Code](https://claude.com/claude-code)