### PR TITLE
Harden `TestStateLock_NoPOL` against proposal/timeout race

### DIFF
--- a/sei-tendermint/internal/consensus/state_test.go
+++ b/sei-tendermint/internal/consensus/state_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -432,6 +433,10 @@ func TestStateFullRound2(t *testing.T) {
 // two validators, 4 rounds.
 // two vals take turns proposing. val1 locks on first one, precommits nil on everything else
 func TestStateLock_NoPOL(t *testing.T) {
+	synctest.Test(t, testStateLockNoPOL)
+}
+
+func testStateLockNoPOL(t *testing.T) {
 	config := configSetup(t)
 	// Deflake: when cs1 is proposer in round 3, proposal construction can race
 	// timeoutPropose on loaded CI runners and force an early prevote nil.


### PR DESCRIPTION
Run this test via sync test to avoid the entire category of race conditions with a minimal diff.

Flaked on [main](https://github.com/sei-protocol/sei-chain/actions/runs/22395014707/job/64826359234).