### PR TITLE
Fix buffer offset in ProposerPriorityHash (CON-200)

### DIFF
--- a/sei-tendermint/types/validator_set.go
+++ b/sei-tendermint/types/validator_set.go
@@ -371,12 +371,12 @@ func (vals *ValidatorSet) ProposerPriorityHash() []byte {
 
 	buf := make([]byte, binary.MaxVarintLen64*len(vals.Validators))
 
-	total := 0
+	offset := 0
 	for _, val := range vals.Validators {
-		n := binary.PutVarint(buf, val.ProposerPriority)
-		total += n
+		n := binary.PutVarint(buf[offset:], val.ProposerPriority)
+		offset += n
 	}
-	return tmhash.Sum(buf[:total])
+	return tmhash.Sum(buf[:offset])
 }
 
 // Iterate will run the given function over the set.

--- a/sei-tendermint/types/validator_set_test.go
+++ b/sei-tendermint/types/validator_set_test.go
@@ -180,6 +180,14 @@ func TestValidatorSet_ProposerPriorityHash(t *testing.T) {
 	vset.IncrementProposerPriority(1)
 	assert.Equal(t, vset.Hash(), vsetCopy.Hash())
 	assert.NotEqual(t, vset.ProposerPriorityHash(), vsetCopy.ProposerPriorityHash())
+
+	// Changing only one validator's priority must change the hash.
+	// This verifies that each validator's priority occupies a distinct
+	// position in the buffer rather than overwriting the same offset.
+	vsetA := vset.Copy()
+	vsetB := vset.Copy()
+	vsetB.Validators[0].ProposerPriority += 1
+	assert.NotEqual(t, vsetA.ProposerPriorityHash(), vsetB.ProposerPriorityHash())
 }
 
 // Test that IncrementProposerPriority requires positive times.


### PR DESCRIPTION
## Summary
- Fix `binary.PutVarint` writing to `buf[0:]` on every iteration instead of advancing the write position
- Each validator's encoded priority now occupies its own position in the buffer
- Add test verifying that changing a single validator's priority produces a different hash

## Test plan
- [x] `go vet ./sei-tendermint/types/...` passes
- [x] `go test ./sei-tendermint/types/...` passes
- [x] New test fails without the fix, passes with it