### PR TITLE
ci: add Autobahn EVM Interoperability (CON-256)

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -161,6 +161,13 @@ jobs:
             ]
           },
           {
+            name: "Autobahn EVM Interoperability",
+            env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
+            scripts: [
+              "./integration_test/evm_module/scripts/evm_interoperability_tests.sh"
+            ]
+          },
+          {
             name: "Disable WASM Tests",
             scripts: [
               "./integration_test/evm_module/scripts/disable_wasm.sh",


### PR DESCRIPTION
Mirrors the existing "EVM Interoperability" CI job with AUTOBAHN=true
plus the GIGA_EXECUTOR/GIGA_STORAGE/GIGA_OCC flags.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
