### PR TITLE
test(evm): migrate response-reading lib.js helpers off -b block (CON-256)

### DIFF
--- a/contracts/test/CW1155toERC1155PointerTest.js
+++ b/contracts/test/CW1155toERC1155PointerTest.js
@@ -103,7 +103,6 @@ describe("CW1155 to ERC1155 Pointer", function () {
                     amount: "5",
                 }
             });
-            expect(res.code).to.equal(0);
             ownerResult = await queryWasm(pointer, "balance_of_batch", [
                 { owner: admin.seiAddress, token_id: "3" },
                 { owner: accounts[1].seiAddress, token_id: "3" },
@@ -146,7 +145,6 @@ describe("CW1155 to ERC1155 Pointer", function () {
                     amount: "5",
                 }
             });
-            expect(res.code).to.not.equal(0);
             ownerResult = await queryWasm(pointer, "balance_of_batch", [
                 { owner: admin.seiAddress, token_id: "0" },
                 { owner: accounts[1].seiAddress, token_id: "0" },
@@ -184,7 +182,6 @@ describe("CW1155 to ERC1155 Pointer", function () {
                     ],
                 }
             });
-            expect(res.code).to.equal(0);
             ownerResult = await queryWasm(pointer, "balance_of_batch", [
                 { owner: admin.seiAddress, token_id: "3" },
                 { owner: accounts[1].seiAddress, token_id: "3" },

--- a/contracts/test/CW1155toERC1155PointerTest.js
+++ b/contracts/test/CW1155toERC1155PointerTest.js
@@ -95,7 +95,7 @@ describe("CW1155 to ERC1155 Pointer", function () {
                     { token_id: "3", owner: accounts[1].seiAddress, amount: "11" },
                 ]
             }});
-            const res = await executeWasm(pointer, {
+            await executeWasm(pointer, {
                 send: {
                     from: admin.seiAddress,
                     to: accounts[1].seiAddress,
@@ -137,7 +137,10 @@ describe("CW1155 to ERC1155 Pointer", function () {
                     { token_id: "0", owner: accounts[1].seiAddress, amount: "0" },
                 ]
             }});
-            const res = await executeWasm(pointer, {
+            // DeliverTx rejection of the unauthorized transfer is verified
+            // by the unchanged balances below; executeWasm returns the
+            // CheckTx response, which doesn't carry the DeliverTx code.
+            await executeWasm(pointer, {
                 send: {
                     from: accounts[1].seiAddress,
                     to: admin.seiAddress,
@@ -172,7 +175,7 @@ describe("CW1155 to ERC1155 Pointer", function () {
                     { token_id: "4", owner: accounts[1].seiAddress, amount: "12" },
                 ]
             }});
-            const res = await executeWasm(pointer, {
+            await executeWasm(pointer, {
                 send_batch: {
                     from: admin.seiAddress,
                     to: accounts[1].seiAddress,

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -422,9 +422,18 @@ async function storeWasm(path, from=adminKeyName) {
     const command = `seid tx wasm store ${path} --from ${from} --gas=5000000 --fees=1000000usei -y -b sync -o json`
     const response = JSON.parse(await execute(command))
     if (response.code !== 0) throw new Error(`storeWasm failed: ${response.raw_log}`)
+    // Capture the new code_id inside the wait: a second re-query after the
+    // wait would race with any other concurrent store landing in the same
+    // window. Serial test execution makes that race dormant today, but
+    // capture-during-wait closes it deterministically.
+    let newCodeId = 0
     try {
         await waitForCondition(
-            async () => (await getMaxWasmCodeId()) > codeIdBefore,
+            async () => {
+                const cur = await getMaxWasmCodeId()
+                if (cur > codeIdBefore) { newCodeId = cur; return true }
+                return false
+            },
             `new wasm code_id > ${codeIdBefore}`,
         )
     } catch (e) {
@@ -433,7 +442,7 @@ async function storeWasm(path, from=adminKeyName) {
         // with the "storeWasm failed" prefix that callers match on.
         throw new Error(`storeWasm failed: ${e.message}`)
     }
-    return String(await getMaxWasmCodeId())
+    return String(newCodeId)
 }
 
 async function getPointerForCw20(cw20Address) {
@@ -547,9 +556,18 @@ async function instantiateWasm(codeId, adminAddr, label, args = {}, from=adminKe
     const command = `seid tx wasm instantiate ${codeId} "${jsonString}" --label ${label} --admin ${adminAddr} --from ${from} --gas=5000000 --fees=1000000usei -y -b sync -o json`;
     const response = JSON.parse(await execute(command));
     if (response.code !== 0) throw new Error(`instantiateWasm failed: ${response.raw_log}`)
+    // Capture the new contract address inside the wait: a second re-query
+    // after the wait would race with any other concurrent instantiation
+    // under the same codeId. Serial tests make that race dormant today,
+    // but capture-during-wait closes it deterministically.
+    let newContract = null
     try {
         await waitForCondition(
-            async () => (await listContractsByCode(codeId)).some(c => !contractsBefore.has(c)),
+            async () => {
+                const cur = await listContractsByCode(codeId)
+                newContract = cur.find(c => !contractsBefore.has(c))
+                return newContract != null
+            },
             `new contract under code ${codeId}`,
         )
     } catch (e) {
@@ -558,8 +576,6 @@ async function instantiateWasm(codeId, adminAddr, label, args = {}, from=adminKe
         // with the "instantiateWasm failed" prefix that callers match on.
         throw new Error(`instantiateWasm failed: ${e.message}`)
     }
-    const newContract = (await listContractsByCode(codeId)).find(c => !contractsBefore.has(c))
-    if (!newContract) throw new Error(`instantiateWasm failed: new contract for code ${codeId} not found after wait`)
     return newContract
 }
 
@@ -888,7 +904,16 @@ async function waitForAdminTxCommit(command) {
     )
     const heightAfter = await getCurrentBlockHeight()
     const inclusionHeight = await findInclusionBlock(response.txhash, heightBefore + 1, heightAfter)
-    if (inclusionHeight !== null) response.height = String(inclusionHeight)
+    if (inclusionHeight !== null) {
+        response.height = String(inclusionHeight)
+    } else {
+        // Anomalous: sender sequence advanced so the tx did land in some
+        // block, but block-walk in [heightBefore+1, heightAfter] couldn't
+        // find it. Likely a transient block-query failure across the whole
+        // range. Surface so it's visible in test output rather than
+        // silently leaving response.height at the CheckTx default.
+        console.log(`waitForAdminTxCommit: tx ${response.txhash} sequence advanced but not found in blocks [${heightBefore + 1}, ${heightAfter}]; response.height left as CheckTx default`)
+    }
     return response
 }
 

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -1,6 +1,7 @@
 const { exec } = require("child_process");
 const {ethers} = require("hardhat"); // Importing exec from child_process
 const axios = require("axios");
+const crypto = require("crypto");
 
 const adminKeyName = "admin"
 
@@ -421,10 +422,17 @@ async function storeWasm(path, from=adminKeyName) {
     const command = `seid tx wasm store ${path} --from ${from} --gas=5000000 --fees=1000000usei -y -b sync -o json`
     const response = JSON.parse(await execute(command))
     if (response.code !== 0) throw new Error(`storeWasm failed: ${response.raw_log}`)
-    await waitForCondition(
-        async () => (await getMaxWasmCodeId()) > codeIdBefore,
-        `new wasm code_id > ${codeIdBefore}`,
-    )
+    try {
+        await waitForCondition(
+            async () => (await getMaxWasmCodeId()) > codeIdBefore,
+            `new wasm code_id > ${codeIdBefore}`,
+        )
+    } catch (e) {
+        // CheckTx accepted the tx but the new code never appeared on chain
+        // (rejected at DeliverTx — e.g. wasm is disabled via gov). Wrap
+        // with the "storeWasm failed" prefix that callers match on.
+        throw new Error(`storeWasm failed: ${e.message}`)
+    }
     return String(await getMaxWasmCodeId())
 }
 
@@ -539,12 +547,19 @@ async function instantiateWasm(codeId, adminAddr, label, args = {}, from=adminKe
     const command = `seid tx wasm instantiate ${codeId} "${jsonString}" --label ${label} --admin ${adminAddr} --from ${from} --gas=5000000 --fees=1000000usei -y -b sync -o json`;
     const response = JSON.parse(await execute(command));
     if (response.code !== 0) throw new Error(`instantiateWasm failed: ${response.raw_log}`)
-    await waitForCondition(
-        async () => (await listContractsByCode(codeId)).some(c => !contractsBefore.has(c)),
-        `new contract under code ${codeId}`,
-    )
+    try {
+        await waitForCondition(
+            async () => (await listContractsByCode(codeId)).some(c => !contractsBefore.has(c)),
+            `new contract under code ${codeId}`,
+        )
+    } catch (e) {
+        // CheckTx accepted the tx but no new contract appeared on chain
+        // (rejected at DeliverTx — e.g. wasm is disabled via gov). Wrap
+        // with the "instantiateWasm failed" prefix that callers match on.
+        throw new Error(`instantiateWasm failed: ${e.message}`)
+    }
     const newContract = (await listContractsByCode(codeId)).find(c => !contractsBefore.has(c))
-    if (!newContract) throw new Error(`new contract not found after instantiateWasm of code ${codeId}`)
+    if (!newContract) throw new Error(`instantiateWasm failed: new contract for code ${codeId} not found after wait`)
     return newContract
 }
 
@@ -736,16 +751,24 @@ async function registerPointerForERC1155(erc1155Address, fees="200000usei", from
 async function registerPointerForCw(cwAddress, type, fees, from) {
     const command = `seid tx evm register-cw-pointer ${type} ${cwAddress} --from ${from} --fees ${fees} -b sync -y -o json`
     const response = JSON.parse(await execute(command))
-    if (response.code !== 0) throw new Error(`register-cw-pointer ${type} rejected: ${response.raw_log}`)
+    if (response.code !== 0) throw new Error(`contract deployment failed: ${response.raw_log}`)
     let pointer = ''
-    await waitForCondition(
-        async () => {
-            const out = await execute(`seid query evm pointer ${type} ${cwAddress} -o json`)
-            pointer = JSON.parse(out).pointer || ''
-            return pointer !== ''
-        },
-        `pointer for ${type} ${cwAddress}`,
-    )
+    try {
+        await waitForCondition(
+            async () => {
+                const out = await execute(`seid query evm pointer ${type} ${cwAddress} -o json`)
+                pointer = JSON.parse(out).pointer || ''
+                return pointer !== ''
+            },
+            `pointer for ${type} ${cwAddress}`,
+        )
+    } catch (e) {
+        // CheckTx accepted the tx but no pointer was registered (rejected
+        // at DeliverTx — e.g. trying to register a pointer for an address
+        // that's already a pointer). Wrap with the "contract deployment
+        // failed" prefix that callers match on.
+        throw new Error(`contract deployment failed: ${e.message}`)
+    }
     return pointer
 }
 
@@ -813,9 +836,40 @@ async function associateWasm(contractAddress) {
     return await waitForAdminTxCommit(command)
 }
 
+// Current latest block height as observed by the local node.
+async function getCurrentBlockHeight() {
+    const status = await execute(`seid status`)
+    return Number(JSON.parse(status).SyncInfo.latest_block_height)
+}
+
+// Scan blocks in [fromHeight, toHeight] for the cosmos tx with the
+// given hex hash; returns the height it landed in, or null if none of
+// the scanned blocks contain it. Cosmos tx hash is the uppercase hex
+// SHA-256 of the protobuf tx bytes, which appear base64-encoded in
+// `block.data.txs`.
+async function findInclusionBlock(txhashHex, fromHeight, toHeight) {
+    const target = txhashHex.toUpperCase()
+    for (let h = fromHeight; h <= toHeight; h++) {
+        try {
+            const block = JSON.parse(await execute(`seid query block ${h}`))
+            const txs = block.block?.data?.txs || []
+            for (const t of txs) {
+                const buf = Buffer.from(t, 'base64')
+                const hash = crypto.createHash('sha256').update(buf).digest('hex').toUpperCase()
+                if (hash === target) return h
+            }
+        } catch (e) {
+            // skip transient block-query failures
+        }
+    }
+    return null
+}
+
 // Submit a -b sync tx from adminKeyName and wait for it to be included
 // in a block via sender sequence advance. Returns the submit (CheckTx)
-// response. Use when the natural side effect of the tx isn't easily
+// response, with `.height` rewritten to the actual inclusion block
+// (recovered by scanning blocks between submit and observed commit for
+// the tx hash). Use when the natural side effect of the tx isn't easily
 // queryable from the helper (e.g. wasm execute, contract association)
 // and callers verify the outcome via state queries themselves.
 //
@@ -824,6 +878,7 @@ async function associateWasm(contractAddress) {
 // failure from the response alone — they must inspect post-state.
 async function waitForAdminTxCommit(command) {
     const senderAddr = await getKeySeiAddress(adminKeyName)
+    const heightBefore = await getCurrentBlockHeight()
     const seqBefore = await getAccountSequence(senderAddr)
     const response = JSON.parse(await execute(command))
     if (response.code !== 0) return response  // CheckTx rejection — surface immediately
@@ -831,6 +886,9 @@ async function waitForAdminTxCommit(command) {
         async () => (await getAccountSequence(senderAddr)) > seqBefore,
         `${adminKeyName} sequence > ${seqBefore}`,
     )
+    const heightAfter = await getCurrentBlockHeight()
+    const inclusionHeight = await findInclusionBlock(response.txhash, heightBefore + 1, heightAfter)
+    if (inclusionHeight !== null) response.height = String(inclusionHeight)
     return response
 }
 

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -417,14 +417,41 @@ async function getPointerForNative(name) {
     return JSON.parse(output);
 }
 
-async function storeWasm(path, from=adminKeyName) {
-    const command = `seid tx wasm store ${path} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode block -o json`
-    const output = await execute(command);
-    const response = JSON.parse(output)
-    if (response.code !== 0) {
-        throw new Error(`storeWasm failed: ${response.raw_log}`)
+// Highest existing wasm code_id, or 0 if the chain has no codes yet.
+// Used as the side-effect signal for storeWasm: after a successful
+// store, the max code_id grows by one.
+async function getMaxWasmCodeId() {
+    try {
+        const out = await execute(`seid query wasm list-code --reverse --limit 1 -o json`)
+        const codes = JSON.parse(out).code_infos || []
+        return codes.length === 0 ? 0 : Number(codes[0].code_id)
+    } catch (e) {
+        return 0
     }
-    return getEventAttribute(response, "store_code", "code_id")
+}
+
+// Contracts instantiated under codeId. Used as the side-effect signal
+// for instantiateWasm: after a successful instantiation, the list
+// grows by exactly one entry.
+async function listContractsByCode(codeId) {
+    try {
+        const out = await execute(`seid query wasm list-contract-by-code ${codeId} -o json`)
+        return JSON.parse(out).contracts || []
+    } catch (e) {
+        return []
+    }
+}
+
+async function storeWasm(path, from=adminKeyName) {
+    const codeIdBefore = await getMaxWasmCodeId()
+    const command = `seid tx wasm store ${path} --from ${from} --gas=5000000 --fees=1000000usei -y -b sync -o json`
+    const response = JSON.parse(await execute(command))
+    if (response.code !== 0) throw new Error(`storeWasm failed: ${response.raw_log}`)
+    await waitForCondition(
+        async () => (await getMaxWasmCodeId()) > codeIdBefore,
+        `new wasm code_id > ${codeIdBefore}`,
+    )
+    return String(await getMaxWasmCodeId())
 }
 
 async function getPointerForCw20(cw20Address) {
@@ -446,7 +473,7 @@ async function getPointerForCw1155(cw1155Address) {
 }
 
 async function deployErc20PointerForCw20(provider, cw20Address, attempts=10, from=adminKeyName, evmRpc="") {
-    let command = `seid tx evm register-evm-pointer CW20 ${cw20Address} --from=${from} -b block`
+    let command = `seid tx evm register-evm-pointer CW20 ${cw20Address} --from=${from} -b sync`
     if (evmRpc) {
         command = command + ` --evm-rpc=${evmRpc}`
     }
@@ -467,7 +494,7 @@ async function deployErc20PointerForCw20(provider, cw20Address, attempts=10, fro
 }
 
 async function deployErc20PointerNative(provider, name, from=adminKeyName, evmRpc="") {
-    let command = `seid tx evm call-precompile pointer addNativePointer ${name} --from=${from} -b block`
+    let command = `seid tx evm call-precompile pointer addNativePointer ${name} --from=${from} -b sync`
     if (evmRpc) {
         command = command + ` --evm-rpc=${evmRpc}`
     }
@@ -486,7 +513,7 @@ async function deployErc20PointerNative(provider, name, from=adminKeyName, evmRp
 }
 
 async function deployErc721PointerForCw721(provider, cw721Address, from=adminKeyName, evmRpc="") {
-    let command = `seid tx evm register-evm-pointer CW721 ${cw721Address} --from=${from} -b block`
+    let command = `seid tx evm register-evm-pointer CW721 ${cw721Address} --from=${from} -b sync`
     if (evmRpc) {
         command = command + ` --evm-rpc=${evmRpc}`
     }
@@ -507,7 +534,7 @@ async function deployErc721PointerForCw721(provider, cw721Address, from=adminKey
 }
 
 async function deployErc1155PointerForCw1155(provider, cw1155Address, from=adminKeyName, evmRpc="") {
-    let command = `seid tx evm register-evm-pointer CW1155 ${cw1155Address} --from=${from} -b block`
+    let command = `seid tx evm register-evm-pointer CW1155 ${cw1155Address} --from=${from} -b sync`
     if (evmRpc) {
         command = command + ` --evm-rpc=${evmRpc}`
     }
@@ -533,20 +560,26 @@ async function deployWasm(path, adminAddr, label, args = {}, from=adminKeyName) 
 }
 
 async function instantiateWasm(codeId, adminAddr, label, args = {}, from=adminKeyName) {
+    const contractsBefore = new Set(await listContractsByCode(codeId))
     const jsonString = JSON.stringify(args).replace(/"/g, '\\"');
-    const command = `seid tx wasm instantiate ${codeId} "${jsonString}" --label ${label} --admin ${adminAddr} --from ${from} --gas=5000000 --fees=1000000usei -y --broadcast-mode block -o json`;
-    const output = await execute(command);
-    const response = JSON.parse(output);
-    if (response.code !== 0) {
-        throw new Error(`instantiateWasm failed: ${response.raw_log}`)
-    }
-    return getEventAttribute(response, "instantiate", "_contract_address");
+    const command = `seid tx wasm instantiate ${codeId} "${jsonString}" --label ${label} --admin ${adminAddr} --from ${from} --gas=5000000 --fees=1000000usei -y -b sync -o json`;
+    const response = JSON.parse(await execute(command));
+    if (response.code !== 0) throw new Error(`instantiateWasm failed: ${response.raw_log}`)
+    await waitForCondition(
+        async () => (await listContractsByCode(codeId)).some(c => !contractsBefore.has(c)),
+        `new contract under code ${codeId}`,
+    )
+    const newContract = (await listContractsByCode(codeId)).find(c => !contractsBefore.has(c))
+    if (!newContract) throw new Error(`new contract not found after instantiateWasm of code ${codeId}`)
+    return newContract
 }
 
 async function proposeCW20toERC20Upgrade(erc20Address, cw20Address, title="erc20-pointer", version=99, description="erc20 pointer",fees="200000usei", from=adminKeyName) {
-    const command = `seid tx evm add-cw-erc20-pointer "${title}" "${description}" ${erc20Address} ${version} 200000000usei ${cw20Address} --from ${from} --fees ${fees} -y -o json --broadcast-mode=block`
-    const output = await execute(command);
-    const proposalId = getEventAttribute(JSON.parse(output), "submit_proposal", "proposal_id")
+    const maxIdBefore = await maxProposalId()
+    const command = `seid tx evm add-cw-erc20-pointer "${title}" "${description}" ${erc20Address} ${version} 200000000usei ${cw20Address} --from ${from} --fees ${fees} -y -o json -b sync`
+    const response = JSON.parse(await execute(command))
+    if (response.code !== 0) throw new Error(`proposeCW20toERC20Upgrade failed: ${response.raw_log}`)
+    const proposalId = await findProposalByTitle(title, maxIdBefore, response.txhash)
     return await passProposal(proposalId)
 }
 
@@ -565,9 +598,7 @@ async function proposeParamChange(title, description, changes, deposit="20000000
     const base64Json = Buffer.from(proposalJson).toString('base64');
     await execute(`echo ${base64Json} | base64 -d > ${tempFile}`);
 
-    // Identify the new proposal by diffing gov state before vs after submit.
-    let maxIdBefore = await maxProposalId();
-
+    const maxIdBefore = await maxProposalId();
     const command = `seid tx gov submit-proposal param-change ${tempFile} --from ${from} --fees ${fees} -y -o json -b sync`;
     const output = await execute(command);
     await execute(`rm ${tempFile}`);
@@ -575,7 +606,14 @@ async function proposeParamChange(title, description, changes, deposit="20000000
     if (response.code !== 0) {
         throw new Error(`Failed to submit proposal: ${response.raw_log}`);
     }
+    return await findProposalByTitle(title, maxIdBefore, response.txhash);
+}
 
+// After a -b sync gov proposal submission, scan gov state for the new
+// proposal whose title matches. The diff against maxIdBefore is what
+// pins it to *this* submission rather than a stale prior-run proposal
+// with the same title.
+async function findProposalByTitle(title, maxIdBefore, txHashForError) {
     const deadline = Date.now() + 30000;
     while (Date.now() < deadline) {
         const cur = await maxProposalId();
@@ -590,7 +628,7 @@ async function proposeParamChange(title, description, changes, deposit="20000000
         maxIdBefore = Math.max(maxIdBefore, cur);
         await sleep(250);
     }
-    throw new Error(`proposal submitted (tx ${response.txhash}) but did not appear in gov state within 30s`);
+    throw new Error(`proposal submitted (tx ${txHashForError}) but did not appear in gov state within 30s`);
 }
 
 // Returns the highest existing proposal id, or 0 if there are no proposals.
@@ -710,33 +748,31 @@ async function passProposal(proposalId,  desposit="200000000usei", fees="200000u
 }
 
 async function registerPointerForERC20(erc20Address, fees="20000usei", from=adminKeyName) {
-    const command = `seid tx evm register-cw-pointer ERC20 ${erc20Address} --from ${from} --fees ${fees} --broadcast-mode block -y -o json`
-    const output = await execute(command);
-    const response = JSON.parse(output)
-    if(response.code !== 0) {
-        throw new Error("contract deployment failed")
-    }
-    return getEventAttribute(response, "pointer_registered", "pointer_address")
+    return await registerPointerForCw(erc20Address, "ERC20", fees, from)
 }
 
 async function registerPointerForERC721(erc721Address, fees="20000usei", from=adminKeyName) {
-    const command = `seid tx evm register-cw-pointer ERC721 ${erc721Address} --from ${from} --fees ${fees} --broadcast-mode block -y -o json`
-    const output = await execute(command);
-    const response = JSON.parse(output)
-    if(response.code !== 0) {
-        throw new Error("contract deployment failed")
-    }
-    return getEventAttribute(response, "pointer_registered", "pointer_address")
+    return await registerPointerForCw(erc721Address, "ERC721", fees, from)
 }
 
 async function registerPointerForERC1155(erc1155Address, fees="200000usei", from=adminKeyName) {
-    const command = `seid tx evm register-cw-pointer ERC1155 ${erc1155Address} --from ${from} --fees ${fees} --broadcast-mode block -y -o json`
-    const output = await execute(command);
-    const response = JSON.parse(output)
-    if(response.code !== 0) {
-        throw new Error("contract deployment failed")
-    }
-    return getEventAttribute(response, "pointer_registered", "pointer_address")
+    return await registerPointerForCw(erc1155Address, "ERC1155", fees, from)
+}
+
+async function registerPointerForCw(cwAddress, type, fees, from) {
+    const command = `seid tx evm register-cw-pointer ${type} ${cwAddress} --from ${from} --fees ${fees} -b sync -y -o json`
+    const response = JSON.parse(await execute(command))
+    if (response.code !== 0) throw new Error(`register-cw-pointer ${type} rejected: ${response.raw_log}`)
+    let pointer = ''
+    await waitForCondition(
+        async () => {
+            const out = await execute(`seid query evm pointer ${type} ${cwAddress} -o json`)
+            pointer = JSON.parse(out).pointer || ''
+            return pointer !== ''
+        },
+        `pointer for ${type} ${cwAddress}`,
+    )
+    return pointer
 }
 
 async function getSeiAddress(evmAddress) {
@@ -799,15 +835,34 @@ async function queryWasm(contractAddress, operation, args={}){
 
 async function executeWasm(contractAddress, msg, coins = "0usei") {
     const jsonString = JSON.stringify(msg).replace(/"/g, '\\"'); // Properly escape JSON string
-    const command = `seid tx wasm execute ${contractAddress} "${jsonString}" --amount ${coins} --from ${adminKeyName} --gas=5000000 --fees=1000000usei -y --broadcast-mode block -o json`;
-    const output = await execute(command);
-    return JSON.parse(output);
+    const command = `seid tx wasm execute ${contractAddress} "${jsonString}" --amount ${coins} --from ${adminKeyName} --gas=5000000 --fees=1000000usei -y -b sync -o json`;
+    return await waitForAdminTxCommit(command)
 }
 
 async function associateWasm(contractAddress) {
-    const command = `seid tx evm associate-contract-address ${contractAddress} --from ${adminKeyName} --gas=5000000 --fees=1000000usei -y --broadcast-mode block -o json`;
-    const output = await execute(command);
-    return JSON.parse(output);
+    const command = `seid tx evm associate-contract-address ${contractAddress} --from ${adminKeyName} --gas=5000000 --fees=1000000usei -y -b sync -o json`;
+    return await waitForAdminTxCommit(command)
+}
+
+// Submit a -b sync tx from adminKeyName and wait for it to be included
+// in a block via sender sequence advance. Returns the submit (CheckTx)
+// response. Use when the natural side effect of the tx isn't easily
+// queryable from the helper (e.g. wasm execute, contract association)
+// and callers verify the outcome via state queries themselves.
+//
+// Note: the returned `code` is the CheckTx code (0 for accepted into
+// mempool), not the DeliverTx code; callers can't assert tx success/
+// failure from the response alone — they must inspect post-state.
+async function waitForAdminTxCommit(command) {
+    const senderAddr = await getKeySeiAddress(adminKeyName)
+    const seqBefore = await getAccountSequence(senderAddr)
+    const response = JSON.parse(await execute(command))
+    if (response.code !== 0) return response  // CheckTx rejection — surface immediately
+    await waitForCondition(
+        async () => (await getAccountSequence(senderAddr)) > seqBefore,
+        `${adminKeyName} sequence > ${seqBefore}`,
+    )
+    return response
 }
 
 async function printClaimMsg(sender, claimer) {

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -3,11 +3,6 @@ const {ethers} = require("hardhat"); // Importing exec from child_process
 const axios = require("axios");
 
 const adminKeyName = "admin"
-const seilocalSignerPrivateKeys = {
-    "0xf87a299e6bc7beba58dbbe5a5aa21d49bcd16d52": "57acb95d82739866a5c29e40b0aa2590742ae50425b7dd5b5d279a986370189e",
-    "0x70997970c51812dc3a010c7d01b50e0d17dc79c8": "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
-    "0x817e1414b633948e50101df0b722dea5f8c29109": "888432482e2cbcf4e2b248a388f2a6d9fe7b59a11e9136fd615942d7421e89bf",
-};
 
 const ABI = {
     ERC20: [
@@ -262,27 +257,6 @@ async function associateKey(keyName) {
         await waitForBlocks()
     }catch(e){
         console.log("skipping associate")
-    }
-}
-
-async function associateSigner(signer) {
-    const evmAddress = (await signer.getAddress()).toLowerCase();
-    const privKey = seilocalSignerPrivateKeys[evmAddress];
-    if (!privKey) {
-        return null;
-    }
-    try {
-        // Custom (non-cosmos-JSON) output, same as associateKey; failure is
-        // tolerated by the surrounding try/catch so a temporal wait is fine.
-        await execute(`seid tx evm associate-address ${privKey} --from ${adminKeyName} -b sync`)
-        await waitForBlocks()
-    } catch (e) {
-        console.log("skipping signer association")
-    }
-    try {
-        return await getSeiAddress(evmAddress);
-    } catch (e) {
-        return null;
     }
 }
 
@@ -805,18 +779,13 @@ async function setupSigners(signers) {
     const result = []
     for(let signer of signers) {
         const evmAddress = await signer.getAddress();
-        let seiAddress = await associateSigner(signer);
-        if (seiAddress) {
-            await fundSeiAddress(seiAddress);
-        } else {
-            await fundAddress(evmAddress);
-            const resp = await signer.sendTransaction({
-                to: evmAddress,
-                value: 0
-            });
-            await resp.wait()
-            seiAddress = await getSeiAddress(evmAddress);
-        }
+        await fundAddress(evmAddress);
+        const resp = await signer.sendTransaction({
+            to: evmAddress,
+            value: 0
+        });
+        await resp.wait()
+        const seiAddress = await getSeiAddress(evmAddress);
         result.push({
             seiAddress,
             evmAddress,


### PR DESCRIPTION
## Summary

Picks up where #3363 left off. Migrates the lib.js helpers that read post-execution events from `-b block` to `-b sync` + per-helper side-effect waits.

Pattern (introduced in #3363, extended here): submit with `-b sync`, then poll the actual on-chain side effect rather than `seid q tx` (which doesn't return under Autobahn). When the side effect is observable, return the post-state value; when it isn't, fall back to admin-sequence-advance + block-walk to recover the inclusion height.

**Migrated:**

- `storeWasm` — side-effect: max wasm code_id grows (new `getMaxWasmCodeId`)
- `instantiateWasm` — side-effect: new contract appears under codeId (new `listContractsByCode`)
- `registerPointerForERC20/721/1155` — side-effect: `seid query evm pointer` returns non-empty (factored into shared `registerPointerForCw`)
- `proposeCW20toERC20Upgrade`, `proposeParamChange` — side-effect: new gov proposal with matching title (factored into `findProposalByTitle`)
- `executeWasm`, `associateWasm` — fallback path: `waitForAdminTxCommit` waits on admin sequence advance, then block-walks to recover the actual inclusion height (no easy single-query side effect for arbitrary wasm execute / contract association)

Wait-timeout cases are wrapped with the same error prefixes (`"storeWasm failed"`, `"instantiateWasm failed"`, `"contract deployment failed"`) that callers already match on, so existing assertions in `DisableWasmTest` and similar continue to work.

**Other:**

- Removed `associateSigner` + hardcoded `seilocalSignerPrivateKeys` — `setupSigners` now uniformly funds the EVM address and reads back the sei address. The conditional branch became redundant after #3431.
- Dropped 3 `res.code` assertions in `CW1155toERC1155PointerTest.js` — `res.code` is now CheckTx (always 0 for mempool admission), not DeliverTx. Outcome verification stays via the existing post-state balance checks.
