### PR TITLE
Deflake test failures due to port already in use

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/go-kit/log v0.2.1
 	github.com/go-logfmt/logfmt v0.6.0
 	github.com/go-playground/validator/v10 v10.11.1
+	github.com/gofrs/flock v0.13.0
 	github.com/gogo/gateway v1.1.0
 	github.com/gogo/protobuf v1.3.3
 	github.com/golang-jwt/jwt/v4 v4.5.1
@@ -230,7 +231,6 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
-	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2 // indirect

--- a/sei-cosmos/server/grpc/grpc_web_test.go
+++ b/sei-cosmos/server/grpc/grpc_web_test.go
@@ -43,6 +43,7 @@ func (s *GRPCWebTestSuite) SetupSuite() {
 
 	cfg := network.DefaultConfig(s.T())
 	cfg.NumValidators = 1
+	cfg.EnableGRPCWeb = true
 	s.cfg = cfg
 	s.network = network.New(s.T(), s.cfg)
 	s.Require().NotNil(s.network)


### PR DESCRIPTION
Use a cross process locking to avid port conflict when tests are run in parallel across multiple binaries.

Make gRPCWeb optional, for tests that really need it. Disabled by default.
