### PR TITLE
Use journal instead of CacheKV for giga snapshot/rollback

### DIFF
--- a/docker/localnode/Dockerfile
+++ b/docker/localnode/Dockerfile
@@ -1,9 +1,21 @@
 FROM golang:1.25.6-bookworm AS go-dist
 
-FROM ubuntu:latest
+FROM ubuntu:24.04
 ENV HOME="/root" PATH="/root/go/bin:/sei-protocol/sei-chain/integration_test/upgrade_module/scripts/:$PATH"
-RUN for i in 1 2 3; do apt-get update && break || { [ $i -lt 3 ] && sleep 5; }; done && \
-    apt-get install -y make build-essential git jq python3 curl vim uuid-runtime
+RUN set -eux; \
+    export DEBIAN_FRONTEND=noninteractive; \
+    for attempt in 1 2 3 4 5; do \
+      if apt-get -o Acquire::Retries=5 -o APT::Update::Error-Mode=any update && \
+         apt-get -o Acquire::Retries=5 install -y --no-install-recommends make build-essential git jq python3 curl vim uuid-runtime; then \
+        rm -rf /var/lib/apt/lists/*; \
+        break; \
+      fi; \
+      rm -rf /var/lib/apt/lists/*; \
+      if [ "${attempt}" = "5" ]; then \
+        exit 1; \
+      fi; \
+      sleep $((attempt * 10)); \
+    done
 COPY --from=go-dist /usr/local/go /usr/local/go
 RUN set -eux; \
     curl -fsSL https://foundry.paradigm.xyz | bash; \
@@ -38,4 +50,3 @@ COPY scripts/step2_genesis.sh /usr/bin/genesis.sh
 COPY scripts/step3_add_validator_to_genesis.sh /usr/bin/add_validator_to_gensis.sh
 COPY scripts/step4_config_override.sh /usr/bin/config_override.sh
 COPY scripts/step5_start_sei.sh /usr/bin/start_sei.sh
-

--- a/docker/localnode/Dockerfile
+++ b/docker/localnode/Dockerfile
@@ -6,7 +6,8 @@ RUN set -eux; \
     export DEBIAN_FRONTEND=noninteractive; \
     for attempt in 1 2 3 4 5; do \
       if apt-get -o Acquire::Retries=5 -o APT::Update::Error-Mode=any update && \
-         apt-get -o Acquire::Retries=5 install -y --no-install-recommends make build-essential git jq python3 curl vim uuid-runtime; then \
+         apt-get -o Acquire::Retries=5 install -y --no-install-recommends make build-essential git jq python3 curl ca-certificates vim uuid-runtime; then \
+        update-ca-certificates; \
         rm -rf /var/lib/apt/lists/*; \
         break; \
       fi; \
@@ -18,13 +19,16 @@ RUN set -eux; \
     done
 COPY --from=go-dist /usr/local/go /usr/local/go
 RUN set -eux; \
-    curl -fsSL https://foundry.paradigm.xyz | bash; \
     for attempt in 1 2 3 4 5; do \
-      if /root/.foundry/bin/foundryup; then \
+      if curl -fsSL https://foundry.paradigm.xyz -o /tmp/foundry.sh && \
+         bash /tmp/foundry.sh && \
+         /root/.foundry/bin/foundryup; then \
+        rm -f /tmp/foundry.sh; \
         break; \
       fi; \
+      rm -f /tmp/foundry.sh; \
       if [ "${attempt}" -eq 5 ]; then \
-        echo "foundryup failed after retries"; \
+        echo "foundry install failed after retries"; \
         exit 1; \
       fi; \
       sleep 2; \

--- a/giga/deps/xevm/state/balance.go
+++ b/giga/deps/xevm/state/balance.go
@@ -55,6 +55,7 @@ func (s *DBImpl) SubBalance(evmAddr common.Address, amtUint256 *uint256.Int, rea
 	surplus := sdk.NewIntFromBigInt(amt)
 	s.tempState.surplus = s.tempState.surplus.Add(surplus)
 	s.journal = append(s.journal, &surplusChange{delta: surplus})
+	s.journal = append(s.journal, &balanceChange{evmAddr: evmAddr, seiAddr: addr, usei: usei, wei: wei, isAdd: false})
 	return *ZeroInt
 }
 
@@ -97,6 +98,7 @@ func (s *DBImpl) AddBalance(evmAddr common.Address, amtUint256 *uint256.Int, rea
 	surplus := sdk.NewIntFromBigInt(amt).Neg()
 	s.tempState.surplus = s.tempState.surplus.Add(surplus)
 	s.journal = append(s.journal, &surplusChange{delta: surplus})
+	s.journal = append(s.journal, &balanceChange{evmAddr: evmAddr, seiAddr: addr, usei: usei, wei: wei, isAdd: true})
 	return *ZeroInt
 }
 

--- a/giga/deps/xevm/state/code.go
+++ b/giga/deps/xevm/state/code.go
@@ -23,6 +23,7 @@ func (s *DBImpl) SetCode(addr common.Address, code []byte) []byte {
 	}
 
 	s.k.SetCode(s.ctx, addr, code)
+	s.journal = append(s.journal, &codeChange{addr: addr, prevCode: oldCode})
 	return oldCode
 }
 

--- a/giga/deps/xevm/state/expected_keepers.go
+++ b/giga/deps/xevm/state/expected_keepers.go
@@ -18,6 +18,7 @@ type EVMKeeper interface {
 	BankKeeper() bankkeeper.Keeper
 	GetBaseDenom(sdk.Context) string
 	DeleteAddressMapping(sdk.Context, sdk.AccAddress, common.Address)
+	SetAddressMapping(sdk.Context, sdk.AccAddress, common.Address)
 	GetCode(sdk.Context, common.Address) []byte
 	SetCode(sdk.Context, common.Address, []byte)
 	GetCodeHash(sdk.Context, common.Address) common.Hash

--- a/giga/deps/xevm/state/journal.go
+++ b/giga/deps/xevm/state/journal.go
@@ -4,12 +4,19 @@ import (
 	"encoding/binary"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/sei-protocol/sei-chain/giga/deps/xevm/types"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 )
 
 type journalEntry interface {
 	// revert undoes the changes introduced by this journal entry.
 	revert(*DBImpl)
+}
+
+// revision marks a snapshot point in the journal.
+type revision struct {
+	id           int
+	journalIndex int
 }
 
 type (
@@ -43,8 +50,46 @@ type (
 		delta sdk.Int
 	}
 
-	watermark struct {
-		version int
+	// storageChange records a KV storage mutation so it can be reverted.
+	storageChange struct {
+		addr common.Address
+		key  common.Hash
+		prev common.Hash
+	}
+
+	// codeChange records a code mutation so it can be reverted.
+	codeChange struct {
+		addr     common.Address
+		prevCode []byte
+	}
+
+	// nonceChange records a nonce mutation so it can be reverted.
+	nonceChange struct {
+		addr common.Address
+		prev uint64
+	}
+
+	// balanceChange records an Add or Sub balance so it can be reverted.
+	balanceChange struct {
+		evmAddr common.Address
+		seiAddr sdk.AccAddress
+		usei    sdk.Int
+		wei     sdk.Int
+		isAdd   bool // true if AddBalance was called
+	}
+
+	// createAccountChange records the previous state cleared by clearAccountStateJournaled.
+	createAccountChange struct {
+		addr      common.Address
+		prevCode  []byte
+		prevNonce uint64
+		prevSlots map[common.Hash]common.Hash
+	}
+
+	// deleteMappingChange records a DeleteAddressMapping so it can be reverted.
+	deleteMappingChange struct {
+		evmAddr common.Address
+		seiAddr sdk.AccAddress
 	}
 )
 
@@ -112,8 +157,6 @@ func (e *transientStorageChange) revert(s *DBImpl) {
 	}
 }
 
-func (e *watermark) revert(s *DBImpl) {}
-
 func (e *accountStatusChange) revert(s *DBImpl) {
 	accts := s.tempState.transientAccounts
 	if e.prev == nil {
@@ -121,4 +164,51 @@ func (e *accountStatusChange) revert(s *DBImpl) {
 	} else {
 		accts[e.account.Hex()] = e.prev
 	}
+}
+
+func (e *storageChange) revert(s *DBImpl) {
+	s.k.SetState(s.ctx, e.addr, e.key, e.prev)
+}
+
+func (e *codeChange) revert(s *DBImpl) {
+	if len(e.prevCode) == 0 {
+		// Directly delete code entries since SetCode(nil) sets to empty but doesn't delete
+		deleteIfExists(s.k.PrefixStore(s.ctx, types.CodeKeyPrefix), e.addr[:])
+		deleteIfExists(s.k.PrefixStore(s.ctx, types.CodeHashKeyPrefix), e.addr[:])
+		deleteIfExists(s.k.PrefixStore(s.ctx, types.CodeSizeKeyPrefix), e.addr[:])
+	} else {
+		s.k.SetCode(s.ctx, e.addr, e.prevCode)
+	}
+}
+
+func (e *nonceChange) revert(s *DBImpl) {
+	s.k.SetNonce(s.ctx, e.addr, e.prev)
+}
+
+func (e *balanceChange) revert(s *DBImpl) {
+	// Suppress events on revert
+	ctx := s.ctx.WithEventManager(sdk.NewEventManager())
+	denom := s.k.GetBaseDenom(s.ctx)
+	if e.isAdd {
+		// Was AddBalance: reverse by subtracting
+		_ = s.k.BankKeeper().SubUnlockedCoins(ctx, e.seiAddr, sdk.NewCoins(sdk.NewCoin(denom, e.usei)), true)
+		_ = s.k.BankKeeper().SubWei(ctx, e.seiAddr, e.wei)
+	} else {
+		// Was SubBalance: reverse by adding
+		_ = s.k.BankKeeper().AddCoins(ctx, e.seiAddr, sdk.NewCoins(sdk.NewCoin(denom, e.usei)), true)
+		_ = s.k.BankKeeper().AddWei(ctx, e.seiAddr, e.wei)
+	}
+}
+
+func (e *createAccountChange) revert(s *DBImpl) {
+	s.k.SetCode(s.ctx, e.addr, e.prevCode)
+	s.k.SetNonce(s.ctx, e.addr, e.prevNonce)
+	for k, v := range e.prevSlots {
+		s.k.SetState(s.ctx, e.addr, k, v)
+	}
+}
+
+func (e *deleteMappingChange) revert(s *DBImpl) {
+	ctx := s.ctx.WithEventManager(sdk.NewEventManager())
+	s.k.SetAddressMapping(ctx, e.seiAddr, e.evmAddr)
 }

--- a/giga/deps/xevm/state/journal.go
+++ b/giga/deps/xevm/state/journal.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"encoding/binary"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/sei-protocol/sei-chain/giga/deps/xevm/types"
@@ -191,12 +192,20 @@ func (e *balanceChange) revert(s *DBImpl) {
 	denom := s.k.GetBaseDenom(s.ctx)
 	if e.isAdd {
 		// Was AddBalance: reverse by subtracting
-		_ = s.k.BankKeeper().SubUnlockedCoins(ctx, e.seiAddr, sdk.NewCoins(sdk.NewCoin(denom, e.usei)), true)
-		_ = s.k.BankKeeper().SubWei(ctx, e.seiAddr, e.wei)
+		if err := s.k.BankKeeper().SubUnlockedCoins(ctx, e.seiAddr, sdk.NewCoins(sdk.NewCoin(denom, e.usei)), true); err != nil {
+			panic(fmt.Sprintf("balanceChange revert SubUnlockedCoins: %v", err))
+		}
+		if err := s.k.BankKeeper().SubWei(ctx, e.seiAddr, e.wei); err != nil {
+			panic(fmt.Sprintf("balanceChange revert SubWei: %v", err))
+		}
 	} else {
 		// Was SubBalance: reverse by adding
-		_ = s.k.BankKeeper().AddCoins(ctx, e.seiAddr, sdk.NewCoins(sdk.NewCoin(denom, e.usei)), true)
-		_ = s.k.BankKeeper().AddWei(ctx, e.seiAddr, e.wei)
+		if err := s.k.BankKeeper().AddCoins(ctx, e.seiAddr, sdk.NewCoins(sdk.NewCoin(denom, e.usei)), true); err != nil {
+			panic(fmt.Sprintf("balanceChange revert AddCoins: %v", err))
+		}
+		if err := s.k.BankKeeper().AddWei(ctx, e.seiAddr, e.wei); err != nil {
+			panic(fmt.Sprintf("balanceChange revert AddWei: %v", err))
+		}
 	}
 }
 

--- a/giga/deps/xevm/state/journal_test.go
+++ b/giga/deps/xevm/state/journal_test.go
@@ -83,10 +83,15 @@ func TestTransientStorageChangeRevert_Update(t *testing.T) {
 	require.Equal(t, prevalue, db.tempState.transientStates[addr.Hex()][key.Hex()])
 }
 
-func TestWatermarkRevert(t *testing.T) {
+func TestAccountStatusChangeRevert_NoOp(t *testing.T) {
+	// Ensure that reverting with nil prev deletes the account entry.
 	db := &DBImpl{tempState: NewTemporaryState()}
-	change := &watermark{version: 1}
-	change.revert(db) // should do nothing, just ensure no panic
+	addr := common.Address{12}
+	db.tempState.transientAccounts[addr.Hex()] = AccountCreated
+	change := &accountStatusChange{account: addr, prev: nil}
+	change.revert(db)
+	_, ok := db.tempState.transientAccounts[addr.Hex()]
+	require.False(t, ok)
 }
 
 func TestAccountStatusChangeRevert_Delete(t *testing.T) {

--- a/giga/deps/xevm/state/nonce.go
+++ b/giga/deps/xevm/state/nonce.go
@@ -10,10 +10,12 @@ func (s *DBImpl) GetNonce(addr common.Address) uint64 {
 }
 
 func (s *DBImpl) SetNonce(addr common.Address, nonce uint64, reason tracing.NonceChangeReason) {
+	prevNonce := s.GetNonce(addr)
 	if s.logger != nil && s.logger.OnNonceChange != nil {
 		// The SetCode method could be modified to return the old code/hash directly.
-		s.logger.OnNonceChangeV2(addr, s.GetNonce(addr), nonce, reason)
+		s.logger.OnNonceChangeV2(addr, prevNonce, nonce, reason)
 	}
 
 	s.k.SetNonce(s.ctx, addr, nonce)
+	s.journal = append(s.journal, &nonceChange{addr: addr, prev: prevNonce})
 }

--- a/giga/deps/xevm/state/nonce.go
+++ b/giga/deps/xevm/state/nonce.go
@@ -11,7 +11,7 @@ func (s *DBImpl) GetNonce(addr common.Address) uint64 {
 
 func (s *DBImpl) SetNonce(addr common.Address, nonce uint64, reason tracing.NonceChangeReason) {
 	prevNonce := s.GetNonce(addr)
-	if s.logger != nil && s.logger.OnNonceChange != nil {
+	if s.logger != nil && s.logger.OnNonceChangeV2 != nil {
 		// The SetCode method could be modified to return the old code/hash directly.
 		s.logger.OnNonceChangeV2(addr, prevNonce, nonce, reason)
 	}

--- a/giga/deps/xevm/state/snapshot_test.go
+++ b/giga/deps/xevm/state/snapshot_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -13,6 +12,7 @@ import (
 	testkeeper "github.com/sei-protocol/sei-chain/giga/deps/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/giga/deps/xevm/state"
 	"github.com/sei-protocol/sei-chain/giga/deps/xevm/types"
+	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	"github.com/stretchr/testify/require"
 )
 

--- a/giga/deps/xevm/state/snapshot_test.go
+++ b/giga/deps/xevm/state/snapshot_test.go
@@ -568,6 +568,64 @@ func TestSnapshotReverts_Logs(t *testing.T) {
 }
 
 // ----------------------------------------------------------------------------
+// Finalize emits events from all surviving snapshots
+// ----------------------------------------------------------------------------
+
+func TestFinalize_EmitsEventsFromAllSurvivingSnapshots(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	before := len(ctx.EventManager().Events())
+
+	// Emit one event before any snapshot.
+	sdb.Ctx().EventManager().EmitEvent(sdk.NewEvent("e0"))
+
+	// Snapshot; emit; snapshot again; emit — no reverts.
+	sdb.Snapshot()
+	sdb.Ctx().EventManager().EmitEvent(sdk.NewEvent("e1"))
+
+	sdb.Snapshot()
+	sdb.Ctx().EventManager().EmitEvent(sdk.NewEvent("e2"))
+
+	_, err := sdb.Finalize()
+	require.NoError(t, err)
+
+	// All three events must reach the outer ctx.
+	after := len(ctx.EventManager().Events())
+	require.Equal(t, before+3, after)
+}
+
+// ----------------------------------------------------------------------------
+// CleanupForTracer resets state and allows snapshotting afterward
+// ----------------------------------------------------------------------------
+
+func TestCleanupForTracer_SnapshotWorksAfterCleanup(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	_, evmAddr := testkeeper.MockAddressPair()
+	key := common.BytesToHash([]byte("slot"))
+	val := common.BytesToHash([]byte("v1"))
+
+	// Do some work, then clean up for the tracer.
+	sdb.SetState(evmAddr, key, val)
+	sdb.CleanupForTracer()
+
+	// After CleanupForTracer the stateDB is reset; the write above is gone.
+	require.Equal(t, common.Hash{}, sdb.GetState(evmAddr, key))
+
+	// Snapshot/revert must work correctly after CleanupForTracer.
+	rev := sdb.Snapshot()
+	sdb.SetState(evmAddr, key, val)
+	require.Equal(t, val, sdb.GetState(evmAddr, key))
+
+	sdb.RevertToSnapshot(rev)
+	require.Equal(t, common.Hash{}, sdb.GetState(evmAddr, key))
+}
+
+// ----------------------------------------------------------------------------
 // Multiple reverts to the same (outer) snapshot, skipping an inner one
 // ----------------------------------------------------------------------------
 

--- a/giga/deps/xevm/state/snapshot_test.go
+++ b/giga/deps/xevm/state/snapshot_test.go
@@ -1,0 +1,594 @@
+package state_test
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+	testkeeper "github.com/sei-protocol/sei-chain/giga/deps/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/giga/deps/xevm/state"
+	"github.com/sei-protocol/sei-chain/giga/deps/xevm/types"
+	"github.com/stretchr/testify/require"
+)
+
+// ----------------------------------------------------------------------------
+// KV-state revert: SetState / storageChange
+// ----------------------------------------------------------------------------
+
+func TestSnapshotReverts_Storage(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	_, evmAddr := testkeeper.MockAddressPair()
+	key := common.BytesToHash([]byte("slot"))
+	val1 := common.BytesToHash([]byte("v1"))
+	val2 := common.BytesToHash([]byte("v2"))
+
+	sdb.SetState(evmAddr, key, val1)
+	require.Equal(t, val1, sdb.GetState(evmAddr, key))
+
+	rev := sdb.Snapshot()
+	sdb.SetState(evmAddr, key, val2)
+	require.Equal(t, val2, sdb.GetState(evmAddr, key))
+
+	sdb.RevertToSnapshot(rev)
+	require.Equal(t, val1, sdb.GetState(evmAddr, key))
+}
+
+func TestSnapshotReverts_StorageToZero(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	_, evmAddr := testkeeper.MockAddressPair()
+	key := common.BytesToHash([]byte("slot"))
+	val := common.BytesToHash([]byte("v1"))
+
+	sdb.SetState(evmAddr, key, val)
+	rev := sdb.Snapshot()
+
+	// Overwrite with zero (deletes the KV entry)
+	sdb.SetState(evmAddr, key, common.Hash{})
+	require.Equal(t, common.Hash{}, sdb.GetState(evmAddr, key))
+
+	sdb.RevertToSnapshot(rev)
+	// Slot should be restored to non-zero
+	require.Equal(t, val, sdb.GetState(evmAddr, key))
+}
+
+func TestSnapshotReverts_MultipleStorageSlots(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	_, evmAddr := testkeeper.MockAddressPair()
+	keyA := common.BytesToHash([]byte("A"))
+	keyB := common.BytesToHash([]byte("B"))
+	valA := common.BytesToHash([]byte("valA"))
+	valB := common.BytesToHash([]byte("valB"))
+
+	sdb.SetState(evmAddr, keyA, valA)
+
+	rev := sdb.Snapshot()
+	sdb.SetState(evmAddr, keyA, common.BytesToHash([]byte("new")))
+	sdb.SetState(evmAddr, keyB, valB)
+
+	sdb.RevertToSnapshot(rev)
+	require.Equal(t, valA, sdb.GetState(evmAddr, keyA))
+	require.Equal(t, common.Hash{}, sdb.GetState(evmAddr, keyB))
+}
+
+// ----------------------------------------------------------------------------
+// KV-state revert: SetCode / codeChange
+// ----------------------------------------------------------------------------
+
+func TestSnapshotReverts_Code(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	_, evmAddr := testkeeper.MockAddressPair()
+
+	sdb.SetCode(evmAddr, []byte("v1"))
+	require.Equal(t, []byte("v1"), sdb.GetCode(evmAddr))
+
+	rev := sdb.Snapshot()
+	sdb.SetCode(evmAddr, []byte("v2"))
+	require.Equal(t, []byte("v2"), sdb.GetCode(evmAddr))
+
+	sdb.RevertToSnapshot(rev)
+	require.Equal(t, []byte("v1"), sdb.GetCode(evmAddr))
+}
+
+func TestSnapshotReverts_CodeToEmpty(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	_, evmAddr := testkeeper.MockAddressPair()
+
+	// No code initially; snapshot; set code; revert → no code again.
+	rev := sdb.Snapshot()
+	sdb.SetCode(evmAddr, []byte("deployed"))
+	require.Equal(t, []byte("deployed"), sdb.GetCode(evmAddr))
+	require.NotZero(t, sdb.GetCodeSize(evmAddr))
+
+	sdb.RevertToSnapshot(rev)
+	require.Nil(t, sdb.GetCode(evmAddr))
+	require.Zero(t, sdb.GetCodeSize(evmAddr))
+}
+
+// ----------------------------------------------------------------------------
+// KV-state revert: SetNonce / nonceChange
+// ----------------------------------------------------------------------------
+
+func TestSnapshotReverts_Nonce(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	_, evmAddr := testkeeper.MockAddressPair()
+
+	sdb.SetNonce(evmAddr, 5, tracing.NonceChangeUnspecified)
+	rev := sdb.Snapshot()
+
+	sdb.SetNonce(evmAddr, 10, tracing.NonceChangeUnspecified)
+	require.EqualValues(t, 10, sdb.GetNonce(evmAddr))
+
+	sdb.RevertToSnapshot(rev)
+	require.EqualValues(t, 5, sdb.GetNonce(evmAddr))
+}
+
+// ----------------------------------------------------------------------------
+// Balance revert: AddBalance / SubBalance / balanceChange
+// ----------------------------------------------------------------------------
+
+func TestSnapshotReverts_AddBalance(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	seiAddr, evmAddr := testkeeper.MockAddressPair()
+	k.SetAddressMapping(ctx, seiAddr, evmAddr)
+
+	// Fund the account first (outside stateDB so it's in committed state)
+	amt := sdk.NewCoins(sdk.NewCoin(k.GetBaseDenom(ctx), sdk.NewInt(1000)))
+	require.NoError(t, k.BankKeeper().MintCoins(sdb.Ctx(), types.ModuleName, amt))
+	require.NoError(t, k.BankKeeper().SendCoinsFromModuleToAccount(sdb.Ctx(), types.ModuleName, seiAddr, amt))
+
+	balanceBefore := sdb.GetBalance(evmAddr)
+	rev := sdb.Snapshot()
+
+	// Add 1 usei worth of wei (1e12 wei)
+	oneUsei := uint256.NewInt(1_000_000_000_000)
+	sdb.AddBalance(evmAddr, oneUsei, tracing.BalanceChangeUnspecified)
+	require.Nil(t, sdb.Err())
+	require.Equal(t, new(big.Int).Add(balanceBefore.ToBig(), oneUsei.ToBig()), sdb.GetBalance(evmAddr).ToBig())
+
+	sdb.RevertToSnapshot(rev)
+	require.Equal(t, balanceBefore.ToBig(), sdb.GetBalance(evmAddr).ToBig())
+}
+
+func TestSnapshotReverts_SubBalance(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	seiAddr, evmAddr := testkeeper.MockAddressPair()
+	k.SetAddressMapping(ctx, seiAddr, evmAddr)
+
+	// Fund with 10 usei
+	amt := sdk.NewCoins(sdk.NewCoin(k.GetBaseDenom(ctx), sdk.NewInt(10)))
+	require.NoError(t, k.BankKeeper().MintCoins(sdb.Ctx(), types.ModuleName, amt))
+	require.NoError(t, k.BankKeeper().SendCoinsFromModuleToAccount(sdb.Ctx(), types.ModuleName, seiAddr, amt))
+
+	balanceBefore := sdb.GetBalance(evmAddr)
+	rev := sdb.Snapshot()
+
+	oneUsei := uint256.NewInt(1_000_000_000_000)
+	sdb.SubBalance(evmAddr, oneUsei, tracing.BalanceChangeUnspecified)
+	require.Nil(t, sdb.Err())
+	require.Equal(t, new(big.Int).Sub(balanceBefore.ToBig(), oneUsei.ToBig()), sdb.GetBalance(evmAddr).ToBig())
+
+	sdb.RevertToSnapshot(rev)
+	require.Equal(t, balanceBefore.ToBig(), sdb.GetBalance(evmAddr).ToBig())
+}
+
+// ----------------------------------------------------------------------------
+// Account creation: createAccountChange (clearAccountStateJournaled)
+// ----------------------------------------------------------------------------
+
+func TestSnapshotReverts_CreateAccount_ClearsAndRestores(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	_, evmAddr := testkeeper.MockAddressPair()
+	key := common.BytesToHash([]byte("slot"))
+	val := common.BytesToHash([]byte("v"))
+
+	// Set up code + storage so the account has state to clear.
+	sdb.SetCode(evmAddr, []byte("existing_code"))
+	sdb.SetState(evmAddr, key, val)
+	sdb.SetNonce(evmAddr, 3, tracing.NonceChangeUnspecified)
+
+	rev := sdb.Snapshot()
+
+	// CreateAccount clears the existing state.
+	sdb.CreateAccount(evmAddr)
+	require.Nil(t, sdb.GetCode(evmAddr))
+	require.Equal(t, common.Hash{}, sdb.GetState(evmAddr, key))
+	require.EqualValues(t, 0, sdb.GetNonce(evmAddr))
+
+	// After revert, old code/storage/nonce must come back.
+	sdb.RevertToSnapshot(rev)
+	require.Equal(t, []byte("existing_code"), sdb.GetCode(evmAddr))
+	require.Equal(t, val, sdb.GetState(evmAddr, key))
+	require.EqualValues(t, 3, sdb.GetNonce(evmAddr))
+}
+
+func TestSnapshotReverts_CreateAccountOnFreshAddress_NoOp(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	_, evmAddr := testkeeper.MockAddressPair()
+
+	// Address has no prior state; CreateAccount should not panic.
+	rev := sdb.Snapshot()
+	sdb.CreateAccount(evmAddr)
+	sdb.RevertToSnapshot(rev)
+	// No assertion needed; just verify no panic and code is still absent.
+	require.Nil(t, sdb.GetCode(evmAddr))
+}
+
+// ----------------------------------------------------------------------------
+// SelfDestruct: deleteMappingChange
+// ----------------------------------------------------------------------------
+
+func TestSnapshotReverts_SelfDestruct_RestoreMapping(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	seiAddr, evmAddr := testkeeper.MockAddressPair()
+	k.SetAddressMapping(ctx, seiAddr, evmAddr)
+
+	// Confirm mapping exists.
+	got, ok := k.GetSeiAddress(sdb.Ctx(), evmAddr)
+	require.True(t, ok)
+	require.Equal(t, seiAddr, got)
+
+	sdb.CreateAccount(evmAddr)
+	sdb.MarkAccount(evmAddr, state.AccountCreated)
+
+	rev := sdb.Snapshot()
+	sdb.SelfDestruct(evmAddr)
+
+	// After SelfDestruct the mapping must be gone.
+	_, ok = k.GetSeiAddress(sdb.Ctx(), evmAddr)
+	require.False(t, ok)
+
+	sdb.RevertToSnapshot(rev)
+
+	// After revert the mapping must be restored.
+	got2, ok2 := k.GetSeiAddress(sdb.Ctx(), evmAddr)
+	require.True(t, ok2)
+	require.Equal(t, seiAddr, got2)
+}
+
+// ----------------------------------------------------------------------------
+// GetCommittedState: reads pre-stateDB state (bypasses stateDB's CMS)
+// ----------------------------------------------------------------------------
+
+func TestGetCommittedState_PreservesOriginal(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	_, evmAddr := testkeeper.MockAddressPair()
+	key := common.BytesToHash([]byte("slot"))
+
+	// SetState writes to the stateDB's CMS; GetCommittedState reads below it.
+	sdb.SetState(evmAddr, key, common.BytesToHash([]byte("v1")))
+	require.Equal(t, common.Hash{}, sdb.GetCommittedState(evmAddr, key))
+
+	rev := sdb.Snapshot()
+	sdb.SetState(evmAddr, key, common.BytesToHash([]byte("v2")))
+	require.Equal(t, common.Hash{}, sdb.GetCommittedState(evmAddr, key))
+
+	sdb.RevertToSnapshot(rev)
+	require.Equal(t, common.Hash{}, sdb.GetCommittedState(evmAddr, key))
+}
+
+// ----------------------------------------------------------------------------
+// Nested snapshots
+// ----------------------------------------------------------------------------
+
+func TestNestedSnapshots_InnerRevertOuterCommit(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	_, evmAddr := testkeeper.MockAddressPair()
+	key := common.BytesToHash([]byte("k"))
+	v1 := common.BytesToHash([]byte("v1"))
+	v2 := common.BytesToHash([]byte("v2"))
+	v3 := common.BytesToHash([]byte("v3"))
+
+	sdb.SetState(evmAddr, key, v1)
+	outer := sdb.Snapshot()
+
+	sdb.SetState(evmAddr, key, v2)
+	inner := sdb.Snapshot()
+
+	sdb.SetState(evmAddr, key, v3)
+
+	// Revert inner only.
+	sdb.RevertToSnapshot(inner)
+	require.Equal(t, v2, sdb.GetState(evmAddr, key))
+
+	// Revert outer.
+	sdb.RevertToSnapshot(outer)
+	require.Equal(t, v1, sdb.GetState(evmAddr, key))
+}
+
+func TestNestedSnapshots_BothReverted(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	_, evmAddr := testkeeper.MockAddressPair()
+	key := common.BytesToHash([]byte("k"))
+
+	outer := sdb.Snapshot()
+
+	sdb.SetState(evmAddr, key, common.BytesToHash([]byte("a")))
+	inner := sdb.Snapshot()
+	sdb.SetState(evmAddr, key, common.BytesToHash([]byte("b")))
+
+	// Revert inner, then outer.
+	sdb.RevertToSnapshot(inner)
+	sdb.RevertToSnapshot(outer)
+	require.Equal(t, common.Hash{}, sdb.GetState(evmAddr, key))
+}
+
+func TestNestedSnapshots_MultipleTypes(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	_, evmAddr := testkeeper.MockAddressPair()
+	key := common.BytesToHash([]byte("slot"))
+	tkey := common.BytesToHash([]byte("tslot"))
+
+	sdb.SetState(evmAddr, key, common.BytesToHash([]byte("s1")))
+	sdb.SetTransientState(evmAddr, tkey, common.BytesToHash([]byte("t1")))
+	sdb.SetNonce(evmAddr, 1, tracing.NonceChangeUnspecified)
+
+	rev := sdb.Snapshot()
+
+	sdb.SetState(evmAddr, key, common.BytesToHash([]byte("s2")))
+	sdb.SetTransientState(evmAddr, tkey, common.BytesToHash([]byte("t2")))
+	sdb.SetNonce(evmAddr, 2, tracing.NonceChangeUnspecified)
+	sdb.SetCode(evmAddr, []byte("code"))
+
+	sdb.RevertToSnapshot(rev)
+
+	require.Equal(t, common.BytesToHash([]byte("s1")), sdb.GetState(evmAddr, key))
+	require.Equal(t, common.BytesToHash([]byte("t1")), sdb.GetTransientState(evmAddr, tkey))
+	require.EqualValues(t, 1, sdb.GetNonce(evmAddr))
+	require.Nil(t, sdb.GetCode(evmAddr))
+}
+
+// ----------------------------------------------------------------------------
+// Event manager isolation: reverted events must not surface at Finalize
+// ----------------------------------------------------------------------------
+
+func TestSnapshotReverts_EventsDiscarded(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	before := len(ctx.EventManager().Events())
+
+	// Emit one event before snapshot.
+	sdb.Ctx().EventManager().EmitEvent(sdk.NewEvent("pre"))
+
+	rev := sdb.Snapshot()
+	// Emit one event inside snapshot.
+	sdb.Ctx().EventManager().EmitEvent(sdk.NewEvent("inside"))
+
+	sdb.RevertToSnapshot(rev)
+
+	_, err := sdb.Finalize()
+	require.NoError(t, err)
+
+	// Only the pre-snapshot event should reach the outer ctx.
+	after := len(ctx.EventManager().Events())
+	require.Equal(t, before+1, after)
+}
+
+func TestSnapshotReverts_EventsPreservedAcrossNestedReverts(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	before := len(ctx.EventManager().Events())
+
+	sdb.Ctx().EventManager().EmitEvent(sdk.NewEvent("e0"))
+
+	outer := sdb.Snapshot()
+	sdb.Ctx().EventManager().EmitEvent(sdk.NewEvent("e1"))
+
+	inner := sdb.Snapshot()
+	sdb.Ctx().EventManager().EmitEvent(sdk.NewEvent("e2"))
+
+	sdb.RevertToSnapshot(inner)
+	sdb.Ctx().EventManager().EmitEvent(sdk.NewEvent("e3"))
+
+	sdb.RevertToSnapshot(outer)
+	sdb.Ctx().EventManager().EmitEvent(sdk.NewEvent("e4"))
+
+	_, err := sdb.Finalize()
+	require.NoError(t, err)
+
+	// e0 (pre-outer), e4 (post-revert of outer) survive; e1, e2, e3 reverted.
+	after := len(ctx.EventManager().Events())
+	require.Equal(t, before+2, after)
+}
+
+// ----------------------------------------------------------------------------
+// Snapshot IDs are monotonically increasing
+// ----------------------------------------------------------------------------
+
+func TestSnapshot_IDsMonotonicallyIncrease(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	id0 := sdb.Snapshot()
+	id1 := sdb.Snapshot()
+	id2 := sdb.Snapshot()
+
+	require.Less(t, id0, id1)
+	require.Less(t, id1, id2)
+}
+
+func TestSnapshot_InvalidRevisionPanics(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	require.Panics(t, func() { sdb.RevertToSnapshot(999) })
+}
+
+// ----------------------------------------------------------------------------
+// Isolation: uncommitted stateDB writes not visible to a second stateDB
+// ----------------------------------------------------------------------------
+
+func TestSnapshot_WritesNotVisibleBeforeFinalize(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	_, evmAddr := testkeeper.MockAddressPair()
+	key := common.BytesToHash([]byte("slot"))
+	val := common.BytesToHash([]byte("v"))
+
+	sdb.SetState(evmAddr, key, val)
+
+	// A fresh stateDB on the same underlying ctx should not see the write.
+	sdb2 := state.NewDBImpl(ctx, k, false)
+	require.Equal(t, common.Hash{}, sdb2.GetState(evmAddr, key))
+
+	_, err := sdb.Finalize()
+	require.NoError(t, err)
+
+	// After Finalize (CMS flushed), a new stateDB sees the value.
+	sdb3 := state.NewDBImpl(ctx, k, false)
+	require.Equal(t, val, sdb3.GetState(evmAddr, key))
+}
+
+// ----------------------------------------------------------------------------
+// Refund revert
+// ----------------------------------------------------------------------------
+
+func TestSnapshotReverts_Refund(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	sdb.AddRefund(100)
+	require.EqualValues(t, 100, sdb.GetRefund())
+
+	rev := sdb.Snapshot()
+	sdb.AddRefund(50)
+	require.EqualValues(t, 150, sdb.GetRefund())
+
+	sdb.RevertToSnapshot(rev)
+	require.EqualValues(t, 100, sdb.GetRefund())
+}
+
+// ----------------------------------------------------------------------------
+// Access list revert
+// ----------------------------------------------------------------------------
+
+func TestSnapshotReverts_AccessList(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	_, addr1 := testkeeper.MockAddressPair()
+	_, addr2 := testkeeper.MockAddressPair()
+	slot := common.BytesToHash([]byte("slot"))
+
+	sdb.AddAddressToAccessList(addr1)
+	require.True(t, sdb.AddressInAccessList(addr1))
+
+	rev := sdb.Snapshot()
+	sdb.AddAddressToAccessList(addr2)
+	sdb.AddSlotToAccessList(addr1, slot)
+
+	sdb.RevertToSnapshot(rev)
+
+	require.True(t, sdb.AddressInAccessList(addr1))
+	require.False(t, sdb.AddressInAccessList(addr2))
+	addrOk, slotOk := sdb.SlotInAccessList(addr1, slot)
+	require.True(t, addrOk)
+	require.False(t, slotOk)
+}
+
+// ----------------------------------------------------------------------------
+// Log revert
+// ----------------------------------------------------------------------------
+
+func TestSnapshotReverts_Logs(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	_, evmAddr := testkeeper.MockAddressPair()
+
+	sdb.AddLog(&ethtypes.Log{Address: evmAddr})
+	require.Len(t, sdb.GetAllLogs(), 1)
+
+	rev := sdb.Snapshot()
+	sdb.AddLog(&ethtypes.Log{Address: evmAddr})
+	require.Len(t, sdb.GetAllLogs(), 2)
+
+	sdb.RevertToSnapshot(rev)
+	require.Len(t, sdb.GetAllLogs(), 1)
+}
+
+// ----------------------------------------------------------------------------
+// Multiple reverts to the same (outer) snapshot, skipping an inner one
+// ----------------------------------------------------------------------------
+
+func TestSnapshotReverts_SkipInnerSnapshot(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	_, evmAddr := testkeeper.MockAddressPair()
+	key := common.BytesToHash([]byte("k"))
+	v1 := common.BytesToHash([]byte("v1"))
+	v2 := common.BytesToHash([]byte("v2"))
+
+	sdb.SetState(evmAddr, key, v1)
+	outer := sdb.Snapshot()
+
+	sdb.SetState(evmAddr, key, v2)
+	_ = sdb.Snapshot() // inner snapshot, not used
+	sdb.SetState(evmAddr, key, common.BytesToHash([]byte("v3")))
+
+	// Revert directly to outer, bypassing inner.
+	sdb.RevertToSnapshot(outer)
+	require.Equal(t, v1, sdb.GetState(evmAddr, key))
+}

--- a/giga/deps/xevm/state/state.go
+++ b/giga/deps/xevm/state/state.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"bytes"
+	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -13,25 +14,21 @@ import (
 )
 
 func (s *DBImpl) CreateAccount(acc common.Address) {
-	// clear any existing state but keep balance untouched
+	// clear any existing state but keep balance untouched, journaled for revert
 	if !s.ctx.IsTracing() {
 		// too slow on historical DB so not doing it for tracing for now.
 		// could cause tracing to be incorrect in theory.
-		s.clearAccountState(acc)
+		s.clearAccountStateJournaled(acc)
 	}
 	s.MarkAccount(acc, AccountCreated)
 }
 
 func (s *DBImpl) GetCommittedState(addr common.Address, hash common.Hash) common.Hash {
-	return s.getState(s.snapshottedCtxs[0], addr, hash)
+	return s.k.GetState(s.committedCtx, addr, hash)
 }
 
 func (s *DBImpl) GetState(addr common.Address, hash common.Hash) common.Hash {
-	return s.getState(s.ctx, addr, hash)
-}
-
-func (s *DBImpl) getState(ctx sdk.Context, addr common.Address, hash common.Hash) common.Hash {
-	return s.k.GetState(ctx, addr, hash)
+	return s.k.GetState(s.ctx, addr, hash)
 }
 
 func (s *DBImpl) SetState(addr common.Address, key common.Hash, val common.Hash) common.Hash {
@@ -41,6 +38,7 @@ func (s *DBImpl) SetState(addr common.Address, key common.Hash, val common.Hash)
 	}
 
 	s.k.SetState(s.ctx, addr, key, val)
+	s.journal = append(s.journal, &storageChange{addr: addr, key: key, prev: old})
 	return old
 }
 
@@ -74,6 +72,7 @@ func (s *DBImpl) SelfDestruct(acc common.Address) uint256.Int {
 	if seiAddr, ok := s.k.GetSeiAddress(s.ctx, acc); ok {
 		// remove the association
 		s.k.DeleteAddressMapping(s.ctx, seiAddr, acc)
+		s.journal = append(s.journal, &deleteMappingChange{evmAddr: acc, seiAddr: seiAddr})
 	}
 	b := s.GetBalance(acc)
 	s.SubBalance(acc, b, tracing.BalanceDecreaseSelfdestruct)
@@ -101,39 +100,46 @@ func (s *DBImpl) HasSelfDestructed(acc common.Address) bool {
 	return bytes.Equal(val, AccountDeleted)
 }
 
+// Snapshot records the current journal length as a revision and pushes the current
+// EventManager onto the stack, creating a fresh one for subsequent events.
 func (s *DBImpl) Snapshot() int {
-	newCtx := s.ctx.WithMultiStore(s.ctx.MultiStore().CacheMultiStore()).WithEventManager(sdk.NewEventManager())
-	s.snapshottedCtxs = append(s.snapshottedCtxs, s.ctx)
-	s.ctx = newCtx
-	version := len(s.snapshottedCtxs) - 1
-	s.journal = append(s.journal, &watermark{version: version})
-	return len(s.snapshottedCtxs) - 1
+	id := s.nextRevisionId
+	s.nextRevisionId++
+	s.validRevisions = append(s.validRevisions, revision{
+		id:           id,
+		journalIndex: len(s.journal),
+	})
+	// Push current EM and create a fresh one so reverted events are discarded.
+	s.snapshottedEventManagers = append(s.snapshottedEventManagers, s.ctx.EventManager())
+	s.ctx = s.ctx.WithEventManager(sdk.NewEventManager())
+	return id
 }
 
+// RevertToSnapshot reverts all journal entries back to the snapshot identified by rev,
+// restores the EventManager, and truncates the revision list.
 func (s *DBImpl) RevertToSnapshot(rev int) {
-	// Add bounds checking
-	if rev < 0 || rev >= len(s.snapshottedCtxs) {
+	// Binary-search for the revision with the given id (like go-ethereum).
+	idx := sort.Search(len(s.validRevisions), func(i int) bool {
+		return s.validRevisions[i].id >= rev
+	})
+	if idx == len(s.validRevisions) || s.validRevisions[idx].id != rev {
 		panic("invalid revision number")
 	}
+	snapshot := s.validRevisions[idx]
 
-	s.ctx = s.snapshottedCtxs[rev]
-	s.snapshottedCtxs = s.snapshottedCtxs[:rev]
-
-	// Find the watermark index to truncate the journal
-	watermarkIndex := -1
-	for i := len(s.journal) - 1; i >= 0; i-- {
-		entry := s.journal[i]
-		entry.revert(s)
-		if wm, ok := entry.(*watermark); ok && wm.version == rev {
-			watermarkIndex = i
-			break
-		}
+	// Revert journal entries in reverse order down to the snapshot point.
+	for i := len(s.journal) - 1; i >= snapshot.journalIndex; i-- {
+		s.journal[i].revert(s)
 	}
+	s.journal = s.journal[:snapshot.journalIndex]
 
-	// Truncate the journal to remove reverted entries
-	if watermarkIndex >= 0 {
-		s.journal = s.journal[:watermarkIndex]
-	}
+	// Restore the EventManager that was active when the snapshot was taken.
+	// snapshottedEventManagers has one entry per snapshot; idx corresponds to this snapshot.
+	s.ctx = s.ctx.WithEventManager(s.snapshottedEventManagers[idx])
+	s.snapshottedEventManagers = s.snapshottedEventManagers[:idx]
+
+	// Truncate the revision list (removing this snapshot and any taken after it).
+	s.validRevisions = s.validRevisions[:idx]
 }
 
 func (s *DBImpl) handleResidualFundsInDestructedAccounts(st *TemporaryState) {
@@ -162,6 +168,8 @@ func (s *DBImpl) clearAccountStateIfDestructed(st *TemporaryState) {
 	}
 }
 
+// clearAccountState unconditionally wipes code and storage for acc.
+// Used by Finalize (self-destruct cleanup) and SetStorage. NOT journaled.
 func (s *DBImpl) clearAccountState(acc common.Address) {
 	if deleteIfExists(s.k.PrefixStore(s.ctx, types.CodeHashKeyPrefix), acc[:]) {
 		s.k.PurgePrefix(s.ctx, types.StateKey(acc))
@@ -169,6 +177,51 @@ func (s *DBImpl) clearAccountState(acc common.Address) {
 		deleteIfExists(s.k.PrefixStore(s.ctx, types.CodeSizeKeyPrefix), acc[:])
 		deleteIfExists(s.k.PrefixStore(s.ctx, types.NonceKeyPrefix), acc[:])
 	}
+}
+
+// clearAccountStateJournaled wipes code, nonce, and storage for acc, recording
+// the previous values in the journal so a RevertToSnapshot can restore them.
+// Called from CreateAccount (when not tracing).
+func (s *DBImpl) clearAccountStateJournaled(acc common.Address) {
+	// Only clear if a code hash exists (mirrors clearAccountState logic).
+	codeHashStore := s.k.PrefixStore(s.ctx, types.CodeHashKeyPrefix)
+	if !codeHashStore.Has(acc[:]) {
+		return
+	}
+
+	// Save previous state for potential revert.
+	prevCode := s.k.GetCode(s.ctx, acc)
+	prevNonce := s.k.GetNonce(s.ctx, acc)
+
+	// Collect all storage slots for this account using GetAllKeyStrsInRange.
+	// The prefix store's GetAllKeyStrsInRange returns raw parent-store keys,
+	// so we strip the per-address state prefix to obtain each slot hash.
+	prevSlots := make(map[common.Hash]common.Hash)
+	statePrefix := types.StateKey(acc)
+	stateStore := s.k.PrefixStore(s.ctx, statePrefix)
+	rawKeys := stateStore.GetAllKeyStrsInRange(nil, nil)
+	prefixLen := len(statePrefix)
+	for _, raw := range rawKeys {
+		if len(raw) <= prefixLen {
+			continue
+		}
+		slotKey := common.BytesToHash([]byte(raw)[prefixLen:])
+		slotVal := s.k.GetState(s.ctx, acc, slotKey)
+		if slotVal != (common.Hash{}) {
+			prevSlots[slotKey] = slotVal
+		}
+	}
+
+	// Append journal entry before making changes.
+	s.journal = append(s.journal, &createAccountChange{
+		addr:      acc,
+		prevCode:  prevCode,
+		prevNonce: prevNonce,
+		prevSlots: prevSlots,
+	})
+
+	// Clear the account state.
+	s.clearAccountState(acc)
 }
 
 func (s *DBImpl) MarkAccount(acc common.Address, status []byte) {

--- a/giga/deps/xevm/state/state.go
+++ b/giga/deps/xevm/state/state.go
@@ -33,6 +33,9 @@ func (s *DBImpl) GetState(addr common.Address, hash common.Hash) common.Hash {
 
 func (s *DBImpl) SetState(addr common.Address, key common.Hash, val common.Hash) common.Hash {
 	old := s.GetState(addr, key)
+	if old == val {
+		return old
+	}
 	if s.logger != nil && s.logger.OnStorageChange != nil {
 		s.logger.OnStorageChange(addr, key, old, val)
 	}

--- a/giga/deps/xevm/state/state_test.go
+++ b/giga/deps/xevm/state/state_test.go
@@ -271,3 +271,27 @@ func TestTransientStorageRevertNilMapPanic(t *testing.T) {
 	// After revert, the transient state should be restored to value1
 	require.Equal(t, value1, statedb.GetTransientState(evmAddr, tkey))
 }
+
+// TestSetState_NoopDedup verifies that writing the same value to a slot does not
+// append a journal entry, matching go-ethereum's behaviour.
+func TestSetState_NoopDedup(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	_, evmAddr := testkeeper.MockAddressPair()
+	sdb := state.NewDBImpl(ctx, k, false)
+
+	key := common.BytesToHash([]byte("k"))
+	val := common.BytesToHash([]byte("v"))
+
+	sdb.SetState(evmAddr, key, val)
+	rev := sdb.Snapshot()
+
+	// Write the same value N times — should produce zero new journal entries.
+	for range 5 {
+		sdb.SetState(evmAddr, key, val)
+	}
+
+	// Reverting must still leave the slot at val (not cleared to zero).
+	sdb.RevertToSnapshot(rev)
+	require.Equal(t, val, sdb.GetState(evmAddr, key))
+}

--- a/giga/deps/xevm/state/statedb.go
+++ b/giga/deps/xevm/state/statedb.go
@@ -117,6 +117,7 @@ func (s *DBImpl) CleanupForTracer() {
 	// Re-create the CMS layer for the tracer.
 	s.committedCtx = s.ctx
 	s.ctx = s.ctx.WithMultiStore(s.ctx.MultiStore().CacheMultiStore()).WithEventManager(sdk.NewEventManager())
+	s.Snapshot()
 }
 
 // ResetForTracer resets in-memory state for a new transaction without flushing

--- a/giga/deps/xevm/state/statedb.go
+++ b/giga/deps/xevm/state/statedb.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"maps"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/stateless"
@@ -17,8 +19,17 @@ var logger = seilog.NewLogger("giga", "deps", "xevm", "state")
 
 // Initialized for each transaction individually
 type DBImpl struct {
-	ctx             sdk.Context
-	snapshottedCtxs []sdk.Context
+	// ctx is the single CacheMultiStore context used for all KV mutations within this stateDB.
+	ctx sdk.Context
+	// committedCtx is the pre-stateDB context, used for GetCommittedState reads and event flushing.
+	committedCtx sdk.Context
+
+	// validRevisions tracks snapshot points (journal index) for RevertToSnapshot.
+	validRevisions []revision
+	nextRevisionId int
+
+	// snapshottedEventManagers holds EMs from prior snapshots that survived (not reverted).
+	snapshottedEventManagers []*sdk.EventManager
 
 	tempState *TemporaryState
 	journal   []journalEntry
@@ -47,17 +58,21 @@ type DBImpl struct {
 
 func NewDBImpl(ctx sdk.Context, k EVMKeeper, simulation bool) *DBImpl {
 	feeCollector, _ := k.GetFeeCollectorAddress(ctx)
+	// Create a single CacheMultiStore layer for all KV mutations within this stateDB.
+	cacheCtx := ctx.WithMultiStore(ctx.MultiStore().CacheMultiStore()).WithEventManager(sdk.NewEventManager())
 	s := &DBImpl{
-		ctx:                ctx,
-		k:                  k,
-		snapshottedCtxs:    []sdk.Context{},
-		coinbaseAddress:    GetCoinbaseAddress(ctx.TxIndex()),
-		simulation:         simulation,
-		tempState:          NewTemporaryState(),
-		journal:            []journalEntry{},
-		coinbaseEvmAddress: feeCollector,
+		ctx:                      cacheCtx,
+		committedCtx:             ctx,
+		k:                        k,
+		validRevisions:           []revision{},
+		snapshottedEventManagers: []*sdk.EventManager{},
+		coinbaseAddress:          GetCoinbaseAddress(ctx.TxIndex()),
+		simulation:               simulation,
+		tempState:                NewTemporaryState(),
+		journal:                  []journalEntry{},
+		coinbaseEvmAddress:       feeCollector,
 	}
-	s.Snapshot() // take an initial snapshot for GetCommitted
+	s.Snapshot()
 	return s
 }
 
@@ -85,20 +100,23 @@ func (s *DBImpl) AddPreimage(_ common.Hash, _ []byte) {}
 func (s *DBImpl) Cleanup() {
 	s.tempState = nil
 	s.logger = nil
-	s.snapshottedCtxs = nil
+	s.snapshottedEventManagers = nil
+	s.validRevisions = nil
 }
 
 func (s *DBImpl) CleanupForTracer() {
-	s.flushCtxs()
-	if len(s.snapshottedCtxs) > 0 {
-		s.ctx = s.snapshottedCtxs[0]
-	}
+	// Reset back to the committed (pre-stateDB) state by discarding the CMS layer.
+	s.ctx = s.committedCtx
 	feeCollector, _ := s.k.GetFeeCollectorAddress(s.Ctx())
 	s.coinbaseEvmAddress = feeCollector
 	s.tempState = NewTemporaryState()
 	s.journal = []journalEntry{}
-	s.snapshottedCtxs = []sdk.Context{}
-	s.Snapshot()
+	s.validRevisions = []revision{}
+	s.snapshottedEventManagers = []*sdk.EventManager{}
+	s.nextRevisionId = 0
+	// Re-create the CMS layer for the tracer.
+	s.committedCtx = s.ctx
+	s.ctx = s.ctx.WithMultiStore(s.ctx.MultiStore().CacheMultiStore()).WithEventManager(sdk.NewEventManager())
 }
 
 // ResetForTracer resets in-memory state for a new transaction without flushing
@@ -126,37 +144,18 @@ func (s *DBImpl) Finalize() (surplus sdk.Int, err error) {
 	s.handleResidualFundsInDestructedAccounts(s.tempState)
 	s.clearAccountStateIfDestructed(s.tempState)
 
-	s.flushCtxs()
-	// write all events in order
-	for i := 1; i < len(s.snapshottedCtxs); i++ {
-		s.flushEvents(s.snapshottedCtxs[i])
+	// Write the single CMS layer to the underlying store.
+	s.ctx.MultiStore().(sdk.CacheMultiStore).Write()
+	s.ctx.GigaMultiStore().WriteGiga()
+
+	// Emit all surviving events (from snapshots + current) to the committed ctx's EventManager.
+	for _, em := range s.snapshottedEventManagers {
+		s.committedCtx.EventManager().EmitEvents(em.Events())
 	}
-	s.flushEvents(s.ctx)
+	s.committedCtx.EventManager().EmitEvents(s.ctx.EventManager().Events())
 
 	surplus = s.tempState.surplus
 	return
-}
-
-func (s *DBImpl) flushCtxs() {
-	if len(s.snapshottedCtxs) == 0 {
-		return
-	}
-	// remove transient states
-	// write cache to underlying
-	s.flushCtx(s.ctx)
-	// write all snapshotted caches in reverse order, except the very first one (base) which will be written by baseapp::runTx
-	for i := len(s.snapshottedCtxs) - 1; i > 0; i-- {
-		s.flushCtx(s.snapshottedCtxs[i])
-	}
-}
-
-func (s *DBImpl) flushCtx(ctx sdk.Context) {
-	ctx.MultiStore().(sdk.CacheMultiStore).Write()
-	ctx.GigaMultiStore().WriteGiga()
-}
-
-func (s *DBImpl) flushEvents(ctx sdk.Context) {
-	s.snapshottedCtxs[0].EventManager().EmitEvents(ctx.EventManager().Events())
 }
 
 // Backward-compatibility functions
@@ -172,21 +171,25 @@ func (s *DBImpl) Copy() vm.StateDB {
 	newCtx := s.ctx.WithMultiStore(s.ctx.MultiStore().CacheMultiStore()).WithEventManager(sdk.NewEventManager())
 	journal := make([]journalEntry, len(s.journal))
 	copy(journal, s.journal)
-	snapshots := make([]sdk.Context, len(s.snapshottedCtxs)+1)
-	copy(snapshots, s.snapshottedCtxs)
-	snapshots[len(s.snapshottedCtxs)] = s.ctx
+	snapshottedEMs := make([]*sdk.EventManager, len(s.snapshottedEventManagers))
+	copy(snapshottedEMs, s.snapshottedEventManagers)
+	validRevisions := make([]revision, len(s.validRevisions))
+	copy(validRevisions, s.validRevisions)
 	return &DBImpl{
-		ctx:                newCtx,
-		snapshottedCtxs:    snapshots,
-		tempState:          s.tempState.DeepCopy(),
-		journal:            journal,
-		k:                  s.k,
-		coinbaseAddress:    s.coinbaseAddress,
-		coinbaseEvmAddress: s.coinbaseEvmAddress,
-		simulation:         s.simulation,
-		err:                s.err,
-		precompileErr:      s.precompileErr,
-		logger:             s.logger,
+		ctx:                      newCtx,
+		committedCtx:             s.committedCtx,
+		validRevisions:           validRevisions,
+		nextRevisionId:           s.nextRevisionId,
+		snapshottedEventManagers: snapshottedEMs,
+		tempState:                s.tempState.DeepCopy(),
+		journal:                  journal,
+		k:                        s.k,
+		coinbaseAddress:          s.coinbaseAddress,
+		coinbaseEvmAddress:       s.coinbaseEvmAddress,
+		simulation:               s.simulation,
+		err:                      s.err,
+		precompileErr:            s.precompileErr,
+		logger:                   s.logger,
 	}
 }
 
@@ -283,30 +286,22 @@ func (ts *TemporaryState) DeepCopy() *TemporaryState {
 	copy(res.logs, ts.logs)
 	res.transientStates = make(map[string]map[string]common.Hash, len(ts.transientStates))
 	for k, v := range ts.transientStates {
-		res.transientStates[k] = make(map[string]common.Hash, len(v))
-		for k2, v2 := range v {
-			res.transientStates[k][k2] = v2
-		}
+		dst := make(map[string]common.Hash, len(v))
+		maps.Copy(dst, v)
+		res.transientStates[k] = dst
 	}
 	res.transientAccounts = make(map[string][]byte, len(ts.transientAccounts))
-	for k, v := range ts.transientAccounts {
-		res.transientAccounts[k] = v
-	}
+	maps.Copy(res.transientAccounts, ts.transientAccounts)
 	res.transientModuleStates = make(map[string][]byte, len(ts.transientModuleStates))
-	for k, v := range ts.transientModuleStates {
-		res.transientModuleStates[k] = v
-	}
+	maps.Copy(res.transientModuleStates, ts.transientModuleStates)
 	res.transientAccessLists = &accessList{}
 	res.transientAccessLists.Addresses = make(map[common.Address]int, len(ts.transientAccessLists.Addresses))
-	for k, v := range ts.transientAccessLists.Addresses {
-		res.transientAccessLists.Addresses[k] = v
-	}
+	maps.Copy(res.transientAccessLists.Addresses, ts.transientAccessLists.Addresses)
 	res.transientAccessLists.Slots = make([]map[common.Hash]struct{}, len(ts.transientAccessLists.Slots))
 	for i, v := range ts.transientAccessLists.Slots {
-		res.transientAccessLists.Slots[i] = make(map[common.Hash]struct{}, len(v))
-		for k2, v2 := range v {
-			res.transientAccessLists.Slots[i][k2] = v2
-		}
+		dst := make(map[common.Hash]struct{}, len(v))
+		maps.Copy(dst, v)
+		res.transientAccessLists.Slots[i] = dst
 	}
 	res.surplus = sdk.NewIntFromBigInt(ts.surplus.BigInt())
 	return res

--- a/giga/deps/xevm/state/statedb_internal_test.go
+++ b/giga/deps/xevm/state/statedb_internal_test.go
@@ -1,0 +1,192 @@
+package state_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+	testkeeper "github.com/sei-protocol/sei-chain/giga/deps/testutil/keeper"
+	evmkeeper "github.com/sei-protocol/sei-chain/giga/deps/xevm/keeper"
+	"github.com/sei-protocol/sei-chain/giga/deps/xevm/state"
+	evmtypes "github.com/sei-protocol/sei-chain/giga/deps/xevm/types"
+	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	"github.com/stretchr/testify/require"
+)
+
+type recipientCheckerRegistrar interface {
+	RegisterRecipientChecker(func(sdk.Context, sdk.AccAddress) bool)
+}
+
+func newMappedStateDB(t *testing.T) (*state.DBImpl, *evmkeeper.Keeper, sdk.AccAddress, common.Address) {
+	t.Helper()
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	seiAddr, evmAddr := testkeeper.MockAddressPair()
+	db := state.NewDBImpl(ctx, k, false)
+	k.SetAddressMapping(db.Ctx(), seiAddr, evmAddr)
+	return db, k, seiAddr, evmAddr
+}
+
+func fundUsei(t *testing.T, k *evmkeeper.Keeper, ctx sdk.Context, seiAddr sdk.AccAddress, amount int64) {
+	t.Helper()
+	coins := sdk.NewCoins(sdk.NewCoin(k.GetBaseDenom(ctx), sdk.NewInt(amount)))
+	require.NoError(t, k.BankKeeper().MintCoins(ctx, evmtypes.ModuleName, coins))
+	require.NoError(t, k.BankKeeper().SendCoinsFromModuleToAccount(ctx, evmtypes.ModuleName, seiAddr, coins))
+}
+
+func TestSetNonceCallsV2LoggerWithPreviousNonce(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	db := state.NewDBImpl(ctx, k, false)
+	_, evmAddr := testkeeper.MockAddressPair()
+
+	db.SetNonce(evmAddr, 7, tracing.NonceChangeUnspecified)
+
+	var gotAddr common.Address
+	var gotPrev, gotNew uint64
+	var gotReason tracing.NonceChangeReason
+	db.SetLogger(&tracing.Hooks{
+		OnNonceChangeV2: func(addr common.Address, prev, new uint64, reason tracing.NonceChangeReason) {
+			gotAddr = addr
+			gotPrev = prev
+			gotNew = new
+			gotReason = reason
+		},
+	})
+
+	db.SetNonce(evmAddr, 9, tracing.NonceChangeEoACall)
+
+	require.Equal(t, evmAddr, gotAddr)
+	require.EqualValues(t, 7, gotPrev)
+	require.EqualValues(t, 9, gotNew)
+	require.Equal(t, tracing.NonceChangeEoACall, gotReason)
+}
+
+func TestCleanupClearsSnapshotBookkeeping(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	db := state.NewDBImpl(ctx, k, false)
+	db.Snapshot()
+
+	require.NotPanics(t, db.Cleanup)
+}
+
+func TestCopyDeepCopiesJournalSnapshotState(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	db := state.NewDBImpl(ctx, k, false)
+	_, evmAddr := testkeeper.MockAddressPair()
+	slot := common.BytesToHash([]byte("slot"))
+	transientValue := common.BytesToHash([]byte("transient"))
+	copyErr := errors.New("copy me")
+	precompileErr := errors.New("precompile")
+
+	db.Ctx().EventManager().EmitEvent(sdk.NewEvent("before-copy"))
+	db.Snapshot()
+	db.SetTransientState(evmAddr, slot, transientValue)
+	db.MarkAccount(evmAddr, state.AccountCreated)
+	db.AddRefund(5)
+	db.AddSlotToAccessList(evmAddr, slot)
+	db.AddLog(&ethtypes.Log{Address: evmAddr})
+	db.AddBalance(evmAddr, uint256.NewInt(7), tracing.BalanceChangeUnspecified)
+	db.WithErr(copyErr)
+	db.SetPrecompileError(precompileErr)
+
+	copied, ok := db.Copy().(*state.DBImpl)
+	require.True(t, ok)
+	require.Equal(t, copyErr, copied.Err())
+	require.Equal(t, precompileErr, copied.GetPrecompileError())
+	require.Equal(t, transientValue, copied.GetTransientState(evmAddr, slot))
+	require.True(t, copied.Created(evmAddr))
+	require.True(t, copied.AddressInAccessList(evmAddr))
+	_, slotOK := copied.SlotInAccessList(evmAddr, slot)
+	require.True(t, slotOK)
+	require.EqualValues(t, 5, copied.GetRefund())
+	require.Len(t, copied.GetAllLogs(), 1)
+	require.Equal(t, uint256.NewInt(7), copied.GetBalance(evmAddr))
+
+	db.SetTransientState(evmAddr, slot, common.Hash{1})
+	db.MarkAccount(evmAddr, state.AccountDeleted)
+	db.AddRefund(3)
+	db.AddSlotToAccessList(evmAddr, common.Hash{2})
+	db.AddLog(&ethtypes.Log{Address: common.Address{3}})
+	db.AddBalance(evmAddr, uint256.NewInt(1), tracing.BalanceChangeUnspecified)
+
+	require.Equal(t, transientValue, copied.GetTransientState(evmAddr, slot))
+	require.True(t, copied.Created(evmAddr))
+	require.EqualValues(t, 5, copied.GetRefund())
+	require.Len(t, copied.GetAllLogs(), 1)
+	_, ok = copied.SlotInAccessList(evmAddr, common.Hash{2})
+	require.False(t, ok)
+}
+
+func TestCreateAccountSkipsMalformedRawStorageKey(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	db := state.NewDBImpl(ctx, k, false)
+	_, evmAddr := testkeeper.MockAddressPair()
+
+	db.SetCode(evmAddr, []byte("code"))
+	k.GetKVStore(db.Ctx()).Set(evmtypes.StateKey(evmAddr), []byte{1})
+
+	require.NotPanics(t, func() { db.CreateAccount(evmAddr) })
+}
+
+func TestSnapshotRevertBalancePanicsOnBankErrors(t *testing.T) {
+	t.Run("sub unlocked coins", func(t *testing.T) {
+		db, k, seiAddr, evmAddr := newMappedStateDB(t)
+		coins := sdk.NewCoins(sdk.NewCoin(k.GetBaseDenom(db.Ctx()), sdk.NewInt(1)))
+
+		rev := db.Snapshot()
+		db.AddBalance(evmAddr, uint256.NewInt(1_000_000_000_000), tracing.BalanceChangeUnspecified)
+		require.NoError(t, db.Err())
+		require.NoError(t, k.BankKeeper().SubUnlockedCoins(db.Ctx(), seiAddr, coins, true))
+
+		require.Panics(t, func() { db.RevertToSnapshot(rev) })
+	})
+
+	t.Run("sub wei", func(t *testing.T) {
+		db, k, seiAddr, evmAddr := newMappedStateDB(t)
+
+		rev := db.Snapshot()
+		db.AddBalance(evmAddr, uint256.NewInt(1), tracing.BalanceChangeUnspecified)
+		require.NoError(t, db.Err())
+		require.NoError(t, k.BankKeeper().SubWei(db.Ctx(), seiAddr, sdk.NewInt(1)))
+
+		require.Panics(t, func() { db.RevertToSnapshot(rev) })
+	})
+
+	t.Run("add coins", func(t *testing.T) {
+		db, k, seiAddr, evmAddr := newMappedStateDB(t)
+		fundUsei(t, k, db.Ctx(), seiAddr, 1)
+
+		rev := db.Snapshot()
+		db.SubBalance(evmAddr, uint256.NewInt(1_000_000_000_000), tracing.BalanceChangeUnspecified)
+		require.NoError(t, db.Err())
+		registrar := k.BankKeeper().(recipientCheckerRegistrar)
+		registrar.RegisterRecipientChecker(func(sdk.Context, sdk.AccAddress) bool { return false })
+
+		require.Panics(t, func() { db.RevertToSnapshot(rev) })
+	})
+
+	t.Run("add wei", func(t *testing.T) {
+		db, k, seiAddr, evmAddr := newMappedStateDB(t)
+		require.NoError(t, k.BankKeeper().AddWei(db.Ctx(), seiAddr, sdk.NewInt(1)))
+
+		rev := db.Snapshot()
+		db.SubBalance(evmAddr, uint256.NewInt(1), tracing.BalanceChangeUnspecified)
+		require.NoError(t, db.Err())
+		registrar := k.BankKeeper().(recipientCheckerRegistrar)
+		calls := 0
+		registrar.RegisterRecipientChecker(func(sdk.Context, sdk.AccAddress) bool {
+			calls++
+			return calls == 1
+		})
+
+		require.Panics(t, func() { db.RevertToSnapshot(rev) })
+	})
+}


### PR DESCRIPTION
## Problem                                                                                                                              
giga/deps/xevm/state implemented Snapshot()/RevertToSnapshot() by stacking CacheMultiStore layers: each Snapshot() call wrapped the current context in a new cache, and RevertToSnapshot() restored an older context (dropping the outer cache) to undo KV-store writes. This meant N nested EVM snapshots within a single transaction produced N nested CacheMultiStore layers, with all the associated allocation and copy-on-write overhead. The transient/in-memory state (access lists, logs, refunds, transient storage, account status) was already journal-driven; only the persisted KV state relied on the CacheMultiStore trick.                                                                                                                                  
## Solution                                                  
Adopt the go-ethereum journal pattern for all state—both KV-stored and in-memory:                                                    
- One CacheMultiStore per stateDB, created at NewDBImpl. It isolates the transaction's writes from the underlying store and is flushed once at Finalize(). No additional layers are created per snapshot.
- Snapshot() = record journal length + revision ID. No context replacement, no cache allocation.                                     
- RevertToSnapshot() = binary-search for the revision, replay journal entries backward. Every KV mutation records the previous value in a new journal entry type; reverting calls the inverse keeper operation.                                                            
### Event-manager isolation                                                                                                              
Snapshot() pushes the current EventManager onto a stack and attaches a fresh one to the context. RevertToSnapshot() pops back to the snapshot's EM, discarding any events emitted inside the reverted range. Finalize() drains all surviving EMs (in order) into committedCtx.EventManager().                                                                                                         
### GetCommittedState
Previously read from snapshottedCtxs[0] (the context before the first stateDB-level CMS layer). Now reads from committedCtx, the original context saved at NewDBImpl time, which sits below the single stateDB CMS and therefore always reflects the pre-transaction committed state.                                                                                                                     
### Other changes
- EVMKeeper interface gains SetAddressMapping so deleteMappingChange can restore address associations on revert.                     
- clearAccountState (used by Finalize) is unchanged and un-journaled; a new clearAccountStateJournaled wrapper (called from CreateAccount) captures prev state before clearing.                                                                                  
- DeepCopy now uses maps.Copy instead of manual loops.    
## Tests (snapshot_test.go, 20 new cases)                                                                                               

