### PR TITLE
fix: accept legacy CommitHash and prevent mmap use-after-free for v6.3->v6.4 upgrade

### DIFF
--- a/sei-cosmos/storev2/rootmulti/store.go
+++ b/sei-cosmos/storev2/rootmulti/store.go
@@ -638,6 +638,19 @@ func (rs *Store) Query(req abci.RequestQuery) abci.ResponseQuery {
 
 	res := store.Query(req)
 
+	// When serving from a historical read-only memiavl instance, the response
+	// byte slices (Key, Value) may point directly into mmap'd memory that will
+	// be unmapped when the deferred scStore.Close() runs. Copy them so the
+	// caller doesn't hit a use-after-free segfault during JSON marshaling.
+	if !latest {
+		if len(res.Key) > 0 {
+			res.Key = append([]byte{}, res.Key...)
+		}
+		if len(res.Value) > 0 {
+			res.Value = append([]byte{}, res.Value...)
+		}
+	}
+
 	// If underlying query failed (e.g. invalid height/path) or doesn' need proof, return as-is.
 	if res.Code != 0 || !needProof {
 		return res

--- a/sei-tendermint/types/block.go
+++ b/sei-tendermint/types/block.go
@@ -89,7 +89,9 @@ func (b *Block) ValidateBasic() error {
 	}
 
 	if w, g := b.LastCommit.Hash(), b.LastCommitHash; !bytes.Equal(w, g) {
-		return fmt.Errorf("wrong Header.LastCommitHash. Expected %X, got %X", w, g)
+		if wLegacy := b.LastCommit.LegacyHash(); !bytes.Equal(wLegacy, g) {
+			return fmt.Errorf("wrong Header.LastCommitHash. Expected %X, got %X", w, g)
+		}
 	}
 
 	// NOTE: b.Data.Txs may be nil, but b.Data.Hash() still works fine.
@@ -900,6 +902,25 @@ func (commit *Commit) Hash() tmbytes.HexBytes {
 		commit.hash = merkle.HashFromByteSlices(bs)
 	}
 	return commit.hash
+}
+
+// LegacyHash computes the commit hash using the pre-v6.4 algorithm, which
+// only includes signatures (not Height, Round, or BlockID). This is needed
+// to validate blocks that were created before the CommitHash change.
+func (commit *Commit) LegacyHash() tmbytes.HexBytes {
+	if commit == nil {
+		return nil
+	}
+	bs := make([][]byte, len(commit.Signatures))
+	for i, commitSig := range commit.Signatures {
+		pbcs := commitSig.ToProto()
+		bz, err := pbcs.Marshal()
+		if err != nil {
+			panic(err)
+		}
+		bs[i] = bz
+	}
+	return merkle.HashFromByteSlices(bs)
 }
 
 // StringIndented returns a string representation of the commit.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes and provide context

Two fixes for deploying release/v6.4 on nodes previously running release/v6.3:

### Fix 1: LastCommitHash mismatch panic on startup

The `Commit.Hash()` algorithm was changed in CON-76 (#2600) to include Height, Round, and BlockID in the Merkle tree alongside signatures. Blocks stored by v6.3 nodes have `LastCommitHash` computed with the old signatures-only algorithm. When v6.4 loads these blocks during ABCI handshake replay, `ValidateBasic` recomputes the hash with the new algorithm, producing a different value and causing a panic:

```
panic: error from proto block: wrong Header.LastCommitHash. Expected 75AA2EF6..., got E3CCCADC...
```

Adds `Commit.LegacyHash()` that uses the old (signatures-only) algorithm, and updates `Block.ValidateBasic()` to fall back to it when the new hash doesn't match.

### Fix 2: SIGSEGV in historical RPC queries (use-after-free of mmap'd memory)

When serving historical queries, `rootmulti.Store.Query()` opens a read-only memiavl instance (mmap'd), queries it, and defers `Close()`. The response byte slices (`Key`, `Value`) may point directly into the mmap'd region. When the deferred `Close()` unmaps the memory before JSON marshaling reads the response, the process segfaults:

```
fatal error: fault
[signal SIGSEGV: segmentation violation code=0x1 addr=0x7fd224098d0a]
encoding/base64.(*Encoding).Encode(...)
```

Copies `res.Key` and `res.Value` for non-latest queries so they survive the mmap unmap.

### Note on PR #3093

The IBC Upgrade Params fix from #3093 is already included in this branch since it was merged into `release/v6.4` before this branch was created.

## Testing performed to validate your change

- `go test ./sei-tendermint/types/` — all tests pass including `TestCommitHash` and `TestBlockValidateBasic`
- `go test ./sei-tendermint/internal/store/` — all store tests pass
- Verified that tampered commits are still correctly rejected (neither new nor legacy hash matches)
- Fix 1 confirmed working on arctic-1 RPC node (handshake completed successfully)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0b2fa4c-bfe9-4cfc-8420-d63c3ac1c87b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0b2fa4c-bfe9-4cfc-8420-d63c3ac1c87b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

