### PR TITLE
Validate block part index matches proof index (CON-20)

### DIFF
--- a/sei-tendermint/crypto/merkle/proof.go
+++ b/sei-tendermint/crypto/merkle/proof.go
@@ -48,7 +48,6 @@ func ProofsFromByteSlices(items [][]byte) (rootHash []byte, proofs []*Proof) {
 }
 
 // Verify that the Proof proves the root hash.
-// Check sp.Index/sp.Total manually if needed
 func (sp *Proof) Verify(rootHash []byte, leaf []byte) error {
 	if sp.Total < 0 {
 		return errors.New("proof total must be positive")

--- a/sei-tendermint/types/part_set.go
+++ b/sei-tendermint/types/part_set.go
@@ -37,6 +37,9 @@ func (part *Part) ValidateBasic() error {
 	if err := part.Proof.ValidateBasic(); err != nil {
 		return fmt.Errorf("wrong Proof: %w", err)
 	}
+	if int64(part.Index) != part.Proof.Index {
+		return fmt.Errorf("part index %d does not match proof index %d", part.Index, part.Proof.Index)
+	}
 	return nil
 }
 

--- a/sei-tendermint/types/part_set_test.go
+++ b/sei-tendermint/types/part_set_test.go
@@ -90,6 +90,30 @@ func TestWrongProof(t *testing.T) {
 	}
 }
 
+func TestAddPartWithSwappedProof(t *testing.T) {
+	// Create a part set with multiple parts
+	data := tmrand.Bytes(testPartSize * 4)
+	partSet := NewPartSetFromData(data, testPartSize)
+
+	// Get two different parts
+	part0 := partSet.GetPart(0)
+	part1 := partSet.GetPart(1)
+
+	// Create a malicious part: part0's index with part1's proof.
+	// The proof is cryptographically valid (it proves part1.Bytes is in the tree)
+	// but it's for a different index position.
+	maliciousPart := &Part{
+		Index: part0.Index,
+		Bytes: part1.Bytes,
+		Proof: part1.Proof,
+	}
+
+	// ValidateBasic should reject this because Part.Index != Proof.Index
+	err := maliciousPart.ValidateBasic()
+	assert.Error(t, err, "ValidateBasic should reject part with mismatched proof index")
+	assert.Contains(t, err.Error(), "does not match proof index")
+}
+
 func TestPartSetHeaderValidateBasic(t *testing.T) {
 	testCases := []struct {
 		testName              string


### PR DESCRIPTION
## Summary
- Add validation in `Part.ValidateBasic()` that `Part.Index` equals `Part.Proof.Index`
- Reject block parts where the Merkle proof refers to a different position than the part claims
- Add test for the new validation

## Test plan
- [x] `go vet ./sei-tendermint/types/...` passes
- [x] `go test ./sei-tendermint/types/...` passes
- [x] New test fails without the fix, passes with it