### PR TITLE
ci: add Autobahn RPC .io/.iox spec fixtures to integration tests (CON-256)

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -154,6 +154,13 @@ jobs:
               "./integration_test/evm_module/scripts/evm_rpc_tests.sh"
             ]
           },
+          {
+            name: "Autobahn RPC .io/.iox (spec fixtures)",
+            env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true",
+            scripts: [
+              "./integration_test/evm_module/scripts/evm_rpc_tests.sh"
+            ]
+          },
         ]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary

- Adds a new matrix entry "Autobahn RPC .io/.iox (spec fixtures)" to `.github/workflows/integration-test.yml`, sibling to the existing EVM RPC .io/.iox entry.
- Reuses the same `evm_rpc_tests.sh` driver against an Autobahn-enabled cluster (`env: AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true`).
- This exercises the EVM RPC spec surface on the Autobahn consensus path, complementing the EVM-mode coverage we already run.

## Test plan

Local verification on this branch:

- [x] Brought up cluster with the exact matrix env (`AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true`); all 4 nodes report `GigaRouter initialized` in their seid log and the chain advances.
- [x] Ran `GOWORK=off ./integration_test/evm_module/scripts/evm_rpc_tests.sh` against the Autobahn cluster: **160/160 spec fixtures pass (100%)**.
- [ ] CI: confirm the new matrix entry comes up green in the Docker Integration Test workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds an extra matrix job; main impact is increased CI time or potential flakiness from running the same RPC fixtures under a different env configuration.
> 
> **Overview**
> Adds a new integration-test matrix entry, **"Autobahn RPC .io/.iox (spec fixtures)"**, which runs the existing `evm_rpc_tests.sh` suite with `AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true` to exercise the same RPC spec fixtures on the Autobahn-enabled cluster path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41174c73a68584345e873ef2211f083c8ef54562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->