### PR TITLE
added a ProposerAddress check to setProposal CON-250

### DIFF
--- a/sei-tendermint/internal/consensus/state.go
+++ b/sei-tendermint/internal/consensus/state.go
@@ -35,7 +35,7 @@ import (
 // Consensus sentinel errors
 var (
 	ErrInvalidProposalSignature     = errors.New("error invalid proposal signature")
-	ErrInvalidProposer     = errors.New("error invalid proposer")
+	ErrInvalidProposer              = errors.New("error invalid proposer")
 	ErrAddingVote                   = errors.New("error adding vote")
 	ErrSignatureFoundInPastBlocks   = errors.New("found signature from the same key")
 	ErrInvalidProposalPartSetHeader = errors.New("error invalid proposal part set header")
@@ -2131,7 +2131,7 @@ func (cs *State) defaultSetProposal(proposal *types.Proposal, recvTime time.Time
 		}
 	}
 
-	if want,got := cs.roundState.Validators().GetProposer().Address, proposal.ProposerAddress; !bytes.Equal(want,got) {
+	if want, got := cs.roundState.Validators().GetProposer().Address, proposal.ProposerAddress; !bytes.Equal(want, got) {
 		return fmt.Errorf("%w: got %v, want %v", ErrInvalidProposer, got, want)
 	}
 	p := proposal.ToProto()

--- a/sei-tendermint/internal/consensus/state.go
+++ b/sei-tendermint/internal/consensus/state.go
@@ -36,6 +36,7 @@ import (
 var (
 	ErrInvalidProposalSignature     = errors.New("error invalid proposal signature")
 	ErrInvalidProposer              = errors.New("error invalid proposer")
+	ErrInvalidHeaderProposer        = errors.New("error invalid header proposer")
 	ErrAddingVote                   = errors.New("error adding vote")
 	ErrSignatureFoundInPastBlocks   = errors.New("found signature from the same key")
 	ErrInvalidProposalPartSetHeader = errors.New("error invalid proposal part set header")
@@ -2133,6 +2134,9 @@ func (cs *State) defaultSetProposal(proposal *types.Proposal, recvTime time.Time
 
 	if want, got := cs.roundState.Validators().GetProposer().Address, proposal.ProposerAddress; !bytes.Equal(want, got) {
 		return fmt.Errorf("%w: got %v, want %v", ErrInvalidProposer, got, want)
+	}
+	if !cs.roundState.Validators().HasAddress(proposal.Header.ProposerAddress) {
+		return fmt.Errorf("%w: %s is not a validator", ErrInvalidHeaderProposer, proposal.Header.ProposerAddress)
 	}
 	p := proposal.ToProto()
 	// Verify signature

--- a/sei-tendermint/internal/consensus/state.go
+++ b/sei-tendermint/internal/consensus/state.go
@@ -35,6 +35,7 @@ import (
 // Consensus sentinel errors
 var (
 	ErrInvalidProposalSignature     = errors.New("error invalid proposal signature")
+	ErrInvalidProposer     = errors.New("error invalid proposer")
 	ErrAddingVote                   = errors.New("error adding vote")
 	ErrSignatureFoundInPastBlocks   = errors.New("found signature from the same key")
 	ErrInvalidProposalPartSetHeader = errors.New("error invalid proposal part set header")
@@ -2130,6 +2131,9 @@ func (cs *State) defaultSetProposal(proposal *types.Proposal, recvTime time.Time
 		}
 	}
 
+	if want,got := cs.roundState.Validators().GetProposer().Address, proposal.ProposerAddress; !bytes.Equal(want,got) {
+		return fmt.Errorf("%w: got %v, want %v", ErrInvalidProposer, got, want)
+	}
 	p := proposal.ToProto()
 	// Verify signature
 	if err := cs.roundState.Validators().GetProposer().PubKey.Verify(

--- a/sei-tendermint/internal/consensus/state_test.go
+++ b/sei-tendermint/internal/consensus/state_test.go
@@ -2509,19 +2509,27 @@ func TestDefaultSetProposalRejectsMismatchedProposerAddress(t *testing.T) {
 
 	cs, vss := makeState(ctx, t, makeStateArgs{config: config, validators: 2})
 	height, round := cs.roundState.Height(), cs.roundState.Round()
-	round++
-	incrementRound(vss[1:]...)
-	startTestRound(ctx, cs, height, round)
+	want := cs.roundState.Validators().GetProposer().PubKey
+	var proposer *validatorStub
+	for _, vs := range vss {
+		got, err := vs.PrivValidator.GetPubKey(ctx)
+		require.NoError(t, err)
+		if want == got {
+			proposer = vs
+			break
+		}
+	}
+	require.NotNil(t, proposer)
 
-	proposal, _ := decideProposal(ctx, t, cs, vss[1], height, round)
+	proposer.Height = height
+	proposer.Round = round
+	proposal, _ := decideProposal(ctx, t, cs, proposer, height, round)
 	proposal.ProposerAddress = ed25519.GenerateSecretKey().Public().Address()
 
 	p := proposal.ToProto()
-	require.NoError(t, vss[1].SignProposal(ctx, config.ChainID(), p))
+	require.NoError(t, proposer.SignProposal(ctx, config.ChainID(), p))
 	proposal.Signature = utils.OrPanic1(crypto.SigFromBytes(p.Signature))
-
-	err := cs.defaultSetProposal(proposal, tmtime.Now())
-	require.ErrorIs(t, err, ErrInvalidProposer)
+	require.ErrorIs(t, cs.setProposal(proposal, tmtime.Now()), ErrInvalidProposer)
 	require.Nil(t, cs.roundState.Proposal())
 }
 

--- a/sei-tendermint/internal/consensus/state_test.go
+++ b/sei-tendermint/internal/consensus/state_test.go
@@ -16,7 +16,6 @@ import (
 	abci "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
 	abcimocks "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types/mocks"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/crypto"
-	"github.com/sei-protocol/sei-chain/sei-tendermint/crypto/ed25519"
 	cstypes "github.com/sei-protocol/sei-chain/sei-tendermint/internal/consensus/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/eventbus"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/mempool"
@@ -588,7 +587,7 @@ func testStateLockNoPOL(t *testing.T) {
 
 	// cs1 is locked on a block at this point, so we must generate a new consensus
 	// state to force a new proposal block to be generated.
-	cs2, _ := makeState(ctx, t, makeStateArgs{config: config, validators: 2})
+	cs2 := newState(ctx, t, cs1.state, vs2, kvstore.NewApplication())
 	// before we time out into new round, set next proposal block
 	prop, propBlock := decideProposal(ctx, t, cs2, vs2, vs2.Height, vs2.Round+1)
 	require.NotNil(t, propBlock, "Failed to create proposal block with vs2")
@@ -2507,12 +2506,95 @@ func TestSetProposal_InvalidProposer(t *testing.T) {
 	config := configSetup(t)
 	ctx := t.Context()
 
-	cs, vss := makeState(ctx, t, makeStateArgs{config: config, validators: 2})
+	cs, vss := makeState(ctx, t, makeStateArgs{config: config})
 	height, round := cs.roundState.Height(), cs.roundState.Round()
-	want := cs.roundState.Validators().GetProposer().PubKey
+
+	timeoutWaitCh := subscribe(ctx, t, cs.eventBus, types.EventQueryTimeoutWait)
+	proposalCh := subscribe(ctx, t, cs.eventBus, types.EventQueryCompleteProposal)
+	addr := getAddr(ctx, cs)
+	voteCh := subscribeToVoter(ctx, t, cs, addr)
+	lockCh := subscribe(ctx, t, cs.eventBus, types.EventQueryLock)
+	newRoundCh := subscribe(ctx, t, cs.eventBus, types.EventQueryNewRound)
+
+	findValidatorStub := func(address []byte) *validatorStub {
+		t.Helper()
+
+		for _, vs := range vss {
+			pubKey, err := vs.GetPubKey(ctx)
+			require.NoError(t, err)
+			if bytes.Equal(pubKey.Address(), address) {
+				return vs
+			}
+		}
+		return nil
+	}
+
+	startTestRound(ctx, cs, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
+
+	round0Validators := cs.GetRoundState().Validators.Copy()
+	round0Proposer := round0Validators.GetProposer()
+	require.NotNil(t, round0Proposer)
+
+	round1Validators := round0Validators.CopyIncrementProposerPriority(1)
+	round1Proposer := round1Validators.GetProposer()
+	require.NotNil(t, round1Proposer)
+	require.False(t, bytes.Equal(round0Proposer.Address, round1Proposer.Address), "test requires different proposers across rounds")
+
+	round1ProposerStub := findValidatorStub(round1Proposer.Address)
+	require.NotNil(t, round1ProposerStub)
+
+	ensureNewProposal(t, proposalCh, height, round)
+	rs := cs.GetRoundState()
+	block := rs.ProposalBlock
+	blockParts := rs.ProposalBlockParts
+	blockID := types.BlockID{
+		Hash:          block.Hash(),
+		PartSetHeader: blockParts.Header(),
+	}
+	require.True(t, bytes.Equal(block.Header.ProposerAddress, round0Proposer.Address))
+
+	ensurePrevote(t, voteCh, height, round)
+	signAddVotes(ctx, t, cs, tmproto.PrevoteType, config.ChainID(), blockID, vss[1:]...)
+	ensureLock(t, lockCh, height, round)
+	ensurePrecommit(t, voteCh, height, round)
+	signAddVotes(ctx, t, cs, tmproto.PrecommitType, config.ChainID(), types.BlockID{}, vss[1:]...)
+	ensureNewTimeout(t, timeoutWaitCh, height, round)
+
+	incrementRound(vss[1:]...)
+	round++
+	ensureNewRound(t, newRoundCh, height, round)
+	require.True(t, bytes.Equal(cs.GetRoundState().Validators.GetProposer().Address, round1Proposer.Address))
+
+	proposal := types.NewProposal(height, round, cs.roundState.ValidRound(), blockID, block.Header.Time, block.GetTxKeys(), block.Header, block.LastCommit, block.Evidence, round1Proposer.Address)
+	require.False(t, bytes.Equal(proposal.ProposerAddress, proposal.Header.ProposerAddress))
+
+	proposal.ProposerAddress = round0Proposer.Address
+	require.True(t, bytes.Equal(proposal.ProposerAddress, proposal.Header.ProposerAddress))
+
+	p := proposal.ToProto()
+	require.NoError(t, round1ProposerStub.SignProposal(ctx, config.ChainID(), p))
+	proposal.Signature = utils.OrPanic1(crypto.SigFromBytes(p.Signature))
+	require.ErrorIs(t, cs.setProposal(proposal, tmtime.Now()), ErrInvalidProposer)
+	require.Nil(t, cs.roundState.Proposal())
+}
+
+func TestSetProposal_InvalidHeaderProposer(t *testing.T) {
+	config := configSetup(t)
+	ctx := t.Context()
+
+	cs, vss := makeState(ctx, t, makeStateArgs{config: config})
+	height, round := cs.roundState.Height(), cs.roundState.Round()
+
+	newRoundCh := subscribe(ctx, t, cs.eventBus, types.EventQueryNewRound)
+
+	startTestRound(ctx, cs, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
+
+	want := cs.GetRoundState().Validators.GetProposer().PubKey
 	var proposer *validatorStub
 	for _, vs := range vss {
-		got, err := vs.PrivValidator.GetPubKey(ctx)
+		got, err := vs.GetPubKey(ctx)
 		require.NoError(t, err)
 		if want == got {
 			proposer = vs
@@ -2520,13 +2602,16 @@ func TestSetProposal_InvalidProposer(t *testing.T) {
 		}
 	}
 	require.NotNil(t, proposer)
+
 	proposal, _ := decideProposal(ctx, t, cs, proposer, height, round)
-	proposal.ProposerAddress = ed25519.GenerateSecretKey().Public().Address()
+
+	proposal.Header.ProposerAddress = tmrand.Bytes(crypto.AddressSize)
+	require.False(t, cs.GetRoundState().Validators.HasAddress(proposal.Header.ProposerAddress))
 
 	p := proposal.ToProto()
 	require.NoError(t, proposer.SignProposal(ctx, config.ChainID(), p))
 	proposal.Signature = utils.OrPanic1(crypto.SigFromBytes(p.Signature))
-	require.ErrorIs(t, cs.setProposal(proposal, tmtime.Now()), ErrInvalidProposer)
+	require.ErrorIs(t, cs.setProposal(proposal, tmtime.Now()), ErrInvalidHeaderProposer)
 	require.Nil(t, cs.roundState.Proposal())
 }
 

--- a/sei-tendermint/internal/consensus/state_test.go
+++ b/sei-tendermint/internal/consensus/state_test.go
@@ -16,6 +16,7 @@ import (
 	abci "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
 	abcimocks "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types/mocks"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/crypto"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/crypto/ed25519"
 	cstypes "github.com/sei-protocol/sei-chain/sei-tendermint/internal/consensus/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/eventbus"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/mempool"
@@ -2500,6 +2501,28 @@ func TestProposalBlockIsNotRecreatedAfterCommitMismatch(t *testing.T) {
 	require.Nil(t, rs.ProposalBlock, "proposal block must stay nil until matching commit block parts arrive")
 	require.Equal(t, wrongBlockID.PartSetHeader, rs.ProposalBlockParts.Header(), "part set header should keep pointing to commit certificate despite duplicate proposals")
 	require.NotEqual(t, originalPartSetHeader, rs.ProposalBlockParts.Header(), "should not revert back to mismatching proposal block parts")
+}
+
+func TestDefaultSetProposalRejectsMismatchedProposerAddress(t *testing.T) {
+	config := configSetup(t)
+	ctx := t.Context()
+
+	cs, vss := makeState(ctx, t, makeStateArgs{config: config, validators: 2})
+	height, round := cs.roundState.Height(), cs.roundState.Round()
+	round++
+	incrementRound(vss[1:]...)
+	startTestRound(ctx, cs, height, round)
+
+	proposal, _ := decideProposal(ctx, t, cs, vss[1], height, round)
+	proposal.ProposerAddress = ed25519.GenerateSecretKey().Public().Address()
+
+	p := proposal.ToProto()
+	require.NoError(t, vss[1].SignProposal(ctx, config.ChainID(), p))
+	proposal.Signature = utils.OrPanic1(crypto.SigFromBytes(p.Signature))
+
+	err := cs.defaultSetProposal(proposal, tmtime.Now())
+	require.ErrorIs(t, err, ErrInvalidProposer)
+	require.Nil(t, cs.roundState.Proposal())
 }
 
 func TestTryCreateProposalBlockSkipsOnPartSetHeaderMismatch(t *testing.T) {

--- a/sei-tendermint/internal/consensus/state_test.go
+++ b/sei-tendermint/internal/consensus/state_test.go
@@ -2587,11 +2587,6 @@ func TestSetProposal_InvalidHeaderProposer(t *testing.T) {
 	cs, vss := makeState(ctx, t, makeStateArgs{config: config})
 	height, round := cs.roundState.Height(), cs.roundState.Round()
 
-	newRoundCh := subscribe(ctx, t, cs.eventBus, types.EventQueryNewRound)
-
-	startTestRound(ctx, cs, height, round)
-	ensureNewRound(t, newRoundCh, height, round)
-
 	want := cs.GetRoundState().Validators.GetProposer().PubKey
 	var proposer *validatorStub
 	for _, vs := range vss {

--- a/sei-tendermint/internal/consensus/state_test.go
+++ b/sei-tendermint/internal/consensus/state_test.go
@@ -16,6 +16,7 @@ import (
 	abci "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
 	abcimocks "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types/mocks"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/crypto"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/crypto/ed25519"
 	cstypes "github.com/sei-protocol/sei-chain/sei-tendermint/internal/consensus/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/eventbus"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/mempool"
@@ -2605,8 +2606,7 @@ func TestSetProposal_InvalidHeaderProposer(t *testing.T) {
 
 	proposal, _ := decideProposal(ctx, t, cs, proposer, height, round)
 
-	proposal.Header.ProposerAddress = tmrand.Bytes(crypto.AddressSize)
-	require.False(t, cs.GetRoundState().Validators.HasAddress(proposal.Header.ProposerAddress))
+	proposal.Header.ProposerAddress = ed25519.GenerateSecretKey().Public().Address()
 
 	p := proposal.ToProto()
 	require.NoError(t, proposer.SignProposal(ctx, config.ChainID(), p))

--- a/sei-tendermint/internal/consensus/state_test.go
+++ b/sei-tendermint/internal/consensus/state_test.go
@@ -810,7 +810,7 @@ func TestStateLock_POLRelock(t *testing.T) {
 	*/
 	incrementRound(vs2, vs3, vs4)
 	round++
-	pubKey, err := vss[0].PrivValidator.GetPubKey(ctx)
+	pubKey, err := vs2.PrivValidator.GetPubKey(ctx)
 	require.NoError(t, err)
 	propR1 := types.NewProposal(height, round, cs1.roundState.ValidRound(), blockID, theBlock.Header.Time, theBlock.GetTxKeys(), theBlock.Header, theBlock.LastCommit, theBlock.Evidence, pubKey.Address())
 	p := propR1.ToProto()
@@ -1494,7 +1494,7 @@ func TestStateLock_POLSafety2(t *testing.T) {
 
 	round++ // moving to the next round
 	// in round 2 we see the polkad block from round 0
-	pubKey, err := vss[0].PrivValidator.GetPubKey(ctx)
+	pubKey, err := vs3.PrivValidator.GetPubKey(ctx)
 	require.NoError(t, err)
 	newProp := types.NewProposal(height, round, 0, propBlockID0, propBlock0.Header.Time, propBlock0.GetTxKeys(), propBlock0.Header, propBlock0.LastCommit, propBlock0.Evidence, pubKey.Address())
 	p := newProp.ToProto()
@@ -1631,7 +1631,7 @@ func TestState_PrevotePOLFromPreviousRound(t *testing.T) {
 	*/
 	incrementRound(vs2, vs3, vs4)
 	round++
-	pubKey, err := vss[1].PrivValidator.GetPubKey(ctx)
+	pubKey, err := vs3.PrivValidator.GetPubKey(ctx)
 	require.NoError(t, err)
 	propR2 := types.NewProposal(height, round, 1, r1BlockID, propBlockR1.Header.Time, propBlockR1.GetTxKeys(), propBlockR1.Header, propBlockR1.LastCommit, propBlockR1.Evidence, pubKey.Address())
 	p := propR2.ToProto()

--- a/sei-tendermint/internal/consensus/state_test.go
+++ b/sei-tendermint/internal/consensus/state_test.go
@@ -2503,7 +2503,7 @@ func TestProposalBlockIsNotRecreatedAfterCommitMismatch(t *testing.T) {
 	require.NotEqual(t, originalPartSetHeader, rs.ProposalBlockParts.Header(), "should not revert back to mismatching proposal block parts")
 }
 
-func TestDefaultSetProposalRejectsMismatchedProposerAddress(t *testing.T) {
+func TestSetProposal_InvalidProposer(t *testing.T) {
 	config := configSetup(t)
 	ctx := t.Context()
 
@@ -2520,9 +2520,6 @@ func TestDefaultSetProposalRejectsMismatchedProposerAddress(t *testing.T) {
 		}
 	}
 	require.NotNil(t, proposer)
-
-	proposer.Height = height
-	proposer.Round = round
 	proposal, _ := decideProposal(ctx, t, cs, proposer, height, round)
 	proposal.ProposerAddress = ed25519.GenerateSecretKey().Public().Address()
 

--- a/sei-tendermint/types/block.go
+++ b/sei-tendermint/types/block.go
@@ -404,7 +404,7 @@ type Header struct {
 
 	// consensus info
 	EvidenceHash    tmbytes.HexBytes `json:"evidence_hash"`    // evidence included in the block
-	ProposerAddress Address          `json:"proposer_address"` // original proposer of the block
+	ProposerAddress Address          `json:"proposer_address"` // proposer recorded in the block header; preserved across re-proposals
 }
 
 // Populate the Header with state-derived data.

--- a/sei-tendermint/types/proposal.go
+++ b/sei-tendermint/types/proposal.go
@@ -36,7 +36,7 @@ type Proposal struct {
 	Header          `json:"header"`
 	LastCommit      *Commit      `json:"last_commit"`
 	Evidence        EvidenceList `json:"evidence"`
-	ProposerAddress Address      `json:"proposer_address"` // original proposer of the block
+	ProposerAddress Address      `json:"proposer_address"` // proposer of this proposal for the given height/round
 }
 
 // NewProposal returns a new Proposal.


### PR DESCRIPTION
This will allow us to distinguish simply malicious messages (invalid signatures) from state divergence (unexpected proposer). The semantic change is that until now ProposerAddress field was simply ignored.