### PR TITLE
Check existing memiavl config before setting default

### DIFF
--- a/sei-db/sc/memiavl/opts.go
+++ b/sei-db/sc/memiavl/opts.go
@@ -83,7 +83,10 @@ func (opts *Options) FillDefaults() {
 		opts.SnapshotWriteRateMBps = config.DefaultSnapshotWriteRateMBps
 	}
 
-	opts.PrefetchThreshold = 0.8
-	opts.Logger = logger.NewNopLogger()
-	opts.SnapshotKeepRecent = config.DefaultSnapshotKeepRecent
+	if opts.PrefetchThreshold <= 0 || opts.PrefetchThreshold > 1 {
+		opts.PrefetchThreshold = 0.8
+	}
+	if opts.Logger == nil {
+		opts.Logger = logger.NewNopLogger()
+	}
 }


### PR DESCRIPTION
Check `PrefetchThreshold` is unset or out of range before falling back on default.

Remove unconditional override of `SnapshotKeepRecent`.
