### PR TITLE
Fix hanging upgrade tests by adding timeouts to wait_for_height

### DIFF
--- a/integration_test/upgrade_module/scripts/wait_for_height.sh
+++ b/integration_test/upgrade_module/scripts/wait_for_height.sh
@@ -12,12 +12,26 @@ fi
 # Fetch the node ID from the environment or default to 0
 NODE_ID=${ID:-0}
 
+# Keep this script bounded to avoid hanging CI jobs indefinitely.
+STATUS_TIMEOUT_SECONDS=${WAIT_FOR_HEIGHT_STATUS_TIMEOUT_SECONDS:-5}
+MAX_WAIT_SECONDS=${WAIT_FOR_HEIGHT_MAX_WAIT_SECONDS:-180}
+MAX_NO_PROGRESS_SECONDS=${WAIT_FOR_HEIGHT_MAX_NO_PROGRESS_SECONDS:-30}
+
 # if other nodes die, this node can have no peers, and it will stay on block-1
 # if that's the case, we should move forward (others are validating)
 STUCK_COUNTER=0
+NO_PROGRESS_COUNTER=0
+LAST_BLOCK_HEIGHT=""
+START_TIME=$(date +%s)
 
 # Loop until the target block height is reached or the service dies, or it gets stuck on target-1 block
 while true; do
+   ELAPSED=$(( $(date +%s) - START_TIME ))
+   if [[ "$ELAPSED" -ge "$MAX_WAIT_SECONDS" ]]; then
+      echo "Timed out after ${MAX_WAIT_SECONDS}s waiting for block $TARGET_BLOCK_HEIGHT"
+      exit 1
+   fi
+
    # Check if the service is running (it might panic at the height and not let us reach it)
    if ! pgrep -f "seid start --chain-id sei" > /dev/null; then
       echo "Seid no longer running (panic)"
@@ -25,7 +39,27 @@ while true; do
    fi
 
    # Query the current block height of the node
-   CURRENT_BLOCK_HEIGHT=$(seid status | jq '.SyncInfo.latest_block_height' -r)
+   CURRENT_BLOCK_HEIGHT=$(timeout "$STATUS_TIMEOUT_SECONDS" seid status 2>/dev/null | jq '.SyncInfo.latest_block_height' -r 2>/dev/null)
+   if ! [[ "$CURRENT_BLOCK_HEIGHT" =~ ^[0-9]+$ ]]; then
+       ((NO_PROGRESS_COUNTER++))
+       if [[ "$NO_PROGRESS_COUNTER" -ge "$MAX_NO_PROGRESS_SECONDS" ]]; then
+           echo "Seid status unavailable for ${NO_PROGRESS_COUNTER}s while waiting for block $TARGET_BLOCK_HEIGHT"
+           exit 1
+       fi
+       sleep 1
+       continue
+   fi
+
+   if [[ -n "$LAST_BLOCK_HEIGHT" && "$CURRENT_BLOCK_HEIGHT" -le "$LAST_BLOCK_HEIGHT" ]]; then
+       ((NO_PROGRESS_COUNTER++))
+       if [[ "$NO_PROGRESS_COUNTER" -ge "$MAX_NO_PROGRESS_SECONDS" ]]; then
+           echo "No block progress for ${NO_PROGRESS_COUNTER}s (current: $CURRENT_BLOCK_HEIGHT, target: $TARGET_BLOCK_HEIGHT)"
+           exit 1
+       fi
+   else
+       NO_PROGRESS_COUNTER=0
+   fi
+   LAST_BLOCK_HEIGHT="$CURRENT_BLOCK_HEIGHT"
 
    if [[ "$CURRENT_BLOCK_HEIGHT" -ge "$TARGET_BLOCK_HEIGHT" ]]; then
        echo "Block height reached at $CURRENT_BLOCK_HEIGHT"
@@ -38,9 +72,11 @@ while true; do
            echo "Exiting because stuck on block-1 (other peers panicked first)"
            exit 1
        fi
+   else
+       STUCK_COUNTER=0
    fi
 
-   echo "Waiting for block $TARGET_BLOCK_HEIGHT (current: $CURRENT_BLOCK_HEIGHT)"
+   echo "Waiting for block $TARGET_BLOCK_HEIGHT (current: $CURRENT_BLOCK_HEIGHT, elapsed: ${ELAPSED}s)"
 
    sleep 1
 done


### PR DESCRIPTION
The minor upgrade integration test was occasionally hanging until the workflow timeout killed it, which cascaded into failing Integration Test Check.

The culprit was `wait_for_height.sh`: it used an unbounded while true loop, so if a node stayed alive but stopped producing blocks, the script would spin forever.

Rewrote `wait_for_height.sh` to fail fast instead of hanging. The script now has configurable timeouts via environment variables: a per-call timeout for seid status (default 5s), a max total wait (default 180s), and a max stall duration when no new blocks appear (default 30s). It then exits with a clear error if any of those thresholds are breached.

Stall tracking resets when the node advances past target-1, and logs now include elapsed time for easier debugging.

Flaked on [main](https://github.com/sei-protocol/sei-chain/actions/runs/22335750775/job/64627784198).
