### PR TITLE
feat: wire autobahn state sync with naive provider (CON-252)

### DIFF
--- a/sei-tendermint/internal/autobahn/data/skipto_test.go
+++ b/sei-tendermint/internal/autobahn/data/skipto_test.go
@@ -1,0 +1,56 @@
+package data
+
+import (
+	"testing"
+
+	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/types"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/require"
+)
+
+// TestState_SkipTo_FreshAdvance: on a freshly constructed State, SkipTo(n)
+// should advance all cursors to n. This is the giga state-sync use case:
+// after the app is at height M via snapshot, call SkipTo(M+1) on the local
+// fresh data state so subsequent peer-streamed blocks insert starting at
+// M+1 instead of genesis.
+func TestState_SkipTo_FreshAdvance(t *testing.T) {
+	rng := utils.TestRng()
+	committee, _ := types.GenCommittee(rng, 3)
+	state := utils.OrPanic1(NewState(&Config{Committee: committee},
+		utils.OrPanic1(NewDataWAL(utils.None[string](), committee))))
+
+	// Sanity: fresh state starts at committee.FirstBlock().
+	require.Equal(t, committee.FirstBlock(), state.NextBlock())
+
+	target := committee.FirstBlock() + 1000
+	state.SkipTo(target)
+
+	// Every cursor visible through the public API should now reflect
+	// target. We only check NextBlock() (public); the other cursors
+	// (first, nextAppProposal, nextQC, nextBlockToPersist) are verified
+	// implicitly by the fact that subsequent Push* calls would fail
+	// with a gap error if any cursor was left behind.
+	require.Equal(t, target, state.NextBlock())
+}
+
+// TestState_SkipTo_NoBackwards: SkipTo with a target <= current first is
+// a no-op (never rewinds). Callers shouldn't rely on this but we guarantee
+// it so an accidental call on a state that's already advanced doesn't
+// corrupt state.
+func TestState_SkipTo_NoBackwards(t *testing.T) {
+	rng := utils.TestRng()
+	committee, _ := types.GenCommittee(rng, 3)
+	state := utils.OrPanic1(NewState(&Config{Committee: committee},
+		utils.OrPanic1(NewDataWAL(utils.None[string](), committee))))
+
+	// First advance to some height.
+	state.SkipTo(committee.FirstBlock() + 500)
+	after := state.NextBlock()
+
+	// SkipTo at or below first must not rewind.
+	state.SkipTo(committee.FirstBlock())
+	require.Equal(t, after, state.NextBlock())
+
+	state.SkipTo(committee.FirstBlock() + 100)
+	require.Equal(t, after, state.NextBlock())
+}

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -434,6 +434,21 @@ func (s *State) NextBlock() types.GlobalBlockNumber {
 	panic("unreachable")
 }
 
+// SkipTo advances all internal cursors to n, discarding everything before it.
+// It is safe to call only on a State that has no data past n (e.g. a fresh
+// State just after NewState, before any Push*). The caller is responsible
+// for ensuring no concurrent Push* races with this call — giga state sync
+// uses it between data.NewState and GigaRouter.Run.
+func (s *State) SkipTo(n types.GlobalBlockNumber) {
+	for inner, ctrl := range s.inner.Lock() {
+		if n <= inner.first {
+			return
+		}
+		inner.skipTo(n)
+		ctrl.Updated()
+	}
+}
+
 // Block returns the block with the given global number.
 // This function is used for syncing - GlobalBlock can be derived from Block and FullCommitQC,
 // which have to be fetched upfront anyway.

--- a/sei-tendermint/internal/p2p/giga_router.go
+++ b/sei-tendermint/internal/p2p/giga_router.go
@@ -190,7 +190,23 @@ func (r *GigaRouter) runExecute(ctx context.Context) error {
 		if !ok {
 			return fmt.Errorf("invalid GenDoc.InitialHeight = %v", r.cfg.GenDoc.InitialHeight)
 		}
+	} else if r.data.NextBlock() <= last {
+		// State-sync restart: app.Commit got us to height `last` via a peer
+		// snapshot, but this node's autobahn data state is fresh (no local
+		// WAL). Block `last` itself is gone — we can't PushAppHash it —
+		// but we still need all data-state cursors aligned to last+1 so
+		// peer-streamed QCs and blocks from last+1 onward insert correctly
+		// and so `runBlockFetcher` / `clientStreamFullCommitQCs` start from
+		// the right height instead of from genesis.
+		//
+		// TODO(autobahn-state-sync): consensus/ and avail/ states also
+		// start fresh; the first live block arriving should still drive
+		// them forward, but this hasn't been exercised end-to-end yet.
+		// Follow-up PR adds an integration test that wipes a node and
+		// rejoins via state sync.
+		r.data.SkipTo(next)
 	} else {
+		// Plain restart with local WAL intact.
 		// NOTE that with the current implementation losing prefix of appHashes on crash is fine:
 		// if everyone votes on apphashes of a suffix of finalized blocks, then AppQC will be reached.
 		if err := r.data.PushAppHash(ctx, last, info.LastBlockAppHash); err != nil {

--- a/sei-tendermint/internal/statesync/giga_stateprovider.go
+++ b/sei-tendermint/internal/statesync/giga_stateprovider.go
@@ -1,0 +1,87 @@
+package statesync
+
+import (
+	"context"
+
+	sm "github.com/sei-protocol/sei-chain/sei-tendermint/internal/state"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
+)
+
+// GigaStateProvider is a minimal StateProvider implementation used when the
+// node is running in autobahn (giga) mode. Unlike the RPC and P2P providers,
+// it does NOT verify the app hash cryptographically before applying chunks —
+// there is currently no cheap way to obtain an authoritative AppHash@h in
+// giga mode (AppQCs are not retained historically, and CometBFT-style signed
+// commits do not exist on giga peers). Instead this provider returns empty
+// stubs; the syncer recognises an empty trustedAppHash and skips the post-
+// restore AppHash comparison.
+//
+// TODO(autobahn-snapshot-proof): peers serving a giga snapshot must include
+// an AppQC@snapshot_height in the snapshot.Metadata. This provider should
+// then decode the AppQC, verify it against the committee, compare its
+// AppHash against the snapshot's self-advertised AppHash, and return the
+// verified AppHash as the authoritative trustedAppHash. Vanilla SyncAny
+// will then retry on mismatch (errRejectSnapshot) and will not loop-trap a
+// joiner against a persistently malicious peer. Until that lands, a bad
+// snapshot wedges the joiner and requires external intervention to retry.
+type GigaStateProvider struct {
+	genDoc *types.GenesisDoc
+}
+
+// NewGigaStateProvider returns a provider that emits minimal trust data for
+// autobahn state sync. genDoc supplies the chain identity and initial
+// validator set that the post-sync bootstrap needs.
+func NewGigaStateProvider(genDoc *types.GenesisDoc) *GigaStateProvider {
+	return &GigaStateProvider{genDoc: genDoc}
+}
+
+// AppHash returns a zero-length slice. The syncer treats an empty
+// trustedAppHash as "skip the post-restore AppHash check" (see
+// syncer.verifyApp). This is the naive trust model described above.
+func (p *GigaStateProvider) AppHash(_ context.Context, _ uint64) ([]byte, error) {
+	return nil, nil
+}
+
+// Commit returns a minimal *types.Commit. Autobahn does not consume
+// CometBFT commits at runtime, but the syncer threads one through to
+// stateStore.Bootstrap; an empty commit satisfies its non-nil requirement
+// without asserting any fabricated signatures.
+func (p *GigaStateProvider) Commit(_ context.Context, height uint64) (*types.Commit, error) {
+	return &types.Commit{Height: int64(height)}, nil //nolint:gosec // uint64->int64 at known-small block heights
+}
+
+// State synthesises the minimum sm.State needed by stateStore.Bootstrap.
+// It populates identity + validator fields from the genesis doc; these
+// match what every giga node already computes locally since the autobahn
+// committee is static and derived from genesis.
+//
+// TODO(epoch): once autobahn supports dynamic committees, Validators and
+// NextValidators must come from the epoch lookup at height h, not the
+// genesis set.
+func (p *GigaStateProvider) State(_ context.Context, height uint64) (sm.State, error) {
+	state := sm.State{
+		ChainID:       p.genDoc.ChainID,
+		InitialHeight: p.genDoc.InitialHeight,
+		//nolint:gosec // heights fit in int64 at any realistic chain height.
+		LastBlockHeight: int64(height),
+	}
+	if state.InitialHeight == 0 {
+		state.InitialHeight = 1
+	}
+
+	// Derive the CometBFT validator set from the genesis validator list. In
+	// giga mode the committee is static (see TODO(epoch) above).
+	vals := make([]*types.Validator, len(p.genDoc.Validators))
+	for i, gv := range p.genDoc.Validators {
+		vals[i] = types.NewValidator(gv.PubKey, gv.Power)
+	}
+	if len(vals) > 0 {
+		state.Validators = types.NewValidatorSet(vals)
+		state.NextValidators = state.Validators.CopyIncrementProposerPriority(1)
+		state.LastValidators = state.Validators
+	}
+
+	state.ConsensusParams = *p.genDoc.ConsensusParams
+
+	return state, nil
+}

--- a/sei-tendermint/internal/statesync/giga_stateprovider_test.go
+++ b/sei-tendermint/internal/statesync/giga_stateprovider_test.go
@@ -1,0 +1,119 @@
+package statesync
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/sei-protocol/sei-chain/sei-tendermint/crypto/ed25519"
+	tmtime "github.com/sei-protocol/sei-chain/sei-tendermint/libs/time"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/require"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
+)
+
+// makeTestGenDoc produces a minimal GenesisDoc suitable for feeding
+// GigaStateProvider — enough for it to synthesise a coherent sm.State.
+func makeTestGenDoc(t *testing.T, numValidators int) *types.GenesisDoc {
+	t.Helper()
+	vals := make([]types.GenesisValidator, numValidators)
+	for i := range vals {
+		priv := ed25519.TestSecretKey([]byte(fmt.Sprintf("giga-sp-%d", i)))
+		pub := priv.Public()
+		vals[i] = types.GenesisValidator{
+			Address: pub.Address(),
+			PubKey:  pub,
+			Power:   10,
+			Name:    fmt.Sprintf("v%d", i),
+		}
+	}
+	cp := types.DefaultConsensusParams()
+	return &types.GenesisDoc{
+		GenesisTime:     tmtime.Now(),
+		ChainID:         "giga-test-chain",
+		InitialHeight:   1,
+		ConsensusParams: cp,
+		Validators:      vals,
+	}
+}
+
+// TestGigaStateProvider_AppHashIsEmpty verifies that the naive giga
+// provider returns an empty AppHash. The syncer treats this as a signal
+// to skip the post-restore AppHash check (see syncer.verifyApp).
+func TestGigaStateProvider_AppHashIsEmpty(t *testing.T) {
+	p := NewGigaStateProvider(makeTestGenDoc(t, 4))
+	h, err := p.AppHash(t.Context(), 1234)
+	require.NoError(t, err)
+	require.Empty(t, h, "naive giga provider must return empty AppHash")
+}
+
+// TestGigaStateProvider_CommitMinimal checks the Commit stub carries
+// nothing more than the requested height — no fabricated signatures.
+func TestGigaStateProvider_CommitMinimal(t *testing.T) {
+	p := NewGigaStateProvider(makeTestGenDoc(t, 4))
+	c, err := p.Commit(t.Context(), 1234)
+	require.NoError(t, err)
+	require.Equal(t, int64(1234), c.Height)
+	require.Empty(t, c.Signatures, "commit must not fabricate signatures")
+}
+
+// TestGigaStateProvider_StatePopulatesBootstrapFields verifies that
+// State returns every field that stateStore.Bootstrap needs populated
+// (ChainID, InitialHeight, LastBlockHeight, Validators, NextValidators,
+// ConsensusParams). Empty/zero for any of these would trip the reactor's
+// post-sync bootstrap.
+func TestGigaStateProvider_StatePopulatesBootstrapFields(t *testing.T) {
+	gd := makeTestGenDoc(t, 4)
+	p := NewGigaStateProvider(gd)
+
+	state, err := p.State(t.Context(), 9999)
+	require.NoError(t, err)
+
+	require.Equal(t, gd.ChainID, state.ChainID)
+	require.Equal(t, gd.InitialHeight, state.InitialHeight)
+	require.Equal(t, int64(9999), state.LastBlockHeight)
+
+	require.NotNil(t, state.Validators)
+	require.Equal(t, 4, len(state.Validators.Validators))
+	require.NotNil(t, state.NextValidators)
+	require.Equal(t, 4, len(state.NextValidators.Validators))
+
+	// ConsensusParams is copied by value; a zeroed one would fail
+	// downstream hash checks.
+	require.NotZero(t, state.ConsensusParams.Block.MaxBytes,
+		"ConsensusParams should be populated from genesis")
+}
+
+// TestGigaStateProvider_StateInitialHeightDefaults ensures a
+// GenesisDoc with InitialHeight == 0 is normalised to 1 (matches the
+// vanilla P2P provider).
+func TestGigaStateProvider_StateInitialHeightDefaults(t *testing.T) {
+	gd := makeTestGenDoc(t, 1)
+	gd.InitialHeight = 0
+	p := NewGigaStateProvider(gd)
+
+	state, err := p.State(t.Context(), 42)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), state.InitialHeight)
+}
+
+// TestGigaStateProvider_NoValidators degenerate case: GenesisDoc without
+// validators. We don't crash; ValidatorSet stays nil. Autobahn nodes are
+// always configured with a validator set in practice, so this exists as a
+// defensiveness check rather than a supported mode.
+func TestGigaStateProvider_NoValidators(t *testing.T) {
+	gd := &types.GenesisDoc{
+		GenesisTime:     time.Unix(0, 0),
+		ChainID:         "giga-empty",
+		InitialHeight:   1,
+		ConsensusParams: types.DefaultConsensusParams(),
+	}
+	p := NewGigaStateProvider(gd)
+	state, err := p.State(t.Context(), 5)
+	require.NoError(t, err)
+	require.Nil(t, state.Validators)
+	require.Nil(t, state.NextValidators)
+}
+
+// Ensure the provider satisfies the StateProvider interface at compile
+// time. Other packages may rely on this.
+var _ StateProvider = (*GigaStateProvider)(nil)

--- a/sei-tendermint/internal/statesync/reactor.go
+++ b/sei-tendermint/internal/statesync/reactor.go
@@ -213,6 +213,12 @@ type Reactor struct {
 	// Used to signal a restart the node on the application level
 	restartEvent                  func()
 	restartNoAvailablePeersWindow time.Duration
+
+	// stateProviderFactory, if non-nil, is used by initStateProvider instead
+	// of the built-in RPC/P2P selection. node.go sets this in giga mode to
+	// inject the autobahn state provider. nil for all non-giga callers —
+	// the existing selection path is preserved.
+	stateProviderFactory func(ctx context.Context) (StateProvider, error)
 }
 
 // NewReactor returns a reference to a new state sync reactor, which implements
@@ -235,6 +241,11 @@ func NewReactor(
 	needsStateSync bool,
 	restartEvent func(),
 	selfRemediationConfig *config.SelfRemediationConfig,
+	// stateProviderFactory: when non-nil, used in place of the built-in
+	// RPC/P2P state provider selection. Intended for giga mode (pass
+	// `func(ctx) { return NewGigaStateProvider(...), nil }`). Pass nil to
+	// preserve the default behaviour.
+	stateProviderFactory func(ctx context.Context) (StateProvider, error),
 ) (*Reactor, error) {
 	snapshotChannel, err := p2p.OpenChannel(router, GetSnapshotChannelDescriptor())
 	if err != nil {
@@ -274,6 +285,7 @@ func NewReactor(
 		lastNoAvailablePeers:          time.Time{},
 		restartEvent:                  restartEvent,
 		restartNoAvailablePeersWindow: time.Duration(selfRemediationConfig.StatesyncNoPeersRestartWindowSeconds) * time.Second, //nolint:gosec // validated in config.ValidateBasic against MaxInt64
+		stateProviderFactory:          stateProviderFactory,
 	}
 
 	r.BaseService = *service.NewBaseService("StateSync", r)
@@ -281,6 +293,16 @@ func NewReactor(
 }
 
 func (r *Reactor) initStateProvider(ctx context.Context, chainID string, initialHeight int64) error {
+	if r.stateProviderFactory != nil {
+		logger.Info("initializing state provider from factory (giga mode)", "module", "stateprovider")
+		sp, err := r.stateProviderFactory(ctx)
+		if err != nil {
+			return fmt.Errorf("giga stateProviderFactory: %w", err)
+		}
+		r.stateProvider = sp
+		return nil
+	}
+
 	to := light.TrustOptions{
 		Period: r.cfg.TrustPeriod,
 		Height: r.cfg.TrustHeight,

--- a/sei-tendermint/internal/statesync/reactor_test.go
+++ b/sei-tendermint/internal/statesync/reactor_test.go
@@ -82,6 +82,7 @@ func setup(
 		false, // run Sync during Start()
 		func() {},
 		config.DefaultSelfRemediationConfig(),
+		nil, // stateProviderFactory: use default RPC/P2P selection
 	)
 	require.NoError(t, err)
 

--- a/sei-tendermint/internal/statesync/syncer.go
+++ b/sei-tendermint/internal/statesync/syncer.go
@@ -573,7 +573,13 @@ func (s *syncer) verifyApp(ctx context.Context, snapshot *snapshot, appVersion u
 			appVersion, resp.AppVersion)
 	}
 
-	if !bytes.Equal(snapshot.trustedAppHash, resp.LastBlockAppHash) {
+	// A provider that returns an empty trustedAppHash is signalling that it
+	// cannot verify the AppHash cryptographically in advance (e.g. the giga
+	// provider — see giga_stateprovider.go). In that case we skip the
+	// comparison and trust the snapshot optimistically. The vanilla RPC and
+	// P2P providers always return a non-empty AppHash, so their behaviour is
+	// unchanged.
+	if len(snapshot.trustedAppHash) > 0 && !bytes.Equal(snapshot.trustedAppHash, resp.LastBlockAppHash) {
 		logger.Error("appHash verification failed",
 			"expected", snapshot.trustedAppHash,
 			"actual", resp.LastBlockAppHash)

--- a/sei-tendermint/internal/statesync/syncer_test.go
+++ b/sei-tendermint/internal/statesync/syncer_test.go
@@ -798,6 +798,55 @@ func TestSyncer_verifyApp(t *testing.T) {
 	}
 }
 
+// TestSyncer_verifyApp_EmptyTrustedAppHashSkipsCheck covers the giga naive
+// path: a state provider that cannot pre-verify the AppHash returns an empty
+// trustedAppHash, and verifyApp must skip the AppHash comparison rather than
+// fail with errVerifyFailed. Height and app-version checks still run.
+func TestSyncer_verifyApp_EmptyTrustedAppHashSkipsCheck(t *testing.T) {
+	const appVersion = 9
+	// trustedAppHash is explicitly empty — this is how the giga state
+	// provider signals "trust the snapshot optimistically".
+	s := &snapshot{Height: 3, Format: 1, Chunks: 5, Hash: []byte{1, 2, 3}, trustedAppHash: nil}
+
+	testcases := map[string]struct {
+		response  *abci.ResponseInfo
+		expectErr error
+	}{
+		// A mismatched AppHash that would fail with the old strict check
+		// must now succeed, because the provider opted out of pre-verification.
+		"accepts any app hash": {&abci.ResponseInfo{
+			LastBlockHeight:  3,
+			LastBlockAppHash: []byte("whatever"),
+			AppVersion:       appVersion,
+		}, nil},
+		// Height check still applies.
+		"still checks height": {&abci.ResponseInfo{
+			LastBlockHeight:  5,
+			LastBlockAppHash: []byte("whatever"),
+			AppVersion:       appVersion,
+		}, errVerifyFailed},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			ctx := t.Context()
+			rts := setup(t, nil, nil, true)
+			app := rts.conn
+			app.info.Push(func(_ context.Context, req *abci.RequestInfo) (*abci.ResponseInfo, error) {
+				utils.OrPanic(utils.TestDiff(&version.RequestInfo, req))
+				return tc.response, nil
+			})
+			err := rts.reactor.syncer.verifyApp(ctx, s, appVersion)
+			unwrapped := errors.Unwrap(err)
+			if unwrapped != nil {
+				err = unwrapped
+			}
+			require.Equal(t, tc.expectErr, err)
+			app.AssertExpectations(t)
+		})
+	}
+}
+
 func toABCI(s *snapshot) *abci.Snapshot {
 	return &abci.Snapshot{
 		Height:   s.Height,

--- a/sei-tendermint/node/node.go
+++ b/sei-tendermint/node/node.go
@@ -257,11 +257,28 @@ func makeNode(
 	// app may modify the validator set, specifying ourself as the only validator.
 	blockSync := !onlyValidatorIsUs(state, pubKey)
 	if gigaEnabled {
-		// TODO(autobahn-recovery): handles only restart with local disk intact.
-		// A node that lost its WAL + app CMS (new validator, disk wipe) needs both
-		// app state sync and an autobahn WAL sync to catch up. Not yet supported.
-		stateSync = false
+		// Autobahn does not use CometBFT block sync — blocks arrive into the
+		// data WAL via the giga p2p layer instead.
 		blockSync = false
+		// The state.LastBlockHeight > 0 guard above doesn't fire for giga:
+		// autobahn never writes to CometBFT's state store, so it stays at 0
+		// even after a successful run. Ask the app directly — if its CMS
+		// holds committed state, we have a local WAL to restart from and
+		// don't need state sync. State sync remains available for a joiner
+		// or disk-wiped node where the app's CMS is empty; runExecute's
+		// last>0 path then resumes from the state-synced height and peers
+		// stream subsequent blocks via the giga service.
+		if stateSync {
+			info, err := app.Info(ctx, &abci.RequestInfo{})
+			if err != nil {
+				return nil, combineCloseError(fmt.Errorf("app.Info: %w", err), makeCloser(closers))
+			}
+			if info.LastBlockHeight > 0 {
+				logger.Info("giga: found local app state, skipping state sync",
+					"height", info.LastBlockHeight)
+				stateSync = false
+			}
+		}
 	}
 	waitSync := stateSync || blockSync
 
@@ -340,6 +357,13 @@ func makeNode(
 	}
 
 	postSyncHook := func(ctx context.Context, state sm.State) error {
+		if gigaEnabled {
+			// In giga mode there's no CometBFT block sync or consensus reactor
+			// to hand control to — csReactor is nil and bcReactor is inert.
+			// The giga router's runExecute picks up from app.Info().LastBlockHeight
+			// on its own, so no further action is required here.
+			return nil
+		}
 		csReactor.SetStateSyncingMetrics(0)
 
 		// TODO: Some form of orchestrator is needed here between the state
@@ -366,7 +390,20 @@ func makeNode(
 	// giga router's runExecute owns InitChain on fresh start (appHeight==0) and
 	// relies on the app's committed CMS to rebuild deliverState on restart.
 	node.shouldHandshake = !stateSync && !gigaEnabled
-	if !gigaEnabled {
+	// In giga mode the state sync reactor is only wired when we actually
+	// intend to sync (joining node / disk-wiped validator). A plain giga
+	// restart skips it (stateSync above was cleared by the app.Info() check).
+	if !gigaEnabled || stateSync {
+		// In giga mode, inject the autobahn state provider factory so the
+		// reactor uses it instead of the RPC/P2P selection. Nil for
+		// non-giga callers preserves existing behaviour.
+		var stateProviderFactory func(ctx context.Context) (statesync.StateProvider, error)
+		if gigaEnabled {
+			gd := genDoc
+			stateProviderFactory = func(_ context.Context) (statesync.StateProvider, error) {
+				return statesync.NewGigaStateProvider(gd), nil
+			}
+		}
 		ssReactor, err := statesync.NewReactor(
 			genDoc.ChainID,
 			genDoc.InitialHeight,
@@ -383,6 +420,7 @@ func makeNode(
 			stateSync,
 			restartEvent,
 			cfg.SelfRemediation,
+			stateProviderFactory,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("statesync.NewReactor(): %w", err)


### PR DESCRIPTION
> Stacks on top of #3300. Base will change to `main` once #3300 merges.

> **Status: draft — initial feedback round.** No integration test yet; see "Scope / Follow-ups" below.

## Summary

Extends #3300 to cover the **new-validator joining** and **disk-wiped node** recovery paths via CometBFT state sync. A joiner state-syncs the app to some height `M`, then `runExecute` resumes at `M+1` pulling subsequent blocks from giga peers.

## Changes

- **`node.go`** — stop force-disabling `stateSync` in giga mode. Gate on a direct `app.Info()` check since CometBFT's `state.LastBlockHeight` never advances under autobahn. `postSyncHook` is a no-op in giga mode (no block-sync reactor to hand control to). `ssReactor` wired only when `stateSync` is actually enabled.
- **`statesync/reactor.go`** — new optional `stateProviderFactory` param to `NewReactor`, used in place of the RPC/P2P selection when set. Non-giga callers pass `nil`; existing behaviour preserved.
- **`statesync/giga_stateprovider.go`** *(new)* — naive provider: empty `AppHash` (opts out of pre-verification), minimal `Commit`, `sm.State` from `GenesisDoc` + static committee.
- **`statesync/syncer.go`** — skip the post-restore `AppHash` comparison when `trustedAppHash` is empty. Vanilla providers always return non-empty, so their behaviour is unchanged.
- **`autobahn/data/state.go`** — expose public `SkipTo` wrapping the existing internal `skipTo`. Used post-state-sync to align data cursors so peer-streamed blocks from `M+1` onward insert correctly.
- **`p2p/giga_router.go`** — new state-sync branch in `runExecute` (`last > 0 && NextBlock() <= last`): `SkipTo(last+1)`, no `PushAppHash`. Fresh / plain-restart branches unchanged from #3300.

## New startup path (case E, added to #3300's A–D)

|  | `shouldHandshake` | `stateSync` | `InitChain` by | first `FinalizeBlock` `deliverState` |
|---|---|---|---|---|
| **E join/recovery, giga (no local WAL)** | **false** | **true** | — (after sync, `last>0` skips it) | CMS rebuilt from snapshot chunks |

## Trust model — naive for v1, AppQC-bundled for v2

This PR **trusts the snapshot producer optimistically**: `stateProvider.AppHash` returns empty, `syncer.verifyApp` skips the comparison, and a corrupt snapshot wedges the joiner until external restart-with-wipe. The vanilla `SyncAny` retry loop only helps against honest-but-unavailable peers, not malicious ones — a malicious peer can loop-trap a joiner.

**The planned v2 mechanism (tracked by `TODO(autobahn-snapshot-proof)` in `giga_stateprovider.go`):**

> Peers serving a giga snapshot MUST include an `AppQC@snapshot_height` in `snapshot.Metadata`. The giga state provider decodes the AppQC, verifies `appQC.Verify(committee)` (2f+1 committee signatures — cryptographically self-verifiable from a single peer), compares `AppQC.AppHash` to the snapshot's claimed `AppHash`, and returns that as the authoritative `trustedAppHash`. Any corrupt snapshot fails `stateProvider.AppHash` and triggers vanilla `SyncAny`'s `errRejectSnapshot` → next snapshot → repeat. No loop-trap, no node restart required.

**Why not in this PR:**
- Autobahn only retains the **latest** AppQC in memory (`avail.latestAppQC` is a single `utils.Option`, not a queue). Historical AppQCs aren't persisted.
- `AppQC@M` forms *after* the app commits block `M` (committee votes are asynchronous), so the snapshot taken at Commit(M) doesn't yet have its anchor.
- v2 needs either (a) a "seal snapshot on AppQC formation" hook between the snapshot manager and avail state, or (b) coordinated delayed snapshot creation. Both are real scope, landing in a follow-up.

Until v2 lands: operators should only point joiners at known-honest peers; a bad snapshot is an ops issue, not a safety issue (the cluster is unaffected, only the joiner is stuck).

## Test plan

- [x] `go build ./...` clean; `gofmt -s -l .` clean
- [x] `go test ./internal/statesync/... ./internal/p2p/... ./internal/autobahn/... ./node/... ./internal/consensus/...` — all green
- [x] New unit tests: 5 × `TestGigaStateProvider_*`, 2 × `TestState_SkipTo_*`, 2 × `TestSyncer_verifyApp_EmptyTrustedAppHashSkipsCheck`

**Not yet:**
- [ ] `JoinFromStateSync` integration subtest — wipe a node's data dir, `statesync.enable = true`, restart, verify catchup. `snapshot-interval=100` already configured in the docker cluster. Deferred to land together with v2 (snapshot-proof), since integration-testing the naive-trust path without proper verification is of limited value.

## Scope / Follow-ups

- **v2 snapshot proof** (`TODO(autobahn-snapshot-proof)`) — bundle `AppQC` in `snapshot.Metadata`, verify cryptographically, enable in-loop retry.
- **Integration test** (`JoinFromStateSync`) — lands with v2.
- **`TODO(epoch)`** in `giga_stateprovider.go` — committee / validator set derivation moves to epoch lookup once autobahn supports dynamic committees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)