### PR TITLE
fix: flock to consensus WAL was not unlocked when shutting down the node

### DIFF
--- a/sei-tendermint/AGENTS.md
+++ b/sei-tendermint/AGENTS.md
@@ -1,4 +1,5 @@
 Within sei-tendermint subdirectory
+* sei-tendermint is a root of the go module, but it is not the root of the repo. When refactoring check references across of the whole repo.
 * use sei-tendermint/libs/utils.Option for optional values, passing nil as function value is not allowed,
     unless explicitly documented (except for maps and slices, for which nil is a valid empty value).
 * use sei-tendermint/libs/utils/scope.Run for structured concurrency (instead of waitgroup)

--- a/sei-tendermint/internal/consensus/common_test.go
+++ b/sei-tendermint/internal/consensus/common_test.go
@@ -426,7 +426,6 @@ func subscribeToVoterBuffered(ctx context.Context, t *testing.T, cs *State, addr
 // consensus states
 
 func newState(
-	ctx context.Context,
 	t *testing.T,
 	state sm.State,
 	pv types.PrivValidator,
@@ -437,27 +436,30 @@ func newState(
 	cfg, err := config.ResetTestRoot(t.TempDir(), "consensus_state_test")
 	require.NoError(t, err)
 
-	return newStateWithConfig(ctx, cfg, state, pv, app)
+	return newStateWithConfig(t, cfg, state, pv, app)
 }
 
 func newStateWithConfig(
-	ctx context.Context,
+	t *testing.T,
 	thisConfig *config.Config,
 	state sm.State,
 	pv types.PrivValidator,
 	app abci.Application,
 ) *State {
-	return newStateWithConfigAndBlockStore(ctx, thisConfig, state, pv, app, store.NewBlockStore(dbm.NewMemDB()))
+	return newStateWithConfigAndBlockStore(t, thisConfig, state, pv, app, store.NewBlockStore(dbm.NewMemDB()))
 }
 
 func newStateWithConfigAndBlockStore(
-	ctx context.Context,
+	t *testing.T,
 	thisConfig *config.Config,
 	state sm.State,
 	pv types.PrivValidator,
 	app abci.Application,
 	blockStore *store.BlockStore,
 ) *State {
+	t.Helper()
+	ctx := t.Context()
+
 	// one for mempool, one for consensus
 	proxyAppConnMem := app
 	proxyAppConnCon := app
@@ -486,8 +488,14 @@ func newStateWithConfigAndBlockStore(
 	}
 
 	blockExec := sm.NewBlockExecutor(stateStore, proxyAppConnCon, mempool, evpool, blockStore, eventBus, sm.NopMetrics())
-	cs, err := NewState(
+	wal, err := OpenWAL(thisConfig.Consensus.WalFile())
+	if err != nil {
+		panic(err)
+	}
+	t.Cleanup(wal.Close)
+	cs := NewState(
 		thisConfig.Consensus,
+		wal,
 		stateStore,
 		blockExec,
 		blockStore,
@@ -497,9 +505,6 @@ func newStateWithConfigAndBlockStore(
 		[]trace.TracerProviderOption{},
 		NopMetrics(),
 	)
-	if err != nil {
-		panic(err)
-	}
 	if err := cs.updateStateFromStore(); err != nil {
 		panic(err)
 	}
@@ -557,7 +562,7 @@ func makeState(ctx context.Context, t *testing.T, args makeStateArgs) (*State, [
 
 	vss := make([]*validatorStub, validators)
 
-	cs := newState(ctx, t, state, privVals[0], app)
+	cs := newState(t, state, privVals[0], app)
 
 	for i := 0; i < validators; i++ {
 		vss[i] = newValidatorStub(privVals[i], int32(i))
@@ -817,7 +822,7 @@ func makeConsensusState(
 		require.NoError(t, err)
 		app.SetValidators(vals)
 
-		css[i] = newStateWithConfigAndBlockStore(ctx, thisConfig, state, privVals[i], app, blockStore)
+		css[i] = newStateWithConfigAndBlockStore(t, thisConfig, state, privVals[i], app, blockStore)
 		css[i].SetTimeoutTicker(tickerFunc())
 	}
 
@@ -880,7 +885,7 @@ func randConsensusNetWithPeers(
 		app.SetValidators(vals)
 		// sm.SaveState(stateDB,state)	//height 1's validatorsInfo already saved in LoadStateFromDBOrGenesisDoc above
 
-		css[i] = newStateWithConfig(ctx, thisConfig, state, privVal, app)
+		css[i] = newStateWithConfig(t, thisConfig, state, privVal, app)
 		css[i].SetTimeoutTicker(tickerFunc())
 	}
 	return css, genDoc, peer0Config, func() {

--- a/sei-tendermint/internal/consensus/common_test.go
+++ b/sei-tendermint/internal/consensus/common_test.go
@@ -500,6 +500,9 @@ func newStateWithConfigAndBlockStore(
 	if err != nil {
 		panic(err)
 	}
+	if err := cs.updateStateFromStore(); err != nil {
+		panic(err)
+	}
 
 	cs.SetPrivValidator(ctx, utils.Some(pv))
 

--- a/sei-tendermint/internal/consensus/common_test.go
+++ b/sei-tendermint/internal/consensus/common_test.go
@@ -495,6 +495,7 @@ func newStateWithConfigAndBlockStore(
 		evpool,
 		eventBus,
 		[]trace.TracerProviderOption{},
+		NopMetrics(),
 	)
 	if err != nil {
 		panic(err)

--- a/sei-tendermint/internal/consensus/mempool_test.go
+++ b/sei-tendermint/internal/consensus/mempool_test.go
@@ -62,7 +62,7 @@ func TestMempoolNoProgressUntilTxsAvailable(t *testing.T) {
 		Validators: 1,
 		Power:      10,
 		Params:     factory.ConsensusParams()})
-	cs := newStateWithConfig(ctx, config, state, privVals[0], NewCounterApplication())
+	cs := newStateWithConfig(t, config, state, privVals[0], NewCounterApplication())
 	height, round := cs.roundState.Height(), cs.roundState.Round()
 	newBlockCh := subscribe(ctx, t, cs.eventBus, types.EventQueryNewBlock)
 	startTestRound(ctx, cs, height, round)
@@ -88,7 +88,7 @@ func TestMempoolProgressAfterCreateEmptyBlocksInterval(t *testing.T) {
 		Validators: 1,
 		Power:      10,
 		Params:     factory.ConsensusParams()})
-	cs := newStateWithConfig(ctx, config, state, privVals[0], NewCounterApplication())
+	cs := newStateWithConfig(t, config, state, privVals[0], NewCounterApplication())
 	height, round := cs.roundState.Height(), cs.roundState.Round()
 
 	newBlockCh := subscribe(ctx, t, cs.eventBus, types.EventQueryNewBlock)
@@ -112,7 +112,7 @@ func TestMempoolProgressInHigherRound(t *testing.T) {
 		Validators: 1,
 		Power:      10,
 		Params:     factory.ConsensusParams()})
-	cs := newStateWithConfig(ctx, config, state, privVals[0], NewCounterApplication())
+	cs := newStateWithConfig(t, config, state, privVals[0], NewCounterApplication())
 	height, round := cs.roundState.Height(), cs.roundState.Round()
 	newBlockCh := subscribe(ctx, t, cs.eventBus, types.EventQueryNewBlock)
 	newRoundCh := subscribe(ctx, t, cs.eventBus, types.EventQueryNewRound)
@@ -167,7 +167,7 @@ func TestMempoolTxConcurrentWithCommit(t *testing.T) {
 	blockStore := store.NewBlockStore(dbm.NewMemDB())
 
 	cs := newStateWithConfigAndBlockStore(
-		ctx, config, state, privVals[0], NewCounterApplication(), blockStore)
+		t, config, state, privVals[0], NewCounterApplication(), blockStore)
 
 	err := stateStore.Save(state)
 	require.NoError(t, err)
@@ -210,7 +210,7 @@ func TestMempoolRmBadTx(t *testing.T) {
 	app := NewCounterApplication()
 	stateStore := sm.NewStore(dbm.NewMemDB())
 	blockStore := store.NewBlockStore(dbm.NewMemDB())
-	cs := newStateWithConfigAndBlockStore(ctx, config, state, privVals[0], app, blockStore)
+	cs := newStateWithConfigAndBlockStore(t, config, state, privVals[0], app, blockStore)
 	err := stateStore.Save(state)
 	require.NoError(t, err)
 

--- a/sei-tendermint/internal/consensus/pbts_test.go
+++ b/sei-tendermint/internal/consensus/pbts_test.go
@@ -116,7 +116,7 @@ func newPBTSTestHarness(ctx context.Context, t *testing.T, tc pbtsTestConfigurat
 		Time:       tc.genesisTime,
 		Validators: validators,
 	})
-	cs := newState(ctx, t, state, privVals[0], kvstore.NewApplication())
+	cs := newState(t, state, privVals[0], kvstore.NewApplication())
 	vss := make([]*validatorStub, validators)
 	for i := 0; i < validators; i++ {
 		vss[i] = newValidatorStub(privVals[i], int32(i))

--- a/sei-tendermint/internal/consensus/reactor_test.go
+++ b/sei-tendermint/internal/consensus/reactor_test.go
@@ -296,10 +296,11 @@ func TestReactorWithEvidence(t *testing.T) {
 		require.NoError(t, eventBus.Start(ctx))
 
 		blockExec := sm.NewBlockExecutor(stateStore, proxyAppConnCon, mempool, evpool, blockStore, eventBus, sm.NopMetrics())
-
-		cs, err := NewState(
-			thisConfig.Consensus, stateStore, blockExec, blockStore, mempool, evpool2, eventBus, []trace.TracerProviderOption{}, NopMetrics())
+		wal, err := OpenWAL(thisConfig.Consensus.WalFile())
 		require.NoError(t, err)
+
+		cs := NewState(
+			thisConfig.Consensus, wal, stateStore, blockExec, blockStore, mempool, evpool2, eventBus, []trace.TracerProviderOption{}, NopMetrics())
 		require.NoError(t, cs.updateStateFromStore())
 		cs.SetPrivValidator(ctx, utils.Some(pv))
 

--- a/sei-tendermint/internal/consensus/reactor_test.go
+++ b/sei-tendermint/internal/consensus/reactor_test.go
@@ -298,7 +298,7 @@ func TestReactorWithEvidence(t *testing.T) {
 		blockExec := sm.NewBlockExecutor(stateStore, proxyAppConnCon, mempool, evpool, blockStore, eventBus, sm.NopMetrics())
 
 		cs, err := NewState(
-			thisConfig.Consensus, stateStore, blockExec, blockStore, mempool, evpool2, eventBus, []trace.TracerProviderOption{})
+			thisConfig.Consensus, stateStore, blockExec, blockStore, mempool, evpool2, eventBus, []trace.TracerProviderOption{}, NopMetrics())
 		require.NoError(t, err)
 		cs.SetPrivValidator(ctx, utils.Some(pv))
 

--- a/sei-tendermint/internal/consensus/reactor_test.go
+++ b/sei-tendermint/internal/consensus/reactor_test.go
@@ -300,6 +300,7 @@ func TestReactorWithEvidence(t *testing.T) {
 		cs, err := NewState(
 			thisConfig.Consensus, stateStore, blockExec, blockStore, mempool, evpool2, eventBus, []trace.TracerProviderOption{}, NopMetrics())
 		require.NoError(t, err)
+		require.NoError(t, cs.updateStateFromStore())
 		cs.SetPrivValidator(ctx, utils.Some(pv))
 
 		cs.SetTimeoutTicker(tickerFunc())

--- a/sei-tendermint/internal/consensus/replay_test.go
+++ b/sei-tendermint/internal/consensus/replay_test.go
@@ -107,7 +107,7 @@ func runStateUntilBlock(t *testing.T, cfg *config.Config, lastBlock int64) {
 	genDoc := utils.OrPanic1(types.GenesisDocFromFile(cfg.GenesisFile()))
 	state.Version.Consensus.App = kvstore.ProtocolVersion // simulate handshake, receive app version
 	cs := newStateWithConfigAndBlockStore(
-		ctx,
+		t,
 		cfg,
 		state,
 		loadPrivValidator(cfg),
@@ -119,7 +119,7 @@ func runStateUntilBlock(t *testing.T, cfg *config.Config, lastBlock int64) {
 	// substitute the WAL so that replaying messages doesn't write to the real WAL.
 	// TODO(gprusak): this is a hack, fix it.
 	realWAL := cs.wal
-	cs.wal, err = openWAL(filepath.Join(t.TempDir(), "other dir"))
+	cs.wal, err = OpenWAL(filepath.Join(t.TempDir(), "other dir"))
 	require.NoError(t, err)
 	defer cs.wal.Close()
 	// Replay manually all messages from WAL except for the msgs of latest height.
@@ -210,7 +210,7 @@ func resetWAL(t *testing.T, walPath string, msgs []WALMessage) {
 			require.NoError(t, os.Remove(filepath.Join(dirPath, e.Name())))
 		}
 	}
-	wal, err := openWAL(walPath)
+	wal, err := OpenWAL(walPath)
 	require.NoError(t, err)
 	defer wal.Close()
 	for _, msg := range msgs {
@@ -226,14 +226,13 @@ func crashWALandCheckLiveness(
 	heightToStop int64,
 ) {
 	t.Helper()
-	ctx := t.Context()
 	t.Logf("Generate WAL with sendTxsFn running in parallel.")
 	state, err := sm.MakeGenesisStateFromFile(cfg.GenesisFile())
 	require.NoError(t, err)
 	genDoc := utils.OrPanic1(types.GenesisDocFromFile(cfg.GenesisFile()))
 	state.Version.Consensus.App = kvstore.ProtocolVersion // simulate handshake, receive app version
 	cs := newStateWithConfigAndBlockStore(
-		ctx,
+		t,
 		cfg,
 		state,
 		loadPrivValidator(cfg),
@@ -247,7 +246,7 @@ func crashWALandCheckLiveness(
 		return waitForBlock(ctx, cs, heightToStop)
 	}))
 	cs.wal.Close()
-	wal, err := openWAL(cfg.Consensus.WalFile())
+	wal, err := OpenWAL(cfg.Consensus.WalFile())
 	require.NoError(t, err)
 	defer wal.Close()
 	msgs := dumpWAL(t, wal)
@@ -667,7 +666,7 @@ func testHandshakeReplay(
 
 		tmpCfg := getConfig(t)
 		runStateUntilBlock(t, tmpCfg, numBlocks)
-		wal, err := openWAL(tmpCfg.Consensus.WalFile())
+		wal, err := OpenWAL(tmpCfg.Consensus.WalFile())
 		require.NoError(t, err)
 		defer wal.Close()
 		chain, commits = makeBlockchainFromWAL(t, wal, numBlocks)

--- a/sei-tendermint/internal/consensus/state.go
+++ b/sei-tendermint/internal/consensus/state.go
@@ -152,11 +152,10 @@ type State struct {
 	// for reporting metrics
 	metrics *Metrics
 
-	tracer                otrace.Tracer
-	tracerProviderOptions []trace.TracerProviderOption
-	heightSpan            otrace.Span
-	heightBeingTraced     int64
-	tracingCtx            context.Context
+	tracer            otrace.Tracer
+	heightSpan        otrace.Span
+	heightBeingTraced int64
+	tracingCtx        context.Context
 }
 
 // NewState returns a new State.
@@ -175,11 +174,6 @@ func NewState(
 	if err != nil {
 		return nil, fmt.Errorf("openWal(): %w", err)
 	}
-	defer func() {
-		if resErr != nil {
-			wal.Close()
-		}
-	}()
 	cs := &State{
 		eventBus:          eventBus,
 		config:            cfg,
@@ -198,21 +192,18 @@ func NewState(
 		eventNewRoundStep: func(*cstypes.RoundState) {},
 		eventVote:         func(*types.Vote) {},
 		eventMsg:          func(msgInfo) {},
+		tracer: trace.NewTracerProvider(traceProviderOps...).Tracer("tm-consensus-state"),
 	}
-
 	// set function defaults (may be overwritten before calling Start)
 	cs.doPrevote = cs.defaultDoPrevote
 	cs.setProposal = cs.defaultSetProposal
-
-	if err := cs.updateStateFromStore(); err != nil {
-		return nil, err
-	}
-
-	tp := trace.NewTracerProvider(traceProviderOps...)
-	cs.tracer = tp.Tracer("tm-consensus-state")
-	cs.tracerProviderOptions = traceProviderOps
-
 	return cs, nil
+}
+
+// Frees the resources of State.
+// TODO(gprusak): WAL should be acquired and released within State.Run, rather than requiring the caller to Close manually.
+func (cs *State) Close() {
+	cs.wal.Close()
 }
 
 func (cs *State) updateStateFromStore() error {

--- a/sei-tendermint/internal/consensus/state.go
+++ b/sei-tendermint/internal/consensus/state.go
@@ -159,9 +159,6 @@ type State struct {
 	tracingCtx            context.Context
 }
 
-// StateOption sets an optional parameter on the State.
-type StateOption func(*State)
-
 // NewState returns a new State.
 func NewState(
 	cfg *config.ConsensusConfig,
@@ -172,7 +169,7 @@ func NewState(
 	evpool evidencePool,
 	eventBus *eventbus.EventBus,
 	traceProviderOps []trace.TracerProviderOption,
-	options ...StateOption,
+	metrics *Metrics,
 ) (res *State, resErr error) {
 	wal, err := openWAL(cfg.WalFile())
 	if err != nil {
@@ -195,7 +192,7 @@ func NewState(
 		timeoutTicker:     NewTimeoutTicker(),
 		doWALCatchup:      true,
 		evpool:            evpool,
-		metrics:           NopMetrics(),
+		metrics:           metrics,
 		wal:               wal,
 		eventValidBlock:   utils.NewAtomicSend(utils.None[*cstypes.RoundState]()),
 		eventNewRoundStep: func(*cstypes.RoundState) {},
@@ -206,11 +203,6 @@ func NewState(
 	// set function defaults (may be overwritten before calling Start)
 	cs.doPrevote = cs.defaultDoPrevote
 	cs.setProposal = cs.defaultSetProposal
-
-	// NOTE: we do not call scheduleRound0 yet, we do that upon Start()
-	for _, option := range options {
-		option(cs)
-	}
 
 	if err := cs.updateStateFromStore(); err != nil {
 		return nil, err
@@ -251,11 +243,6 @@ func (cs *State) updateStateFromStore() error {
 	cs.updateToState(state)
 
 	return nil
-}
-
-// StateMetrics sets the metrics.
-func StateMetrics(metrics *Metrics) StateOption {
-	return func(cs *State) { cs.metrics = metrics }
 }
 
 // String returns a string.

--- a/sei-tendermint/internal/consensus/state.go
+++ b/sei-tendermint/internal/consensus/state.go
@@ -161,6 +161,7 @@ type State struct {
 // NewState returns a new State.
 func NewState(
 	cfg *config.ConsensusConfig,
+	wal *WAL,
 	store sm.Store,
 	blockExec *sm.BlockExecutor,
 	blockStore sm.BlockStore,
@@ -169,11 +170,7 @@ func NewState(
 	eventBus *eventbus.EventBus,
 	traceProviderOps []trace.TracerProviderOption,
 	metrics *Metrics,
-) (res *State, resErr error) {
-	wal, err := openWAL(cfg.WalFile())
-	if err != nil {
-		return nil, fmt.Errorf("openWal(): %w", err)
-	}
+) *State {
 	cs := &State{
 		eventBus:          eventBus,
 		config:            cfg,
@@ -192,18 +189,12 @@ func NewState(
 		eventNewRoundStep: func(*cstypes.RoundState) {},
 		eventVote:         func(*types.Vote) {},
 		eventMsg:          func(msgInfo) {},
-		tracer: trace.NewTracerProvider(traceProviderOps...).Tracer("tm-consensus-state"),
+		tracer:            trace.NewTracerProvider(traceProviderOps...).Tracer("tm-consensus-state"),
 	}
 	// set function defaults (may be overwritten before calling Start)
 	cs.doPrevote = cs.defaultDoPrevote
 	cs.setProposal = cs.defaultSetProposal
-	return cs, nil
-}
-
-// Frees the resources of State.
-// TODO(gprusak): WAL should be acquired and released within State.Run, rather than requiring the caller to Close manually.
-func (cs *State) Close() {
-	cs.wal.Close()
+	return cs
 }
 
 func (cs *State) updateStateFromStore() error {

--- a/sei-tendermint/internal/consensus/state.go
+++ b/sei-tendermint/internal/consensus/state.go
@@ -101,8 +101,7 @@ type State struct {
 	// store blocks and commits
 	blockStore sm.BlockStore
 
-	stateStore        sm.Store
-	skipBootstrapping bool
+	stateStore sm.Store
 
 	// create and execute blocks
 	blockExec *sm.BlockExecutor
@@ -163,12 +162,6 @@ type State struct {
 // StateOption sets an optional parameter on the State.
 type StateOption func(*State)
 
-// SkipStateStoreBootstrap is a state option forces the constructor to
-// skip state bootstrapping during construction.
-func SkipStateStoreBootstrap(sm *State) {
-	sm.skipBootstrapping = true
-}
-
 // NewState returns a new State.
 func NewState(
 	cfg *config.ConsensusConfig,
@@ -219,13 +212,8 @@ func NewState(
 		option(cs)
 	}
 
-	// this is not ideal, but it lets the consensus tests start
-	// node-fragments gracefully while letting the nodes
-	// themselves avoid this.
-	if !cs.skipBootstrapping {
-		if err := cs.updateStateFromStore(); err != nil {
-			return nil, err
-		}
+	if err := cs.updateStateFromStore(); err != nil {
+		return nil, err
 	}
 
 	tp := trace.NewTracerProvider(traceProviderOps...)

--- a/sei-tendermint/internal/consensus/state_test.go
+++ b/sei-tendermint/internal/consensus/state_test.go
@@ -588,7 +588,7 @@ func testStateLockNoPOL(t *testing.T) {
 
 	// cs1 is locked on a block at this point, so we must generate a new consensus
 	// state to force a new proposal block to be generated.
-	cs2 := newState(ctx, t, cs1.state, vs2, kvstore.NewApplication())
+	cs2 := newState(t, cs1.state, vs2, kvstore.NewApplication())
 	// before we time out into new round, set next proposal block
 	prop, propBlock := decideProposal(ctx, t, cs2, vs2, vs2.Height, vs2.Round+1)
 	require.NotNil(t, propBlock, "Failed to create proposal block with vs2")
@@ -710,7 +710,7 @@ func TestStateLock_POLUpdateLock(t *testing.T) {
 	round++
 
 	// Generate a new proposal block.
-	cs2 := newState(ctx, t, cs1.state, vs2, kvstore.NewApplication())
+	cs2 := newState(t, cs1.state, vs2, kvstore.NewApplication())
 	propR1, propBlockR1 := decideProposal(ctx, t, cs2, vs2, vs2.Height, vs2.Round)
 	propBlockR1Parts, err := propBlockR1.MakePartSet(partSize)
 	require.NoError(t, err)
@@ -988,7 +988,7 @@ func TestStateLock_PrevoteNilWhenLockedAndDifferentProposal(t *testing.T) {
 	*/
 	incrementRound(vs2, vs3, vs4)
 	round++
-	cs2 := newState(ctx, t, cs1.state, vs2, kvstore.NewApplication())
+	cs2 := newState(t, cs1.state, vs2, kvstore.NewApplication())
 	propR1, propBlockR1 := decideProposal(ctx, t, cs2, vs2, vs2.Height, vs2.Round)
 	propBlockR1Parts, err := propBlockR1.MakePartSet(types.BlockPartSizeBytes)
 	require.NoError(t, err)
@@ -1090,7 +1090,7 @@ func TestStateLock_POLDoesNotUnlock(t *testing.T) {
 	*/
 	round++
 	incrementRound(vs2, vs3, vs4)
-	cs2 := newState(ctx, t, cs1.state, vs2, kvstore.NewApplication())
+	cs2 := newState(t, cs1.state, vs2, kvstore.NewApplication())
 	prop, propBlock := decideProposal(ctx, t, cs2, vs2, vs2.Height, vs2.Round)
 	propBlockParts, err := propBlock.MakePartSet(types.BlockPartSizeBytes)
 	require.NoError(t, err)
@@ -1124,7 +1124,7 @@ func TestStateLock_POLDoesNotUnlock(t *testing.T) {
 	*/
 	round++
 	incrementRound(vs2, vs3, vs4)
-	cs3 := newState(ctx, t, cs1.state, vs2, kvstore.NewApplication())
+	cs3 := newState(t, cs1.state, vs2, kvstore.NewApplication())
 	prop, propBlock = decideProposal(ctx, t, cs3, vs3, vs3.Height, vs3.Round)
 	propBlockParts, err = propBlock.MakePartSet(types.BlockPartSizeBytes)
 	require.NoError(t, err)
@@ -1209,7 +1209,7 @@ func TestStateLock_MissingProposalWhenPOLSeenDoesNotUpdateLock(t *testing.T) {
 	*/
 	incrementRound(vs2, vs3, vs4)
 	round++
-	cs2 := newState(ctx, t, cs1.state, vs2, kvstore.NewApplication())
+	cs2 := newState(t, cs1.state, vs2, kvstore.NewApplication())
 	prop, propBlock := decideProposal(ctx, t, cs2, vs2, vs2.Height, vs2.Round)
 	require.NotNil(t, propBlock, "Failed to create proposal block with vs2")
 	require.NotNil(t, prop, "Failed to create proposal block with vs2")
@@ -1345,7 +1345,7 @@ func TestStateLock_POLSafety1(t *testing.T) {
 	// Pre-build the round 2 proposal before cs1 transitions rounds to avoid
 	// burning round 2's propose timeout budget under CI load.
 	r2Round := round + 1
-	cs2 := newState(ctx, t, cs1.state, vs2, kvstore.NewApplication())
+	cs2 := newState(t, cs1.state, vs2, kvstore.NewApplication())
 	prop, propBlock := decideProposal(ctx, t, cs2, vs2, vs2.Height, r2Round)
 	propBlockParts, err := propBlock.MakePartSet(partSize)
 	require.NoError(t, err)
@@ -1590,7 +1590,7 @@ func TestState_PrevotePOLFromPreviousRound(t *testing.T) {
 	incrementRound(vs2, vs3, vs4)
 	round++
 	// Generate a new proposal block.
-	cs2 := newState(ctx, t, cs1.state, vs2, kvstore.NewApplication())
+	cs2 := newState(t, cs1.state, vs2, kvstore.NewApplication())
 	cs2.roundState.SetValidRound(1)
 	propR1, propBlockR1 := decideProposal(ctx, t, cs2, vs2, vs2.Height, round)
 

--- a/sei-tendermint/internal/consensus/wal.go
+++ b/sei-tendermint/internal/consensus/wal.go
@@ -194,8 +194,8 @@ func walFromProto(msg *tmcons.WALMessage) (WALMessage, error) {
 // Can be used for crash-recovery and deterministic replay.
 type WAL struct{ inner utils.Mutex[*wal.Log] }
 
-// openWAL opens WAL.
-func openWAL(walFile string) (res *WAL, resErr error) {
+// OpenWAL opens WAL.
+func OpenWAL(walFile string) (res *WAL, resErr error) {
 	if err := tmos.EnsureDir(filepath.Dir(walFile), 0700); err != nil {
 		return nil, err
 	}

--- a/sei-tendermint/internal/consensus/wal_test.go
+++ b/sei-tendermint/internal/consensus/wal_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestWAL_AppendRead(t *testing.T) {
-	wal, err := openWAL(path.Join(t.TempDir(), "testwal"))
+	wal, err := OpenWAL(path.Join(t.TempDir(), "testwal"))
 	require.NoError(t, err)
 	defer wal.Close()
 
@@ -32,7 +32,7 @@ func TestWAL_AppendRead(t *testing.T) {
 }
 
 func TestWAL_ErrBadSize(t *testing.T) {
-	wal, err := openWAL(path.Join(t.TempDir(), "testlog"))
+	wal, err := OpenWAL(path.Join(t.TempDir(), "testlog"))
 	require.NoError(t, err)
 
 	// 1) Write returns an error if msg is too big
@@ -58,7 +58,7 @@ func TestWAL_ErrBadSize(t *testing.T) {
 func TestWAL_ReadLastMsgs(t *testing.T) {
 	cfg := getConfig(t)
 	runStateUntilBlock(t, cfg, 3)
-	wal, err := openWAL(cfg.Consensus.WalFile())
+	wal, err := OpenWAL(cfg.Consensus.WalFile())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sei-tendermint/node/node.go
+++ b/sei-tendermint/node/node.go
@@ -88,32 +88,37 @@ func makeNode(
 	dbProvider config.DBProvider,
 	tracerProviderOptions []trace.TracerProviderOption,
 	nodeMetrics *NodeMetrics,
-) (service.Service, error) {
+) (_ service.Service, err error) {
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithCancel(ctx)
 	closers := []closer{convertCancelCloser(cancel)}
+	defer func() {
+		if err != nil {
+			err = combineCloseError(err, makeCloser(closers))
+		}
+	}()
 	app = proxy.New(app, nodeMetrics.proxy)
 
 	blockStore, stateDB, dbCloser, err := initDBs(cfg, dbProvider)
-	if err != nil {
-		return nil, combineCloseError(err, dbCloser)
-	}
 	closers = append(closers, dbCloser)
+	if err != nil {
+		return nil, fmt.Errorf("initDBs(): %w", err)
+	}
 
 	stateStore := sm.NewStore(stateDB)
 
 	genDoc, err := genesisDocProvider()
 	if err != nil {
-		return nil, combineCloseError(err, makeCloser(closers))
+		return nil, fmt.Errorf("genesisDocProvider(): %w", err)
 	}
 
 	if err = genDoc.ValidateAndComplete(); err != nil {
-		return nil, combineCloseError(fmt.Errorf("error in genesis doc: %w", err), makeCloser(closers))
+		return nil, fmt.Errorf("error in genesis doc: %w", err)
 	}
 
 	state, err := LoadStateFromDBOrGenesisDocProvider(stateStore, genDoc)
 	if err != nil {
-		return nil, combineCloseError(err, makeCloser(closers))
+		return nil, fmt.Errorf("LoadStateFromDBOrGenesisDocProvider(): %w", err)
 	}
 
 	eventBus := eventbus.NewDefault()
@@ -127,12 +132,12 @@ func makeNode(
 			Metrics:    nodeMetrics.eventlog,
 		})
 		if err != nil {
-			return nil, combineCloseError(fmt.Errorf("initializing event log: %w", err), makeCloser(closers))
+			return nil, fmt.Errorf("initializing event log: %w", err)
 		}
 	}
 	eventSinks, err := sink.EventSinksFromConfig(cfg, dbProvider, genDoc.ChainID)
 	if err != nil {
-		return nil, combineCloseError(err, makeCloser(closers))
+		return nil, fmt.Errorf("sink.EventSinksFromConfig(): %w", err)
 	}
 	indexerService := indexer.NewService(indexer.ServiceArgs{
 		Sinks:    eventSinks,
@@ -142,15 +147,14 @@ func makeNode(
 
 	privValidator, err := createPrivval(ctx, cfg, genDoc, filePrivval)
 	if err != nil {
-		return nil, combineCloseError(err, makeCloser(closers))
+		return nil, fmt.Errorf("createPrivval(): %w", err)
 	}
 
 	pubKey := utils.None[crypto.PubKey]()
 	if cfg.Mode == config.ModeValidator {
 		key, err := privValidator.GetPubKey(ctx)
 		if err != nil {
-			return nil, combineCloseError(fmt.Errorf("can't get pubkey: %w", err),
-				makeCloser(closers))
+			return nil, fmt.Errorf("can't get pubkey: %w", err)
 		}
 		pubKey = utils.Some(key)
 	}
@@ -185,9 +189,7 @@ func makeNode(
 
 	// Autobahn requires a local validator key; remote signers are not supported.
 	if cfg.AutobahnConfigFile != "" && cfg.PrivValidator.ListenAddr != "" {
-		return nil, combineCloseError(
-			fmt.Errorf("autobahn does not support remote validator signers (priv-validator.laddr is set)"),
-			makeCloser(closers))
+		return nil, fmt.Errorf("autobahn does not support remote validator signers (priv-validator.laddr is set)")
 	}
 	gigaEnabled := cfg.AutobahnConfigFile != ""
 	mp := mempool.NewTxMempool(cfg.Mempool.ToMempoolConfig(), app, nodeMetrics.mempool, sm.TxConstraintsFetcherFromStore(stateStore))
@@ -203,14 +205,11 @@ func makeNode(
 	)
 	closers = append(closers, peerCloser)
 	if err != nil {
-		return nil, combineCloseError(
-			fmt.Errorf("failed to create router: %w", err),
-			makeCloser(closers))
+		return nil, fmt.Errorf("failed to create router: %w", err)
 	}
 	node.router = router
 	node.mempool = mp
 	node.rpcEnv.Router = router
-	node.shutdownOps = makeCloser(closers)
 
 	// Mempool gossiping is not compatible with Giga,
 	// so we disable the mempool reactor.
@@ -227,7 +226,7 @@ func makeNode(
 		stateStore, blockStore, node.router, nodeMetrics.evidence, eventBus)
 	closers = append(closers, edbCloser)
 	if err != nil {
-		return nil, combineCloseError(err, makeCloser(closers))
+		return nil, fmt.Errorf("createEvidenceReactor(): %w", err)
 	}
 	node.services = append(node.services, evReactor)
 	node.rpcEnv.EvidencePool = evPool
@@ -277,8 +276,12 @@ func makeNode(
 		nodeMetrics.consensus,
 	)
 	if err != nil {
-		return nil, combineCloseError(err, makeCloser(closers))
+		return nil, fmt.Errorf("consensus.NewState(): %w", err)
 	}
+	closers = append(closers, func () error {
+		csState.Close()
+		return nil
+	})
 	node.rpcEnv.ConsensusState = csState
 
 	var csReactor *consensus.Reactor
@@ -397,6 +400,7 @@ func makeNode(
 	node.rpcEnv.PubKey = pubKey
 
 	node.BaseService = *service.NewBaseService("Node", node)
+	node.shutdownOps = makeCloser(closers)
 
 	return node, nil
 }

--- a/sei-tendermint/node/node.go
+++ b/sei-tendermint/node/node.go
@@ -264,8 +264,18 @@ func makeNode(
 	}
 	waitSync := stateSync || blockSync
 
-	csState, err := consensus.NewState(
+	consensusWAL, err := consensus.OpenWAL(cfg.Consensus.WalFile())
+	if err != nil {
+		return nil, fmt.Errorf("consensus.OpenWAL(): %w", err)
+	}
+	closers = append(closers, func() error {
+		consensusWAL.Close()
+		return nil
+	})
+
+	csState := consensus.NewState(
 		cfg.Consensus,
+		consensusWAL,
 		stateStore,
 		blockExec,
 		blockStore,
@@ -275,13 +285,6 @@ func makeNode(
 		tracerProviderOptions,
 		nodeMetrics.consensus,
 	)
-	if err != nil {
-		return nil, fmt.Errorf("consensus.NewState(): %w", err)
-	}
-	closers = append(closers, func () error {
-		csState.Close()
-		return nil
-	})
 	node.rpcEnv.ConsensusState = csState
 
 	var csReactor *consensus.Reactor

--- a/sei-tendermint/node/node.go
+++ b/sei-tendermint/node/node.go
@@ -275,7 +275,6 @@ func makeNode(
 		eventBus,
 		tracerProviderOptions,
 		consensus.StateMetrics(nodeMetrics.consensus),
-		consensus.SkipStateStoreBootstrap,
 	)
 	if err != nil {
 		return nil, combineCloseError(err, makeCloser(closers))

--- a/sei-tendermint/node/node.go
+++ b/sei-tendermint/node/node.go
@@ -274,7 +274,7 @@ func makeNode(
 		evPool,
 		eventBus,
 		tracerProviderOptions,
-		consensus.StateMetrics(nodeMetrics.consensus),
+		nodeMetrics.consensus,
 	)
 	if err != nil {
 		return nil, combineCloseError(err, makeCloser(closers))

--- a/sei-tendermint/node/node_test.go
+++ b/sei-tendermint/node/node_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/service"
 	tmtime "github.com/sei-protocol/sei-chain/sei-tendermint/libs/time"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/tcp"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/privval"
 	tmproto "github.com/sei-protocol/sei-chain/sei-tendermint/proto/tendermint/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
@@ -93,6 +94,39 @@ func TestNodeStartStop(t *testing.T) {
 	defer cancel()
 	_, err = blocksSub.Next(tctx)
 	require.NoError(t, err, "waiting for event")
+}
+
+func TestNodeRestartEventAllowsRecreate(t *testing.T) {
+	cfg, err := config.ResetTestRoot(t.TempDir(), "node_restart_event_test")
+	require.NoError(t, err)
+	cfg.Mode = config.ModeFull
+	cfg.RPC.ListenAddress = fmt.Sprintf("tcp://%s", tcp.TestReserveAddr())
+
+	ctx := t.Context()
+
+	newNode := func() service.Service {
+		app := kvstore.NewApplication()
+		app.SetValidators(utils.OrPanic1(types.GenesisDocFromFile(cfg.GenesisFile())).ValidatorUpdates())
+
+		n, err := New(
+			ctx,
+			cfg,
+			func() {},
+			app,
+			nil,
+			nil,
+			DefaultMetricsProvider(cfg.Instrumentation)(cfg.ChainID()),
+		)
+		require.NoError(t, err)
+		return n
+	}
+
+	for range 2 {
+		current := newNode()
+		require.NoError(t, current.Start(ctx))
+		current.Stop()
+		current.Wait()
+	}
 }
 
 func getTestNode(ctx context.Context, t *testing.T, conf *config.Config) *nodeImpl {

--- a/sei-tendermint/node/seed.go
+++ b/sei-tendermint/node/seed.go
@@ -118,7 +118,6 @@ func makeSeedNode(
 		nodeKey: nodeKey,
 		router:  router,
 
-
 		pexReactor: pexReactor,
 		rpcEnv: &rpccore.Environment{
 			App: abci.NewBaseApplication(),

--- a/sei-tendermint/node/seed.go
+++ b/sei-tendermint/node/seed.go
@@ -51,7 +51,13 @@ func makeSeedNode(
 	nodeKey types.NodeKey,
 	genesisDocProvider genesisDocProvider,
 	nodeMetrics *NodeMetrics,
-) (service.Service, error) {
+) (_ service.Service, err error) {
+	closers := []closer{}
+	defer func() {
+		if err != nil {
+			err = combineCloseError(err, makeCloser(closers))
+		}
+	}()
 	if !cfg.P2P.PexReactor {
 		return nil, errors.New("cannot run seed nodes with PEX disabled")
 	}
@@ -81,10 +87,9 @@ func makeSeedNode(
 		genDoc,
 		dbProvider,
 	)
+	closers = append(closers, peerCloser)
 	if err != nil {
-		return nil, combineCloseError(
-			fmt.Errorf("failed to create router: %w", err),
-			peerCloser)
+		return nil, fmt.Errorf("failed to create router: %w", err)
 	}
 
 	pexReactor, err := pex.NewReactor(router, pex.DefaultSendInterval)
@@ -92,16 +97,15 @@ func makeSeedNode(
 		return nil, fmt.Errorf("pex.NewReactor(): %w", err)
 	}
 
-	closers := make([]closer, 0, 2)
 	blockStore, stateDB, dbCloser, err := initDBs(cfg, dbProvider)
-	if err != nil {
-		return nil, combineCloseError(err, dbCloser)
-	}
 	closers = append(closers, dbCloser)
+	if err != nil {
+		return nil, fmt.Errorf("initDBs: %w", err)
+	}
 
 	eventSinks, err := sink.EventSinksFromConfig(cfg, dbProvider, genDoc.ChainID)
 	if err != nil {
-		return nil, combineCloseError(err, makeCloser(closers))
+		return nil, fmt.Errorf("sink.EventSinksFromConfig(): %w", err)
 	}
 	eventBus := eventbus.NewDefault()
 
@@ -114,7 +118,6 @@ func makeSeedNode(
 		nodeKey: nodeKey,
 		router:  router,
 
-		shutdownOps: peerCloser,
 
 		pexReactor: pexReactor,
 		rpcEnv: &rpccore.Environment{
@@ -133,7 +136,7 @@ func makeSeedNode(
 		nodeInfo: nodeInfo,
 	}
 	node.BaseService = *service.NewBaseService("SeedNode", node)
-
+	node.shutdownOps = makeCloser(closers)
 	return node, nil
 }
 


### PR DESCRIPTION
It is not a problem during normal shutdown (process is dropping flocks when terminated), but in case node has fallen too many blocks behind, node service restarted within the process and fails.
* I have moved the WAL management out of consensus state (for consistency with other DBs)
* I have moved "closers" in newNode to be called from a deferred call
* I have removed variadic arguments from consensus.NewState
* I have added a test checking that WAL gets closed