### PR TITLE
test(evm): drop waitForBaseFeeToBeGt in trace balance diff test (CON-256)

### DIFF
--- a/contracts/test/EVMCompatabilityTest.js
+++ b/contracts/test/EVMCompatabilityTest.js
@@ -407,7 +407,6 @@ describe("EVM Test", function () {
             type: 2
           });
           await heavyTxResponse.wait();
-          await waitForBaseFeeToBeGt(ethers.parseUnits('1', 'gwei'))
 
           const txResponse = await owner.sendTransaction({
             to: owner.address,


### PR DESCRIPTION
The `trace balance diff matches up with actual balance change` test was failing on Autobahn-backed clusters with `Error: base fee hasn't risen above 1000000000 in 10000ms`.

Under Autobahn, evmrpc's `latest` watermark is the MIN over tendermint head, baseapp checkState, statestore, and receiptstore — a defensive lower bound across all data sources. Block production runs at ~10 blocks/sec but those data sources catch up in ~1.3-second batches, so `eth_getBlockByNumber("latest")` advances in chunks of 7–13 blocks rather than continuously. The 2-block EIP-1559 elevation window from a heavy tx happens entirely inside one of those chunks and is never observable via "latest" — `waitForBaseFeeToBeGt` polls forever and times out.

The wait was defensive setup, not part of the assertion. The test verifies (a) effective gas price matches the EIP-1559 formula and (b) trace balance diff matches chain balance diff, both reading `block_.baseFeePerGas` from the receipt's actual block. Both assertions are independent of whether base fee was elevated when the test tx landed. The third test case (`tip=10gwei, max=10gwei`) exercises the cap branch even at the floor (1+10>10), so coverage isn't lost.

Test now passes under both engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)