### PR TITLE
evmrpc: include reverts in *ExcludeTraceFail discriminator (CON-296)

### DIFF
--- a/evmrpc/setup_test.go
+++ b/evmrpc/setup_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/gorilla/websocket"
@@ -1058,11 +1059,15 @@ func setupLogs() {
 		TxHashHex:         TestNonPanicTxHash,
 		EffectiveGasPrice: 1000000,
 	})
+	// Ante-failure receipt: EffectiveGasPrice=0 is the signal that the tx
+	// was rejected before reaching the VM (see x/evm/keeper/abci.go's
+	// deferred-info path). VmError carries a nonce-error string so the
+	// isReceiptFromAnteError post-v5.8.0 check matches.
 	EVMKeeper.MockReceipt(CtxDebugTracePanic, common.HexToHash(TestPanicTxHash), &types.Receipt{
-		BlockNumber:       MockHeight103,
-		TransactionIndex:  1,
-		TxHashHex:         TestPanicTxHash,
-		EffectiveGasPrice: 1000000,
+		BlockNumber:      MockHeight103,
+		TransactionIndex: 1,
+		TxHashHex:        TestPanicTxHash,
+		VmError:          core.ErrNonceTooHigh.Error(),
 	})
 	txNonEvmBz, _ := Encoder(TxNonEvmWithSyntheticLog)
 	txNonEvmHash := sha256.Sum256(txNonEvmBz)

--- a/evmrpc/tracers.go
+++ b/evmrpc/tracers.go
@@ -457,23 +457,28 @@ func (api *SeiDebugAPI) TraceBlockByHashExcludeTraceFail(ctx context.Context, ha
 	return finalTraces, nil
 }
 
-// isPanicOrSyntheticTx returns true if the tx is a panic tx or a synthetic tx, used
-// in the *ExcludeTraceFail endpoints. Both classes are excluded because their traces
-// would be empty or meaningless.
+// isPanicOrSyntheticTx returns true if the tx isn't traceable — used by the
+// *ExcludeTraceFail endpoints to filter out txs whose trace would be empty
+// or meaningless.
 //
-// Decision is made from the receipt store alone, decoupling this check from the
-// block-level trace path. Background: under Autobahn, BlockResults.TxsResults is
-// not yet wired (sei-tendermint/internal/rpc/core/blocks.go BlockResults stub),
-// so debug_traceBlockByNumber returns []. The previous implementation re-traced
-// the block and used trace.Error to identify panic txs and trace-list absence to
-// identify synthetic txs — under Autobahn the trace list is always empty, so
-// every tx looked synthetic.
+// Per evmrpc/README.md ("Tracing Failure Management Endpoints"), the target
+// is txs "included in blocks but not executed" — pre-state-check failures
+// (nonce mismatch, insufficient funds) and chain-generated synthetic txs.
+// Reverts, OOG, and other in-VM failures all ran and produced traces; they
+// stay in.
 //
-// Receipt-store mapping (works under both Autobahn and legacy):
-//   - GetReceipt error  → no receipt (ante-rejected, unknown hash, etc.)  → exclude
+// Receipt fields are sufficient to discriminate. WriteReceipt
+// (x/evm/keeper/receipt.go) populates EffectiveGasPrice from msg.GasPrice
+// for any tx that reached the VM. The ante-deferred path
+// (x/evm/keeper/abci.go) writes a stub receipt with EffectiveGasPrice=0
+// for nonce-bumping ante failures. isReceiptFromAnteError captures that
+// signal, and the same helper is used by filterTransactions for block
+// endpoints — so block and tx ExcludeTraceFail filter the same set.
+//
+//   - GetReceipt error                          → no receipt yet           → exclude
 //   - TxType == ShellEVMTxType (math.MaxUint32) → chain-generated synthetic → exclude
-//   - Status == 0 (failed receipt)              → panic-like                → exclude
-//   - Status == 1 (success)                    → real, traceable          → include
+//   - isReceiptFromAnteError(receipt)           → never executed           → exclude
+//   - anything else (success / revert / OOG)    → executed, has a trace    → include
 func (api *DebugAPI) isPanicOrSyntheticTx(ctx context.Context, hash common.Hash) (isPanic bool, err error) {
 	if api.isPanicCache != nil {
 		if cached, ok := api.isPanicCache.Get(hash); ok {
@@ -490,7 +495,7 @@ func (api *DebugAPI) isPanicOrSyntheticTx(ctx context.Context, hash common.Hash)
 		return true, nil
 	}
 
-	exclude := receipt.TxType == evmtypes.ShellEVMTxType || receipt.Status == 0
+	exclude := receipt.TxType == evmtypes.ShellEVMTxType || isReceiptFromAnteError(sdkctx, receipt)
 	if api.isPanicCache != nil {
 		api.isPanicCache.Add(hash, exclude)
 	}

--- a/evmrpc/tx_test.go
+++ b/evmrpc/tx_test.go
@@ -143,19 +143,76 @@ func TestGetVMError(t *testing.T) {
 	require.Equal(t, "receipt not found", resObj["error"].(map[string]interface{})["message"])
 }
 
+// Pins the discriminator used by sei_getTransactionReceiptExcludeTraceFail.
+// Per evmrpc/README.md, the endpoint should filter out txs that were
+// "included in blocks but not executed" — pre-state-check failures and
+// chain-generated synthetic txs. Reverts ran in the VM and produce a real
+// trace; they must come through.
 func TestGetTransactionReceiptExcludeTraceFail(t *testing.T) {
-	body := fmt.Sprintf("{\"jsonrpc\": \"2.0\",\"method\": \"%s_getTransactionReceiptExcludeTraceFail\",\"params\":[\"%s\"],\"id\":\"test\"}", "sei", TestPanicTxHash)
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s:%d", TestAddr, TestPort), strings.NewReader(body))
-	require.Nil(t, err)
-	req.Header.Set("Content-Type", "application/json")
-	res, err := http.DefaultClient.Do(req)
-	require.Nil(t, err)
-	resBody, err := io.ReadAll(res.Body)
-	require.Nil(t, err)
-	resObj := map[string]interface{}{}
-	require.Nil(t, json.Unmarshal(resBody, &resObj))
-	require.Greater(t, len(resObj["error"].(map[string]interface{})["message"].(string)), 0)
-	require.Nil(t, resObj["result"])
+	call := func(hash string) map[string]interface{} {
+		body := fmt.Sprintf("{\"jsonrpc\": \"2.0\",\"method\": \"sei_getTransactionReceiptExcludeTraceFail\",\"params\":[\"%s\"],\"id\":\"test\"}", hash)
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s:%d", TestAddr, TestPort), strings.NewReader(body))
+		require.Nil(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		res, err := http.DefaultClient.Do(req)
+		require.Nil(t, err)
+		resBody, err := io.ReadAll(res.Body)
+		require.Nil(t, err)
+		resObj := map[string]interface{}{}
+		require.Nil(t, json.Unmarshal(resBody, &resObj))
+		return resObj
+	}
+
+	cases := []struct {
+		name        string
+		hash        string
+		expectPanic bool // true => endpoint returns ErrPanicTx
+	}{
+		{
+			// Ante failure (deferred-info receipt: EffectiveGasPrice=0, VmError set).
+			// Not executed → no trace → exclude.
+			name:        "ante failure is excluded",
+			hash:        TestPanicTxHash,
+			expectPanic: true,
+		},
+		{
+			// Chain-generated synthetic (TxType=ShellEVMTxType). No real EVM
+			// execution → no trace → exclude.
+			name:        "synthetic is excluded",
+			hash:        TestSyntheticTxHash,
+			expectPanic: true,
+		},
+		{
+			// Revert (Status=0 with EffectiveGasPrice>0). The VM ran and
+			// produced a trace; the REVERT just shows up inside it.
+			// Including this case is what distinguishes us from the prior
+			// over-strict Status==0 mapping.
+			name:        "revert is included",
+			hash:        TestNonPanicTxHash,
+			expectPanic: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resObj := call(tc.hash)
+			errObj, hasErr := resObj["error"].(map[string]interface{})
+			if tc.expectPanic {
+				require.True(t, hasErr, "expected ErrPanicTx but got result=%v", resObj["result"])
+				require.Equal(t, evmrpc.ErrPanicTx.Error(), errObj["message"])
+				require.Nil(t, resObj["result"])
+				return
+			}
+			if hasErr {
+				// Allow downstream errors that aren't the panic-tx exclusion —
+				// the mock fixture isn't a complete revert (no signer-recoverable
+				// tx in the block from the receipt's perspective), so the
+				// endpoint may fail at a later step. The point is the panic-tx
+				// check itself must not exclude the revert.
+				require.NotEqual(t, evmrpc.ErrPanicTx.Error(), errObj["message"], "revert tx was excluded as panic")
+			}
+		})
+	}
 }
 
 // The panic/synthetic decision for a missing receipt must not be cached.


### PR DESCRIPTION
## Summary

`isPanicOrSyntheticTx` excluded any `Status==0` receipt from the `*ExcludeTraceFail` endpoints, which conflates two cases:

- **Ante failures** — tx never reached the VM, no trace exists, can't be traced
- **In-VM failures** (reverts, OOG, EIP-7623 floor) — tx ran in the VM and produced a complete trace

[`evmrpc/README.md`'s Tracing Failure Management Endpoints section](https://github.com/sei-protocol/sei-chain/blob/main/evmrpc/README.md) describes the target as the first set only — txs *"included in blocks but not executed."* Reverts have a real trace; they should stay in. The pre-#3402 trace-based path also kept them (filtered on `trace.Error`, which is empty for reverts).

## Discriminator

Receipt fields are sufficient. `WriteReceipt` (`x/evm/keeper/receipt.go`) sets `EffectiveGasPrice = msg.GasPrice` for any tx that reached the VM. The ante-deferred receipt path (`x/evm/keeper/abci.go`) writes a stub receipt with `EffectiveGasPrice = 0`. `isReceiptFromAnteError` already encodes this check, and it's the same helper `filterTransactions` uses for block endpoints — so block and tx `*ExcludeTraceFail` now agree on what they filter.

```go
// before
exclude := receipt.TxType == evmtypes.ShellEVMTxType || receipt.Status == 0
// after
exclude := receipt.TxType == evmtypes.ShellEVMTxType || isReceiptFromAnteError(sdkctx, receipt)
```

## Test coverage

The existing single-case test was anchored to `TestPanicTxHash`, whose receipt had `EffectiveGasPrice: 1000000` — by the correct discriminator that's a revert, mislabelled as a panic. The test passed only because the over-strict mapping happened to exclude it for the wrong reason.

Aligned the fixture with its name (real ante-failure receipt: `EffectiveGasPrice=0`, `VmError="nonce too high"`) and replaced the single assertion with a table pinning the matrix:

| Fixture | Receipt shape | Expected |
|---|---|---|
| `TestPanicTxHash` (now ante) | `EffectiveGasPrice=0`, nonce-error `VmError` | excluded |
| `TestSyntheticTxHash` | `TxType=ShellEVMTxType` | excluded |
| `TestNonPanicTxHash` (revert) | `Status=0`, `EffectiveGasPrice>0` | **included** |

The "revert is included" case is the one that catches future regressions in this direction.

## Backward compat

#3402 introduced the over-strict mapping (May 2026). It's on `main` only — `git branch -r --contains eb17459e5 | grep release/v6` returns nothing — so no released version exposes the over-strict behavior. This fix lands before #3402 reaches any release branch.

## Test plan

- [x] `gofmt -s -l` clean
- [x] `go build ./evmrpc/...` clean
- [x] `go test ./evmrpc/ -count=1` passes (22s)
- [x] New test matrix passes 100/100 with `-count=100`
- [x] Confirmed `revert_is_included` fails with the fix reverted (`"Should not be: transaction is panic tx"`), passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)