### PR TITLE
fix: capture startTime before defer and fix goroutine error propagation in EVM RPC metrics

### DIFF
--- a/evmrpc/filter.go
+++ b/evmrpc/filter.go
@@ -398,8 +398,9 @@ func (a *FilterAPI) NewFilter(
 	ctx context.Context,
 	crit filters.FilterCriteria,
 ) (id ethrpc.ID, err error) {
+	startTime := time.Now()
 	defer func() {
-		recordMetricsWithError(ctx, fmt.Sprintf("%s_newFilter", a.namespace), a.connectionType, time.Now(), err, recover())
+		recordMetricsWithError(ctx, fmt.Sprintf("%s_newFilter", a.namespace), a.connectionType, startTime, err, recover())
 	}()
 
 	_, cancel := context.WithCancel(a.shutdownCtx)
@@ -421,8 +422,9 @@ func (a *FilterAPI) NewFilter(
 func (a *FilterAPI) NewBlockFilter(
 	ctx context.Context,
 ) (id ethrpc.ID, err error) {
+	startTime := time.Now()
 	defer func() {
-		recordMetricsWithError(ctx, fmt.Sprintf("%s_newBlockFilter", a.namespace), a.connectionType, time.Now(), err, recover())
+		recordMetricsWithError(ctx, fmt.Sprintf("%s_newBlockFilter", a.namespace), a.connectionType, startTime, err, recover())
 	}()
 
 	_, cancel := context.WithCancel(a.shutdownCtx)
@@ -444,8 +446,9 @@ func (a *FilterAPI) NewPendingTransactionFilter(
 	ctx context.Context,
 	_ *bool,
 ) (id ethrpc.ID, err error) {
+	startTime := time.Now()
 	defer func() {
-		recordMetricsWithError(ctx, fmt.Sprintf("%s_newPendingTransactionFilter", a.namespace), a.connectionType, time.Now(), err, recover())
+		recordMetricsWithError(ctx, fmt.Sprintf("%s_newPendingTransactionFilter", a.namespace), a.connectionType, startTime, err, recover())
 	}()
 	return "", &ErrEVMNotSupported{Msg: "eth_newPendingTransactionFilter is not supported on Sei EVM RPC"}
 }
@@ -456,8 +459,9 @@ func (a *FilterAPI) GetFilterChanges(
 	ctx context.Context,
 	filterID ethrpc.ID,
 ) (res interface{}, err error) {
+	startTime := time.Now()
 	defer func() {
-		recordMetricsWithError(ctx, fmt.Sprintf("%s_getFilterChanges", a.namespace), a.connectionType, time.Now(), err, recover())
+		recordMetricsWithError(ctx, fmt.Sprintf("%s_getFilterChanges", a.namespace), a.connectionType, startTime, err, recover())
 	}()
 
 	// Read filter with read lock
@@ -526,8 +530,9 @@ func (a *FilterAPI) GetFilterLogs(
 	ctx context.Context,
 	filterID ethrpc.ID,
 ) (res []*ethtypes.Log, err error) {
+	startTime := time.Now()
 	defer func() {
-		recordMetricsWithError(ctx, fmt.Sprintf("%s_getFilterLogs", a.namespace), a.connectionType, time.Now(), err, recover())
+		recordMetricsWithError(ctx, fmt.Sprintf("%s_getFilterLogs", a.namespace), a.connectionType, startTime, err, recover())
 	}()
 
 	// Read filter with read lock
@@ -675,7 +680,10 @@ func (a *FilterAPI) UninstallFilter(
 	ctx context.Context,
 	filterID ethrpc.ID,
 ) (res bool) {
-	defer recordMetrics(ctx, fmt.Sprintf("%s_uninstallFilter", a.namespace), a.connectionType, time.Now())
+	startTime := time.Now()
+	defer func() {
+		recordMetrics(ctx, fmt.Sprintf("%s_uninstallFilter", a.namespace), a.connectionType, startTime)
+	}()
 
 	// Check if filter exists
 	a.filtersMu.RLock()

--- a/evmrpc/subscribe.go
+++ b/evmrpc/subscribe.go
@@ -236,18 +236,22 @@ func (a *SubscriptionAPI) Logs(ctx context.Context, filter *filters.FilterCriter
 
 	if filter.BlockHash != nil {
 		go func() {
+			var err error
+			defer func() {
+				if err != nil {
+					recordMetricsWithError(ctx, "eth_logs", a.connectionType, startTime, err, recover())
+				}
+			}()
 			defer recoverAndLog()
 			defer wpMetrics.RecordSubscriptionEnd()
 			logs, _, err := a.logFetcher.GetLogsByFilters(ctx, *filter, 0)
 			if err != nil {
 				wpMetrics.RecordSubscriptionError()
 				_ = notifier.Notify(rpcSub.ID, err)
-				_err = err
 				return
 			}
 			for _, log := range logs {
-				if err := notifier.Notify(rpcSub.ID, log); err != nil {
-					_err = err
+				if err = notifier.Notify(rpcSub.ID, log); err != nil {
 					return
 				}
 			}
@@ -256,20 +260,26 @@ func (a *SubscriptionAPI) Logs(ctx context.Context, filter *filters.FilterCriter
 	}
 
 	go func() {
+		var err error
+		defer func() {
+			if err != nil {
+				recordMetricsWithError(ctx, "eth_logs", a.connectionType, startTime, err, recover())
+			}
+		}()
 		defer recoverAndLog()
 		defer wpMetrics.RecordSubscriptionEnd()
 		begin := int64(0)
 		for {
-			logs, lastToHeight, err := a.logFetcher.GetLogsByFilters(ctx, *filter, begin)
+			var logs []*ethtypes.Log
+			var lastToHeight int64
+			logs, lastToHeight, err = a.logFetcher.GetLogsByFilters(ctx, *filter, begin)
 			if err != nil {
 				wpMetrics.RecordSubscriptionError()
 				_ = notifier.Notify(rpcSub.ID, err)
-				_err = err
 				return
 			}
 			for _, log := range logs {
-				if err := notifier.Notify(rpcSub.ID, log); err != nil {
-					_err = err
+				if err = notifier.Notify(rpcSub.ID, log); err != nil {
 					return
 				}
 			}

--- a/evmrpc/subscribe.go
+++ b/evmrpc/subscribe.go
@@ -239,7 +239,9 @@ func (a *SubscriptionAPI) Logs(ctx context.Context, filter *filters.FilterCriter
 			var err error
 			defer recoverAndLog()
 			defer func() {
-				recordMetricsWithError(ctx, "eth_logs", a.connectionType, startTime, err, recover())
+				if p := recover(); p != nil || err != nil {
+					recordMetricsWithError(ctx, "eth_logs", a.connectionType, startTime, err, p)
+				}
 			}()
 			defer wpMetrics.RecordSubscriptionEnd()
 			logs, _, err := a.logFetcher.GetLogsByFilters(ctx, *filter, 0)
@@ -261,7 +263,9 @@ func (a *SubscriptionAPI) Logs(ctx context.Context, filter *filters.FilterCriter
 		var err error
 		defer recoverAndLog()
 		defer func() {
-			recordMetricsWithError(ctx, "eth_logs", a.connectionType, startTime, err, recover())
+			if p := recover(); p != nil || err != nil {
+				recordMetricsWithError(ctx, "eth_logs", a.connectionType, startTime, err, p)
+			}
 		}()
 		defer wpMetrics.RecordSubscriptionEnd()
 		begin := int64(0)

--- a/evmrpc/subscribe.go
+++ b/evmrpc/subscribe.go
@@ -238,11 +238,6 @@ func (a *SubscriptionAPI) Logs(ctx context.Context, filter *filters.FilterCriter
 		go func() {
 			var err error
 			defer recoverAndLog()
-			defer func() {
-				if p := recover(); p != nil || err != nil {
-					recordMetricsWithError(ctx, "eth_logs", a.connectionType, startTime, err, p)
-				}
-			}()
 			defer wpMetrics.RecordSubscriptionEnd()
 			logs, _, err := a.logFetcher.GetLogsByFilters(ctx, *filter, 0)
 			if err != nil {
@@ -262,11 +257,6 @@ func (a *SubscriptionAPI) Logs(ctx context.Context, filter *filters.FilterCriter
 	go func() {
 		var err error
 		defer recoverAndLog()
-		defer func() {
-			if p := recover(); p != nil || err != nil {
-				recordMetricsWithError(ctx, "eth_logs", a.connectionType, startTime, err, p)
-			}
-		}()
 		defer wpMetrics.RecordSubscriptionEnd()
 		begin := int64(0)
 		for {

--- a/evmrpc/subscribe.go
+++ b/evmrpc/subscribe.go
@@ -237,12 +237,10 @@ func (a *SubscriptionAPI) Logs(ctx context.Context, filter *filters.FilterCriter
 	if filter.BlockHash != nil {
 		go func() {
 			var err error
-			defer func() {
-				if err != nil {
-					recordMetricsWithError(ctx, "eth_logs", a.connectionType, startTime, err, recover())
-				}
-			}()
 			defer recoverAndLog()
+			defer func() {
+				recordMetricsWithError(ctx, "eth_logs", a.connectionType, startTime, err, recover())
+			}()
 			defer wpMetrics.RecordSubscriptionEnd()
 			logs, _, err := a.logFetcher.GetLogsByFilters(ctx, *filter, 0)
 			if err != nil {
@@ -261,12 +259,10 @@ func (a *SubscriptionAPI) Logs(ctx context.Context, filter *filters.FilterCriter
 
 	go func() {
 		var err error
-		defer func() {
-			if err != nil {
-				recordMetricsWithError(ctx, "eth_logs", a.connectionType, startTime, err, recover())
-			}
-		}()
 		defer recoverAndLog()
+		defer func() {
+			recordMetricsWithError(ctx, "eth_logs", a.connectionType, startTime, err, recover())
+		}()
 		defer wpMetrics.RecordSubscriptionEnd()
 		begin := int64(0)
 		for {

--- a/evmrpc/subscribe.go
+++ b/evmrpc/subscribe.go
@@ -157,8 +157,9 @@ func handleListener(c chan map[string]interface{}, ethHeader map[string]interfac
 }
 
 func (a *SubscriptionAPI) NewHeads(ctx context.Context) (s *rpc.Subscription, err error) {
+	startTime := time.Now()
 	defer func() {
-		recordMetricsWithError(ctx, "eth_newHeads", a.connectionType, time.Now(), err, recover())
+		recordMetricsWithError(ctx, "eth_newHeads", a.connectionType, startTime, err, recover())
 	}()
 	notifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {
@@ -201,8 +202,9 @@ func (a *SubscriptionAPI) NewHeads(ctx context.Context) (s *rpc.Subscription, er
 }
 
 func (a *SubscriptionAPI) Logs(ctx context.Context, filter *filters.FilterCriteria) (s *rpc.Subscription, _err error) {
+	startTime := time.Now()
 	defer func() {
-		recordMetricsWithError(ctx, "eth_logs", a.connectionType, time.Now(), _err, recover())
+		recordMetricsWithError(ctx, "eth_logs", a.connectionType, startTime, _err, recover())
 	}()
 	notifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {


### PR DESCRIPTION
## Summary

Two bugs in EVM RPC metric recording for `evmrpc/filter.go` and `evmrpc/subscribe.go`:

- **`time.Now()` in deferred closures recorded near-zero latency.** `time.Now()` inside a deferred closure is evaluated when the defer fires (at function return), not when the function starts — so it measured essentially zero elapsed time. Fixed by capturing `startTime := time.Now()` at function entry and passing it into the closure.

- **Named return `_err` was written from goroutines in `Logs`.** The outer function returns before its goroutines run, so by the time a goroutine assigns `_err`, the outer function's defer has already fired with no error recorded. Those writes had no effect on metric recording. Fixed by removing `_err` assignments from goroutines and scoping `err` locally within each goroutine. Goroutine-level errors are tracked separately via `wpMetrics.RecordSubscriptionError()`.
