### PR TITLE
fix(evmrpc): use synthetic IDs in slow-path batch to handle duplicate and null request IDs

### DIFF
--- a/evmrpc/sei_legacy_http.go
+++ b/evmrpc/sei_legacy_http.go
@@ -269,7 +269,9 @@ func mergeSeiLegacyHTTPBatch(
 	for j, raw := range unmarshalledInnerBody {
 		idRaw, hasKey, err := jsonRPCObjectIDKey(raw)
 		if err != nil {
-			continue // it will error later with internalErrorCode
+			// Skip malformed inner entry; the matching slot will fall through to
+			// the internalErrorCode branch in the merge loop below.
+			continue
 		}
 		entries[j] = raw
 		if !hasKey || isJSONRPCNotificationID(idRaw) {

--- a/evmrpc/sei_legacy_http.go
+++ b/evmrpc/sei_legacy_http.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 )
 
 // seiLegacyHTTPMaxBody matches github.com/ethereum/go-ethereum/rpc.defaultBodyLimit (5MiB), the
@@ -121,6 +122,8 @@ func (g *seiLegacyHTTPGate) handleBatch(w http.ResponseWriter, r *http.Request, 
 	methods := make([]string, len(msgs))
 	ids := make([]json.RawMessage, len(msgs))
 	invalidReq := make([]bool, len(msgs))
+	blocked := make([]bool, len(msgs))
+	blockedErr := make([]error, len(msgs))
 	for i, raw := range msgs {
 		var msg struct {
 			Method string          `json:"method"`
@@ -133,25 +136,28 @@ func (g *seiLegacyHTTPGate) handleBatch(w http.ResponseWriter, r *http.Request, 
 		}
 		methods[i] = msg.Method
 		ids[i] = msg.ID
-	}
-	blocked := make([]bool, len(msgs))
-	blockedErr := make([]error, len(msgs))
-	for i := range msgs {
-		if invalidReq[i] {
-			continue
-		}
 		if err := seiLegacyGateError(methods[i], g.allowlist); err != nil {
 			blocked[i] = true
 			blockedErr[i] = err
 		}
 	}
+
 	var forward []json.RawMessage
+	synthIDs := make([]json.RawMessage, len(msgs))
 	forwardLegacy := false
+	synthCounter := 0
 	for i := range msgs {
 		if invalidReq[i] || blocked[i] {
 			continue
 		}
-		forward = append(forward, msgs[i])
+		msg := msgs[i]
+		if !isJSONRPCNotificationID(ids[i]) {
+			sid := json.RawMessage(strconv.AppendInt(nil, int64(synthCounter), 10))
+			synthIDs[i] = sid
+			synthCounter++
+			msg = setJSONObjectID(msg, sid)
+		}
+		forward = append(forward, msg)
 		if !forwardLegacy && seiLegacyForwardedGatedMethod(methods[i], g.allowlist) {
 			forwardLegacy = true
 		}
@@ -187,7 +193,7 @@ func (g *seiLegacyHTTPGate) handleBatch(w http.ResponseWriter, r *http.Request, 
 		return io.NopCloser(bytes.NewReader(forwardBody)), nil
 	}
 	g.inner.ServeHTTP(rec, sub)
-	outArr := mergeSeiLegacyHTTPBatch(invalidReq, blocked, blockedErr, ids, len(msgs), rec.Body.Bytes())
+	outArr := mergeSeiLegacyHTTPBatch(invalidReq, blocked, blockedErr, ids, synthIDs, len(msgs), rec.Body.Bytes())
 	copyHTTPHeader(w.Header(), rec.Header())
 	if forwardLegacy {
 		w.Header().Set(SeiLegacyDeprecationHTTPHeader, SeiLegacyDeprecationMessage)
@@ -224,11 +230,15 @@ func seiLegacyBatchResponsesNoForward(
 
 // mergeSeiLegacyHTTPBatch merges inner batch results with gate/invalid slots. Output is ordered like the
 // original batch but omits entries for JSON-RPC notifications (no "id" member), per JSON-RPC 2.0 batch rules.
+// synthIDs holds the unique synthetic ID assigned to each forwarded non-notification request (nil for all
+// others). The inner server echoes these synthetic IDs back, so idToIdx is always collision-free regardless
+// of duplicate or null original IDs. Original IDs are restored in the output via patchJSONRPCResponseIDIfNeeded.
 func mergeSeiLegacyHTTPBatch(
 	invalidReq []bool,
 	blocked []bool,
 	blockedErr []error,
 	ids []json.RawMessage,
+	synthIDs []json.RawMessage,
 	lenMsgs int,
 	innerBody []byte,
 ) []json.RawMessage {
@@ -249,55 +259,50 @@ func mergeSeiLegacyHTTPBatch(
 		return out
 	}
 
-	var innerArr []json.RawMessage
-	if err := json.Unmarshal(innerBody, &innerArr); err != nil {
+	var unmarshalledInnerBody []json.RawMessage
+	if err := json.Unmarshal(innerBody, &unmarshalledInnerBody); err != nil {
 		return appendMergeFailure()
 	}
 
-	entries := make([]json.RawMessage, len(innerArr))
-	idToIdx := make(map[string]int, len(innerArr))
-	for j, raw := range innerArr {
+	entries := make([]json.RawMessage, len(unmarshalledInnerBody))
+	idToIdx := make(map[string]int, len(unmarshalledInnerBody))
+	for j, raw := range unmarshalledInnerBody {
 		idRaw, hasKey, err := jsonRPCObjectIDKey(raw)
 		if err != nil {
-			return appendMergeFailure()
+			continue // it will error later with internalErrorCode
 		}
 		entries[j] = raw
 		if !hasKey || isJSONRPCNotificationID(idRaw) {
 			continue
 		}
 		k := rpcIDKey(idRaw)
-		if firstIdx, ok := idToIdx[k]; ok {
-			// Duplicate id with different bodies: fail the merge.
-			if !bytes.Equal(entries[firstIdx], raw) {
-				return appendMergeFailure()
-			}
-			continue
+		if _, ok := idToIdx[k]; !ok {
+			idToIdx[k] = j
 		}
-		idToIdx[k] = j
 	}
 
 	out := make([]json.RawMessage, 0, lenMsgs)
-	used := make([]bool, len(innerArr))
+	used := make([]bool, len(unmarshalledInnerBody))
 	for i := 0; i < lenMsgs; i++ {
 		if invalidReq[i] {
-			out = append(out, json.RawMessage(marshalJSONRPCError(orNullID(ids[i]), invalidRequestCode, seiLegacyBatchInvalidReqMsg)))
+			out = append(out, marshalJSONRPCError(orNullID(ids[i]), invalidRequestCode, seiLegacyBatchInvalidReqMsg))
 			continue
 		}
 		if isJSONRPCNotificationID(ids[i]) {
 			continue
 		}
 		if blocked[i] {
-			out = append(out, json.RawMessage(marshalBlockedResponse(orNullID(ids[i]), blockedErr[i])))
+			out = append(out, marshalBlockedResponse(orNullID(ids[i]), blockedErr[i]))
 			continue
 		}
-		k := rpcIDKey(ids[i])
+		k := rpcIDKey(synthIDs[i])
 		idx, ok := idToIdx[k]
 		if !ok || used[idx] {
-			out = append(out, json.RawMessage(marshalJSONRPCError(orNullID(ids[i]), internalErrorCode, seiLegacyBatchInternalErr)))
+			out = append(out, marshalJSONRPCError(orNullID(ids[i]), internalErrorCode, seiLegacyBatchInternalErr))
 			continue
 		}
 		used[idx] = true
-		out = append(out, json.RawMessage(patchJSONRPCResponseIDIfNeeded(entries[idx], ids[i])))
+		out = append(out, patchJSONRPCResponseIDIfNeeded(entries[idx], ids[i]))
 	}
 
 	return out
@@ -376,6 +381,21 @@ func writeJSONRPCBatchResponse(w http.ResponseWriter, code int, arr []json.RawMe
 		return
 	}
 	writeJSONArrayResponse(w, code, arr)
+}
+
+// setJSONObjectID returns obj with its "id" field replaced by newID.
+// Returns obj unchanged if it cannot be parsed as a JSON object.
+func setJSONObjectID(obj json.RawMessage, newID json.RawMessage) json.RawMessage {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(obj, &m); err != nil {
+		return obj
+	}
+	m["id"] = newID
+	b, err := json.Marshal(m)
+	if err != nil {
+		return obj
+	}
+	return b
 }
 
 func writeJSONArrayResponse(w http.ResponseWriter, code int, arr []json.RawMessage) {

--- a/evmrpc/sei_legacy_test.go
+++ b/evmrpc/sei_legacy_test.go
@@ -341,7 +341,7 @@ func TestWrapSeiLegacyHTTP_BatchMixed(t *testing.T) {
 		if !strings.Contains(string(b), "eth_chainId") {
 			t.Fatalf("unexpected forward body: %s", b)
 		}
-		_, _ = w.Write([]byte(`[{"jsonrpc":"2.0","id":2,"result":"0x1"}]`))
+		_, _ = w.Write([]byte(`[{"jsonrpc":"2.0","id":0,"result":"0x1"}]`))
 	})
 	h := wrapSeiLegacyHTTP(inner, BuildSeiLegacyEnabledSet(nil))
 	body := `[{"jsonrpc":"2.0","id":1,"method":"sei_getBlockByNumber","params":[]},{"jsonrpc":"2.0","id":2,"method":"eth_chainId","params":[]}]`
@@ -381,7 +381,7 @@ func TestWrapSeiLegacyHTTP_BatchInvalidNonObjectNotForwarded(t *testing.T) {
 		if fwd[0]["method"] != "eth_chainId" {
 			t.Fatalf("unexpected forward: %+v", fwd[0])
 		}
-		_, _ = w.Write([]byte(`[{"jsonrpc":"2.0","id":1,"result":"0xaa"}]`))
+		_, _ = w.Write([]byte(`[{"jsonrpc":"2.0","id":0,"result":"0xaa"}]`))
 	})
 	h := wrapSeiLegacyHTTP(inner, BuildSeiLegacyEnabledSet(nil))
 	body := `[{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]},42]`
@@ -477,6 +477,89 @@ func TestWrapSeiLegacyHTTP_BatchNullIDIsNotNotification(t *testing.T) {
 	}
 	if batch[0]["result"] != "a" || batch[1]["result"] != "b" {
 		t.Fatalf("unexpected merge order or results: %+v, %+v", batch[0], batch[1])
+	}
+}
+
+// TestWrapSeiLegacyHTTP_BatchTwoNullIDsDifferentResults is the regression test for the bug where multiple
+// "id":null requests in a slow-path batch caused appendMergeFailure to replace ALL responses (including
+// unrelated unique-ID ones) with internal errors. The fix assigns unique synthetic IDs before forwarding so
+// idToIdx is always collision-free.
+func TestWrapSeiLegacyHTTP_BatchTwoNullIDsDifferentResults(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		var fwd []map[string]any
+		// 4 items: synthID-0, synthID-1, notification (no id), synthID-2.
+		if err := json.Unmarshal(b, &fwd); err != nil || len(fwd) != 4 {
+			t.Fatalf("inner should receive 4 forwarded calls, got err=%v body=%s", err, b)
+		}
+		// First two: null-ID requests rewritten to synthetic IDs 0 and 1.
+		for j := 0; j < 2; j++ {
+			id, ok := fwd[j]["id"].(float64)
+			if !ok {
+				t.Fatalf("item %d: expected synthetic integer id, got %#v", j, fwd[j]["id"])
+			}
+			if int(id) != j {
+				t.Fatalf("item %d: expected synthetic id %d, got %v", j, j, id)
+			}
+		}
+		// Third: notification forwarded as-is — must have no "id" key.
+		if _, ok := fwd[2]["id"]; ok {
+			t.Fatalf("item 2: notification must not have id, got %#v", fwd[2]["id"])
+		}
+		// Fourth: regular request rewritten to synthetic ID 2.
+		if id, ok := fwd[3]["id"].(float64); !ok || int(id) != 2 {
+			t.Fatalf("item 3: expected synthetic id 2, got %#v", fwd[3]["id"])
+		}
+		// Inner returns no response for the notification; three responses for the rest.
+		_, _ = w.Write([]byte(`[
+			{"jsonrpc":"2.0","id":0,"result":"foo"},
+			{"jsonrpc":"2.0","id":1,"result":"bar"},
+			{"jsonrpc":"2.0","id":2,"result":"baz"}
+		]`))
+	})
+	h := wrapSeiLegacyHTTP(inner, BuildSeiLegacyEnabledSet(nil))
+	// Two null-ID requests + a notification + a regular request + a blocked sei_ method.
+	// The blocked method triggers the slow path; the notification must be omitted from output.
+	body := `[
+		{"jsonrpc":"2.0","id":null,"method":"eth_chainId","params":[]},
+		{"jsonrpc":"2.0","id":null,"method":"eth_gasPrice","params":[]},
+		{"jsonrpc":"2.0","method":"eth_chainId","params":[]},
+		{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]},
+		{"jsonrpc":"2.0","id":2,"method":"sei_getBlockByNumber","params":[]}
+	]`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	var batch []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &batch); err != nil {
+		t.Fatalf("unmarshal: %v, body: %s", err, rec.Body.String())
+	}
+	// 5 input slots: notification is omitted → 4 output entries.
+	if len(batch) != 4 {
+		t.Fatalf("want 4 responses (notification omitted), got %d: %s", len(batch), rec.Body.String())
+	}
+	if batch[0]["result"] != "foo" {
+		t.Fatalf("slot 0: want result 'foo', got %+v", batch[0])
+	}
+	if batch[0]["id"] != nil {
+		t.Fatalf("slot 0: want id null, got %v", batch[0]["id"])
+	}
+	if batch[1]["result"] != "bar" {
+		t.Fatalf("slot 1: want result 'bar', got %+v", batch[1])
+	}
+	if batch[1]["id"] != nil {
+		t.Fatalf("slot 1: want id null, got %v", batch[1]["id"])
+	}
+	if batch[2]["result"] != "baz" {
+		t.Fatalf("slot 2: want result 'baz', got %+v", batch[2])
+	}
+	if id, _ := batch[2]["id"].(float64); int(id) != 1 {
+		t.Fatalf("slot 2: want id 1, got %v", batch[2]["id"])
+	}
+	errObj, _ := batch[3]["error"].(map[string]any)
+	if errObj == nil || errObj["data"] != "legacy_sei_deprecated" {
+		t.Fatalf("slot 3: want legacy gate error, got %+v", batch[3])
 	}
 }
 
@@ -579,10 +662,10 @@ func TestWrapSeiLegacyHTTP_BatchSingleBlockedNotificationEmptyHTTPBody(t *testin
 
 func TestWrapSeiLegacyHTTP_BatchInnerReorderedByID(t *testing.T) {
 	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		// Inner returns results permuted vs forwarded request order.
+		// Inner returns results permuted vs forwarded request order (using synthetic IDs 0, 1).
 		_, _ = w.Write([]byte(`[
-			{"jsonrpc":"2.0","id":20,"result":"second"},
-			{"jsonrpc":"2.0","id":10,"result":"first"}
+			{"jsonrpc":"2.0","id":1,"result":"second"},
+			{"jsonrpc":"2.0","id":0,"result":"first"}
 		]`))
 	})
 	h := wrapSeiLegacyHTTP(inner, BuildSeiLegacyEnabledSet(nil))
@@ -612,7 +695,7 @@ func TestWrapSeiLegacyHTTP_BatchInnerReorderedByID(t *testing.T) {
 
 func TestWrapSeiLegacyHTTP_BatchMissingInnerResponseForID(t *testing.T) {
 	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`[{"jsonrpc":"2.0","id":10,"result":"onlyOne"}]`))
+		_, _ = w.Write([]byte(`[{"jsonrpc":"2.0","id":0,"result":"onlyOne"}]`))
 	})
 	h := wrapSeiLegacyHTTP(inner, BuildSeiLegacyEnabledSet(nil))
 	body := `[
@@ -685,9 +768,10 @@ func TestMergeSeiLegacyHTTPBatch_PatchesMismatchedResponseID(t *testing.T) {
 	blocked := []bool{false}
 	var blockedErr []error
 	ids := []json.RawMessage{json.RawMessage(`42`)}
+	synthIDs := []json.RawMessage{json.RawMessage(`0`)}
 	inner := []byte(`[{"jsonrpc":"2.0","id":0,"result":"x"}]`)
 	invalid := []bool{false}
-	out := mergeSeiLegacyHTTPBatch(invalid, blocked, blockedErr, ids, 1, inner)
+	out := mergeSeiLegacyHTTPBatch(invalid, blocked, blockedErr, ids, synthIDs, 1, inner)
 	if len(out) != 1 {
 		t.Fatalf("got %d", len(out))
 	}


### PR DESCRIPTION
## Problem

In the slow-path (gated) `handleBatch` flow, `mergeSeiLegacyHTTPBatch` built `idToIdx` keyed on the original request ID echoed back by the inner server. When a batch contained multiple requests sharing the same ID — including multiple `"id":null` entries — the old code detected the ID collision and fell through to `appendMergeFailure`, replacing **all** responses in the batch with internal errors.

## Fix

Assign a unique sequential synthetic integer ID (0, 1, 2, …) to each forwarded non-notification request before dispatching to the inner server. The inner server echoes these synthetic IDs back, so `idToIdx` is always collision-free regardless of duplicate or null original IDs. Original IDs are restored in the output via `patchJSONRPCResponseIDIfNeeded`.

Changes:
- Merge the blocked-check into the same parse loop to avoid a second pass over `msgs`
- Replace `appendMergeFailure` on duplicate inner-ID with a best-effort `continue` (the synthetic-ID scheme makes this unreachable in normal operation, but it's safer than a hard failure)
- Drop redundant `json.RawMessage(...)` casts on already-`[]byte` return values

## Tests

- Added `TestWrapSeiLegacyHTTP_BatchTwoNullIDsDifferentResults`: regression test covering two `"id":null` requests + a notification + a unique-ID request + a blocked sei_ method in one batch — verifies correct per-slot responses and that the notification is omitted from output
- Updated existing tests to expect synthetic IDs (0, 1, …) instead of original IDs in the forwarded body

## Linear

Closes PLT-282, PLT-292