### PR TITLE
Export ProposerPriorityHash metric for divergence monitoring

### DIFF
--- a/sei-tendermint/internal/state/execution.go
+++ b/sei-tendermint/internal/state/execution.go
@@ -3,6 +3,7 @@ package state
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"time"
@@ -23,7 +24,6 @@ var logger = seilog.NewLogger("tendermint", "internal", "state")
 // proposerPriorityHashInterval is how often (in heights) the
 // ProposerPriorityHash metric is exported. Used so operators can compare
 // hashes across validators and detect ProposerPriority divergence.
-// Must be a power of 2 so the check uses bitwise AND instead of modulo.
 const proposerPriorityHashInterval = 1024
 
 //-----------------------------------------------------------------------------
@@ -322,15 +322,15 @@ func (blockExec *BlockExecutor) ApplyBlock(ctx context.Context, state State, blo
 	// metrics backend. Exporting as a numeric value keeps cardinality
 	// constant at one series per node.
 	//
-	// Why only 6 bytes?
-	// Prometheus gauges are float64. A float64 can represent integers up to
-	// 2^53 exactly; beyond that, precision is lost. Packing the first 6
-	// bytes (48 bits) of the SHA-256 hash stays safely inside the mantissa.
-	// Collision probability across 40 validators is ~40^2 / 2^49 ≈ 3e-12,
-	// effectively zero for this use case.
+	// Why take only the first 8 bytes?
+	// Prometheus gauges are float64, which only represents integers up to
+	// 2^53 exactly. We take the first 8 bytes of the SHA-256 hash and cast
+	// to float64; the top 11 bits are lost to the mantissa, effectively
+	// giving us 53 bits of entropy. Collision probability across 40
+	// validators is ~40^2/2^54 ≈ 9e-14, effectively zero.
 	//
 	// Paired with ProposerPriorityHashHeight so operators know which height
-	// the hash corresponds to. A log line also emits the full 16-hex prefix
+	// the hash corresponds to. A log line also emits the full 32-byte hash
 	// for grep-based debugging.
 	//
 	// Note on restart staleness: Prometheus Gauges live in memory. After a
@@ -338,17 +338,9 @@ func (blockExec *BlockExecutor) ApplyBlock(ctx context.Context, state State, blo
 	// the following multiple of proposerPriorityHashInterval — up to ~8.5
 	// min of stale/zero data at Sei's block times. Acceptable for a
 	// monitoring signal that is only checked in response to incidents.
-	//
-	// proposerPriorityHashInterval is a power of 2 so we use bitwise AND
-	// instead of modulo.
-	if block.Height&(proposerPriorityHashInterval-1) == 0 {
+	if block.Height%proposerPriorityHashInterval == 0 {
 		if full := state.Validators.ProposerPriorityHash(); len(full) >= 8 {
-			// Pack the first 6 bytes big-endian into a uint64, then cast to
-			// float64 — safe because 2^48 < 2^53 (float64 mantissa).
-			var packed uint64
-			for i := 0; i < 6; i++ {
-				packed = (packed << 8) | uint64(full[i])
-			}
+			packed := binary.BigEndian.Uint64(full[:8])
 			blockExec.metrics.ProposerPriorityHash.Set(float64(packed))
 			blockExec.metrics.ProposerPriorityHashHeight.Set(float64(block.Height))
 			// Log both the full 32-byte hash (for unambiguous comparison)

--- a/sei-tendermint/internal/state/execution.go
+++ b/sei-tendermint/internal/state/execution.go
@@ -20,6 +20,12 @@ import (
 
 var logger = seilog.NewLogger("tendermint", "internal", "state")
 
+// proposerPriorityHashInterval is how often (in heights) the
+// ProposerPriorityHash metric is exported. Used so operators can compare
+// hashes across validators and detect ProposerPriority divergence.
+// Must be a power of 2 so the check uses bitwise AND instead of modulo.
+const proposerPriorityHashInterval = 1024
+
 //-----------------------------------------------------------------------------
 // BlockExecutor handles block execution and state updates.
 // It exposes ApplyBlock(), which validates & executes the block, updates state w/ ABCI responses,
@@ -302,6 +308,56 @@ func (blockExec *BlockExecutor) ApplyBlock(ctx context.Context, state State, blo
 	}
 	if updateStateSpan != nil {
 		updateStateSpan.End()
+	}
+
+	// Export ProposerPriorityHash every proposerPriorityHashInterval heights so
+	// operators can detect ProposerPriority divergence between validators by
+	// comparing gauge values across nodes at the same height.
+	//
+	// Why emit the hash as a numeric *value* rather than a label?
+	// A label-based design (gauge with hash as label) would create a new
+	// Prometheus time series every time the hash changes — since validator
+	// priorities change every block, each emission would yield a brand-new
+	// series. Over time this accumulates unbounded cardinality in the
+	// metrics backend. Exporting as a numeric value keeps cardinality
+	// constant at one series per node.
+	//
+	// Why only 6 bytes?
+	// Prometheus gauges are float64. A float64 can represent integers up to
+	// 2^53 exactly; beyond that, precision is lost. Packing the first 6
+	// bytes (48 bits) of the SHA-256 hash stays safely inside the mantissa.
+	// Collision probability across 40 validators is ~40^2 / 2^49 ≈ 3e-12,
+	// effectively zero for this use case.
+	//
+	// Paired with ProposerPriorityHashHeight so operators know which height
+	// the hash corresponds to. A log line also emits the full 16-hex prefix
+	// for grep-based debugging.
+	//
+	// Note on restart staleness: Prometheus Gauges live in memory. After a
+	// process restart the gauges reset to zero until the next emission at
+	// the following multiple of proposerPriorityHashInterval — up to ~8.5
+	// min of stale/zero data at Sei's block times. Acceptable for a
+	// monitoring signal that is only checked in response to incidents.
+	//
+	// proposerPriorityHashInterval is a power of 2 so we use bitwise AND
+	// instead of modulo.
+	if block.Height&(proposerPriorityHashInterval-1) == 0 {
+		if full := state.Validators.ProposerPriorityHash(); len(full) >= 8 {
+			// Pack the first 6 bytes big-endian into a uint64, then cast to
+			// float64 — safe because 2^48 < 2^53 (float64 mantissa).
+			var packed uint64
+			for i := 0; i < 6; i++ {
+				packed = (packed << 8) | uint64(full[i])
+			}
+			blockExec.metrics.ProposerPriorityHash.Set(float64(packed))
+			blockExec.metrics.ProposerPriorityHashHeight.Set(float64(block.Height))
+			// Log both the full 32-byte hash (for unambiguous comparison)
+			// and the packed value (to correlate with the Prometheus gauge).
+			logger.Info("proposer priority hash checkpoint",
+				"height", block.Height,
+				"hash", fmt.Sprintf("%X", full),
+				"packed", packed)
+		}
 	}
 	var commitSpan otrace.Span = nil
 	if tracer != nil {

--- a/sei-tendermint/internal/state/execution_test.go
+++ b/sei-tendermint/internal/state/execution_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -25,6 +26,16 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/version"
 )
+
+// recordingGauge is a minimal metrics.Gauge implementation that records every
+// Set call for test assertion. No labels expected.
+type recordingGauge struct {
+	sets []float64
+}
+
+func (g *recordingGauge) With(labelValues ...string) metrics.Gauge { return g }
+func (g *recordingGauge) Set(value float64)                        { g.sets = append(g.sets, value) }
+func (g *recordingGauge) Add(float64)                              {}
 
 var (
 	chainID             = "execution_chain"
@@ -55,6 +66,64 @@ func TestApplyBlock(t *testing.T) {
 
 	// TODO check state and mempool
 	assert.EqualValues(t, 1, state.Version.Consensus.App, "App version wasn't updated")
+}
+
+// TestApplyBlockProposerPriorityHash verifies that ApplyBlock emits the
+// ProposerPriorityHash metric at heights divisible by the export interval,
+// that the encoded value matches the first 6 bytes of the validator set's
+// ProposerPriorityHash, and that the paired height metric is also emitted.
+func TestApplyBlockProposerPriorityHash(t *testing.T) {
+	const interval = sm.ProposerPriorityHashInterval
+
+	app := &testApp{}
+	ctx := t.Context()
+
+	eventBus := eventbus.NewDefault()
+	require.NoError(t, eventBus.Start(ctx))
+
+	state, stateDB, privVals := makeState(t, 1, 1)
+	stateStore := sm.NewStore(stateDB)
+	blockStore := store.NewBlockStore(dbm.NewMemDB())
+	mp := makeTxMempool(t, app)
+
+	evpool := &mocks.EvidencePool{}
+	evpool.On("PendingEvidence", mock.Anything).Return([]types.Evidence{}, 0)
+	evpool.On("Update", ctx, mock.Anything, mock.Anything).Return()
+	evpool.On("CheckEvidence", ctx, mock.Anything).Return(nil)
+
+	hashGauge := &recordingGauge{}
+	heightGauge := &recordingGauge{}
+	testMetrics := sm.NopMetrics()
+	testMetrics.ProposerPriorityHash = hashGauge
+	testMetrics.ProposerPriorityHashHeight = heightGauge
+
+	blockExec := sm.NewBlockExecutor(stateStore, app, mp, evpool, blockStore, eventBus, testMetrics)
+
+	// Apply blocks 1..interval. Only height == interval should emit the metric.
+	var lastCommit *types.Commit = new(types.Commit)
+	for height := int64(1); height <= interval; height++ {
+		proposerAddr := state.Validators.Validators[0].Address
+		state, _, lastCommit = makeAndCommitGoodBlock(
+			ctx, t, state, height, lastCommit, proposerAddr, blockExec, privVals, nil,
+		)
+	}
+
+	// Expect exactly one emission at the interval boundary.
+	require.Len(t, hashGauge.sets, 1, "hash metric should fire exactly once at height %d", interval)
+	require.Len(t, heightGauge.sets, 1, "height metric should fire exactly once at height %d", interval)
+
+	// Height metric should equal the interval.
+	require.Equal(t, float64(interval), heightGauge.sets[0])
+
+	// Hash metric should equal the first 6 bytes of ProposerPriorityHash
+	// packed as a big-endian uint64, cast to float64.
+	full := state.Validators.ProposerPriorityHash()
+	require.GreaterOrEqual(t, len(full), 8)
+	var expected uint64
+	for i := 0; i < 6; i++ {
+		expected = (expected << 8) | uint64(full[i])
+	}
+	require.Equal(t, float64(expected), hashGauge.sets[0], "emitted hash value does not match first 6 bytes of ProposerPriorityHash")
 }
 
 // TestFinalizeBlockDecidedLastCommit ensures we correctly send the

--- a/sei-tendermint/internal/state/execution_test.go
+++ b/sei-tendermint/internal/state/execution_test.go
@@ -2,6 +2,7 @@ package state_test
 
 import (
 	"context"
+	"encoding/binary"
 	"testing"
 	"time"
 
@@ -115,15 +116,12 @@ func TestApplyBlockProposerPriorityHash(t *testing.T) {
 	// Height metric should equal the interval.
 	require.Equal(t, float64(interval), heightGauge.sets[0])
 
-	// Hash metric should equal the first 6 bytes of ProposerPriorityHash
+	// Hash metric should equal the first 8 bytes of ProposerPriorityHash
 	// packed as a big-endian uint64, cast to float64.
 	full := state.Validators.ProposerPriorityHash()
 	require.GreaterOrEqual(t, len(full), 8)
-	var expected uint64
-	for i := 0; i < 6; i++ {
-		expected = (expected << 8) | uint64(full[i])
-	}
-	require.Equal(t, float64(expected), hashGauge.sets[0], "emitted hash value does not match first 6 bytes of ProposerPriorityHash")
+	expected := binary.BigEndian.Uint64(full[:8])
+	require.Equal(t, float64(expected), hashGauge.sets[0], "emitted hash value does not match first 8 bytes of ProposerPriorityHash")
 }
 
 // TestFinalizeBlockDecidedLastCommit ensures we correctly send the

--- a/sei-tendermint/internal/state/export_test.go
+++ b/sei-tendermint/internal/state/export_test.go
@@ -10,3 +10,6 @@ import (
 func ValidateValidatorUpdates(abciUpdates []abci.ValidatorUpdate, params types.ValidatorParams) error {
 	return validateValidatorUpdates(abciUpdates, params)
 }
+
+// ProposerPriorityHashInterval is the interval constant exposed for testing.
+const ProposerPriorityHashInterval = proposerPriorityHashInterval

--- a/sei-tendermint/internal/state/metrics.gen.go
+++ b/sei-tendermint/internal/state/metrics.gen.go
@@ -86,20 +86,34 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 
 			Buckets: stdprometheus.ExponentialBucketsRange(0.01, 10, 10),
 		}, labels).With(labelsAndValues...),
+		ProposerPriorityHash: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "proposer_priority_hash",
+			Help:      "ProposerPriorityHash encodes the first 6 bytes of the hash of the current validator set's proposer priorities as a float64 value. Exported periodically (every proposerPriorityHashInterval heights) for operator visibility; divergence between validators at the same ProposerPriorityHashHeight indicates corrupted ProposerPriority state. Paired with ProposerPriorityHashHeight so operators can correlate.",
+		}, labels).With(labelsAndValues...),
+		ProposerPriorityHashHeight: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "proposer_priority_hash_height",
+			Help:      "ProposerPriorityHashHeight is the block height at which the most recent ProposerPriorityHash was computed. Operators comparing hashes across validators should only compare samples at the same height.",
+		}, labels).With(labelsAndValues...),
 	}
 }
 
 func NopMetrics() *Metrics {
 	return &Metrics{
-		BlockProcessingTime:      discard.NewHistogram(),
-		ConsensusParamUpdates:    discard.NewCounter(),
-		ValidatorSetUpdates:      discard.NewCounter(),
-		ApplicationCommitTime:    discard.NewHistogram(),
-		UpdateMempoolTime:        discard.NewHistogram(),
-		FinalizeBlockLatency:     discard.NewHistogram(),
-		SaveBlockResponseLatency: discard.NewHistogram(),
-		SaveBlockLatency:         discard.NewHistogram(),
-		PruneBlockLatency:        discard.NewHistogram(),
-		FireEventsLatency:        discard.NewHistogram(),
+		BlockProcessingTime:        discard.NewHistogram(),
+		ConsensusParamUpdates:      discard.NewCounter(),
+		ValidatorSetUpdates:        discard.NewCounter(),
+		ApplicationCommitTime:      discard.NewHistogram(),
+		UpdateMempoolTime:          discard.NewHistogram(),
+		FinalizeBlockLatency:       discard.NewHistogram(),
+		SaveBlockResponseLatency:   discard.NewHistogram(),
+		SaveBlockLatency:           discard.NewHistogram(),
+		PruneBlockLatency:          discard.NewHistogram(),
+		FireEventsLatency:          discard.NewHistogram(),
+		ProposerPriorityHash:       discard.NewGauge(),
+		ProposerPriorityHashHeight: discard.NewGauge(),
 	}
 }

--- a/sei-tendermint/internal/state/metrics.go
+++ b/sei-tendermint/internal/state/metrics.go
@@ -48,4 +48,17 @@ type Metrics struct {
 
 	// FireEventsLatency measures how long it takes to fire events for indexing
 	FireEventsLatency metrics.Histogram `metrics_buckettype:"exprange" metrics_bucketsizes:"0.01, 10, 10"`
+
+	// ProposerPriorityHash encodes the first 6 bytes of the hash of the
+	// current validator set's proposer priorities as a float64 value.
+	// Exported periodically (every proposerPriorityHashInterval heights) for
+	// operator visibility; divergence between validators at the same
+	// ProposerPriorityHashHeight indicates corrupted ProposerPriority state.
+	// Paired with ProposerPriorityHashHeight so operators can correlate.
+	ProposerPriorityHash metrics.Gauge
+
+	// ProposerPriorityHashHeight is the block height at which the most recent
+	// ProposerPriorityHash was computed. Operators comparing hashes across
+	// validators should only compare samples at the same height.
+	ProposerPriorityHashHeight metrics.Gauge
 }


### PR DESCRIPTION
## Summary
- Add two Prometheus gauges exported every 1024 heights to let operators detect ProposerPriority divergence between validators
- `tendermint_state_proposer_priority_hash`: first 6 bytes of the hash packed into a float64 (48 bits fits in the float64 mantissa; constant cardinality of one series per node)
- `tendermint_state_proposer_priority_hash_height`: paired height so operators correlate samples taken at the same checkpoint
- Log line at each checkpoint carries the full 32-byte hex hash plus the packed value for grep-based debugging

## Test plan
- [x] `go vet ./sei-tendermint/internal/state/...` passes
- [x] `go test ./sei-tendermint/internal/state` passes
- [x] New test `TestApplyBlockProposerPriorityHash` applies 1024 real blocks and verifies exactly one emission at the interval boundary, with the correct packed hash and height values