### PR TITLE
Regenerate v6.5 changelog in prep to cut rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 # Changelog
 ## v6.5
 sei-chain
+* [#3378](https://github.com/sei-protocol/sei-chain/pull/3378) Backport `release/v6.5`: Update v6.5 changelog in prep to release rc1
 * [#3367](https://github.com/sei-protocol/sei-chain/pull/3367) Backport `release/v6.5`: fix(evmrpc): return null for out-of-range index in eth_getTransactionByBlock*AndIndex
 * [#3364](https://github.com/sei-protocol/sei-chain/pull/3364) Backport `release/v6.5`: V6.5 upgrade handler
 * [#3356](https://github.com/sei-protocol/sei-chain/pull/3356) Backport `release/v6.5`: Use exact v6.5 upgrade name


### PR DESCRIPTION
Add the latest changes to changelog in prep to cut rc1 tag
