### PR TITLE
evmrpc: filter ante stubs from *ExcludeTraceFail (CON-296)

### DIFF
--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -83,7 +83,6 @@ type BlockAPI struct {
 
 type SeiBlockAPI struct {
 	*BlockAPI
-	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error)
 }
 
 func NewBlockAPI(tmClient client.LocalClient, k *keeper.Keeper, ctxProvider func(int64) sdk.Context, txConfigProvider func(int64) client.TxConfig, connectionType ConnectionType, watermarks *WatermarkManager, globalBlockCache BlockCache, cacheCreationMutex *sync.Mutex) *BlockAPI {
@@ -108,7 +107,6 @@ func NewSeiBlockAPI(
 	ctxProvider func(int64) sdk.Context,
 	txConfigProvider func(int64) client.TxConfig,
 	connectionType ConnectionType,
-	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error),
 	watermarks *WatermarkManager,
 	globalBlockCache BlockCache,
 	cacheCreationMutex *sync.Mutex,
@@ -127,8 +125,7 @@ func NewSeiBlockAPI(
 		cacheCreationMutex:   cacheCreationMutex,
 	}
 	return &SeiBlockAPI{
-		BlockAPI:  blockAPI,
-		isPanicTx: isPanicTx,
+		BlockAPI: blockAPI,
 	}
 }
 
@@ -138,12 +135,11 @@ func NewSei2BlockAPI(
 	ctxProvider func(int64) sdk.Context,
 	txConfigProvider func(int64) client.TxConfig,
 	connectionType ConnectionType,
-	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error),
 	watermarks *WatermarkManager,
 	globalBlockCache BlockCache,
 	cacheCreationMutex *sync.Mutex,
 ) *SeiBlockAPI {
-	blockAPI := NewSeiBlockAPI(tmClient, k, ctxProvider, txConfigProvider, connectionType, isPanicTx, watermarks, globalBlockCache, cacheCreationMutex)
+	blockAPI := NewSeiBlockAPI(tmClient, k, ctxProvider, txConfigProvider, connectionType, watermarks, globalBlockCache, cacheCreationMutex)
 	blockAPI.namespace = Sei2Namespace
 	blockAPI.includeBankTransfers = true
 	return blockAPI
@@ -154,13 +150,14 @@ func (a *SeiBlockAPI) GetBlockByNumberExcludeTraceFail(ctx context.Context, numb
 	if number == 0 {
 		return encodeGenesisBlock(), nil
 	}
-	// exclude synthetic txs
-	return a.getBlockByNumber(ctx, number, fullTx, false, a.isPanicTx)
+	// Exclude synthetic txs (filterTransactions drops them) and ante-failure
+	// stub receipts (EncodeTmBlock drops them via excludeUntraceable).
+	return a.getBlockByNumber(ctx, number, fullTx, false, true)
 }
 
 func (a *SeiBlockAPI) GetBlockByHashExcludeTraceFail(ctx context.Context, blockHash common.Hash, fullTx bool) (result map[string]interface{}, returnErr error) {
-	// exclude synthetic txs
-	return a.getBlockByHash(ctx, blockHash, fullTx, false, a.isPanicTx)
+	// See note on GetBlockByNumberExcludeTraceFail.
+	return a.getBlockByHash(ctx, blockHash, fullTx, false, true)
 }
 
 func (a *BlockAPI) GetBlockTransactionCountByNumber(ctx context.Context, number rpc.BlockNumber) (result *hexutil.Uint, returnErr error) {
@@ -199,10 +196,10 @@ func (a *BlockAPI) GetBlockTransactionCountByHash(ctx context.Context, blockHash
 
 func (a *BlockAPI) GetBlockByHash(ctx context.Context, blockHash common.Hash, fullTx bool) (result map[string]interface{}, returnErr error) {
 	// used for both: eth_ and sei_ namespaces
-	return a.getBlockByHash(ctx, blockHash, fullTx, a.includeShellReceipts, nil)
+	return a.getBlockByHash(ctx, blockHash, fullTx, a.includeShellReceipts, false)
 }
 
-func (a *BlockAPI) getBlockByHash(ctx context.Context, blockHash common.Hash, fullTx bool, includeSyntheticTxs bool, isPanicTx func(ctx context.Context, hash common.Hash) (bool, error)) (result map[string]interface{}, returnErr error) {
+func (a *BlockAPI) getBlockByHash(ctx context.Context, blockHash common.Hash, fullTx bool, includeSyntheticTxs bool, excludeUntraceable bool) (result map[string]interface{}, returnErr error) {
 	startTime := time.Now()
 	defer func() {
 		recordMetricsWithError(ctx, fmt.Sprintf("%s_getBlockByHash", a.namespace), a.connectionType, startTime, returnErr, recover())
@@ -233,7 +230,7 @@ func (a *BlockAPI) getBlockByHash(ctx context.Context, blockHash common.Hash, fu
 	if err != nil {
 		return nil, err
 	}
-	return EncodeTmBlock(a.ctxProvider, a.txConfigProvider, block, blockRes, a.keeper, fullTx, a.includeBankTransfers, includeSyntheticTxs, isPanicTx, a.globalBlockCache, a.cacheCreationMutex)
+	return EncodeTmBlock(a.ctxProvider, a.txConfigProvider, block, blockRes, a.keeper, fullTx, a.includeBankTransfers, includeSyntheticTxs, excludeUntraceable, a.globalBlockCache, a.cacheCreationMutex)
 }
 
 func (a *BlockAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (result map[string]interface{}, returnErr error) {
@@ -245,7 +242,7 @@ func (a *BlockAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber,
 		// for compatibility with the graph, always return genesis block
 		return encodeGenesisBlock(), nil
 	}
-	return a.getBlockByNumber(ctx, number, fullTx, a.includeShellReceipts, nil)
+	return a.getBlockByNumber(ctx, number, fullTx, a.includeShellReceipts, false)
 }
 
 func (a *BlockAPI) getBlockByNumber(
@@ -253,7 +250,7 @@ func (a *BlockAPI) getBlockByNumber(
 	number rpc.BlockNumber,
 	fullTx bool,
 	includeSyntheticTxs bool,
-	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error),
+	excludeUntraceable bool,
 ) (result map[string]interface{}, returnErr error) {
 	numberPtr, err := getBlockNumber(ctx, a.tmClient, number)
 	if err != nil {
@@ -280,7 +277,7 @@ func (a *BlockAPI) getBlockByNumber(
 	if err != nil {
 		return nil, err
 	}
-	return EncodeTmBlock(a.ctxProvider, a.txConfigProvider, block, blockRes, a.keeper, fullTx, a.includeBankTransfers, includeSyntheticTxs, isPanicTx, a.globalBlockCache, a.cacheCreationMutex)
+	return EncodeTmBlock(a.ctxProvider, a.txConfigProvider, block, blockRes, a.keeper, fullTx, a.includeBankTransfers, includeSyntheticTxs, excludeUntraceable, a.globalBlockCache, a.cacheCreationMutex)
 }
 
 func (a *BlockAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (result []map[string]interface{}, returnErr error) {
@@ -362,6 +359,17 @@ func (a *BlockAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.Block
 	return compactReceipts, nil
 }
 
+// EncodeTmBlock renders a tendermint block as an eth_getBlockBy* response.
+//
+// excludeUntraceable, when true, drops EVM txs whose receipt is an
+// ante-deferred stub (EffectiveGasPrice==0 && GasUsed==0). x/evm/keeper/abci.go
+// writes such stubs for txs that passed the nonce check but failed a later
+// ante step (insufficient funds, insufficient fee, etc.); they never reached
+// the VM and have no meaningful trace. Used by the *ExcludeTraceFail block
+// endpoints to satisfy evmrpc/README.md's "included in blocks but not
+// executed" filter; the regular eth_getBlockBy* endpoints pass false so
+// these txs still surface in normal block responses (per PR #2343's
+// TestAnteFailureOthers — users want to see them).
 func EncodeTmBlock(
 	ctxProvider func(int64) sdk.Context,
 	txConfigProvider func(int64) client.TxConfig,
@@ -371,7 +379,7 @@ func EncodeTmBlock(
 	fullTx bool,
 	includeBankTransfers bool,
 	includeSyntheticTxs bool,
-	isPanicOrSynthetic func(ctx context.Context, hash common.Hash) (bool, error),
+	excludeUntraceable bool,
 	globalBlockCache BlockCache,
 	cacheCreationMutex *sync.Mutex,
 ) (map[string]interface{}, error) {
@@ -405,6 +413,15 @@ func EncodeTmBlock(
 			hash := ethtx.Hash()
 			receipt, found := getOrSetCachedReceipt(cacheCreationMutex, globalBlockCache, latestCtx, k, block, hash)
 			if !found {
+				continue
+			}
+			// Untraceable ante-stub receipt — tx never reached the VM, no
+			// meaningful trace. filterTransactions's isReceiptFromAnteError
+			// only catches the nonce-error subset post-v5.8.0 (per PR #2343,
+			// which keeps insufficient-funds receipts visible to the regular
+			// eth_getBlockBy* endpoints). *ExcludeTraceFail needs the broader
+			// check on the deferred-info stub shape directly.
+			if excludeUntraceable && receipt.EffectiveGasPrice == 0 && receipt.GasUsed == 0 {
 				continue
 			}
 			if !fullTx {

--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -415,13 +415,15 @@ func EncodeTmBlock(
 			if !found {
 				continue
 			}
-			// Untraceable ante-stub receipt — tx never reached the VM, no
-			// meaningful trace. filterTransactions's isReceiptFromAnteError
-			// only catches the nonce-error subset post-v5.8.0 (per PR #2343,
-			// which keeps insufficient-funds receipts visible to the regular
-			// eth_getBlockBy* endpoints). *ExcludeTraceFail needs the broader
-			// check on the deferred-info stub shape directly.
-			if excludeUntraceable && receipt.EffectiveGasPrice == 0 && receipt.GasUsed == 0 {
+			// Untraceable receipt — tx never reached the VM (ante-deferred
+			// stub) or is chain-generated synthetic. filterTransactions's
+			// isReceiptFromAnteError only catches the nonce-error subset
+			// post-v5.8.0 (per PR #2343, which keeps insufficient-funds
+			// receipts visible to the regular eth_getBlockBy* endpoints);
+			// *ExcludeTraceFail needs the broader discriminator. See
+			// isReceiptUntraceable for the shared definition used at every
+			// *ExcludeTraceFail site.
+			if excludeUntraceable && isReceiptUntraceable(receipt) {
 				continue
 			}
 			if !fullTx {

--- a/evmrpc/block_test.go
+++ b/evmrpc/block_test.go
@@ -3,6 +3,7 @@ package evmrpc_test
 import (
 	"crypto/sha256"
 	"math/big"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/export"
 	"github.com/sei-protocol/sei-chain/evmrpc"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/client"
@@ -22,7 +24,9 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/rpc/coretypes"
 	tmtypes "github.com/sei-protocol/sei-chain/sei-tendermint/types"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/x/evm/config"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
+	"github.com/sei-protocol/sei-chain/x/evm/types/ethtx"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,7 +54,7 @@ func TestEncodeTmBlock_EmptyTransactions(t *testing.T) {
 	}
 
 	// Call EncodeTmBlock with empty transactions
-	result, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, block, blockRes, k, true, false, false, nil, evmrpc.NewBlockCache(3000), &sync.Mutex{})
+	result, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, block, blockRes, k, true, false, false, false, evmrpc.NewBlockCache(3000), &sync.Mutex{})
 	require.Nil(t, err)
 
 	// Assert txHash is equal to ethtypes.EmptyTxsHash
@@ -96,7 +100,7 @@ func TestEncodeBankMsg(t *testing.T) {
 			},
 		},
 	}
-	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, &resBlockRes, k, true, false, false, nil, evmrpc.NewBlockCache(3000), &sync.Mutex{})
+	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, &resBlockRes, k, true, false, false, false, evmrpc.NewBlockCache(3000), &sync.Mutex{})
 	require.Nil(t, err)
 	txs := res["transactions"].([]interface{})
 	require.Equal(t, 0, len(txs))
@@ -149,7 +153,7 @@ func TestEncodeWasmExecuteMsg(t *testing.T) {
 			},
 		},
 	}
-	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, &resBlockRes, k, true, false, true, nil, evmrpc.NewBlockCache(3000), &sync.Mutex{})
+	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, &resBlockRes, k, true, false, true, false, evmrpc.NewBlockCache(3000), &sync.Mutex{})
 	require.Nil(t, err)
 	txs := res["transactions"].([]interface{})
 	require.Equal(t, 1, len(txs))
@@ -210,7 +214,7 @@ func TestEncodeBankTransferMsg(t *testing.T) {
 			},
 		},
 	}
-	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, &resBlockRes, k, true, true, false, nil, evmrpc.NewBlockCache(3000), &sync.Mutex{})
+	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, &resBlockRes, k, true, true, false, false, evmrpc.NewBlockCache(3000), &sync.Mutex{})
 	require.Nil(t, err)
 	txs := res["transactions"].([]interface{})
 	require.Equal(t, 1, len(txs))
@@ -228,6 +232,99 @@ func TestEncodeBankTransferMsg(t *testing.T) {
 		R:                nil,
 		S:                nil,
 	}, txs[0].(*export.RPCTransaction))
+}
+
+// TestEncodeTmBlock_ExcludeUntraceable pins the block-side counterpart of the
+// tx-side discriminator: a correct-nonce ante failure (e.g. insufficient
+// funds) lands a stub receipt in the receipt store. filterTransactions's
+// isReceiptFromAnteError post-v5.8.0 only matches nonce-error VmError
+// content, so the stub flows through to EncodeTmBlock — where
+// excludeUntraceable=true catches it via EffectiveGasPrice==0 && GasUsed==0.
+//
+// We use the global EVMKeeper (where setup_test.go's fixtures live) and a
+// post-v5.8.0 ctx so filterTransactions takes the production branch.
+// DebugTracePanicTx isn't suitable here (Nonce=100, gets filtered by
+// filterTransactions's nonce-bumping check before reaching EncodeTmBlock);
+// we register a correct-nonce ante-stub fixture instead.
+func TestEncodeTmBlock_ExcludeUntraceable(t *testing.T) {
+	k := EVMKeeper
+
+	// Build a correct-nonce EVM tx whose receipt mimics an ante-deferred
+	// stub: EffectiveGasPrice=0, GasUsed=0, VmError set. We need a fresh
+	// sender so startOfBlockNonce equals the tx's nonce — otherwise
+	// filterTransactions's nonce-bumping branch filters it out at
+	// utils.go:253 before EncodeTmBlock sees it.
+	chainID := big.NewInt(config.DefaultChainID)
+	privKey, _ := crypto.GenerateKey()
+	signer := ethtypes.MakeSigner(types.DefaultChainConfig().EthereumConfig(chainID), big.NewInt(Ctx.BlockHeight()), uint64(Ctx.BlockTime().Unix()))
+	to := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	rawTx, err := ethtypes.SignTx(ethtypes.NewTx(&ethtypes.DynamicFeeTx{
+		Nonce: 0, GasFeeCap: big.NewInt(10), Gas: 22000, To: &to, Value: big.NewInt(0), ChainID: chainID,
+	}), signer, privKey)
+	require.NoError(t, err)
+	td, err := ethtx.NewDynamicFeeTx(rawTx)
+	require.NoError(t, err)
+	msg, err := types.NewMsgEVMTransaction(td)
+	require.NoError(t, err)
+	builder := TxConfig.NewTxBuilder()
+	require.NoError(t, builder.SetMsgs(msg))
+	anteStubTx := builder.GetTx()
+	anteStubBz, _ := Encoder(anteStubTx)
+	anteStubHash := rawTx.Hash()
+
+	// Mock the stub receipt on EVMKeeper so getOrSetCachedReceipt finds it.
+	stubHeight := int64(MockHeight103)
+	stubCtx := Ctx.WithBlockHeight(stubHeight)
+	require.NoError(t, k.MockReceipt(stubCtx, anteStubHash, &types.Receipt{
+		BlockNumber:      uint64(stubHeight),
+		TransactionIndex: 0,
+		TxHashHex:        anteStubHash.Hex(),
+		VmError:          "insufficient funds",
+	}))
+
+	nonPanicBz, _ := Encoder(DebugTraceNonPanicTx)
+
+	block := &coretypes.ResultBlock{
+		BlockID: MockBlockID,
+		Block: &tmtypes.Block{
+			Header: mockBlockHeader(stubHeight),
+			Data: tmtypes.Data{
+				Txs: []tmtypes.Tx{anteStubBz, nonPanicBz},
+			},
+			LastCommit: &tmtypes.Commit{Height: stubHeight - 1},
+		},
+	}
+	blockRes := &coretypes.ResultBlockResults{
+		TxsResults: []*abci.ExecTxResult{{Data: anteStubBz}, {Data: nonPanicBz}},
+		ConsensusParamUpdates: &types2.ConsensusParams{
+			Block: &types2.BlockParams{MaxBytes: 100000000, MaxGas: 200000000},
+		},
+	}
+
+	// Post-v5.8.0 ctx so filterTransactions's isReceiptFromAnteError stays
+	// narrow (nonce-only VmError) — the production path where the stub
+	// flows through and EncodeTmBlock has to apply its own check.
+	ctx := Ctx.WithBlockHeight(stubHeight).WithClosestUpgradeName(LatestCtxUpgradeName)
+	ctxProvider := func(int64) sdk.Context { return ctx }
+	txConfigProvider := func(int64) client.TxConfig { return TxConfig }
+
+	// excludeUntraceable=true: ante stub dropped, revert kept.
+	res, err := evmrpc.EncodeTmBlock(ctxProvider, txConfigProvider, block, blockRes, k,
+		false /*fullTx*/, false /*includeBankTransfers*/, false /*includeSyntheticTxs*/, true, /*excludeUntraceable*/
+		evmrpc.NewBlockCache(3000), &sync.Mutex{})
+	require.NoError(t, err)
+	txs := res["transactions"].([]interface{})
+	require.Len(t, txs, 1, "expected only the revert to survive, got %v", txs)
+	require.Equal(t, strings.ToLower(TestNonPanicTxHash), strings.ToLower(txs[0].(string)))
+
+	// excludeUntraceable=false: ante stub flows through (matches regular
+	// eth_getBlockBy* behavior per PR #2343's TestAnteFailureOthers).
+	res, err = evmrpc.EncodeTmBlock(ctxProvider, txConfigProvider, block, blockRes, k,
+		false /*fullTx*/, false /*includeBankTransfers*/, false /*includeSyntheticTxs*/, false, /*excludeUntraceable*/
+		evmrpc.NewBlockCache(3000), &sync.Mutex{})
+	require.NoError(t, err)
+	txs = res["transactions"].([]interface{})
+	require.Len(t, txs, 2, "expected revert + ante stub to flow through, got %v", txs)
 }
 
 func TestEVMLaunchHeightValidation(t *testing.T) {

--- a/evmrpc/block_txcount_parity_test.go
+++ b/evmrpc/block_txcount_parity_test.go
@@ -125,7 +125,7 @@ func TestBlockTransactionCountMatchesGetBlockByNumber(t *testing.T) {
 	decodeOnly := countDecodeOnlyEvmTxs(block.Block.Txs, TxConfig.TxDecoder())
 	require.Equal(t, 2, decodeOnly)
 
-	encoded, err := evmrpc.EncodeTmBlock(ctxProvider, txConfigProvider, block, blockRes, k, false, false, false, nil, cache, mu)
+	encoded, err := evmrpc.EncodeTmBlock(ctxProvider, txConfigProvider, block, blockRes, k, false, false, false, false, cache, mu)
 	require.NoError(t, err)
 	list := encoded["transactions"].([]interface{})
 

--- a/evmrpc/height_availability_test.go
+++ b/evmrpc/height_availability_test.go
@@ -219,9 +219,7 @@ func TestGetBlockReceiptsGenesisByNumber(t *testing.T) {
 func TestGetBlockByNumberExcludeTraceFailGenesis(t *testing.T) {
 	t.Parallel()
 
-	api := NewSeiBlockAPI(nil, nil, testCtxProvider, testTxConfigProvider, ConnectionTypeHTTP,
-		func(context.Context, common.Hash) (bool, error) { return false, nil },
-		nil, nil, nil)
+	api := NewSeiBlockAPI(nil, nil, testCtxProvider, testTxConfigProvider, ConnectionTypeHTTP, nil, nil, nil)
 	block, err := api.GetBlockByNumberExcludeTraceFail(context.Background(), 0, false)
 	require.NoError(t, err)
 	require.NotNil(t, block)

--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -123,11 +123,11 @@ func NewEVMHTTPServer(
 		},
 		{
 			Namespace: "sei",
-			Service:   NewSeiBlockAPI(tmClient, k, ctxProvider, txConfigProvider, ConnectionTypeHTTP, isPanicOrSyntheticTxFunc, watermarks, globalBlockCache, cacheCreationMutex),
+			Service:   NewSeiBlockAPI(tmClient, k, ctxProvider, txConfigProvider, ConnectionTypeHTTP, watermarks, globalBlockCache, cacheCreationMutex),
 		},
 		{
 			Namespace: "sei2",
-			Service:   NewSei2BlockAPI(tmClient, k, ctxProvider, txConfigProvider, ConnectionTypeHTTP, isPanicOrSyntheticTxFunc, watermarks, globalBlockCache, cacheCreationMutex),
+			Service:   NewSei2BlockAPI(tmClient, k, ctxProvider, txConfigProvider, ConnectionTypeHTTP, watermarks, globalBlockCache, cacheCreationMutex),
 		},
 		{
 			Namespace: "eth",

--- a/evmrpc/setup_test.go
+++ b/evmrpc/setup_test.go
@@ -59,12 +59,19 @@ const MockHeight103 = 103
 const MockHeight101 = 101
 const MockHeight100 = 100
 
-// LatestCtxUpgradeName: post-v5.8.0 string assigned to the LatestCtxHeight
-// context. The default Ctx has empty ClosestUpgradeName and
-// semver.Compare("", "v5.8.0") returns -1 (treated as pre-v5.8.0), so
-// without this any test reading isReceiptFromAnteError via the latest
-// context would coincidentally land on the pre-v5.8.0 branch and miss
-// post-v5.8.0-only regressions.
+// LatestCtxUpgradeName makes the test ctx look like a real chain that has
+// applied a post-v5.8.0 upgrade. The default Ctx has empty
+// ClosestUpgradeName and semver.Compare("", "v5.8.0") returns -1 (treated
+// as pre-v5.8.0), so any code path that branches on upgrade name via
+// LatestCtxHeight or a block-height ctx would silently exercise the
+// pre-v5.8.0 branch — a stale environment for current chains and a way
+// for post-v5.8.0-only regressions to slip past unit tests.
+//
+// Used by TestEncodeTmBlock_ExcludeUntraceable directly (to drive
+// filterTransactions's isReceiptFromAnteError onto the production branch)
+// and by the LatestCtxHeight override in ctxProvider below (defensive —
+// catches any future ctxProvider(LatestCtxHeight) consumer that grows an
+// upgrade-name-sensitive check).
 const LatestCtxUpgradeName = "v6.0.0"
 
 var DebugTraceHashHex = "0xa16d8f7ea8741acd23f15fc19b0dd26512aff68c01c6260d7c3a51b297399d32"
@@ -602,11 +609,9 @@ func init() {
 			return MultiTxCtx.WithIsTracing(true)
 		}
 		if height == evmrpc.LatestCtxHeight {
-			// Simulate a real chain that has applied a post-v5.8.0 upgrade.
-			// Without this, baseCtx's ClosestUpgradeName is empty and
-			// semver.Compare("", "v5.8.0") = -1, which trips the pre-v5.8.0
-			// branch of isReceiptFromAnteError — masking divergences from the
-			// production post-v5.8.0 path.
+			// See LatestCtxUpgradeName above — make the latest ctx look
+			// post-v5.8.0 so any consumer that branches on upgrade name
+			// sees the production path, not the pre-v5.8.0 fallback.
 			return baseCtx.WithIsTracing(true).WithClosestUpgradeName(LatestCtxUpgradeName)
 		}
 		return Ctx.WithIsTracing(true)

--- a/evmrpc/setup_test.go
+++ b/evmrpc/setup_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/gorilla/websocket"
@@ -28,6 +27,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/client"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/crypto/hd"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
 	abci "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/bytes"
 	types2 "github.com/sei-protocol/sei-chain/sei-tendermint/proto/tendermint/types"
@@ -58,6 +58,14 @@ const MockHeight2 = 2
 const MockHeight103 = 103
 const MockHeight101 = 101
 const MockHeight100 = 100
+
+// LatestCtxUpgradeName: post-v5.8.0 string assigned to the LatestCtxHeight
+// context. The default Ctx has empty ClosestUpgradeName and
+// semver.Compare("", "v5.8.0") returns -1 (treated as pre-v5.8.0), so
+// without this any test reading isReceiptFromAnteError via the latest
+// context would coincidentally land on the pre-v5.8.0 branch and miss
+// post-v5.8.0-only regressions.
+const LatestCtxUpgradeName = "v6.0.0"
 
 var DebugTraceHashHex = "0xa16d8f7ea8741acd23f15fc19b0dd26512aff68c01c6260d7c3a51b297399d32"
 var DebugTraceBlockHash = "0xBE17E0261E539CB7E9A91E123A6D794E0163D656FCF9B8EAC07823F7ED28512B"
@@ -594,7 +602,12 @@ func init() {
 			return MultiTxCtx.WithIsTracing(true)
 		}
 		if height == evmrpc.LatestCtxHeight {
-			return baseCtx.WithIsTracing(true)
+			// Simulate a real chain that has applied a post-v5.8.0 upgrade.
+			// Without this, baseCtx's ClosestUpgradeName is empty and
+			// semver.Compare("", "v5.8.0") = -1, which trips the pre-v5.8.0
+			// branch of isReceiptFromAnteError — masking divergences from the
+			// production post-v5.8.0 path.
+			return baseCtx.WithIsTracing(true).WithClosestUpgradeName(LatestCtxUpgradeName)
 		}
 		return Ctx.WithIsTracing(true)
 	}
@@ -1078,15 +1091,18 @@ func setupLogs() {
 		TxHashHex:         TestNonPanicTxHash,
 		EffectiveGasPrice: 1000000,
 	})
-	// Ante-failure receipt: EffectiveGasPrice=0 is the signal that the tx
-	// was rejected before reaching the VM (see x/evm/keeper/abci.go's
-	// deferred-info path). VmError carries a nonce-error string so the
-	// isReceiptFromAnteError post-v5.8.0 check matches.
+	// Ante-failure stub receipt as written by x/evm/keeper/abci.go's
+	// deferred-info path: EffectiveGasPrice=0 and GasUsed=0 (both unset).
+	// VmError carries the underlying ante error — insufficient funds is the
+	// common production case (correct nonce, fee check fails). The actual
+	// nonce-too-high/low strings never appear in stub receipts because those
+	// txs don't pass the nonce check and thus don't call SetNonceBumped,
+	// which is the gate that writes the receipt.
 	EVMKeeper.MockReceipt(CtxDebugTracePanic, common.HexToHash(TestPanicTxHash), &types.Receipt{
 		BlockNumber:      MockHeight103,
 		TransactionIndex: 1,
 		TxHashHex:        TestPanicTxHash,
-		VmError:          core.ErrNonceTooHigh.Error(),
+		VmError:          sdkerrors.ErrInsufficientFunds.Error(),
 	})
 	txNonEvmBz, _ := Encoder(TxNonEvmWithSyntheticLog)
 	txNonEvmHash := sha256.Sum256(txNonEvmBz)

--- a/evmrpc/tests/block_test.go
+++ b/evmrpc/tests/block_test.go
@@ -118,6 +118,27 @@ func TestAnteFailureOthers(t *testing.T) {
 	)
 }
 
+// Mirrors TestAnteFailureOthers but inverts the expectation: where the
+// regular eth_getBlockByHash includes insufficient-funds stub receipts
+// post-v5.8.0 (per PR #2343), the *ExcludeTraceFail variant must drop
+// them — the tx bumped its nonce in ante but never reached the VM.
+func TestGetBlockByHashExcludeTraceFail_AnteStub(t *testing.T) {
+	stubTxBz := signAndEncodeTx(sendInsufficientFunds(0), mnemonic1)
+	SetupTestServer(t, [][][]byte{{stubTxBz}}, mnemonicInitializer(mnemonic1)).Run(
+		func(port int) {
+			// Confirm the stub flows through the regular endpoint (PR #2343 baseline).
+			res := sendRequestWithNamespace("eth", port, "getBlockByHash", common.HexToHash("0x6f2168eb453152b1f68874fe32cea6fcb199bfd63836acb72a8eb33e666613fe").Hex(), true)
+			txs := res["result"].(map[string]interface{})["transactions"].([]interface{})
+			require.Len(t, txs, 1, "regular eth_getBlockByHash should keep the insufficient-funds tx, got %v", txs)
+
+			// The *ExcludeTraceFail variant must drop it.
+			res = sendRequestWithNamespace("sei", port, "getBlockByHashExcludeTraceFail", common.HexToHash("0x6f2168eb453152b1f68874fe32cea6fcb199bfd63836acb72a8eb33e666613fe").Hex(), true)
+			txs = res["result"].(map[string]interface{})["transactions"].([]interface{})
+			require.Len(t, txs, 0, "sei_getBlockByHashExcludeTraceFail should drop the insufficient-funds stub, got %v", txs)
+		},
+	)
+}
+
 func TestGetBlockReceipts(t *testing.T) {
 	txBz1 := signAndEncodeTx(send(0), mnemonic1)
 	txBz2 := signAndEncodeTx(send(1), mnemonic1)

--- a/evmrpc/tests/tracers_test.go
+++ b/evmrpc/tests/tracers_test.go
@@ -55,6 +55,24 @@ func TestTraceBlockByNumberExcludeTraceFail(t *testing.T) {
 	)
 }
 
+// Correct-nonce ante failures (insufficient funds / fee / etc.) land a
+// deferred-info stub receipt with EffectiveGasPrice=0 && GasUsed=0. With
+// callTracer / flatCallTracer the tracer embeds the error in the JSON and
+// leaves trace.Error empty, so the legacy trace.Error filter doesn't catch
+// them. The receipt-shape check in stripUntraceableTraces does.
+func TestTraceBlockByNumberExcludeTraceFail_AnteStub(t *testing.T) {
+	stubTxBz := signAndEncodeTx(sendInsufficientFunds(0), mnemonic1)
+	SetupTestServer(t, [][][]byte{{stubTxBz}}, mnemonicInitializer(mnemonic1)).Run(
+		func(port int) {
+			res := sendRequestWithNamespace("sei", port, "traceBlockByNumberExcludeTraceFail", "0x2", map[string]interface{}{
+				"timeout": "60s", "tracer": "callTracer",
+			})
+			txs := res["result"].([]interface{})
+			require.Len(t, txs, 0, "correct-nonce insufficient-funds tx should be filtered out, got %v", txs)
+		},
+	)
+}
+
 func TestTraceBlockByHash(t *testing.T) {
 	txBz := signAndEncodeTx(send(0), mnemonic1)
 	SetupTestServer(t, [][][]byte{{txBz}}, mnemonicInitializer(mnemonic1)).Run(

--- a/evmrpc/tests/tracers_test.go
+++ b/evmrpc/tests/tracers_test.go
@@ -60,15 +60,20 @@ func TestTraceBlockByNumberExcludeTraceFail(t *testing.T) {
 // callTracer / flatCallTracer the tracer embeds the error in the JSON and
 // leaves trace.Error empty, so the legacy trace.Error filter doesn't catch
 // them. The receipt-shape check in stripUntraceableTraces does.
+//
+// Block layout exercises both directions of the discriminator:
+//   - send(0): successful tx (Status=1, EffGP>0, GasUsed>0) → INCLUDED
+//   - sendInsufficientFunds(1): correct-nonce ante stub → EXCLUDED
 func TestTraceBlockByNumberExcludeTraceFail_AnteStub(t *testing.T) {
-	stubTxBz := signAndEncodeTx(sendInsufficientFunds(0), mnemonic1)
-	SetupTestServer(t, [][][]byte{{stubTxBz}}, mnemonicInitializer(mnemonic1)).Run(
+	successTxBz := signAndEncodeTx(send(0), mnemonic1)
+	stubTxBz := signAndEncodeTx(sendInsufficientFunds(1), mnemonic1)
+	SetupTestServer(t, [][][]byte{{successTxBz, stubTxBz}}, mnemonicInitializer(mnemonic1)).Run(
 		func(port int) {
 			res := sendRequestWithNamespace("sei", port, "traceBlockByNumberExcludeTraceFail", "0x2", map[string]interface{}{
 				"timeout": "60s", "tracer": "callTracer",
 			})
 			txs := res["result"].([]interface{})
-			require.Len(t, txs, 0, "correct-nonce insufficient-funds tx should be filtered out, got %v", txs)
+			require.Len(t, txs, 1, "ante stub filtered, successful tx kept; got %v", txs)
 		},
 	)
 }

--- a/evmrpc/tests/tracers_test.go
+++ b/evmrpc/tests/tracers_test.go
@@ -59,7 +59,7 @@ func TestTraceBlockByNumberExcludeTraceFail(t *testing.T) {
 // deferred-info stub receipt with EffectiveGasPrice=0 && GasUsed=0. With
 // callTracer / flatCallTracer the tracer embeds the error in the JSON and
 // leaves trace.Error empty, so the legacy trace.Error filter doesn't catch
-// them. The receipt-shape check in stripUntraceableTraces does.
+// them. The receipt-shape check in dropUntraceableTraces does.
 //
 // Block layout exercises both directions of the discriminator:
 //   - send(0): successful tx (Status=1, EffGP>0, GasUsed>0) → INCLUDED

--- a/evmrpc/tests/tx.go
+++ b/evmrpc/tests/tx.go
@@ -33,6 +33,28 @@ func send(nonce uint64) ethtypes.TxData {
 	}
 }
 
+// sendInsufficientFunds builds a correct-nonce tx whose intrinsic fee
+// (GasFeeCap * Gas) exceeds mnemonicInitializer's funded balance, triggering
+// an "insufficient funds" ante failure. Unlike send(N) for high N, this
+// passes the nonce check, so SetNonceBumped fires and the chain writes a
+// deferred-info stub receipt — the case the trace-side filter needs to
+// catch.
+func sendInsufficientFunds(nonce uint64) ethtypes.TxData {
+	_, recipient := testkeeper.MockAddressPair()
+	// mnemonicInitializer funds 10_000_000_000 usei = 1e22 wei. A fee of
+	// 2.1e34 wei is comfortably over budget.
+	hugeFee := new(big.Int).Exp(big.NewInt(10), big.NewInt(30), nil)
+	return &ethtypes.DynamicFeeTx{
+		Nonce:     nonce,
+		GasFeeCap: hugeFee,
+		Gas:       21000,
+		To:        &recipient,
+		Value:     big.NewInt(0),
+		Data:      []byte{},
+		ChainID:   chainId,
+	}
+}
+
 func sendAmount(nonce uint64, amount *big.Int) ethtypes.TxData {
 	_, recipient := testkeeper.MockAddressPair()
 	return &ethtypes.DynamicFeeTx{

--- a/evmrpc/trace_db_reader_test.go
+++ b/evmrpc/trace_db_reader_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/stretchr/testify/require"
 
+	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	"github.com/sei-protocol/sei-chain/x/evm/keeper"
 )
 
@@ -109,7 +110,7 @@ func TestFilterExcludeFailFromBlockCache(t *testing.T) {
 	require.NoError(t, c.PutBlock(9, "callTracer", row))
 
 	t.Run("filters errored entries on hit", func(t *testing.T) {
-		got, ok := filterExcludeFailFromBlockCache(c, 9, "callTracer")
+		got, ok := filterExcludeFailFromBlockCache(c, 9, "callTracer", nil, sdk.Context{})
 		require.True(t, ok)
 		require.Len(t, got, 2)
 		require.Equal(t, tx1, got[0].TxHash)
@@ -117,13 +118,13 @@ func TestFilterExcludeFailFromBlockCache(t *testing.T) {
 	})
 
 	t.Run("missing per-block row -> miss", func(t *testing.T) {
-		_, ok := filterExcludeFailFromBlockCache(c, 99, "callTracer")
+		_, ok := filterExcludeFailFromBlockCache(c, 99, "callTracer", nil, sdk.Context{})
 		require.False(t, ok)
 	})
 
 	t.Run("malformed row -> miss", func(t *testing.T) {
 		require.NoError(t, c.PutBlock(10, "callTracer", json.RawMessage(`not-json`)))
-		_, ok := filterExcludeFailFromBlockCache(c, 10, "callTracer")
+		_, ok := filterExcludeFailFromBlockCache(c, 10, "callTracer", nil, sdk.Context{})
 		require.False(t, ok)
 	})
 }

--- a/evmrpc/tracers.go
+++ b/evmrpc/tracers.go
@@ -463,21 +463,28 @@ func (api *SeiDebugAPI) TraceBlockByHashExcludeTraceFail(ctx context.Context, ha
 //
 // Per evmrpc/README.md ("Tracing Failure Management Endpoints"), the target
 // is txs "included in blocks but not executed" — pre-state-check failures
-// (nonce mismatch, insufficient funds) and chain-generated synthetic txs.
-// Reverts, OOG, and other in-VM failures all ran and produced traces; they
-// stay in.
+// (nonce mismatch, insufficient funds, etc.) and chain-generated synthetic
+// txs. Reverts, OOG, and other in-VM failures all ran and produced traces;
+// they stay in.
 //
-// Receipt fields are sufficient to discriminate. WriteReceipt
-// (x/evm/keeper/receipt.go) populates EffectiveGasPrice from msg.GasPrice
-// for any tx that reached the VM. The ante-deferred path
-// (x/evm/keeper/abci.go) writes a stub receipt with EffectiveGasPrice=0
-// for nonce-bumping ante failures. isReceiptFromAnteError captures that
-// signal, and the same helper is used by filterTransactions for block
-// endpoints — so block and tx ExcludeTraceFail filter the same set.
+// Discriminator: receipts are written in two paths. WriteReceipt
+// (x/evm/keeper/receipt.go) covers executed txs and sets EffectiveGasPrice
+// from msg.GasPrice (>0 on chains with positive min gas price) and GasUsed
+// > 0 (intrinsic gas at minimum). The ante-deferred stub path
+// (x/evm/keeper/abci.go) writes EffectiveGasPrice=0 and GasUsed=0 for any
+// nonce-bumping ante failure — regardless of which check failed (insufficient
+// funds, fee, mempool admission, etc.). Both fields zero is the signal that
+// the tx never reached the VM.
+//
+// (This does NOT use filterTransactions's isReceiptFromAnteError. That
+// helper's post-v5.8.0 branch is intentionally narrow — PR #2343's
+// TestAnteFailureOthers explicitly requires insufficient-funds receipts to
+// be *included* in regular eth_getBlockBy* responses. *ExcludeTraceFail has
+// the opposite semantic per the README, so it needs its own check.)
 //
 //   - GetReceipt error                          → no receipt yet           → exclude
 //   - TxType == ShellEVMTxType (math.MaxUint32) → chain-generated synthetic → exclude
-//   - isReceiptFromAnteError(receipt)           → never executed           → exclude
+//   - EffectiveGasPrice==0 && GasUsed==0        → ante-deferred stub        → exclude
 //   - anything else (success / revert / OOG)    → executed, has a trace    → include
 func (api *DebugAPI) isPanicOrSyntheticTx(ctx context.Context, hash common.Hash) (isPanic bool, err error) {
 	if api.isPanicCache != nil {
@@ -495,7 +502,8 @@ func (api *DebugAPI) isPanicOrSyntheticTx(ctx context.Context, hash common.Hash)
 		return true, nil
 	}
 
-	exclude := receipt.TxType == evmtypes.ShellEVMTxType || isReceiptFromAnteError(sdkctx, receipt)
+	exclude := receipt.TxType == evmtypes.ShellEVMTxType ||
+		(receipt.EffectiveGasPrice == 0 && receipt.GasUsed == 0)
 	if api.isPanicCache != nil {
 		api.isPanicCache.Add(hash, exclude)
 	}

--- a/evmrpc/tracers.go
+++ b/evmrpc/tracers.go
@@ -25,7 +25,6 @@ import (
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	"github.com/sei-protocol/sei-chain/x/evm/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
-	evmtypes "github.com/sei-protocol/sei-chain/x/evm/types"
 )
 
 const (
@@ -348,8 +347,7 @@ func stripUntraceableTraces(traces []*tracers.TxTraceResult, k *keeper.Keeper, s
 			continue
 		}
 		if k != nil {
-			if receipt, err := k.GetReceipt(sdkctx, trace.TxHash); err == nil &&
-				receipt.EffectiveGasPrice == 0 && receipt.GasUsed == 0 {
+			if receipt, err := k.GetReceipt(sdkctx, trace.TxHash); err == nil && isReceiptUntraceable(receipt) {
 				continue
 			}
 		}
@@ -512,8 +510,7 @@ func (api *DebugAPI) isPanicOrSyntheticTx(ctx context.Context, hash common.Hash)
 		return true, nil
 	}
 
-	exclude := receipt.TxType == evmtypes.ShellEVMTxType ||
-		(receipt.EffectiveGasPrice == 0 && receipt.GasUsed == 0)
+	exclude := isReceiptUntraceable(receipt)
 	if api.isPanicCache != nil {
 		api.isPanicCache.Add(hash, exclude)
 	}

--- a/evmrpc/tracers.go
+++ b/evmrpc/tracers.go
@@ -317,7 +317,7 @@ func (api *DebugAPI) tryExcludeFailBlockTraceCacheByHash(ctx context.Context, ha
 // filterExcludeFailFromBlockCache is the cached counterpart to the fresh
 // trace path in TraceBlockBy{Number,Hash}ExcludeTraceFail. Any change to
 // what *ExcludeTraceFail filters out must keep these two in sync —
-// delegate the per-trace decision to stripUntraceableTraces here just
+// delegate the per-trace decision to dropUntraceableTraces here just
 // as the fresh path does, so the discriminator stays single-sourced.
 // (TestTraceBlockByNumberExcludeTraceFail_AnteStub exercises the fresh
 // path with TraceBakeEnabled=false; the cache path's filtering is
@@ -331,10 +331,10 @@ func filterExcludeFailFromBlockCache(cache *keeper.TraceDB, height int64, tracer
 	if err := json.Unmarshal(bz, &traces); err != nil {
 		return nil, false
 	}
-	return stripUntraceableTraces(traces, k, sdkctx), true
+	return dropUntraceableTraces(traces, k, sdkctx), true
 }
 
-// stripUntraceableTraces filters out trace results that shouldn't surface from
+// dropUntraceableTraces filters out trace results that shouldn't surface from
 // the *ExcludeTraceFail trace endpoints. With a non-nil keeper, every
 // surviving trace must have a receipt that isReceiptUntraceable rejects —
 // matching the receipt-side semantic at isPanicOrSyntheticTx (missing
@@ -356,7 +356,7 @@ func filterExcludeFailFromBlockCache(cache *keeper.TraceDB, height int64, tracer
 //
 // A nil keeper disables the receipt branch (used by the cache-filter unit
 // test in isolation); the trace.Error check still applies.
-func stripUntraceableTraces(traces []*tracers.TxTraceResult, k *keeper.Keeper, sdkctx sdk.Context) []*tracers.TxTraceResult {
+func dropUntraceableTraces(traces []*tracers.TxTraceResult, k *keeper.Keeper, sdkctx sdk.Context) []*tracers.TxTraceResult {
 	out := make([]*tracers.TxTraceResult, 0, len(traces))
 	for _, trace := range traces {
 		if trace == nil || len(trace.Error) > 0 {
@@ -448,7 +448,7 @@ func (api *SeiDebugAPI) TraceBlockByNumberExcludeTraceFail(ctx context.Context, 
 	if !ok {
 		return nil, fmt.Errorf("unexpected type: %T", result)
 	}
-	return stripUntraceableTraces(traces, api.keeper, api.ctxProvider(LatestCtxHeight)), nil
+	return dropUntraceableTraces(traces, api.keeper, api.ctxProvider(LatestCtxHeight)), nil
 }
 
 func (api *SeiDebugAPI) TraceBlockByHashExcludeTraceFail(ctx context.Context, hash common.Hash, config *tracers.TraceConfig) (result interface{}, returnErr error) {
@@ -479,7 +479,7 @@ func (api *SeiDebugAPI) TraceBlockByHashExcludeTraceFail(ctx context.Context, ha
 	if !ok {
 		return nil, fmt.Errorf("unexpected type: %T", result)
 	}
-	return stripUntraceableTraces(traces, api.keeper, api.ctxProvider(LatestCtxHeight)), nil
+	return dropUntraceableTraces(traces, api.keeper, api.ctxProvider(LatestCtxHeight)), nil
 }
 
 // isPanicOrSyntheticTx returns true if the tx isn't traceable — used by the

--- a/evmrpc/tracers.go
+++ b/evmrpc/tracers.go
@@ -299,7 +299,7 @@ func (api *DebugAPI) tryExcludeFailBlockTraceCacheByNumber(ctx context.Context, 
 	if err != nil || block == nil {
 		return nil, false
 	}
-	return filterExcludeFailFromBlockCache(cache, int64(block.NumberU64()), name) //nolint:gosec
+	return filterExcludeFailFromBlockCache(cache, int64(block.NumberU64()), name, api.keeper, api.ctxProvider(LatestCtxHeight)) //nolint:gosec
 }
 
 func (api *DebugAPI) tryExcludeFailBlockTraceCacheByHash(ctx context.Context, hash common.Hash, config *tracers.TraceConfig) ([]*tracers.TxTraceResult, bool) {
@@ -312,10 +312,10 @@ func (api *DebugAPI) tryExcludeFailBlockTraceCacheByHash(ctx context.Context, ha
 	if err != nil || block == nil {
 		return nil, false
 	}
-	return filterExcludeFailFromBlockCache(cache, int64(block.NumberU64()), name) //nolint:gosec
+	return filterExcludeFailFromBlockCache(cache, int64(block.NumberU64()), name, api.keeper, api.ctxProvider(LatestCtxHeight)) //nolint:gosec
 }
 
-func filterExcludeFailFromBlockCache(cache *keeper.TraceDB, height int64, tracer string) ([]*tracers.TxTraceResult, bool) {
+func filterExcludeFailFromBlockCache(cache *keeper.TraceDB, height int64, tracer string, k *keeper.Keeper, sdkctx sdk.Context) ([]*tracers.TxTraceResult, bool) {
 	bz, ok, err := cache.GetBlock(height, tracer)
 	if err != nil || !ok {
 		return nil, false
@@ -324,14 +324,38 @@ func filterExcludeFailFromBlockCache(cache *keeper.TraceDB, height int64, tracer
 	if err := json.Unmarshal(bz, &traces); err != nil {
 		return nil, false
 	}
+	return stripUntraceableTraces(traces, k, sdkctx), true
+}
+
+// stripUntraceableTraces filters out trace results that shouldn't surface from
+// the *ExcludeTraceFail trace endpoints:
+//
+//   - trace.Error != "": tracer-level failure (timeout, internal error, etc.).
+//   - Receipt is an ante-deferred stub (EffectiveGasPrice==0 && GasUsed==0):
+//     the tx bumped its nonce in ante but never reached the VM. The trace
+//     ran but the result is meaningless — for callTracer / flatCallTracer
+//     (and the default-tracer insufficient-funds path) errorTrace embeds
+//     the error in the JSON and leaves TxTraceResult.Error empty, so the
+//     trace.Error check alone can't catch this. Mirrors the receipt-side
+//     and block-side discriminator at isPanicOrSyntheticTx / EncodeTmBlock.
+//
+// A nil keeper disables the receipt-stub check (kept for unit tests of the
+// cache-filter behavior in isolation); the trace.Error check still applies.
+func stripUntraceableTraces(traces []*tracers.TxTraceResult, k *keeper.Keeper, sdkctx sdk.Context) []*tracers.TxTraceResult {
 	out := make([]*tracers.TxTraceResult, 0, len(traces))
-	for _, t := range traces {
-		if t == nil || len(t.Error) > 0 {
+	for _, trace := range traces {
+		if trace == nil || len(trace.Error) > 0 {
 			continue
 		}
-		out = append(out, t)
+		if k != nil {
+			if receipt, err := k.GetReceipt(sdkctx, trace.TxHash); err == nil &&
+				receipt.EffectiveGasPrice == 0 && receipt.GasUsed == 0 {
+				continue
+			}
+		}
+		out = append(out, trace)
 	}
-	return out, true
+	return out
 }
 
 func txHashesOf(txs gethtypes.Transactions) []common.Hash {
@@ -409,14 +433,7 @@ func (api *SeiDebugAPI) TraceBlockByNumberExcludeTraceFail(ctx context.Context, 
 	if !ok {
 		return nil, fmt.Errorf("unexpected type: %T", result)
 	}
-	finalTraces := make([]*tracers.TxTraceResult, 0, len(traces))
-	for _, trace := range traces {
-		if len(trace.Error) > 0 {
-			continue
-		}
-		finalTraces = append(finalTraces, trace)
-	}
-	return finalTraces, nil
+	return stripUntraceableTraces(traces, api.keeper, api.ctxProvider(LatestCtxHeight)), nil
 }
 
 func (api *SeiDebugAPI) TraceBlockByHashExcludeTraceFail(ctx context.Context, hash common.Hash, config *tracers.TraceConfig) (result interface{}, returnErr error) {
@@ -447,14 +464,7 @@ func (api *SeiDebugAPI) TraceBlockByHashExcludeTraceFail(ctx context.Context, ha
 	if !ok {
 		return nil, fmt.Errorf("unexpected type: %T", result)
 	}
-	finalTraces := make([]*tracers.TxTraceResult, 0, len(traces))
-	for _, trace := range traces {
-		if len(trace.Error) > 0 {
-			continue
-		}
-		finalTraces = append(finalTraces, trace)
-	}
-	return finalTraces, nil
+	return stripUntraceableTraces(traces, api.keeper, api.ctxProvider(LatestCtxHeight)), nil
 }
 
 // isPanicOrSyntheticTx returns true if the tx isn't traceable — used by the

--- a/evmrpc/tracers.go
+++ b/evmrpc/tracers.go
@@ -335,19 +335,27 @@ func filterExcludeFailFromBlockCache(cache *keeper.TraceDB, height int64, tracer
 }
 
 // stripUntraceableTraces filters out trace results that shouldn't surface from
-// the *ExcludeTraceFail trace endpoints:
+// the *ExcludeTraceFail trace endpoints. With a non-nil keeper, every
+// surviving trace must have a receipt that isReceiptUntraceable rejects —
+// matching the receipt-side semantic at isPanicOrSyntheticTx (missing
+// receipt → exclude, untraceable receipt → exclude). Drops are:
 //
 //   - trace.Error != "": tracer-level failure (timeout, internal error, etc.).
-//   - Receipt is an ante-deferred stub (EffectiveGasPrice==0 && GasUsed==0):
-//     the tx bumped its nonce in ante but never reached the VM. The trace
-//     ran but the result is meaningless — for callTracer / flatCallTracer
-//     (and the default-tracer insufficient-funds path) errorTrace embeds
-//     the error in the JSON and leaves TxTraceResult.Error empty, so the
-//     trace.Error check alone can't catch this. Mirrors the receipt-side
-//     and block-side discriminator at isPanicOrSyntheticTx / EncodeTmBlock.
+//   - GetReceipt errors: no receipt for the tx hash. Unreachable in practice
+//     (the trace path's pre-filter in Backend.BlockByNumber drops no-receipt
+//     txs before they get traced, and the baker only caches traces for
+//     txs with receipts), but excluded here for parity with the tx-side
+//     check so isReceiptUntraceable's "shared discriminator" promise holds
+//     across every site.
+//   - isReceiptUntraceable(receipt): synthetic (TxType==ShellEVMTxType) or
+//     ante-deferred stub (EffectiveGasPrice==0 && GasUsed==0). For
+//     callTracer / flatCallTracer (and the default-tracer insufficient-funds
+//     path) errorTrace embeds the underlying error in the JSON and leaves
+//     TxTraceResult.Error empty, so the trace.Error check alone can't catch
+//     this — the receipt-shape check does.
 //
-// A nil keeper disables the receipt-stub check (kept for unit tests of the
-// cache-filter behavior in isolation); the trace.Error check still applies.
+// A nil keeper disables the receipt branch (used by the cache-filter unit
+// test in isolation); the trace.Error check still applies.
 func stripUntraceableTraces(traces []*tracers.TxTraceResult, k *keeper.Keeper, sdkctx sdk.Context) []*tracers.TxTraceResult {
 	out := make([]*tracers.TxTraceResult, 0, len(traces))
 	for _, trace := range traces {
@@ -355,7 +363,8 @@ func stripUntraceableTraces(traces []*tracers.TxTraceResult, k *keeper.Keeper, s
 			continue
 		}
 		if k != nil {
-			if receipt, err := k.GetReceipt(sdkctx, trace.TxHash); err == nil && isReceiptUntraceable(receipt) {
+			receipt, err := k.GetReceipt(sdkctx, trace.TxHash)
+			if err != nil || isReceiptUntraceable(receipt) {
 				continue
 			}
 		}

--- a/evmrpc/tracers.go
+++ b/evmrpc/tracers.go
@@ -314,6 +314,14 @@ func (api *DebugAPI) tryExcludeFailBlockTraceCacheByHash(ctx context.Context, ha
 	return filterExcludeFailFromBlockCache(cache, int64(block.NumberU64()), name, api.keeper, api.ctxProvider(LatestCtxHeight)) //nolint:gosec
 }
 
+// filterExcludeFailFromBlockCache is the cached counterpart to the fresh
+// trace path in TraceBlockBy{Number,Hash}ExcludeTraceFail. Any change to
+// what *ExcludeTraceFail filters out must keep these two in sync —
+// delegate the per-trace decision to stripUntraceableTraces here just
+// as the fresh path does, so the discriminator stays single-sourced.
+// (TestTraceBlockByNumberExcludeTraceFail_AnteStub exercises the fresh
+// path with TraceBakeEnabled=false; the cache path's filtering is
+// covered transitively via the shared helper.)
 func filterExcludeFailFromBlockCache(cache *keeper.TraceDB, height int64, tracer string, k *keeper.Keeper, sdkctx sdk.Context) ([]*tracers.TxTraceResult, bool) {
 	bz, ok, err := cache.GetBlock(height, tracer)
 	if err != nil || !ok {

--- a/evmrpc/tx_test.go
+++ b/evmrpc/tx_test.go
@@ -169,9 +169,14 @@ func TestGetTransactionReceiptExcludeTraceFail(t *testing.T) {
 		expectPanic bool // true => endpoint returns ErrPanicTx
 	}{
 		{
-			// Ante failure (deferred-info receipt: EffectiveGasPrice=0, VmError set).
-			// Not executed → no trace → exclude.
-			name:        "ante failure is excluded",
+			// Non-nonce ante failure (deferred-info stub receipt:
+			// EffectiveGasPrice=0, GasUsed=0, VmError="insufficient funds").
+			// The chain only writes stub receipts for txs whose nonce passed
+			// validation but failed a later ante check — so nonce-too-high /
+			// nonce-too-low never appear here; the realistic VmError content
+			// is "insufficient funds", "insufficient fee", etc. The
+			// discriminator must catch this regardless of VmError content.
+			name:        "non-nonce ante failure is excluded",
 			hash:        TestPanicTxHash,
 			expectPanic: true,
 		},

--- a/evmrpc/utils.go
+++ b/evmrpc/utils.go
@@ -369,6 +369,28 @@ func isReceiptFromAnteError(ctx sdk.Context, receipt *types.Receipt) bool {
 		strings.Contains(receipt.VmError, core.ErrNonceTooLow.Error()))
 }
 
+// isReceiptUntraceable returns true if the receipt represents a tx whose
+// trace would be empty or meaningless. Shared discriminator used by every
+// *ExcludeTraceFail site (tx, block, trace) so they filter the same set.
+//
+//   - TxType == ShellEVMTxType: chain-generated synthetic, no real EVM
+//     execution. app/receipt.go writes these for wasm txs to surface CW20
+//     events on the EVM side; they have no trace.
+//   - EffectiveGasPrice == 0 && GasUsed == 0: ante-deferred stub receipt
+//     from x/evm/keeper/abci.go — the tx bumped its nonce in ante but
+//     never reached the VM. WriteReceipt for any executed tx sets both
+//     fields > 0 (intrinsic gas at minimum, msg.GasPrice for the fee on
+//     a chain with positive min fee), so reverts and OOG pass through.
+//
+// This is intentionally narrower than isReceiptFromAnteError's
+// post-v5.8.0 branch: that helper is tuned to keep insufficient-funds
+// receipts visible to the regular eth_getBlockBy* endpoints (per
+// PR #2343). *ExcludeTraceFail wants the opposite per evmrpc/README.md.
+func isReceiptUntraceable(receipt *types.Receipt) bool {
+	return receipt.TxType == types.ShellEVMTxType ||
+		(receipt.EffectiveGasPrice == 0 && receipt.GasUsed == 0)
+}
+
 type ParallelRunner struct {
 	Done  sync.WaitGroup
 	Queue chan func()


### PR DESCRIPTION
## Summary

All three `*ExcludeTraceFail` endpoints (`sei_getTransactionReceiptExcludeTraceFail`, `sei_getBlockBy*ExcludeTraceFail`, `sei_traceBlockBy*ExcludeTraceFail`) leak non-nonce ante failures. The chain writes deferred-info stub receipts for them (`EffectiveGasPrice=0`, `GasUsed=0`); none of the existing filters catch this shape.

We can't widen `isReceiptFromAnteError` — [PR #2343](https://github.com/sei-protocol/sei-chain/pull/2343) narrowed it deliberately so regular `eth_getBlockBy*` keeps surfacing those receipts (real state changes from the nonce bump).

## Fix

One discriminator, three call sites:

```go
// utils.go
func isReceiptUntraceable(receipt *types.Receipt) bool {
    return receipt.TxType == types.ShellEVMTxType ||
        (receipt.EffectiveGasPrice == 0 && receipt.GasUsed == 0)
}
```

Applied at `isPanicOrSyntheticTx` (tx), `EncodeTmBlock` via new `excludeUntraceable bool` (block, `false` for regular endpoints), and `stripUntraceableTraces` (trace, both fresh and cached paths).

## Test coverage matrix

| Receipt class | Tx side | Block direct | Block HTTP | Trace HTTP |
|---|---|---|---|---|
| Synthetic (`TxType=Shell`) | ✓ | filterTransactions | — | filterTransactions |
| Ante stub (`EffGP=0, GasUsed=0`) | ✓ | ✓ | ✓ | ✓ |
| Revert / OOG (`EffGP>0, GasUsed>0`) | ✓ | ✓ | sanity baseline | — |
| Success (`Status=1`) | logical-identical to revert in discriminator | logical-identical | logical-identical | ✓ (kept alongside stub) |
| No receipt | ✓ (late-receipt test) | filterTransactions | — | filterTransactions; helper-internal parity |

Tests:
- `TestGetTransactionReceiptExcludeTraceFail` (tx-level table)
- `TestEncodeTmBlock_ExcludeUntraceable` (direct, both `true`/`false`)
- `TestGetBlockByHashExcludeTraceFail_AnteStub` (HTTP, asserts PR #2343 baseline + filter divergence in one test)
- `TestTraceBlockByNumberExcludeTraceFail_AnteStub` (HTTP, stub dropped + success kept)

Each fails when its discriminator is disabled. Full evmrpc suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)