### PR TITLE
Limit num of LoadVersion calls for historical proof

### DIFF
--- a/sei-cosmos/storev2/rootmulti/store.go
+++ b/sei-cosmos/storev2/rootmulti/store.go
@@ -277,7 +277,7 @@ func (rs *Store) CacheMultiStoreForExport(version int64) (types.CacheMultiStore,
 		return rs.CacheMultiStore(), nil
 	}
 	// Open SC stores for wasm snapshot, this op is blocking and could take a long time
-	scStore, err := rs.scStore.LoadVersion(version, true)
+	scStore, err := rs.scStore.LoadVersionForExport(version)
 	if err != nil {
 		return nil, err
 	}

--- a/sei-db/config/toml.go
+++ b/sei-db/config/toml.go
@@ -51,6 +51,12 @@ sc-snapshot-prefetch-threshold = {{ .StateCommit.MemIAVLConfig.SnapshotPrefetchT
 # Maximum snapshot write rate in MB/s (global across all trees). 0 = unlimited. Default 100.
 sc-snapshot-write-rate-mbps = {{ .StateCommit.MemIAVLConfig.SnapshotWriteRateMBps }}
 
+# MaxInFlightLoadVersion limits the number of queued read-only LoadVersion calls.
+# Each historical read opens a full read-only DB, which is expensive in disk I/O.
+# Requests are executed serially; when the queue is full, new requests fail fast.
+# Default 4.
+sc-max-in-flight-load-version = {{ .StateCommit.MemIAVLConfig.MaxInFlightLoadVersion }}
+
 ###############################################################################
 ###                        FlatKV (EVM) Configuration                       ###
 ###############################################################################

--- a/sei-db/config/toml_test.go
+++ b/sei-db/config/toml_test.go
@@ -47,6 +47,7 @@ func TestStateCommitConfigTemplate(t *testing.T) {
 	require.Contains(t, output, "sc-snapshot-min-time-interval =", "Missing sc-snapshot-min-time-interval")
 	require.Contains(t, output, "sc-snapshot-prefetch-threshold =", "Missing sc-snapshot-prefetch-threshold")
 	require.Contains(t, output, "sc-snapshot-write-rate-mbps =", "Missing sc-snapshot-write-rate-mbps")
+	require.Contains(t, output, "sc-max-in-flight-load-version =", "Missing sc-max-in-flight-load-version")
 
 	// sc-snapshot-writer-limit is intentionally removed from template (hardcoded to 4)
 	// but old configs with this field still parse fine via mapstructure

--- a/sei-db/state_db/sc/composite/store.go
+++ b/sei-db/state_db/sc/composite/store.go
@@ -76,6 +76,11 @@ func (cs *CompositeCommitStore) SetInitialVersion(initialVersion int64) error {
 	return cs.cosmosCommitter.SetInitialVersion(initialVersion)
 }
 
+func (cs *CompositeCommitStore) LoadVersionForExport(targetVersion int64) (types.Committer, error) {
+	// TODO: Add EVM exporter
+	return cs.cosmosCommitter.LoadVersionForExport(targetVersion)
+}
+
 // LoadVersion loads the specified version of the database.
 // Being used for two scenarios:
 // ReadOnly: Either for state sync or for historical proof

--- a/sei-db/state_db/sc/memiavl/config.go
+++ b/sei-db/state_db/sc/memiavl/config.go
@@ -8,6 +8,7 @@ const (
 	DefaultSnapshotPrefetchThreshold = 0.8 // prefetch if <80% pages in cache
 	DefaultSnapshotWriteRateMBps     = 100 // 100 MB/s default
 	DefaultSnapshotWriterLimit       = 4   // controls tree concurrency but not I/O rate (use SnapshotWriteRateMBps for that)
+	DefaultMaxInFlightLoadVersion    = 4
 )
 
 type Config struct {
@@ -40,6 +41,11 @@ type Config struct {
 
 	// SnapshotWriteRateMBps is the global snapshot write rate limit in MB/s. 0 = unlimited. Default 100.
 	SnapshotWriteRateMBps int `mapstructure:"snapshot-write-rate-mbps"`
+
+	// MaxInFlightLoadVersion limits the number of concurrent LoadVersion calls.
+	// Each historical read opens a full read-only DB, which is expensive in disk I/O.
+	// Requests beyond this limit fail fast. 0 means use the default (4).
+	MaxInFlightLoadVersion int `mapstructure:"max-historical-read-concurrency"`
 }
 
 func DefaultConfig() Config {
@@ -51,5 +57,6 @@ func DefaultConfig() Config {
 		SnapshotPrefetchThreshold: DefaultSnapshotPrefetchThreshold,
 		SnapshotWriteRateMBps:     DefaultSnapshotWriteRateMBps,
 		SnapshotWriterLimit:       DefaultSnapshotWriterLimit,
+		MaxInFlightLoadVersion:    DefaultMaxInFlightLoadVersion,
 	}
 }

--- a/sei-db/state_db/sc/types/types.go
+++ b/sei-db/state_db/sc/types/types.go
@@ -28,6 +28,8 @@ type Committer interface {
 
 	LastCommitInfo() *proto.CommitInfo
 
+	LoadVersionForExport(targetVersion int64) (Committer, error)
+
 	LoadVersion(targetVersion int64, readOnly bool) (Committer, error)
 
 	Rollback(targetVersion int64) error


### PR DESCRIPTION
## Describe your changes and provide context
Problem:
SeiDB memIAVL is very inefficient at serving historical queries when state is large, since it needs to call LoadVersion each time to open the DB at an old height in order to serve a single query. 
When there are ton of historical proof queries, this could trigger lot of concurrent calls to LoadVersion, which would lead to CPU/Disk saturation.

Solution:
Here we are intorducing a max inflight limit for LoadVersion, as a trade off we decide to protect the system disk/cpu resource by rate limiting and serialize the incoming historical proof request. 


## Testing performed to validate your change

