### PR TITLE
fix(evmrpc): return null for out-of-range index in eth_getTransactionByBlock*AndIndex

### DIFF
--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -320,7 +320,8 @@ func (t *TransactionAPI) GetTransactionCount(ctx context.Context, address common
 func (t *TransactionAPI) getTransactionWithBlock(block *coretypes.ResultBlock, txIndex uint32, includeSynthetic bool) (*export.RPCTransaction, error) {
 	msgs := filterTransactions(t.keeper, t.ctxProvider, t.txConfigProvider, block, includeSynthetic, false, t.cacheCreationMutex, t.globalBlockCache)
 	if txIndex >= uint32(len(msgs)) { //nolint:gosec
-		return nil, errors.New("transaction index out of range")
+		// Ethereum JSON-RPC: eth_getTransactionByBlock*AndIndex returns null when the index has no transaction.
+		return nil, nil
 	}
 	msg := msgs[txIndex]
 	evmTx, ok := msg.msg.(*types.MsgEVMTransaction)

--- a/evmrpc/tx_test.go
+++ b/evmrpc/tx_test.go
@@ -386,9 +386,9 @@ func TestGetTransactionWithBlockIndexOutOfRange(t *testing.T) {
 	resObj := map[string]interface{}{}
 	require.Nil(t, json.Unmarshal(resBody, &resObj))
 
-	// Should get an error for index out of range
-	errMap := resObj["error"].(map[string]interface{})
-	require.Contains(t, errMap["message"].(string), "transaction index out of range")
+	// Ethereum JSON-RPC: out-of-range index yields null result, not an error
+	require.Nil(t, resObj["error"])
+	require.Nil(t, resObj["result"])
 }
 
 func TestEncodeReceiptTransactionNotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

- `eth_getTransactionByBlockNumberAndIndex` and `eth_getTransactionByBlockHashAndIndex` were returning a JSON-RPC error when the requested transaction index exceeded the number of transactions in the block.
- Per the [Ethereum JSON-RPC spec](https://ethereum.github.io/execution-apis/api/methods/eth_getTransactionByBlockNumberAndIndex), these methods must return `null` (not an error) when no transaction exists at the given index.
- Changed `getTransactionWithBlock` to return `(nil, nil)` instead of `(nil, error)` on out-of-range index, and updated the corresponding test.

