### PR TITLE
fix(evmrpc): treat id=null as a valid request, not a JSON-RPC notification

### DIFF
--- a/evmrpc/sei_legacy_http.go
+++ b/evmrpc/sei_legacy_http.go
@@ -201,7 +201,7 @@ const seiLegacyBatchInvalidReqMsg = "Invalid Request"
 
 // seiLegacyBatchResponsesNoForward builds the batch JSON-RPC response when nothing is forwarded to the
 // inner server: invalid slots yield -32600, blocked gated methods yield gate errors, and notifications
-// are omitted (JSON-RPC 2.0: no response for notifications, including in batches).
+// (requests with no "id" member) are omitted (JSON-RPC 2.0: no response for notifications, including in batches).
 func seiLegacyBatchResponsesNoForward(
 	invalidReq []bool,
 	blockedErr []error,
@@ -223,7 +223,7 @@ func seiLegacyBatchResponsesNoForward(
 }
 
 // mergeSeiLegacyHTTPBatch merges inner batch results with gate/invalid slots. Output is ordered like the
-// original batch but omits entries for JSON-RPC notifications (no id), per JSON-RPC 2.0 batch rules.
+// original batch but omits entries for JSON-RPC notifications (no "id" member), per JSON-RPC 2.0 batch rules.
 func mergeSeiLegacyHTTPBatch(
 	invalidReq []bool,
 	blocked []bool,
@@ -307,11 +307,10 @@ func rpcIDKey(id json.RawMessage) string {
 	return string(bytes.TrimSpace(id))
 }
 
+// isJSONRPCNotificationID is true when the request omits "id" (JSON-RPC Notification).
+// "id": null is discouraged but valid per JSON-RPC 2.0 and MUST receive a response like any other id.
 func isJSONRPCNotificationID(id json.RawMessage) bool {
-	if len(id) == 0 {
-		return true
-	}
-	return bytes.Equal(bytes.TrimSpace(id), []byte("null"))
+	return len(id) == 0
 }
 
 func jsonRPCObjectIDKey(raw json.RawMessage) (idField json.RawMessage, hasKey bool, err error) {

--- a/evmrpc/sei_legacy_test.go
+++ b/evmrpc/sei_legacy_test.go
@@ -441,6 +441,45 @@ func TestWrapSeiLegacyHTTP_BatchNotificationOmittedFromMergedResponse(t *testing
 	}
 }
 
+func TestWrapSeiLegacyHTTP_BatchNullIDIsNotNotification(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		var fwd []map[string]any
+		if err := json.Unmarshal(b, &fwd); err != nil || len(fwd) != 2 {
+			t.Fatalf("inner should receive 2 calls, got err=%v body=%s", err, b)
+		}
+		if _, ok := fwd[0]["id"]; !ok {
+			t.Fatalf("first item must include id (null): %#v", fwd[0])
+		}
+		if fwd[0]["id"] != nil {
+			t.Fatalf("first item id should decode as nil: %#v", fwd[0])
+		}
+		_, _ = w.Write([]byte(`[
+			{"jsonrpc":"2.0","id":null,"result":"a"},
+			{"jsonrpc":"2.0","id":1,"result":"b"}
+		]`))
+	})
+	h := wrapSeiLegacyHTTP(inner, BuildSeiLegacyEnabledSet(nil))
+	body := `[
+		{"jsonrpc":"2.0","id":null,"method":"eth_chainId","params":[]},
+		{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}
+	]`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	var batch []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &batch); err != nil {
+		t.Fatal(err)
+	}
+	if len(batch) != 2 {
+		t.Fatalf("want 2 responses (null id is not a notification), got %d: %s", len(batch), rec.Body.String())
+	}
+	if batch[0]["result"] != "a" || batch[1]["result"] != "b" {
+		t.Fatalf("unexpected merge order or results: %+v, %+v", batch[0], batch[1])
+	}
+}
+
 func TestWrapSeiLegacyHTTP_BatchLeadingNotificationMergedWithBlockedCall(t *testing.T) {
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b, _ := io.ReadAll(r.Body)


### PR DESCRIPTION
## Summary

JSON-RPC 2.0 defines a **Notification** as a request object with **no `id` member**. A request with `"id": null` is discouraged by the spec but is still a valid call and **must** receive a response.

The previous implementation of `isJSONRPCNotificationID` returned `true` for both a missing `id` and an explicit `"id": null`, causing requests with `null` ids to be silently dropped from batch responses.

### Changes
- `isJSONRPCNotificationID` now returns `true` only when the raw `id` field is absent (`len(id) == 0`), not when it is `null`
- Added `TestWrapSeiLegacyHTTP_BatchNullIDIsNotNotification` to verify that a batch containing `"id": null` forwards the request and includes the response

## Test plan
- [x] `go test ./evmrpc/... -run TestWrapSeiLegacyHTTP_Batch`