### PR TITLE
test(evm): migrate lib.js helpers to -b sync, wait for tx inclusion (CON-256)

### DIFF
--- a/contracts/test/AssociateTest.js
+++ b/contracts/test/AssociateTest.js
@@ -1,4 +1,4 @@
-const { fundAddress, fundSeiAddress, getSeiBalance, associateKey, importKey, waitForReceipt, bankSend, evmSend, getNativeAccount} = require("./lib");
+const { fundAddress, fundSeiAddress, getSeiBalance, associateKey, importKey, waitForReceipt, bankSend, evmSend, getNativeAccount, execute, getKeySeiAddress, getAccountSequence, waitForCondition} = require("./lib");
 const { expect } = require("chai");
 
 describe("Associate Balances", function () {
@@ -86,7 +86,18 @@ describe("Associate Balances", function () {
 
         // it should not be able to send funds to the cast address after association
         expect(await getSeiBalance(addr.castAddress)).to.equal(0);
-        await fundSeiAddress(addr.castAddress, "100");
+        // fundSeiAddress would deadlock here: its wait condition is "recipient
+        // balance reaches target", which is exactly what this test asserts
+        // should NOT happen (post-association routing blocks crediting the
+        // cast address). Wait for admin's sequence to advance instead — the
+        // causal "tx committed" signal that's independent of the side effect.
+        const adminAddr = await getKeySeiAddress("admin")
+        const seqBefore = await getAccountSequence(adminAddr)
+        await execute(`seid tx bank send admin ${addr.castAddress} 100usei -b sync -y --fees 20000usei`)
+        await waitForCondition(
+            async () => (await getAccountSequence(adminAddr)) > seqBefore,
+            `admin sequence > ${seqBefore}`,
+        )
         expect(await getSeiBalance(addr.castAddress)).to.equal(0);
     });
 

--- a/contracts/test/EVMPrecompileTest.js
+++ b/contracts/test/EVMPrecompileTest.js
@@ -125,16 +125,15 @@ describe("EVM Precompile Tester", function () {
         let govProposal;
 
         before(async function () {
-            // Mirrors ../contracts/test/param_change_proposal.json, which is
-            // still consumed by integration_test/gov_module/gov_proposal_test.yaml.
+            const proposalSpec = require('./param_change_proposal.json');
             govProposal = await proposeParamChange(
-                "Gov Param Change",
-                "Update quorum to 0.45",
-                [{ subspace: "gov", key: "tallyparams", value: { quorum: "0.45" } }],
+                proposalSpec.title,
+                proposalSpec.description,
+                proposalSpec.changes,
                 "200000000usei",
                 "20000usei",
                 "admin",
-                false, // not expedited — matches the JSON file
+                proposalSpec.is_expedited,
             );
 
             const signer = accounts[0].signer

--- a/contracts/test/EVMPrecompileTest.js
+++ b/contracts/test/EVMPrecompileTest.js
@@ -125,10 +125,8 @@ describe("EVM Precompile Tester", function () {
         let govProposal;
 
         before(async function () {
-            // Use lib.js proposeParamChange (Autobahn-compatible: -b sync + poll
-            // gov state) instead of an inline `seid tx -b block` which hangs
-            // 60s under Autobahn. Mirrors ../contracts/test/param_change_proposal.json
-            // (kept on disk for any tooling that still consumes it).
+            // Mirrors ../contracts/test/param_change_proposal.json, which is
+            // still consumed by integration_test/gov_module/gov_proposal_test.yaml.
             govProposal = await proposeParamChange(
                 "Gov Param Change",
                 "Update quorum to 0.45",

--- a/contracts/test/EVMPrecompileTest.js
+++ b/contracts/test/EVMPrecompileTest.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 
 const { expectRevert } = require('@openzeppelin/test-helpers');
-const { setupSigners, getAdmin, deployWasm, storeWasm, execute, isDocker, ABI, createTokenFactoryTokenAndMint, getSeiBalance, rawHttpDebugTraceWithCallTracer} = require("./lib");
+const { setupSigners, getAdmin, deployWasm, storeWasm, execute, isDocker, ABI, createTokenFactoryTokenAndMint, getSeiBalance, rawHttpDebugTraceWithCallTracer, proposeParamChange} = require("./lib");
 
 function sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
@@ -125,8 +125,19 @@ describe("EVM Precompile Tester", function () {
         let govProposal;
 
         before(async function () {
-            const govProposalResponse = JSON.parse(await execute(`seid tx gov submit-proposal param-change ../contracts/test/param_change_proposal.json --from admin --fees 20000usei -b block -y -o json`))
-            govProposal = govProposalResponse.logs[0].events[3].attributes[1].value;
+            // Use lib.js proposeParamChange (Autobahn-compatible: -b sync + poll
+            // gov state) instead of an inline `seid tx -b block` which hangs
+            // 60s under Autobahn. Mirrors ../contracts/test/param_change_proposal.json
+            // (kept on disk for any tooling that still consumes it).
+            govProposal = await proposeParamChange(
+                "Gov Param Change",
+                "Update quorum to 0.45",
+                [{ subspace: "gov", key: "tallyparams", value: { quorum: "0.45" } }],
+                "200000000usei",
+                "20000usei",
+                "admin",
+                false, // not expedited — matches the JSON file
+            );
 
             const signer = accounts[0].signer
             const contractABIPath = '../../precompiles/gov/abi.json';

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -138,31 +138,30 @@ async function evmSend(addr, fromKey, amount="10000000000000000000000000") {
     return evmTxHash
 }
 
-async function bankSend(toAddr, fromKey, amount="100000000000", denom="usei") {
-    const before = await getSeiBalanceBigInt(toAddr, denom)
-    const result = await execute(`seid tx bank send ${fromKey} ${toAddr} ${amount}${denom} -b sync -o json --fees 20000usei -y`);
+async function bankSend(toAddr, fromKey, amount="100000000000") {
+    const before = await getSeiBalanceBigInt(toAddr)
+    const result = await execute(`seid tx bank send ${fromKey} ${toAddr} ${amount}usei -b sync -o json --fees 20000usei -y`);
     const parsed = JSON.parse(result)
     if (parsed.code !== 0) throw new Error(`bank send rejected: ${parsed.raw_log}`)
-    // The recipient's balance changes once the tx commits, regardless of
-    // whether it's a self-send. Non-self-send: balance goes up by amount.
-    // Self-send (sender == recipient): balance goes down by fees (amount
-    // cancels). Either way, `current !== before` flips once on commit.
+    // Non-self-send: balance goes up by amount. Self-send (sender ==
+    // recipient): balance goes down by fees (amount cancels). Either
+    // way, `current !== before` flips once on commit.
     await waitForCondition(
-        async () => (await getSeiBalanceBigInt(toAddr, denom)) !== before,
-        `${toAddr} ${denom} balance to change from ${before}`,
+        async () => (await getSeiBalanceBigInt(toAddr)) !== before,
+        `${toAddr} usei balance to change from ${before}`,
     )
     return result
 }
 
-async function fundSeiAddress(seiAddr, amount="100000000000", denom="usei", funder=adminKeyName) {
-    const before = await getSeiBalanceBigInt(seiAddr, denom)
-    const result = await execute(`seid tx bank send ${funder} ${seiAddr} ${amount}${denom} -b sync -o json --fees 20000usei -y`);
+async function fundSeiAddress(seiAddr, amount="100000000000") {
+    const before = await getSeiBalanceBigInt(seiAddr)
+    const result = await execute(`seid tx bank send ${adminKeyName} ${seiAddr} ${amount}usei -b sync -o json --fees 20000usei -y`);
     const parsed = JSON.parse(result)
     if (parsed.code !== 0) throw new Error(`fundSeiAddress rejected: ${parsed.raw_log}`)
     const target = before + BigInt(amount)
     await waitForCondition(
-        async () => (await getSeiBalanceBigInt(seiAddr, denom)) >= target,
-        `${seiAddr} ${denom} balance >= ${target}`,
+        async () => (await getSeiBalanceBigInt(seiAddr)) >= target,
+        `${seiAddr} usei balance >= ${target}`,
     )
     return result
 }

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -104,9 +104,7 @@ async function getEvmTx(provider, cosmosTxHash) {
 }
 
 async function fundAddress(addr, amount="1000000000000000000000") {
-    const result = await evmSend(addr, adminKeyName, amount)
-    await delay()
-    return result
+    return await evmSend(addr, adminKeyName, amount)
 }
 
 async function evmSend(addr, fromKey, amount="10000000000000000000000000") {
@@ -157,7 +155,6 @@ async function getNativeAccount(keyName) {
     await associateKey(adminKeyName)
     const seiAddress = await getKeySeiAddress(keyName)
     await fundSeiAddress(seiAddress)
-    await delay()
     const evmAddress = await getEvmAddress(seiAddress)
     return {
         seiAddress,
@@ -260,16 +257,19 @@ async function rawHttpDebugTraceWithCallTracer(txHash) {
 
 async function createTokenFactoryTokenAndMint(name, amount, recipient, from=adminKeyName) {
     const command = `seid tx tokenfactory create-denom ${name} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`
-    await execute(command);
+    const response = JSON.parse(await execute(command))
+    if (response.code !== 0) throw new Error(`create-denom rejected: ${response.raw_log}`)
     // Tokenfactory denom is deterministic: factory/<creator-bech32>/<subdenom>.
     const token_denom = `factory/${await getKeySeiAddress(from)}/${name}`
     await waitForBlocks()
     const mint_command = `seid tx tokenfactory mint ${amount}${token_denom} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`
-    await execute(mint_command);
+    const mintResp = JSON.parse(await execute(mint_command))
+    if (mintResp.code !== 0) throw new Error(`mint rejected: ${mintResp.raw_log}`)
     await waitForBlocks()
 
     const send_command = `seid tx bank send ${from} ${recipient} ${amount}${token_denom} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`
-    await execute(send_command);
+    const sendResp = JSON.parse(await execute(send_command))
+    if (sendResp.code !== 0) throw new Error(`bank send rejected: ${sendResp.raw_log}`)
     await waitForBlocks()
     return token_denom
 }
@@ -656,10 +656,8 @@ async function setupSigners(signers) {
         let seiAddress = await associateSigner(signer);
         if (seiAddress) {
             await fundSeiAddress(seiAddress);
-            await delay()
         } else {
             await fundAddress(evmAddress);
-            await delay()
             const resp = await signer.sendTransaction({
                 to: evmAddress,
                 value: 0

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -82,6 +82,21 @@ async function delay() {
     await sleep(1000)
 }
 
+// Wait until the chain advances by `blocks` blocks. Used after `-b sync`
+// submissions to give the next block time to include the tx — engine-agnostic
+// substitute for a fixed sleep, since block times differ between CometBFT
+// (~1s) and Autobahn (~100ms).
+async function waitForBlocks(blocks=1, timeoutMs=15000) {
+    const start = await ethers.provider.getBlockNumber()
+    const deadline = Date.now() + timeoutMs
+    while (Date.now() < deadline) {
+        const cur = await ethers.provider.getBlockNumber()
+        if (cur >= start + blocks) return
+        await sleep(50)
+    }
+    throw new Error(`block didn't advance by ${blocks} in ${timeoutMs}ms (start=${start})`)
+}
+
 async function getCosmosTx(provider, evmTxHash) {
     return await provider.send("sei_getCosmosTx", [evmTxHash])
 }
@@ -103,13 +118,13 @@ async function evmSend(addr, fromKey, amount="10000000000000000000000000") {
 
 async function bankSend(toAddr, fromKey, amount="100000000000", denom="usei") {
     const result = await execute(`seid tx bank send ${fromKey} ${toAddr} ${amount}${denom} -b sync --fees 20000usei -y`);
-    await sleep(2000)
+    await waitForBlocks(1)
     return result
 }
 
 async function fundSeiAddress(seiAddr, amount="100000000000", denom="usei", funder=adminKeyName) {
     const result = await execute(`seid tx bank send ${funder} ${seiAddr} ${amount}${denom} -b sync --fees 20000usei -y`);
-    await sleep(2000)
+    await waitForBlocks(1)
     return result
 }
 
@@ -163,7 +178,7 @@ async function getKeySeiAddress(name) {
 async function associateKey(keyName) {
     try {
         await execute(`seid tx evm associate-address --from ${keyName} -b sync`)
-        await sleep(2000)
+        await waitForBlocks(1)
     }catch(e){
         console.log("skipping associate")
     }

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -138,30 +138,31 @@ async function evmSend(addr, fromKey, amount="10000000000000000000000000") {
     return evmTxHash
 }
 
-async function bankSend(toAddr, fromKey, amount="100000000000") {
-    const before = await getSeiBalanceBigInt(toAddr)
-    const result = await execute(`seid tx bank send ${fromKey} ${toAddr} ${amount}usei -b sync -o json --fees 20000usei -y`);
+async function bankSend(toAddr, fromKey, amount="100000000000", denom="usei") {
+    const before = await getSeiBalanceBigInt(toAddr, denom)
+    const result = await execute(`seid tx bank send ${fromKey} ${toAddr} ${amount}${denom} -b sync -o json --fees 20000usei -y`);
     const parsed = JSON.parse(result)
     if (parsed.code !== 0) throw new Error(`bank send rejected: ${parsed.raw_log}`)
-    // Non-self-send: balance goes up by amount. Self-send (sender ==
-    // recipient): balance goes down by fees (amount cancels). Either
-    // way, `current !== before` flips once on commit.
+    // The recipient's balance changes once the tx commits, regardless of
+    // whether it's a self-send. Non-self-send: balance goes up by amount.
+    // Self-send (sender == recipient): balance goes down by fees (amount
+    // cancels). Either way, `current !== before` flips once on commit.
     await waitForCondition(
-        async () => (await getSeiBalanceBigInt(toAddr)) !== before,
-        `${toAddr} usei balance to change from ${before}`,
+        async () => (await getSeiBalanceBigInt(toAddr, denom)) !== before,
+        `${toAddr} ${denom} balance to change from ${before}`,
     )
     return result
 }
 
-async function fundSeiAddress(seiAddr, amount="100000000000") {
-    const before = await getSeiBalanceBigInt(seiAddr)
-    const result = await execute(`seid tx bank send ${adminKeyName} ${seiAddr} ${amount}usei -b sync -o json --fees 20000usei -y`);
+async function fundSeiAddress(seiAddr, amount="100000000000", denom="usei", funder=adminKeyName) {
+    const before = await getSeiBalanceBigInt(seiAddr, denom)
+    const result = await execute(`seid tx bank send ${funder} ${seiAddr} ${amount}${denom} -b sync -o json --fees 20000usei -y`);
     const parsed = JSON.parse(result)
     if (parsed.code !== 0) throw new Error(`fundSeiAddress rejected: ${parsed.raw_log}`)
     const target = before + BigInt(amount)
     await waitForCondition(
-        async () => (await getSeiBalanceBigInt(seiAddr)) >= target,
-        `${seiAddr} usei balance >= ${target}`,
+        async () => (await getSeiBalanceBigInt(seiAddr, denom)) >= target,
+        `${seiAddr} ${denom} balance >= ${target}`,
     )
     return result
 }

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -139,29 +139,48 @@ async function evmSend(addr, fromKey, amount="10000000000000000000000000") {
 }
 
 async function bankSend(toAddr, fromKey, amount="100000000000", denom="usei") {
-    const before = await getSeiBalance(toAddr, denom)
+    const before = await getSeiBalanceBigInt(toAddr, denom)
     const result = await execute(`seid tx bank send ${fromKey} ${toAddr} ${amount}${denom} -b sync -o json --fees 20000usei -y`);
     const parsed = JSON.parse(result)
     if (parsed.code !== 0) throw new Error(`bank send rejected: ${parsed.raw_log}`)
-    const target = before + parseInt(amount, 10)
+    // The recipient's balance changes once the tx commits, regardless of
+    // whether it's a self-send. Non-self-send: balance goes up by amount.
+    // Self-send (sender == recipient): balance goes down by fees (amount
+    // cancels). Either way, `current !== before` flips once on commit.
     await waitForCondition(
-        async () => (await getSeiBalance(toAddr, denom)) >= target,
-        `${toAddr} ${denom} balance >= ${target}`,
+        async () => (await getSeiBalanceBigInt(toAddr, denom)) !== before,
+        `${toAddr} ${denom} balance to change from ${before}`,
     )
     return result
 }
 
 async function fundSeiAddress(seiAddr, amount="100000000000", denom="usei", funder=adminKeyName) {
-    const before = await getSeiBalance(seiAddr, denom)
+    const before = await getSeiBalanceBigInt(seiAddr, denom)
     const result = await execute(`seid tx bank send ${funder} ${seiAddr} ${amount}${denom} -b sync -o json --fees 20000usei -y`);
     const parsed = JSON.parse(result)
     if (parsed.code !== 0) throw new Error(`fundSeiAddress rejected: ${parsed.raw_log}`)
-    const target = before + parseInt(amount, 10)
+    const target = before + BigInt(amount)
     await waitForCondition(
-        async () => (await getSeiBalance(seiAddr, denom)) >= target,
+        async () => (await getSeiBalanceBigInt(seiAddr, denom)) >= target,
         `${seiAddr} ${denom} balance >= ${target}`,
     )
     return result
+}
+
+// BigInt variant of getSeiBalance. Genesis-funded accounts hold balances
+// well above 2^53, where JS Number arithmetic loses precision (a
+// `before + amount` comparison can silently round wrong). Polling
+// helpers should use this; existing Number-returning getSeiBalance is
+// kept for callers that don't run into the precision range.
+async function getSeiBalanceBigInt(seiAddr, denom="usei") {
+    const result = await execute(`seid query bank balances ${seiAddr} -o json`);
+    const balances = JSON.parse(result)
+    for(let b of balances.balances) {
+        if(b.denom === denom) {
+            return BigInt(b.amount)
+        }
+    }
+    return 0n
 }
 
 async function getSeiBalance(seiAddr, denom="usei") {
@@ -193,7 +212,12 @@ async function importKey(name, keyfile) {
 async function getNativeAccount(keyName) {
     await associateKey(adminKeyName)
     const seiAddress = await getKeySeiAddress(keyName)
-    await fundSeiAddress(seiAddress)
+    // Skip funding the admin from admin — it's a no-op self-send that burns
+    // fees and (under -b sync) leaves the helper polling for a balance change
+    // that, for self-sends, is just -fees rather than +amount.
+    if (keyName !== adminKeyName) {
+        await fundSeiAddress(seiAddress)
+    }
     const evmAddress = await getEvmAddress(seiAddress)
     return {
         seiAddress,
@@ -317,9 +341,9 @@ async function createTokenFactoryTokenAndMint(name, amount, recipient, from=admi
 
     // End-to-end side-effect check: all 3 txs (create + mint + send)
     // succeeded iff the recipient holds the minted amount of the new denom.
-    const target = parseInt(amount, 10)
+    const target = BigInt(amount)
     await waitForCondition(
-        async () => (await getSeiBalance(recipient, token_denom)) >= target,
+        async () => (await getSeiBalanceBigInt(recipient, token_denom)) >= target,
         `${recipient} ${token_denom} balance >= ${target}`,
     )
     return token_denom

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -102,13 +102,15 @@ async function evmSend(addr, fromKey, amount="10000000000000000000000000") {
 }
 
 async function bankSend(toAddr, fromKey, amount="100000000000", denom="usei") {
-    const result = await execute(`seid tx bank send ${fromKey} ${toAddr} ${amount}${denom} -b block --fees 20000usei -y`);
-    await delay()
+    const result = await execute(`seid tx bank send ${fromKey} ${toAddr} ${amount}${denom} -b sync --fees 20000usei -y`);
+    await sleep(2000)
     return result
 }
 
 async function fundSeiAddress(seiAddr, amount="100000000000", denom="usei", funder=adminKeyName) {
-    return await execute(`seid tx bank send ${funder} ${seiAddr} ${amount}${denom} -b block --fees 20000usei -y`);
+    const result = await execute(`seid tx bank send ${funder} ${seiAddr} ${amount}${denom} -b sync --fees 20000usei -y`);
+    await sleep(2000)
+    return result
 }
 
 async function getSeiBalance(seiAddr, denom="usei") {
@@ -633,14 +635,16 @@ async function queryWasm(contractAddress, operation, args={}){
 
 async function executeWasm(contractAddress, msg, coins = "0usei") {
     const jsonString = JSON.stringify(msg).replace(/"/g, '\\"'); // Properly escape JSON string
-    const command = `seid tx wasm execute ${contractAddress} "${jsonString}" --amount ${coins} --from ${adminKeyName} --gas=5000000 --fees=1000000usei -y --broadcast-mode block -o json`;
+    const command = `seid tx wasm execute ${contractAddress} "${jsonString}" --amount ${coins} --from ${adminKeyName} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`;
     const output = await execute(command);
+    await sleep(2000)
     return JSON.parse(output);
 }
 
 async function associateWasm(contractAddress) {
-    const command = `seid tx evm associate-contract-address ${contractAddress} --from ${adminKeyName} --gas=5000000 --fees=1000000usei -y --broadcast-mode block -o json`;
+    const command = `seid tx evm associate-contract-address ${contractAddress} --from ${adminKeyName} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`;
     const output = await execute(command);
+    await sleep(2000)
     return JSON.parse(output);
 }
 

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -451,7 +451,7 @@ async function proposeParamChange(title, description, changes, deposit="20000000
     await execute(`echo ${base64Json} | base64 -d > ${tempFile}`);
 
     // Identify the new proposal by diffing gov state before vs after submit.
-    const maxIdBefore = await maxProposalId();
+    let maxIdBefore = await maxProposalId();
 
     const command = `seid tx gov submit-proposal param-change ${tempFile} --from ${from} --fees ${fees} -y -o json -b sync`;
     const output = await execute(command);
@@ -464,14 +464,12 @@ async function proposeParamChange(title, description, changes, deposit="20000000
     const deadline = Date.now() + 30000;
     while (Date.now() < deadline) {
         const cur = await maxProposalId();
-        if (cur > maxIdBefore) {
-            const detail = JSON.parse(await execute(`seid q gov proposal ${cur} -o json`));
+        for (let id = maxIdBefore + 1; id <= cur; id++) {
+            const detail = JSON.parse(await execute(`seid q gov proposal ${id} -o json`));
             const observedTitle = detail.content?.title ?? detail.title;
-            if (observedTitle !== title) {
-                throw new Error(`proposal ${cur} title "${observedTitle}" does not match submitted "${title}" — concurrent submission?`);
-            }
-            return String(cur);
+            if (observedTitle === title) return String(id);
         }
+        maxIdBefore = cur;
         await sleep(250);
     }
     throw new Error(`proposal submitted (tx ${response.txhash}) but did not appear in gov state within 30s`);

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -95,6 +95,28 @@ async function waitForBlocks(blocks=2, timeoutMs=15000) {
     throw new Error(`block didn't advance by ${blocks} in ${timeoutMs}ms (start=${start})`)
 }
 
+// Poll seid q tx until the cosmos tx is committed on chain. Replaces
+// waitForBlocks() after -b sync submissions: block counting is a
+// temporal wait, not a causal one — under load a helper could return
+// while its tx was still in the mempool, leaving the next test to start
+// against an inconsistent chain. waitForCosmosTx makes -b sync helpers
+// semantically equivalent to -b block: they return once the tx is on
+// chain regardless of its code, matching -b block which exits 0 for
+// included-but-failed txs. Callers that care about tx success should
+// inspect the returned response's `code` field.
+async function waitForCosmosTx(txhash, timeoutMs=1000) {
+    const deadline = Date.now() + timeoutMs
+    while (Date.now() < deadline) {
+        try {
+            return JSON.parse(await execute(`seid q tx ${txhash} -o json`))
+        } catch (e) {
+            // "tx not found" while the tx is still in the mempool. Retry.
+        }
+        await sleep(100)
+    }
+    throw new Error(`tx ${txhash} not committed within ${timeoutMs}ms`)
+}
+
 async function getCosmosTx(provider, evmTxHash) {
     return await provider.send("sei_getCosmosTx", [evmTxHash])
 }
@@ -108,20 +130,28 @@ async function fundAddress(addr, amount="1000000000000000000000") {
 }
 
 async function evmSend(addr, fromKey, amount="10000000000000000000000000") {
+    // seid tx evm send prints "Transaction hash: 0x..." on its own format
+    // (not the standard cosmos JSON response), so we extract from text and
+    // wait via the JSON-RPC receipt — semantically equivalent to -b block.
     const output = await execute(`seid tx evm send ${addr} ${amount} --from ${fromKey} -b sync -y`);
-    await waitForBlocks()
-    return output.replace(/.*0x/, "0x").trim()
+    const evmTxHash = output.replace(/.*0x/, "0x").trim()
+    await waitForReceipt(evmTxHash)
+    return evmTxHash
 }
 
 async function bankSend(toAddr, fromKey, amount="100000000000", denom="usei") {
-    const result = await execute(`seid tx bank send ${fromKey} ${toAddr} ${amount}${denom} -b sync --fees 20000usei -y`);
-    await waitForBlocks()
+    const result = await execute(`seid tx bank send ${fromKey} ${toAddr} ${amount}${denom} -b sync -o json --fees 20000usei -y`);
+    const parsed = JSON.parse(result)
+    if (parsed.code !== 0) throw new Error(`bank send rejected: ${parsed.raw_log}`)
+    await waitForCosmosTx(parsed.txhash)
     return result
 }
 
 async function fundSeiAddress(seiAddr, amount="100000000000", denom="usei", funder=adminKeyName) {
-    const result = await execute(`seid tx bank send ${funder} ${seiAddr} ${amount}${denom} -b sync --fees 20000usei -y`);
-    await waitForBlocks()
+    const result = await execute(`seid tx bank send ${funder} ${seiAddr} ${amount}${denom} -b sync -o json --fees 20000usei -y`);
+    const parsed = JSON.parse(result)
+    if (parsed.code !== 0) throw new Error(`fundSeiAddress rejected: ${parsed.raw_log}`)
+    await waitForCosmosTx(parsed.txhash)
     return result
 }
 
@@ -173,6 +203,10 @@ async function getKeySeiAddress(name) {
 
 async function associateKey(keyName) {
     try {
+        // seid tx evm associate-address has a custom (non-cosmos-JSON) output
+        // format. The try/catch already tolerates failure here, and subsequent
+        // associate calls will succeed once the chain catches up, so a temporal
+        // wait is acceptable.
         await execute(`seid tx evm associate-address --from ${keyName} -b sync`)
         await waitForBlocks()
     }catch(e){
@@ -261,16 +295,16 @@ async function createTokenFactoryTokenAndMint(name, amount, recipient, from=admi
     if (response.code !== 0) throw new Error(`create-denom rejected: ${response.raw_log}`)
     // Tokenfactory denom is deterministic: factory/<creator-bech32>/<subdenom>.
     const token_denom = `factory/${await getKeySeiAddress(from)}/${name}`
-    await waitForBlocks()
+    await waitForCosmosTx(response.txhash)
     const mint_command = `seid tx tokenfactory mint ${amount}${token_denom} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`
     const mintResp = JSON.parse(await execute(mint_command))
     if (mintResp.code !== 0) throw new Error(`mint rejected: ${mintResp.raw_log}`)
-    await waitForBlocks()
+    await waitForCosmosTx(mintResp.txhash)
 
     const send_command = `seid tx bank send ${from} ${recipient} ${amount}${token_denom} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`
     const sendResp = JSON.parse(await execute(send_command))
     if (sendResp.code !== 0) throw new Error(`bank send rejected: ${sendResp.raw_log}`)
-    await waitForBlocks()
+    await waitForCosmosTx(sendResp.txhash)
     return token_denom
 }
 

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -635,16 +635,14 @@ async function queryWasm(contractAddress, operation, args={}){
 
 async function executeWasm(contractAddress, msg, coins = "0usei") {
     const jsonString = JSON.stringify(msg).replace(/"/g, '\\"'); // Properly escape JSON string
-    const command = `seid tx wasm execute ${contractAddress} "${jsonString}" --amount ${coins} --from ${adminKeyName} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`;
+    const command = `seid tx wasm execute ${contractAddress} "${jsonString}" --amount ${coins} --from ${adminKeyName} --gas=5000000 --fees=1000000usei -y --broadcast-mode block -o json`;
     const output = await execute(command);
-    await sleep(2000)
     return JSON.parse(output);
 }
 
 async function associateWasm(contractAddress) {
-    const command = `seid tx evm associate-contract-address ${contractAddress} --from ${adminKeyName} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`;
+    const command = `seid tx evm associate-contract-address ${contractAddress} --from ${adminKeyName} --gas=5000000 --fees=1000000usei -y --broadcast-mode block -o json`;
     const output = await execute(command);
-    await sleep(2000)
     return JSON.parse(output);
 }
 

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -325,23 +325,43 @@ async function rawHttpDebugTraceWithCallTracer(txHash) {
 }
 
 async function createTokenFactoryTokenAndMint(name, amount, recipient, from=adminKeyName) {
-    const command = `seid tx tokenfactory create-denom ${name} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`
-    const response = JSON.parse(await execute(command))
-    if (response.code !== 0) throw new Error(`create-denom rejected: ${response.raw_log}`)
+    const fromSeiAddr = await getKeySeiAddress(from)
     // Tokenfactory denom is deterministic: factory/<creator-bech32>/<subdenom>.
-    const token_denom = `factory/${await getKeySeiAddress(from)}/${name}`
-
-    const mint_command = `seid tx tokenfactory mint ${amount}${token_denom} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`
-    const mintResp = JSON.parse(await execute(mint_command))
-    if (mintResp.code !== 0) throw new Error(`mint rejected: ${mintResp.raw_log}`)
-
-    const send_command = `seid tx bank send ${from} ${recipient} ${amount}${token_denom} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`
-    const sendResp = JSON.parse(await execute(send_command))
-    if (sendResp.code !== 0) throw new Error(`bank send rejected: ${sendResp.raw_log}`)
-
-    // End-to-end side-effect check: all 3 txs (create + mint + send)
-    // succeeded iff the recipient holds the minted amount of the new denom.
+    const token_denom = `factory/${fromSeiAddr}/${name}`
     const target = BigInt(amount)
+
+    // Step 1: create-denom. Wait for the denom to exist before submitting
+    // the next tx — each `seid tx` reads the node's committed account
+    // sequence, so consecutive -b sync submissions from the same key
+    // without a between-commit wait construct duplicate-sequence txs and
+    // get rejected with "account sequence mismatch".
+    const create_cmd = `seid tx tokenfactory create-denom ${name} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`
+    const response = JSON.parse(await execute(create_cmd))
+    if (response.code !== 0) throw new Error(`create-denom rejected: ${response.raw_log}`)
+    await waitForCondition(
+        async () => {
+            try {
+                const out = await execute(`seid query tokenfactory denom-authority-metadata ${token_denom} --output json`)
+                return JSON.parse(out).authority_metadata !== undefined
+            } catch (e) { return false }
+        },
+        `denom ${token_denom} to be created`,
+    )
+
+    // Step 2: mint to ${from}. Wait until the creator holds the minted
+    // amount before the bank send, for the same sequence reason.
+    const mint_cmd = `seid tx tokenfactory mint ${amount}${token_denom} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`
+    const mintResp = JSON.parse(await execute(mint_cmd))
+    if (mintResp.code !== 0) throw new Error(`mint rejected: ${mintResp.raw_log}`)
+    await waitForCondition(
+        async () => (await getSeiBalanceBigInt(fromSeiAddr, token_denom)) >= target,
+        `${from} ${token_denom} balance >= ${target}`,
+    )
+
+    // Step 3: bank send to recipient. Wait for the recipient to hold the amount.
+    const send_cmd = `seid tx bank send ${from} ${recipient} ${amount}${token_denom} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`
+    const sendResp = JSON.parse(await execute(send_cmd))
+    if (sendResp.code !== 0) throw new Error(`bank send rejected: ${sendResp.raw_log}`)
     await waitForCondition(
         async () => (await getSeiBalanceBigInt(recipient, token_denom)) >= target,
         `${recipient} ${token_denom} balance >= ${target}`,

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -183,6 +183,22 @@ async function getSeiBalanceBigInt(seiAddr, denom="usei") {
     return 0n
 }
 
+// Causal commit signal: returns the on-chain account sequence for
+// seiAddr, or null if the account doesn't exist yet. A sender's
+// sequence advances atomically when its tx is included in a block,
+// regardless of whether the tx's intended side effect (e.g. a balance
+// credit) happened. Use this when the natural side-effect check can't
+// distinguish "tx hasn't committed" from "tx committed but no-op'd"
+// (e.g. bank send to a post-association cast address).
+async function getAccountSequence(seiAddr) {
+    try {
+        const out = await execute(`seid query account ${seiAddr} -o json`)
+        return parseInt(JSON.parse(out).sequence ?? "0", 10)
+    } catch (e) {
+        return null
+    }
+}
+
 async function getSeiBalance(seiAddr, denom="usei") {
     const result = await execute(`seid query bank balances ${seiAddr} -o json`);
     const balances = JSON.parse(result)
@@ -974,4 +990,6 @@ module.exports = {
     ABI,
     waitForBaseFeeToEq,
     waitForBaseFeeToBeGt,
+    waitForCondition,
+    getAccountSequence,
 };

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -103,7 +103,7 @@ async function waitForBlocks(blocks=2, timeoutMs=15000) {
 // it cares about (e.g. account balance, denom existence). Works under
 // both Autobahn and legacy because the check goes through whatever query
 // path the caller already relies on.
-async function waitForCondition(check, description, timeoutMs=15000, intervalMs=200) {
+async function waitForCondition(check, description, timeoutMs=30000, intervalMs=200) {
     const deadline = Date.now() + timeoutMs
     while (Date.now() < deadline) {
         try {

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -224,8 +224,10 @@ async function associateSigner(signer) {
         return null;
     }
     try {
-        await execute(`seid tx evm associate-address ${privKey} --from ${adminKeyName} -b block`)
-        await delay()
+        // Custom (non-cosmos-JSON) output, same as associateKey; failure is
+        // tolerated by the surrounding try/catch so a temporal wait is fine.
+        await execute(`seid tx evm associate-address ${privKey} --from ${adminKeyName} -b sync`)
+        await waitForBlocks()
     } catch (e) {
         console.log("skipping signer association")
     }

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -104,7 +104,7 @@ async function waitForBlocks(blocks=2, timeoutMs=15000) {
 // chain regardless of its code, matching -b block which exits 0 for
 // included-but-failed txs. Callers that care about tx success should
 // inspect the returned response's `code` field.
-async function waitForCosmosTx(txhash, timeoutMs=1000) {
+async function waitForCosmosTx(txhash, timeoutMs=15000) {
     const deadline = Date.now() + timeoutMs
     while (Date.now() < deadline) {
         try {
@@ -112,7 +112,10 @@ async function waitForCosmosTx(txhash, timeoutMs=1000) {
         } catch (e) {
             // "tx not found" while the tx is still in the mempool. Retry.
         }
-        await sleep(100)
+        // Local cluster's timeout_commit is 2s, so one block ≈ 2s.
+        // Polling more frequently than ~500ms just spawns extra docker exec
+        // calls (each ~200-300ms of overhead) without speeding up detection.
+        await sleep(500)
     }
     throw new Error(`tx ${txhash} not committed within ${timeoutMs}ms`)
 }

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -268,16 +268,36 @@ async function rawHttpDebugTraceWithCallTracer(txHash) {
 }
 
 async function createTokenFactoryTokenAndMint(name, amount, recipient, from=adminKeyName) {
-    const command = `seid tx tokenfactory create-denom ${name} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode block -o json`
-    const output = await execute(command);
-    const response = JSON.parse(output)
-    const token_denom = getEventAttribute(response, "create_denom", "new_token_denom")
-    const mint_command = `seid tx tokenfactory mint ${amount}${token_denom} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode block -o json`
-    await execute(mint_command);
+    // -b sync everywhere (no -b block hang under Autobahn). The tokenfactory
+    // denom format is factory/<creator-bech32>/<subdenom>, so we construct
+    // the denom locally from the from-key's address rather than reading
+    // the create_denom event from the tx response — -b sync doesn't carry
+    // deliver_tx events.
+    const creator = await getKeySeiAddress(from);
+    const token_denom = `factory/${creator}/${name}`;
 
-    const send_command = `seid tx bank send ${from} ${recipient} ${amount}${token_denom} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode block -o json`
-    await execute(send_command);
-    return token_denom
+    const createOut = await execute(`seid tx tokenfactory create-denom ${name} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`);
+    const createResp = JSON.parse(createOut);
+    if (createResp.code !== 0) {
+        throw new Error(`createTokenFactoryTokenAndMint: create-denom rejected: ${createResp.raw_log}`);
+    }
+    await waitForBlocks();
+
+    const mintOut = await execute(`seid tx tokenfactory mint ${amount}${token_denom} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`);
+    const mintResp = JSON.parse(mintOut);
+    if (mintResp.code !== 0) {
+        throw new Error(`createTokenFactoryTokenAndMint: mint rejected: ${mintResp.raw_log}`);
+    }
+    await waitForBlocks();
+
+    const sendOut = await execute(`seid tx bank send ${from} ${recipient} ${amount}${token_denom} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`);
+    const sendResp = JSON.parse(sendOut);
+    if (sendResp.code !== 0) {
+        throw new Error(`createTokenFactoryTokenAndMint: bank send rejected: ${sendResp.raw_log}`);
+    }
+    await waitForBlocks();
+
+    return token_denom;
 }
 
 async function getChainId() {

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -342,7 +342,9 @@ async function createTokenFactoryTokenAndMint(name, amount, recipient, from=admi
         async () => {
             try {
                 const out = await execute(`seid query tokenfactory denom-authority-metadata ${token_denom} --output json`)
-                return JSON.parse(out).authority_metadata !== undefined
+                // For a non-existent denom this query returns {"authority_metadata":{"admin":""}}
+                // (no error). Only a non-empty admin indicates the create-denom is committed.
+                return (JSON.parse(out).authority_metadata?.admin || '') !== ''
             } catch (e) { return false }
         },
         `denom ${token_denom} to be created`,
@@ -564,7 +566,10 @@ async function proposeParamChange(title, description, changes, deposit="20000000
             const observedTitle = detail.content?.title ?? detail.title;
             if (observedTitle === title) return String(id);
         }
-        maxIdBefore = cur;
+        // Use max so a transient maxProposalId() failure (returns 0) can't
+        // shrink the window and let a prior-run proposal with the same title
+        // re-match on the next iteration.
+        maxIdBefore = Math.max(maxIdBefore, cur);
         await sleep(250);
     }
     throw new Error(`proposal submitted (tx ${response.txhash}) but did not appear in gov state within 30s`);

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -82,13 +82,8 @@ async function delay() {
     await sleep(1000)
 }
 
-// Wait until the chain advances by `blocks` blocks. Used after `-b sync`
-// submissions to give the chain time to include the tx — engine-agnostic
-// substitute for a fixed sleep, since block times differ between CometBFT
-// (~1s) and Autobahn (~100ms). Default is 2 blocks rather than 1 because
-// the next block can be empty (the submitted tx is still in mempool and
-// lands one block later); 2 blocks closes that race in nearly all cases
-// without re-introducing a fixed sleep.
+// Default 2 because the very next block after submit can be empty
+// (tx still in mempool, lands one block later).
 async function waitForBlocks(blocks=2, timeoutMs=15000) {
     const start = await ethers.provider.getBlockNumber()
     const deadline = Date.now() + timeoutMs
@@ -115,10 +110,6 @@ async function fundAddress(addr, amount="1000000000000000000000") {
 }
 
 async function evmSend(addr, fromKey, amount="10000000000000000000000000") {
-    // -b sync (returns on mempool acceptance) instead of -b block (subscribes
-    // to EventDataTx). Under Autobahn, executeBlock doesn't fire EventDataTx,
-    // so -b block hangs to its 60s timeout. -b sync is sufficient because
-    // callers don't read the deliver_tx event payload from this output.
     const output = await execute(`seid tx evm send ${addr} ${amount} --from ${fromKey} -b sync -y`);
     await waitForBlocks()
     return output.replace(/.*0x/, "0x").trim()
@@ -268,11 +259,7 @@ async function rawHttpDebugTraceWithCallTracer(txHash) {
 }
 
 async function createTokenFactoryTokenAndMint(name, amount, recipient, from=adminKeyName) {
-    // -b sync everywhere (no -b block hang under Autobahn). The tokenfactory
-    // denom format is factory/<creator-bech32>/<subdenom>, so we construct
-    // the denom locally from the from-key's address rather than reading
-    // the create_denom event from the tx response — -b sync doesn't carry
-    // deliver_tx events.
+    // Tokenfactory denom is deterministic: factory/<creator-bech32>/<subdenom>.
     const creator = await getKeySeiAddress(from);
     const token_denom = `factory/${creator}/${name}`;
 
@@ -476,16 +463,9 @@ async function proposeParamChange(title, description, changes, deposit="20000000
     const base64Json = Buffer.from(proposalJson).toString('base64');
     await execute(`echo ${base64Json} | base64 -d > ${tempFile}`);
 
-    // Snapshot max proposal id before submit so we can identify the new one
-    // by polling — see comment below for why we don't use the tx response.
+    // Identify the new proposal by diffing gov state before vs after submit.
     const maxIdBefore = await maxProposalId();
 
-    // -b sync (returns on mempool acceptance) instead of -b block (subscribes
-    // to EventDataTx). Under Autobahn, executeBlock doesn't fire EventDataTx,
-    // so -b block hangs to its 60s timeout on every call. -b sync also means
-    // the tx response no longer carries the deliver_tx events — including the
-    // submit_proposal event we used to read proposal_id from — so we instead
-    // poll gov state until a new proposal appears.
     const command = `seid tx gov submit-proposal param-change ${tempFile} --from ${from} --fees ${fees} -y -o json -b sync`;
     const output = await execute(command);
     await execute(`rm ${tempFile}`);
@@ -494,9 +474,6 @@ async function proposeParamChange(title, description, changes, deposit="20000000
         throw new Error(`Failed to submit proposal: ${response.raw_log}`);
     }
 
-    // Poll for the new proposal to land. Tx hash lookup (`seid q tx <hash>`)
-    // would need a Cosmos-side tx indexer, which Autobahn doesn't run.
-    // 30s should comfortably cover the inclusion + commit window.
     const deadline = Date.now() + 30000;
     while (Date.now() < deadline) {
         const cur = await maxProposalId();
@@ -510,12 +487,8 @@ async function proposeParamChange(title, description, changes, deposit="20000000
 async function maxProposalId() {
     let out;
     try {
-        // seid exits non-zero with "Error: no proposals found" on an empty
-        // gov set; treat that as id=0 and fall through to JSON parsing for
-        // the populated case. Avoid using a `|| echo` fallback inside the
-        // pipeline because the docker-exec wrapper double-quotes the inner
-        // command and a JSON literal with single quotes would terminate
-        // the outer quote region.
+        // seid exits non-zero ("Error: no proposals found") on an empty
+        // gov set; the try/catch treats that as id=0.
         out = await execute(`seid q gov proposals --reverse --limit 1 -o json 2>/dev/null`);
     } catch (e) {
         return 0;

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -162,8 +162,8 @@ async function getKeySeiAddress(name) {
 
 async function associateKey(keyName) {
     try {
-        await execute(`seid tx evm associate-address --from ${keyName} -b block`)
-        await delay()
+        await execute(`seid tx evm associate-address --from ${keyName} -b sync`)
+        await sleep(2000)
     }catch(e){
         console.log("skipping associate")
     }
@@ -524,9 +524,9 @@ async function ensureWasmDisabled(from=adminKeyName) {
 
 async function passProposal(proposalId,  desposit="200000000usei", fees="200000usei", from=adminKeyName) {
     if(await isDocker()) {
-        await executeOnAllNodes(`seid tx gov vote ${proposalId} yes --from node_admin -b block -y --fees ${fees}`)
+        await executeOnAllNodes(`seid tx gov vote ${proposalId} yes --from node_admin -b sync -y --fees ${fees}`)
     } else {
-        await execute(`seid tx gov vote ${proposalId} yes --from ${from} -b block -y --fees ${fees}`)
+        await execute(`seid tx gov vote ${proposalId} yes --from ${from} -b sync -y --fees ${fees}`)
     }
     // Poll for proposal status with shorter delay for faster tests
     for(let i=0; i<200; i++) {

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -115,7 +115,12 @@ async function fundAddress(addr, amount="1000000000000000000000") {
 }
 
 async function evmSend(addr, fromKey, amount="10000000000000000000000000") {
-    const output = await execute(`seid tx evm send ${addr} ${amount} --from ${fromKey} -b block -y`);
+    // -b sync (returns on mempool acceptance) instead of -b block (subscribes
+    // to EventDataTx). Under Autobahn, executeBlock doesn't fire EventDataTx,
+    // so -b block hangs to its 60s timeout. -b sync is sufficient because
+    // callers don't read the deliver_tx event payload from this output.
+    const output = await execute(`seid tx evm send ${addr} ${amount} --from ${fromKey} -b sync -y`);
+    await waitForBlocks()
     return output.replace(/.*0x/, "0x").trim()
 }
 
@@ -446,19 +451,59 @@ async function proposeParamChange(title, description, changes, deposit="20000000
     };
     const proposalJson = JSON.stringify(proposal);
     const tempFile = `/tmp/param_change_${Date.now()}.json`;
-    
+
     // Use base64 encoding to avoid quote escaping issues in Docker
     const base64Json = Buffer.from(proposalJson).toString('base64');
     await execute(`echo ${base64Json} | base64 -d > ${tempFile}`);
-    
-    const command = `seid tx gov submit-proposal param-change ${tempFile} --from ${from} --fees ${fees} -y -o json --broadcast-mode=block`;
+
+    // Snapshot max proposal id before submit so we can identify the new one
+    // by polling — see comment below for why we don't use the tx response.
+    const maxIdBefore = await maxProposalId();
+
+    // -b sync (returns on mempool acceptance) instead of -b block (subscribes
+    // to EventDataTx). Under Autobahn, executeBlock doesn't fire EventDataTx,
+    // so -b block hangs to its 60s timeout on every call. -b sync also means
+    // the tx response no longer carries the deliver_tx events — including the
+    // submit_proposal event we used to read proposal_id from — so we instead
+    // poll gov state until a new proposal appears.
+    const command = `seid tx gov submit-proposal param-change ${tempFile} --from ${from} --fees ${fees} -y -o json -b sync`;
     const output = await execute(command);
     await execute(`rm ${tempFile}`);
     const response = JSON.parse(output);
     if (response.code !== 0) {
         throw new Error(`Failed to submit proposal: ${response.raw_log}`);
     }
-    return getEventAttribute(response, "submit_proposal", "proposal_id");
+
+    // Poll for the new proposal to land. Tx hash lookup (`seid q tx <hash>`)
+    // would need a Cosmos-side tx indexer, which Autobahn doesn't run.
+    // 30s should comfortably cover the inclusion + commit window.
+    const deadline = Date.now() + 30000;
+    while (Date.now() < deadline) {
+        const cur = await maxProposalId();
+        if (cur > maxIdBefore) return String(cur);
+        await sleep(250);
+    }
+    throw new Error(`proposal submitted (tx ${response.txhash}) but did not appear in gov state within 30s`);
+}
+
+// Returns the highest existing proposal id, or 0 if there are no proposals.
+async function maxProposalId() {
+    let out;
+    try {
+        // seid exits non-zero with "Error: no proposals found" on an empty
+        // gov set; treat that as id=0 and fall through to JSON parsing for
+        // the populated case. Avoid using a `|| echo` fallback inside the
+        // pipeline because the docker-exec wrapper double-quotes the inner
+        // command and a JSON literal with single quotes would terminate
+        // the outer quote region.
+        out = await execute(`seid q gov proposals --reverse --limit 1 -o json 2>/dev/null`);
+    } catch (e) {
+        return 0;
+    }
+    if (!out || !out.trim()) return 0;
+    const proposals = JSON.parse(out).proposals || [];
+    if (proposals.length === 0) return 0;
+    return Number(proposals[0].proposal_id || proposals[0].id);
 }
 
 async function proposeDisableWasm(title="Disable WASM", description="Disable cosmwasm store code and instantiate operations", deposit="200000000usei", fees="200000usei", from=adminKeyName) {

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -259,32 +259,19 @@ async function rawHttpDebugTraceWithCallTracer(txHash) {
 }
 
 async function createTokenFactoryTokenAndMint(name, amount, recipient, from=adminKeyName) {
+    const command = `seid tx tokenfactory create-denom ${name} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`
+    await execute(command);
     // Tokenfactory denom is deterministic: factory/<creator-bech32>/<subdenom>.
-    const creator = await getKeySeiAddress(from);
-    const token_denom = `factory/${creator}/${name}`;
+    const token_denom = `factory/${await getKeySeiAddress(from)}/${name}`
+    await waitForBlocks()
+    const mint_command = `seid tx tokenfactory mint ${amount}${token_denom} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`
+    await execute(mint_command);
+    await waitForBlocks()
 
-    const createOut = await execute(`seid tx tokenfactory create-denom ${name} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`);
-    const createResp = JSON.parse(createOut);
-    if (createResp.code !== 0) {
-        throw new Error(`createTokenFactoryTokenAndMint: create-denom rejected: ${createResp.raw_log}`);
-    }
-    await waitForBlocks();
-
-    const mintOut = await execute(`seid tx tokenfactory mint ${amount}${token_denom} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`);
-    const mintResp = JSON.parse(mintOut);
-    if (mintResp.code !== 0) {
-        throw new Error(`createTokenFactoryTokenAndMint: mint rejected: ${mintResp.raw_log}`);
-    }
-    await waitForBlocks();
-
-    const sendOut = await execute(`seid tx bank send ${from} ${recipient} ${amount}${token_denom} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`);
-    const sendResp = JSON.parse(sendOut);
-    if (sendResp.code !== 0) {
-        throw new Error(`createTokenFactoryTokenAndMint: bank send rejected: ${sendResp.raw_log}`);
-    }
-    await waitForBlocks();
-
-    return token_denom;
+    const send_command = `seid tx bank send ${from} ${recipient} ${amount}${token_denom} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`
+    await execute(send_command);
+    await waitForBlocks()
+    return token_denom
 }
 
 async function getChainId() {

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -83,10 +83,13 @@ async function delay() {
 }
 
 // Wait until the chain advances by `blocks` blocks. Used after `-b sync`
-// submissions to give the next block time to include the tx — engine-agnostic
+// submissions to give the chain time to include the tx — engine-agnostic
 // substitute for a fixed sleep, since block times differ between CometBFT
-// (~1s) and Autobahn (~100ms).
-async function waitForBlocks(blocks=1, timeoutMs=15000) {
+// (~1s) and Autobahn (~100ms). Default is 2 blocks rather than 1 because
+// the next block can be empty (the submitted tx is still in mempool and
+// lands one block later); 2 blocks closes that race in nearly all cases
+// without re-introducing a fixed sleep.
+async function waitForBlocks(blocks=2, timeoutMs=15000) {
     const start = await ethers.provider.getBlockNumber()
     const deadline = Date.now() + timeoutMs
     while (Date.now() < deadline) {
@@ -118,13 +121,13 @@ async function evmSend(addr, fromKey, amount="10000000000000000000000000") {
 
 async function bankSend(toAddr, fromKey, amount="100000000000", denom="usei") {
     const result = await execute(`seid tx bank send ${fromKey} ${toAddr} ${amount}${denom} -b sync --fees 20000usei -y`);
-    await waitForBlocks(1)
+    await waitForBlocks()
     return result
 }
 
 async function fundSeiAddress(seiAddr, amount="100000000000", denom="usei", funder=adminKeyName) {
     const result = await execute(`seid tx bank send ${funder} ${seiAddr} ${amount}${denom} -b sync --fees 20000usei -y`);
-    await waitForBlocks(1)
+    await waitForBlocks()
     return result
 }
 
@@ -178,7 +181,7 @@ async function getKeySeiAddress(name) {
 async function associateKey(keyName) {
     try {
         await execute(`seid tx evm associate-address --from ${keyName} -b sync`)
-        await waitForBlocks(1)
+        await waitForBlocks()
     }catch(e){
         console.log("skipping associate")
     }

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -477,7 +477,14 @@ async function proposeParamChange(title, description, changes, deposit="20000000
     const deadline = Date.now() + 30000;
     while (Date.now() < deadline) {
         const cur = await maxProposalId();
-        if (cur > maxIdBefore) return String(cur);
+        if (cur > maxIdBefore) {
+            const detail = JSON.parse(await execute(`seid q gov proposal ${cur} -o json`));
+            const observedTitle = detail.content?.title ?? detail.title;
+            if (observedTitle !== title) {
+                throw new Error(`proposal ${cur} title "${observedTitle}" does not match submitted "${title}" — concurrent submission?`);
+            }
+            return String(cur);
+        }
         await sleep(250);
     }
     throw new Error(`proposal submitted (tx ${response.txhash}) but did not appear in gov state within 30s`);

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -139,17 +139,19 @@ async function evmSend(addr, fromKey, amount="10000000000000000000000000") {
 }
 
 async function bankSend(toAddr, fromKey, amount="100000000000", denom="usei") {
-    const before = await getSeiBalanceBigInt(toAddr, denom)
+    const senderAddr = await getKeySeiAddress(fromKey)
+    // Non-self-send: recipient's `denom` balance goes up by `amount`.
+    // Self-send: `denom` amount cancels; the recipient (also the sender)
+    // pays fees in usei, so usei drops. Track whichever balance is
+    // expected to change post-commit so the wait is a side-effect check.
+    const trackedDenom = senderAddr === toAddr ? "usei" : denom
+    const before = await getSeiBalanceBigInt(toAddr, trackedDenom)
     const result = await execute(`seid tx bank send ${fromKey} ${toAddr} ${amount}${denom} -b sync -o json --fees 20000usei -y`);
     const parsed = JSON.parse(result)
     if (parsed.code !== 0) throw new Error(`bank send rejected: ${parsed.raw_log}`)
-    // The recipient's balance changes once the tx commits, regardless of
-    // whether it's a self-send. Non-self-send: balance goes up by amount.
-    // Self-send (sender == recipient): balance goes down by fees (amount
-    // cancels). Either way, `current !== before` flips once on commit.
     await waitForCondition(
-        async () => (await getSeiBalanceBigInt(toAddr, denom)) !== before,
-        `${toAddr} ${denom} balance to change from ${before}`,
+        async () => (await getSeiBalanceBigInt(toAddr, trackedDenom)) !== before,
+        `${toAddr} ${trackedDenom} balance to change from ${before}`,
     )
     return result
 }

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -95,29 +95,25 @@ async function waitForBlocks(blocks=2, timeoutMs=15000) {
     throw new Error(`block didn't advance by ${blocks} in ${timeoutMs}ms (start=${start})`)
 }
 
-// Poll seid q tx until the cosmos tx is committed on chain. Replaces
-// waitForBlocks() after -b sync submissions: block counting is a
-// temporal wait, not a causal one — under load a helper could return
-// while its tx was still in the mempool, leaving the next test to start
-// against an inconsistent chain. waitForCosmosTx makes -b sync helpers
-// semantically equivalent to -b block: they return once the tx is on
-// chain regardless of its code, matching -b block which exits 0 for
-// included-but-failed txs. Callers that care about tx success should
-// inspect the returned response's `code` field.
-async function waitForCosmosTx(txhash, timeoutMs=15000) {
+// Poll an arbitrary side-effect check until it returns truthy. Used by
+// helpers that need to wait for a -b sync tx to take effect: instead of
+// polling `seid q tx <hash>` (which doesn't work under Autobahn — the
+// cosmos tx indexer isn't wired) or `waitForBlocks` (temporal, not
+// causal), each caller passes a closure that queries the actual state
+// it cares about (e.g. account balance, denom existence). Works under
+// both Autobahn and legacy because the check goes through whatever query
+// path the caller already relies on.
+async function waitForCondition(check, description, timeoutMs=15000, intervalMs=200) {
     const deadline = Date.now() + timeoutMs
     while (Date.now() < deadline) {
         try {
-            return JSON.parse(await execute(`seid q tx ${txhash} -o json`))
+            if (await check()) return
         } catch (e) {
-            // "tx not found" while the tx is still in the mempool. Retry.
+            // tolerate transient query failures; retry until deadline
         }
-        // Local cluster's timeout_commit is 2s, so one block ≈ 2s.
-        // Polling more frequently than ~500ms just spawns extra docker exec
-        // calls (each ~200-300ms of overhead) without speeding up detection.
-        await sleep(500)
+        await sleep(intervalMs)
     }
-    throw new Error(`tx ${txhash} not committed within ${timeoutMs}ms`)
+    throw new Error(`timed out waiting for ${description} within ${timeoutMs}ms`)
 }
 
 async function getCosmosTx(provider, evmTxHash) {
@@ -143,18 +139,28 @@ async function evmSend(addr, fromKey, amount="10000000000000000000000000") {
 }
 
 async function bankSend(toAddr, fromKey, amount="100000000000", denom="usei") {
+    const before = await getSeiBalance(toAddr, denom)
     const result = await execute(`seid tx bank send ${fromKey} ${toAddr} ${amount}${denom} -b sync -o json --fees 20000usei -y`);
     const parsed = JSON.parse(result)
     if (parsed.code !== 0) throw new Error(`bank send rejected: ${parsed.raw_log}`)
-    await waitForCosmosTx(parsed.txhash)
+    const target = before + parseInt(amount, 10)
+    await waitForCondition(
+        async () => (await getSeiBalance(toAddr, denom)) >= target,
+        `${toAddr} ${denom} balance >= ${target}`,
+    )
     return result
 }
 
 async function fundSeiAddress(seiAddr, amount="100000000000", denom="usei", funder=adminKeyName) {
+    const before = await getSeiBalance(seiAddr, denom)
     const result = await execute(`seid tx bank send ${funder} ${seiAddr} ${amount}${denom} -b sync -o json --fees 20000usei -y`);
     const parsed = JSON.parse(result)
     if (parsed.code !== 0) throw new Error(`fundSeiAddress rejected: ${parsed.raw_log}`)
-    await waitForCosmosTx(parsed.txhash)
+    const target = before + parseInt(amount, 10)
+    await waitForCondition(
+        async () => (await getSeiBalance(seiAddr, denom)) >= target,
+        `${seiAddr} ${denom} balance >= ${target}`,
+    )
     return result
 }
 
@@ -300,16 +306,22 @@ async function createTokenFactoryTokenAndMint(name, amount, recipient, from=admi
     if (response.code !== 0) throw new Error(`create-denom rejected: ${response.raw_log}`)
     // Tokenfactory denom is deterministic: factory/<creator-bech32>/<subdenom>.
     const token_denom = `factory/${await getKeySeiAddress(from)}/${name}`
-    await waitForCosmosTx(response.txhash)
+
     const mint_command = `seid tx tokenfactory mint ${amount}${token_denom} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`
     const mintResp = JSON.parse(await execute(mint_command))
     if (mintResp.code !== 0) throw new Error(`mint rejected: ${mintResp.raw_log}`)
-    await waitForCosmosTx(mintResp.txhash)
 
     const send_command = `seid tx bank send ${from} ${recipient} ${amount}${token_denom} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode sync -o json`
     const sendResp = JSON.parse(await execute(send_command))
     if (sendResp.code !== 0) throw new Error(`bank send rejected: ${sendResp.raw_log}`)
-    await waitForCosmosTx(sendResp.txhash)
+
+    // End-to-end side-effect check: all 3 txs (create + mint + send)
+    // succeeded iff the recipient holds the minted amount of the new denom.
+    const target = parseInt(amount, 10)
+    await waitForCondition(
+        async () => (await getSeiBalance(recipient, token_denom)) >= target,
+        `${recipient} ${token_denom} balance >= ${target}`,
+    )
     return token_denom
 }
 

--- a/integration_test/contracts/deploy_flatkv_evm_fixture.sh
+++ b/integration_test/contracts/deploy_flatkv_evm_fixture.sh
@@ -119,7 +119,7 @@ run_seid tx evm associate-address \
   --from "$FROM" \
   "${KEYRING_ARGS[@]}" \
   --chain-id "$CHAIN_ID" \
-  -b block \
+  -b sync \
   -y >/tmp/flatkv_evm_associate.out 2>&1 || true
 
 echo "Sending native EVM transfer to create/update recipient account..."


### PR DESCRIPTION
## Summary

`-b block` subscribes to `EventDataTx`; Autobahn's `executeBlock` doesn't fire those events, so `-b block` deterministically times out at 60s.

Migrated `lib.js` cosmos-tx helpers to `-b sync` + a new `waitForCondition(check, description)` that polls the actual side effect (balance change, denom existence, proposal landing). Block-counting (`waitForBlocks`) is temporal — under load a helper can return while its tx is still in the mempool. Side-effect polling matches `-b block`'s causal semantics on both engines.

**Migrated:**

- `evmSend` — `waitForReceipt` on the EVM hash
- `bankSend`, `fundSeiAddress`, `createTokenFactoryTokenAndMint` — `waitForCondition` on balance/denom
- `proposeParamChange` — polls gov state with new `maxProposalId()` + title match
- `passProposal` vote — caller polls proposal status afterward
- `associateKey`, `associateSigner`, `deploy_flatkv_evm_fixture.sh associate-address` — fire-and-forget; `waitForBlocks` is sufficient
- `EVMPrecompileTest.js` Gov before-hook uses `proposeParamChange` instead of inline `-b block`
- `AssociateTest.js` cast-address case uses new `getAccountSequence` (asserts balance stays at 0, so can't poll balance)

Helpers that read post-execution events (`storeWasm`, `executeWasm`, `associateWasm`, pointer registration) stay on `-b block` — `-b sync` returns CheckTx code, not DeliverTx; migrating them needs a separate "submit then poll for result" change.

## Verification

| Test set | main | this PR |
|---|---|---|
| CometBFT precompile (6) | 17s | 15s |
| CometBFT trace (3) | 16s | 6s |
| Autobahn precompile (6) | hangs at `before all` | 10s |
| Autobahn trace balance diff | hangs at 10s | 885ms |
