### PR TITLE
feat(giga): don't fail if evmone can't load

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -811,6 +811,8 @@ func New(
 		// evmone is loaded best-effort
 		if evmoneVM, err := gigalib.InitEvmoneVM(); err == nil {
 			app.GigaEvmKeeper.EvmoneVM = evmoneVM
+		} else {
+			logger.Debug("failed to load evmone VM", "error", err)
 		}
 		if gigaExecutorConfig.OCCEnabled {
 			logger.Info("benchmark: Giga Executor with OCC is ENABLED - using new EVM execution path with parallel execution")

--- a/app/app.go
+++ b/app/app.go
@@ -808,11 +808,10 @@ func New(
 	app.GigaOCCEnabled = gigaExecutorConfig.OCCEnabled
 	tmtypes.SkipLastResultsHashValidation.Store(gigaExecutorConfig.Enabled)
 	if gigaExecutorConfig.Enabled {
-		evmoneVM, err := gigalib.InitEvmoneVM()
-		if err != nil {
-			panic(fmt.Sprintf("failed to load evmone: %s", err))
+		// evmone is loaded best-effort
+		if evmoneVM, err := gigalib.InitEvmoneVM(); err == nil {
+			app.GigaEvmKeeper.EvmoneVM = evmoneVM
 		}
-		app.GigaEvmKeeper.EvmoneVM = evmoneVM
 		if gigaExecutorConfig.OCCEnabled {
 			logger.Info("benchmark: Giga Executor with OCC is ENABLED - using new EVM execution path with parallel execution")
 		} else {

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -163,13 +163,11 @@ func NewGigaTestWrapperWithRegularStore(t *testing.T, tm time.Time, valPub crypt
 	// Configure GigaBankKeeper to use regular KVStore instead of GigaKVStore
 	wrapper.App.GigaBankKeeper.UseRegularStore = true
 
-	// Initialize evmone VM if not already initialized
+	// Initialize evmone VM if not already initialized (best effort)
 	if wrapper.App.GigaEvmKeeper.EvmoneVM == nil {
-		evmoneVM, err := gigalib.InitEvmoneVM()
-		if err != nil {
-			panic(fmt.Sprintf("failed to load evmone: %s", err))
+		if evmoneVM, err := gigalib.InitEvmoneVM(); err == nil {
+			wrapper.App.GigaEvmKeeper.EvmoneVM = evmoneVM
 		}
-		wrapper.App.GigaEvmKeeper.EvmoneVM = evmoneVM
 	}
 
 	// Init genesis for GigaEvmKeeper (now uses regular KVStore)


### PR DESCRIPTION
## Describe your changes and provide context

This allows nodes on Ubuntu 22.04 or earlier to use Giga without having to install new deps.

## Testing performed to validate your change

Tests pass.