### PR TITLE
reverted TxMempool.CheckTx to previous behavior (CON-266)

### DIFF
--- a/app/abci.go
+++ b/app/abci.go
@@ -70,21 +70,31 @@ func (app *App) EndBlock(ctx sdk.Context, height int64, blockGasUsed int64) (res
 	return res
 }
 
-func (app *App) CheckTx(ctx context.Context, req *abci.RequestCheckTxV2) (*abci.ResponseCheckTxV2, error) {
+func (app *App) CheckTx(ctx context.Context, req *abci.RequestCheckTxV2) *abci.ResponseCheckTxV2 {
+	wrapErr := func(err error) *abci.ResponseCheckTxV2 {
+		space, code, _ := sdkerrors.ABCIInfo(err, false)
+		return &abci.ResponseCheckTxV2{
+			ResponseCheckTx: &abci.ResponseCheckTx{
+				Codespace: space,
+				Code:      code,
+				Log:       err.Error(),
+			},
+		}
+	}
 	_, span := app.GetBaseApp().TracingInfo.StartWithContext("CheckTx", ctx)
 	defer span.End()
 	defer telemetry.MeasureSince(time.Now(), "abci", "check_tx")
 	sdkCtx := app.GetCheckTxContext(req.Tx, req.Type == abci.CheckTxTypeV2Recheck)
 	tx, err := app.txDecoder(req.Tx)
 	if err != nil {
-		return nil, err
+		return wrapErr(err)
 	}
 	checksum := sha256.Sum256(req.Tx)
 	gInfo, result, txCtx, err := legacyabci.CheckTx(sdkCtx, tx, app.GetTxConfig(), &app.CheckTxKeepers, checksum, func(ctx sdk.Context) (sdk.Context, sdk.CacheMultiStore) {
 		return app.CacheTxContext(ctx, checksum)
 	}, app.GetCheckCtx, app.TracingInfo)
 	if err != nil {
-		return nil, err
+		return wrapErr(err)
 	}
 
 	res := &abci.ResponseCheckTxV2{
@@ -107,7 +117,7 @@ func (app *App) CheckTx(ctx context.Context, req *abci.RequestCheckTxV2) (*abci.
 		res.ExpireTxHandler = utils.Some(txCtx.ExpireTxHandler())
 	}
 
-	return res, nil
+	return res
 }
 
 func (app *App) DeliverTx(ctx sdk.Context, req abci.RequestDeliverTxV2, tx sdk.Tx, checksum [32]byte) abci.ResponseDeliverTx {

--- a/sei-cosmos/baseapp/abci.go
+++ b/sei-cosmos/baseapp/abci.go
@@ -134,8 +134,8 @@ func (app *BaseApp) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) (res abc
 // internal CheckTx state if the AnteHandler passes. Otherwise, the ResponseCheckTx
 // will contain releveant error information. Regardless of tx execution outcome,
 // the ResponseCheckTx will contain relevant gas execution context.
-func (app *BaseApp) CheckTx(ctx context.Context, req *abci.RequestCheckTxV2) (*abci.ResponseCheckTxV2, error) {
-	return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{}}, nil
+func (app *BaseApp) CheckTx(ctx context.Context, req *abci.RequestCheckTxV2) *abci.ResponseCheckTxV2 {
+	return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{}}
 }
 
 // DeliverTxBatch executes multiple txs

--- a/sei-cosmos/server/rollback_test.go
+++ b/sei-cosmos/server/rollback_test.go
@@ -66,8 +66,8 @@ func (m *mockApplication) Query(ctx context.Context, req *abci.RequestQuery) (*a
 	return &abci.ResponseQuery{}, nil
 }
 
-func (m *mockApplication) CheckTx(ctx context.Context, req *abci.RequestCheckTxV2) (*abci.ResponseCheckTxV2, error) {
-	return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{Code: abci.CodeTypeOK}}, nil
+func (m *mockApplication) CheckTx(ctx context.Context, req *abci.RequestCheckTxV2) *abci.ResponseCheckTxV2 {
+	return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{Code: abci.CodeTypeOK}}
 }
 
 func (m *mockApplication) GetTxPriorityHint(ctx context.Context, req *abci.RequestGetTxPriorityHintV2) (*abci.ResponseGetTxPriorityHint, error) {

--- a/sei-cosmos/types/errors/abci.go
+++ b/sei-cosmos/types/errors/abci.go
@@ -11,7 +11,7 @@ import (
 const (
 	// SuccessABCICode declares an ABCI response use 0 to signal that the
 	// processing was successful and no error is returned.
-	SuccessABCICode = 0
+	SuccessABCICode = abci.CodeTypeOK
 
 	// All unclassified errors that do not provide an ABCI code are clubbed
 	// under an internal error code and a generic message instead of
@@ -46,17 +46,6 @@ func ABCIInfo(err error, debug bool) (codespace string, code uint32, log string)
 	}
 
 	return abciCodespace(err), abciCode(err), encode(err)
-}
-
-// ResponseCheckTx returns an ABCI ResponseCheckTx object with fields filled in
-// from the given error and gas values.
-func ResponseCheckTx(err error, gw, gu uint64, debug bool) abci.ResponseCheckTx {
-	space, code, _ := ABCIInfo(err, debug)
-	return abci.ResponseCheckTx{
-		Codespace: space,
-		Code:      code,
-		GasWanted: safeIntFromUint64(gw),
-	}
 }
 
 // ResponseDeliverTx returns an ABCI ResponseDeliverTx object with fields filled in

--- a/sei-tendermint/abci/example/kvstore/kvstore.go
+++ b/sei-tendermint/abci/example/kvstore/kvstore.go
@@ -209,8 +209,8 @@ func (app *Application) FinalizeBlock(_ context.Context, req *types.RequestFinal
 	return &types.ResponseFinalizeBlock{TxResults: respTxs, ValidatorUpdates: app.ValUpdates, AppHash: appHash}, nil
 }
 
-func (*Application) CheckTx(_ context.Context, req *types.RequestCheckTxV2) (*types.ResponseCheckTxV2, error) {
-	return &types.ResponseCheckTxV2{ResponseCheckTx: &types.ResponseCheckTx{Code: code.CodeTypeOK, GasWanted: 1}}, nil
+func (*Application) CheckTx(_ context.Context, req *types.RequestCheckTxV2) *types.ResponseCheckTxV2 {
+	return &types.ResponseCheckTxV2{ResponseCheckTx: &types.ResponseCheckTx{Code: code.CodeTypeOK, GasWanted: 1}}
 }
 
 func (app *Application) Commit(_ context.Context) (*types.ResponseCommit, error) {

--- a/sei-tendermint/abci/types/application.go
+++ b/sei-tendermint/abci/types/application.go
@@ -15,7 +15,7 @@ type Application interface {
 	GetValidators() []ValidatorUpdate
 
 	// Mempool Connection
-	CheckTx(context.Context, *RequestCheckTxV2) (*ResponseCheckTxV2, error)                             // Validate a tx for the mempool
+	CheckTx(context.Context, *RequestCheckTxV2) *ResponseCheckTxV2                                      // Validate a tx for the mempool
 	GetTxPriorityHint(context.Context, *RequestGetTxPriorityHintV2) (*ResponseGetTxPriorityHint, error) // Get tx priority before checkTx
 
 	// Consensus Connection
@@ -45,8 +45,8 @@ func (BaseApplication) Info(_ context.Context, req *RequestInfo) (*ResponseInfo,
 }
 func (BaseApplication) GetValidators() []ValidatorUpdate { return nil }
 
-func (BaseApplication) CheckTx(_ context.Context, req *RequestCheckTxV2) (*ResponseCheckTxV2, error) {
-	return &ResponseCheckTxV2{ResponseCheckTx: &ResponseCheckTx{Code: CodeTypeOK}}, nil
+func (BaseApplication) CheckTx(_ context.Context, req *RequestCheckTxV2) *ResponseCheckTxV2 {
+	return &ResponseCheckTxV2{ResponseCheckTx: &ResponseCheckTx{Code: CodeTypeOK}}
 }
 
 func (BaseApplication) Commit(_ context.Context) (*ResponseCommit, error) {

--- a/sei-tendermint/abci/types/mocks/application.go
+++ b/sei-tendermint/abci/types/mocks/application.go
@@ -45,7 +45,7 @@ func (_m *Application) ApplySnapshotChunk(_a0 context.Context, _a1 *types.Reques
 }
 
 // CheckTx provides a mock function with given fields: _a0, _a1
-func (_m *Application) CheckTx(_a0 context.Context, _a1 *types.RequestCheckTxV2) (*types.ResponseCheckTxV2, error) {
+func (_m *Application) CheckTx(_a0 context.Context, _a1 *types.RequestCheckTxV2) *types.ResponseCheckTxV2 {
 	ret := _m.Called(_a0, _a1)
 
 	if len(ret) == 0 {
@@ -53,10 +53,6 @@ func (_m *Application) CheckTx(_a0 context.Context, _a1 *types.RequestCheckTxV2)
 	}
 
 	var r0 *types.ResponseCheckTxV2
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *types.RequestCheckTxV2) (*types.ResponseCheckTxV2, error)); ok {
-		return rf(_a0, _a1)
-	}
 	if rf, ok := ret.Get(0).(func(context.Context, *types.RequestCheckTxV2) *types.ResponseCheckTxV2); ok {
 		r0 = rf(_a0, _a1)
 	} else {
@@ -65,13 +61,7 @@ func (_m *Application) CheckTx(_a0 context.Context, _a1 *types.RequestCheckTxV2)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *types.RequestCheckTxV2) error); ok {
-		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // Commit provides a mock function with given fields: _a0

--- a/sei-tendermint/abci/types/types.go
+++ b/sei-tendermint/abci/types/types.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/crypto"
@@ -17,6 +18,13 @@ const (
 // IsOK returns true if Code is OK.
 func (r ResponseCheckTx) IsOK() bool {
 	return r.Code == CodeTypeOK
+}
+
+func (r ResponseCheckTx) Err() error {
+	if r.IsOK() {
+		return nil
+	}
+	return errors.New(r.Log)
 }
 
 // IsErr returns true if Code is something other than OK.

--- a/sei-tendermint/internal/consensus/mempool_test.go
+++ b/sei-tendermint/internal/consensus/mempool_test.go
@@ -325,18 +325,16 @@ func (app *CounterApplication) FinalizeBlock(_ context.Context, req *abci.Reques
 	return res, nil
 }
 
-func (app *CounterApplication) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) (*abci.ResponseCheckTxV2, error) {
+func (app *CounterApplication) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) *abci.ResponseCheckTxV2 {
 	app.mu.Lock()
 	defer app.mu.Unlock()
 
 	txValue := txAsUint64(req.Tx)
 	if txValue != uint64(app.mempoolTxCount) {
-		return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{
-			Code: code.CodeTypeBadNonce,
-		}}, nil
+		return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{Code: code.CodeTypeBadNonce}}
 	}
 	app.mempoolTxCount++
-	return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{Code: code.CodeTypeOK}}, nil
+	return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{Code: code.CodeTypeOK}}
 }
 
 func txAsUint64(tx []byte) uint64 {

--- a/sei-tendermint/internal/mempool/mempool.go
+++ b/sei-tendermint/internal/mempool/mempool.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -387,11 +386,11 @@ func (txmp *TxMempool) CheckTx(ctx context.Context, tx types.Tx, txInfo TxInfo) 
 
 		hint, err := txmp.app.GetTxPriorityHint(ctx, &abci.RequestGetTxPriorityHintV2{Tx: tx})
 		if err != nil {
-			txmp.metrics.observeCheckTxPriorityDistribution(0, true, txInfo.SenderNodeID, err)
+			txmp.metrics.observeCheckTxPriorityDistribution(0, true, txInfo.SenderNodeID, true)
 			logger.Error("failed to get tx priority hint", "err", err)
 			return nil, err
 		}
-		txmp.metrics.observeCheckTxPriorityDistribution(hint.Priority, true, txInfo.SenderNodeID, nil)
+		txmp.metrics.observeCheckTxPriorityDistribution(hint.Priority, true, txInfo.SenderNodeID, false)
 
 		cutoff, found := txmp.priorityReservoir.Percentile()
 		if found && hint.Priority <= cutoff {
@@ -420,14 +419,14 @@ func (txmp *TxMempool) CheckTx(ctx context.Context, tx types.Tx, txInfo TxInfo) 
 		txmp.metrics.NumberOfLocalCheckTx.Add(1)
 	}
 	res, err := txmp.app.CheckTxSafe(ctx, &abci.RequestCheckTxV2{Tx: tx})
-	if err != nil {
+	if err != nil || !res.IsOK() {
 		txmp.metrics.NumberOfFailedCheckTxs.Add(1)
-		txmp.metrics.observeCheckTxPriorityDistribution(0, false, txInfo.SenderNodeID, err)
+		txmp.metrics.observeCheckTxPriorityDistribution(0, false, txInfo.SenderNodeID, true)
 		txmp.cache.Remove(txHash)
-		return nil, err
+		return res.ResponseCheckTx, err
 	}
 	txmp.metrics.NumberOfSuccessfulCheckTxs.Add(1)
-	txmp.metrics.observeCheckTxPriorityDistribution(res.Priority, false, txInfo.SenderNodeID, nil)
+	txmp.metrics.observeCheckTxPriorityDistribution(res.Priority, false, txInfo.SenderNodeID, false)
 
 	wtx := &WrappedTx{
 		hashedTx:   newHashedTx(tx),
@@ -1063,8 +1062,12 @@ func (txmp *TxMempool) updateReCheckTxs(ctx context.Context) {
 				Tx:   wtx.Tx(),
 				Type: abci.CheckTxTypeV2Recheck,
 			})
+			if err == nil {
+				err = res.Err()
+			}
 			if err != nil {
 				// no need in retrying since the tx will be rechecked after the next block
+
 				logger.Debug("failed to execute CheckTx during recheck", "err", err, "hash", wtx.Hash())
 				continue
 			}
@@ -1243,20 +1246,6 @@ func (txmp *TxMempool) notifyTxsAvailable() {
 	case txmp.txsAvailable <- struct{}{}:
 	default:
 	}
-}
-
-// AppendCheckTxErr wraps error message into an ABCIMessageLogs json string
-func (txmp *TxMempool) AppendCheckTxErr(existingLogs string, log string) string {
-	var builder strings.Builder
-
-	builder.WriteString(existingLogs)
-	// If there are already logs, append the new log with a separator
-	if builder.Len() > 0 {
-		builder.WriteString("; ")
-	}
-	builder.WriteString(log)
-
-	return builder.String()
 }
 
 func (txmp *TxMempool) handlePendingTransactions() {

--- a/sei-tendermint/internal/mempool/mempool.go
+++ b/sei-tendermint/internal/mempool/mempool.go
@@ -423,7 +423,12 @@ func (txmp *TxMempool) CheckTx(ctx context.Context, tx types.Tx, txInfo TxInfo) 
 		txmp.metrics.NumberOfFailedCheckTxs.Add(1)
 		txmp.metrics.observeCheckTxPriorityDistribution(0, false, txInfo.SenderNodeID, true)
 		txmp.cache.Remove(txHash)
-		return res.ResponseCheckTx, err
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !res.IsOK() {
+		return res.ResponseCheckTx, nil
 	}
 	txmp.metrics.NumberOfSuccessfulCheckTxs.Add(1)
 	txmp.metrics.observeCheckTxPriorityDistribution(res.Priority, false, txInfo.SenderNodeID, false)

--- a/sei-tendermint/internal/mempool/mempool_test.go
+++ b/sei-tendermint/internal/mempool/mempool_test.go
@@ -40,7 +40,7 @@ type testTx struct {
 var DefaultGasEstimated = int64(1)
 var DefaultGasWanted = int64(1)
 
-func (app *application) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) (*abci.ResponseCheckTxV2, error) {
+func (app *application) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) *abci.ResponseCheckTxV2 {
 
 	var priority int64
 
@@ -67,7 +67,7 @@ func (app *application) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) (
 				Code:         100,
 				GasWanted:    gasWanted,
 				GasEstimated: gasEstimated,
-			}}, nil
+			}}
 		}
 		nonce, err := strconv.ParseUint(string(parts[3]), 10, 64)
 		if err != nil {
@@ -77,7 +77,7 @@ func (app *application) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) (
 				Code:         101,
 				GasWanted:    gasWanted,
 				GasEstimated: gasEstimated,
-			}}, nil
+			}}
 		}
 		if app.occupiedNonces == nil {
 			app.occupiedNonces = make(map[string][]uint64)
@@ -126,7 +126,7 @@ func (app *application) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) (
 		if !active {
 			res.IsPending = utils.Some(abci.PendingTxChecker(func() abci.PendingTxCheckerResponse { return abci.Pending }))
 		}
-		return res, nil
+		return res
 	}
 
 	// infer the priority from the raw transaction value (sender=key=value)
@@ -139,7 +139,7 @@ func (app *application) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) (
 				Code:         100,
 				GasWanted:    gasWanted,
 				GasEstimated: gasEstimated,
-			}}, nil
+			}}
 		}
 
 		priority = v
@@ -149,14 +149,14 @@ func (app *application) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) (
 			Code:         101,
 			GasWanted:    gasWanted,
 			GasEstimated: gasEstimated,
-		}}, nil
+		}}
 	}
 	return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{
 		Priority:     priority,
 		Code:         code.CodeTypeOK,
 		GasWanted:    gasWanted,
 		GasEstimated: gasEstimated,
-	}}, nil
+	}}
 }
 
 func (app *application) GetTxPriorityHint(context.Context, *abci.RequestGetTxPriorityHintV2) (*abci.ResponseGetTxPriorityHint, error) {
@@ -953,24 +953,6 @@ func TestTxMempool_ExpiredTxs_NumBlocks(t *testing.T) {
 
 	require.GreaterOrEqual(t, txmp.Size(), 45)
 	require.GreaterOrEqual(t, txmp.expirationIndex.Size(), 45)
-}
-
-func TestAppendCheckTxErr(t *testing.T) {
-	client := &application{Application: kvstore.NewApplication()}
-	txmp := setup(t, proxy.New(client, proxy.NopMetrics()), 500, NopTxConstraintsFetcher)
-	existingLogData := "existing error log"
-	newLogData := "sample error log"
-
-	// Append new error
-	actualResult := txmp.AppendCheckTxErr(existingLogData, newLogData)
-	expectedResult := fmt.Sprintf("%s; %s", existingLogData, newLogData)
-
-	require.Equal(t, expectedResult, actualResult)
-
-	// Append new error to empty log
-	actualResult = txmp.AppendCheckTxErr("", newLogData)
-
-	require.Equal(t, newLogData, actualResult)
 }
 
 func TestMempoolExpiration(t *testing.T) {

--- a/sei-tendermint/internal/mempool/metrics.go
+++ b/sei-tendermint/internal/mempool/metrics.go
@@ -105,11 +105,11 @@ type Metrics struct {
 	CheckTxMetDropUtilisationThreshold metrics.Counter
 }
 
-func (m *Metrics) observeCheckTxPriorityDistribution(priority int64, hint bool, senderNodeID types.NodeID, err error) {
+func (m *Metrics) observeCheckTxPriorityDistribution(priority int64, hint bool, senderNodeID types.NodeID, isError bool) {
 	normalizedPriority := float64(priority) / float64(math.MaxInt64) // Normalize to [0.0, 1.0]
 	m.CheckTxPriorityDistribution.With(
 		"hint", strconv.FormatBool(hint),
 		"local", strconv.FormatBool(senderNodeID == ""),
-		"error", strconv.FormatBool(err != nil),
+		"error", strconv.FormatBool(isError),
 	).Observe(normalizedPriority)
 }

--- a/sei-tendermint/internal/mempool/recheck_drain_test.go
+++ b/sei-tendermint/internal/mempool/recheck_drain_test.go
@@ -56,10 +56,10 @@ func (a *evmNonceApp) parseTx(tx []byte) (sender string, nonce uint64, priority 
 	return string(parts[1]), n, p, true
 }
 
-func (a *evmNonceApp) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) (*abci.ResponseCheckTxV2, error) {
+func (a *evmNonceApp) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) *abci.ResponseCheckTxV2 {
 	sender, nonce, priority, ok := a.parseTx(req.Tx)
 	if !ok {
-		return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{Code: 1}}, nil
+		return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{Code: 1}}
 	}
 
 	a.mu.Lock()
@@ -68,7 +68,7 @@ func (a *evmNonceApp) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) (*a
 
 	if nonce < expected {
 		// Already mined. Reject.
-		return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{Code: 2}}, nil
+		return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{Code: 2}}
 	}
 
 	res := &abci.ResponseCheckTxV2{
@@ -104,7 +104,7 @@ func (a *evmNonceApp) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) (*a
 			}
 		}))
 	}
-	return res, nil
+	return res
 }
 
 func (a *evmNonceApp) GetTxPriorityHint(context.Context, *abci.RequestGetTxPriorityHintV2) (*abci.ResponseGetTxPriorityHint, error) {

--- a/sei-tendermint/internal/p2p/giga_router_test.go
+++ b/sei-tendermint/internal/p2p/giga_router_test.go
@@ -90,13 +90,13 @@ func (a *testApp) Info(_ context.Context, _ *abci.RequestInfo) (*abci.ResponseIn
 	panic("unreachable")
 }
 
-func (a *testApp) CheckTx(context.Context, *abci.RequestCheckTxV2) (*abci.ResponseCheckTxV2, error) {
+func (a *testApp) CheckTx(context.Context, *abci.RequestCheckTxV2) *abci.ResponseCheckTxV2 {
 	return &abci.ResponseCheckTxV2{
 		ResponseCheckTx: &abci.ResponseCheckTx{
 			Code:      abci.CodeTypeOK,
 			GasWanted: 1,
 		},
-	}, nil
+	}
 }
 
 func (a *testApp) InitChain(_ context.Context, req *abci.RequestInitChain) (*abci.ResponseInitChain, error) {

--- a/sei-tendermint/internal/proxy/proxy.go
+++ b/sei-tendermint/internal/proxy/proxy.go
@@ -54,7 +54,7 @@ func (app *Proxy) CheckTxSafe(ctx context.Context, req *types.RequestCheckTxV2) 
 			err = fmt.Errorf("panic recovered in CheckTxSafe: %v\n%v", r, string(debug.Stack()))
 		}
 	}()
-	return app.app.CheckTx(ctx, req)
+	return app.app.CheckTx(ctx, req), nil
 }
 
 func (app *Proxy) Info(ctx context.Context, req *types.RequestInfo) (*types.ResponseInfo, error) {

--- a/sei-tendermint/internal/proxy/proxy_test.go
+++ b/sei-tendermint/internal/proxy/proxy_test.go
@@ -12,7 +12,7 @@ type panicCheckTxApp struct {
 	types.BaseApplication
 }
 
-func (panicCheckTxApp) CheckTx(_ context.Context, _ *types.RequestCheckTxV2) (*types.ResponseCheckTxV2, error) {
+func (panicCheckTxApp) CheckTx(_ context.Context, _ *types.RequestCheckTxV2) *types.ResponseCheckTxV2 {
 	panic("boom")
 }
 

--- a/sei-tendermint/internal/state/helpers_test.go
+++ b/sei-tendermint/internal/state/helpers_test.go
@@ -317,8 +317,8 @@ func (app *testApp) FinalizeBlock(_ context.Context, req *abci.RequestFinalizeBl
 	}, nil
 }
 
-func (app *testApp) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) (*abci.ResponseCheckTxV2, error) {
-	return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{}}, nil
+func (app *testApp) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) *abci.ResponseCheckTxV2 {
+	return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{}}
 }
 
 func (app *testApp) Commit(context.Context) (*abci.ResponseCommit, error) {

--- a/sei-tendermint/test/e2e/app/app.go
+++ b/sei-tendermint/test/e2e/app/app.go
@@ -145,7 +145,7 @@ func (app *Application) InitChain(_ context.Context, req *abci.RequestInitChain)
 }
 
 // CheckTx implements ABCI.
-func (app *Application) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) (*abci.ResponseCheckTxV2, error) {
+func (app *Application) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) *abci.ResponseCheckTxV2 {
 	app.mu.Lock()
 	defer app.mu.Unlock()
 
@@ -153,7 +153,7 @@ func (app *Application) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) (
 	if err != nil {
 		return &abci.ResponseCheckTxV2{
 			ResponseCheckTx: &abci.ResponseCheckTx{Code: code.CodeTypeEncodingError},
-		}, nil
+		}
 	}
 
 	if app.cfg.CheckTxDelayMS != 0 {
@@ -162,7 +162,7 @@ func (app *Application) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) (
 
 	return &abci.ResponseCheckTxV2{
 		ResponseCheckTx: &abci.ResponseCheckTx{Code: code.CodeTypeOK, GasWanted: 1},
-	}, nil
+	}
 }
 
 // FinalizeBlock implements ABCI.


### PR DESCRIPTION
https://github.com/sei-protocol/sei-chain/pull/3334 made TxMempool.CheckTx and Application.CheckTx return an error instead of ResponseCheckTx with an error code. This PR reverts to the previous behavior. Since there is no case in which Application.CheckTx returns unwrapped error, the signature has been tightened to always return ResponseCheckTxV2. Proxy.CheckTxSafe() keeps returning (*ResponseCheckTxV2,error) though, so that in case of panic the stack trace is not send as part of the RPC response.