### PR TITLE
blocksync: fix sendError in block sync (CON-276)

### DIFF
--- a/sei-tendermint/internal/blocksync/pool.go
+++ b/sei-tendermint/internal/blocksync/pool.go
@@ -174,6 +174,12 @@ func (pool *BlockPool) makeRequestersRoutine(ctx context.Context) {
 }
 
 func (pool *BlockPool) removeTimedoutPeers() {
+	var errsToSend []peerError
+	defer func() {
+		for _, pe := range errsToSend {
+			pool.sendError(pe.err, pe.peerID)
+		}
+	}()
 	pool.mtx.Lock()
 	defer pool.mtx.Unlock()
 
@@ -184,7 +190,7 @@ func (pool *BlockPool) removeTimedoutPeers() {
 			// curRate can be 0 on start
 			if curRate != 0 && curRate < minRecvRate {
 				err := errors.New("peer is not sending us data fast enough")
-				pool.sendError(err, peer.id)
+				errsToSend = append(errsToSend, peerError{err, peer.id})
 				logger.Error("SendTimeout", "peer", peer.id,
 					"reason", err,
 					"curRate-kbps", curRate/1024,
@@ -303,6 +309,15 @@ func (pool *BlockPool) RedoRequest(height int64) types.NodeID {
 // do not add the block and return an error.
 // TODO: ensure that blocks come in order for each peer.
 func (pool *BlockPool) AddBlock(peerID types.NodeID, block *types.Block, blockSize int) error {
+	var (
+		pendingErr    error
+		pendingPeerID types.NodeID
+	)
+	defer func() {
+		if pendingErr != nil {
+			pool.sendError(pendingErr, pendingPeerID)
+		}
+	}()
 	pool.mtx.Lock()
 	defer pool.mtx.Unlock()
 
@@ -313,7 +328,8 @@ func (pool *BlockPool) AddBlock(peerID types.NodeID, block *types.Block, blockSi
 			diff *= -1
 		}
 		if diff > maxDiffBetweenCurrentAndReceivedBlockHeight {
-			pool.sendError(errors.New("peer sent us a block we didn't expect with a height too far ahead/behind"), peerID)
+			pendingErr = errors.New("peer sent us a block we didn't expect with a height too far ahead/behind")
+			pendingPeerID = peerID
 		}
 		return fmt.Errorf("peer sent us a block we didn't expect (peer: %s, current height: %d, block height: %d)", peerID, pool.height, block.Height)
 	}
@@ -325,13 +341,12 @@ func (pool *BlockPool) AddBlock(peerID types.NodeID, block *types.Block, blockSi
 		if peer != nil {
 			peer.decrPending(blockSize)
 		}
-	} else {
-		err := errors.New("requester is different or block already exists")
-		pool.sendError(err, peerID)
-		return fmt.Errorf("%w (peer: %s, requester: %s, block height: %d)", err, peerID, requester.getPeerID(), block.Height)
+		return nil
 	}
 
-	return nil
+	pendingErr = errors.New("requester is different or block already exists")
+	pendingPeerID = peerID
+	return fmt.Errorf("%w (peer: %s, requester: %s, block height: %d)", pendingErr, peerID, requester.getPeerID(), block.Height)
 }
 
 // MaxPeerHeight returns the highest reported height.
@@ -578,12 +593,12 @@ func (peer *bpPeer) decrPending(recvSize int) {
 
 func (peer *bpPeer) onTimeout() {
 	peer.pool.mtx.Lock()
-	defer peer.pool.mtx.Unlock()
+	peer.didTimeout = true
+	peer.pool.mtx.Unlock()
 
 	err := errors.New("peer did not send us anything")
-	peer.pool.sendError(err, peer.id)
 	logger.Error("SendTimeout", "id", peer.id, "reason", err, "timeout", peerTimeout)
-	peer.didTimeout = true
+	peer.pool.sendError(err, peer.id)
 }
 
 //-------------------------------------

--- a/sei-tendermint/internal/blocksync/pool_test.go
+++ b/sei-tendermint/internal/blocksync/pool_test.go
@@ -3,6 +3,7 @@ package blocksync
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -317,4 +318,59 @@ func testBlockPoolRejectsWrongPeerWithoutDiscardingGoodBlock(t *testing.T, goodF
 	first, second := pool.PeekTwoBlocks()
 	require.Equal(t, goodBlock, first)
 	require.Equal(t, secondBlock, second)
+}
+
+// TestBlockPoolAddBlockReleasesLockBeforeSend asserts that AddBlock does
+// not hold pool.mtx across a send on errorsCh.
+func TestBlockPoolAddBlockReleasesLockBeforeSend(t *testing.T) {
+	ctx := t.Context()
+
+	peerID := types.NodeID(strings.Repeat("a", 40))
+	peers := testPeers{peerID: {peerID, 1, 100, make(chan inputData)}}
+
+	errorsCh := make(chan peerError, 1)
+	requestsCh := make(chan BlockRequest, 1000)
+	pool := NewBlockPool(1, requestsCh, errorsCh, makeRouter(peers))
+	require.NoError(t, pool.Start(ctx))
+	t.Cleanup(func() { pool.Wait() })
+
+	pool.SetPeerRange(peerID, 1, 100)
+
+	errorsCh <- peerError{errors.New("filler"), peerID}
+
+	farHeight := int64(1 + maxDiffBetweenCurrentAndReceivedBlockHeight + 1000)
+	farBlock := &types.Block{Header: types.Header{Height: farHeight}}
+
+	addBlockDone := make(chan struct{})
+	go func() {
+		_ = pool.AddBlock(peerID, farBlock, 123)
+		close(addBlockDone)
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	probeDone := make(chan struct{})
+	go func() {
+		_ = pool.MaxPeerHeight()
+		close(probeDone)
+	}()
+
+	select {
+	case <-probeDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pool.mtx not released before AddBlock sent on errorsCh")
+	}
+
+	<-errorsCh
+
+	select {
+	case <-addBlockDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("AddBlock did not complete after errorsCh was drained")
+	}
+
+	select {
+	case <-errorsCh:
+	default:
+	}
 }

--- a/sei-tendermint/internal/blocksync/pool_test.go
+++ b/sei-tendermint/internal/blocksync/pool_test.go
@@ -3,9 +3,9 @@ package blocksync
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"math"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -322,13 +322,19 @@ func testBlockPoolRejectsWrongPeerWithoutDiscardingGoodBlock(t *testing.T, goodF
 
 // TestBlockPoolAddBlockReleasesLockBeforeSend asserts that AddBlock does
 // not hold pool.mtx across a send on errorsCh.
+//
+// The test parks AddBlock on its sendError call (by leaving the
+// unbuffered errorsCh unread) and then asserts via runtime.Stack +
+// pool.mtx.TryLock that the mutex is acquirable while the goroutine is
+// parked there. Without the fix, AddBlock holds pool.mtx for the
+// duration of the parked send and TryLock never succeeds.
 func TestBlockPoolAddBlockReleasesLockBeforeSend(t *testing.T) {
 	ctx := t.Context()
 
 	peerID := types.NodeID(strings.Repeat("a", 40))
 	peers := testPeers{peerID: {peerID, 1, 100, make(chan inputData)}}
 
-	errorsCh := make(chan peerError, 1)
+	errorsCh := make(chan peerError)
 	requestsCh := make(chan BlockRequest, 1000)
 	pool := NewBlockPool(1, requestsCh, errorsCh, makeRouter(peers))
 	require.NoError(t, pool.Start(ctx))
@@ -336,8 +342,11 @@ func TestBlockPoolAddBlockReleasesLockBeforeSend(t *testing.T) {
 
 	pool.SetPeerRange(peerID, 1, 100)
 
-	errorsCh <- peerError{errors.New("filler"), peerID}
-
+	// pool.height starts at 1 and the peer reports height 100, so no
+	// requester is created for far-ahead heights. A block more than
+	// maxDiffBetweenCurrentAndReceivedBlockHeight above pool.height takes
+	// AddBlock's "too far ahead" branch, which is one of the sendError
+	// code paths.
 	farHeight := int64(1 + maxDiffBetweenCurrentAndReceivedBlockHeight + 1000)
 	farBlock := &types.Block{Header: types.Header{Height: farHeight}}
 
@@ -346,31 +355,34 @@ func TestBlockPoolAddBlockReleasesLockBeforeSend(t *testing.T) {
 		_ = pool.AddBlock(peerID, farBlock, 123)
 		close(addBlockDone)
 	}()
+	t.Cleanup(func() {
+		// Drain so the AddBlock goroutine can exit even if the assertion
+		// below fails.
+		select {
+		case <-errorsCh:
+		case <-addBlockDone:
+		}
+		<-addBlockDone
+	})
 
-	time.Sleep(200 * time.Millisecond)
-
-	probeDone := make(chan struct{})
-	go func() {
-		_ = pool.MaxPeerHeight()
-		close(probeDone)
-	}()
-
-	select {
-	case <-probeDone:
-	case <-time.After(2 * time.Second):
-		t.Fatal("pool.mtx not released before AddBlock sent on errorsCh")
-	}
+	require.Eventually(t, func() bool {
+		if !anyGoroutineParkedIn("blocksync.(*BlockPool).sendError") {
+			return false
+		}
+		if !pool.mtx.TryLock() {
+			return false
+		}
+		pool.mtx.Unlock()
+		return true
+	}, 5*time.Second, 10*time.Millisecond,
+		"pool.mtx not released while a goroutine is parked in sendError")
 
 	<-errorsCh
+	<-addBlockDone
+}
 
-	select {
-	case <-addBlockDone:
-	case <-time.After(2 * time.Second):
-		t.Fatal("AddBlock did not complete after errorsCh was drained")
-	}
-
-	select {
-	case <-errorsCh:
-	default:
-	}
+func anyGoroutineParkedIn(frame string) bool {
+	buf := make([]byte, 64<<10)
+	n := runtime.Stack(buf, true)
+	return strings.Contains(string(buf[:n]), frame)
 }


### PR DESCRIPTION
## Describe your changes and provide context

`BlockPool.AddBlock`, `BlockPool.removeTimedoutPeers`, and `bpPeer.onTimeout` previously called `sendError` (a blocking send on `errorsCh`) while still holding `pool.mtx`. This change releases the mutex before the send.

In `AddBlock` and `removeTimedoutPeers` the send is registered as a `defer` *before* the `defer pool.mtx.Unlock()`, so LIFO ordering runs `Unlock` first and then performs the send. This keeps panic safety from the deferred unlock and avoids tracking an explicit `Unlock` on every return path. `onTimeout`'s critical section is a single boolean write, so it uses an explicit `Unlock` instead.

`AddBlock`'s return values and error wrapping are unchanged.

## Testing performed to validate your change

- `go test ./sei-tendermint/internal/blocksync/... -race -count=1` — full package green.
- New regression test `TestBlockPoolAddBlockReleasesLockBeforeSend` asserts the invariant for `AddBlock`. Verified discriminating by temporarily reverting the `AddBlock` edit — the test then blocks until the package timeout.
- `gofmt -s -l` clean.