### PR TITLE
fix: deduplicate block fetch in getTransactionReceipt

### DIFF
--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -132,16 +132,17 @@ func getTransactionReceipt(
 		}
 		return nil, err
 	}
+	// Fetch block once — used both for ante-failure receipt population and encoding.
+	height := int64(receipt.BlockNumber) //nolint:gosec
+	block, err := blockByNumberRespectingWatermarks(ctx, t.tmClient, t.watermarks, &height, 1)
+	if err != nil {
+		return nil, err
+	}
+
 	// Fill in the receipt if the transaction has failed and used 0 gas
 	// This case is for when a tx fails before it makes it to the VM
 	if receipt.Status == 0 && receipt.GasUsed == 0 {
 		receipt = cloneReceiptForMutation(receipt)
-		// Get the block
-		height := int64(receipt.BlockNumber) //nolint:gosec
-		block, err := blockByNumberRespectingWatermarks(ctx, t.tmClient, t.watermarks, &height, 1)
-		if err != nil {
-			return nil, err
-		}
 
 		// Find the transaction in the block
 		for _, tx := range block.Block.Txs {
@@ -167,11 +168,6 @@ func getTransactionReceipt(
 				break
 			}
 		}
-	}
-	height := int64(receipt.BlockNumber) //nolint:gosec
-	block, err := blockByNumberRespectingWatermarks(ctx, t.tmClient, t.watermarks, &height, 1)
-	if err != nil {
-		return nil, err
 	}
 	return encodeReceipt(t.ctxProvider, t.txConfigProvider, receipt, t.keeper, block, includeSynthetic, t.globalBlockCache, t.cacheCreationMutex)
 }


### PR DESCRIPTION
## Summary
- `getTransactionReceipt` was fetching the same block twice via `blockByNumberRespectingWatermarks`: once inside the ante-failure branch (`Status==0 && GasUsed==0`) at line 141, and again unconditionally at line 172 for `encodeReceipt`
- Hoisted the block fetch above the conditional so both the ante-failure sender recovery path and the receipt encoding path share a single fetch

## Motivation
Every `eth_getTransactionReceipt` call that hits the ante-failure path (tx failed before reaching the VM) paid for two redundant block store lookups. This is a hot RPC method — wallets, explorers, and indexers poll it continuously.

## Test plan
- [x] All 6 `TestGetTransactionReceipt*` tests pass
- [x] All 25 `TestGetTransaction*` tests pass (zero regressions)
- [x] `gofmt -s -l evmrpc/tx.go` produces no output
- [x] `go build ./evmrpc/` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)