### PR TITLE
Fix lint issues and clean up simulation gas accounting

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -78,7 +78,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, sdk.AnteHandler, e
 	anteDecorators := []sdk.AnteDecorator{
 		ante.NewSetUpContextDecorator(antedecorators.GetGasMeterSetter(options.ParamsKeeper.(paramskeeper.Keeper))), // outermost AnteDecorator. SetUpContext must be called first
 		antedecorators.NewGaslessDecorator([]sdk.AnteDecorator{ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.ParamsKeeper.(paramskeeper.Keeper), options.TxFeeChecker)}, *options.OracleKeeper, options.EVMKeeper),
-		wasmkeeper.NewLimitSimulationGasDecorator(options.WasmConfig.SimulationGasLimit, antedecorators.GetGasMeterSetter(options.ParamsKeeper.(paramskeeper.Keeper))), // after setup context to enforce limits early
+		wasmkeeper.NewLimitSimulationGasDecorator(options.WasmConfig.SimulationGasLimit, wasmkeeper.DefaultGasMeterSetter()), // after setup context to enforce limits early
 		ante.NewRejectExtensionOptionsDecorator(),
 		oracle.NewSpammingPreventionDecorator(*options.OracleKeeper),
 		oracle.NewOracleVoteAloneDecorator(),

--- a/app/ante/cosmos_checktx.go
+++ b/app/ante/cosmos_checktx.go
@@ -264,7 +264,7 @@ func CheckAndChargeFees(ctx sdk.Context, tx sdk.Tx, accountKeeper authkeeper.Acc
 
 		// Determine the required fees by multiplying each required minimum gas
 		// price by the gas limit, where fee = ceil(minGasPrice * gasLimit).
-		glDec := sdk.NewDec(int64(gas))
+		glDec := sdk.NewDec(int64(gas)) //nolint:gosec // G115: gas is bounded by block gas limit, cannot overflow int64
 		for i, gp := range minGasPrices {
 			fee := gp.Amount.Mul(glDec)
 			requiredFees[i] = sdk.NewCoin(gp.Denom, fee.Ceil().RoundInt())

--- a/app/antedecorators/gas_test.go
+++ b/app/antedecorators/gas_test.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	paramtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/params/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/proto/tendermint/types"
+	wasmkeeper "github.com/sei-protocol/sei-chain/sei-wasmd/x/wasm/keeper"
 	wasmtypes "github.com/sei-protocol/sei-chain/sei-wasmd/x/wasm/types"
 	"github.com/stretchr/testify/require"
 )
@@ -50,4 +51,47 @@ func TestMultiplierGasSetter(t *testing.T) {
 	require.Equal(t, uint64(25), ctxWithGasMeter.GasMeter().GasConsumed())
 	require.Equal(t, false, ctxWithGasMeter.GasMeter().IsOutOfGas())
 
+}
+
+// TestLimitSimulationGasDecoratorAppliesConfiguredLimit verifies that the
+// decorator installs a gas meter that honours the configured simulation
+// limit and inherits the Cosmos gas multiplier from the parent context.
+func TestLimitSimulationGasDecoratorAppliesConfiguredLimit(t *testing.T) {
+	testApp := app.Setup(t, false, false, false)
+	ctx := testApp.NewContext(false, types.Header{}).WithBlockHeight(2)
+	testApp.ParamsKeeper.SetCosmosGasParams(ctx, paramtypes.CosmosGasParams{CosmosGasMultiplierNumerator: 1, CosmosGasMultiplierDenominator: 4})
+	testApp.ParamsKeeper.SetFeesParams(ctx, paramtypes.DefaultGenesis().GetFeesParams())
+
+	testTx := app.NewTestTx([]sdk.Msg{&wasmtypes.MsgExecuteContract{
+		Contract: "sei1y3pxq5dp900czh0mkudhjdqjq5m8cpmmps8yjw",
+		Msg:      []byte(`"{"xyz":{}}`),
+	}})
+
+	// Seed the context with the SetUpContextDecorator's gas meter so that
+	// DefaultGasMeterSetter inherits the configured multiplier.
+	ctx = antedecorators.GetGasMeterSetter(testApp.ParamsKeeper)(true, ctx, 0, testTx)
+
+	var simLimit sdk.Gas = 1000
+	decorator := wasmkeeper.NewLimitSimulationGasDecorator(&simLimit, wasmkeeper.DefaultGasMeterSetter())
+
+	var capturedCtx sdk.Context
+	_, err := decorator.AnteHandle(ctx, testTx, true, func(c sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+		capturedCtx = c
+		return c, nil
+	})
+	require.NoError(t, err)
+
+	gm := capturedCtx.GasMeter()
+	require.Equal(t, sdk.Gas(simLimit), gm.Limit())
+	n, d := gm.Multiplier()
+	require.Equal(t, uint64(1), n)
+	require.Equal(t, uint64(4), d)
+
+	// Consumption below the limit succeeds and is scaled by the multiplier.
+	require.NotPanics(t, func() { gm.ConsumeGas(100, "under-limit") })
+	require.Equal(t, uint64(25), gm.GasConsumed())
+
+	// Consumption above the limit panics with out-of-gas.
+	require.Panics(t, func() { gm.ConsumeGas(simLimit*d, "over-limit") })
+	require.True(t, gm.IsOutOfGas())
 }

--- a/sei-cosmos/baseapp/baseapp.go
+++ b/sei-cosmos/baseapp/baseapp.go
@@ -855,6 +855,9 @@ func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, tx sdk.Tx, checksum [
 	spanCtx, span := app.TracingInfo.StartWithContext("RunTx", ctx.TraceSpanContext())
 	defer span.End()
 	ctx = ctx.WithTraceSpanContext(spanCtx)
+	if mode == runTxModeSimulate {
+		ctx = ctx.WithIsSimulation(true)
+	}
 	span.SetAttributes(attribute.String("txHash", fmt.Sprintf("%X", checksum)))
 	runTxRes.ctx = ctx
 

--- a/sei-cosmos/types/context.go
+++ b/sei-cosmos/types/context.go
@@ -67,8 +67,9 @@ type Context struct {
 
 	traceSpanContext context.Context
 
-	isTracing   bool
-	storeTracer gaskv.IStoreTracer
+	isTracing    bool
+	isSimulation bool
+	storeTracer  gaskv.IStoreTracer
 }
 
 // Proposed rename, not done to avoid API breakage
@@ -214,6 +215,12 @@ func (c Context) TraceSpanContext() context.Context {
 
 func (c Context) IsTracing() bool {
 	return c.isTracing
+}
+
+// IsSimulation reports whether the context is being run in transaction
+// simulation mode.
+func (c Context) IsSimulation() bool {
+	return c.isSimulation
 }
 
 func (c Context) StoreTracer() gaskv.IStoreTracer {
@@ -473,6 +480,12 @@ func (c Context) WithIsTracing(it bool) Context {
 	} else {
 		c.storeTracer = nil
 	}
+	return c
+}
+
+// WithIsSimulation sets the simulation flag on the context.
+func (c Context) WithIsSimulation(isSimulation bool) Context {
+	c.isSimulation = isSimulation
 	return c
 }
 

--- a/sei-cosmos/types/context_test.go
+++ b/sei-cosmos/types/context_test.go
@@ -102,6 +102,13 @@ func (s *contextTestSuite) TestContextWithCustom() {
 	s.Require().True(ctx.IsCheckTx())
 	s.Require().True(ctx.IsReCheckTx())
 
+	// test IsSimulation
+	s.Require().False(ctx.IsSimulation())
+	ctx = ctx.WithIsSimulation(true)
+	s.Require().True(ctx.IsSimulation())
+	ctx = ctx.WithIsSimulation(false)
+	s.Require().False(ctx.IsSimulation())
+
 	// test consensus param
 	s.Require().Nil(ctx.ConsensusParams())
 	cp := &tmproto.ConsensusParams{}

--- a/sei-wasmd/x/wasm/keeper/keeper.go
+++ b/sei-wasmd/x/wasm/keeper/keeper.go
@@ -83,6 +83,7 @@ type Keeper struct {
 	paramsKeeper          types.ParamsKeeper
 	upgradeKeeper         types.UpgradeKeeper
 	wasmVM                types.WasmerEngine
+	simulationWasmVM      types.WasmerEngine
 	rpcWasmVM             types.WasmerEngine
 	rpcWasmVM152          types.WasmerEngine
 	rpcWasmVM155          types.WasmerEngine
@@ -124,6 +125,10 @@ func NewKeeper(
 	if err != nil {
 		panic(err)
 	}
+	simulationWasmer, err := wasmvm.NewVM(filepath.Join(homeDir, "wasm"), supportedFeatures, contractMemoryLimit, wasmConfig.ContractDebugMode, wasmConfig.MemoryCacheSize)
+	if err != nil {
+		panic(err)
+	}
 	rpcWasmer, err := wasmvm.NewVM(filepath.Join(homeDir, "wasm"), supportedFeatures, contractMemoryLimit, wasmConfig.ContractDebugMode, wasmConfig.MemoryCacheSize)
 	if err != nil {
 		panic(err)
@@ -146,6 +151,7 @@ func NewKeeper(
 		cdc:               cdc,
 		paramsKeeper:      paramsKeeper,
 		wasmVM:            NewVMWrapper(wasmer),
+		simulationWasmVM:  NewVMWrapper(simulationWasmer),
 		rpcWasmVM:         NewVMWrapper(rpcWasmer),
 		rpcWasmVM152:      NewVMWrapper(rpcWasmer152),
 		rpcWasmVM155:      NewVMWrapper(rpcWasmer155),
@@ -172,6 +178,9 @@ func NewKeeper(
 }
 
 func (k Keeper) getWasmer(ctx sdk.Context) types.WasmerEngine {
+	if ctx.IsSimulation() {
+		return k.simulationWasmVM
+	}
 	if ctx.IsTracing() {
 		if ctx.ChainID() != "pacific-1" {
 			return k.rpcWasmVM

--- a/sei-wasmd/x/wasm/keeper/keeper_test.go
+++ b/sei-wasmd/x/wasm/keeper/keeper_test.go
@@ -340,6 +340,28 @@ func TestIsSimulationMode(t *testing.T) {
 	}
 }
 
+// TestGetWasmerEngineSelection verifies that getWasmer returns the engine
+// matching the execution-mode flag set on the context.
+func TestGetWasmerEngineSelection(t *testing.T) {
+	regular := &wasmtesting.MockWasmer{}
+	simulation := &wasmtesting.MockWasmer{}
+	rpc := &wasmtesting.MockWasmer{}
+	k := Keeper{
+		wasmVM:           regular,
+		simulationWasmVM: simulation,
+		rpcWasmVM:        rpc,
+	}
+
+	regularCtx := sdk.Context{}.WithBlockHeader(tmproto.Header{Height: 1, ChainID: "test"})
+	require.Same(t, regular, k.getWasmer(regularCtx))
+
+	simCtx := regularCtx.WithIsSimulation(true)
+	require.Same(t, simulation, k.getWasmer(simCtx))
+
+	traceCtx := regularCtx.WithIsTracing(true)
+	require.Same(t, rpc, k.getWasmer(traceCtx))
+}
+
 func TestCreateWithGzippedPayload(t *testing.T) {
 	ctx, keepers := CreateTestInput(t, false, SupportedFeatures)
 	keeper := keepers.ContractKeeper


### PR DESCRIPTION
Align simulation ante wiring with upstream and add a dedicated simulation VM Pass wasmkeeper.DefaultGasMeterSetter() to NewLimitSimulationGasDecorator in app/ante.go to match the reference wiring at sei-wasmd/app/ante.go.

Add a dedicated simulationWasmVM on Keeper alongside the existing rpcWasmVM, plus an IsSimulation flag on sdk.Context that BaseApp.runTx sets for runTxModeSimulate. Keeper.getWasmer returns the dedicated VM for simulate-mode contexts, mirroring the existing tracing wiring.

Adds unit tests for the ante wiring, the context flag, and the engine selection.
