### PR TITLE
Use exact v6.5 upgrade name

### DIFF
--- a/app/tags_test.go
+++ b/app/tags_test.go
@@ -1,0 +1,13 @@
+package app_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/semver"
+)
+
+func TestSemver_Comparison(t *testing.T) {
+	require.Zero(t, semver.Compare("v6.5", "v6.5.0"))
+	require.Zero(t, semver.Compare("v6.5.0", "v6.5"))
+}

--- a/x/evm/keeper/pointer.go
+++ b/x/evm/keeper/pointer.go
@@ -282,7 +282,7 @@ func (k *Keeper) DeleteCW1155ERC1155Pointer(ctx sdk.Context, erc1155Address comm
 
 func (k *Keeper) GetPointerInfo(ctx sdk.Context, pref []byte, maxVersion uint16) (addr []byte, version uint16, exists bool) {
 	store := prefix.NewStore(ctx.KVStore(k.GetStoreKey()), pref)
-	if semver.Compare(ctx.ClosestUpgradeName(), "v6.5.0") < 0 {
+	if semver.Compare(ctx.ClosestUpgradeName(), "v6.5") < 0 {
 		iter := store.ReverseIterator(nil, nil)
 		defer func() { _ = iter.Close() }()
 		if iter.Valid() {
@@ -319,7 +319,7 @@ func (k *Keeper) GetAnyPointeeInfo(ctx sdk.Context, cwAddress string) (common.Ad
 
 func (k *Keeper) GetAnyPointerInfo(ctx sdk.Context, pref []byte) (addr []byte, version uint16, exists bool) {
 	store := prefix.NewStore(ctx.KVStore(k.GetStoreKey()), pref)
-	if semver.Compare(ctx.ClosestUpgradeName(), "v6.5.0") < 0 {
+	if semver.Compare(ctx.ClosestUpgradeName(), "v6.5") < 0 {
 		iter := store.ReverseIterator(nil, nil)
 		defer func() { _ = iter.Close() }()
 		if iter.Valid() {


### PR DESCRIPTION
Use exact upgrade name for clarity. Add tests to assert that it does not matter in terms of correctness as long as we use semver compare.
