### PR TITLE
Deflake `TestStateLock_NoPOL` by widening propose timeout in test

### DIFF
--- a/sei-tendermint/internal/consensus/state_test.go
+++ b/sei-tendermint/internal/consensus/state_test.go
@@ -433,6 +433,10 @@ func TestStateFullRound2(t *testing.T) {
 // two vals take turns proposing. val1 locks on first one, precommits nil on everything else
 func TestStateLock_NoPOL(t *testing.T) {
 	config := configSetup(t)
+	// Deflake: when cs1 is proposer in round 3, proposal construction can race
+	// timeoutPropose on loaded CI runners and force an early prevote nil.
+	config.Consensus.UnsafeProposeTimeoutOverride = 250 * time.Millisecond
+	config.Consensus.UnsafeProposeTimeoutDeltaOverride = 0
 	ctx := t.Context()
 
 	cs1, vss := makeState(ctx, t, makeStateArgs{config: config, validators: 2})


### PR DESCRIPTION
In round 3 of `TestStateLock_NoPOL`, cs1 is proposer. Under CI load, proposal construction can race timeoutPropose, causing an early prevote for nil before the proposal is fully processed.

The test then asserts a locked-block prevote and fails.

Added test-lcoal timeout overrides. This mirrors the existing deflake pattern used in nearby lock-safety tests and keeps behavior deterministic under load.

Flaked on [main](https://github.com/sei-protocol/sei-chain/actions/runs/22335750771/job/64627784175).