### PR TITLE
feat: gate block-validation bypasses behind //go:build mock_block_validation

### DIFF
--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -50,6 +50,18 @@ jobs:
           build-args: |
             SEI_CHAIN_REF=${{ inputs.ref || github.sha }}
             GO_BUILD_TAGS=mock_balances
+      - name: Build and push seid with mock block validation
+        uses: docker/build-push-action@v6
+        with:
+          context: '.'
+          cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:shared
+          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:shared,mode=max
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.login-ecr.outputs.registry }}/sei/sei-chain:mock_block_validation-${{ inputs.tag || inputs.ref || github.sha }}
+          build-args: |
+            SEI_CHAIN_REF=${{ inputs.ref || github.sha }}
+            GO_BUILD_TAGS=mock_block_validation
       - name: Build and push seid
         uses: docker/build-push-action@v6
         with:

--- a/sei-cosmos/server/start.go
+++ b/sei-cosmos/server/start.go
@@ -343,6 +343,7 @@ func startInProcess(
 			gen,
 			tracerProviderOptions,
 			nodeMetricsProvider,
+			tmtypes.DefaultConsensusPolicy(),
 		)
 		if err != nil {
 			return fmt.Errorf("error creating node: %w", err)

--- a/sei-cosmos/testutil/network/util.go
+++ b/sei-cosmos/testutil/network/util.go
@@ -58,6 +58,7 @@ func startInProcess(cfg Config, val *Validator) error {
 		defaultGensis,
 		[]trace.TracerProviderOption{},
 		node.NoOpMetricsProvider(),
+		types.DefaultConsensusPolicy(),
 	)
 
 	if err != nil {

--- a/sei-tendermint/internal/blocksync/reactor_test.go
+++ b/sei-tendermint/internal/blocksync/reactor_test.go
@@ -107,6 +107,7 @@ func makeReactor(
 		blockStore,
 		eventbus,
 		sm.NopMetrics(),
+		types.DefaultConsensusPolicy(),
 	)
 
 	r, err := NewReactor(

--- a/sei-tendermint/internal/consensus/common_test.go
+++ b/sei-tendermint/internal/consensus/common_test.go
@@ -519,7 +519,7 @@ func newStateWithConfigAndBlockStore(
 		panic(fmt.Errorf("eventBus.Start(): %w", err))
 	}
 
-	blockExec := sm.NewBlockExecutor(stateStore, app, mempool, evpool, blockStore, eventBus, sm.NopMetrics())
+	blockExec := sm.NewBlockExecutor(stateStore, app, mempool, evpool, blockStore, eventBus, sm.NopMetrics(), types.DefaultConsensusPolicy())
 	wal, err := OpenWAL(thisConfig.Consensus.WalFile())
 	if err != nil {
 		panic(err)

--- a/sei-tendermint/internal/consensus/reactor_test.go
+++ b/sei-tendermint/internal/consensus/reactor_test.go
@@ -294,7 +294,7 @@ func TestReactorWithEvidence(t *testing.T) {
 		eventBus := eventbus.NewDefault()
 		require.NoError(t, eventBus.Start(ctx))
 
-		blockExec := sm.NewBlockExecutor(stateStore, proxyApp, mempool, evpool, blockStore, eventBus, sm.NopMetrics())
+		blockExec := sm.NewBlockExecutor(stateStore, proxyApp, mempool, evpool, blockStore, eventBus, sm.NopMetrics(), types.DefaultConsensusPolicy())
 		wal, err := OpenWAL(thisConfig.Consensus.WalFile())
 		require.NoError(t, err)
 

--- a/sei-tendermint/internal/consensus/replay.go
+++ b/sei-tendermint/internal/consensus/replay.go
@@ -110,11 +110,12 @@ func (cs *State) catchupReplay(ctx context.Context, csHeight int64) error {
 //---------------------------------------------------
 
 type Handshaker struct {
-	stateStore   sm.Store
-	initialState sm.State
-	store        sm.BlockStore
-	eventBus     *eventbus.EventBus
-	genDoc       *types.GenesisDoc
+	stateStore      sm.Store
+	initialState    sm.State
+	store           sm.BlockStore
+	eventBus        *eventbus.EventBus
+	genDoc          *types.GenesisDoc
+	consensusPolicy types.ConsensusPolicy
 
 	nBlocks int // number of blocks applied to the state
 }
@@ -125,13 +126,15 @@ func NewHandshaker(
 	store sm.BlockStore,
 	eventBus *eventbus.EventBus,
 	genDoc *types.GenesisDoc,
+	consensusPolicy types.ConsensusPolicy,
 ) *Handshaker {
 	return &Handshaker{
-		stateStore:   stateStore,
-		initialState: state,
-		store:        store,
-		eventBus:     eventBus,
-		genDoc:       genDoc,
+		stateStore:      stateStore,
+		initialState:    state,
+		store:           store,
+		eventBus:        eventBus,
+		genDoc:          genDoc,
+		consensusPolicy: consensusPolicy,
 	}
 }
 
@@ -392,7 +395,7 @@ func (h *Handshaker) replayBlocks(
 		if i == finalBlock && !mutateState {
 			// We emit events for the index services at the final block due to the sync issue when
 			// the node shutdown during the block committing status.
-			blockExec := sm.NewBlockExecutor(h.stateStore, app, newReplayTxMempool(app), sm.EmptyEvidencePool{}, h.store, h.eventBus, sm.NopMetrics())
+			blockExec := sm.NewBlockExecutor(h.stateStore, app, newReplayTxMempool(app), sm.EmptyEvidencePool{}, h.store, h.eventBus, sm.NopMetrics(), h.consensusPolicy)
 			appHash, err = sm.ExecCommitBlock(ctx,
 				blockExec, app, block, h.stateStore, h.genDoc.InitialHeight, state)
 			if err != nil {
@@ -435,7 +438,7 @@ func (h *Handshaker) replayBlock(
 
 	// Use stubs for both mempool and evidence pool since no transactions nor
 	// evidence are needed here - block already exists.
-	blockExec := sm.NewBlockExecutor(h.stateStore, app, newReplayTxMempool(app), sm.EmptyEvidencePool{}, h.store, h.eventBus, sm.NopMetrics())
+	blockExec := sm.NewBlockExecutor(h.stateStore, app, newReplayTxMempool(app), sm.EmptyEvidencePool{}, h.store, h.eventBus, sm.NopMetrics(), h.consensusPolicy)
 
 	var err error
 	state, err = blockExec.ApplyBlock(ctx, state, meta.BlockID, block, nil)

--- a/sei-tendermint/internal/consensus/replay_test.go
+++ b/sei-tendermint/internal/consensus/replay_test.go
@@ -696,7 +696,7 @@ func testHandshakeReplay(
 	// now start the app using the handshake - it should sync
 	genDoc, err := sm.MakeGenesisDocFromFile(cfg.GenesisFile())
 	require.NoError(t, err)
-	handshaker := NewHandshaker(stateStore, state, store, eventBus, genDoc)
+	handshaker := NewHandshaker(stateStore, state, store, eventBus, genDoc, types.DefaultConsensusPolicy())
 	proxyApp := proxy.New(app, proxy.NopMetrics())
 	err = handshaker.Handshake(ctx, proxyApp)
 	if expectError {
@@ -744,7 +744,7 @@ func applyBlock(
 	eventBus *eventbus.EventBus,
 ) sm.State {
 	testPartSize := types.BlockPartSizeBytes
-	blockExec := sm.NewBlockExecutor(stateStore, appClient, mempool, evpool, blockStore, eventBus, sm.NopMetrics())
+	blockExec := sm.NewBlockExecutor(stateStore, appClient, mempool, evpool, blockStore, eventBus, sm.NopMetrics(), types.DefaultConsensusPolicy())
 
 	bps, err := blk.MakePartSet(testPartSize)
 	require.NoError(t, err)
@@ -882,7 +882,7 @@ func TestHandshakeErrorsIfAppReturnsWrongAppHash(t *testing.T) {
 	//		- 0x03
 	{
 		app := &badApp{numBlocks: 3, allHashesAreWrong: true}
-		h := NewHandshaker(stateStore, state, store, eventBus, genDoc)
+		h := NewHandshaker(stateStore, state, store, eventBus, genDoc, types.DefaultConsensusPolicy())
 		proxyApp := proxy.New(app, proxy.NopMetrics())
 		assert.Error(t, h.Handshake(ctx, proxyApp))
 	}
@@ -893,7 +893,7 @@ func TestHandshakeErrorsIfAppReturnsWrongAppHash(t *testing.T) {
 	//		- RANDOM HASH
 	{
 		app := &badApp{numBlocks: 3, onlyLastHashIsWrong: true}
-		h := NewHandshaker(stateStore, state, store, eventBus, genDoc)
+		h := NewHandshaker(stateStore, state, store, eventBus, genDoc, types.DefaultConsensusPolicy())
 		proxyApp := proxy.New(app, proxy.NopMetrics())
 		require.Error(t, h.Handshake(ctx, proxyApp))
 	}
@@ -1122,7 +1122,7 @@ func TestHandshakeUpdatesValidators(t *testing.T) {
 	// now start the app using the handshake - it should sync
 	genDoc, err = sm.MakeGenesisDocFromFile(cfg.GenesisFile())
 	require.NoError(t, err)
-	handshaker := NewHandshaker(stateStore, state, store, eventBus, genDoc)
+	handshaker := NewHandshaker(stateStore, state, store, eventBus, genDoc, types.DefaultConsensusPolicy())
 	proxyApp := proxy.New(app, proxy.NopMetrics())
 	require.NoError(t, handshaker.Handshake(ctx, proxyApp), "error on abci handshake")
 

--- a/sei-tendermint/internal/state/execution.go
+++ b/sei-tendermint/internal/state/execution.go
@@ -53,6 +53,12 @@ type BlockExecutor struct {
 
 	metrics *Metrics
 
+	// consensusPolicy is a compile-time validation bypass that only takes
+	// effect in mock_block_validation builds; production binaries always see
+	// the zero-value (no bypass). Distinct from types.SkipLastResultsHashValidation
+	// below, which is a runtime atomic.Bool flipped on for the Giga executor.
+	consensusPolicy types.ConsensusPolicy
+
 	// cache the verification results over a single height
 	cache map[string]struct{}
 }
@@ -66,16 +72,18 @@ func NewBlockExecutor(
 	blockStore BlockStore,
 	eventBus *eventbus.EventBus,
 	metrics *Metrics,
+	consensusPolicy types.ConsensusPolicy,
 ) *BlockExecutor {
 	return &BlockExecutor{
-		eventBus:   eventBus,
-		store:      stateStore,
-		app:        app,
-		mempool:    pool,
-		evpool:     evpool,
-		metrics:    metrics,
-		cache:      make(map[string]struct{}),
-		blockStore: blockStore,
+		eventBus:        eventBus,
+		store:           stateStore,
+		app:             app,
+		mempool:         pool,
+		evpool:          evpool,
+		metrics:         metrics,
+		cache:           make(map[string]struct{}),
+		blockStore:      blockStore,
+		consensusPolicy: consensusPolicy,
 	}
 }
 
@@ -156,7 +164,7 @@ func (blockExec *BlockExecutor) ValidateBlock(ctx context.Context, state State, 
 		return nil
 	}
 
-	err := validateBlock(state, block)
+	err := validateBlock(state, block, blockExec.consensusPolicy)
 	if err != nil {
 		// Check if this is a LastResultsHash mismatch and log detailed info
 		if !types.SkipLastResultsHashValidation.Load() && !bytes.Equal(block.LastResultsHash, state.LastResultsHash) {

--- a/sei-tendermint/internal/state/execution_test.go
+++ b/sei-tendermint/internal/state/execution_test.go
@@ -57,7 +57,7 @@ func TestApplyBlock(t *testing.T) {
 	blockStore := store.NewBlockStore(dbm.NewMemDB())
 	proxyApp := proxy.New(app, proxy.NopMetrics())
 	mp := makeTxMempool(t, proxyApp)
-	blockExec := sm.NewBlockExecutor(stateStore, proxyApp, mp, sm.EmptyEvidencePool{}, blockStore, eventBus, sm.NopMetrics())
+	blockExec := sm.NewBlockExecutor(stateStore, proxyApp, mp, sm.EmptyEvidencePool{}, blockStore, eventBus, sm.NopMetrics(), types.DefaultConsensusPolicy())
 
 	block := sf.MakeBlock(state, 1, new(types.Commit))
 	bps, err := block.MakePartSet(testPartSize)
@@ -101,7 +101,7 @@ func TestApplyBlockProposerPriorityHash(t *testing.T) {
 	testMetrics.ProposerPriorityHash = hashGauge
 	testMetrics.ProposerPriorityHashHeight = heightGauge
 
-	blockExec := sm.NewBlockExecutor(stateStore, proxyApp, mp, evpool, blockStore, eventBus, testMetrics)
+	blockExec := sm.NewBlockExecutor(stateStore, proxyApp, mp, evpool, blockStore, eventBus, testMetrics, types.DefaultConsensusPolicy())
 
 	// Apply blocks 1..interval. Only height == interval should emit the metric.
 	var lastCommit *types.Commit = new(types.Commit)
@@ -162,7 +162,7 @@ func TestFinalizeBlockDecidedLastCommit(t *testing.T) {
 			eventBus := eventbus.NewDefault()
 			require.NoError(t, eventBus.Start(ctx))
 
-			blockExec := sm.NewBlockExecutor(stateStore, proxyApp, mp, evpool, blockStore, eventBus, sm.NopMetrics())
+			blockExec := sm.NewBlockExecutor(stateStore, proxyApp, mp, evpool, blockStore, eventBus, sm.NopMetrics(), types.DefaultConsensusPolicy())
 			state, _, lastCommit := makeAndCommitGoodBlock(ctx, t, state, 1, new(types.Commit), state.NextValidators.Validators[0].Address, blockExec, privVals, nil)
 
 			for idx, isAbsent := range tc.absentCommitSigs {
@@ -275,7 +275,7 @@ func TestFinalizeBlockByzantineValidators(t *testing.T) {
 
 	blockStore := store.NewBlockStore(dbm.NewMemDB())
 
-	blockExec := sm.NewBlockExecutor(stateStore, proxyApp, mp, evpool, blockStore, eventBus, sm.NopMetrics())
+	blockExec := sm.NewBlockExecutor(stateStore, proxyApp, mp, evpool, blockStore, eventBus, sm.NopMetrics(), types.DefaultConsensusPolicy())
 
 	block := sf.MakeBlock(state, 1, new(types.Commit))
 	block.Evidence = ev
@@ -316,6 +316,7 @@ func TestProcessProposal(t *testing.T) {
 		blockStore,
 		eventBus,
 		sm.NopMetrics(),
+		types.DefaultConsensusPolicy(),
 	)
 
 	block0 := sf.MakeBlock(state, height-1, new(types.Commit))
@@ -513,6 +514,7 @@ func TestFinalizeBlockValidatorUpdates(t *testing.T) {
 		blockStore,
 		eventBus,
 		sm.NopMetrics(),
+		types.DefaultConsensusPolicy(),
 	)
 
 	updatesSub, err := eventBus.SubscribeWithArgs(ctx, pubsub.SubscribeArgs{
@@ -577,6 +579,7 @@ func TestFinalizeBlockValidatorUpdatesResultingInEmptySet(t *testing.T) {
 		blockStore,
 		eventBus,
 		sm.NopMetrics(),
+		types.DefaultConsensusPolicy(),
 	)
 
 	block := sf.MakeBlock(state, 1, new(types.Commit))

--- a/sei-tendermint/internal/state/validation.go
+++ b/sei-tendermint/internal/state/validation.go
@@ -11,9 +11,9 @@ import (
 //-----------------------------------------------------
 // Validate block
 
-func validateBlock(state State, block *types.Block) error {
+func validateBlock(state State, block *types.Block, policy types.ConsensusPolicy) error {
 	// Validate internal consistency.
-	if err := block.ValidateBasic(); err != nil {
+	if err := block.ValidateBasic(policy); err != nil {
 		return fmt.Errorf("ValidateBasic(): %w", err)
 	}
 
@@ -49,7 +49,7 @@ func validateBlock(state State, block *types.Block) error {
 	}
 
 	// Validate app info
-	if !bytes.Equal(block.AppHash, state.AppHash) {
+	if !policy.SkipAppHashValidation() && !bytes.Equal(block.AppHash, state.AppHash) {
 		return fmt.Errorf("wrong Block.Header.AppHash.  Expected %X, got %v",
 			state.AppHash,
 			block.AppHash,

--- a/sei-tendermint/internal/state/validation_test.go
+++ b/sei-tendermint/internal/state/validation_test.go
@@ -50,6 +50,7 @@ func TestValidateBlockHeader(t *testing.T) {
 		blockStore,
 		eventBus,
 		sm.NopMetrics(),
+		types.DefaultConsensusPolicy(),
 	)
 	lastCommit := &types.Commit{}
 
@@ -143,6 +144,7 @@ func TestValidateBlockCommit(t *testing.T) {
 		blockStore,
 		eventBus,
 		sm.NopMetrics(),
+		types.DefaultConsensusPolicy(),
 	)
 	lastCommit := &types.Commit{}
 	wrongSigsCommit := &types.Commit{Height: 1}
@@ -280,6 +282,7 @@ func TestValidateBlockEvidence(t *testing.T) {
 		blockStore,
 		eventBus,
 		sm.NopMetrics(),
+		types.DefaultConsensusPolicy(),
 	)
 	lastCommit := &types.Commit{}
 

--- a/sei-tendermint/light/rpc/client.go
+++ b/sei-tendermint/light/rpc/client.go
@@ -357,7 +357,7 @@ func (c *Client) Block(ctx context.Context, height *int64) (*coretypes.ResultBlo
 	if err := res.BlockID.ValidateBasic(); err != nil {
 		return nil, err
 	}
-	if err := res.Block.ValidateBasic(); err != nil {
+	if err := res.Block.ValidateBasic(types.DefaultConsensusPolicy()); err != nil {
 		return nil, err
 	}
 	if bmH, bH := res.BlockID.Hash, res.Block.Hash(); !bytes.Equal(bmH, bH) {
@@ -391,7 +391,7 @@ func (c *Client) BlockByHash(ctx context.Context, hash tmbytes.HexBytes) (*coret
 	if err := res.BlockID.ValidateBasic(); err != nil {
 		return nil, err
 	}
-	if err := res.Block.ValidateBasic(); err != nil {
+	if err := res.Block.ValidateBasic(types.DefaultConsensusPolicy()); err != nil {
 		return nil, err
 	}
 	if bmH, bH := res.BlockID.Hash, res.Block.Hash(); !bytes.Equal(bmH, bH) {

--- a/sei-tendermint/node/node.go
+++ b/sei-tendermint/node/node.go
@@ -53,6 +53,7 @@ type nodeImpl struct {
 	genesisDoc      *types.GenesisDoc   // initial validator set
 	privValidator   types.PrivValidator // local node's validator key
 	shouldHandshake bool                // set during makeNode
+	consensusPolicy types.ConsensusPolicy
 
 	// network
 	router           *p2p.Router
@@ -87,6 +88,7 @@ func makeNode(
 	dbProvider config.DBProvider,
 	tracerProviderOptions []trace.TracerProviderOption,
 	nodeMetrics *NodeMetrics,
+	consensusPolicy types.ConsensusPolicy,
 ) (_ service.Service, err error) {
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithCancel(ctx)
@@ -157,9 +159,10 @@ func makeNode(
 	}
 	// TODO construct node here:
 	node := &nodeImpl{
-		config:        cfg,
-		genesisDoc:    genDoc,
-		privValidator: privValidator,
+		config:          cfg,
+		genesisDoc:      genDoc,
+		privValidator:   privValidator,
+		consensusPolicy: consensusPolicy,
 
 		nodeKey: nodeKey,
 
@@ -240,6 +243,7 @@ func makeNode(
 		blockStore,
 		eventBus,
 		nodeMetrics.state,
+		consensusPolicy,
 	)
 
 	// Determine whether we should attempt state sync.
@@ -426,7 +430,7 @@ func (n *nodeImpl) OnStart(ctx context.Context) error {
 		// Create the handshaker, which calls RequestInfo, sets the AppVersion on the state,
 		// and replays any blocks as necessary to sync tendermint with the app.
 		if err := consensus.NewHandshaker(
-			n.stateStore, n.initialState, n.blockStore, n.rpcEnv.EventBus, n.genesisDoc,
+			n.stateStore, n.initialState, n.blockStore, n.rpcEnv.EventBus, n.genesisDoc, n.consensusPolicy,
 		).Handshake(ctx, n.rpcEnv.App); err != nil {
 			return err
 		}

--- a/sei-tendermint/node/node_test.go
+++ b/sei-tendermint/node/node_test.go
@@ -49,6 +49,7 @@ func newLocalNodeService(ctx context.Context, cfg *config.Config) (service.Servi
 		nil,
 		nil,
 		DefaultMetricsProvider(cfg.Instrumentation)(cfg.ChainID()),
+		types.DefaultConsensusPolicy(),
 	)
 }
 
@@ -116,6 +117,7 @@ func TestNodeRestartEventAllowsRecreate(t *testing.T) {
 			nil,
 			nil,
 			DefaultMetricsProvider(cfg.Instrumentation)(cfg.ChainID()),
+			types.DefaultConsensusPolicy(),
 		)
 		require.NoError(t, err)
 		return n
@@ -363,6 +365,7 @@ func TestCreateProposalBlock(t *testing.T) {
 		blockStore,
 		eventBus,
 		sm.NopMetrics(),
+		types.DefaultConsensusPolicy(),
 	)
 
 	commit := &types.Commit{Height: height - 1}
@@ -437,6 +440,7 @@ func TestMaxTxsProposalBlockSize(t *testing.T) {
 		blockStore,
 		eventBus,
 		sm.NopMetrics(),
+		types.DefaultConsensusPolicy(),
 	)
 
 	commit := &types.Commit{Height: height - 1}
@@ -508,6 +512,7 @@ func TestMaxProposalBlockSize(t *testing.T) {
 		blockStore,
 		eventBus,
 		sm.NopMetrics(),
+		types.DefaultConsensusPolicy(),
 	)
 
 	blockID := types.BlockID{

--- a/sei-tendermint/node/public.go
+++ b/sei-tendermint/node/public.go
@@ -30,6 +30,7 @@ func New(
 	gen *tmtypes.GenesisDoc,
 	tracerProviderOptions []trace.TracerProviderOption,
 	nodeMetrics *NodeMetrics,
+	consensusPolicy tmtypes.ConsensusPolicy,
 ) (service.Service, error) {
 	proxyApp := proxy.New(app, nodeMetrics.proxy)
 	nodeKey, err := tmtypes.LoadOrGenNodeKey(conf.NodeKeyFile())
@@ -63,6 +64,7 @@ func New(
 			config.DefaultDBProvider,
 			tracerProviderOptions,
 			nodeMetrics,
+			consensusPolicy,
 		)
 	case config.ModeSeed:
 		return makeSeedNode(

--- a/sei-tendermint/rpc/test/helpers.go
+++ b/sei-tendermint/rpc/test/helpers.go
@@ -104,6 +104,7 @@ func StartTendermint(
 		nil,
 		[]trace.TracerProviderOption{},
 		node.NoOpMetricsProvider(),
+		types.DefaultConsensusPolicy(),
 	)
 	if err != nil {
 		return nil, func(_ context.Context) error { cancel(); return nil }, fmt.Errorf("node.New(%q): %w", conf.Mode, err)

--- a/sei-tendermint/test/e2e/node/main.go
+++ b/sei-tendermint/test/e2e/node/main.go
@@ -33,6 +33,7 @@ import (
 	rpcserver "github.com/sei-protocol/sei-chain/sei-tendermint/rpc/jsonrpc/server"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/test/e2e/app"
 	e2e "github.com/sei-protocol/sei-chain/sei-tendermint/test/e2e/pkg"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
 )
 
 var logger = seilog.NewLogger("tendermint", "test", "e2e", "node")
@@ -129,6 +130,7 @@ func startNode(ctx context.Context, cfg *Config) error {
 		nil,
 		[]trace.TracerProviderOption{},
 		nil,
+		types.DefaultConsensusPolicy(),
 	)
 	if err != nil {
 		return err
@@ -144,7 +146,7 @@ func startSeedNode(ctx context.Context) error {
 
 	tmcfg.Mode = config.ModeSeed
 
-	n, err := node.New(ctx, tmcfg, func() {}, nil, nil, []trace.TracerProviderOption{}, nil)
+	n, err := node.New(ctx, tmcfg, func() {}, nil, nil, []trace.TracerProviderOption{}, nil, types.DefaultConsensusPolicy())
 	if err != nil {
 		return err
 	}

--- a/sei-tendermint/test/e2e/tests/block_test.go
+++ b/sei-tendermint/test/e2e/tests/block_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	e2e "github.com/sei-protocol/sei-chain/sei-tendermint/test/e2e/pkg"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
 )
 
 // Tests that block headers are identical across nodes where present.
@@ -45,7 +46,7 @@ func TestBlock_Header(t *testing.T) {
 			require.Equal(t, block, resp.Block,
 				"block mismatch for height %d", block.Header.Height)
 
-			require.NoError(t, resp.Block.ValidateBasic(),
+			require.NoError(t, resp.Block.ValidateBasic(types.DefaultConsensusPolicy()),
 				"block at height %d is invalid", block.Header.Height)
 		}
 	})

--- a/sei-tendermint/types/block.go
+++ b/sei-tendermint/types/block.go
@@ -68,7 +68,7 @@ func (b *Block) GetTxHashes() []TxHash {
 // ValidateBasic performs basic validation that doesn't involve state data.
 // It checks the internal consistency of the block.
 // Further validation is done using state#ValidateBlock.
-func (b *Block) ValidateBasic() error {
+func (b *Block) ValidateBasic(policy ConsensusPolicy) error {
 	if b == nil {
 		return errors.New("nil block")
 	}
@@ -95,9 +95,11 @@ func (b *Block) ValidateBasic() error {
 		}
 	}
 
-	// NOTE: b.Data.Txs may be nil, but b.Data.Hash() still works fine.
-	if w, g := b.Data.Hash(false), b.DataHash; !bytes.Equal(w, g) {
-		return fmt.Errorf("wrong Header.DataHash. Expected %X, got %X. Len of txs %d", w, g, len(b.Txs))
+	if !policy.SkipDataHashValidation() {
+		// NOTE: b.Data.Txs may be nil, but b.Data.Hash() still works fine.
+		if w, g := b.Data.Hash(false), b.DataHash; !bytes.Equal(w, g) {
+			return fmt.Errorf("wrong Header.DataHash. Expected %X, got %X. Len of txs %d", w, g, len(b.Txs))
+		}
 	}
 
 	// NOTE: b.Evidence may be nil, but we're just looping.
@@ -309,7 +311,7 @@ func BlockFromProto(bp *tmproto.Block) (*Block, error) {
 		b.LastCommit = lc
 	}
 
-	return b, b.ValidateBasic()
+	return b, b.ValidateBasic(DefaultConsensusPolicy())
 }
 
 //-----------------------------------------------------------------------------

--- a/sei-tendermint/types/block_test.go
+++ b/sei-tendermint/types/block_test.go
@@ -61,7 +61,7 @@ func TestBlockAddEvidence(t *testing.T) {
 func TestBlockValidateBasic(t *testing.T) {
 	ctx := t.Context()
 
-	require.Error(t, (*Block)(nil).ValidateBasic())
+	require.Error(t, (*Block)(nil).ValidateBasic(DefaultConsensusPolicy()))
 
 	txs := []Tx{Tx("foo"), Tx("bar")}
 	lastID := makeBlockIDRandom()
@@ -120,7 +120,7 @@ func TestBlockValidateBasic(t *testing.T) {
 			block := MakeBlock(h, txs, commit, evList)
 			block.ProposerAddress = valSet.GetProposer().Address
 			tc.malleateBlock(block)
-			err = block.ValidateBasic()
+			err = block.ValidateBasic(DefaultConsensusPolicy())
 			t.Log(err)
 			assert.Equal(t, tc.expErr, err != nil, "#%d: %v", i, err)
 		})

--- a/sei-tendermint/types/consensus_policy.go
+++ b/sei-tendermint/types/consensus_policy.go
@@ -1,0 +1,7 @@
+package types
+
+// DefaultConsensusPolicy returns the zero-value policy. Behavior is
+// build-tag-dependent: production builds enforce every check; mock_block_validation
+// builds bypass every gated check (see consensus_policy_default.go and
+// consensus_policy_mock_block_validation.go).
+func DefaultConsensusPolicy() ConsensusPolicy { return ConsensusPolicy{} }

--- a/sei-tendermint/types/consensus_policy_default.go
+++ b/sei-tendermint/types/consensus_policy_default.go
@@ -1,0 +1,10 @@
+//go:build !mock_block_validation
+
+package types
+
+// ConsensusPolicy is empty in production builds. Its methods return
+// constant false so the compiler DCEs the bypass branches.
+type ConsensusPolicy struct{}
+
+func (ConsensusPolicy) SkipAppHashValidation() bool  { return false }
+func (ConsensusPolicy) SkipDataHashValidation() bool { return false }

--- a/sei-tendermint/types/consensus_policy_mock_block_validation.go
+++ b/sei-tendermint/types/consensus_policy_mock_block_validation.go
@@ -1,0 +1,10 @@
+//go:build mock_block_validation
+
+package types
+
+// ConsensusPolicy is empty in mock_block_validation builds. Each Skip*
+// method returns true unconditionally — running this binary IS the bypass.
+type ConsensusPolicy struct{}
+
+func (ConsensusPolicy) SkipAppHashValidation() bool  { return true }
+func (ConsensusPolicy) SkipDataHashValidation() bool { return true }


### PR DESCRIPTION
## Why

A node running an alternate execution engine (e.g., Giga V2) needs to bypass certain header-hash checks to validate against canonical-chain blocks. The previous shape exposed `--skip-app-hash-validation` as a runtime CLI flag on every seid binary, which made the production validator one config edit away from accepting bad blocks.

## Approach

The build tag `mock_block_validation` is the toggle — there is no runtime knob.

```go
// types/consensus_policy_default.go (//go:build !mock_block_validation)
type ConsensusPolicy struct{}
func (ConsensusPolicy) SkipAppHashValidation() bool  { return false }
func (ConsensusPolicy) SkipDataHashValidation() bool { return false }

// types/consensus_policy_mock_block_validation.go (//go:build mock_block_validation)
type ConsensusPolicy struct{}
func (ConsensusPolicy) SkipAppHashValidation() bool  { return true }
func (ConsensusPolicy) SkipDataHashValidation() bool { return true }
```

`ConsensusPolicy` is an empty struct in both builds; methods return different constants per build and the compiler folds them. Bypass branches DCE in production. There is no Go API in either build to construct a policy with the opposite behavior.

`Block.ValidateBasic(policy)` wraps the gated hash checks in `if !policy.Skip*() { ... }` in-place — no structural changes to the function body. `validateBlock(state, block, policy)` carries the policy from `BlockExecutor` down. Production `start.go` passes `DefaultConsensusPolicy()` unconditionally — no cobra, no AppOptions, no viper.

## Naming

`mock_block_validation` matches the repo's existing `mock_balances` precedent — both are mock build tags for engineering / debug binaries. Underscore form is required for valid Go build tags. Image tag uses hyphen for readability: `sei-chain:mock-block-validation-<sha>`.

## Per-check flags, narrow scope

The original `ftr-skip-apphash` branch gated 6 hash checks under one umbrella flag; this PR ships 2:

| Hash check | Gated | Reason |
|---|---|---|
| AppHash | Yes | State root from execution — guaranteed to diverge for an alternate execution engine. |
| DataHash | Yes | Defensive against tx-encoding format skew across versions. |
| LastCommitHash | **No** | Validator-authenticity territory (merkle root of validator signatures). Should match against a same-version canonical chain. |
| EvidenceHash | **No** | Validator-authenticity territory (merkle root of misbehavior evidence). Same reasoning. |
| ValidatorsHash, NextValidatorsHash | **No** | Validator-set updates flow through cosmos-sdk x/staking, not through the EVM execution engine. Should match. |
| ConsensusHash, LastBlockID, VerifyCommit, ProposerAddress | No (unconditional) | Network-config or canonical-chain-derived; identical regardless of local execution. |
| LastResultsHash | (separate) | Gated by the existing `SkipLastResultsHashValidation` global, set from `gigaExecutorConfig.Enabled` — a first-class production runtime feature with intentional gas-accounting divergence, different security model. |

If a non-gated check fails on a candidate node, that's actionable signal — either a real bug in the setup or a wire-format incompatibility worth investigating, not silently bypassed.

## CI

`.github/workflows/ecr.yml` adds a single new build step alongside the existing `mock_balances` and production builds, mirroring the same pattern. Every push produces:

- `sei-chain:<sha>` — production
- `sei-chain:mock-<sha>` — mock_balances (unchanged)
- `sei-chain:mock-block-validation-<sha>` — new

## Verification

- `strings seid-default | grep skip-app-hash` → 0 hits (no flag, no string in either binary)
- `go build ./...` and `go build -tags mock_block_validation ./...` both clean

## Out of scope

- The two Dockerfile commits from `ftr-skip-apphash` (libevmone runtime + ubuntu 24.04 base for GLIBCXX) are giga-runtime support and ship as a separate PR.
- A `BlockValidator` interface that hides per-step validation behind a strategy-pattern abstraction was discussed and deferred — defensible refactor when there's a second consumer.