### PR TITLE
Reduce SS changelog retention to use the async buffer size

### DIFF
--- a/sei-db/db_engine/pebbledb/mvcc/db.go
+++ b/sei-db/db_engine/pebbledb/mvcc/db.go
@@ -45,6 +45,7 @@ const (
 	ImportCommitBatchSize = 10000
 	PruneCommitBatchSize  = 50
 	DeleteCommitBatchSize = 50
+	MinWALEntriesToKeep   = 1000
 )
 
 var (
@@ -171,8 +172,9 @@ func OpenDB(dataDir string, config config.StateStoreConfig) (*Database, error) {
 		_ = db.Close()
 		return nil, errors.New("KeepRecent must be non-negative")
 	}
+	walKeepRecent := math.Max(MinWALEntriesToKeep, float64(config.AsyncWriteBuffer+1))
 	streamHandler, err := wal.NewChangelogWAL(logger.NewNopLogger(), utils.GetChangelogPath(dataDir), wal.Config{
-		KeepRecent:    uint64(config.KeepRecent),
+		KeepRecent:    uint64(walKeepRecent),
 		PruneInterval: time.Duration(config.PruneIntervalSeconds) * time.Second,
 	})
 	if err != nil {

--- a/sei-db/db_engine/rocksdb/mvcc/db.go
+++ b/sei-db/db_engine/rocksdb/mvcc/db.go
@@ -34,6 +34,7 @@ const (
 
 	// TODO: Make configurable
 	ImportCommitBatchSize = 10000
+	MinWALEntriesToKeep   = 1000
 )
 
 var (
@@ -112,9 +113,9 @@ func OpenDB(dataDir string, config config.StateStoreConfig) (*Database, error) {
 		pendingChanges:  make(chan VersionedChangesets, config.AsyncWriteBuffer),
 	}
 	database.latestVersion.Store(latestVersion)
-
+	walKeepRecent := math.Max(MinWALEntriesToKeep, float64(config.AsyncWriteBuffer+1))
 	streamHandler, err := wal.NewChangelogWAL(logger.NewNopLogger(), utils.GetChangelogPath(dataDir), wal.Config{
-		KeepRecent:    uint64(config.KeepRecent),
+		KeepRecent:    uint64(walKeepRecent),
 		PruneInterval: time.Duration(config.PruneIntervalSeconds) * time.Second,
 	})
 	if err != nil {


### PR DESCRIPTION
## Describe your changes and provide context
This PR reduce the changelog retention for SS to a min value of 1000 entries (1000 blocks), and max up to the SS async write buffer size.

## Testing performed to validate your change

