### PR TITLE
evmrpc: drop dead isPanicOrSynthetic param from EncodeTmBlock (CON-296)

### DIFF
--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -83,7 +83,6 @@ type BlockAPI struct {
 
 type SeiBlockAPI struct {
 	*BlockAPI
-	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error)
 }
 
 func NewBlockAPI(tmClient client.LocalClient, k *keeper.Keeper, ctxProvider func(int64) sdk.Context, txConfigProvider func(int64) client.TxConfig, connectionType ConnectionType, watermarks *WatermarkManager, globalBlockCache BlockCache, cacheCreationMutex *sync.Mutex) *BlockAPI {
@@ -108,7 +107,6 @@ func NewSeiBlockAPI(
 	ctxProvider func(int64) sdk.Context,
 	txConfigProvider func(int64) client.TxConfig,
 	connectionType ConnectionType,
-	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error),
 	watermarks *WatermarkManager,
 	globalBlockCache BlockCache,
 	cacheCreationMutex *sync.Mutex,
@@ -127,8 +125,7 @@ func NewSeiBlockAPI(
 		cacheCreationMutex:   cacheCreationMutex,
 	}
 	return &SeiBlockAPI{
-		BlockAPI:  blockAPI,
-		isPanicTx: isPanicTx,
+		BlockAPI: blockAPI,
 	}
 }
 
@@ -138,12 +135,11 @@ func NewSei2BlockAPI(
 	ctxProvider func(int64) sdk.Context,
 	txConfigProvider func(int64) client.TxConfig,
 	connectionType ConnectionType,
-	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error),
 	watermarks *WatermarkManager,
 	globalBlockCache BlockCache,
 	cacheCreationMutex *sync.Mutex,
 ) *SeiBlockAPI {
-	blockAPI := NewSeiBlockAPI(tmClient, k, ctxProvider, txConfigProvider, connectionType, isPanicTx, watermarks, globalBlockCache, cacheCreationMutex)
+	blockAPI := NewSeiBlockAPI(tmClient, k, ctxProvider, txConfigProvider, connectionType, watermarks, globalBlockCache, cacheCreationMutex)
 	blockAPI.namespace = Sei2Namespace
 	blockAPI.includeBankTransfers = true
 	return blockAPI
@@ -154,13 +150,15 @@ func (a *SeiBlockAPI) GetBlockByNumberExcludeTraceFail(ctx context.Context, numb
 	if number == 0 {
 		return encodeGenesisBlock(), nil
 	}
-	// exclude synthetic txs
-	return a.getBlockByNumber(ctx, number, fullTx, false, a.isPanicTx)
+	// Exclude synthetic txs. Ante failures are already dropped by
+	// filterTransactions via isReceiptFromAnteError, and reverts have valid
+	// traces and should pass through — so no additional per-tx filter here.
+	return a.getBlockByNumber(ctx, number, fullTx, false)
 }
 
 func (a *SeiBlockAPI) GetBlockByHashExcludeTraceFail(ctx context.Context, blockHash common.Hash, fullTx bool) (result map[string]interface{}, returnErr error) {
-	// exclude synthetic txs
-	return a.getBlockByHash(ctx, blockHash, fullTx, false, a.isPanicTx)
+	// See note on GetBlockByNumberExcludeTraceFail.
+	return a.getBlockByHash(ctx, blockHash, fullTx, false)
 }
 
 func (a *BlockAPI) GetBlockTransactionCountByNumber(ctx context.Context, number rpc.BlockNumber) (result *hexutil.Uint, returnErr error) {
@@ -199,10 +197,10 @@ func (a *BlockAPI) GetBlockTransactionCountByHash(ctx context.Context, blockHash
 
 func (a *BlockAPI) GetBlockByHash(ctx context.Context, blockHash common.Hash, fullTx bool) (result map[string]interface{}, returnErr error) {
 	// used for both: eth_ and sei_ namespaces
-	return a.getBlockByHash(ctx, blockHash, fullTx, a.includeShellReceipts, nil)
+	return a.getBlockByHash(ctx, blockHash, fullTx, a.includeShellReceipts)
 }
 
-func (a *BlockAPI) getBlockByHash(ctx context.Context, blockHash common.Hash, fullTx bool, includeSyntheticTxs bool, isPanicTx func(ctx context.Context, hash common.Hash) (bool, error)) (result map[string]interface{}, returnErr error) {
+func (a *BlockAPI) getBlockByHash(ctx context.Context, blockHash common.Hash, fullTx bool, includeSyntheticTxs bool) (result map[string]interface{}, returnErr error) {
 	startTime := time.Now()
 	defer func() {
 		recordMetricsWithError(ctx, fmt.Sprintf("%s_getBlockByHash", a.namespace), a.connectionType, startTime, returnErr, recover())
@@ -233,7 +231,7 @@ func (a *BlockAPI) getBlockByHash(ctx context.Context, blockHash common.Hash, fu
 	if err != nil {
 		return nil, err
 	}
-	return EncodeTmBlock(a.ctxProvider, a.txConfigProvider, block, blockRes, a.keeper, fullTx, a.includeBankTransfers, includeSyntheticTxs, isPanicTx, a.globalBlockCache, a.cacheCreationMutex)
+	return EncodeTmBlock(a.ctxProvider, a.txConfigProvider, block, blockRes, a.keeper, fullTx, a.includeBankTransfers, includeSyntheticTxs, a.globalBlockCache, a.cacheCreationMutex)
 }
 
 func (a *BlockAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (result map[string]interface{}, returnErr error) {
@@ -245,7 +243,7 @@ func (a *BlockAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber,
 		// for compatibility with the graph, always return genesis block
 		return encodeGenesisBlock(), nil
 	}
-	return a.getBlockByNumber(ctx, number, fullTx, a.includeShellReceipts, nil)
+	return a.getBlockByNumber(ctx, number, fullTx, a.includeShellReceipts)
 }
 
 func (a *BlockAPI) getBlockByNumber(
@@ -253,7 +251,6 @@ func (a *BlockAPI) getBlockByNumber(
 	number rpc.BlockNumber,
 	fullTx bool,
 	includeSyntheticTxs bool,
-	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error),
 ) (result map[string]interface{}, returnErr error) {
 	numberPtr, err := getBlockNumber(ctx, a.tmClient, number)
 	if err != nil {
@@ -280,7 +277,7 @@ func (a *BlockAPI) getBlockByNumber(
 	if err != nil {
 		return nil, err
 	}
-	return EncodeTmBlock(a.ctxProvider, a.txConfigProvider, block, blockRes, a.keeper, fullTx, a.includeBankTransfers, includeSyntheticTxs, isPanicTx, a.globalBlockCache, a.cacheCreationMutex)
+	return EncodeTmBlock(a.ctxProvider, a.txConfigProvider, block, blockRes, a.keeper, fullTx, a.includeBankTransfers, includeSyntheticTxs, a.globalBlockCache, a.cacheCreationMutex)
 }
 
 func (a *BlockAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (result []map[string]interface{}, returnErr error) {
@@ -371,7 +368,6 @@ func EncodeTmBlock(
 	fullTx bool,
 	includeBankTransfers bool,
 	includeSyntheticTxs bool,
-	isPanicOrSynthetic func(ctx context.Context, hash common.Hash) (bool, error),
 	globalBlockCache BlockCache,
 	cacheCreationMutex *sync.Mutex,
 ) (map[string]interface{}, error) {

--- a/evmrpc/block_test.go
+++ b/evmrpc/block_test.go
@@ -50,7 +50,7 @@ func TestEncodeTmBlock_EmptyTransactions(t *testing.T) {
 	}
 
 	// Call EncodeTmBlock with empty transactions
-	result, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, block, blockRes, k, true, false, false, nil, evmrpc.NewBlockCache(3000), &sync.Mutex{})
+	result, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, block, blockRes, k, true, false, false, evmrpc.NewBlockCache(3000), &sync.Mutex{})
 	require.Nil(t, err)
 
 	// Assert txHash is equal to ethtypes.EmptyTxsHash
@@ -96,7 +96,7 @@ func TestEncodeBankMsg(t *testing.T) {
 			},
 		},
 	}
-	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, &resBlockRes, k, true, false, false, nil, evmrpc.NewBlockCache(3000), &sync.Mutex{})
+	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, &resBlockRes, k, true, false, false, evmrpc.NewBlockCache(3000), &sync.Mutex{})
 	require.Nil(t, err)
 	txs := res["transactions"].([]interface{})
 	require.Equal(t, 0, len(txs))
@@ -149,7 +149,7 @@ func TestEncodeWasmExecuteMsg(t *testing.T) {
 			},
 		},
 	}
-	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, &resBlockRes, k, true, false, true, nil, evmrpc.NewBlockCache(3000), &sync.Mutex{})
+	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, &resBlockRes, k, true, false, true, evmrpc.NewBlockCache(3000), &sync.Mutex{})
 	require.Nil(t, err)
 	txs := res["transactions"].([]interface{})
 	require.Equal(t, 1, len(txs))
@@ -210,7 +210,7 @@ func TestEncodeBankTransferMsg(t *testing.T) {
 			},
 		},
 	}
-	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, &resBlockRes, k, true, true, false, nil, evmrpc.NewBlockCache(3000), &sync.Mutex{})
+	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, &resBlockRes, k, true, true, false, evmrpc.NewBlockCache(3000), &sync.Mutex{})
 	require.Nil(t, err)
 	txs := res["transactions"].([]interface{})
 	require.Equal(t, 1, len(txs))

--- a/evmrpc/block_txcount_parity_test.go
+++ b/evmrpc/block_txcount_parity_test.go
@@ -125,7 +125,7 @@ func TestBlockTransactionCountMatchesGetBlockByNumber(t *testing.T) {
 	decodeOnly := countDecodeOnlyEvmTxs(block.Block.Txs, TxConfig.TxDecoder())
 	require.Equal(t, 2, decodeOnly)
 
-	encoded, err := evmrpc.EncodeTmBlock(ctxProvider, txConfigProvider, block, blockRes, k, false, false, false, nil, cache, mu)
+	encoded, err := evmrpc.EncodeTmBlock(ctxProvider, txConfigProvider, block, blockRes, k, false, false, false, cache, mu)
 	require.NoError(t, err)
 	list := encoded["transactions"].([]interface{})
 

--- a/evmrpc/height_availability_test.go
+++ b/evmrpc/height_availability_test.go
@@ -219,9 +219,7 @@ func TestGetBlockReceiptsGenesisByNumber(t *testing.T) {
 func TestGetBlockByNumberExcludeTraceFailGenesis(t *testing.T) {
 	t.Parallel()
 
-	api := NewSeiBlockAPI(nil, nil, testCtxProvider, testTxConfigProvider, ConnectionTypeHTTP,
-		func(context.Context, common.Hash) (bool, error) { return false, nil },
-		nil, nil, nil)
+	api := NewSeiBlockAPI(nil, nil, testCtxProvider, testTxConfigProvider, ConnectionTypeHTTP, nil, nil, nil)
 	block, err := api.GetBlockByNumberExcludeTraceFail(context.Background(), 0, false)
 	require.NoError(t, err)
 	require.NotNil(t, block)

--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -123,11 +123,11 @@ func NewEVMHTTPServer(
 		},
 		{
 			Namespace: "sei",
-			Service:   NewSeiBlockAPI(tmClient, k, ctxProvider, txConfigProvider, ConnectionTypeHTTP, isPanicOrSyntheticTxFunc, watermarks, globalBlockCache, cacheCreationMutex),
+			Service:   NewSeiBlockAPI(tmClient, k, ctxProvider, txConfigProvider, ConnectionTypeHTTP, watermarks, globalBlockCache, cacheCreationMutex),
 		},
 		{
 			Namespace: "sei2",
-			Service:   NewSei2BlockAPI(tmClient, k, ctxProvider, txConfigProvider, ConnectionTypeHTTP, isPanicOrSyntheticTxFunc, watermarks, globalBlockCache, cacheCreationMutex),
+			Service:   NewSei2BlockAPI(tmClient, k, ctxProvider, txConfigProvider, ConnectionTypeHTTP, watermarks, globalBlockCache, cacheCreationMutex),
 		},
 		{
 			Namespace: "eth",


### PR DESCRIPTION
## Summary

`EncodeTmBlock` has carried an `isPanicOrSynthetic func(...)` parameter since [PR #2058 (Jan 2025)](https://github.com/sei-protocol/sei-chain/pull/2058). [PR #2388 (Sep 2025)](https://github.com/sei-protocol/sei-chain/pull/2388)'s cherry-pick refactored the loop to source msgs from `filterTransactions` and dropped the in-loop call to `isPanicOrSynthetic`, but kept the parameter and the entire wiring chain that feeds it (`SeiBlockAPI.isPanicTx`, `NewSeiBlockAPI`/`NewSei2BlockAPI` constructor params, `getBlockByHash`/`getBlockByNumber` signatures, the closure in `server.go`).

This PR removes the dead parameter and its plumbing. No replacement check is added.

## Why no replacement check

The relevant intent statement is in [`evmrpc/README.md`](https://github.com/sei-protocol/sei-chain/blob/main/evmrpc/README.md)'s "Tracing Failure Management Endpoints" section:

> Due to Sei's unique mempool implementation and the absence of transaction simulation, some transactions may fail **pre-state checks**. These failures can occur due to:
> - Nonce mismatches ("nonce too low" or "nonce too high")
> - Insufficient funds
> - Other panic conditions
>
> These transactions are included in blocks but **not executed**. The following endpoints help filter out these failed transactions.

So `*ExcludeTraceFail` should exclude:

| Class | Already filtered by |
|---|---|
| Chain-generated synthetic (`TxType == ShellEVMTxType`) | `filterTransactions(includeSyntheticTxs=false)` — explicit check at [utils.go:262](https://github.com/sei-protocol/sei-chain/blob/main/evmrpc/utils.go#L262) |
| Ante / pre-state failures (`EffectiveGasPrice==0` + nonce VmError) | `filterTransactions` via `isReceiptFromAnteError` at [utils.go:249](https://github.com/sei-protocol/sei-chain/blob/main/evmrpc/utils.go#L249) |

What's *not* in scope per the README: in-VM failures like reverts. Those have valid traces (the REVERT path is rendered inside the trace output, `trace.Error` stays empty), and the legacy trace-based implementation included them. So `EncodeTmBlock` doesn't need any additional per-tx panic filter — the two classes the README cares about are both already dropped before they reach the loop body.

PR #2058's original logic (re-trace the block, filter on `trace.Error`) was consistent with this — `trace.Error` is set for ante failures (no execution to trace) but empty for reverts. PR #2388's silent regression (dead param) didn't change visible behavior on the block side, because `filterTransactions`'s `isReceiptFromAnteError` already covered the same set. So this PR is a no-op for behavior: it just removes the orphaned plumbing.

## Scope

- Removes `EncodeTmBlock`'s `isPanicOrSynthetic` parameter
- Removes `getBlockByHash` / `getBlockByNumber`'s `isPanicTx` parameter
- Removes `SeiBlockAPI.isPanicTx` field
- Removes `isPanicTx` from `NewSeiBlockAPI` / `NewSei2BlockAPI` constructor signatures
- Drops the `isPanicOrSyntheticTxFunc` arguments at `server.go`'s `NewSeiBlockAPI` / `NewSei2BlockAPI` call sites
- Drops the inline stub at `evmrpc/height_availability_test.go`
- Updates three test call sites of `EncodeTmBlock` to drop the `nil` argument

The tx-side `SeiTransactionAPI.isPanicTx` (used by `sei_getTransactionReceiptExcludeTraceFail`) is **kept**. That endpoint checks before fetching the receipt so it can return `ErrPanicTx` to the client — a different shape from the block path. The tx-side discriminator itself is being corrected separately in #3450.

## Test plan

- [x] `gofmt -s -l` clean on all modified files
- [x] `go build ./...` clean
- [x] `go test ./evmrpc/ -count=1` passes (22s)
- [x] `go test ./evmrpc/tests/ -count=1` passes (27s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)