### PR TITLE
feat(loadtest): migrate metrics to OpenTelemetry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -229,7 +229,7 @@ require (
 	github.com/pion/transport/v2 v2.2.1 // indirect
 	github.com/pion/transport/v3 v3.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/otlptranslator v0.0.2 // indirect
+	github.com/prometheus/otlptranslator v0.0.2
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/loadtest/loadtest_client.go
+++ b/loadtest/loadtest_client.go
@@ -20,7 +20,6 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	typestx "github.com/sei-protocol/sei-chain/sei-cosmos/types/tx"
 	stakingtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/staking/types"
-	"github.com/sei-protocol/sei-chain/utils/metrics"
 	"golang.org/x/sync/semaphore"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
@@ -194,7 +193,7 @@ func (c *LoadTestClient) BuildTxs(
 			}
 			// Generate a message type first
 			messageType := c.getRandomMessageType(config.MessageTypes)
-			metrics.IncrProducerEventCount(messageType)
+			incrProducerEventCount(messageType)
 			var signedTx SignedTx
 			// Sign EVM and Cosmos TX differently
 			switch messageType {
@@ -264,7 +263,7 @@ func (c *LoadTestClient) SendTxs(
 			return
 		case tx, ok := <-txQueue:
 			atomic.AddInt64(sentCountPerMsgType[tx.MsgType], 1)
-			metrics.IncrConsumerEventCount(tx.MsgType)
+			incrConsumerEventCount(tx.MsgType)
 			if !ok {
 				fmt.Printf("Stopping consumers\n")
 				return

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -39,7 +39,6 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/sei-protocol/sei-chain/app"
-	"github.com/sei-protocol/sei-chain/utils/metrics"
 	tokenfactorytypes "github.com/sei-protocol/sei-chain/x/tokenfactory/types"
 )
 
@@ -139,6 +138,12 @@ func deployEvmContracts(config *Config) {
 }
 
 func run(config *Config) {
+	shutdownOtel, err := initLoadtestOtelMetrics()
+	if err != nil {
+		panic(err)
+	}
+	defer func() { _ = shutdownOtel(context.Background()) }()
+
 	config.EVMAddresses = &EVMAddresses{}
 	// Start metrics collector in another thread
 	metricsServer := MetricsServer{}
@@ -273,7 +278,7 @@ func printStats(
 		//nolint:gosec
 		tps := float64(sentCount-prevTotalSent) / elapsed.Seconds()
 		totalTps += tps
-		defer metrics.SetThroughputMetricByType("tps", float32(tps), msgType)
+		defer setThroughputMetricByType("tps", float32(tps), msgType)
 	}
 
 	var totalDuration time.Duration

--- a/loadtest/metrics.go
+++ b/loadtest/metrics.go
@@ -7,8 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
-	"github.com/sei-protocol/sei-chain/sei-cosmos/types/rest"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const (
@@ -17,35 +16,13 @@ const (
 )
 
 type MetricsServer struct {
-	metrics *telemetry.Metrics
-	server  *http.Server
-}
-
-func (s *MetricsServer) metricsHandler(w http.ResponseWriter, _ *http.Request) {
-	gr, err := s.metrics.Gather("prometheus")
-	if err != nil {
-		rest.WriteErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("failed to gather metrics: %s", err))
-		return
-	}
-
-	w.Header().Set("Content-Type", gr.ContentType)
-	_, _ = w.Write(gr.Metrics)
+	server *http.Server
 }
 
 func (s *MetricsServer) StartMetricsClient(config Config) {
-	m, err := telemetry.New(telemetry.Config{
-		ServiceName:             "loadtest-client",
-		Enabled:                 true,
-		EnableHostnameLabel:     true,
-		EnableServiceLabel:      true,
-		PrometheusRetentionTime: 600,
-	})
-	if err != nil {
-		panic(err)
-	}
-	s.metrics = m
-	http.HandleFunc("/healthz", s.healthzHandler)
-	http.HandleFunc("/metrics", s.metricsHandler)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", s.healthzHandler)
+	mux.Handle("/metrics", promhttp.HandlerFor(loadtestPrometheusGatherer(), promhttp.HandlerOpts{}))
 
 	metricsPort := config.MetricsPort
 	if config.MetricsPort == 0 {
@@ -57,9 +34,10 @@ func (s *MetricsServer) StartMetricsClient(config Config) {
 
 	s.server = &http.Server{
 		Addr:              listenAddr,
+		Handler:           mux,
 		ReadHeaderTimeout: 3 * time.Second,
 	}
-	err = s.server.ListenAndServe()
+	err := s.server.ListenAndServe()
 	if err != nil {
 		panic(err)
 	}

--- a/loadtest/otel_metrics.go
+++ b/loadtest/otel_metrics.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/otlptranslator"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	otelprometheus "go.opentelemetry.io/otel/exporters/prometheus"
+	"go.opentelemetry.io/otel/metric"
+	otelmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+const loadtestTelemetryServiceName = "loadtest-client"
+
+var (
+	loadtestOtelErr error
+
+	loadtestPromReg    *prometheus.Registry
+	loadtestShutdownMP func(context.Context) error
+
+	loadtestProduceCounter metric.Int64Counter
+	loadtestConsumeCounter metric.Int64Counter
+	loadtestTpsGauge       metric.Float64Gauge
+
+	loadtestHost string
+)
+
+func loadtestMetricOpts(msgType string) metric.MeasurementOption {
+	var once sync.Once
+	once.Do(func() {
+		loadtestHost, _ = os.Hostname()
+		if loadtestHost == "" {
+			loadtestHost = "unknown"
+		}
+	})
+	return metric.WithAttributes(
+		attribute.String("msg_type", msgType),
+		attribute.String("service", loadtestTelemetryServiceName),
+		attribute.String("host", loadtestHost),
+	)
+}
+
+// initLoadtestOtelMetrics configures the process-wide OTel MeterProvider and Prometheus
+// registry used by the loadtest metrics HTTP server. Call once from run() before any
+// producer/consumer records metrics.
+func initLoadtestOtelMetrics() (func(context.Context) error, error) {
+	var once sync.Once
+	once.Do(func() {
+		loadtestPromReg = prometheus.NewRegistry()
+
+		exporter, err := otelprometheus.New(
+			otelprometheus.WithRegisterer(loadtestPromReg),
+			otelprometheus.WithTranslationStrategy(otlptranslator.UnderscoreEscapingWithoutSuffixes),
+			otelprometheus.WithoutTargetInfo(),
+			otelprometheus.WithoutScopeInfo(),
+		)
+		if err != nil {
+			loadtestOtelErr = fmt.Errorf("create otel prometheus exporter: %w", err)
+			return
+		}
+
+		provider := otelmetric.NewMeterProvider(otelmetric.WithReader(exporter))
+		otel.SetMeterProvider(provider)
+
+		meter := provider.Meter("loadtest")
+
+		loadtestProduceCounter, loadtestOtelErr = meter.Int64Counter("sei_loadtest_produce_count")
+		if loadtestOtelErr != nil {
+			loadtestOtelErr = fmt.Errorf("produce counter: %w", loadtestOtelErr)
+			return
+		}
+		loadtestConsumeCounter, loadtestOtelErr = meter.Int64Counter("sei_loadtest_consume_count")
+		if loadtestOtelErr != nil {
+			loadtestOtelErr = fmt.Errorf("consume counter: %w", loadtestOtelErr)
+			return
+		}
+		loadtestTpsGauge, loadtestOtelErr = meter.Float64Gauge("sei_loadtest_tps_tps")
+		if loadtestOtelErr != nil {
+			loadtestOtelErr = fmt.Errorf("tps gauge: %w", loadtestOtelErr)
+			return
+		}
+
+		loadtestShutdownMP = provider.Shutdown
+	})
+
+	if loadtestOtelErr != nil {
+		return nil, loadtestOtelErr
+	}
+	if loadtestShutdownMP == nil {
+		return nil, fmt.Errorf("loadtest otel metrics: shutdown unset")
+	}
+	return loadtestShutdownMP, nil
+}
+
+func incrProducerEventCount(msgType string) {
+	ctx := context.Background()
+	loadtestProduceCounter.Add(ctx, 1, loadtestMetricOpts(msgType))
+}
+
+func incrConsumerEventCount(msgType string) {
+	ctx := context.Background()
+	loadtestConsumeCounter.Add(ctx, 1, loadtestMetricOpts(msgType))
+}
+
+func setThroughputMetricByType(metricName string, value float32, msgType string) {
+	ctx := context.Background()
+	// Legacy keys were sei, loadtest, tps, <metricName>. Loadtest only passes "tps".
+	if metricName != "tps" {
+		return
+	}
+	loadtestTpsGauge.Record(ctx, float64(value), loadtestMetricOpts(msgType))
+}
+
+func loadtestPrometheusGatherer() prometheus.Gatherer {
+	return loadtestPromReg
+}

--- a/loadtest/otel_metrics_scrape_test.go
+++ b/loadtest/otel_metrics_scrape_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadTestOtelMetricsPrometheusScrape(t *testing.T) {
+	shutdown, err := initLoadtestOtelMetrics()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+
+	const bankMessageType = "bank"
+	incrProducerEventCount(bankMessageType)
+	incrConsumerEventCount(bankMessageType)
+	setThroughputMetricByType("tps", 2.5, bankMessageType)
+
+	mfs, err := loadtestPrometheusGatherer().Gather()
+	require.NoError(t, err)
+
+	host, err := os.Hostname()
+	require.NoError(t, err)
+
+	prod := findMetricFamily(mfs, "sei_loadtest_produce_count")
+	require.NotNil(t, prod, "missing sei_loadtest_produce_count")
+	require.Len(t, prod.Metric, 1)
+	assertLoadtestLabels(t, prod.Metric[0], bankMessageType, host)
+	require.Equal(t, float64(1), prod.Metric[0].GetCounter().GetValue())
+
+	cons := findMetricFamily(mfs, "sei_loadtest_consume_count")
+	require.NotNil(t, cons, "missing sei_loadtest_consume_count")
+	require.Len(t, cons.Metric, 1)
+	assertLoadtestLabels(t, cons.Metric[0], bankMessageType, host)
+	require.Equal(t, float64(1), cons.Metric[0].GetCounter().GetValue())
+
+	tps := findMetricFamily(mfs, "sei_loadtest_tps_tps")
+	require.NotNil(t, tps, "missing sei_loadtest_tps_tps")
+	require.Len(t, tps.Metric, 1)
+	assertLoadtestLabels(t, tps.Metric[0], bankMessageType, host)
+	require.Equal(t, 2.5, tps.Metric[0].GetGauge().GetValue())
+}
+
+func findMetricFamily(mfs []*dto.MetricFamily, name string) *dto.MetricFamily {
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			return mf
+		}
+	}
+	return nil
+}
+
+func assertLoadtestLabels(t *testing.T, m *dto.Metric, wantMsgType, wantHost string) {
+	t.Helper()
+	labels := make(map[string]string)
+	for _, lp := range m.Label {
+		labels[lp.GetName()] = lp.GetValue()
+	}
+	require.Equal(t, wantMsgType, labels["msg_type"])
+	require.Equal(t, loadtestTelemetryServiceName, labels["service"])
+	require.Equal(t, wantHost, labels["host"])
+}


### PR DESCRIPTION
## Summary

Replaces the loadtest package's legacy `utils/metrics` and `sei-cosmos/telemetry` instrumentation with OpenTelemetry (OTel), exporting metrics via the standard Prometheus bridge.

- Adds `otel_metrics.go`: initializes a process-scoped OTel `MeterProvider` backed by a dedicated Prometheus registry. Instruments three metrics: `sei_loadtest_produce_count`, `sei_loadtest_consume_count`, and `sei_loadtest_tps_tps`.
- Replaces `metrics.IncrProducerEventCount` / `IncrConsumerEventCount` / `SetThroughputMetricByType` calls in `loadtest_client.go` and `main.go` with package-local wrappers over the OTel counters/gauge.
- Simplifies `metrics.go`: removes the old `telemetry.Metrics`-based handler; the `/metrics` endpoint now serves from the OTel-registered Prometheus gatherer via `promhttp`.
- `run()` initializes the OTel provider on startup and defers a clean shutdown.
- Adds scrape-level tests (`otel_metrics_scrape_test.go`) to verify metrics are exposed correctly.

## Test plan

- [x] `go test ./loadtest/...` passes, including new scrape tests
- [x] Loadtest binary runs and `/metrics` endpoint exposes `sei_loadtest_*` metrics with `msg_type`, `service`, and `host` labels