### PR TITLE
chore(giga): remove mentions of experimental and evmone

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -488,8 +488,7 @@ type App struct {
 
 	benchmarkManager *benchmark.Manager
 
-	// GigaExecutorEnabled controls whether to use the Giga executor (evmone-based)
-	// instead of geth's interpreter for EVM execution. Experimental feature.
+	// GigaExecutorEnabled controls whether to use the Giga executor.
 	GigaExecutorEnabled bool
 	// GigaOCCEnabled controls whether to use OCC with the Giga executor
 	GigaOCCEnabled bool
@@ -1654,8 +1653,6 @@ func (app *App) CacheContext(ctx sdk.Context) (sdk.Context, sdk.CacheMultiStore)
 // ExecuteTxsConcurrently calls the appropriate function for processing transacitons
 func (app *App) ExecuteTxsConcurrently(ctx sdk.Context, txs [][]byte, typedTxs []sdk.Tx) ([]*abci.ExecTxResult, sdk.Context) {
 	processSynchronously := app.shouldProcessSingleRecipientEVMTransfersSynchronously(typedTxs)
-
-	// Giga only supports synchronous execution for now
 	if app.GigaExecutorEnabled && app.GigaOCCEnabled && !processSynchronously {
 		return app.ProcessTXsWithOCCGiga(ctx, txs, typedTxs)
 	} else if app.GigaExecutorEnabled {

--- a/benchmark/CLAUDE.md
+++ b/benchmark/CLAUDE.md
@@ -35,7 +35,7 @@ BENCHMARK_CONFIG=benchmark/scenarios/erc20.json benchmark/benchmark.sh
 | `LOG_FILE` | `""` | Redirect seid output to file |
 | `BENCHMARK_CONFIG` | `$SCRIPT_DIR/scenarios/evm.json` | Scenario config file (absolute path resolved from script location) |
 | `BENCHMARK_TXS_PER_BATCH` | `1000` | Transactions per batch |
-| `GIGA_EXECUTOR` | `false` | Enable evmone-based EVM executor |
+| `GIGA_EXECUTOR` | `false` | Enable Giga EVM-optimized executor |
 | `GIGA_OCC` | `false` | Enable OCC for Giga Executor |
 | `DB_BACKEND` | `goleveldb` | Database backend (goleveldb, memdb, cleveldb, rocksdb) |
 | `MOCK_BALANCES` | `true` | Use mock balances during benchmark |

--- a/benchmark/benchmark.sh
+++ b/benchmark/benchmark.sh
@@ -169,9 +169,9 @@ sed -i.bak -e 's/occ-enabled = .*/occ-enabled = true/' "$APP_TOML_PATH"
 sed -i.bak -e 's/sc-enable = .*/sc-enable = true/' "$APP_TOML_PATH"
 sed -i.bak -e 's/ss-enable = .*/ss-enable = true/' "$APP_TOML_PATH"
 
-# Enable Giga Executor (evmone-based) if requested
+# Enable Giga Executor if requested
 if [ "$GIGA_EXECUTOR" = true ]; then
-  echo "Enabling Giga Executor (evmone-based EVM)..."
+  echo "Enabling Giga Executor..."
   if grep -q "\[giga_executor\]" "$APP_TOML_PATH"; then
     # If the section exists, update enabled to true
     if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/contracts/test/EVMGigaTest.js
+++ b/contracts/test/EVMGigaTest.js
@@ -6,8 +6,7 @@ const { setupSigners, fundAddress, delay } = require("./lib");
 /**
  * EVMGigaTest - Integration tests for GIGA executor mode
  * 
- * These tests verify core EVM functionality when running with the GIGA executor
- * (evmone-based) and OCC (Optimistic Concurrency Control) enabled.
+ * These tests verify core EVM functionality when running with the GIGA executor and OCC (Optimistic Concurrency Control) enabled.
  * 
  * Tests cover:
  * - Native SEI transfers between accounts

--- a/docker/localnode/scripts/step4_config_override.sh
+++ b/docker/localnode/scripts/step4_config_override.sh
@@ -46,9 +46,9 @@ if [ "$GIGA_STORAGE" = "true" ]; then
   sed -i 's/evm-ss-split = .*/evm-ss-split = true/' ~/.sei/config/app.toml
 fi
 
-# Enable Giga Executor (evmone-based) if requested
+# Enable Giga Executor if requested
 if [ "$GIGA_EXECUTOR" = "true" ]; then
-  echo "Enabling Giga Executor (evmone-based EVM) for node $NODE_ID..."
+  echo "Enabling Giga Executor for node $NODE_ID..."
   if grep -q "\[giga_executor\]" ~/.sei/config/app.toml; then
     # If the section exists, update enabled to true
     sed -i 's/enabled = false/enabled = true/' ~/.sei/config/app.toml

--- a/giga/executor/config/config.go
+++ b/giga/executor/config/config.go
@@ -7,7 +7,7 @@ import (
 
 // Config defines configuration for the Giga Executor
 type Config struct {
-	// Enabled controls whether to use the Giga executor (evmone-based) instead of geth's interpreter
+	// Enabled controls whether to use the Giga executor
 	Enabled bool `mapstructure:"enabled"`
 	// OCCEnabled controls whether to use OCC (Optimistic Concurrency Control) with the Giga executor
 	OCCEnabled bool `mapstructure:"occ_enabled"`
@@ -46,8 +46,7 @@ const ConfigTemplate = `
 ###############################################################################
 
 [giga_executor]
-# enabled controls whether to use the Giga executor (evmone-based) instead of geth's interpreter.
-# This is an experimental feature for improved EVM throughput.
+# enabled controls whether to use the Giga executor for improved EVM throughput.
 # Default: false
 enabled = {{ .GigaExecutor.Enabled }}
 

--- a/scripts/initialize_local_chain.sh
+++ b/scripts/initialize_local_chain.sh
@@ -100,9 +100,9 @@ sed -i.bak -e 's/occ-enabled = .*/occ-enabled = true/' $APP_TOML_PATH
 sed -i.bak -e 's/sc-enable = .*/sc-enable = true/' $APP_TOML_PATH
 sed -i.bak -e 's/ss-enable = .*/ss-enable = true/' $APP_TOML_PATH
 
-# Enable Giga Executor (evmone-based) if requested
+# Enable Giga Executor if requested
 if [ "$GIGA_EXECUTOR" = true ]; then
-  echo "Enabling Giga Executor (evmone-based EVM)..."
+  echo "Enabling Giga Executor..."
   if grep -q "\[giga_executor\]" $APP_TOML_PATH; then
     # If the section exists, update enabled to true
     if [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
## Describe your changes and provide context

The Giga executor is no longer experimental, so we should remove mentions of that in comments and config.

It's also not (strictly) evmone-based, so we remove mentions of that as well.

## Testing performed to validate your change


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment/documentation-only updates around the Giga executor; no runtime behavior or configuration keys change, so risk is low.
> 
> **Overview**
> **Cleans up Giga executor messaging** by removing references to it being *experimental* or strictly *evmone-based* across app comments, config templates, docs, scripts, and integration test descriptions.
> 
> No functional changes: the `GIGA_EXECUTOR`/`GIGA_OCC` flags, TOML keys, and transaction execution routing remain the same; only user-facing wording and log/script text is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22e2b4c1494472088b50b62df0e122c7c993c8cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->