### PR TITLE
Support autobahn node restart by skipping CometBFT handshaker (CON-252)

### DIFF
--- a/integration_test/autobahn/autobahn_test.go
+++ b/integration_test/autobahn/autobahn_test.go
@@ -283,13 +283,55 @@ func TestAutobahn(t *testing.T) {
 	t.Run("BankTransfer", testBankTransfer)
 	t.Run("LivenessUnderMaxFaults", testLivenessUnderMaxFaults)
 	t.Run("HaltsBeyondMaxFaults", testHaltsBeyondMaxFaults)
-	// TODO: Re-enable once autobahn supports node restart. Currently, a restarted seid
-	// fails because autobahn writes to the app state but not to the CometBFT block/state
-	// store. On restart, the CometBFT handshaker sees appHeight >> storeHeight and
-	// cannot reconcile.
-	t.Run("Recovery", func(t *testing.T) {
-		t.Skip("autobahn node restart not yet supported")
-	})
+	t.Run("Recovery", testRecovery)
+}
+
+// restartNode re-invokes the container's seid-start script inside sei-node-<i>.
+// The script backgrounds seid and exits, so `docker exec -d` is the right mode:
+// it returns immediately while seid keeps running.
+func restartNode(t *testing.T, i int) {
+	t.Helper()
+	t.Logf("restarting seid on node %d...", i)
+	name := fmt.Sprintf("sei-node-%d", i)
+	cmd := exec.Command("docker", "exec", "-d",
+		"-e", fmt.Sprintf("ID=%d", i),
+		name, "/usr/bin/start_sei.sh")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("restartNode %d: %v\n%s", i, err, out)
+	}
+}
+
+// testRecovery: HaltsBeyondMaxFaults left the chain halted with maxFaults+1
+// nodes killed. Restart one of them — fault count returns to maxFaults, quorum
+// is restored, chain should resume. This exercises the autobahn restart path
+// (handshaker skipped, runExecute resumes from app.Info().LastBlockHeight).
+func testRecovery(t *testing.T) {
+	hBefore := getHeight(t)
+	t.Logf("height entering Recovery: %d (expected halted)", hBefore)
+
+	// Restart the node HaltsBeyondMaxFaults killed last.
+	target := clusterSize - 1 - maxFaults
+	restartNode(t, target)
+
+	// Poll for the chain to advance. Give the restarted seid time to init
+	// and rejoin consensus.
+	deadline := time.Now().Add(90 * time.Second)
+	var hAfter int64
+	for time.Now().Before(deadline) {
+		hAfter = getHeight(t)
+		if hAfter > hBefore {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Logf("height after restart: %d", hAfter)
+	if hAfter <= hBefore {
+		t.Fatalf("chain did not resume advancing after restart of node %d (%d -> %d)",
+			target, hBefore, hAfter)
+	}
+
+	// Log on the restarted node should now contain a fresh GigaRouter init.
+	assertAutobahnEnabled(t)
 }
 
 func testBlockProduction(t *testing.T) {

--- a/integration_test/autobahn/autobahn_test.go
+++ b/integration_test/autobahn/autobahn_test.go
@@ -301,15 +301,34 @@ func restartNode(t *testing.T, i int) {
 	}
 }
 
-// testRecovery: HaltsBeyondMaxFaults left the chain halted with maxFaults+1
-// nodes killed. Restart one of them — fault count returns to maxFaults, quorum
-// is restored, chain should resume. This exercises the autobahn restart path
-// (handshaker skipped, runExecute resumes from app.Info().LastBlockHeight).
+// testRecovery establishes its own halted precondition, then restarts one
+// node — fault count returns to maxFaults, quorum is restored, chain should
+// resume. Exercises the autobahn restart path (handshaker skipped,
+// runExecute resumes from app.Info().LastBlockHeight).
+//
+// Self-contained: does not rely on prior subtests. killNode is idempotent
+// (pkill tolerates an already-dead process), so this works whether run in
+// isolation or after LivenessUnderMaxFaults / HaltsBeyondMaxFaults.
 func testRecovery(t *testing.T) {
-	hBefore := getHeight(t)
-	t.Logf("height entering Recovery: %d (expected halted)", hBefore)
+	assertAutobahnEnabled(t)
 
-	// Restart the node HaltsBeyondMaxFaults killed last.
+	// Force the halted precondition: kill maxFaults+1 nodes. If earlier
+	// subtests already killed some of these, those kills are no-ops.
+	for i := 0; i <= maxFaults; i++ {
+		killNode(t, clusterSize-1-i)
+	}
+
+	// Let the chain settle into its halted height, then confirm it's halted.
+	time.Sleep(10 * time.Second)
+	hBefore := getHeight(t)
+	time.Sleep(5 * time.Second)
+	if h := getHeight(t); h != hBefore {
+		t.Fatalf("expected halted chain after killing %d nodes, but height advanced (%d -> %d)",
+			maxFaults+1, hBefore, h)
+	}
+	t.Logf("chain halted at height %d; restarting one node", hBefore)
+
+	// Restart one node to restore quorum.
 	target := clusterSize - 1 - maxFaults
 	restartNode(t, target)
 
@@ -330,7 +349,9 @@ func testRecovery(t *testing.T) {
 			target, hBefore, hAfter)
 	}
 
-	// Log on the restarted node should now contain a fresh GigaRouter init.
+	// start_sei.sh truncates the log on restart (`>` not `>>`), so this grep
+	// on the restarted node's log necessarily matches a post-restart GigaRouter
+	// init, not a stale one.
 	assertAutobahnEnabled(t)
 }
 

--- a/integration_test/autobahn/autobahn_test.go
+++ b/integration_test/autobahn/autobahn_test.go
@@ -289,6 +289,11 @@ func TestAutobahn(t *testing.T) {
 // restartNode re-invokes the container's seid-start script inside sei-node-<i>.
 // The script backgrounds seid and exits, so `docker exec -d` is the right mode:
 // it returns immediately while seid keeps running.
+//
+// Precondition: seid must NOT already be running on the target. start_sei.sh
+// unconditionally spawns a new seid process; calling this while one is alive
+// produces two seid instances in the same container (port/CMS-lock conflict).
+// Callers should `killNode` first, or extend the script to pkill defensively.
 func restartNode(t *testing.T, i int) {
 	t.Helper()
 	t.Logf("restarting seid on node %d...", i)
@@ -349,9 +354,10 @@ func testRecovery(t *testing.T) {
 			target, hBefore, hAfter)
 	}
 
-	// start_sei.sh truncates the log on restart (`>` not `>>`), so this grep
-	// on the restarted node's log necessarily matches a post-restart GigaRouter
-	// init, not a stale one.
+	// assertAutobahnEnabled greps every running container's log. The restarted
+	// node is among them, and start_sei.sh truncates its log on restart (`>`
+	// not `>>`), so the match on that one container necessarily comes from a
+	// post-restart GigaRouter init — i.e., the restart reached giga setup.
 	assertAutobahnEnabled(t)
 }
 

--- a/sei-tendermint/internal/p2p/giga_router.go
+++ b/sei-tendermint/internal/p2p/giga_router.go
@@ -182,6 +182,11 @@ func (r *GigaRouter) runExecute(ctx context.Context) error {
 		// the app's committed CMS already holds the latest state, and
 		// BaseApp.FinalizeBlock rebuilds deliverState from it via its
 		// nil-check fallback.
+		//
+		// Note: if a process crashed after InitChain but before the first
+		// Commit, LastBlockHeight is still 0 and we enter this branch again
+		// on restart. Re-calling InitChain is safe in that case because
+		// nothing was committed — it behaves as a fresh init.
 		if _, err := app.InitChain(ctx, r.cfg.GenDoc.ToRequestInitChain()); err != nil {
 			return fmt.Errorf("App.InitChain(): %w", err)
 		}

--- a/sei-tendermint/internal/p2p/giga_router.go
+++ b/sei-tendermint/internal/p2p/giga_router.go
@@ -171,19 +171,20 @@ func (r *GigaRouter) runExecute(ctx context.Context) error {
 	}
 	next := last + 1
 	if last == 0 {
-		// The CometBFT handshaker already called InitChain when it saw
-		// appHeight==0 (see consensus/replay.go). We must NOT call it again —
-		// a second InitChain re-runs initChainer and corrupts state.
-		// Just set next to InitialHeight so the first FinalizeBlock uses the
-		// deliverState that the handshaker's InitChain set up.
+		// Fresh start: the CometBFT handshaker is skipped in giga mode
+		// (see node.go: shouldHandshake = !stateSync && !gigaEnabled), so
+		// nobody has called InitChain yet. Call it here ourselves; this sets
+		// up the app's deliverState (matching real SDK: InitChain leaves
+		// deliverState populated with no intermediate Commit, so the first
+		// FinalizeBlock below runs against it).
 		//
-		// WARNING: This assumes the handshaker ran before GigaRouter.Run().
-		// State sync (--state-sync) skips the handshaker (node.go:358:
-		// shouldHandshake = !stateSync), so autobahn + state sync would
-		// reach here without InitChain ever being called, causing the first
-		// FinalizeBlock to fail on nil deliverState. If state sync support
-		// is added, runExecute must detect whether InitChain is needed
-		// (e.g. check DeliverContext != nil) and call it when missing.
+		// On restart (last > 0, below), InitChain must NOT be called again;
+		// the app's committed CMS already holds the latest state, and
+		// BaseApp.FinalizeBlock rebuilds deliverState from it via its
+		// nil-check fallback.
+		if _, err := app.InitChain(ctx, r.cfg.GenDoc.ToRequestInitChain()); err != nil {
+			return fmt.Errorf("App.InitChain(): %w", err)
+		}
 		var ok bool
 		next, ok = utils.SafeCast[atypes.GlobalBlockNumber](r.cfg.GenDoc.InitialHeight)
 		if !ok {

--- a/sei-tendermint/internal/p2p/giga_router_test.go
+++ b/sei-tendermint/internal/p2p/giga_router_test.go
@@ -198,10 +198,9 @@ func (c *testNodeCfg) GigaNodeAddr() GigaNodeAddr {
 }
 
 // TestInitChainCommitThenFinalize is a contract test for testApp: it verifies
-// that testApp supports the autobahn block execution flow where the CometBFT
-// handshaker calls InitChain (no Commit), then GigaRouter.runExecute() calls
-// FinalizeBlock at InitialHeight using the deliverState set up by InitChain,
-// followed by Commit.
+// that testApp supports the autobahn block execution flow where runExecute
+// calls InitChain (no Commit), then FinalizeBlock at InitialHeight using the
+// deliverState set up by InitChain, followed by Commit.
 func TestInitChainCommitThenFinalize(t *testing.T) {
 	rng := utils.TestRng()
 	app := newTestApp()
@@ -283,11 +282,8 @@ func TestGigaRouter_FinalizeBlocks(t *testing.T) {
 			nodeInfo.Network = genDoc.ChainID
 			e := Endpoint{AddrPort: cfg.addr}
 			app := newTestApp()
-			// Simulate CometBFT handshaker calling InitChain (see consensus/replay.go).
-			// In production, the handshaker always runs before GigaRouter.Run().
-			if _, err := app.InitChain(ctx, genDoc.ToRequestInitChain()); err != nil {
-				return fmt.Errorf("app.InitChain(): %w", err)
-			}
+			// In giga mode the CometBFT handshaker is skipped; the router's
+			// runExecute calls InitChain itself on fresh start.
 			txMempool := mempool.NewTxMempool(mempool.TestConfig(), app, mempool.NopMetrics(), mempool.NopTxConstraintsFetcher)
 			router, err := NewRouter(
 				NopMetrics(),

--- a/sei-tendermint/node/node.go
+++ b/sei-tendermint/node/node.go
@@ -257,6 +257,9 @@ func makeNode(
 	// app may modify the validator set, specifying ourself as the only validator.
 	blockSync := !onlyValidatorIsUs(state, pubKey)
 	if gigaEnabled {
+		// TODO(autobahn-recovery): handles only restart with local disk intact.
+		// A node that lost its WAL + app CMS (new validator, disk wipe) needs both
+		// app state sync and an autobahn WAL sync to catch up. Not yet supported.
 		stateSync = false
 		blockSync = false
 	}
@@ -355,7 +358,14 @@ func makeNode(
 	// FIXME The way we do phased startups (e.g. replay -> block sync -> consensus) is very messy,
 	// we should clean this whole thing up. See:
 	// https://github.com/tendermint/tendermint/issues/4644
-	node.shouldHandshake = !stateSync
+	// The CometBFT handshaker reconciles the block store and state store with the app
+	// by replaying blocks and calling InitChain at genesis. Autobahn (giga) maintains
+	// its own data WAL and does not update the CometBFT block/state stores, so on
+	// restart the handshaker would observe storeHeight=0 < appHeight=N and fail with
+	// ErrAppBlockHeightTooHigh. We skip the handshaker in giga mode; instead the
+	// giga router's runExecute owns InitChain on fresh start (appHeight==0) and
+	// relies on the app's committed CMS to rebuild deliverState on restart.
+	node.shouldHandshake = !stateSync && !gigaEnabled
 	if !gigaEnabled {
 		ssReactor, err := statesync.NewReactor(
 			genDoc.ChainID,


### PR DESCRIPTION
## Summary

Enables an autobahn validator to be stopped and restarted. The CometBFT handshaker used to abort because autobahn never writes to the CometBFT block/state stores, so it observed `storeHeight=0 < appHeight=N` → `ErrAppBlockHeightTooHigh`.

- `node.go`: `shouldHandshake = !stateSync && !gigaEnabled` — skip the handshaker in giga mode.
- `giga_router.go` (`runExecute`): now owns `InitChain`. Calls it on fresh start (`last == 0`); skips it on restart (`last > 0`), where `BaseApp.FinalizeBlock`'s existing nil-check rebuilds `deliverState` from the committed CMS.
- `giga_router_test.go`: drop the simulated-handshaker `InitChain` from `TestGigaRouter_FinalizeBlocks`; tighten the contract-test doc on `TestInitChainCommitThenFinalize`.
- `integration_test/autobahn/autobahn_test.go`: replace the `t.Skip` in the Recovery subtest with a real restart test. Adds `restartNode` helper.

## Startup paths

|  | shouldHandshake | InitChain by | FinalizeBlock's deliverState |
|---|---|---|---|
| A (fresh, no giga) | true | handshaker | InitChain |
| B (fresh, giga) | **false** | **runExecute** | InitChain |
| C (restart, no giga) | true | — (appHeight>0) | handshaker replay if needed, else existing |
| D (restart, giga) | **false** | — (last>0) | `BaseApp` nil-check fallback from committed CMS |

Cases B and D are what change. In B, `runExecute` takes over the `InitChain` duty the handshaker used to perform. In D, skipping the handshaker is the whole fix: the CometBFT state/block stores are never populated by autobahn, so reconciling against them is vacuous; the app's committed CMS is the source of truth, and `BaseApp.FinalizeBlock`'s existing `if deliverState == nil { setDeliverState(header) }` fallback picks it up on the first block post-restart.

## Scope / TODO

Covers **restart with local disk intact** (`app.Info().LastBlockHeight = N`, autobahn WAL has block ≥ N). Does **not** cover a new validator joining or a disk-wiped node — that needs app state sync + autobahn WAL sync. Tracked via `TODO(autobahn-recovery)` in `node.go`.

## Test plan

- [x] `go build ./...` clean; `gofmt -s -l .` clean
- [x] `go test ./internal/p2p/... ./node/... ./internal/consensus/... ./internal/autobahn/...` — green
- [x] `make autobahn-integration-test` — all 5 subtests pass. Recovery: halted @ 482 → resumed @ 537 in 12.4s after restarting a killed node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)