### PR TITLE
Trace semaphore timeout order

### DIFF
--- a/evmrpc/tracers.go
+++ b/evmrpc/tracers.go
@@ -48,12 +48,18 @@ type DebugAPI struct {
 // acquireTraceSemaphore attempts to acquire a slot from the traceCallSemaphore.
 // It returns a function that must be called (typically with defer) to release the semaphore.
 // If the semaphore is nil (unlimited concurrency), it does nothing and returns a no-op release function.
-func (api *DebugAPI) acquireTraceSemaphore() func() {
+// The acquisition respects the context - if the context is cancelled or times out while waiting
+// for a slot, it returns an error instead of blocking indefinitely.
+func (api *DebugAPI) acquireTraceSemaphore(ctx context.Context) (func(), error) {
 	if api.traceCallSemaphore != nil {
-		api.traceCallSemaphore <- struct{}{}
-		return func() { <-api.traceCallSemaphore }
+		select {
+		case api.traceCallSemaphore <- struct{}{}:
+			return func() { <-api.traceCallSemaphore }, nil
+		case <-ctx.Done():
+			return func() {}, ctx.Err()
+		}
 	}
-	return func() {} // No-op if semaphore is not active
+	return func() {}, nil // No-op if semaphore is not active
 }
 
 type SeiDebugAPI struct {
@@ -144,11 +150,14 @@ func NewSeiDebugAPI(
 }
 
 func (api *DebugAPI) TraceTransaction(ctx context.Context, hash common.Hash, config *tracers.TraceConfig) (result interface{}, returnErr error) {
-	release := api.acquireTraceSemaphore()
-	defer release()
-
 	ctx, cancel := context.WithTimeout(ctx, api.traceTimeout)
 	defer cancel()
+
+	release, err := api.acquireTraceSemaphore(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 
 	startTime := time.Now()
 	defer recordMetricsWithError("debug_traceTransaction", api.connectionType, startTime, returnErr)
@@ -173,11 +182,14 @@ func (api *DebugAPI) AsRawJSON(result interface{}) ([]byte, bool) {
 }
 
 func (api *SeiDebugAPI) TraceBlockByNumberExcludeTraceFail(ctx context.Context, number rpc.BlockNumber, config *tracers.TraceConfig) (result interface{}, returnErr error) {
-	release := api.acquireTraceSemaphore() // Use the embedded DebugAPI's semaphore
-	defer release()
-
 	ctx, cancel := context.WithTimeout(ctx, api.traceTimeout)
 	defer cancel()
+
+	release, err := api.acquireTraceSemaphore(ctx) // Use the embedded DebugAPI's semaphore
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 
 	latest := api.ctxProvider(LatestCtxHeight).BlockHeight()
 	if api.maxBlockLookback >= 0 && number.Int64() < latest-api.maxBlockLookback {
@@ -206,11 +218,14 @@ func (api *SeiDebugAPI) TraceBlockByNumberExcludeTraceFail(ctx context.Context, 
 }
 
 func (api *SeiDebugAPI) TraceBlockByHashExcludeTraceFail(ctx context.Context, hash common.Hash, config *tracers.TraceConfig) (result interface{}, returnErr error) {
-	release := api.acquireTraceSemaphore() // Use the embedded DebugAPI's semaphore
-	defer release()
-
 	ctx, cancel := context.WithTimeout(ctx, api.traceTimeout)
 	defer cancel()
+
+	release, err := api.acquireTraceSemaphore(ctx) // Use the embedded DebugAPI's semaphore
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 
 	startTime := time.Now()
 	defer recordMetricsWithError("sei_traceBlockByHashExcludeTraceFail", api.connectionType, startTime, returnErr)
@@ -287,11 +302,14 @@ func (api *DebugAPI) isPanicOrSyntheticTx(ctx context.Context, hash common.Hash)
 }
 
 func (api *DebugAPI) TraceBlockByNumber(ctx context.Context, number rpc.BlockNumber, config *tracers.TraceConfig) (result interface{}, returnErr error) {
-	release := api.acquireTraceSemaphore()
-	defer release()
-
 	ctx, cancel := context.WithTimeout(ctx, api.traceTimeout)
 	defer cancel()
+
+	release, err := api.acquireTraceSemaphore(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 
 	latest := api.ctxProvider(LatestCtxHeight).BlockHeight()
 	if api.maxBlockLookback >= 0 && number.Int64() < latest-api.maxBlockLookback {
@@ -305,11 +323,14 @@ func (api *DebugAPI) TraceBlockByNumber(ctx context.Context, number rpc.BlockNum
 }
 
 func (api *DebugAPI) TraceBlockByHash(ctx context.Context, hash common.Hash, config *tracers.TraceConfig) (result interface{}, returnErr error) {
-	release := api.acquireTraceSemaphore()
-	defer release()
-
 	ctx, cancel := context.WithTimeout(ctx, api.traceTimeout)
 	defer cancel()
+
+	release, err := api.acquireTraceSemaphore(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 
 	startTime := time.Now()
 	defer recordMetricsWithError("debug_traceBlockByHash", api.connectionType, startTime, returnErr)
@@ -318,11 +339,14 @@ func (api *DebugAPI) TraceBlockByHash(ctx context.Context, hash common.Hash, con
 }
 
 func (api *DebugAPI) TraceCall(ctx context.Context, args export.TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, config *tracers.TraceCallConfig) (result interface{}, returnErr error) {
-	release := api.acquireTraceSemaphore()
-	defer release()
-
 	ctx, cancel := context.WithTimeout(ctx, api.traceTimeout)
 	defer cancel()
+
+	release, err := api.acquireTraceSemaphore(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 
 	startTime := time.Now()
 	defer recordMetricsWithError("debug_traceCall", api.connectionType, startTime, returnErr)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes and provide context

This PR addresses a critical bug in the `evmrpc` debug tracing API where trace requests could hang indefinitely. Previously, the `acquireTraceSemaphore` operation was a blocking channel send that occurred *before* the `context.WithTimeout` was applied. This caused requests to block forever waiting for a semaphore slot, ignoring the configured `traceTimeout` and client cancellations.

The changes:
1.  Modify `acquireTraceSemaphore` to be context-aware, allowing it to respect `ctx.Done()` (e.g., from a timeout or client disconnect).
2.  Reorder all trace methods to apply `context.WithTimeout` *before* acquiring the semaphore.

This ensures that the `traceTimeout` correctly governs the entire request lifecycle (including waiting for a semaphore slot), prevents indefinite hangs, avoids wasted work for disconnected clients, and mitigates goroutine accumulation.

## Testing performed to validate your change

The code was verified to compile and format correctly.

---
[Slack Thread](https://sei-network-io.slack.com/archives/D099MGT9RSR/p1772736879397569?thread_ts=1772736879.397569&cid=D099MGT9RSR)

<p><a href="https://cursor.com/agents/bc-687c4f3c-28f5-570e-b85d-c17dc398d720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-687c4f3c-28f5-570e-b85d-c17dc398d720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->