### PR TITLE
evmrpc: remove blockRes from EncodeTmBlock (CON-256)

### DIFF
--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -467,7 +467,13 @@ func EncodeTmBlock(
 			var bloom ethtypes.Bloom
 			bloom.SetBytes(receipt.LogsBloom)
 			bitutil.ORBytes(blockBloom, blockBloom, bloom[:])
-			blockGasUsed += blockRes.TxsResults[msg.index].GasUsed
+			// TxsResults is empty under Autobahn (BlockResults returns a stub
+			// without per-tx results); receipt.GasUsed is the fallback source.
+			if msg.index < len(blockRes.TxsResults) {
+				blockGasUsed += blockRes.TxsResults[msg.index].GasUsed
+			} else {
+				blockGasUsed += int64(receipt.GasUsed) //nolint:gosec
+			}
 		case *banktypes.MsgSend:
 			th := sha256.Sum256(block.Block.Txs[msg.index])
 			if !fullTx {
@@ -489,7 +495,11 @@ func EncodeTmBlock(
 				rpcTx.TransactionIndex = (*hexutil.Uint64)(&ti)
 				transactions = append(transactions, rpcTx)
 			}
-			blockGasUsed += blockRes.TxsResults[msg.index].GasUsed
+			// TxsResults is empty under Autobahn; bank-send gas is omitted
+			// from blockGasUsed there (no receipt is fetched in this branch).
+			if msg.index < len(blockRes.TxsResults) {
+				blockGasUsed += blockRes.TxsResults[msg.index].GasUsed
+			}
 		}
 	}
 	if len(transactions) == 0 {

--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -226,11 +226,7 @@ func (a *BlockAPI) getBlockByHash(ctx context.Context, blockHash common.Hash, fu
 		return nil, err
 	}
 
-	blockRes, err := blockResultsWithRetry(ctx, a.tmClient, &block.Block.Height)
-	if err != nil {
-		return nil, err
-	}
-	return EncodeTmBlock(a.ctxProvider, a.txConfigProvider, block, blockRes, a.keeper, fullTx, a.includeBankTransfers, includeSyntheticTxs, excludeUntraceable, a.globalBlockCache, a.cacheCreationMutex)
+	return EncodeTmBlock(a.ctxProvider, a.txConfigProvider, block, a.keeper, fullTx, a.includeBankTransfers, includeSyntheticTxs, excludeUntraceable, a.globalBlockCache, a.cacheCreationMutex)
 }
 
 func (a *BlockAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (result map[string]interface{}, returnErr error) {
@@ -273,11 +269,7 @@ func (a *BlockAPI) getBlockByNumber(
 	if err != nil {
 		return nil, err
 	}
-	blockRes, err := blockResultsWithRetry(ctx, a.tmClient, &block.Block.Height)
-	if err != nil {
-		return nil, err
-	}
-	return EncodeTmBlock(a.ctxProvider, a.txConfigProvider, block, blockRes, a.keeper, fullTx, a.includeBankTransfers, includeSyntheticTxs, excludeUntraceable, a.globalBlockCache, a.cacheCreationMutex)
+	return EncodeTmBlock(a.ctxProvider, a.txConfigProvider, block, a.keeper, fullTx, a.includeBankTransfers, includeSyntheticTxs, excludeUntraceable, a.globalBlockCache, a.cacheCreationMutex)
 }
 
 func (a *BlockAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (result []map[string]interface{}, returnErr error) {
@@ -374,7 +366,6 @@ func EncodeTmBlock(
 	ctxProvider func(int64) sdk.Context,
 	txConfigProvider func(int64) client.TxConfig,
 	block *coretypes.ResultBlock,
-	blockRes *coretypes.ResultBlockResults,
 	k *keeper.Keeper,
 	fullTx bool,
 	includeBankTransfers bool,
@@ -467,15 +458,10 @@ func EncodeTmBlock(
 			var bloom ethtypes.Bloom
 			bloom.SetBytes(receipt.LogsBloom)
 			bitutil.ORBytes(blockBloom, blockBloom, bloom[:])
-			// TxsResults is empty under Autobahn (BlockResults returns a stub
-			// without per-tx results); receipt.GasUsed is the fallback source.
-			if msg.index < len(blockRes.TxsResults) {
-				blockGasUsed += blockRes.TxsResults[msg.index].GasUsed
-			} else {
-				blockGasUsed += int64(receipt.GasUsed) //nolint:gosec
-			}
+			blockGasUsed += int64(receipt.GasUsed) //nolint:gosec
 		case *banktypes.MsgSend:
 			th := sha256.Sum256(block.Block.Txs[msg.index])
+			receipt, _ := getOrSetCachedReceipt(cacheCreationMutex, globalBlockCache, latestCtx, k, block, th)
 			if !fullTx {
 				transactions = append(transactions, "0x"+hex.EncodeToString(th[:]))
 			} else {
@@ -495,10 +481,8 @@ func EncodeTmBlock(
 				rpcTx.TransactionIndex = (*hexutil.Uint64)(&ti)
 				transactions = append(transactions, rpcTx)
 			}
-			// TxsResults is empty under Autobahn; bank-send gas is omitted
-			// from blockGasUsed there (no receipt is fetched in this branch).
-			if msg.index < len(blockRes.TxsResults) {
-				blockGasUsed += blockRes.TxsResults[msg.index].GasUsed
+			if receipt != nil {
+				blockGasUsed += int64(receipt.GasUsed) //nolint:gosec
 			}
 		}
 	}
@@ -507,13 +491,9 @@ func EncodeTmBlock(
 	}
 
 	// Source block.gasLimit from the active ConsensusParams in the SDK
-	// context, not from blockRes.ConsensusParamUpdates. The latter is only
-	// populated when the app proposes a consensus-param update (most
-	// blocks: nil); it's also out-of-sync under Autobahn where /block_results
-	// synthesizes a placeholder. The SDK ctx always has the params that
-	// were in effect at this block — same place the EVM runtime reads
-	// `block.gaslimit` from (x/evm/keeper/keeper.go's BlockContext.GasLimit),
-	// so eth_getBlockByNumber.gasLimit and the GASLIMIT opcode return the
+	// context — same place the EVM runtime reads block.gaslimit from
+	// (x/evm/keeper/keeper.go's BlockContext.GasLimit), so
+	// eth_getBlockByNumber.gasLimit and the GASLIMIT opcode return the
 	// same number.
 	var gasLimit int64
 	if cp := ctx.ConsensusParams(); cp != nil && cp.Block != nil {

--- a/evmrpc/block_test.go
+++ b/evmrpc/block_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	types2 "github.com/sei-protocol/sei-chain/sei-tendermint/proto/tendermint/types"
 	wasmtypes "github.com/sei-protocol/sei-chain/sei-wasmd/x/wasm/types"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -20,7 +19,6 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/client"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	banktypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/bank/types"
-	abci "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/rpc/coretypes"
 	tmtypes "github.com/sei-protocol/sei-chain/sei-tendermint/types"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
@@ -43,18 +41,9 @@ func TestEncodeTmBlock_EmptyTransactions(t *testing.T) {
 			},
 		},
 	}
-	blockRes := &coretypes.ResultBlockResults{
-		TxsResults: []*abci.ExecTxResult{},
-		ConsensusParamUpdates: &types2.ConsensusParams{
-			Block: &types2.BlockParams{
-				MaxBytes: 100000000,
-				MaxGas:   200000000,
-			},
-		},
-	}
 
 	// Call EncodeTmBlock with empty transactions
-	result, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, block, blockRes, k, true, false, false, false, evmrpc.NewBlockCache(3000), &sync.Mutex{})
+	result, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, block, k, true, false, false, false, evmrpc.NewBlockCache(3000), &sync.Mutex{})
 	require.Nil(t, err)
 
 	// Assert txHash is equal to ethtypes.EmptyTxsHash
@@ -84,23 +73,7 @@ func TestEncodeBankMsg(t *testing.T) {
 			},
 		},
 	}
-	resBlockRes := coretypes.ResultBlockResults{
-		TxsResults: []*abci.ExecTxResult{
-			{
-				Data: func() []byte {
-					bz, _ := Encoder(tx)
-					return bz
-				}(),
-			},
-		},
-		ConsensusParamUpdates: &types2.ConsensusParams{
-			Block: &types2.BlockParams{
-				MaxBytes: 100000000,
-				MaxGas:   200000000,
-			},
-		},
-	}
-	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, &resBlockRes, k, true, false, false, false, evmrpc.NewBlockCache(3000), &sync.Mutex{})
+	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, k, true, false, false, false, evmrpc.NewBlockCache(3000), &sync.Mutex{})
 	require.Nil(t, err)
 	txs := res["transactions"].([]interface{})
 	require.Equal(t, 0, len(txs))
@@ -140,20 +113,7 @@ func TestEncodeWasmExecuteMsg(t *testing.T) {
 			},
 		},
 	}
-	resBlockRes := coretypes.ResultBlockResults{
-		TxsResults: []*abci.ExecTxResult{
-			{
-				Data: bz,
-			},
-		},
-		ConsensusParamUpdates: &types2.ConsensusParams{
-			Block: &types2.BlockParams{
-				MaxBytes: 100000000,
-				MaxGas:   200000000,
-			},
-		},
-	}
-	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, &resBlockRes, k, true, false, true, false, evmrpc.NewBlockCache(3000), &sync.Mutex{})
+	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, k, true, false, true, false, evmrpc.NewBlockCache(3000), &sync.Mutex{})
 	require.Nil(t, err)
 	txs := res["transactions"].([]interface{})
 	require.Equal(t, 1, len(txs))
@@ -201,20 +161,7 @@ func TestEncodeBankTransferMsg(t *testing.T) {
 			},
 		},
 	}
-	resBlockRes := coretypes.ResultBlockResults{
-		TxsResults: []*abci.ExecTxResult{
-			{
-				Data: bz,
-			},
-		},
-		ConsensusParamUpdates: &types2.ConsensusParams{
-			Block: &types2.BlockParams{
-				MaxBytes: 100000000,
-				MaxGas:   200000000,
-			},
-		},
-	}
-	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, &resBlockRes, k, true, true, false, false, evmrpc.NewBlockCache(3000), &sync.Mutex{})
+	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, k, true, true, false, false, evmrpc.NewBlockCache(3000), &sync.Mutex{})
 	require.Nil(t, err)
 	txs := res["transactions"].([]interface{})
 	require.Equal(t, 1, len(txs))
@@ -234,10 +181,8 @@ func TestEncodeBankTransferMsg(t *testing.T) {
 	}, txs[0].(*export.RPCTransaction))
 }
 
-// Under Autobahn, BlockResults returns a stub with empty TxsResults.
-// EncodeTmBlock must not index it for Wasm txs; the receipt's GasUsed is
-// the fallback source for the block's gasUsed total.
-func TestEncodeWasmExecuteMsg_EmptyTxsResults(t *testing.T) {
+// Wasm-execute txs contribute receipt.GasUsed to the block's gasUsed total.
+func TestEncodeWasmExecuteMsg_GasUsedFromReceipt(t *testing.T) {
 	k := &testkeeper.EVMTestApp.EvmKeeper
 	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil).WithBlockHeight(MockHeight8)
 	fromSeiAddr, fromEvmAddr := testkeeper.MockAddressPair()
@@ -270,26 +215,18 @@ func TestEncodeWasmExecuteMsg_EmptyTxsResults(t *testing.T) {
 			},
 		},
 	}
-	resBlockRes := coretypes.ResultBlockResults{
-		TxsResults: []*abci.ExecTxResult{}, // Autobahn stub: no per-tx results.
-		ConsensusParamUpdates: &types2.ConsensusParams{
-			Block: &types2.BlockParams{
-				MaxBytes: 100000000,
-				MaxGas:   200000000,
-			},
-		},
-	}
-	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, &resBlockRes, k, true, false, true, false, evmrpc.NewBlockCache(3000), &sync.Mutex{})
+	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, k, true, false, true, false, evmrpc.NewBlockCache(3000), &sync.Mutex{})
 	require.Nil(t, err)
 	require.Equal(t, hexutil.Uint64(54321), res["gasUsed"])
 	txs := res["transactions"].([]interface{})
 	require.Equal(t, 1, len(txs))
 }
 
-// Under Autobahn, BlockResults returns a stub with empty TxsResults.
-// EncodeTmBlock must not index it for bank-send txs; no receipt is fetched
-// in that branch, so the bank tx contributes 0 to the block's gasUsed total.
-func TestEncodeBankTransferMsg_EmptyTxsResults(t *testing.T) {
+// Bank-send txs without a matching EVM receipt contribute 0 to the block's
+// gasUsed total. (This is the Autobahn case for plain MsgSend txs; under
+// legacy, bank sends that emit EVM-relevant events would have a synthetic
+// receipt and contribute receipt.GasUsed.)
+func TestEncodeBankTransferMsg_NoReceiptGasUsedZero(t *testing.T) {
 	k := &testkeeper.EVMTestApp.EvmKeeper
 	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
 	fromSeiAddr, fromEvmAddr := testkeeper.MockAddressPair()
@@ -315,16 +252,7 @@ func TestEncodeBankTransferMsg_EmptyTxsResults(t *testing.T) {
 			},
 		},
 	}
-	resBlockRes := coretypes.ResultBlockResults{
-		TxsResults: []*abci.ExecTxResult{}, // Autobahn stub: no per-tx results.
-		ConsensusParamUpdates: &types2.ConsensusParams{
-			Block: &types2.BlockParams{
-				MaxBytes: 100000000,
-				MaxGas:   200000000,
-			},
-		},
-	}
-	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, &resBlockRes, k, true, true, false, false, evmrpc.NewBlockCache(3000), &sync.Mutex{})
+	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, k, true, true, false, false, evmrpc.NewBlockCache(3000), &sync.Mutex{})
 	require.Nil(t, err)
 	require.Equal(t, hexutil.Uint64(0), res["gasUsed"])
 	txs := res["transactions"].([]interface{})
@@ -391,12 +319,6 @@ func TestEncodeTmBlock_ExcludeUntraceable(t *testing.T) {
 			LastCommit: &tmtypes.Commit{Height: stubHeight - 1},
 		},
 	}
-	blockRes := &coretypes.ResultBlockResults{
-		TxsResults: []*abci.ExecTxResult{{Data: anteStubBz}, {Data: nonPanicBz}},
-		ConsensusParamUpdates: &types2.ConsensusParams{
-			Block: &types2.BlockParams{MaxBytes: 100000000, MaxGas: 200000000},
-		},
-	}
 
 	// Post-v5.8.0 ctx so filterTransactions's isReceiptFromAnteError stays
 	// narrow (nonce-only VmError) — the production path where the stub
@@ -406,7 +328,7 @@ func TestEncodeTmBlock_ExcludeUntraceable(t *testing.T) {
 	txConfigProvider := func(int64) client.TxConfig { return TxConfig }
 
 	// excludeUntraceable=true: ante stub dropped, revert kept.
-	res, err := evmrpc.EncodeTmBlock(ctxProvider, txConfigProvider, block, blockRes, k,
+	res, err := evmrpc.EncodeTmBlock(ctxProvider, txConfigProvider, block, k,
 		false /*fullTx*/, false /*includeBankTransfers*/, false /*includeSyntheticTxs*/, true, /*excludeUntraceable*/
 		evmrpc.NewBlockCache(3000), &sync.Mutex{})
 	require.NoError(t, err)
@@ -416,7 +338,7 @@ func TestEncodeTmBlock_ExcludeUntraceable(t *testing.T) {
 
 	// excludeUntraceable=false: ante stub flows through (matches regular
 	// eth_getBlockBy* behavior per PR #2343's TestAnteFailureOthers).
-	res, err = evmrpc.EncodeTmBlock(ctxProvider, txConfigProvider, block, blockRes, k,
+	res, err = evmrpc.EncodeTmBlock(ctxProvider, txConfigProvider, block, k,
 		false /*fullTx*/, false /*includeBankTransfers*/, false /*includeSyntheticTxs*/, false, /*excludeUntraceable*/
 		evmrpc.NewBlockCache(3000), &sync.Mutex{})
 	require.NoError(t, err)

--- a/evmrpc/block_test.go
+++ b/evmrpc/block_test.go
@@ -234,6 +234,103 @@ func TestEncodeBankTransferMsg(t *testing.T) {
 	}, txs[0].(*export.RPCTransaction))
 }
 
+// Under Autobahn, BlockResults returns a stub with empty TxsResults.
+// EncodeTmBlock must not index it for Wasm txs; the receipt's GasUsed is
+// the fallback source for the block's gasUsed total.
+func TestEncodeWasmExecuteMsg_EmptyTxsResults(t *testing.T) {
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil).WithBlockHeight(MockHeight8)
+	fromSeiAddr, fromEvmAddr := testkeeper.MockAddressPair()
+	toSeiAddr, _ := testkeeper.MockAddressPair()
+	b := TxConfig.NewTxBuilder()
+	b.SetMsgs(&wasmtypes.MsgExecuteContract{
+		Sender:   fromSeiAddr.String(),
+		Contract: toSeiAddr.String(),
+		Msg:      []byte{1, 2, 3},
+	})
+	tx := b.GetTx()
+	bz, _ := Encoder(tx)
+	txHash := sha256.Sum256(bz)
+	hash := common.BytesToHash(txHash[:])
+	testkeeper.MustMockReceipt(t, k, ctx, hash, &types.Receipt{
+		TransactionIndex: 1,
+		From:             fromEvmAddr.Hex(),
+		TxHashHex:        hash.Hex(),
+		GasUsed:          54321,
+	})
+	resBlock := coretypes.ResultBlock{
+		BlockID: MockBlockID,
+		Block: &tmtypes.Block{
+			Header: mockBlockHeader(MockHeight8),
+			Data: tmtypes.Data{
+				Txs: []tmtypes.Tx{bz},
+			},
+			LastCommit: &tmtypes.Commit{
+				Height: MockHeight8 - 1,
+			},
+		},
+	}
+	resBlockRes := coretypes.ResultBlockResults{
+		TxsResults: []*abci.ExecTxResult{}, // Autobahn stub: no per-tx results.
+		ConsensusParamUpdates: &types2.ConsensusParams{
+			Block: &types2.BlockParams{
+				MaxBytes: 100000000,
+				MaxGas:   200000000,
+			},
+		},
+	}
+	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, &resBlockRes, k, true, false, true, false, evmrpc.NewBlockCache(3000), &sync.Mutex{})
+	require.Nil(t, err)
+	require.Equal(t, hexutil.Uint64(54321), res["gasUsed"])
+	txs := res["transactions"].([]interface{})
+	require.Equal(t, 1, len(txs))
+}
+
+// Under Autobahn, BlockResults returns a stub with empty TxsResults.
+// EncodeTmBlock must not index it for bank-send txs; no receipt is fetched
+// in that branch, so the bank tx contributes 0 to the block's gasUsed total.
+func TestEncodeBankTransferMsg_EmptyTxsResults(t *testing.T) {
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx(nil)
+	fromSeiAddr, fromEvmAddr := testkeeper.MockAddressPair()
+	k.SetAddressMapping(ctx, fromSeiAddr, fromEvmAddr)
+	toSeiAddr, _ := testkeeper.MockAddressPair()
+	b := TxConfig.NewTxBuilder()
+	b.SetMsgs(&banktypes.MsgSend{
+		FromAddress: fromSeiAddr.String(),
+		ToAddress:   toSeiAddr.String(),
+		Amount:      sdk.NewCoins(sdk.NewCoin("usei", sdk.OneInt())),
+	})
+	tx := b.GetTx()
+	bz, _ := Encoder(tx)
+	resBlock := coretypes.ResultBlock{
+		BlockID: MockBlockID,
+		Block: &tmtypes.Block{
+			Header: mockBlockHeader(MockHeight8),
+			Data: tmtypes.Data{
+				Txs: []tmtypes.Tx{bz},
+			},
+			LastCommit: &tmtypes.Commit{
+				Height: MockHeight8 - 1,
+			},
+		},
+	}
+	resBlockRes := coretypes.ResultBlockResults{
+		TxsResults: []*abci.ExecTxResult{}, // Autobahn stub: no per-tx results.
+		ConsensusParamUpdates: &types2.ConsensusParams{
+			Block: &types2.BlockParams{
+				MaxBytes: 100000000,
+				MaxGas:   200000000,
+			},
+		},
+	}
+	res, err := evmrpc.EncodeTmBlock(func(i int64) sdk.Context { return ctx }, func(i int64) client.TxConfig { return TxConfig }, &resBlock, &resBlockRes, k, true, true, false, false, evmrpc.NewBlockCache(3000), &sync.Mutex{})
+	require.Nil(t, err)
+	require.Equal(t, hexutil.Uint64(0), res["gasUsed"])
+	txs := res["transactions"].([]interface{})
+	require.Equal(t, 1, len(txs))
+}
+
 // TestEncodeTmBlock_ExcludeUntraceable pins the block-side counterpart of the
 // tx-side discriminator: a correct-nonce ante failure (e.g. insufficient
 // funds) lands a stub receipt in the receipt store. filterTransactions's

--- a/evmrpc/block_txcount_parity_test.go
+++ b/evmrpc/block_txcount_parity_test.go
@@ -16,9 +16,7 @@ import (
 	"github.com/sei-protocol/sei-chain/evmrpc"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/client"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
-	abci "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
 	tmbytes "github.com/sei-protocol/sei-chain/sei-tendermint/libs/bytes"
-	types2 "github.com/sei-protocol/sei-chain/sei-tendermint/proto/tendermint/types"
 	tmmock "github.com/sei-protocol/sei-chain/sei-tendermint/rpc/client/mock"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/rpc/coretypes"
 	tmtypes "github.com/sei-protocol/sei-chain/sei-tendermint/types"
@@ -107,15 +105,6 @@ func TestBlockTransactionCountMatchesGetBlockByNumber(t *testing.T) {
 			},
 		},
 	}
-	blockRes := &coretypes.ResultBlockResults{
-		TxsResults: []*abci.ExecTxResult{{Data: bz1}, {Data: bz2}},
-		ConsensusParamUpdates: &types2.ConsensusParams{
-			Block: &types2.BlockParams{
-				MaxBytes: 100000000,
-				MaxGas:   200000000,
-			},
-		},
-	}
 
 	ctxProvider := func(h int64) sdk.Context {
 		if h == evmrpc.LatestCtxHeight {
@@ -130,7 +119,7 @@ func TestBlockTransactionCountMatchesGetBlockByNumber(t *testing.T) {
 	decodeOnly := countDecodeOnlyEvmTxs(block.Block.Txs, TxConfig.TxDecoder())
 	require.Equal(t, 2, decodeOnly)
 
-	encoded, err := evmrpc.EncodeTmBlock(ctxProvider, txConfigProvider, block, blockRes, k, false, false, false, false, cache, mu)
+	encoded, err := evmrpc.EncodeTmBlock(ctxProvider, txConfigProvider, block, k, false, false, false, false, cache, mu)
 	require.NoError(t, err)
 	list := encoded["transactions"].([]interface{})
 

--- a/evmrpc/utils.go
+++ b/evmrpc/utils.go
@@ -139,20 +139,6 @@ func getAddressPrivKeyMap(kb keyring.Keyring) map[string]*ecdsa.PrivateKey {
 	return res
 }
 
-func blockResultsWithRetry(ctx context.Context, client client.LocalClient, height *int64) (*coretypes.ResultBlockResults, error) {
-	blockRes, err := client.BlockResults(ctx, height)
-	if err != nil {
-		// retry once, since application DB and block DB are not committed atomically so it's possible for
-		// receipt to exist while block results aren't committed yet
-		time.Sleep(1 * time.Second)
-		blockRes, err = client.BlockResults(ctx, height)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return blockRes, err
-}
-
 func blockByNumberWithRetry(ctx context.Context, client client.LocalClient, height *int64, maxRetries int) (*coretypes.ResultBlock, error) {
 	blockRes, err := client.Block(ctx, height)
 	var retryCount = 0


### PR DESCRIPTION
Under Autobahn, `/block_results` returns a stub with empty `TxsResults`
(see [`sei-tendermint/internal/rpc/core/blocks.go`](../tree/main/sei-tendermint/internal/rpc/core/blocks.go)),
so indexing `blockRes.TxsResults[i]` in `EncodeTmBlock` crashed
`sei_getBlockByNumber` and `sei_getBlockByHash` on blocks containing
Wasm or bank txs.

`EncodeTmBlock` didn't need `blockRes` at all — `receipt.GasUsed` is
the natural per-tx gas source (already used for EVM txs). Wasm
receipts are guaranteed by `filterTransactions`; bank receipts are
fetched in the bank branch (0 contribution if absent).
`blockResultsWithRetry` is removed.

Two regression tests pin the new contract:
- `TestEncodeWasmExecuteMsg_GasUsedFromReceipt`
- `TestEncodeBankTransferMsg_NoReceiptGasUsedZero`

## ⚠️ Behavior change

For `sei2_getBlockBy*`, blocks containing plain `MsgSend` txs (no wasm
event interaction) now report a smaller `block.gasUsed`. The bank tx's
cosmos gas was previously summed from `TxsResults[i].GasUsed`; plain
`MsgSend` has no synthetic receipt (the post-DeliverTx hook in
[`app/receipt.go`](../tree/main/app/receipt.go) early-returns when
`wasmEvents` is empty), so it contributes 0 here.

Other paths are unaffected:
- `eth_*` doesn't process non-EVM txs (filtered out at `filterTransactions`).
- `sei_*` only processes wasm, and `receipt.GasUsed ≡ TxsResults[i].GasUsed`
  for wasm (synthetic receipts read the same outer gas meter).
- `sei2_*` wasm-tx accounting: same equivalence as `sei_*`.

## Test plan

- [x] `go test ./evmrpc/` (21s)
- [x] `go test ./evmrpc/tests/` (28s)
- [x] `gofmt -s -l` clean
- [x] Verified end-to-end against #3468's Autobahn EVM Module CI job

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>