### PR TITLE
Stabilize FlatKV crash recovery CI test

### DIFF
--- a/integration_test/contracts/verify_flatkv_crash_recovery.sh
+++ b/integration_test/contracts/verify_flatkv_crash_recovery.sh
@@ -20,9 +20,11 @@
 #
 # Voting-weight assumption: sei-node-3 is killed because the 4-validator
 # devnet is configured so that any single validator falling below the 1/3
-# threshold leaves the other three above 2/3 and the chain continues to
-# produce blocks. If the cluster topology changes, override
-# CRASH_NODE_INDEX.
+# threshold should leave the other three above 2/3. In practice, CI can kill
+# the node after it has participated in the current height, and Tendermint may
+# not commit the next block until the validator is restarted. That temporary
+# liveness stall is orthogonal to the FlatKV crash-recovery invariant below.
+# If the cluster topology changes, override CRASH_NODE_INDEX.
 
 set -euo pipefail
 
@@ -158,8 +160,11 @@ echo "Pre-kill survivor height: $PRE_KILL_HEIGHT"
 echo "Killing $CRASH_NODE with SIGKILL..."
 docker exec "$CRASH_NODE" pkill -9 -f "seid start" >/dev/null 2>&1 || true
 
-# Step 3: confirm the kill landed and stayed landed long enough for the
-# chain to keep advancing (proving the kill genuinely disrupted that node).
+# Step 3: confirm the kill landed and give the surviving validators a chance
+# to advance while the victim is down. Lack of progress here is not a FlatKV
+# recovery failure: the SIGKILL can land after the victim participates in the
+# current Tendermint height, and the devnet may not commit again until that
+# validator comes back.
 sleep 2
 if docker exec "$CRASH_NODE" pgrep -f "seid start" >/dev/null 2>&1; then
   echo "ERROR: $CRASH_NODE did not actually die after SIGKILL" >&2
@@ -185,14 +190,13 @@ while [ "$elapsed" -lt "$KILL_DOWN_SECS" ]; do
   elapsed=$((elapsed + 2))
 done
 
-# Survivors should still be producing blocks (3/4 voting weight > 2/3).
 if [ "$SURVIVOR_DURING_KILL" -le "$PRE_KILL_HEIGHT" ]; then
-  echo "ERROR: surviving validator $SURVIVOR_NODE did not produce a single block while $CRASH_NODE was down for ${KILL_DOWN_SECS}s" >&2
+  echo "WARN: surviving validator $SURVIVOR_NODE did not produce a block while $CRASH_NODE was down for ${KILL_DOWN_SECS}s" >&2
   echo "  pre_kill=$PRE_KILL_HEIGHT during_kill=$SURVIVOR_DURING_KILL" >&2
-  dump_node_log "$SURVIVOR_NODE"
-  exit 1
+  echo "  continuing with restart; post-restart progress is checked before digest comparison" >&2
+else
+  echo "Survivor $SURVIVOR_NODE advanced $PRE_KILL_HEIGHT -> $SURVIVOR_DURING_KILL while $CRASH_NODE was down (within ${elapsed}s)"
 fi
-echo "Survivor $SURVIVOR_NODE advanced $PRE_KILL_HEIGHT -> $SURVIVOR_DURING_KILL while $CRASH_NODE was down (within ${elapsed}s)"
 
 # Step 4: restart the killed validator. Use the same detached-exec pattern as
 # import_flatkv_evm_cluster.sh; a non-detached docker exec closes stdout/
@@ -267,6 +271,15 @@ if [ "$elapsed" -ge "$CATCHUP_TIMEOUT" ]; then
   dump_node_log "$SURVIVOR_NODE"
   exit 1
 fi
+
+# Ensure the post-restart chain commits far enough past the crash height that
+# pick_compare_height (which subtracts COMPARE_BUFFER) selects a version that
+# was produced after the SIGKILL/restart cycle.
+POST_RESTART_COMPARE_FLOOR=$((PRE_KILL_HEIGHT + COMPARE_BUFFER + 1))
+echo "Waiting for all validators to reach post-restart comparison floor $POST_RESTART_COMPARE_FLOOR"
+for i in $(seq 0 $((NODE_COUNT - 1))); do
+  wait_for_height "sei-node-$i" "$POST_RESTART_COMPARE_FLOOR" "$CATCHUP_TIMEOUT"
+done
 
 # Step 6: build seidb everywhere (the crashed node may have had its previous
 # build wiped; the others may have never built it), pick a chain height


### PR DESCRIPTION
The `verify_flatkv_crash_recovery.sh` was treating survivor progress while sei-node-3 remained down as a hard FlatKV recovery invariant. The CI flake showed pre_kill=360 during_kill=360: the SIGKILL landed after the victim had participated in the next Tendermint height, and the devnet did not commit another block until the validator was restarted. That temporary consensus stall is orthogonal to FlatKV crash recovery.

Make the no-progress-while-down case diagnostic instead of fatal, then restart the victim and require every validator to advance past pre_kill + COMPARE_BUFFER before selecting the FlatKV comparison height. This keeps the storage check just as strong: the digest comparison is still over a height committed after the SIGKILL/restart cycle by all validators, so corruption or divergence introduced by FlatKV crash recovery will still fail the test.

Flaked in unrelated changes [here](https://github.com/sei-protocol/sei-chain/actions/runs/26035091204/job/76530891935?pr=3456).

