### PR TITLE
Add --overwrite to benchmark script to satisfy new check

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -77,7 +77,7 @@ else
   make install-bench
 fi
 # initialize chain with chain ID and add the first key
-~/go/bin/seid init demo --chain-id sei-chain
+~/go/bin/seid init demo --chain-id sei-chain --overwrite
 ~/go/bin/seid keys add $keyname --keyring-backend test
 # add the key as a genesis account with massive balances of several different tokens
 ~/go/bin/seid add-genesis-account $(~/go/bin/seid keys show $keyname -a --keyring-backend test) 100000000000000000000usei,100000000000000000000uusdc,100000000000000000000uatom --keyring-backend test


### PR DESCRIPTION
## Describe your changes and provide context
- A recent commit added a new requirement that `--overwrite` be passed: 00e41381c
- This adds the flag to benchmark (it was already in the init local chain script)