### PR TITLE
feat(giga): implement iterator for the cachekv

### DIFF
--- a/giga/deps/store/cachekv.go
+++ b/giga/deps/store/cachekv.go
@@ -183,11 +183,76 @@ func (store *Store) GetAllKeyStrsInRange(start, end []byte) (res []string) {
 }
 
 func (store *Store) Iterator(start, end []byte) types.Iterator {
-	panic("unexpected iterator call on cachekv store")
+	// Get all keys in range (merges parent + cache)
+	keyStrs := store.GetAllKeyStrsInRange(start, end)
+	sort.Strings(keyStrs)
+
+	// Build key-value pairs
+	items := make([]kv, 0, len(keyStrs))
+	for _, k := range keyStrs {
+		v := store.Get([]byte(k))
+		if v != nil { // Skip deleted keys
+			items = append(items, kv{key: []byte(k), value: v})
+		}
+	}
+
+	return newMemIterator(items)
 }
 
 // ReverseIterator implements types.KVStore.
-// Stub: delegates to parent store reverse iterator (minimal implementation to satisfy interface)
 func (store *Store) ReverseIterator(start, end []byte) types.Iterator {
 	panic("unexpected reverse iterator call on cachekv store")
+}
+
+// kv represents a key-value pair for iteration
+type kv struct {
+	key   []byte
+	value []byte
+}
+
+// memIterator iterates over an in-memory slice of key-value pairs
+type memIterator struct {
+	items []kv
+	index int
+}
+
+func newMemIterator(items []kv) *memIterator {
+	return &memIterator{
+		items: items,
+		index: 0,
+	}
+}
+
+func (mi *memIterator) Domain() (start []byte, end []byte) {
+	return nil, nil
+}
+
+func (mi *memIterator) Valid() bool {
+	return mi.index < len(mi.items)
+}
+
+func (mi *memIterator) Next() {
+	mi.index++
+}
+
+func (mi *memIterator) Key() []byte {
+	if !mi.Valid() {
+		panic("iterator is invalid")
+	}
+	return mi.items[mi.index].key
+}
+
+func (mi *memIterator) Value() []byte {
+	if !mi.Valid() {
+		panic("iterator is invalid")
+	}
+	return mi.items[mi.index].value
+}
+
+func (mi *memIterator) Close() error {
+	return nil
+}
+
+func (mi *memIterator) Error() error {
+	return nil
 }

--- a/giga/deps/xbank/keeper/view.go
+++ b/giga/deps/xbank/keeper/view.go
@@ -96,18 +96,35 @@ func (k BaseViewKeeper) LockedCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Co
 	return sdk.NewCoins()
 }
 
+// GetAllBalances returns all the balances for a given account address.
+func (k BaseViewKeeper) GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
+	accountStore := k.getAccountStore(ctx, addr)
+
+	balances := sdk.NewCoins()
+	iterator := accountStore.Iterator(nil, nil)
+	defer func() { _ = iterator.Close() }()
+
+	for ; iterator.Valid(); iterator.Next() {
+		var balance sdk.Coin
+		k.cdc.MustUnmarshal(iterator.Value(), &balance)
+		balances = append(balances, balance)
+	}
+
+	return balances.Sort()
+}
+
 // SpendableCoins returns the total balances of spendable coins for an account
 // by address. If the account has no spendable coins, an empty Coins slice is
 // returned.
 func (k BaseViewKeeper) SpendableCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
-	total := k.GetBalance(ctx, addr, "usei").Amount
-	locked := k.LockedCoins(ctx, addr).AmountOf("usei")
+	total := k.GetAllBalances(ctx, addr)
+	locked := k.LockedCoins(ctx, addr)
 
-	spendable := total.Sub(locked)
-	if spendable.IsNegative() {
+	spendable, hasNeg := total.SafeSub(locked)
+	if hasNeg {
 		return sdk.NewCoins()
 	}
-	return sdk.NewCoins(sdk.NewCoin("usei", spendable))
+	return spendable
 }
 
 // getAccountStore gets the account store of the given address.


### PR DESCRIPTION
## Describe your changes and provide context

Since we need Giga to interoperate with v2, we need to return all balances for accounts that are being migrated. This PR implements the Iterator to do that.

If we don't want to implement Iterator on the cachekv, an alternative is to just squish the logic into `GetAllBalances` or `SpendableCoins` directly. That would look something like this:

```
// rangeStore is an interface for stores that support GetAllKeyStrsInRange
type rangeStore interface {
	GetAllKeyStrsInRange(start, end []byte) []string
	Get(key []byte) []byte
}

// GetAllBalances returns all the balances for a given account address.
func (k BaseViewKeeper) GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
	store := k.GetKVStore(ctx)
	accountPrefix := types.CreateAccountBalancesPrefix(addr)

	// Try to use GetAllKeyStrsInRange directly (avoids Iterator which may not be supported)
	if rs, ok := store.(rangeStore); ok {
		// Calculate end key for prefix range (prefix + 0xFF...)
		end := make([]byte, len(accountPrefix))
		copy(end, accountPrefix)
		for i := len(end) - 1; i >= 0; i-- {
			end[i]++
			if end[i] != 0 {
				break
			}
		}

		keyStrs := rs.GetAllKeyStrsInRange(accountPrefix, end)
		balances := sdk.NewCoins()
		for _, keyStr := range keyStrs {
			bz := rs.Get([]byte(keyStr))
			if bz != nil {
				var balance sdk.Coin
				k.cdc.MustUnmarshal(bz, &balance)
				balances = append(balances, balance)
			}
		}
		return balances.Sort()
	}

	// Fall back to standard iteration for non-GIGA stores
	accountStore := prefix.NewStore(store, accountPrefix)
	balances := sdk.NewCoins()
	iterator := accountStore.Iterator(nil, nil)
	defer iterator.Close()

	for ; iterator.Valid(); iterator.Next() {
		var balance sdk.Coin
		k.cdc.MustUnmarshal(iterator.Value(), &balance)
		balances = append(balances, balance)
	}

	return balances.Sort()
}
```

## Testing performed to validate your change

