### PR TITLE
Fix 400 error querying blocks with no transactions

### DIFF
--- a/sei-cosmos/x/auth/tx/service.go
+++ b/sei-cosmos/x/auth/tx/service.go
@@ -198,7 +198,7 @@ func (s txServer) GetBlockWithTxs(ctx context.Context, req *txtypes.GetBlockWith
 	blockTxs := block.Data.Txs
 	blockTxsLn := uint64(len(blockTxs))
 	txs := make([]*txtypes.Tx, 0, limit)
-	if offset >= blockTxsLn {
+	if blockTxsLn > 0 && offset >= blockTxsLn {
 		return nil, sdkerrors.ErrInvalidRequest.Wrapf("out of range: cannot paginate %d txs with offset %d and limit %d", blockTxsLn, offset, limit)
 	}
 	decodeTxAt := func(i uint64) error {


### PR DESCRIPTION
## Describe your changes and provide context

Fixes #3239

The GetBlockWithTxs endpoint was failing when querying an empty block. It was checking if offset >= blockTxsLn without first verifying blockTxsLn > 0, so any request (even offset=0) would error out when there were no transactions.

Added a check for blockTxsLn > 0 before the offset validation. Handles empty blocks correctly now.

## Testing performed to validate your change

Tested locally with both empty and non-empty blocks. Empty blocks now work, and offset validation still works for non-empty blocks.