### PR TITLE
remove iterator usage in PointerInfo

### DIFF
--- a/x/evm/keeper/pointer.go
+++ b/x/evm/keeper/pointer.go
@@ -281,29 +281,15 @@ func (k *Keeper) DeleteCW1155ERC1155Pointer(ctx sdk.Context, erc1155Address comm
 
 func (k *Keeper) GetPointerInfo(ctx sdk.Context, pref []byte, maxVersion uint16) (addr []byte, version uint16, exists bool) {
 	store := prefix.NewStore(ctx.KVStore(k.GetStoreKey()), pref)
-	iter := store.ReverseIterator(nil, nil)
-	defer func() { _ = iter.Close() }()
-	exists = iter.Valid()
-	if !exists {
-		if !ctx.IsTracing() {
-			return
+	for v := int64(maxVersion); v >= 0; v-- {
+		key := make([]byte, 2)
+		vv := uint16(v) //nolint:gosec
+		binary.BigEndian.PutUint16(key, vv)
+		if value := store.Get(key); value != nil {
+			return value, vv, true
 		}
-		// Note that ReverseIterator seems buggy (i.e. would not return anything) when used with
-		// certain historical heights whereas point query would return results.
-		store := prefix.NewStore(ctx.WithGasMeter(sdk.NewInfiniteGasMeterWithMultiplier(ctx)).KVStore(k.GetStoreKey()), pref)
-		for v := int64(maxVersion); v >= 0; v-- {
-			key := make([]byte, 2)
-			vv := uint16(v) //nolint:gosec
-			binary.BigEndian.PutUint16(key, vv)
-			if value := store.Get(key); value != nil {
-				return value, vv, true
-			}
-		}
-		return nil, 0, false
 	}
-	version = binary.BigEndian.Uint16(iter.Key())
-	addr = iter.Value()
-	return
+	return nil, 0, false
 }
 
 func (k *Keeper) GetAnyPointeeInfo(ctx sdk.Context, cwAddress string) (common.Address, uint16, bool) {
@@ -324,15 +310,15 @@ func (k *Keeper) GetAnyPointeeInfo(ctx sdk.Context, cwAddress string) (common.Ad
 
 func (k *Keeper) GetAnyPointerInfo(ctx sdk.Context, pref []byte) (addr []byte, version uint16, exists bool) {
 	store := prefix.NewStore(ctx.KVStore(k.GetStoreKey()), pref)
-	iter := store.ReverseIterator(nil, nil)
-	defer func() { _ = iter.Close() }()
-	exists = iter.Valid()
-	if !exists {
-		return
+	for v := int64(maxCurrentPointerVersion(ctx)); v >= 0; v-- {
+		key := make([]byte, 2)
+		vv := uint16(v) //nolint:gosec
+		binary.BigEndian.PutUint16(key, vv)
+		if value := store.Get(key); value != nil {
+			return value, vv, true
+		}
 	}
-	version = binary.BigEndian.Uint16(iter.Key())
-	addr = iter.Value()
-	return
+	return nil, 0, false
 }
 
 func (k *Keeper) setPointerInfo(ctx sdk.Context, pref []byte, addr []byte, version uint16) error {
@@ -348,6 +334,23 @@ func (k *Keeper) deletePointerInfo(ctx sdk.Context, pref []byte, version uint16)
 	versionBz := make([]byte, 2)
 	binary.BigEndian.PutUint16(versionBz, version)
 	store.Delete(versionBz)
+}
+
+func maxCurrentPointerVersion(ctx sdk.Context) uint16 {
+	v := native.CurrentVersion
+	for _, candidate := range []uint16{
+		cw20.CurrentVersion(ctx),
+		cw721.CurrentVersion,
+		cw1155.CurrentVersion,
+		erc20.CurrentVersion,
+		erc721.CurrentVersion,
+		erc1155.CurrentVersion,
+	} {
+		if candidate > v {
+			v = candidate
+		}
+	}
+	return v
 }
 
 func (k *Keeper) GetStoredPointerCodeID(ctx sdk.Context, pointerType types.PointerType) uint64 {

--- a/x/evm/keeper/pointer.go
+++ b/x/evm/keeper/pointer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store/prefix"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
+	"golang.org/x/mod/semver"
 
 	"github.com/sei-protocol/sei-chain/x/evm/artifacts/cw1155"
 	"github.com/sei-protocol/sei-chain/x/evm/artifacts/cw20"
@@ -281,6 +282,14 @@ func (k *Keeper) DeleteCW1155ERC1155Pointer(ctx sdk.Context, erc1155Address comm
 
 func (k *Keeper) GetPointerInfo(ctx sdk.Context, pref []byte, maxVersion uint16) (addr []byte, version uint16, exists bool) {
 	store := prefix.NewStore(ctx.KVStore(k.GetStoreKey()), pref)
+	if semver.Compare(ctx.ClosestUpgradeName(), "v6.5.0") < 0 {
+		iter := store.ReverseIterator(nil, nil)
+		defer func() { _ = iter.Close() }()
+		if iter.Valid() {
+			return iter.Value(), binary.BigEndian.Uint16(iter.Key()), true
+		}
+		return nil, 0, false
+	}
 	for v := int64(maxVersion); v >= 0; v-- {
 		key := make([]byte, 2)
 		vv := uint16(v) //nolint:gosec
@@ -310,6 +319,14 @@ func (k *Keeper) GetAnyPointeeInfo(ctx sdk.Context, cwAddress string) (common.Ad
 
 func (k *Keeper) GetAnyPointerInfo(ctx sdk.Context, pref []byte) (addr []byte, version uint16, exists bool) {
 	store := prefix.NewStore(ctx.KVStore(k.GetStoreKey()), pref)
+	if semver.Compare(ctx.ClosestUpgradeName(), "v6.5.0") < 0 {
+		iter := store.ReverseIterator(nil, nil)
+		defer func() { _ = iter.Close() }()
+		if iter.Valid() {
+			return iter.Value(), binary.BigEndian.Uint16(iter.Key()), true
+		}
+		return nil, 0, false
+	}
 	for v := int64(maxCurrentPointerVersion(ctx)); v >= 0; v-- {
 		key := make([]byte, 2)
 		vv := uint16(v) //nolint:gosec


### PR DESCRIPTION
## Describe your changes and provide context
Use point query starting from current version to 0 to replace iterator usage, since current version is at most single digit

## Testing performed to validate your change
no functional change except different gas usage
