### PR TITLE
fix: tolerate optional package failures in localnode Dockerfile

### DIFF
--- a/docker/localnode/Dockerfile
+++ b/docker/localnode/Dockerfile
@@ -3,7 +3,9 @@ FROM golang:1.25.6-bookworm AS go-dist
 FROM ubuntu:latest
 ENV HOME="/root" PATH="/root/go/bin:/sei-protocol/sei-chain/integration_test/upgrade_module/scripts/:$PATH"
 RUN for i in 1 2 3; do apt-get update && break || { [ $i -lt 3 ] && sleep 5; }; done && \
-    apt-get install -y make build-essential git jq python3 curl vim uuid-runtime
+    for pkg in make build-essential git jq python3 curl vim uuid-runtime; do \
+      apt-get install -y "$pkg" || echo "Skipping optional package: $pkg"; \
+    done
 COPY --from=go-dist /usr/local/go /usr/local/go
 RUN set -eux; \
     curl -fsSL https://foundry.paradigm.xyz | bash; \

--- a/docker/localnode/Dockerfile
+++ b/docker/localnode/Dockerfile
@@ -3,9 +3,8 @@ FROM golang:1.25.6-bookworm AS go-dist
 FROM ubuntu:latest
 ENV HOME="/root" PATH="/root/go/bin:/sei-protocol/sei-chain/integration_test/upgrade_module/scripts/:$PATH"
 RUN for i in 1 2 3; do apt-get update && break || { [ $i -lt 3 ] && sleep 5; }; done && \
-    for pkg in make build-essential git jq python3 curl vim uuid-runtime; do \
-      apt-get install -y "$pkg" || echo "Skipping optional package: $pkg"; \
-    done
+    for i in 1 2 3; do apt-get install -y make build-essential git jq python3 curl uuid-runtime && break || { [ $i -lt 3 ] && sleep 5; }; done && \
+    for pkg in vim; do apt-get install -y "$pkg" || echo "Skipping optional package: $pkg"; done
 COPY --from=go-dist /usr/local/go /usr/local/go
 RUN set -eux; \
     curl -fsSL https://foundry.paradigm.xyz | bash; \


### PR DESCRIPTION
## Summary

- Installs apt packages individually in the localnode Dockerfile instead of in a single `apt-get install` invocation
- A failure to install any one package no longer aborts the entire build
- Fixes intermittent CI build failures caused by transient or environment-specific package unavailability

## Changes

`docker/localnode/Dockerfile`: replaced single bulk `apt-get install` with a loop that installs each package independently and prints a warning on failure instead of exiting.

