### PR TITLE
Parquet disable full range scan

### DIFF
--- a/sei-db/ledger_db/receipt/parquet_store.go
+++ b/sei-db/ledger_db/receipt/parquet_store.go
@@ -155,18 +155,23 @@ func (s *parquetReceiptStore) GetReceiptFromStore(ctx sdk.Context, txHash common
 	return receipt, nil
 }
 
-// indexedReceiptLookup uses the tx hash index (when available) to narrow
-// the parquet search to a single file, falling back to a full scan.
+// indexedReceiptLookup uses the tx hash index to narrow the parquet search to
+// a single file. When the index is disabled the lookup returns
+// ErrTxIndexDisabled instead of performing a full parquet scan, which would
+// be prohibitively expensive at production scale.
 func (s *parquetReceiptStore) indexedReceiptLookup(ctx context.Context, txHash common.Hash) (*parquet.ReceiptResult, error) {
-	if s.txHashIndex != nil {
-		blockNum, ok, err := s.txHashIndex.GetBlockNumber(ctx, txHash)
-		if err != nil {
-			logger.Error("tx hash index lookup failed, falling back to full scan", "err", err)
-		} else if ok {
-			return s.store.GetReceiptByTxHashInBlock(ctx, txHash, blockNum)
-		}
+	if s.txHashIndex == nil {
+		return nil, ErrTxIndexDisabled
 	}
-	return s.store.GetReceiptByTxHash(ctx, txHash)
+	blockNum, ok, err := s.txHashIndex.GetBlockNumber(ctx, txHash)
+	if err != nil {
+		logger.Error("tx hash index lookup failed, falling back to full scan", "err", err)
+		return s.store.GetReceiptByTxHash(ctx, txHash)
+	}
+	if !ok {
+		return s.store.GetReceiptByTxHash(ctx, txHash)
+	}
+	return s.store.GetReceiptByTxHashInBlock(ctx, txHash, blockNum)
 }
 
 func (s *parquetReceiptStore) SetReceipts(ctx sdk.Context, receipts []ReceiptRecord) error {

--- a/sei-db/ledger_db/receipt/receipt_store.go
+++ b/sei-db/ledger_db/receipt/receipt_store.go
@@ -33,8 +33,11 @@ var (
 	// ErrTxIndexDisabled indicates that a receipt-by-tx-hash lookup missed the
 	// in-memory cache and cannot be served because the parquet backend's pebble
 	// tx hash index is disabled. A full parquet scan would require reading every
-	// file on disk and is intentionally not attempted.
-	ErrTxIndexDisabled = errors.New("receipt tx hash index is disabled; parquet fallback scan is not allowed")
+	// file on disk and is intentionally not attempted. The error wraps
+	// ErrNotFound so callers that treat "not found" as a null/nil result (e.g.
+	// eth_getTransactionReceipt) continue to behave correctly; the wrapping
+	// preserves the underlying reason for operators and tests via errors.Is.
+	ErrTxIndexDisabled = fmt.Errorf("receipt tx hash index is disabled; parquet fallback scan is not allowed: %w", ErrNotFound)
 )
 
 // ReceiptStore exposes receipt-specific operations without leaking the StateStore interface.

--- a/sei-db/ledger_db/receipt/receipt_store.go
+++ b/sei-db/ledger_db/receipt/receipt_store.go
@@ -30,6 +30,11 @@ var (
 	ErrNotFound               = errors.New("receipt not found")
 	ErrNotConfigured          = errors.New("receipt store not configured")
 	ErrRangeQueryNotSupported = errors.New("range query not supported by this backend")
+	// ErrTxIndexDisabled indicates that a receipt-by-tx-hash lookup missed the
+	// in-memory cache and cannot be served because the parquet backend's pebble
+	// tx hash index is disabled. A full parquet scan would require reading every
+	// file on disk and is intentionally not attempted.
+	ErrTxIndexDisabled = errors.New("receipt tx hash index is disabled; parquet fallback scan is not allowed")
 )
 
 // ReceiptStore exposes receipt-specific operations without leaking the StateStore interface.

--- a/sei-db/ledger_db/receipt/tx_hash_index_test.go
+++ b/sei-db/ledger_db/receipt/tx_hash_index_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/eth/filters"
 	dbconfig "github.com/sei-protocol/sei-chain/sei-db/config"
 	"github.com/stretchr/testify/require"
 )
@@ -174,6 +175,146 @@ func TestParquetStoreDisabledIndex(t *testing.T) {
 	got, err := store.GetReceiptFromStore(ctx, txHash)
 	require.NoError(t, err)
 	require.Equal(t, txHash.Hex(), got.TxHashHex)
+}
+
+// When the pebble tx hash index is disabled, a cache miss must not trigger a
+// full parquet scan. Unknown tx hashes should fail fast with
+// ErrTxIndexDisabled.
+func TestParquetStoreDisabledIndexCacheMissReturnsError(t *testing.T) {
+	ctx, storeKey := newTestContext()
+	cfg := newParquetTestConfig(t)
+	cfg.TxIndexBackend = ""
+
+	store, err := NewReceiptStore(cfg, storeKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	unknown := common.HexToHash("0xabcdef")
+	_, err = store.GetReceipt(ctx, unknown)
+	require.ErrorIs(t, err, ErrTxIndexDisabled)
+
+	_, err = store.GetReceiptFromStore(ctx, unknown)
+	require.ErrorIs(t, err, ErrTxIndexDisabled)
+}
+
+// Once a previously cached receipt is evicted (via cache rotation), queries
+// must fail with ErrTxIndexDisabled instead of falling back to the parquet
+// files. This is the core regression guard: we never want to quietly do a
+// full-file scan when the index is off.
+func TestParquetStoreDisabledIndexEvictedCacheReturnsError(t *testing.T) {
+	ctx, storeKey := newTestContext()
+	cfg := newParquetTestConfig(t)
+	cfg.TxIndexBackend = ""
+
+	store, err := NewReceiptStore(cfg, storeKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	addr := common.HexToAddress("0x1")
+	txHash := common.HexToHash("0xbeef01")
+	receipt := makeTestReceipt(txHash, 1, 0, addr, nil)
+
+	require.NoError(t, store.SetReceipts(ctx.WithBlockHeight(1), []ReceiptRecord{
+		{TxHash: txHash, Receipt: receipt},
+	}))
+
+	// Sanity check: the receipt is served from cache while it is still hot.
+	got, err := store.GetReceiptFromStore(ctx, txHash)
+	require.NoError(t, err)
+	require.Equal(t, txHash.Hex(), got.TxHashHex)
+
+	// Evict by rotating past the chunk that holds this receipt. Two rotations
+	// move the chunk into the prune slot and clear it on the next rotate.
+	cached := store.(*cachedReceiptStore)
+	cached.cache.Rotate()
+	cached.cache.Rotate()
+
+	_, err = store.GetReceipt(ctx, txHash)
+	require.ErrorIs(t, err, ErrTxIndexDisabled,
+		"cache miss with disabled index must not fall back to parquet scan")
+
+	_, err = store.GetReceiptFromStore(ctx, txHash)
+	require.ErrorIs(t, err, ErrTxIndexDisabled)
+}
+
+// Directly exercises the parquet backend (bypassing the cache) to pin down
+// the exact place the error is raised. This guards against accidentally
+// reintroducing a fallback scan in GetReceipt / GetReceiptFromStore.
+func TestParquetReceiptStoreBackendReturnsErrorWhenIndexDisabled(t *testing.T) {
+	ctx, storeKey := newTestContext()
+	cfg := newParquetTestConfig(t)
+	cfg.TxIndexBackend = ""
+
+	store, err := NewReceiptStore(cfg, storeKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	backend := store.(*cachedReceiptStore).backend.(*parquetReceiptStore)
+	require.Nil(t, backend.txHashIndex, "test precondition: tx hash index should be nil when disabled")
+
+	_, err = backend.GetReceipt(ctx, common.HexToHash("0x1"))
+	require.ErrorIs(t, err, ErrTxIndexDisabled)
+
+	_, err = backend.GetReceiptFromStore(ctx, common.HexToHash("0x1"))
+	require.ErrorIs(t, err, ErrTxIndexDisabled)
+}
+
+// FilterLogs uses block-range queries that don't touch the tx hash index.
+// Disabling the index must not break log filtering.
+func TestParquetStoreDisabledIndexFilterLogsStillWorks(t *testing.T) {
+	ctx, storeKey := newTestContext()
+	cfg := newParquetTestConfig(t)
+	cfg.TxIndexBackend = ""
+
+	store, err := NewReceiptStore(cfg, storeKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	addr := common.HexToAddress("0x55")
+	topic := common.HexToHash("0x77")
+	txHash := common.HexToHash("0x99")
+	receipt := makeTestReceipt(txHash, 5, 0, addr, []common.Hash{topic})
+
+	require.NoError(t, store.SetReceipts(ctx.WithBlockHeight(5), []ReceiptRecord{
+		{TxHash: txHash, Receipt: receipt},
+	}))
+
+	logs, err := store.FilterLogs(ctx, 5, 5, filters.FilterCriteria{
+		Addresses: []common.Address{addr},
+		Topics:    [][]common.Hash{{topic}},
+	})
+	require.NoError(t, err)
+	require.Len(t, logs, 1)
+	require.Equal(t, uint64(5), logs[0].BlockNumber)
+}
+
+// When the index is enabled (default), the indexed path is used and the error
+// is not raised. This guards against over-eagerly returning the disabled-index
+// error in the wrong code path.
+func TestParquetStoreIndexedLookupDoesNotReturnDisabledError(t *testing.T) {
+	ctx, storeKey := newTestContext()
+	cfg := newParquetTestConfig(t) // default TxIndexBackend = pebbledb
+
+	store, err := NewReceiptStore(cfg, storeKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	addr := common.HexToAddress("0x1")
+	txHash := common.HexToHash("0xcafe01")
+	receipt := makeTestReceipt(txHash, 1, 0, addr, nil)
+	require.NoError(t, store.SetReceipts(ctx.WithBlockHeight(1), []ReceiptRecord{
+		{TxHash: txHash, Receipt: receipt},
+	}))
+
+	// Hit with indexed backend still works (served by cache or by index).
+	got, err := store.GetReceiptFromStore(ctx, txHash)
+	require.NoError(t, err)
+	require.Equal(t, txHash.Hex(), got.TxHashHex)
+
+	// Unknown hash with index enabled is ErrNotFound, not ErrTxIndexDisabled.
+	_, err = store.GetReceiptFromStore(ctx, common.HexToHash("0xdead"))
+	require.ErrorIs(t, err, ErrNotFound)
+	require.NotErrorIs(t, err, ErrTxIndexDisabled)
 }
 
 func TestParquetStoreWALReplayPopulatesIndex(t *testing.T) {

--- a/sei-db/ledger_db/receipt/tx_hash_index_test.go
+++ b/sei-db/ledger_db/receipt/tx_hash_index_test.go
@@ -254,9 +254,13 @@ func TestParquetReceiptStoreBackendReturnsErrorWhenIndexDisabled(t *testing.T) {
 
 	_, err = backend.GetReceipt(ctx, common.HexToHash("0x1"))
 	require.ErrorIs(t, err, ErrTxIndexDisabled)
+	// The error must also be reported as ErrNotFound so RPC callers that treat
+	// "not found" as a null response keep their standard behavior.
+	require.ErrorIs(t, err, ErrNotFound)
 
 	_, err = backend.GetReceiptFromStore(ctx, common.HexToHash("0x1"))
 	require.ErrorIs(t, err, ErrTxIndexDisabled)
+	require.ErrorIs(t, err, ErrNotFound)
 }
 
 // FilterLogs uses block-range queries that don't touch the tx hash index.


### PR DESCRIPTION
## Describe your changes and provide context
If the pebbledb tx index for the new parquet-based receiptdb is disabled, we will currently fallback to range scans over all the parquet files. This is a problem because it is a very expensive operation. This PR disallows the full range scan if the tx index is disabled.

## Testing performed to validate your change
unit tests.

