### PR TITLE
rpc: route /block + /block_results + /block_by_hash + /validators through Autobahn under GigaEnabled (CON-257)

### DIFF
--- a/integration_test/autobahn/autobahn_test.go
+++ b/integration_test/autobahn/autobahn_test.go
@@ -29,10 +29,16 @@ import (
 )
 
 const (
-	abciInfoURL   = "http://localhost:26657/abci_info"
+	tmRPCBase     = "http://localhost:26657"
+	abciInfoURL   = tmRPCBase + "/abci_info"
 	heightRetries = 60
 	heightBackoff = 500 * time.Millisecond
 	heightTimeout = 100 * time.Millisecond
+	// tmRPCTimeout covers single-shot tmRPC verifications post-bootstrap.
+	// Looser than heightTimeout (which is intentionally tight to keep
+	// height-polling retries quick) because these calls happen on a chain
+	// we've already confirmed is live.
+	tmRPCTimeout = 5 * time.Second
 
 	// Cluster lifecycle (TestMain).
 	clusterBootTimeout  = 5 * time.Minute
@@ -40,7 +46,10 @@ const (
 	autobahnSettleDelay = 30 * time.Second
 )
 
-var heightClient = &http.Client{Timeout: heightTimeout}
+var (
+	heightClient = &http.Client{Timeout: heightTimeout}
+	tmRPCClient  = &http.Client{Timeout: tmRPCTimeout}
+)
 
 // clusterSize is set once at TestAutobahn start from the number of running
 // sei-node-* containers. Subtests read it (and maxFaults) from here.
@@ -370,6 +379,112 @@ func testBlockProduction(t *testing.T) {
 	t.Logf("height after 5s: %d", h2)
 	if h2 <= h1 {
 		t.Fatalf("block height not advancing (%d -> %d)", h1, h2)
+	}
+
+	// Verify the Autobahn-routed tmRPC handlers serve real data at h2 (a
+	// recently committed height — past tail of the chain, so historical
+	// query paths are exercised without racing the producer). Each
+	// endpoint asserts one observable property; a single mismatch fails
+	// the test with the specific shape that broke.
+	assertTmRPCEndpoints(t, h2)
+}
+
+// assertTmRPCEndpoints exercises the tmRPC surface that PR #3310 wires up
+// under Autobahn (env.Block, env.BlockResults, env.BlockByHash, env.Validators).
+// One call per endpoint is enough — these handlers are pure RPC translation
+// over the same data.State / GenDoc plumbing, so a single positive case at
+// a real height catches both wrong-routing (e.g. CometBFT path returning
+// nulls because BlockStore is empty) and shape-drift regressions.
+func assertTmRPCEndpoints(t *testing.T, h int64) {
+	t.Helper()
+
+	// /block at h: must return a fully-populated translated block.
+	var rb coretypes.ResultBlock
+	fetchTmRPC(t, fmt.Sprintf("%s/block?height=%d", tmRPCBase, h), &rb)
+	if rb.Block == nil {
+		t.Fatalf("/block?height=%d: nil block (env.Block likely fell through to empty BlockStore)", h)
+	}
+	if rb.Block.Height != h {
+		t.Fatalf("/block?height=%d: got block.height=%d", h, rb.Block.Height)
+	}
+	if len(rb.BlockID.Hash) == 0 {
+		t.Fatalf("/block?height=%d: empty BlockID.Hash (Autobahn header → CometBFT BlockID translation skipped)", h)
+	}
+
+	// /block_by_hash with the hash we just received: must round-trip to
+	// the same height. Exercises GigaRouter's hash → height index in
+	// data.State.inner.blockHashes. Note: use bare-hex form (no `0x`
+	// prefix) — the 0x form goes through a binary-base64 round-trip in
+	// the URI handler that doesn't cleanly traverse HexBytes.UnmarshalText
+	// for our request shape; bare hex stays on the string path.
+	var rbh coretypes.ResultBlock
+	fetchTmRPC(t, fmt.Sprintf("%s/block_by_hash?hash=%x", tmRPCBase, rb.BlockID.Hash), &rbh)
+	if rbh.Block == nil {
+		t.Fatalf("/block_by_hash(%x): nil block (hash index miss)", rb.BlockID.Hash)
+	}
+	if rbh.Block.Height != h {
+		t.Fatalf("/block_by_hash(%x): got height %d, want %d (round-trip mismatch)",
+			rb.BlockID.Hash, rbh.Block.Height, h)
+	}
+
+	// /block_results at h: header echo. We don't assert TxsResults shape —
+	// it's intentionally empty under Autobahn (FinalizeBlock responses
+	// aren't persisted; documented in PR #3310).
+	var rbr coretypes.ResultBlockResults
+	fetchTmRPC(t, fmt.Sprintf("%s/block_results?height=%d", tmRPCBase, h), &rbr)
+	if rbr.Height != h {
+		t.Fatalf("/block_results?height=%d: got height=%d", h, rbr.Height)
+	}
+
+	// /validators at h: committee is fixed at genesis under Autobahn, so
+	// any retained height returns it. block_height in the response must
+	// match the requested height (catches the old "stuck at 1" StateStore
+	// behavior).
+	var rv coretypes.ResultValidators
+	fetchTmRPC(t, fmt.Sprintf("%s/validators?height=%d", tmRPCBase, h), &rv)
+	if rv.BlockHeight != h {
+		t.Fatalf("/validators?height=%d: got block_height=%d (StateStore-stuck-at-1 regression?)",
+			h, rv.BlockHeight)
+	}
+	if rv.Total < 1 || len(rv.Validators) < 1 {
+		t.Fatalf("/validators?height=%d: empty committee (total=%d, count=%d)",
+			h, rv.Total, len(rv.Validators))
+	}
+}
+
+// fetchTmRPC issues a GET against a tmRPC URL-form endpoint and decodes the
+// (unwrapped, non-JSONRPC) response into `into` via tmjson, which handles the
+// int-as-string convention CometBFT uses on the wire. Mirrors fetchHeight's
+// shape but with the looser tmRPCTimeout for one-shot verifications.
+//
+// Detects server-side errors before unmarshaling: tmRPC URL-form returns
+// either the result struct directly (success) or a {code,message,data}
+// object (error). Without this check, an error response would silently
+// unmarshal into a zero-valued result struct because none of the keys
+// match, causing tests to read "missing field" as "data missing" rather
+// than "the call failed".
+func fetchTmRPC[T any](t *testing.T, url string, into *T) {
+	t.Helper()
+	resp, err := tmRPCClient.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read %s: %v", url, err)
+	}
+	var maybeErr struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Data    string `json:"data"`
+	}
+	if json.Unmarshal(body, &maybeErr) == nil && maybeErr.Code != 0 {
+		t.Fatalf("GET %s: server error code=%d message=%q data=%q",
+			url, maybeErr.Code, maybeErr.Message, maybeErr.Data)
+	}
+	if err := tmjson.Unmarshal(body, into); err != nil {
+		t.Fatalf("parse %s: %v\nbody: %s", url, err, body)
 	}
 }
 

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -458,8 +458,13 @@ func (s *State) NextBlock() types.GlobalBlockNumber {
 // the hash index is maintained in lockstep by insertBlock / pruneFirst.
 //
 // Returns an error in the signature for forward-compat with the eventual
-// switch to sei-db/ledger_db/block.BlockDB.GetBlockByHash, which can fail
-// with real I/O errors. The current in-memory implementation never errors.
+// switch to sei-db/ledger_db/block.BlockDB.GetBlockByHash. Today's
+// in-memory implementation never errors.
+//
+// TODO(autobahn): when BlockDB is wired, take a ctx parameter and narrow
+// the error contract — db-internal errors should surface by shutting down
+// the persistence background task (matching how persistence handles errors
+// today), so the query path's error stays bounded to context.Canceled.
 func (s *State) GlobalBlockByHash(hash types.BlockHeaderHash) (utils.Option[*types.GlobalBlock], error) {
 	for inner := range s.inner.Lock() {
 		n, ok := inner.blockHashes[hash]

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -149,6 +149,17 @@ type inner struct {
 	blocks       map[types.GlobalBlockNumber]*types.Block             // [first,nextBlock) + subset of [nextBlock,nextQC)
 	appProposals map[types.GlobalBlockNumber]appProposalWithTimestamp // [first,nextAppProposal)
 
+	// blockHashes is a hash → height index mirroring blocks. Maintained
+	// in lockstep with blocks via insertBlock / pruneFirst, so it covers
+	// exactly the same retain window without a separate prune cursor or
+	// startup warmup. Powers BlockByHash.
+	//
+	// TODO(autobahn): remove once a writer is wired into block execution
+	// that populates sei-db/ledger_db/block.BlockDB. BlockDB has a built-in
+	// hash index that survives process restart and lives outside Autobahn's
+	// RetainHeight pruning, making this in-memory index obsolete.
+	blockHashes map[types.BlockHeaderHash]types.GlobalBlockNumber
+
 	// first <= nextAppProposal <= nextBlockToPersist <= nextBlock <= nextQC
 	//
 	// This invariant guarantees no race between pruning and persisting:
@@ -168,6 +179,7 @@ func newInner(committee *types.Committee) *inner {
 		qcs:                map[types.GlobalBlockNumber]*types.FullCommitQC{},
 		blocks:             map[types.GlobalBlockNumber]*types.Block{},
 		appProposals:       map[types.GlobalBlockNumber]appProposalWithTimestamp{},
+		blockHashes:        map[types.BlockHeaderHash]types.GlobalBlockNumber{},
 		first:              first,
 		nextAppProposal:    first,
 		nextBlockToPersist: first,
@@ -226,10 +238,12 @@ func (i *inner) insertBlock(committee *types.Committee, n types.GlobalBlockNumbe
 	qc := i.qcs[n]
 	storedGR := qc.QC().GlobalRange(committee)
 	want := qc.Headers()[n-storedGR.First].Hash()
-	if got := block.Header().Hash(); want != got {
+	got := block.Header().Hash()
+	if want != got {
 		return fmt.Errorf("block %d header hash mismatch: want %v, got %v", n, want, got)
 	}
 	i.blocks[n] = block
+	i.blockHashes[got] = n
 	return nil
 }
 
@@ -255,6 +269,7 @@ func (i *inner) pruneFirst(now time.Time, m *dataMetrics) {
 	delete(i.appProposals, i.first)
 	delete(i.blocks, i.first)
 	delete(i.qcs, i.first)
+	delete(i.blockHashes, b.Header().Hash())
 	i.first += 1
 }
 
@@ -434,6 +449,28 @@ func (s *State) NextBlock() types.GlobalBlockNumber {
 	panic("unreachable")
 }
 
+// GlobalBlockByHash returns the finalized GlobalBlock whose stored header
+// hashes to the given value, or None if no such block is currently in the
+// retained range. The lookup-and-construct happens under a single lock so
+// the returned block matches the looked-up hash atomically — pruning can't
+// change which height a hash maps to between the index check and the block
+// construction. Tracks the same retain window as Block / GlobalBlock since
+// the hash index is maintained in lockstep by insertBlock / pruneFirst.
+//
+// Returns an error in the signature for forward-compat with the eventual
+// switch to sei-db/ledger_db/block.BlockDB.GetBlockByHash, which can fail
+// with real I/O errors. The current in-memory implementation never errors.
+func (s *State) GlobalBlockByHash(hash types.BlockHeaderHash) (utils.Option[*types.GlobalBlock], error) {
+	for inner := range s.inner.Lock() {
+		n, ok := inner.blockHashes[hash]
+		if !ok {
+			return utils.None[*types.GlobalBlock](), nil
+		}
+		return utils.Some(inner.globalBlockAt(s.Committee(), n)), nil
+	}
+	panic("unreachable")
+}
+
 // Block returns the block with the given global number.
 // This function is used for syncing - GlobalBlock can be derived from Block and FullCommitQC,
 // which have to be fetched upfront anyway.
@@ -469,6 +506,21 @@ func (s *State) TryBlock(n types.GlobalBlockNumber) (*types.Block, error) {
 	panic("unreachable")
 }
 
+// globalBlockAt assembles the GlobalBlock at height n from inner state.
+// Caller must already hold the inner lock and have verified n is in
+// [inner.first, inner.nextBlock).
+func (i *inner) globalBlockAt(c *types.Committee, n types.GlobalBlockNumber) *types.GlobalBlock {
+	b := i.blocks[n]
+	qc := i.qcs[n].QC()
+	return &types.GlobalBlock{
+		GlobalNumber:  n,
+		Timestamp:     qc.Proposal().BlockTimestamp(c, n).OrPanic("global block not in QC"),
+		Header:        b.Header(),
+		Payload:       b.Payload(),
+		FinalAppState: qc.Proposal().App(),
+	}
+}
+
 // GlobalBlock returns the block with the given global number.
 // Returns ErrPruned if the block has already been pruned.
 func (s *State) GlobalBlock(ctx context.Context, n types.GlobalBlockNumber) (*types.GlobalBlock, error) {
@@ -481,15 +533,7 @@ func (s *State) GlobalBlock(ctx context.Context, n types.GlobalBlockNumber) (*ty
 		if n < inner.first {
 			return nil, ErrPruned
 		}
-		b := inner.blocks[n]
-		qc := inner.qcs[n].QC()
-		return &types.GlobalBlock{
-			GlobalNumber:  n,
-			Timestamp:     qc.Proposal().BlockTimestamp(s.Committee(), n).OrPanic("global block not in QC"),
-			Header:        b.Header(),
-			Payload:       b.Payload(),
-			FinalAppState: qc.Proposal().App(),
-		}, nil
+		return inner.globalBlockAt(s.Committee(), n), nil
 	}
 	panic("unreachable")
 }

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -507,8 +507,8 @@ func (s *State) TryBlock(n types.GlobalBlockNumber) (*types.Block, error) {
 }
 
 // globalBlockAt assembles the GlobalBlock at height n from inner state.
-// Caller must already hold the inner lock and have verified n is in
-// [inner.first, inner.nextBlock).
+// Caller must have verified n is in [inner.first, inner.nextBlock); n
+// outside that range nil-derefs on inner.blocks[n] / inner.qcs[n].
 func (i *inner) globalBlockAt(c *types.Committee, n types.GlobalBlockNumber) *types.GlobalBlock {
 	b := i.blocks[n]
 	qc := i.qcs[n].QC()

--- a/sei-tendermint/internal/autobahn/data/state_test.go
+++ b/sei-tendermint/internal/autobahn/data/state_test.go
@@ -331,6 +331,58 @@ func TestPushBlockAcceptsBlockWithQC(t *testing.T) {
 	require.Equal(t, blocks[0], got)
 }
 
+// TestGlobalBlockByHash isolates the hash-keyed lookup from the
+// consensus-driven harness. We push a single QC + block via the same code
+// path the network would (insertBlock writes to inner.blockHashes), then:
+//
+//   - the block's own header hash resolves to Some(*GlobalBlock) with the
+//     expected height/header/payload — the index points at the right
+//     block, atomically with the block construction
+//   - a zero hash and a random hash both resolve to None — distinct
+//     unknown-hash inputs all read as "not found", no panics
+//   - err is nil throughout — today's in-memory implementation has no
+//     failure mode; the error return on GlobalBlockByHash is reserved
+//     for the future BlockDB-backed path
+func TestGlobalBlockByHash(t *testing.T) {
+	ctx := t.Context()
+	rng := utils.TestRng()
+	committee, keys := types.GenCommittee(rng, 3)
+
+	state := utils.OrPanic1(NewState(&Config{
+		Committee: committee,
+	}, utils.OrPanic1(NewDataWAL(utils.None[string](), committee))))
+
+	qc, blocks := TestCommitQC(rng, committee, keys, utils.None[*types.CommitQC]())
+	require.NoError(t, state.PushQC(ctx, qc, blocks))
+	gr := qc.QC().GlobalRange(committee)
+	n := gr.First
+	wantBlock := blocks[0]
+	wantHash := wantBlock.Header().Hash()
+
+	// Known hash → Some with correct fields.
+	gotOpt, err := state.GlobalBlockByHash(wantHash)
+	require.NoError(t, err)
+	gotGB, ok := gotOpt.Get()
+	require.True(t, ok, "GlobalBlockByHash(known) returned None")
+	require.Equal(t, n, gotGB.GlobalNumber)
+	require.Equal(t, wantBlock.Header(), gotGB.Header)
+	require.Equal(t, wantBlock.Payload(), gotGB.Payload)
+
+	// Zero hash → None.
+	zeroOpt, err := state.GlobalBlockByHash(types.BlockHeaderHash{})
+	require.NoError(t, err)
+	_, ok = zeroOpt.Get()
+	require.False(t, ok, "GlobalBlockByHash(zero) returned Some")
+
+	// Random unknown hash → None.
+	var randHash types.BlockHeaderHash
+	rng.Read(randHash[:])
+	randOpt, err := state.GlobalBlockByHash(randHash)
+	require.NoError(t, err)
+	_, ok = randOpt.Get()
+	require.False(t, ok, "GlobalBlockByHash(random) returned Some")
+}
+
 // ── Reconcile tests (grouped by case number) ──────────────────────────
 
 // TestStateRecoveryBlocksOnly simulates a crash after blocks are written

--- a/sei-tendermint/internal/autobahn/producer/state.go
+++ b/sei-tendermint/internal/autobahn/producer/state.go
@@ -30,6 +30,18 @@ func (c *Config) maxTxsPerBlock() uint64 {
 	return min(c.MaxTxsPerBlock, c.MaxGasPerBlock/minTxGas)
 }
 
+// MaxGasPerBlockI64 returns MaxGasPerBlock clamped to the int64 range.
+// Config validation only enforces > 0 (sei-tendermint/config/autobahn.go),
+// so a misconfigured chain with a value above math.MaxInt64 can't silently
+// overflow when consumed by APIs that take int64 (the mempool's ReapLimits,
+// the RPC layer's ConsensusParamUpdates.Block.MaxGas). Centralizing the
+// clamp here means callers pick this up by name instead of repeating
+// utils.Clamp[int64] at every site, and any future change to the clamp
+// rule (or the underlying field type) lives in one place.
+func (c *Config) MaxGasPerBlockI64() int64 {
+	return utils.Clamp[int64](c.MaxGasPerBlock)
+}
+
 // State is the block producer state.
 type State struct {
 	cfg       *Config
@@ -64,8 +76,8 @@ func (s *State) makePayload(ctx context.Context) (*types.Payload, error) {
 	txs, gasEstimated := s.txMempool.PopTxs(mempool.ReapLimits{
 		MaxTxs:          utils.Some(min(types.MaxTxsPerBlock, s.cfg.maxTxsPerBlock())),
 		MaxBytes:        utils.Some(utils.Clamp[int64](types.MaxTxsBytesPerBlock)),
-		MaxGasWanted:    utils.Some(utils.Clamp[int64](s.cfg.MaxGasPerBlock)),
-		MaxGasEstimated: utils.Some(utils.Clamp[int64](s.cfg.MaxGasPerBlock)),
+		MaxGasWanted:    utils.Some(s.cfg.MaxGasPerBlockI64()),
+		MaxGasEstimated: utils.Some(s.cfg.MaxGasPerBlockI64()),
 	})
 	payloadTxs := make([][]byte, 0, len(txs))
 	for _, tx := range txs {

--- a/sei-tendermint/internal/p2p/giga_router.go
+++ b/sei-tendermint/internal/p2p/giga_router.go
@@ -163,11 +163,11 @@ func (r *GigaRouter) BlockByNumber(ctx context.Context, n int64) (*coretypes.Res
 	if err != nil {
 		// Map Autobahn's pruning sentinel to CometBFT's, so callers
 		// (env.Block, evmrpc, ops tooling) get the same error type they
-		// already handle on the CometBFT path. env.getHeight returns
-		// ErrHeightNotAvailable for the same case (height < base).
+		// already handle on the CometBFT path. base is None because the
+		// active lower bound (data.State.inner.first) is internal to
+		// data.State; both call sites format through the same helper.
 		if errors.Is(err, data.ErrPruned) {
-			return nil, fmt.Errorf("%w (requested height: %d)",
-				coretypes.ErrHeightNotAvailable, n)
+			return nil, coretypes.WrapErrHeightNotAvailable(n, utils.None[int64]())
 		}
 		return nil, fmt.Errorf("data.GlobalBlock(%v): %w", gbn, err)
 	}

--- a/sei-tendermint/internal/p2p/giga_router.go
+++ b/sei-tendermint/internal/p2p/giga_router.go
@@ -172,17 +172,55 @@ func (r *GigaRouter) BlockByNumber(ctx context.Context, n int64) (*coretypes.Res
 		}
 		return nil, fmt.Errorf("data.GlobalBlock(%v): %w", gbn, err)
 	}
-	// Mimic the CometBFT env.Block contract so external tools (block
-	// explorers, ethers/web3 clients, monitoring) don't see different shapes
-	// when Sei runs under Autobahn vs CometBFT. Under CometBFT a missing
-	// block returns ResultBlock{Block: nil}; partial state populates what's
-	// present and leaves the rest at zero values — the call never fails on
-	// missing data. We do the same here: populate what we have, leave the
-	// rest at zero, never nil-deref. A malformed-block condition (nil header
-	// or payload despite a successful lookup) shows up as zero-valued fields
-	// in the response — observable without crashing the handler.
-	if gb == nil {
+	return r.translateGlobalBlock(gb), nil
+}
+
+// BlockByHash returns the finalized global block whose Autobahn header hashes
+// to the given bytes, translated into the CometBFT coretypes.ResultBlock
+// shape (same translation as BlockByNumber). Matches CometBFT semantics for
+// unknown hashes: returns &ResultBlock{Block: nil} with no error.
+//
+// Lookup-and-construct happens under a single data.State lock acquire, so
+// the returned block matches the requested hash atomically. Hashes below
+// the pruning watermark are not indexed and read as "unknown".
+//
+// TODO(autobahn): replace this with a direct read from
+// sei-db/ledger_db/block.BlockDB.GetBlockByHash once a writer is wired into
+// block execution. The data.State-side index can also go away at that point.
+func (r *GigaRouter) BlockByHash(_ context.Context, hash []byte) (*coretypes.ResultBlock, error) {
+	if len(hash) != len(atypes.BlockHeaderHash{}) {
+		// Wrong-size hashes can never match anything we indexed; treat as
+		// unknown to mirror CometBFT's BlockStore.LoadBlockByHash behavior.
+		// (Also makes the slice→array conversion below unreachable for
+		// length-mismatch panics.)
 		return &coretypes.ResultBlock{}, nil
+	}
+	opt, err := r.data.GlobalBlockByHash(atypes.BlockHeaderHash(hash))
+	if err != nil {
+		return nil, fmt.Errorf("data.GlobalBlockByHash: %w", err)
+	}
+	// None case is handled by translateGlobalBlock — a None Option's Get
+	// returns (nil, false), translateGlobalBlock returns the empty
+	// ResultBlock for nil input, so unknown hashes get the same
+	// CometBFT-symmetric zero-result shape automatically.
+	gb, _ := opt.Get()
+	return r.translateGlobalBlock(gb), nil
+}
+
+// translateGlobalBlock converts an Autobahn GlobalBlock to the CometBFT
+// coretypes.ResultBlock shape used by env.Block / env.BlockByHash and
+// downstream evmrpc consumers. Mimics the CometBFT contract — external
+// tools (block explorers, ethers/web3 clients, monitoring) don't see
+// different shapes when Sei runs under Autobahn vs CometBFT. Under CometBFT
+// a missing block returns ResultBlock{Block: nil}; partial state populates
+// what's present and leaves the rest at zero values — the call never fails
+// on missing data. We do the same: populate what we have, leave the rest
+// at zero, never nil-deref. A malformed-block condition (nil header or
+// payload despite a successful lookup) shows up as zero-valued fields in
+// the response — observable without crashing the handler.
+func (r *GigaRouter) translateGlobalBlock(gb *atypes.GlobalBlock) *coretypes.ResultBlock {
+	if gb == nil {
+		return &coretypes.ResultBlock{}
 	}
 	var blockHash tmbytes.HexBytes
 	if gb.Header != nil {
@@ -207,7 +245,7 @@ func (r *GigaRouter) BlockByNumber(ctx context.Context, n int64) (*coretypes.Res
 			},
 			Data: types.Data{Txs: tmTxs},
 		},
-	}, nil
+	}
 }
 
 func (r *GigaRouter) executeBlock(ctx context.Context, b *atypes.GlobalBlock) (*abci.ResponseCommit, error) {

--- a/sei-tendermint/internal/p2p/giga_router.go
+++ b/sei-tendermint/internal/p2p/giga_router.go
@@ -154,12 +154,8 @@ func (r *GigaRouter) MaxGasPerBlock() int64 {
 // Sei's RetainHeight and exposes only a height index (no GetBlockByHash).
 // BlockDB has the right shape (height + hash indexes, async pruning) and
 // is the long-term home for this read path.
-func (r *GigaRouter) BlockByNumber(ctx context.Context, n int64) (*coretypes.ResultBlock, error) {
-	gbn, ok := utils.SafeCast[atypes.GlobalBlockNumber](n)
-	if !ok {
-		return nil, fmt.Errorf("invalid height %d", n)
-	}
-	gb, err := r.data.GlobalBlock(ctx, gbn)
+func (r *GigaRouter) BlockByNumber(ctx context.Context, n atypes.GlobalBlockNumber) (*coretypes.ResultBlock, error) {
+	gb, err := r.data.GlobalBlock(ctx, n)
 	if err != nil {
 		// Map Autobahn's pruning sentinel to CometBFT's, so callers
 		// (env.Block, evmrpc, ops tooling) get the same error type they
@@ -167,9 +163,9 @@ func (r *GigaRouter) BlockByNumber(ctx context.Context, n int64) (*coretypes.Res
 		// active lower bound (data.State.inner.first) is internal to
 		// data.State; both call sites format through the same helper.
 		if errors.Is(err, data.ErrPruned) {
-			return nil, coretypes.WrapErrHeightNotAvailable(n, utils.None[int64]())
+			return nil, coretypes.WrapErrHeightNotAvailable(utils.Clamp[int64](n), utils.None[int64]())
 		}
-		return nil, fmt.Errorf("data.GlobalBlock(%v): %w", gbn, err)
+		return nil, fmt.Errorf("data.GlobalBlock(%v): %w", n, err)
 	}
 	return r.translateGlobalBlock(gb), nil
 }

--- a/sei-tendermint/internal/p2p/giga_router.go
+++ b/sei-tendermint/internal/p2p/giga_router.go
@@ -174,27 +174,22 @@ func (r *GigaRouter) BlockByNumber(ctx context.Context, n int64) (*coretypes.Res
 	return r.translateGlobalBlock(gb), nil
 }
 
-// BlockByHash returns the finalized global block whose Autobahn header hashes
-// to the given bytes, translated into the CometBFT coretypes.ResultBlock
-// shape (same translation as BlockByNumber). Matches CometBFT semantics for
+// BlockByHash returns the finalized global block keyed by Autobahn block-
+// header hash, translated into the CometBFT coretypes.ResultBlock shape
+// (same translation as BlockByNumber). Matches CometBFT semantics for
 // unknown hashes: returns &ResultBlock{Block: nil} with no error.
 //
 // Lookup-and-construct happens under a single data.State lock acquire, so
 // the returned block matches the requested hash atomically. Hashes below
-// the pruning watermark are not indexed and read as "unknown".
+// the pruning watermark are not indexed and read as "unknown". Wrong-size
+// inputs are rejected at the call site (env.BlockByHash) so this method
+// can stay strongly typed on atypes.BlockHeaderHash.
 //
 // TODO(autobahn): replace this with a direct read from
 // sei-db/ledger_db/block.BlockDB.GetBlockByHash once a writer is wired into
 // block execution. The data.State-side index can also go away at that point.
-func (r *GigaRouter) BlockByHash(_ context.Context, hash []byte) (*coretypes.ResultBlock, error) {
-	if len(hash) != len(atypes.BlockHeaderHash{}) {
-		// Wrong-size hashes can never match anything we indexed; treat as
-		// unknown to mirror CometBFT's BlockStore.LoadBlockByHash behavior.
-		// (Also makes the slice→array conversion below unreachable for
-		// length-mismatch panics.)
-		return &coretypes.ResultBlock{}, nil
-	}
-	opt, err := r.data.GlobalBlockByHash(atypes.BlockHeaderHash(hash))
+func (r *GigaRouter) BlockByHash(_ context.Context, hash atypes.BlockHeaderHash) (*coretypes.ResultBlock, error) {
+	opt, err := r.data.GlobalBlockByHash(hash)
 	if err != nil {
 		return nil, fmt.Errorf("data.GlobalBlockByHash: %w", err)
 	}

--- a/sei-tendermint/internal/p2p/giga_router.go
+++ b/sei-tendermint/internal/p2p/giga_router.go
@@ -193,44 +193,35 @@ func (r *GigaRouter) BlockByHash(_ context.Context, hash atypes.BlockHeaderHash)
 	if err != nil {
 		return nil, fmt.Errorf("data.GlobalBlockByHash: %w", err)
 	}
-	// None case is handled by translateGlobalBlock — a None Option's Get
-	// returns (nil, false), translateGlobalBlock returns the empty
-	// ResultBlock for nil input, so unknown hashes get the same
-	// CometBFT-symmetric zero-result shape automatically.
-	gb, _ := opt.Get()
+	// Reject the unknown-hash case here so translateGlobalBlock can rely
+	// on the *GlobalBlock type contract (non-nil, with non-nil Header
+	// and Payload) — same way executeBlock dereferences b.Header
+	// without checking. Mirrors CometBFT's BlockStore.LoadBlockByHash
+	// returning &ResultBlock{Block: nil} for an unknown hash.
+	gb, ok := opt.Get()
+	if !ok {
+		return &coretypes.ResultBlock{}, nil
+	}
 	return r.translateGlobalBlock(gb), nil
 }
 
 // translateGlobalBlock converts an Autobahn GlobalBlock to the CometBFT
 // coretypes.ResultBlock shape used by env.Block / env.BlockByHash and
-// downstream evmrpc consumers. Mimics the CometBFT contract — external
-// tools (block explorers, ethers/web3 clients, monitoring) don't see
-// different shapes when Sei runs under Autobahn vs CometBFT. Under CometBFT
-// a missing block returns ResultBlock{Block: nil}; partial state populates
-// what's present and leaves the rest at zero values — the call never fails
-// on missing data. We do the same: populate what we have, leave the rest
-// at zero, never nil-deref. A malformed-block condition (nil header or
-// payload despite a successful lookup) shows up as zero-valued fields in
-// the response — observable without crashing the handler.
+// downstream evmrpc consumers. Caller must pass a non-nil *GlobalBlock
+// with non-nil Header and Payload — that's the contract data.State
+// guarantees on a successful lookup, and matches how executeBlock
+// dereferences b.Header without a nil-check on the same type. The
+// "no such block" case is rejected at the BlockByHash call site
+// before delegating here.
 func (r *GigaRouter) translateGlobalBlock(gb *atypes.GlobalBlock) *coretypes.ResultBlock {
-	if gb == nil {
-		return &coretypes.ResultBlock{}
+	srcTxs := gb.Payload.Txs()
+	tmTxs := make(types.Txs, len(srcTxs))
+	for i, tx := range srcTxs {
+		tmTxs[i] = tx
 	}
-	var blockHash tmbytes.HexBytes
-	if gb.Header != nil {
-		h := gb.Header.Hash()
-		blockHash = tmbytes.HexBytes(h.Bytes())
-	}
-	var tmTxs types.Txs
-	if gb.Payload != nil {
-		srcTxs := gb.Payload.Txs()
-		tmTxs = make(types.Txs, len(srcTxs))
-		for i, tx := range srcTxs {
-			tmTxs[i] = tx
-		}
-	}
+	h := gb.Header.Hash()
 	return &coretypes.ResultBlock{
-		BlockID: types.BlockID{Hash: blockHash},
+		BlockID: types.BlockID{Hash: tmbytes.HexBytes(h.Bytes())},
 		Block: &types.Block{
 			Header: types.Header{
 				ChainID: r.cfg.GenDoc.ChainID,

--- a/sei-tendermint/internal/p2p/giga_router.go
+++ b/sei-tendermint/internal/p2p/giga_router.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -146,6 +147,14 @@ func (r *GigaRouter) MaxGasPerBlock() int64 {
 // evmrpc does not read them on the receipt path. If gb.Header is nil
 // BlockID.Hash also stays empty; if gb.Payload is nil Block.Data.Txs
 // stays empty (see the malformed-block handling below).
+//
+// TODO(autobahn): switch this to read from sei-db/ledger_db/block.BlockDB
+// once a writer is wired (e.g. from app.FinalizeBlocker or executeBlock).
+// Today no production code calls BlockDB.WriteBlock, so Autobahn's in-memory
+// data.State is the only place a full block lives — but it's pruned per
+// Sei's RetainHeight and exposes only a height index (no GetBlockByHash).
+// BlockDB has the right shape (height + hash indexes, async pruning) and
+// is the long-term home for this read path.
 func (r *GigaRouter) BlockByNumber(ctx context.Context, n int64) (*coretypes.ResultBlock, error) {
 	gbn, ok := utils.SafeCast[atypes.GlobalBlockNumber](n)
 	if !ok {
@@ -153,6 +162,14 @@ func (r *GigaRouter) BlockByNumber(ctx context.Context, n int64) (*coretypes.Res
 	}
 	gb, err := r.data.GlobalBlock(ctx, gbn)
 	if err != nil {
+		// Map Autobahn's pruning sentinel to CometBFT's, so callers
+		// (env.Block, evmrpc, ops tooling) get the same error type they
+		// already handle on the CometBFT path. env.getHeight returns
+		// ErrHeightNotAvailable for the same case (height < base).
+		if errors.Is(err, data.ErrPruned) {
+			return nil, fmt.Errorf("%w (requested height: %d)",
+				coretypes.ErrHeightNotAvailable, n)
+		}
 		return nil, fmt.Errorf("data.GlobalBlock(%v): %w", gbn, err)
 	}
 	// Mimic the CometBFT env.Block contract so external tools (block

--- a/sei-tendermint/internal/p2p/giga_router.go
+++ b/sei-tendermint/internal/p2p/giga_router.go
@@ -16,9 +16,11 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/mempool"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/p2p/giga"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/p2p/rpc"
+	tmbytes "github.com/sei-protocol/sei-chain/sei-tendermint/libs/bytes"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/scope"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/tcp"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/rpc/coretypes"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/version"
 )
@@ -118,6 +120,77 @@ func (r *GigaRouter) LastCommittedBlockNumber() int64 {
 	// committed block number is Next-1.
 	gr := atypes.GlobalRangeOpt(r.lastCommitQCRecv.Load(), r.data.Committee())
 	return int64(gr.Next) - 1 // nolint:gosec // gr.Next is uint64 but bounded by actual chain height.
+}
+
+// MaxGasPerBlock returns the producer's configured max gas per block,
+// clamped to int64 range. Config validation only enforces > 0
+// (sei-tendermint/config/autobahn.go), so we Clamp here to match the
+// producer's own internal use at producer/state.go and avoid a silent
+// overflow on a misconfigured chain. Exposed so the RPC layer can populate
+// ResultBlockResults.ConsensusParamUpdates under Autobahn (where
+// FinalizeBlock responses are not stored on disk).
+func (r *GigaRouter) MaxGasPerBlock() int64 {
+	return utils.Clamp[int64](r.cfg.Producer.MaxGasPerBlock)
+}
+
+// BlockByNumber returns the finalized global block at height n translated
+// into the CometBFT coretypes.ResultBlock shape. This lets consumers
+// (notably evmrpc, which wraps receipts/logs with block context) keep
+// working under Autobahn without CometBFT's BlockStore being populated.
+//
+// Fields populated when the underlying GlobalBlock is well-formed:
+// BlockID.Hash (Autobahn lane-block header hash — the same bytes passed to
+// app.FinalizeBlock's Hash param, which the EVM receipt store records as
+// blockHash), Block.Header.ChainID/Height/Time, Block.Data.Txs. Other
+// fields (AppHash, ProposerAddress, LastCommit, …) stay at zero values —
+// evmrpc does not read them on the receipt path. If gb.Header is nil
+// BlockID.Hash also stays empty; if gb.Payload is nil Block.Data.Txs
+// stays empty (see the malformed-block handling below).
+func (r *GigaRouter) BlockByNumber(ctx context.Context, n int64) (*coretypes.ResultBlock, error) {
+	gbn, ok := utils.SafeCast[atypes.GlobalBlockNumber](n)
+	if !ok {
+		return nil, fmt.Errorf("invalid height %d", n)
+	}
+	gb, err := r.data.GlobalBlock(ctx, gbn)
+	if err != nil {
+		return nil, fmt.Errorf("data.GlobalBlock(%v): %w", gbn, err)
+	}
+	// Mimic the CometBFT env.Block contract so external tools (block
+	// explorers, ethers/web3 clients, monitoring) don't see different shapes
+	// when Sei runs under Autobahn vs CometBFT. Under CometBFT a missing
+	// block returns ResultBlock{Block: nil}; partial state populates what's
+	// present and leaves the rest at zero values — the call never fails on
+	// missing data. We do the same here: populate what we have, leave the
+	// rest at zero, never nil-deref. A malformed-block condition (nil header
+	// or payload despite a successful lookup) shows up as zero-valued fields
+	// in the response — observable without crashing the handler.
+	if gb == nil {
+		return &coretypes.ResultBlock{}, nil
+	}
+	var blockHash tmbytes.HexBytes
+	if gb.Header != nil {
+		h := gb.Header.Hash()
+		blockHash = tmbytes.HexBytes(h.Bytes())
+	}
+	var tmTxs types.Txs
+	if gb.Payload != nil {
+		srcTxs := gb.Payload.Txs()
+		tmTxs = make(types.Txs, len(srcTxs))
+		for i, tx := range srcTxs {
+			tmTxs[i] = tx
+		}
+	}
+	return &coretypes.ResultBlock{
+		BlockID: types.BlockID{Hash: blockHash},
+		Block: &types.Block{
+			Header: types.Header{
+				ChainID: r.cfg.GenDoc.ChainID,
+				Height:  utils.Clamp[int64](uint64(gb.GlobalNumber)),
+				Time:    gb.Timestamp,
+			},
+			Data: types.Data{Txs: tmTxs},
+		},
+	}, nil
 }
 
 func (r *GigaRouter) executeBlock(ctx context.Context, b *atypes.GlobalBlock) (*abci.ResponseCommit, error) {

--- a/sei-tendermint/internal/p2p/giga_router.go
+++ b/sei-tendermint/internal/p2p/giga_router.go
@@ -123,15 +123,14 @@ func (r *GigaRouter) LastCommittedBlockNumber() int64 {
 	return int64(gr.Next) - 1 // nolint:gosec // gr.Next is uint64 but bounded by actual chain height.
 }
 
-// MaxGasPerBlock returns the producer's configured max gas per block,
-// clamped to int64 range. Config validation only enforces > 0
-// (sei-tendermint/config/autobahn.go), so we Clamp here to match the
-// producer's own internal use at producer/state.go and avoid a silent
-// overflow on a misconfigured chain. Exposed so the RPC layer can populate
+// MaxGasPerBlock returns the producer's configured max gas per block (int64).
+// Thin pass-through to producer.Config.MaxGasPerBlockI64 — the clamp logic
+// lives there. Exposed at the GigaRouter level so the RPC layer can populate
 // ResultBlockResults.ConsensusParamUpdates under Autobahn (where
-// FinalizeBlock responses are not stored on disk).
+// FinalizeBlock responses are not stored on disk) without reaching into
+// the unexported router.cfg.
 func (r *GigaRouter) MaxGasPerBlock() int64 {
-	return utils.Clamp[int64](r.cfg.Producer.MaxGasPerBlock)
+	return r.cfg.Producer.MaxGasPerBlockI64()
 }
 
 // BlockByNumber returns the finalized global block at height n translated
@@ -240,8 +239,11 @@ func (r *GigaRouter) translateGlobalBlock(gb *atypes.GlobalBlock) *coretypes.Res
 		Block: &types.Block{
 			Header: types.Header{
 				ChainID: r.cfg.GenDoc.ChainID,
-				Height:  utils.Clamp[int64](uint64(gb.GlobalNumber)),
-				Time:    gb.Timestamp,
+				// Clamp accepts any constraints.Integer for From, so
+				// gb.GlobalNumber (a typed uint64) goes in directly — no
+				// intermediate uint64() conversion needed.
+				Height: utils.Clamp[int64](gb.GlobalNumber),
+				Time:   gb.Timestamp,
 			},
 			Data: types.Data{Txs: tmTxs},
 		},

--- a/sei-tendermint/internal/p2p/giga_router_test.go
+++ b/sei-tendermint/internal/p2p/giga_router_test.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
@@ -392,6 +393,45 @@ func TestGigaRouter_FinalizeBlocks(t *testing.T) {
 			if rb.Block.Header.ChainID != genDoc.ChainID {
 				return fmt.Errorf("router[%v].BlockByNumber(%v): chain id %q, want %q",
 					i, committed, rb.Block.Header.ChainID, genDoc.ChainID)
+			}
+			// Covers GigaRouter.BlockByHash — the accessor used by the
+			// Autobahn branch in env.BlockByHash. Take the hash from the
+			// BlockByNumber result and look up the same block by hash;
+			// verify it round-trips to the same height + chain id.
+			rbh, err := giga.BlockByHash(ctx, rb.BlockID.Hash)
+			if err != nil {
+				return fmt.Errorf("router[%v].BlockByHash(%x): %w", i, rb.BlockID.Hash, err)
+			}
+			if rbh == nil || rbh.Block == nil {
+				return fmt.Errorf("router[%v].BlockByHash(%x): nil block", i, rb.BlockID.Hash)
+			}
+			if rbh.Block.Height != committed {
+				return fmt.Errorf("router[%v].BlockByHash(%x): got height %v, want %v",
+					i, rb.BlockID.Hash, rbh.Block.Height, committed)
+			}
+			if !bytes.Equal(rbh.BlockID.Hash, rb.BlockID.Hash) {
+				return fmt.Errorf("router[%v].BlockByHash(%x): got hash %x, want round-trip",
+					i, rb.BlockID.Hash, rbh.BlockID.Hash)
+			}
+			// Unknown-hash case: must return zero-result with no error,
+			// matching CometBFT's BlockStore.LoadBlockByHash semantics.
+			rbu, err := giga.BlockByHash(ctx, make([]byte, 32))
+			if err != nil {
+				return fmt.Errorf("router[%v].BlockByHash(unknown): %w", i, err)
+			}
+			if rbu == nil {
+				return fmt.Errorf("router[%v].BlockByHash(unknown): nil result", i)
+			}
+			if rbu.Block != nil {
+				return fmt.Errorf("router[%v].BlockByHash(unknown): got non-nil block, want nil", i)
+			}
+			// Wrong-size hashes are also "unknown" in the CometBFT contract.
+			rbw, err := giga.BlockByHash(ctx, []byte{0x01, 0x02})
+			if err != nil {
+				return fmt.Errorf("router[%v].BlockByHash(wrong-size): %w", i, err)
+			}
+			if rbw == nil || rbw.Block != nil {
+				return fmt.Errorf("router[%v].BlockByHash(wrong-size): want zero result, got %+v", i, rbw)
 			}
 		}
 		// At least one of the global blocks we just finalized must carry txs

--- a/sei-tendermint/internal/p2p/giga_router_test.go
+++ b/sei-tendermint/internal/p2p/giga_router_test.go
@@ -322,9 +322,7 @@ func TestGigaRouter_FinalizeBlocks(t *testing.T) {
 					}),
 				},
 			)
-			if err != nil {
-				return fmt.Errorf("NewRouter(): %w", err)
-			}
+			require.NoError(t, err, "NewRouter[%v]", i)
 			s.SpawnBgNamed(fmt.Sprintf("router[%v]", i), func() error { return utils.IgnoreCancel(router.Run(ctx)) })
 			apps = append(apps, app)
 			routers = append(routers, router)
@@ -346,61 +344,40 @@ func TestGigaRouter_FinalizeBlocks(t *testing.T) {
 		// Each node should finalize all txs locally.
 		for _, app := range apps {
 			for _, tx := range allTxs {
-				if err := app.WaitForTx(ctx, tx); err != nil {
-					return fmt.Errorf("WaitForTx(): %w", err)
-				}
+				require.NoError(t, app.WaitForTx(ctx, tx), "WaitForTx")
 			}
 		}
 		// Nodes should agree on the final state.
 		want := apps[0].Snapshot()
 		for i, app := range apps {
 			t.Logf("app[%v]", i)
-			if err := utils.TestDiff(want, app.Snapshot()); err != nil {
-				return fmt.Errorf("state mismatch: %w", err)
-			}
+			require.NoError(t, utils.TestDiff(want, app.Snapshot()), "state mismatch app[%v]", i)
 		}
 		// Covers Router.Giga() + GigaRouter.LastCommittedBlockNumber() — after
 		// blocks have been finalized every node should report a non-zero
 		// consensus-committed height through the new accessors used by /status.
 		for i, r := range routers {
 			giga, ok := r.Giga().Get()
-			if !ok {
-				return fmt.Errorf("router[%v].Giga(): none, want some", i)
-			}
+			require.True(t, ok, "router[%v].Giga()", i)
 			committed := giga.LastCommittedBlockNumber()
-			if committed <= 0 {
-				return fmt.Errorf("router[%v].LastCommittedBlockNumber() = %v, want > 0", i, committed)
-			}
+			require.Positive(t, committed, "router[%v].LastCommittedBlockNumber()", i)
 			// Covers GigaRouter.BlockByNumber — the accessor used by the
 			// Autobahn branch in env.Block to serve /block and evmrpc block
 			// lookups. Fetch the last committed block and verify it carries
 			// the expected height + hash, the right chain id, and that the
 			// payload Txs round-tripped (we just submitted txs).
 			rb, err := giga.BlockByNumber(ctx, atypes.GlobalBlockNumber(committed)) //nolint:gosec // committed is positive (validated above)
-			if err != nil {
-				return fmt.Errorf("router[%v].BlockByNumber(%v): %w", i, committed, err)
-			}
-			if rb == nil || rb.Block == nil {
-				return fmt.Errorf("router[%v].BlockByNumber(%v): nil block", i, committed)
-			}
-			if rb.Block.Height != committed {
-				return fmt.Errorf("router[%v].BlockByNumber(%v): got height %v", i, committed, rb.Block.Height)
-			}
-			if len(rb.BlockID.Hash) == 0 {
-				return fmt.Errorf("router[%v].BlockByNumber(%v): empty block hash", i, committed)
-			}
-			if rb.Block.Header.ChainID != genDoc.ChainID {
-				return fmt.Errorf("router[%v].BlockByNumber(%v): chain id %q, want %q",
-					i, committed, rb.Block.Header.ChainID, genDoc.ChainID)
-			}
+			require.NoError(t, err, "router[%v].BlockByNumber(%v)", i, committed)
+			require.NotNil(t, rb.Block, "router[%v].BlockByNumber(%v).Block", i, committed)
+			require.Equal(t, committed, rb.Block.Height, "router[%v].BlockByNumber(%v) height", i, committed)
+			require.NotEmpty(t, rb.BlockID.Hash, "router[%v].BlockByNumber(%v) block hash", i, committed)
+			require.Equal(t, genDoc.ChainID, rb.Block.Header.ChainID, "router[%v].BlockByNumber(%v) chain id", i, committed)
 			// Round-trip the just-fetched block hash back through
 			// BlockByHash and assert we get the same ResultBlock back.
 			var hashKey atypes.BlockHeaderHash
 			copy(hashKey[:], rb.BlockID.Hash)
 			rbh, err := giga.BlockByHash(ctx, hashKey)
-			if err != nil {
-				return fmt.Errorf("router[%v].BlockByHash(%x): %w", i, rb.BlockID.Hash, err)
-			}
+			require.NoError(t, err, "router[%v].BlockByHash(%x)", i, rb.BlockID.Hash)
 			require.Equal(t, rb, rbh, "router[%v].BlockByHash(%x) ≠ BlockByNumber(%v)", i, rb.BlockID.Hash, committed)
 		}
 		// Payload.Txs round-trips: for every retained block, the txs the
@@ -417,18 +394,14 @@ func TestGigaRouter_FinalizeBlocks(t *testing.T) {
 				continue // pruned out of the retain window
 			}
 			rb, err := giga0.BlockByNumber(ctx, gbn)
-			if err != nil {
-				return fmt.Errorf("router[0].BlockByNumber(%v): %w", h, err)
-			}
+			require.NoError(t, err, "router[0].BlockByNumber(%v)", h)
 			// Convert rb.Block.Data.Txs ([]types.Tx) back to [][]byte
 			// to compare against gb.Payload.Txs() directly.
 			rbBytes := make([][]byte, len(rb.Block.Data.Txs))
 			for j, t := range rb.Block.Data.Txs {
 				rbBytes[j] = t
 			}
-			if err := utils.TestDiff(gb.Payload.Txs(), rbBytes); err != nil {
-				return fmt.Errorf("router[0].BlockByNumber(%v).Block.Data.Txs ≠ data.GlobalBlock(%v).Payload.Txs: %w", h, h, err)
-			}
+			require.Equal(t, gb.Payload.Txs(), rbBytes, "router[0].BlockByNumber(%v).Block.Data.Txs ≠ data.GlobalBlock(%v).Payload.Txs", h, h)
 		}
 		return nil
 	})

--- a/sei-tendermint/internal/p2p/giga_router_test.go
+++ b/sei-tendermint/internal/p2p/giga_router_test.go
@@ -367,9 +367,53 @@ func TestGigaRouter_FinalizeBlocks(t *testing.T) {
 			if !ok {
 				return fmt.Errorf("router[%v].Giga(): none, want some", i)
 			}
-			if n := giga.LastCommittedBlockNumber(); n <= 0 {
-				return fmt.Errorf("router[%v].LastCommittedBlockNumber() = %v, want > 0", i, n)
+			committed := giga.LastCommittedBlockNumber()
+			if committed <= 0 {
+				return fmt.Errorf("router[%v].LastCommittedBlockNumber() = %v, want > 0", i, committed)
 			}
+			// Covers GigaRouter.BlockByNumber — the accessor used by the
+			// Autobahn branch in env.Block to serve /block and evmrpc block
+			// lookups. Fetch the last committed block and verify it carries
+			// the expected height + hash, the right chain id, and that the
+			// payload Txs round-tripped (we just submitted txs).
+			rb, err := giga.BlockByNumber(ctx, committed)
+			if err != nil {
+				return fmt.Errorf("router[%v].BlockByNumber(%v): %w", i, committed, err)
+			}
+			if rb == nil || rb.Block == nil {
+				return fmt.Errorf("router[%v].BlockByNumber(%v): nil block", i, committed)
+			}
+			if rb.Block.Height != committed {
+				return fmt.Errorf("router[%v].BlockByNumber(%v): got height %v", i, committed, rb.Block.Height)
+			}
+			if len(rb.BlockID.Hash) == 0 {
+				return fmt.Errorf("router[%v].BlockByNumber(%v): empty block hash", i, committed)
+			}
+			if rb.Block.Header.ChainID != genDoc.ChainID {
+				return fmt.Errorf("router[%v].BlockByNumber(%v): chain id %q, want %q",
+					i, committed, rb.Block.Header.ChainID, genDoc.ChainID)
+			}
+		}
+		// At least one of the global blocks we just finalized must carry txs
+		// — the producers fed maxTxsPerBlock*blocksPerLane txs into the
+		// mempool. Walk a small range from the latest backwards and assert
+		// we saw at least one non-empty payload, exercising the
+		// Payload.Txs round-trip end-to-end.
+		giga0, _ := routers[0].Giga().Get()
+		latest := giga0.LastCommittedBlockNumber()
+		sawTxs := false
+		for h := latest; h > 0 && h > latest-int64(blocksPerLane*len(cfgs)); h-- {
+			rb, err := giga0.BlockByNumber(ctx, h)
+			if err != nil {
+				return fmt.Errorf("router[0].BlockByNumber(%v): %w", h, err)
+			}
+			if rb != nil && rb.Block != nil && len(rb.Block.Data.Txs) > 0 {
+				sawTxs = true
+				break
+			}
+		}
+		if !sawTxs {
+			return fmt.Errorf("router[0].BlockByNumber: no non-empty payload found in last %v blocks", blocksPerLane*len(cfgs))
 		}
 		return nil
 	})

--- a/sei-tendermint/internal/p2p/giga_router_test.go
+++ b/sei-tendermint/internal/p2p/giga_router_test.go
@@ -394,11 +394,11 @@ func TestGigaRouter_FinalizeBlocks(t *testing.T) {
 				return fmt.Errorf("router[%v].BlockByNumber(%v): chain id %q, want %q",
 					i, committed, rb.Block.Header.ChainID, genDoc.ChainID)
 			}
-			// Covers GigaRouter.BlockByHash — the accessor used by the
-			// Autobahn branch in env.BlockByHash. Take the hash from the
-			// BlockByNumber result and look up the same block by hash;
-			// verify it round-trips to the same height + chain id.
-			rbh, err := giga.BlockByHash(ctx, rb.BlockID.Hash)
+			// Round-trip the just-fetched block hash back through
+			// BlockByHash and assert we land on the same height + bytes.
+			var hashKey atypes.BlockHeaderHash
+			copy(hashKey[:], rb.BlockID.Hash)
+			rbh, err := giga.BlockByHash(ctx, hashKey)
 			if err != nil {
 				return fmt.Errorf("router[%v].BlockByHash(%x): %w", i, rb.BlockID.Hash, err)
 			}
@@ -412,26 +412,6 @@ func TestGigaRouter_FinalizeBlocks(t *testing.T) {
 			if !bytes.Equal(rbh.BlockID.Hash, rb.BlockID.Hash) {
 				return fmt.Errorf("router[%v].BlockByHash(%x): got hash %x, want round-trip",
 					i, rb.BlockID.Hash, rbh.BlockID.Hash)
-			}
-			// Unknown-hash case: must return zero-result with no error,
-			// matching CometBFT's BlockStore.LoadBlockByHash semantics.
-			rbu, err := giga.BlockByHash(ctx, make([]byte, 32))
-			if err != nil {
-				return fmt.Errorf("router[%v].BlockByHash(unknown): %w", i, err)
-			}
-			if rbu == nil {
-				return fmt.Errorf("router[%v].BlockByHash(unknown): nil result", i)
-			}
-			if rbu.Block != nil {
-				return fmt.Errorf("router[%v].BlockByHash(unknown): got non-nil block, want nil", i)
-			}
-			// Wrong-size hashes are also "unknown" in the CometBFT contract.
-			rbw, err := giga.BlockByHash(ctx, []byte{0x01, 0x02})
-			if err != nil {
-				return fmt.Errorf("router[%v].BlockByHash(wrong-size): %w", i, err)
-			}
-			if rbw == nil || rbw.Block != nil {
-				return fmt.Errorf("router[%v].BlockByHash(wrong-size): want zero result, got %+v", i, rbw)
 			}
 		}
 		// At least one of the global blocks we just finalized must carry txs

--- a/sei-tendermint/internal/p2p/giga_router_test.go
+++ b/sei-tendermint/internal/p2p/giga_router_test.go
@@ -1,7 +1,6 @@
 package p2p
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
@@ -377,7 +376,7 @@ func TestGigaRouter_FinalizeBlocks(t *testing.T) {
 			// lookups. Fetch the last committed block and verify it carries
 			// the expected height + hash, the right chain id, and that the
 			// payload Txs round-tripped (we just submitted txs).
-			rb, err := giga.BlockByNumber(ctx, committed)
+			rb, err := giga.BlockByNumber(ctx, atypes.GlobalBlockNumber(committed)) //nolint:gosec // committed is positive (validated above)
 			if err != nil {
 				return fmt.Errorf("router[%v].BlockByNumber(%v): %w", i, committed, err)
 			}
@@ -395,45 +394,41 @@ func TestGigaRouter_FinalizeBlocks(t *testing.T) {
 					i, committed, rb.Block.Header.ChainID, genDoc.ChainID)
 			}
 			// Round-trip the just-fetched block hash back through
-			// BlockByHash and assert we land on the same height + bytes.
+			// BlockByHash and assert we get the same ResultBlock back.
 			var hashKey atypes.BlockHeaderHash
 			copy(hashKey[:], rb.BlockID.Hash)
 			rbh, err := giga.BlockByHash(ctx, hashKey)
 			if err != nil {
 				return fmt.Errorf("router[%v].BlockByHash(%x): %w", i, rb.BlockID.Hash, err)
 			}
-			if rbh == nil || rbh.Block == nil {
-				return fmt.Errorf("router[%v].BlockByHash(%x): nil block", i, rb.BlockID.Hash)
-			}
-			if rbh.Block.Height != committed {
-				return fmt.Errorf("router[%v].BlockByHash(%x): got height %v, want %v",
-					i, rb.BlockID.Hash, rbh.Block.Height, committed)
-			}
-			if !bytes.Equal(rbh.BlockID.Hash, rb.BlockID.Hash) {
-				return fmt.Errorf("router[%v].BlockByHash(%x): got hash %x, want round-trip",
-					i, rb.BlockID.Hash, rbh.BlockID.Hash)
-			}
+			require.Equal(t, rb, rbh, "router[%v].BlockByHash(%x) ≠ BlockByNumber(%v)", i, rb.BlockID.Hash, committed)
 		}
-		// At least one of the global blocks we just finalized must carry txs
-		// — the producers fed maxTxsPerBlock*blocksPerLane txs into the
-		// mempool. Walk a small range from the latest backwards and assert
-		// we saw at least one non-empty payload, exercising the
-		// Payload.Txs round-trip end-to-end.
+		// Payload.Txs round-trips: for every retained block, the txs the
+		// data layer holds (GlobalBlock.Payload.Txs) must equal the txs
+		// surfaced through BlockByNumber. Iterates the full retain window
+		// rather than a fixed tail so the assertion holds regardless of
+		// where producers placed the test txs.
 		giga0, _ := routers[0].Giga().Get()
 		latest := giga0.LastCommittedBlockNumber()
-		sawTxs := false
-		for h := latest; h > 0 && h > latest-int64(blocksPerLane*len(cfgs)); h-- {
-			rb, err := giga0.BlockByNumber(ctx, h)
+		for h := int64(1); h <= latest; h++ {
+			gbn := atypes.GlobalBlockNumber(h) //nolint:gosec // h is positive
+			gb, err := giga0.data.GlobalBlock(ctx, gbn)
+			if err != nil {
+				continue // pruned out of the retain window
+			}
+			rb, err := giga0.BlockByNumber(ctx, gbn)
 			if err != nil {
 				return fmt.Errorf("router[0].BlockByNumber(%v): %w", h, err)
 			}
-			if rb != nil && rb.Block != nil && len(rb.Block.Data.Txs) > 0 {
-				sawTxs = true
-				break
+			// Convert rb.Block.Data.Txs ([]types.Tx) back to [][]byte
+			// to compare against gb.Payload.Txs() directly.
+			rbBytes := make([][]byte, len(rb.Block.Data.Txs))
+			for j, t := range rb.Block.Data.Txs {
+				rbBytes[j] = t
 			}
-		}
-		if !sawTxs {
-			return fmt.Errorf("router[0].BlockByNumber: no non-empty payload found in last %v blocks", blocksPerLane*len(cfgs))
+			if err := utils.TestDiff(gb.Payload.Txs(), rbBytes); err != nil {
+				return fmt.Errorf("router[0].BlockByNumber(%v).Block.Data.Txs ≠ data.GlobalBlock(%v).Payload.Txs: %w", h, h, err)
+			}
 		}
 		return nil
 	})

--- a/sei-tendermint/internal/rpc/core/blocks.go
+++ b/sei-tendermint/internal/rpc/core/blocks.go
@@ -154,10 +154,12 @@ func (env *Environment) gigaRouter() (*p2p.GigaRouter, error) {
 // TODO(autobahn): wire a real lower bound and pass it as `base` to
 // env.getHeight. We currently pass env.BlockStore.Base() (always 0 under
 // Autobahn), which means any positive height < chain head passes validation
-// here and only fails later inside data.GlobalBlock — a cheap RPC probe
-// then induces a database lookup on every request. With a real lower bound
-// the rejection happens at this layer, capping the cost of random-height
-// probing.
+// here and is rejected one layer down (data.GlobalBlock returns
+// data.ErrPruned, which BlockByNumber maps to ErrHeightNotAvailable). With
+// a real lower bound the rejection happens at this layer instead. The
+// natural source becomes available once sei-db/ledger_db/block.BlockDB is
+// wired into block execution: switch this and BlockByNumber to read from
+// BlockDB, and source `base` from BlockDB.GetLowestBlockHeight.
 func (env *Environment) autobahnResolveHeight(ctx context.Context, heightPtr *int64) (int64, error) {
 	info, err := env.ABCIInfo(ctx)
 	if err != nil {

--- a/sei-tendermint/internal/rpc/core/blocks.go
+++ b/sei-tendermint/internal/rpc/core/blocks.go
@@ -170,7 +170,20 @@ func (env *Environment) autobahnCheckAndGetHeight(ctx context.Context, heightPtr
 
 // BlockByHash gets block by hash.
 // More: https://docs.tendermint.com/master/rpc/#/Info/block_by_hash
+//
+// Under Autobahn (GigaEnabled) the CometBFT BlockStore is not populated, so
+// we route through the GigaRouter's temporary in-memory hash index. Match
+// CometBFT semantics: an unknown hash returns &ResultBlock{Block: nil} with
+// no error, never an error response — external tools (block explorers,
+// monitoring) treat that as "no such block" rather than a failure.
 func (env *Environment) BlockByHash(ctx context.Context, req *coretypes.RequestBlockByHash) (*coretypes.ResultBlock, error) {
+	if env.GigaEnabled {
+		giga, err := env.gigaRouter()
+		if err != nil {
+			return nil, err
+		}
+		return giga.BlockByHash(ctx, req.Hash)
+	}
 	block := env.BlockStore.LoadBlockByHash(req.Hash)
 	if block == nil {
 		return &coretypes.ResultBlock{BlockID: types.BlockID{}, Block: nil}, nil

--- a/sei-tendermint/internal/rpc/core/blocks.go
+++ b/sei-tendermint/internal/rpc/core/blocks.go
@@ -2,11 +2,9 @@ package core
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 
-	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/p2p"
 	tmquery "github.com/sei-protocol/sei-chain/sei-tendermint/internal/pubsub/query"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/state/indexer"
 	tmmath "github.com/sei-protocol/sei-chain/sei-tendermint/libs/math"
@@ -91,19 +89,13 @@ func filterMinMax(base, height, min, max, limit int64) (int64, int64, error) {
 // If no height is provided, it will fetch the latest block.
 // More: https://docs.tendermint.com/master/rpc/#/Info/block
 //
-// Under Autobahn (GigaEnabled) the CometBFT BlockStore is not populated;
-// route through GigaRouter, which reads the finalized global block from
-// data.State and returns it in the same coretypes.ResultBlock shape.
-// This keeps every downstream consumer (evmrpc, /block HTTP, seid q block)
-// working without individually branching on consensus mode. Only the
-// by-number path is Autobahn-aware for now; by-hash still goes through
-// the CometBFT path (see Environment.BlockByHash) — TODO.
+// Under Autobahn the CometBFT BlockStore is not populated; route through
+// GigaRouter, which reads the finalized global block from data.State and
+// returns it in the same coretypes.ResultBlock shape. This keeps every
+// downstream consumer (evmrpc, /block HTTP, seid q block) working without
+// individually branching on consensus mode.
 func (env *Environment) Block(ctx context.Context, req *coretypes.RequestBlockInfo) (*coretypes.ResultBlock, error) {
-	if env.GigaEnabled {
-		giga, err := env.gigaRouter()
-		if err != nil {
-			return nil, err
-		}
+	if giga, ok := env.gigaRouter().Get(); ok {
 		height, err := env.autobahnCheckAndGetHeight(ctx, (*int64)(req.Height))
 		if err != nil {
 			return nil, err
@@ -123,23 +115,6 @@ func (env *Environment) Block(ctx context.Context, req *coretypes.RequestBlockIn
 
 	block := env.BlockStore.LoadBlock(height)
 	return &coretypes.ResultBlock{BlockID: blockMeta.BlockID, Block: block}, nil
-}
-
-// gigaRouter returns the GigaRouter when Autobahn is enabled. Callers should
-// only invoke this when env.GigaEnabled is true; if either env.Router or
-// env.Router.Giga() is unset under that condition the wiring in node.go is
-// broken (GigaEnabled is set alongside the router) — surface that loudly
-// rather than silently falling through to a CometBFT path that would also
-// fail under Autobahn.
-func (env *Environment) gigaRouter() (*p2p.GigaRouter, error) {
-	if env.Router == nil {
-		return nil, errors.New("autobahn: Environment.Router is not set")
-	}
-	giga, ok := env.Router.Giga().Get()
-	if !ok {
-		return nil, errors.New("autobahn: Router.Giga() is not set")
-	}
-	return giga, nil
 }
 
 // autobahnCheckAndGetHeight resolves a caller-supplied height pointer to a
@@ -171,17 +146,13 @@ func (env *Environment) autobahnCheckAndGetHeight(ctx context.Context, heightPtr
 // BlockByHash gets block by hash.
 // More: https://docs.tendermint.com/master/rpc/#/Info/block_by_hash
 //
-// Under Autobahn (GigaEnabled) the CometBFT BlockStore is not populated, so
-// we route through the GigaRouter's temporary in-memory hash index. Match
-// CometBFT semantics: an unknown hash returns &ResultBlock{Block: nil} with
-// no error, never an error response — external tools (block explorers,
+// Under Autobahn the CometBFT BlockStore is not populated, so we route
+// through the GigaRouter's temporary in-memory hash index. Match CometBFT
+// semantics: an unknown hash returns &ResultBlock{Block: nil} with no
+// error, never an error response — external tools (block explorers,
 // monitoring) treat that as "no such block" rather than a failure.
 func (env *Environment) BlockByHash(ctx context.Context, req *coretypes.RequestBlockByHash) (*coretypes.ResultBlock, error) {
-	if env.GigaEnabled {
-		giga, err := env.gigaRouter()
-		if err != nil {
-			return nil, err
-		}
+	if giga, ok := env.gigaRouter().Get(); ok {
 		return giga.BlockByHash(ctx, req.Hash)
 	}
 	block := env.BlockStore.LoadBlockByHash(req.Hash)
@@ -269,11 +240,7 @@ func (env *Environment) Commit(ctx context.Context, req *coretypes.RequestBlockI
 // renders correctly, just without per-tx ExecTxResult details. Properly
 // populating these under Autobahn is a separate follow-up.
 func (env *Environment) BlockResults(ctx context.Context, req *coretypes.RequestBlockInfo) (*coretypes.ResultBlockResults, error) {
-	if env.GigaEnabled {
-		giga, err := env.gigaRouter()
-		if err != nil {
-			return nil, err
-		}
+	if giga, ok := env.gigaRouter().Get(); ok {
 		height, err := env.autobahnCheckAndGetHeight(ctx, (*int64)(req.Height))
 		if err != nil {
 			return nil, err

--- a/sei-tendermint/internal/rpc/core/blocks.go
+++ b/sei-tendermint/internal/rpc/core/blocks.go
@@ -2,12 +2,15 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
+	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/p2p"
 	tmquery "github.com/sei-protocol/sei-chain/sei-tendermint/internal/pubsub/query"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/state/indexer"
 	tmmath "github.com/sei-protocol/sei-chain/sei-tendermint/libs/math"
+	tmproto "github.com/sei-protocol/sei-chain/sei-tendermint/proto/tendermint/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/rpc/coretypes"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
 )
@@ -87,7 +90,27 @@ func filterMinMax(base, height, min, max, limit int64) (int64, int64, error) {
 // Block gets block at a given height.
 // If no height is provided, it will fetch the latest block.
 // More: https://docs.tendermint.com/master/rpc/#/Info/block
+//
+// Under Autobahn (GigaEnabled) the CometBFT BlockStore is not populated;
+// route through GigaRouter, which reads the finalized global block from
+// data.State and returns it in the same coretypes.ResultBlock shape.
+// This keeps every downstream consumer (evmrpc, /block HTTP, seid q block)
+// working without individually branching on consensus mode. Only the
+// by-number path is Autobahn-aware for now; by-hash still goes through
+// the CometBFT path (see Environment.BlockByHash) — TODO.
 func (env *Environment) Block(ctx context.Context, req *coretypes.RequestBlockInfo) (*coretypes.ResultBlock, error) {
+	if env.GigaEnabled {
+		giga, err := env.gigaRouter()
+		if err != nil {
+			return nil, err
+		}
+		height, err := env.autobahnResolveHeight(ctx, (*int64)(req.Height))
+		if err != nil {
+			return nil, err
+		}
+		return giga.BlockByNumber(ctx, height)
+	}
+
 	height, err := env.getHeight(env.BlockStore.Height(), (*int64)(req.Height))
 	if err != nil {
 		return nil, err
@@ -100,6 +123,48 @@ func (env *Environment) Block(ctx context.Context, req *coretypes.RequestBlockIn
 
 	block := env.BlockStore.LoadBlock(height)
 	return &coretypes.ResultBlock{BlockID: blockMeta.BlockID, Block: block}, nil
+}
+
+// gigaRouter returns the GigaRouter when Autobahn is enabled. Callers should
+// only invoke this when env.GigaEnabled is true; if either env.Router or
+// env.Router.Giga() is unset under that condition the wiring in node.go is
+// broken (GigaEnabled is set alongside the router) — surface that loudly
+// rather than silently falling through to a CometBFT path that would also
+// fail under Autobahn.
+func (env *Environment) gigaRouter() (*p2p.GigaRouter, error) {
+	if env.Router == nil {
+		return nil, errors.New("autobahn: Environment.Router is not set")
+	}
+	giga, ok := env.Router.Giga().Get()
+	if !ok {
+		return nil, errors.New("autobahn: Router.Giga() is not set")
+	}
+	return giga, nil
+}
+
+// autobahnResolveHeight resolves a caller-supplied height pointer to a
+// concrete int64 and validates it against the current ABCI head. nil (or
+// zero) means "latest". Returns the same error sentinels as env.getHeight
+// (ErrZeroOrNegativeHeight, ErrHeightExceedsChainHead, ErrHeightNotAvailable)
+// so downstream consumers like evmrpc — which translate
+// ErrHeightExceedsChainHead-class errors into the Ethereum-spec `null`
+// response for non-existent blocks — see consistent shapes under both
+// consensus engines.
+//
+// TODO(autobahn): wire a real lower bound (Autobahn pruning watermark, e.g.
+// avail.State.FirstCommitQC or equivalent) and pass it as `base` to
+// env.getHeight. We currently pass env.BlockStore.Base() (always 0 under
+// Autobahn), which means any positive height < chain head passes validation
+// here and only fails later inside data.GlobalBlock — a cheap RPC probe
+// then induces a database lookup on every request. With a real watermark
+// the rejection happens at this layer, capping the cost of random-height
+// probing.
+func (env *Environment) autobahnResolveHeight(ctx context.Context, heightPtr *int64) (int64, error) {
+	info, err := env.ABCIInfo(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return env.getHeight(info.Response.LastBlockHeight, heightPtr)
 }
 
 // BlockByHash gets block by hash.
@@ -181,7 +246,35 @@ func (env *Environment) Commit(ctx context.Context, req *coretypes.RequestBlockI
 //
 // Results are for the height of the block containing the txs.
 // More: https://docs.tendermint.com/master/rpc/#/Info/block_results
+//
+// Under Autobahn, FinalizeBlock responses are not persisted to StateStore
+// (giga_router.executeBlock never calls SaveFinalizeBlockResponses), so this
+// returns a valid-but-empty ResultBlockResults at the requested height. That
+// lets downstream consumers (evmrpc's eth_getBlockByNumber, which looks up
+// BlockResults to enrich the response) keep working — the block envelope
+// renders correctly, just without per-tx ExecTxResult details. Properly
+// populating these under Autobahn is a separate follow-up.
 func (env *Environment) BlockResults(ctx context.Context, req *coretypes.RequestBlockInfo) (*coretypes.ResultBlockResults, error) {
+	if env.GigaEnabled {
+		giga, err := env.gigaRouter()
+		if err != nil {
+			return nil, err
+		}
+		height, err := env.autobahnResolveHeight(ctx, (*int64)(req.Height))
+		if err != nil {
+			return nil, err
+		}
+		// evmrpc's EncodeTmBlock reads ConsensusParamUpdates.Block.MaxGas to
+		// populate the eth_getBlockByNumber gasLimit field. Populate it from
+		// Autobahn's producer config so that path doesn't nil-deref.
+		return &coretypes.ResultBlockResults{
+			Height: height,
+			ConsensusParamUpdates: &tmproto.ConsensusParams{
+				Block: &tmproto.BlockParams{MaxGas: giga.MaxGasPerBlock()},
+			},
+		}, nil
+	}
+
 	height, err := env.getHeight(env.BlockStore.Height(), (*int64)(req.Height))
 	if err != nil {
 		return nil, err

--- a/sei-tendermint/internal/rpc/core/blocks.go
+++ b/sei-tendermint/internal/rpc/core/blocks.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 
+	atypes "github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/types"
 	tmquery "github.com/sei-protocol/sei-chain/sei-tendermint/internal/pubsub/query"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/state/indexer"
 	tmmath "github.com/sei-protocol/sei-chain/sei-tendermint/libs/math"
@@ -151,9 +152,18 @@ func (env *Environment) autobahnCheckAndGetHeight(ctx context.Context, heightPtr
 // semantics: an unknown hash returns &ResultBlock{Block: nil} with no
 // error, never an error response — external tools (block explorers,
 // monitoring) treat that as "no such block" rather than a failure.
+//
+// The Tendermint RPC boundary (req.Hash is bytes.HexBytes — a []byte alias
+// for wire-format flexibility) gets converted to the strongly-typed
+// atypes.BlockHeaderHash here, before reaching GigaRouter.BlockByHash.
+// Wrong-size inputs short-circuit to the same zero-result CometBFT
+// returns for an unknown hash.
 func (env *Environment) BlockByHash(ctx context.Context, req *coretypes.RequestBlockByHash) (*coretypes.ResultBlock, error) {
 	if giga, ok := env.gigaRouter().Get(); ok {
-		return giga.BlockByHash(ctx, req.Hash)
+		if len(req.Hash) != len(atypes.BlockHeaderHash{}) {
+			return &coretypes.ResultBlock{}, nil
+		}
+		return giga.BlockByHash(ctx, atypes.BlockHeaderHash(req.Hash))
 	}
 	block := env.BlockStore.LoadBlockByHash(req.Hash)
 	if block == nil {

--- a/sei-tendermint/internal/rpc/core/blocks.go
+++ b/sei-tendermint/internal/rpc/core/blocks.go
@@ -104,7 +104,7 @@ func (env *Environment) Block(ctx context.Context, req *coretypes.RequestBlockIn
 		if err != nil {
 			return nil, err
 		}
-		height, err := env.autobahnResolveHeight(ctx, (*int64)(req.Height))
+		height, err := env.autobahnCheckAndGetHeight(ctx, (*int64)(req.Height))
 		if err != nil {
 			return nil, err
 		}
@@ -142,7 +142,7 @@ func (env *Environment) gigaRouter() (*p2p.GigaRouter, error) {
 	return giga, nil
 }
 
-// autobahnResolveHeight resolves a caller-supplied height pointer to a
+// autobahnCheckAndGetHeight resolves a caller-supplied height pointer to a
 // concrete int64 and validates it against the current ABCI head. nil (or
 // zero) means "latest". Returns the same error sentinels as env.getHeight
 // (ErrZeroOrNegativeHeight, ErrHeightExceedsChainHead, ErrHeightNotAvailable)
@@ -160,7 +160,7 @@ func (env *Environment) gigaRouter() (*p2p.GigaRouter, error) {
 // natural source becomes available once sei-db/ledger_db/block.BlockDB is
 // wired into block execution: switch this and BlockByNumber to read from
 // BlockDB, and source `base` from BlockDB.GetLowestBlockHeight.
-func (env *Environment) autobahnResolveHeight(ctx context.Context, heightPtr *int64) (int64, error) {
+func (env *Environment) autobahnCheckAndGetHeight(ctx context.Context, heightPtr *int64) (int64, error) {
 	info, err := env.ABCIInfo(ctx)
 	if err != nil {
 		return 0, err
@@ -261,7 +261,7 @@ func (env *Environment) BlockResults(ctx context.Context, req *coretypes.Request
 		if err != nil {
 			return nil, err
 		}
-		height, err := env.autobahnResolveHeight(ctx, (*int64)(req.Height))
+		height, err := env.autobahnCheckAndGetHeight(ctx, (*int64)(req.Height))
 		if err != nil {
 			return nil, err
 		}

--- a/sei-tendermint/internal/rpc/core/blocks.go
+++ b/sei-tendermint/internal/rpc/core/blocks.go
@@ -151,12 +151,11 @@ func (env *Environment) gigaRouter() (*p2p.GigaRouter, error) {
 // response for non-existent blocks — see consistent shapes under both
 // consensus engines.
 //
-// TODO(autobahn): wire a real lower bound (Autobahn pruning watermark, e.g.
-// avail.State.FirstCommitQC or equivalent) and pass it as `base` to
+// TODO(autobahn): wire a real lower bound and pass it as `base` to
 // env.getHeight. We currently pass env.BlockStore.Base() (always 0 under
 // Autobahn), which means any positive height < chain head passes validation
 // here and only fails later inside data.GlobalBlock — a cheap RPC probe
-// then induces a database lookup on every request. With a real watermark
+// then induces a database lookup on every request. With a real lower bound
 // the rejection happens at this layer, capping the cost of random-height
 // probing.
 func (env *Environment) autobahnResolveHeight(ctx context.Context, heightPtr *int64) (int64, error) {

--- a/sei-tendermint/internal/rpc/core/blocks.go
+++ b/sei-tendermint/internal/rpc/core/blocks.go
@@ -9,6 +9,7 @@ import (
 	tmquery "github.com/sei-protocol/sei-chain/sei-tendermint/internal/pubsub/query"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/state/indexer"
 	tmmath "github.com/sei-protocol/sei-chain/sei-tendermint/libs/math"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 	tmproto "github.com/sei-protocol/sei-chain/sei-tendermint/proto/tendermint/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/rpc/coretypes"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
@@ -101,7 +102,14 @@ func (env *Environment) Block(ctx context.Context, req *coretypes.RequestBlockIn
 		if err != nil {
 			return nil, err
 		}
-		return giga.BlockByNumber(ctx, height)
+		// Cast happens at the boundary so giga.BlockByNumber stays
+		// strongly typed on atypes.GlobalBlockNumber. autobahnCheckAndGetHeight
+		// has already validated height is positive and within chain head.
+		gbn, ok := utils.SafeCast[atypes.GlobalBlockNumber](height)
+		if !ok {
+			return nil, fmt.Errorf("invalid height %d", height)
+		}
+		return giga.BlockByNumber(ctx, gbn)
 	}
 
 	height, err := env.getHeight(env.BlockStore.Height(), (*int64)(req.Height))

--- a/sei-tendermint/internal/rpc/core/consensus.go
+++ b/sei-tendermint/internal/rpc/core/consensus.go
@@ -23,7 +23,7 @@ import (
 // retained height returns the genesis committee. Pagination + error shape
 // mirror the CometBFT path so external tools see consistent responses.
 func (env *Environment) Validators(ctx context.Context, req *coretypes.RequestValidators) (*coretypes.ResultValidators, error) {
-	if _, ok := env.gigaRouter().Get(); ok {
+	if env.gigaRouter().IsPresent() {
 		height, err := env.autobahnCheckAndGetHeight(ctx, (*int64)(req.Height))
 		if err != nil {
 			return nil, err

--- a/sei-tendermint/internal/rpc/core/consensus.go
+++ b/sei-tendermint/internal/rpc/core/consensus.go
@@ -18,12 +18,12 @@ import (
 //
 // More: https://docs.tendermint.com/master/rpc/#/Info/validators
 //
-// Under Autobahn (GigaEnabled) the CometBFT StateStore is not populated, but
-// the committee is fixed at genesis (no validator-updates path under Autobahn),
-// so any retained height returns the genesis committee. Pagination + error
-// shape mirror the CometBFT path so external tools see consistent responses.
+// Under Autobahn the CometBFT StateStore is not populated, but the committee
+// is fixed at genesis (no validator-updates path under Autobahn), so any
+// retained height returns the genesis committee. Pagination + error shape
+// mirror the CometBFT path so external tools see consistent responses.
 func (env *Environment) Validators(ctx context.Context, req *coretypes.RequestValidators) (*coretypes.ResultValidators, error) {
-	if env.GigaEnabled {
+	if _, ok := env.gigaRouter().Get(); ok {
 		height, err := env.autobahnCheckAndGetHeight(ctx, (*int64)(req.Height))
 		if err != nil {
 			return nil, err

--- a/sei-tendermint/internal/rpc/core/consensus.go
+++ b/sei-tendermint/internal/rpc/core/consensus.go
@@ -17,7 +17,45 @@ import (
 // for the validators in the set as used in computing their Merkle root.
 //
 // More: https://docs.tendermint.com/master/rpc/#/Info/validators
+//
+// Under Autobahn (GigaEnabled) the CometBFT StateStore is not populated, but
+// the committee is fixed at genesis (no validator-updates path under Autobahn),
+// so any retained height returns the genesis committee. Pagination + error
+// shape mirror the CometBFT path so external tools see consistent responses.
 func (env *Environment) Validators(ctx context.Context, req *coretypes.RequestValidators) (*coretypes.ResultValidators, error) {
+	if env.GigaEnabled {
+		height, err := env.autobahnCheckAndGetHeight(ctx, (*int64)(req.Height))
+		if err != nil {
+			return nil, err
+		}
+		gvals := env.GenDoc.Validators
+		vs := make([]*types.Validator, 0, len(gvals))
+		for _, gv := range gvals {
+			vs = append(vs, &types.Validator{
+				Address:     gv.Address,
+				PubKey:      gv.PubKey,
+				VotingPower: gv.Power,
+				// ProposerPriority left at 0; Autobahn uses round-robin
+				// per-block leader selection (Committee.Leader), not
+				// Tendermint's proposer-priority accumulator.
+			})
+		}
+		totalCount := len(vs)
+		perPage := env.validatePerPage(req.PerPage.IntPtr())
+		page, err := validatePage(req.Page.IntPtr(), perPage, totalCount)
+		if err != nil {
+			return nil, err
+		}
+		skipCount := validateSkipCount(page, perPage)
+		v := vs[skipCount : skipCount+tmmath.MinInt(perPage, totalCount-skipCount)]
+		return &coretypes.ResultValidators{
+			BlockHeight: height,
+			Validators:  v,
+			Count:       len(v),
+			Total:       totalCount,
+		}, nil
+	}
+
 	// The latest validator that we know is the NextValidator of the last block.
 	height, err := env.getHeight(env.latestUncommittedHeight(), (*int64)(req.Height))
 	if err != nil {

--- a/sei-tendermint/internal/rpc/core/env.go
+++ b/sei-tendermint/internal/rpc/core/env.go
@@ -79,13 +79,6 @@ type Environment struct {
 	Listeners   []string
 	NodeInfo    types.NodeInfo
 
-	// GigaEnabled mirrors the `gigaEnabled` local in node.go (derived from
-	// cfg.AutobahnConfigFile != ""). Handlers that produce CometBFT-flavored
-	// responses whose sources are not populated under Autobahn (e.g. /status's
-	// SyncInfo.LatestBlockHeight from BlockStore) branch on this to pull the
-	// equivalent value from the app layer instead.
-	GigaEnabled bool
-
 	Router *p2p.Router
 
 	// objects
@@ -125,6 +118,26 @@ func validatePage(pagePtr *int, perPage, totalCount int) (int, error) {
 	}
 
 	return page, nil
+}
+
+// gigaRouter returns the GigaRouter when one is wired into env.Router (which
+// is the definition of "Autobahn is active for this Environment"). Returns
+// None when running under CometBFT or when the Router itself isn't set.
+// Handlers that produce different shapes under Autobahn just branch on the
+// returned Option:
+//
+//	if r, ok := env.gigaRouter().Get(); ok {
+//	    // Autobahn path, r is the router
+//	}
+//
+// This both replaces a previous bool gate (GigaEnabled) and gives every
+// handler the typed accessor in one step — no duplicate "is autobahn?"
+// state to keep in sync with the actual router presence.
+func (env *Environment) gigaRouter() utils.Option[*p2p.GigaRouter] {
+	if env.Router == nil {
+		return utils.None[*p2p.GigaRouter]()
+	}
+	return env.Router.Giga()
 }
 
 func (env *Environment) validatePerPage(perPagePtr *int) int {

--- a/sei-tendermint/internal/rpc/core/env.go
+++ b/sei-tendermint/internal/rpc/core/env.go
@@ -207,7 +207,7 @@ func (env *Environment) getHeight(latestHeight int64, heightPtr *int64) (int64, 
 		}
 		base := env.BlockStore.Base()
 		if height < base {
-			return 0, fmt.Errorf("%w (requested height: %d, base height: %d)", coretypes.ErrHeightNotAvailable, height, base)
+			return 0, coretypes.WrapErrHeightNotAvailable(height, utils.Some(base))
 		}
 		return height, nil
 	}

--- a/sei-tendermint/internal/rpc/core/env.go
+++ b/sei-tendermint/internal/rpc/core/env.go
@@ -134,7 +134,7 @@ func validatePage(pagePtr *int, perPage, totalCount int) (int, error) {
 // handler the typed accessor in one step — no duplicate "is autobahn?"
 // state to keep in sync with the actual router presence.
 func (env *Environment) gigaRouter() utils.Option[*p2p.GigaRouter] {
-	if env.Router == nil {
+	if env.Router == nil { // inspect mode
 		return utils.None[*p2p.GigaRouter]()
 	}
 	return env.Router.Giga()

--- a/sei-tendermint/internal/rpc/core/env.go
+++ b/sei-tendermint/internal/rpc/core/env.go
@@ -129,10 +129,6 @@ func validatePage(pagePtr *int, perPage, totalCount int) (int, error) {
 //	if r, ok := env.gigaRouter().Get(); ok {
 //	    // Autobahn path, r is the router
 //	}
-//
-// This both replaces a previous bool gate (GigaEnabled) and gives every
-// handler the typed accessor in one step — no duplicate "is autobahn?"
-// state to keep in sync with the actual router presence.
 func (env *Environment) gigaRouter() utils.Option[*p2p.GigaRouter] {
 	if env.Router == nil { // inspect mode
 		return utils.None[*p2p.GigaRouter]()

--- a/sei-tendermint/internal/rpc/core/status.go
+++ b/sei-tendermint/internal/rpc/core/status.go
@@ -74,23 +74,19 @@ func (env *Environment) Status(ctx context.Context) (*coretypes.ResultStatus, er
 	// ABCIInfo reports both the last height the app committed in FinalizeBlock
 	// and the matching app hash. Block hash and block time stay empty; see
 	// the TODO on Status for what's left.
-	if env.GigaEnabled {
-		if abciInfo, err := env.ABCIInfo(ctx); err == nil {
-			latestHeight = abciInfo.Response.LastBlockHeight
-			latestAppHash = abciInfo.Response.LastBlockAppHash
-		}
-	}
-
+	//
 	// LastCommittedBlockHeight reports the last block consensus has finalized.
 	// Under CometBFT commit == app-apply in one step, so latestHeight IS the
 	// committed height. Under Autobahn they can briefly differ; pull the
 	// consensus-committed number from the GigaRouter's cached CommitQC watch
 	// (lock-free per-call atomic load).
 	lastCommittedBlockHeight := latestHeight
-	if env.GigaEnabled {
-		if giga, ok := env.Router.Giga().Get(); ok {
-			lastCommittedBlockHeight = giga.LastCommittedBlockNumber()
+	if giga, ok := env.gigaRouter().Get(); ok {
+		if abciInfo, err := env.ABCIInfo(ctx); err == nil {
+			latestHeight = abciInfo.Response.LastBlockHeight
+			latestAppHash = abciInfo.Response.LastBlockAppHash
 		}
+		lastCommittedBlockHeight = giga.LastCommittedBlockNumber()
 		// Invariant: under Autobahn, consensus finalizes before the app
 		// executes, so the committed height leads (or equals) the executed
 		// height. Committed=0 is a legitimate startup window before the first
@@ -179,7 +175,7 @@ func (env *Environment) validatorAtHeight(h int64) utils.Option[*types.Validator
 	// validator set), so we skip that fast path and fall straight through to
 	// the state-store lookup below, which is kept in sync regardless of
 	// consensus engine.
-	if !env.GigaEnabled {
+	if _, autobahn := env.gigaRouter().Get(); !autobahn {
 		lastBlockHeight, vals := env.ConsensusState.GetValidators()
 		if lastBlockHeight == h {
 			for _, val := range vals {

--- a/sei-tendermint/internal/rpc/core/status.go
+++ b/sei-tendermint/internal/rpc/core/status.go
@@ -169,13 +169,11 @@ func (env *Environment) validatorAtHeight(h int64) utils.Option[*types.Validator
 	}
 	privValAddress := k.Address()
 
-	// Under CometBFT we first try the in-memory current validator set for a
-	// fresher voting power. Under Autobahn the CometBFT consensus State is not
-	// advanced (and calling GetValidators would nil-deref on an unpopulated
-	// validator set), so we skip that fast path and fall straight through to
-	// the state-store lookup below, which is kept in sync regardless of
-	// consensus engine.
-	if _, autobahn := env.gigaRouter().Get(); !autobahn {
+	// Skip the in-memory consensus-state lookup under Autobahn: the CometBFT
+	// consensus State is never advanced, so GetValidators would nil-deref
+	// on an unpopulated validator set. The state-store lookup below is kept
+	// in sync under both engines.
+	if !env.gigaRouter().IsPresent() {
 		lastBlockHeight, vals := env.ConsensusState.GetValidators()
 		if lastBlockHeight == h {
 			for _, val := range vals {

--- a/sei-tendermint/node/node.go
+++ b/sei-tendermint/node/node.go
@@ -189,7 +189,6 @@ func makeNode(
 		return nil, fmt.Errorf("autobahn does not support remote validator signers (priv-validator.laddr is set)")
 	}
 	gigaEnabled := cfg.AutobahnConfigFile != ""
-	node.rpcEnv.GigaEnabled = gigaEnabled
 	mp := mempool.NewTxMempool(cfg.Mempool.ToMempoolConfig(), proxyApp, nodeMetrics.mempool, sm.TxConstraintsFetcherFromStore(stateStore))
 	router, peerCloser, err := createRouter(
 		nodeMetrics.p2p,

--- a/sei-tendermint/rpc/coretypes/responses.go
+++ b/sei-tendermint/rpc/coretypes/responses.go
@@ -29,6 +29,24 @@ var (
 	ErrInvalidRequest = errors.New("invalid request")
 )
 
+// WrapErrHeightNotAvailable wraps ErrHeightNotAvailable with the requested
+// height and (when known) the lower bound that excluded it. Pass Some(base)
+// when the caller has the active lower bound — e.g. CometBFT's
+// BlockStore.Base() in env.getHeight. Pass None when the caller only knows
+// the height was unavailable but not what the bound is — e.g. the Autobahn
+// path where data.GlobalBlock returns data.ErrPruned and the bound
+// (data.State.inner.first) is internal to data.State.
+//
+// Centralizing this format means both paths produce identical error
+// strings for the same case modulo the optional base height, so callers
+// (evmrpc, ops tooling) get one shape to recognize.
+func WrapErrHeightNotAvailable(height int64, base utils.Option[int64]) error {
+	if b, ok := base.Get(); ok {
+		return fmt.Errorf("%w (requested height: %d, base height: %d)", ErrHeightNotAvailable, height, b)
+	}
+	return fmt.Errorf("%w (requested height: %d)", ErrHeightNotAvailable, height)
+}
+
 // List of blocks
 type ResultBlockchainInfo struct {
 	LastHeight int64              `json:"last_height,string"`


### PR DESCRIPTION
## Summary

Adds Autobahn handlers for `/block`, `/block_results`, `/block_by_hash`, and `/validators`, gated on `env.gigaRouter()` returning Some.

## Verified (live 4-node Autobahn cluster)

| Endpoint | Before | After |
|---|---|---|
| `eth_chainId`, `net_version`, `eth_blockNumber` | ✓ | ✓ |
| `eth_gasPrice` | crash | ✓ |
| `eth_getBlockByNumber("latest")` | error / nulls | ✓ |
| `eth_getBlockByNumber("0xFUTURE")` | error | ✓ `result: null` (spec) |
| `eth_getBlockByHash(<latest>)` | `result: null` | ✓ full block |
| `eth_getBlockByHash(<unknown>)` | `result: null` | ✓ `result: null` |
| `eth_call` / `eth_estimateGas` / `eth_getLogs` / `eth_feeHistory` | crash / error | ✓ |
| `eth_getTransactionReceipt` / `eth_getTransactionByHash` | null fields | ✓ |
| `seid tx evm send` → receipt poll | — | ✓ end-to-end |
| `/validators` | stuck at `block_height: 1` | ✓ matches actual chain head |
| `/validators?per_page=2&page={1,2,3}` | — | ✓ proper paging + range error |
| `/validators?height={200,999999}` | wrong head reported | ✓ historical query / proper sentinel |

## Non-state-breaking

All changes in the RPC serving path. Block execution (`app.FinalizeBlock` / `app.Commit`) and consensus data persistence untouched. App hashes match across versions — safe to deploy asymmetrically.

## Out of scope (TODOs in code)

- **Lower-bound height check under Autobahn**: currently `env.BlockStore.Base()=0`; will source from `BlockDB.GetLowestBlockHeight` once BlockDB is wired.
- **`env.BlockResults` per-tx detail**: empty under Autobahn (FinalizeBlock responses not persisted). evmrpc doesn't read them; revisit if downstream needs them.
- **`env.Commit` / `env.Header` / `env.HeaderByHash` / `/tx` / `/tx_search`**: not on evmrpc's critical path; separate workstream.
- **`data.State.inner.blockHashes`**: temporary in-memory index; replaced by `sei-db/ledger_db/block.BlockDB` once a writer is wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)