### PR TITLE
Create parent dirs for RocksDB backend fully

### DIFF
--- a/sei-db/state_db/ss/backend/backend_rocksdb.go
+++ b/sei-db/state_db/ss/backend/backend_rocksdb.go
@@ -11,9 +11,7 @@ import (
 )
 
 func openRocksDB(dbHome string, cfg config.StateStoreConfig) (types.StateStore, error) {
-	// pebble.Open internally calls MkdirAll to create the full directory tree,
-	// but RocksDB's CreateIfMissing only creates the leaf directory. Normalize
-	// the behaviour here so both backends work with arbitrary nested paths.
+	// RocksDB's CreateIfMissing only creates the leaf directory
 	if err := os.MkdirAll(dbHome, 0o750); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Describe your changes and provide context
- For some rare cases where parent dirs are deleted, rocksdb doesn't use internal MkdirAll like what pebble does
- Add back in

## Testing performed to validate your change
- Verified fully on node
