### PR TITLE
fix: benchmark-compare port slots start at offset 1000

### DIFF
--- a/benchmark/benchmark-compare.sh
+++ b/benchmark/benchmark-compare.sh
@@ -37,12 +37,14 @@ DB_BACKEND=${DB_BACKEND:-goleveldb}
 RUN_ID=${RUN_ID:-$$}
 BASE_DIR="/tmp/sei-bench-${RUN_ID}"
 
-# Auto-claim a port offset slot using atomic mkdir if not explicitly set
+# Auto-claim a port offset slot using atomic mkdir if not explicitly set.
+# Slots start at offset 1000 (not 0) so compare runs never collide with
+# standalone benchmark.sh which uses the default PORT_OFFSET=0 ports.
 PORT_SLOT_DIR=""
 if [ -z "${RUN_PORT_OFFSET+x}" ]; then
   for slot in $(seq 0 29); do
     if mkdir "/tmp/sei-bench-port-slot-${slot}" 2>/dev/null; then
-      RUN_PORT_OFFSET=$((slot * 1000))
+      RUN_PORT_OFFSET=$((1000 + slot * 1000))
       PORT_SLOT_DIR="/tmp/sei-bench-port-slot-${slot}"
       break
     fi


### PR DESCRIPTION
## Summary

- `benchmark-compare.sh` slot 0 previously mapped to `RUN_PORT_OFFSET=0`, which uses the same default ports as standalone `benchmark.sh` (offset 0)
- If a stale `seid` from a previous standalone run is holding those ports, the baseline node in a compare run panics with `bind: address already in use`
- Fix: change slot-to-offset mapping from `slot * 1000` to `1000 + slot * 1000`, so compare runs start at offset 1000+ and never overlap with standalone benchmark default ports

Complements #2900 which added auto-claim port offsets to `benchmark.sh` itself.

## Test plan

- [x] Run `benchmark-compare.sh` — first slot should claim offset 1000, not 0
- [x] Run standalone `benchmark.sh` concurrently with `benchmark-compare.sh` — no port collisions
- [x] Multiple concurrent `benchmark-compare.sh` invocations still auto-claim non-overlapping slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)