### PR TITLE
fix(giga): don't migrate balance on failed txs

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1744,16 +1744,7 @@ func (app *App) executeEVMTxWithGigaExecutor(ctx sdk.Context, msg *evmtypes.MsgE
 		}, nil
 	}
 
-	// Associate the address if not already associated (same as EVMPreprocessDecorator)
-	if _, isAssociated := app.GigaEvmKeeper.GetEVMAddress(ctx, seiAddr); !isAssociated {
-		associateHelper := helpers.NewAssociationHelper(&app.GigaEvmKeeper, app.GigaBankKeeper, &app.AccountKeeper)
-		if err := associateHelper.AssociateAddresses(ctx, seiAddr, sender, pubkey, false); err != nil {
-			return &abci.ExecTxResult{
-				Code: 1,
-				Log:  fmt.Sprintf("failed to associate addresses: %v", err),
-			}, nil
-		}
-	}
+	_, isAssociated := app.GigaEvmKeeper.GetEVMAddress(ctx, seiAddr)
 
 	// ============================================================================
 	// Fee validation (mirrors V2's ante handler checks in evm_checktx.go)
@@ -1811,6 +1802,32 @@ func (app *App) executeEVMTxWithGigaExecutor(ctx sdk.Context, msg *evmtypes.MsgE
 		}
 	}
 
+	// 5. Insufficient balance check for gas * price + value (INSUFFICIENT_FUNDS_FOR_TRANSFER)
+	if validationErr == nil {
+		// BuyGas checks balance against GasLimit * GasFeeCap + Value (see go-ethereum/core/state_transition.go:264-291)
+		balanceCheck := new(big.Int).Mul(new(big.Int).SetUint64(ethTx.Gas()), ethTx.GasFeeCap())
+		balanceCheck.Add(balanceCheck, ethTx.Value())
+
+		senderBalance := app.GigaEvmKeeper.GetBalance(ctx, seiAddr)
+
+		// For unassociated addresses, V2's PreprocessDecorator migrates the cast address balance
+		// BEFORE the fee check (in a CacheMultiStore). We need to include the cast address balance
+		// in our check to match V2's behavior, even though we defer the actual migration.
+		if !isAssociated {
+			// Cast address is the EVM address bytes interpreted as a Sei address
+			castAddr := sdk.AccAddress(sender[:])
+			castBalance := app.GigaEvmKeeper.GetBalance(ctx, castAddr)
+			senderBalance = new(big.Int).Add(senderBalance, castBalance)
+		}
+
+		if senderBalance.Cmp(balanceCheck) < 0 {
+			validationErr = &abci.ExecTxResult{
+				Code: sdkerrors.ErrInsufficientFunds.ABCICode(),
+				Log:  fmt.Sprintf("insufficient funds for gas * price + value: address %s have %v want %v: insufficient funds", sender.Hex(), senderBalance, balanceCheck),
+			}
+		}
+	}
+
 	// Prepare context for EVM transaction (set infinite gas meter like original flow)
 	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeterWithMultiplier(ctx))
 
@@ -1827,6 +1844,29 @@ func (app *App) executeEVMTxWithGigaExecutor(ctx sdk.Context, msg *evmtypes.MsgE
 		validationErr.GasUsed = int64(intrinsicGas)  //nolint:gosec
 		validationErr.GasWanted = int64(ethTx.Gas()) //nolint:gosec
 		return validationErr, nil
+	}
+
+	if !isAssociated {
+		// Set address mapping
+		app.GigaEvmKeeper.SetAddressMapping(ctx, seiAddr, sender)
+		// Set pubkey on account if not already set
+		if acc := app.AccountKeeper.GetAccount(ctx, seiAddr); acc != nil && acc.GetPubKey() == nil {
+			if err := acc.SetPubKey(pubkey); err != nil {
+				return &abci.ExecTxResult{
+					Code: 1,
+					Log:  fmt.Sprintf("failed to set pubkey: %v", err),
+				}, nil
+			}
+			app.AccountKeeper.SetAccount(ctx, acc)
+		}
+		// Migrate balance from cast address
+		associateHelper := helpers.NewAssociationHelper(&app.GigaEvmKeeper, app.GigaBankKeeper, &app.AccountKeeper)
+		if err := associateHelper.MigrateBalance(ctx, sender, seiAddr, false); err != nil {
+			return &abci.ExecTxResult{
+				Code: 1,
+				Log:  fmt.Sprintf("failed to migrate balance: %v", err),
+			}, nil
+		}
 	}
 
 	// Create state DB for this transaction (only for valid transactions)


### PR DESCRIPTION
## Describe your changes and provide context

If the first tx from an associated address fails, v2 does NOT perform the balance migration. Giga shouldn't either.

Bit of a freak case, but we ran into it [here](https://seiscan.io/tx/0x7aa0679c76f33701744e767c74f3ea8e2d6e9cb42fe1bd07b15aaff2a8c15849).

Also pulls in the insufficient funds check from #2960 

## Testing performed to validate your change

