### PR TITLE
fix(evm): populate fields on V2 synthetic receipts for state-transition errors

### DIFF
--- a/x/evm/keeper/abci.go
+++ b/x/evm/keeper/abci.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"math"
+	"math/big"
 	"time"
 
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -9,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	authtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/types"
@@ -96,6 +98,12 @@ func (k *Keeper) EndBlock(ctx sdk.Context, height int64, blockGasUsed int64) {
 		logger.Info("pruned zero-value contract storage slots while scanning keys", "pruned-count", deleted, "key-count", scanned)
 	}
 
+	// Capture the current block's base fee BEFORE AdjustDynamicBaseFeePerGas
+	// overwrites it with the next block's value. Used below to populate
+	// EffectiveGasPrice on synthetic receipts for txs that bumped nonce but
+	// failed in msg_server before WriteReceipt.
+	currentBlockBaseFee := k.GetBaseFee(ctx)
+
 	newBaseFee := k.AdjustDynamicBaseFeePerGas(ctx, uint64(blockGasUsed)) // nolint:gosec
 	if newBaseFee != nil {
 		baseFeeBI := newBaseFee.TruncateInt().BigInt()
@@ -125,12 +133,7 @@ func (k *Keeper) EndBlock(ctx sdk.Context, height int64, blockGasUsed int64) {
 			if !k.GetNonceBumped(ctx, deferredInfo.TxIndex) {
 				continue
 			}
-			_ = k.SetTransientReceipt(ctx, txHash, &types.Receipt{
-				TxHashHex:        txHash.Hex(),
-				TransactionIndex: deferredInfo.TxIndex,
-				VmError:          deferredInfo.Error,
-				BlockNumber:      uint64(ctx.BlockHeight()), // nolint:gosec
-			})
+			_ = k.SetTransientReceipt(ctx, txHash, k.buildSyntheticReceipt(ctx, deferredInfo, currentBlockBaseFee))
 			continue
 		}
 		idx := int(deferredInfo.TxIndex)
@@ -184,4 +187,62 @@ func (k *Keeper) EndBlock(ctx sdk.Context, height int64, blockGasUsed int64) {
 	}
 	k.SetBlockBloom(ctx, allBlooms)
 	k.SetEvmOnlyBlockBloom(ctx, evmOnlyBlooms)
+}
+
+// buildSyntheticReceipt constructs the receipt written at EndBlock for a tx
+// that bumped the sender's nonce but failed in msg_server before WriteReceipt
+// (e.g. EIP-7623 floor-data-gas underflow, panic during applyEVMMessage).
+//
+// The closest in-spec analog is OOG, which reports GasUsed = gasLimit and
+// EffectiveGasPrice = the tx's effective price. Reporting zeros here would
+// misrepresent what the sender was charged in the ante handler — the user
+// did pay gasLimit * effectiveGasPrice, with no refund.
+func (k *Keeper) buildSyntheticReceipt(ctx sdk.Context, deferredInfo *types.DeferredInfo, baseFee *big.Int) *types.Receipt {
+	txHash := common.BytesToHash(deferredInfo.TxHash)
+	r := &types.Receipt{
+		TxHashHex:        txHash.Hex(),
+		TransactionIndex: deferredInfo.TxIndex,
+		VmError:          deferredInfo.Error,
+		BlockNumber:      uint64(ctx.BlockHeight()), //nolint:gosec
+		Status:           uint32(ethtypes.ReceiptStatusFailed),
+	}
+
+	idx := int(deferredInfo.TxIndex)
+	if idx < 0 || idx >= len(k.msgs) || k.msgs[idx] == nil {
+		return r
+	}
+	msg := k.msgs[idx]
+	etx, _ := msg.AsTransaction()
+	if etx == nil {
+		return r
+	}
+
+	r.TxType = uint32(etx.Type())
+	r.GasUsed = etx.Gas()
+
+	if msg.Derived != nil {
+		r.From = msg.Derived.SenderEVMAddr.Hex()
+		if etx.To() == nil {
+			r.ContractAddress = crypto.CreateAddress(msg.Derived.SenderEVMAddr, etx.Nonce()).Hex()
+		}
+	}
+	if etx.To() != nil {
+		r.To = etx.To().Hex()
+		if len(etx.Data()) > 0 {
+			r.ContractAddress = etx.To().Hex()
+		}
+	}
+
+	// EIP-1559 effective gas price: min(GasFeeCap, GasTipCap + baseFee).
+	// Falls back to the legacy GasPrice when baseFee is unavailable.
+	eff := new(big.Int).Set(etx.GasPrice())
+	if baseFee != nil {
+		eff = new(big.Int).Add(etx.GasTipCap(), baseFee)
+		if eff.Cmp(etx.GasFeeCap()) > 0 {
+			eff.Set(etx.GasFeeCap())
+		}
+	}
+	r.EffectiveGasPrice = eff.Uint64()
+
+	return r
 }

--- a/x/evm/keeper/abci_test.go
+++ b/x/evm/keeper/abci_test.go
@@ -3,8 +3,11 @@ package keeper_test
 import (
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/sei-protocol/sei-chain/app"
 	abci "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
+	"github.com/sei-protocol/sei-chain/x/evm/derived"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 	"github.com/stretchr/testify/require"
 )
@@ -35,6 +38,11 @@ func TestEndBlock_ReceiptCreatedWhenNonceBumped(t *testing.T) {
 	ctx := a.GetContextForDeliverTx([]byte{}).WithBlockHeight(8)
 
 	msg := mockEVMTransactionMessage(t)
+	// The synthetic-receipt path uses msg.Derived.SenderEVMAddr to populate
+	// the receipt's `From` (and `ContractAddress` for contract-creation txs).
+	// In production this is set by the ante handler's preprocess step.
+	sender := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	msg.Derived = &derived.Derived{SenderEVMAddr: sender}
 	etx, _ := msg.AsTransaction()
 	txHash := etx.Hash()
 
@@ -50,4 +58,17 @@ func TestEndBlock_ReceiptCreatedWhenNonceBumped(t *testing.T) {
 	require.Equal(t, txHash.Hex(), receipt.TxHashHex)
 	require.Equal(t, "some ante error", receipt.VmError)
 	require.Equal(t, uint64(8), receipt.BlockNumber)
+
+	// Receipt-iff-nonce-bumped invariant: the sender paid gasLimit *
+	// effectiveGasPrice in ante, so the receipt must reflect that (the closest
+	// in-spec analog is OOG: GasUsed = gasLimit). Without these fields RPC
+	// clients see GasUsed=0 / From=zero for a charged-and-included tx.
+	require.Equal(t, uint32(ethtypes.ReceiptStatusFailed), receipt.Status)
+	require.Equal(t, uint32(etx.Type()), receipt.TxType)
+	require.Equal(t, etx.Gas(), receipt.GasUsed)
+	require.Equal(t, sender.Hex(), receipt.From)
+	require.NotZero(t, receipt.EffectiveGasPrice)
+	if etx.To() != nil {
+		require.Equal(t, etx.To().Hex(), receipt.To)
+	}
 }


### PR DESCRIPTION
## Why

Follow-up to #3383, which fixed the Giga path's receipt-iff-nonce-bumped invariant for EIP-7623 floor-data-gas failures. That PR's Giga code writes the receipt with `GasUsed = ethTx.Gas()` and EIP-1559 `EffectiveGasPrice`. The V2 path, which catches the same failure shape via the EndBlock synthetic-receipt loop, was emitting only `TxHashHex`, `TransactionIndex`, `VmError`, and `BlockNumber` — everything else defaulted to zero/empty.

So an RPC client polling `eth_getTransactionReceipt` for a floor-data-gas-failed tx on V2 saw `GasUsed=0`, `EffectiveGasPrice=0`, `From=""`, `TxType=0`. The sender did pay `gasLimit * effectiveGasPrice` in the ante handler with no refund, so this misrepresents what was actually charged.

The closest in-spec analog for this failure shape is **OOG**, which go-ethereum reports as `GasUsed = gasLimit`. (Mainnet go-ethereum would reject these txs before block inclusion entirely — but Sei's ante/Execute split means they can land in a block, and we have to pick a convention. OOG is the right one.)

## What

In [`x/evm/keeper/abci.go`](x/evm/keeper/abci.go):

- Capture `GetBaseFee(ctx)` **before** `AdjustDynamicBaseFeePerGas` runs — that call overwrites the stored value with the next block's base fee, so reading it later in the loop would return the wrong price.
- Factor synthetic-receipt construction into a `buildSyntheticReceipt` helper that populates `GasUsed=etx.Gas()`, `Status=Failed`, `TxType`, `From`, `To`/`ContractAddress`, and EIP-1559 `EffectiveGasPrice` from the original message and captured base fee.
- Defensive fallbacks for missing `msg`, missing `Derived`, or `baseFee == nil` (pre-v6.2.0 pacific-1).

## Downstream effects of the field changes

Three read-time call sites that touch synthetic-receipt-shaped data:

1. **[`evmrpc/tx.go:147`](evmrpc/tx.go)** — `eth_getTransactionReceipt` read-time backfill. Predicate is `Status==0 && GasUsed==0`. New receipts skip it (already populated). **Old receipts** (`GasUsed==0`) continue to hit it and get `GasUsed=0` reaffirmed — historical wire-format preserved. Not touched.

2. **[`evmrpc/utils.go:254`](evmrpc/utils.go)** — block-tx-list nonce verification. Predicate is `Status==0 && EffectiveGasPrice==0`. New receipts skip it (now populated) — safe, the EndBlock loop already gates writes on `GetNonceBumped`. The verification was a belt-and-suspenders. Not touched.

3. **[`evmrpc/info.go:377,406,456`](evmrpc/info.go)** — `eth_feeHistory` / gas-price congestion / `CalculateGasUsedRatio` sum `receipt.GasUsed` across a block. For floor-data-gas-failed txs, contribution goes from `0` → `etx.Gas()`. So:
   - `eth_feeHistory` reward percentiles include floor-data-gas txs as full-gas contributors.
   - `eth_gasPrice` congestion detection may flip `isChainCongested` slightly sooner.
   - `CalculateGasUsedRatio` reports higher ratios for blocks containing these failures.

   Note: `AdjustDynamicBaseFeePerGas` uses cosmos-sdk's `blockGasUsed` (block gas meter), not receipts, so base fee adjustment is unaffected. Post-fix, the receipt says "I used etx.Gas()" while the block gas meter says "I used 0" — matches the spec interpretation: the user paid for the full gas (receipt), but no opcodes ran (gas meter). Floor-data-gas failures are rare enough that the practical impact on (1)-(3) is minimal.

## Tests

`TestEndBlock_ReceiptCreatedWhenNonceBumped` extended to set `msg.Derived` (mirroring what the ante handler does in prod) and assert the new `Status`/`TxType`/`GasUsed`/`From`/`EffectiveGasPrice`/`To` fields.

## Things done

- [x] `gofmt -s` clean
- [x] `go test ./x/evm/keeper/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)