### PR TITLE
fix: add retry to apt-get update in Docker CI

### DIFF
--- a/docker/localnode/Dockerfile
+++ b/docker/localnode/Dockerfile
@@ -2,7 +2,8 @@ FROM golang:1.25.6-bookworm AS go-dist
 
 FROM ubuntu:latest
 ENV HOME="/root" PATH="/root/go/bin:/sei-protocol/sei-chain/integration_test/upgrade_module/scripts/:$PATH"
-RUN apt-get update && apt-get install -y make build-essential git jq python3 curl vim uuid-runtime
+RUN for i in 1 2 3; do apt-get update && break || sleep 5; done && \
+    apt-get install -y make build-essential git jq python3 curl vim uuid-runtime
 COPY --from=go-dist /usr/local/go /usr/local/go
 RUN set -eux; \
     curl -fsSL https://foundry.paradigm.xyz | bash; \

--- a/docker/localnode/Dockerfile
+++ b/docker/localnode/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.25.6-bookworm AS go-dist
 
 FROM ubuntu:latest
 ENV HOME="/root" PATH="/root/go/bin:/sei-protocol/sei-chain/integration_test/upgrade_module/scripts/:$PATH"
-RUN for i in 1 2 3; do apt-get update && break || sleep 5; done && \
+RUN for i in 1 2 3; do apt-get update && break || { [ $i -lt 3 ] && sleep 5; }; done && \
     apt-get install -y make build-essential git jq python3 curl vim uuid-runtime
 COPY --from=go-dist /usr/local/go /usr/local/go
 RUN set -eux; \


### PR DESCRIPTION
## Summary
- Add retry loop (3 attempts, 5s sleep) to `apt-get update` in `docker/localnode/Dockerfile`
- Ubuntu mirrors intermittently return hash mismatches or stale package indices, causing all integration test jobs to fail at the Docker build step

🤖 Generated with [Claude Code](https://claude.com/claude-code)