### PR TITLE
mempool: pass recheck=false from Autobahn block-finalize (CON-256)

### DIFF
--- a/sei-tendermint/internal/mempool/mempool.go
+++ b/sei-tendermint/internal/mempool/mempool.go
@@ -724,6 +724,51 @@ func (txmp *TxMempool) ReapMaxTxs(max int) types.Txs {
 // re-CheckTx for them (if applicable), otherwise, we notify the caller more
 // transactions are available.
 //
+// WARNING: callers should almost always pass recheck=false. recheck=true
+// re-runs CheckTx on every tx still in the mempool after each block, and
+// handleRecheckResult treats a "now IsPending" response as terminal: it
+// evicts the tx and async-re-CheckTx-es it, which lands it back in
+// pendingTxs. For chains whose antehandler returns IsPending for any
+// ahead-of-nonce EVM tx (Sei), this evicts perfectly-valid queued txs.
+//
+// Example. txA (nonce 3), txB (nonce 2), txC (nonce 1) on the same sender.
+//
+//  1. txA, txB, txC are submitted in this order.
+//  2. txA and txB enter pendingTxs (their nonce is ahead of the sender's
+//     expected nonce at CheckTx time so the EVM antehandler marks them
+//     IsPending). txC enters the priority index (its nonce matches expected).
+//  3. Block 1 reaps and mines txC. The sender's expected nonce becomes 2.
+//  4. handlePendingTransactions promotes txA and txB into the priority
+//     index. The per-sender evmQueue is now [txB (head), txA (tail)].
+//
+// From step 5 onwards the recheck flag matters:
+//
+// recheck=false (correct):
+//
+//  5. updateReCheckTxs is skipped. The priority index keeps txB and txA.
+//  6. Block 2 reaps the whole evmQueue. Both txB and txA mine.
+//
+// All 3 txs mine in 2 blocks, regardless of how out-of-order they arrived.
+//
+// recheck=true (broken):
+//
+//  5. updateReCheckTxs re-runs CheckTx on each tx in the priority index:
+//     - txB: nonce 2 == expected 2 → not IsPending → stays.
+//     - txA: nonce 3  > expected 2 → IsPending again. handleRecheckResult
+//     evicts it and async-re-CheckTx-es it, which lands it back in
+//     pendingTxs.
+//  6. Block 2 reaps txB only (txA is no longer in the priority index).
+//     handlePendingTransactions re-promotes txA. txA's nonce now matches
+//     expected, so it survives the recheck this time.
+//  7. Block 3 mines txA.
+//
+// All 3 txs take 3 blocks. With many out-of-order sequential nonces from
+// one sender, this stalls the chain to 1-tx-per-block-per-sender throughput.
+//
+// CometBFT's default for ConsensusParams.ABCI.RecheckTx is false. Recheck
+// primarily defended against state-dependent invalidation that modern
+// chains catch in ProcessProposal/DeliverTx anyway.
+//
 // NOTE:
 // - The caller must explicitly acquire a write-lock.
 func (txmp *TxMempool) Update(

--- a/sei-tendermint/internal/mempool/recheck_drain_test.go
+++ b/sei-tendermint/internal/mempool/recheck_drain_test.go
@@ -1,0 +1,177 @@
+package mempool
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/sei-protocol/sei-chain/sei-tendermint/abci/example/code"
+	abci "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/proxy"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/require"
+)
+
+// evmNonceApp models a Sei-like EVM antehandler for mempool tests:
+//   - tracks the next-expected nonce per sender (the "mined" nonce frontier)
+//   - on CheckTx for txNonce > nextNonce, returns IsPending whose checker
+//     resolves to Accepted as soon as nextNonce catches up.
+//
+// Test format: "evm=<sender>=<nonce>=<priority>".
+type evmNonceApp struct {
+	abci.Application
+
+	mu        sync.Mutex
+	nextNonce map[string]uint64
+}
+
+func newEVMNonceApp() *evmNonceApp {
+	return &evmNonceApp{nextNonce: map[string]uint64{}}
+}
+
+// markMined bumps the sender's next-expected nonce by 1, simulating that the
+// previous next-expected nonce just landed in a block.
+func (a *evmNonceApp) markMined(sender string) {
+	a.mu.Lock()
+	a.nextNonce[sender]++
+	a.mu.Unlock()
+}
+
+func (a *evmNonceApp) parseTx(tx []byte) (sender string, nonce uint64, priority int64, ok bool) {
+	parts := bytes.Split(tx, []byte("="))
+	if len(parts) != 4 || string(parts[0]) != "evm" {
+		return "", 0, 0, false
+	}
+	n, err := strconv.ParseUint(string(parts[2]), 10, 64)
+	if err != nil {
+		return "", 0, 0, false
+	}
+	p, err := strconv.ParseInt(string(parts[3]), 10, 64)
+	if err != nil {
+		return "", 0, 0, false
+	}
+	return string(parts[1]), n, p, true
+}
+
+func (a *evmNonceApp) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) (*abci.ResponseCheckTxV2, error) {
+	sender, nonce, priority, ok := a.parseTx(req.Tx)
+	if !ok {
+		return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{Code: 1}}, nil
+	}
+
+	a.mu.Lock()
+	expected := a.nextNonce[sender]
+	a.mu.Unlock()
+
+	if nonce < expected {
+		// Already mined. Reject.
+		return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{Code: 2}}, nil
+	}
+
+	res := &abci.ResponseCheckTxV2{
+		ResponseCheckTx: &abci.ResponseCheckTx{
+			Code:         code.CodeTypeOK,
+			Priority:     priority,
+			GasWanted:    DefaultGasWanted,
+			GasEstimated: DefaultGasEstimated,
+		},
+		EVMNonce:         nonce,
+		EVMSenderAddress: sender,
+		IsEVM:            true,
+		Priority:         priority,
+	}
+	if nonce > expected {
+		// Ahead of expected — mark pending. The checker re-evaluates against
+		// the live nextNonce map at handlePendingTransactions time.
+		// Mirror Sei's EVM antehandler: once the sender has *any* expected-nonce
+		// progress (i.e. nextNonce has advanced past where this tx was submitted),
+		// all sequentially-queued nonces from that sender are eligible. This is
+		// what `CalculateNextNonce(includePending=true)` does in x/evm/keeper.
+		res.IsPending = utils.Some(abci.PendingTxChecker(func() abci.PendingTxCheckerResponse {
+			a.mu.Lock()
+			cur := a.nextNonce[sender]
+			a.mu.Unlock()
+			switch {
+			case nonce < cur:
+				return abci.Rejected
+			case nonce >= cur:
+				return abci.Accepted
+			default:
+				return abci.Pending
+			}
+		}))
+	}
+	return res, nil
+}
+
+func (a *evmNonceApp) GetTxPriorityHint(context.Context, *abci.RequestGetTxPriorityHintV2) (*abci.ResponseGetTxPriorityHint, error) {
+	return &abci.ResponseGetTxPriorityHint{Priority: 1}, nil
+}
+
+// TestTxMempool_DescendingNonceDrain exercises the producer-style flow:
+// submit N EVM nonces from a single sender in descending order (worst case
+// for the gap-pending pool — every tx except the last is ahead of expected
+// at CheckTx time), then drain by repeatedly PopTxs-ing and Update-ing.
+//
+// Regression for the recheck=true eviction loop: with recheck=true, the
+// EVM antehandler's IsPending response for the rest of the per-sender
+// evmQueue causes handleRecheckResult to evict + async re-CheckTx every
+// non-head tx, dumping them back into pendingTxs. The mempool's priority
+// pool collapses to 1 each Update cycle and the chain only mines 1 per
+// block, vs draining all N in roughly one PopTxs/Update cycle here.
+func TestTxMempool_DescendingNonceDrain(t *testing.T) {
+	const sender = "alice"
+	const N = 100
+
+	ctx := t.Context()
+	app := newEVMNonceApp()
+	txmp := setup(t, proxy.New(app, proxy.NopMetrics()), 5000, NopTxConstraintsFetcher)
+
+	// Submit nonces N-1, N-2, ..., 1, 0. Every tx except the last enters
+	// pendingTxs because its nonce is ahead of the sender's expected nonce
+	// (0) at CheckTx time. The last tx (nonce 0) matches expected and lands
+	// in the priority index as the evmQueue head.
+	for n := N - 1; n >= 0; n-- {
+		tx := []byte(fmt.Sprintf("evm=%s=%d=1", sender, n))
+		_, err := txmp.CheckTx(ctx, tx, TxInfo{})
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, N, txmp.Size(), "mempool should hold all submitted txs")
+
+	// Drain: repeatedly reap a batch, "mine" each tx (advance nextNonce), then
+	// Update the mempool. With recheck=false the producer reaps ALL N txs in at
+	// most a couple of blocks: the first PopTxs grabs the head, Update promotes
+	// the rest of the per-sender evmQueue, the second PopTxs reaps everything.
+	// We bound the loop tightly so a regression to recheck=true (which evicts
+	// the queue tail and forces 1-tx-per-block forever) fails fast instead of
+	// silently passing.
+	const maxBlocks = 5
+	totalMined := 0
+	for height := int64(1); txmp.Size() > 0 && height <= maxBlocks; height++ {
+		txs, _ := txmp.PopTxs(ReapLimits{
+			MaxTxs:          utils.Some(uint64(N)),
+			MaxBytes:        utils.Some(int64(1 << 30)),
+			MaxGasWanted:    utils.Some(int64(1 << 30)),
+			MaxGasEstimated: utils.Some(int64(1 << 30)),
+		})
+		require.NotEmpty(t, txs, "PopTxs returned no txs at height %d (mempool stalled)", height)
+
+		txResults := make([]*abci.ExecTxResult, len(txs))
+		for i := range txs {
+			app.markMined(sender)
+			txResults[i] = &abci.ExecTxResult{Code: code.CodeTypeOK}
+		}
+		totalMined += len(txs)
+
+		// recheck=false matches the post-fix Autobahn path and CometBFT's default.
+		require.NoError(t, txmp.Update(ctx, height, txs, txResults, NopTxConstraintsFetcher, false))
+	}
+
+	require.Equal(t, N, totalMined, "all N txs should have mined within %d blocks", maxBlocks)
+	require.Zero(t, txmp.Size(), "mempool should fully drain within %d blocks", maxBlocks)
+	require.Equal(t, uint64(N), app.nextNonce[sender], "all N nonces should have been mined")
+}

--- a/sei-tendermint/internal/p2p/giga_router.go
+++ b/sei-tendermint/internal/p2p/giga_router.go
@@ -291,7 +291,8 @@ func (r *GigaRouter) executeBlock(ctx context.Context, b *atypes.GlobalBlock) (*
 		// Therefore we disable constraints for now, until epochs are supported AND
 		// chain state understands that consensus parameters can change only at the epoch boundary.
 		mempool.NopTxConstraintsFetcher,
-		true,
+		// recheck=false; see TxMempool.Update doc for why.
+		false,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("r.cfg.TxMempool.Update(%v): %w", b.GlobalNumber, err)


### PR DESCRIPTION
GigaRouter.executeBlock now passes recheck=false to TxMempool.Update, matching the default value of ConsensusParams.ABCI.RecheckTx that the CometBFT path uses. The doc comment on TxMempool.Update walks through the example showing why recheck=true stalls out-of-order sequential EVM nonces from one sender to one-per-block.

This also fixes a related symptom under bursty submission, where some txs would return a hash from eth_sendRawTransaction and then never appear on chain. When handleRecheckResult evicted a tx with shouldReenqueue=true, the async re-CheckTx for the queue tail would hit "tx already exists in cache" and drop the tx silently. Verified on a 4-node Autobahn cluster: a 100-tx burst from one sender now ends with all 107 submitted txs (test setup + workload) accounted for in the mempool, vs ~10-15% silently dropped before.

## Things done

- [x] giga_router.executeBlock passes recheck=false
- [x] TxMempool.Update doc comment + worked example
- [x] TestTxMempool_DescendingNonceDrain regression test (fails on recheck=true: 2/100 mine; passes on recheck=false: all 100 mine in ≤2 blocks)
- [x] gofmt, vet, golangci-lint clean; mempool + p2p test suites pass
- [x] Verified end-to-end on a 4-node Autobahn cluster (full EVMCompatabilityTest "send 100 transactions" passes in ~1s)