### PR TITLE
autobahn: wire persistent_state_dir into data WAL (CON-256)

### DIFF
--- a/docker/localnode/scripts/step4_config_override.sh
+++ b/docker/localnode/scripts/step4_config_override.sh
@@ -96,7 +96,8 @@ if [ "$AUTOBAHN" = "true" ]; then
     NODE_DIRS="$NODE_DIRS build/generated/node_${i}"
   done
 
-  # Generate autobahn config using seid
+  # Generate autobahn config using seid. The default persistent_state_dir
+  # is a subdir under --home, which is what we want for the docker cluster.
   seid tendermint gen-autobahn-config $NODE_DIRS --output "$AUTOBAHN_CONFIG"
 
   # Inject autobahn config file path into config.toml

--- a/sei-tendermint/cmd/tendermint/commands/gen_autobahn_config.go
+++ b/sei-tendermint/cmd/tendermint/commands/gen_autobahn_config.go
@@ -33,6 +33,7 @@ Output is written to the file specified by --output.`,
 			if output == "" {
 				return fmt.Errorf("--output flag is required")
 			}
+			persistentStateDir, _ := cmd.Flags().GetString("persistent-state-dir")
 
 			var validators []config.AutobahnValidator
 			for _, dir := range args {
@@ -80,6 +81,14 @@ Output is written to the file specified by --output.`,
 				})
 			}
 
+			// Default to a relative subdir under the node's --home so consensus
+			// and data WALs survive process restarts without operator action.
+			// node/setup.go rootifies the path against cfg.RootDir at load time,
+			// matching how other paths in the tendermint config are resolved.
+			// An empty --persistent-state-dir flag explicitly disables persistence.
+			if persistentStateDir == "" && !cmd.Flags().Changed("persistent-state-dir") {
+				persistentStateDir = "data/autobahn"
+			}
 			cfg := config.AutobahnFileConfig{
 				Validators:       validators,
 				MaxTxsPerBlock:   5_000,
@@ -88,6 +97,9 @@ Output is written to the file specified by --output.`,
 				AllowEmptyBlocks: true,
 				ViewTimeout:      utils.Duration(1500 * time.Millisecond),
 				DialInterval:     utils.Duration(10 * time.Second),
+			}
+			if persistentStateDir != "" {
+				cfg.PersistentStateDir = utils.Some(persistentStateDir)
 			}
 
 			data, err := json.MarshalIndent(cfg, "", "  ")
@@ -102,5 +114,6 @@ Output is written to the file specified by --output.`,
 		},
 	}
 	cmd.Flags().StringP("output", "o", "", "output file path for the autobahn config")
+	cmd.Flags().String("persistent-state-dir", "data/autobahn", "directory to persist autobahn consensus and data WALs across restarts; relative paths are resolved against the node's --home dir; pass --persistent-state-dir= (empty) to disable persistence and run in-memory only")
 	return cmd
 }

--- a/sei-tendermint/internal/p2p/giga_router.go
+++ b/sei-tendermint/internal/p2p/giga_router.go
@@ -45,6 +45,10 @@ type GigaRouterConfig struct {
 	Producer       *producer.Config
 	TxMempool      *mempool.TxMempool
 	GenDoc         *types.GenesisDoc
+	// PersistentStateDir is the directory used by the data layer's
+	// block and commitqc WALs. If None, the WALs are no-ops and data
+	// recovery on restart depends entirely on peers re-sharing state.
+	PersistentStateDir utils.Option[string]
 }
 
 type GigaRouter struct {
@@ -83,7 +87,7 @@ func NewGigaRouter(cfg *GigaRouterConfig, key NodeSecretKey) (*GigaRouter, error
 		return nil, fmt.Errorf("atypes.NewRoundRobinElection(): %w", err)
 	}
 	// Automated pruning is disabled, because it is controlled by the application.
-	dataWAL, err := data.NewDataWAL(utils.None[string](), committee)
+	dataWAL, err := data.NewDataWAL(cfg.PersistentStateDir, committee)
 	if err != nil {
 		return nil, fmt.Errorf("data.NewDataWAL(): %w", err)
 	}
@@ -91,6 +95,11 @@ func NewGigaRouter(cfg *GigaRouterConfig, key NodeSecretKey) (*GigaRouter, error
 	if err != nil {
 		return nil, fmt.Errorf("data.NewState(): %w", err)
 	}
+	// Consensus and data WALs share the same on-disk root and use distinct
+	// subdirectories under it (inner / blocks / commitqcs vs globalblocks /
+	// fullcommitqcs), so propagate the router's PersistentStateDir into the
+	// consensus config rather than asking callers to set both.
+	cfg.Consensus.PersistentStateDir = cfg.PersistentStateDir
 	consensusState, err := consensus.NewState(cfg.Consensus, dataState)
 	if err != nil {
 		return nil, fmt.Errorf("consensus.NewState(): %w", err)

--- a/sei-tendermint/node/setup.go
+++ b/sei-tendermint/node/setup.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	_ "net/http/pprof" // nolint: gosec // securely exposed on separate, optional port
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -192,6 +193,7 @@ func loadAutobahnFileConfig(path string) (*config.AutobahnFileConfig, error) {
 // buildGigaConfig constructs a GigaRouterConfig from the autobahn config file, node key, and genesis doc.
 func buildGigaConfig(
 	autobahnConfigFile string,
+	rootDir string,
 	nodeKey types.NodeKey,
 	validatorKey atypes.SecretKey,
 	txMempool *mempool.TxMempool,
@@ -203,6 +205,14 @@ func buildGigaConfig(
 	fc, err := loadAutobahnFileConfig(autobahnConfigFile)
 	if err != nil {
 		return nil, fmt.Errorf("loading autobahn config from %q: %w", autobahnConfigFile, err)
+	}
+	// Resolve a relative persistent_state_dir against the node's --home dir,
+	// matching how other paths in the tendermint config are handled
+	// (config.go's rootify). Absolute paths pass through unchanged. An
+	// explicitly-unset PersistentStateDir (None) stays None, meaning the
+	// operator opted into in-memory-only mode.
+	if dir, ok := fc.PersistentStateDir.Get(); ok && !filepath.IsAbs(dir) {
+		fc.PersistentStateDir = utils.Some(filepath.Join(rootDir, dir))
 	}
 
 	validatorAddrs := map[atypes.PublicKey]p2p.GigaNodeAddr{}
@@ -242,14 +252,16 @@ func buildGigaConfig(
 	maxGasPerBlock := uint64(genDoc.ConsensusParams.Block.MaxGas) //nolint:gosec // validated > 0 above
 
 	return &p2p.GigaRouterConfig{
-		DialInterval:   time.Duration(fc.DialInterval),
-		ValidatorAddrs: validatorAddrs,
+		DialInterval:       time.Duration(fc.DialInterval),
+		ValidatorAddrs:     validatorAddrs,
+		PersistentStateDir: fc.PersistentStateDir,
+		// Consensus.PersistentStateDir is set by NewGigaRouter from the
+		// outer PersistentStateDir, so it isn't repeated here.
 		Consensus: &autobahnConsensus.Config{
 			Key: validatorKey,
 			ViewTimeout: func(atypes.View) time.Duration {
 				return time.Duration(fc.ViewTimeout)
 			},
-			PersistentStateDir: fc.PersistentStateDir,
 		},
 		Producer: &producer.Config{
 			MaxGasPerBlock:   maxGasPerBlock,
@@ -366,7 +378,7 @@ func createRouter(
 		if !ok {
 			return nil, closer, errors.New("autobahn requires a tx mempool")
 		}
-		gigaCfg, err := buildGigaConfig(cfg.AutobahnConfigFile, nodeKey, valKey, mp, genDoc)
+		gigaCfg, err := buildGigaConfig(cfg.AutobahnConfigFile, cfg.RootDir, nodeKey, valKey, mp, genDoc)
 		if err != nil {
 			return nil, closer, fmt.Errorf("buildGigaConfig: %w", err)
 		}


### PR DESCRIPTION
## Summary

The data layer's block and commitqc WALs were constructed with `utils.None[string]()`, making them no-ops: writes returned success but nothing landed on disk, and `NewState` loaded an empty WAL on every restart.

The autobahn config file already has `persistent_state_dir`, and it was already wired into the consensus layer. Thread the same value into the data layer.

## Why this matters

Single-node restarts survived only by peer-fed `PushQC` (the still-running peers re-shared blocks from memory). A coordinated cluster restart — which the upgrade test path triggers when all 4 validators panic at the upgrade height — had no recovery path because every node had simultaneously lost its in-memory data. `runExecute`'s `PushAppHash(N, hash)` waited forever on `nextBlockToPersist > N`, and no peer could satisfy the wait.

With the WAL wiring in place, `NewState` loads QCs and blocks from disk on restart, `nextBlockToPersist` recovers to the correct value, and the chain resumes.

## Changes

- `gen_autobahn_config`: add `--persistent-state-dir` flag, emit value into `AutobahnFileConfig.PersistentStateDir`
- `step4_config_override.sh`: pass `--persistent-state-dir \$HOME/.sei/data/autobahn` when generating the docker cluster's autobahn config
- `p2p.GigaRouterConfig`: add `PersistentStateDir` field
- `node/setup.go`: forward `fc.PersistentStateDir` into the new field
- `p2p/giga_router.go`: pass `cfg.PersistentStateDir` to `data.NewDataWAL` instead of `utils.None`

## Test plan

- [x] Autobahn Upgrade Module (Major) passes on this branch (was deadlocking before)
- [x] Autobahn Upgrade Module (Minor) passes
- [x] CometBFT Upgrade Module Major/Minor still pass