### PR TITLE
metrics(app): add app_block_gas_wanted and app_block_gas_wanted_ratio histograms (PLT-354)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -2787,9 +2787,9 @@ func (app *App) checkTotalBlockGas(ctx sdk.Context, typedTxs []sdk.Tx) (result b
 		}
 	}
 
-	appMetrics.blockGasWanted.Record(ctx.Context(), int64(totalGasWanted)) //nolint:gosec
-	if maxGasWanted := ctx.ConsensusParams().Block.MaxGasWanted; maxGasWanted > 0 {
-		appMetrics.blockGasWantedRatio.Record(ctx.Context(), float64(totalGasWanted)/float64(maxGasWanted)) //nolint:gosec
+	appMetrics.blockGasWanted.Record(ctx.Context(), float64(totalGasWanted))
+	if cp := ctx.ConsensusParams(); cp != nil && cp.Block != nil && cp.Block.MaxGasWanted > 0 {
+		appMetrics.blockGasWantedRatio.Record(ctx.Context(), float64(totalGasWanted)/float64(cp.Block.MaxGasWanted))
 	}
 	return true
 }

--- a/app/app.go
+++ b/app/app.go
@@ -2787,7 +2787,7 @@ func (app *App) checkTotalBlockGas(ctx sdk.Context, typedTxs []sdk.Tx) (result b
 		}
 	}
 
-	appMetrics.blockGasWanted.Record(ctx.Context(), float64(totalGasWanted))
+	appMetrics.blockGasWanted.Record(ctx.Context(), int64(totalGasWanted)) //nolint:gosec
 	if cp := ctx.ConsensusParams(); cp != nil && cp.Block != nil && cp.Block.MaxGasWanted > 0 {
 		appMetrics.blockGasWantedRatio.Record(ctx.Context(), float64(totalGasWanted)/float64(cp.Block.MaxGasWanted))
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -2787,6 +2787,10 @@ func (app *App) checkTotalBlockGas(ctx sdk.Context, typedTxs []sdk.Tx) (result b
 		}
 	}
 
+	appMetrics.blockGasWanted.Record(ctx.Context(), int64(totalGasWanted)) //nolint:gosec
+	if maxGasWanted := ctx.ConsensusParams().Block.MaxGasWanted; maxGasWanted > 0 {
+		appMetrics.blockGasWantedRatio.Record(ctx.Context(), float64(totalGasWanted)/float64(maxGasWanted)) //nolint:gosec
+	}
 	return true
 }
 

--- a/app/metrics.go
+++ b/app/metrics.go
@@ -65,7 +65,7 @@ var (
 		gigaFallback         metric.Int64Counter
 
 		// Per-block gas utilisation
-		blockGasWanted      metric.Float64Histogram
+		blockGasWanted      metric.Int64Histogram
 		blockGasWantedRatio metric.Float64Histogram
 
 		// Light invariance check
@@ -167,7 +167,7 @@ var (
 			metric.WithUnit("{count}"),
 		)),
 
-		blockGasWanted: must(meter.Float64Histogram(
+		blockGasWanted: must(meter.Int64Histogram(
 			"app_block_gas_wanted",
 			metric.WithDescription("Per-block total gas wanted across all transactions"),
 			metric.WithUnit("{gas}"),

--- a/app/metrics.go
+++ b/app/metrics.go
@@ -65,7 +65,7 @@ var (
 		gigaFallback         metric.Int64Counter
 
 		// Per-block gas utilisation
-		blockGasWanted      metric.Int64Histogram
+		blockGasWanted      metric.Float64Histogram
 		blockGasWantedRatio metric.Float64Histogram
 
 		// Light invariance check
@@ -167,7 +167,7 @@ var (
 			metric.WithUnit("{count}"),
 		)),
 
-		blockGasWanted: must(meter.Int64Histogram(
+		blockGasWanted: must(meter.Float64Histogram(
 			"app_block_gas_wanted",
 			metric.WithDescription("Per-block total gas wanted across all transactions"),
 			metric.WithUnit("{gas}"),

--- a/app/metrics.go
+++ b/app/metrics.go
@@ -25,6 +25,20 @@ var (
 		0.000025, 0.000050, 0.0001, 0.0005, 0.001, 0.0025, 0.005, 0.010, 0.020, 0.050, 0.075, 0.1, 0.25, 0.5, 1, 10,
 	)
 
+	// blockGasWantedBuckets covers the 0–50 M gas range (current MaxGasWanted cap) with
+	// 1 M steps up to 10 M and 5 M steps thereafter so both lightly- and heavily-loaded
+	// blocks get useful quantiles.
+	blockGasWantedBuckets = metric.WithExplicitBucketBoundaries(
+		1e6, 2e6, 3e6, 4e6, 5e6, 6e6, 7e6, 8e6, 9e6, 10e6,
+		15e6, 20e6, 25e6, 30e6, 35e6, 40e6, 45e6, 50e6,
+	)
+
+	// blockGasWantedRatioBuckets covers the 0.0–1.0 utilisation range so we can see
+	// how close blocks are to the MaxGasWanted cap.
+	blockGasWantedRatioBuckets = metric.WithExplicitBucketBoundaries(
+		0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 1.0,
+	)
+
 	appMetrics = struct {
 		// ABCI phase durations
 		beginBlockDuration     metric.Float64Histogram
@@ -49,6 +63,10 @@ var (
 		optimisticProcessing metric.Int64Counter
 		failedGasWantedCheck metric.Int64Counter
 		gigaFallback         metric.Int64Counter
+
+		// Per-block gas utilisation
+		blockGasWanted      metric.Int64Histogram
+		blockGasWantedRatio metric.Float64Histogram
 
 		// Light invariance check
 		invarianceDuration      metric.Float64Histogram
@@ -147,6 +165,20 @@ var (
 			"app_giga_fallback_to_v2",
 			metric.WithDescription("Times giga executor fell back to V2 processing"),
 			metric.WithUnit("{count}"),
+		)),
+
+		blockGasWanted: must(meter.Int64Histogram(
+			"app_block_gas_wanted",
+			metric.WithDescription("Per-block total gas wanted across all transactions"),
+			metric.WithUnit("{gas}"),
+			blockGasWantedBuckets,
+		)),
+
+		blockGasWantedRatio: must(meter.Float64Histogram(
+			"app_block_gas_wanted_ratio",
+			metric.WithDescription("Per-block ratio of total gas wanted to MaxGasWanted consensus parameter"),
+			metric.WithUnit("1"),
+			blockGasWantedRatioBuckets,
 		)),
 
 		invarianceDuration: must(meter.Float64Histogram(


### PR DESCRIPTION
## Summary

Adds two OTel histogram instruments to make per-block gas utilisation observable — answering "how close are blocks getting to the `MaxGasWanted` cap in practice" without offline block parsing.

- `app_block_gas_wanted` (`Int64Histogram`, unit `{gas}`) — absolute `totalGasWanted` summed across all transactions in an accepted proposal
- `app_block_gas_wanted_ratio` (`Float64Histogram`, unit `1`) — `totalGasWanted / MaxGasWanted`, stays meaningful if the cap is raised via governance

Both are emitted in `checkTotalBlockGas` (`app/app.go`) on the **success path only** — the function already short-circuits with `return false` when the sum exceeds the cap, so only complete, accepted totals are recorded. The existing `app_failed_total_gas_wanted_check` counter covers rejection events.

Bucket boundaries:
- Gas: 1 M–10 M in 1 M steps, then 5 M steps to 50 M (current cap)
- Ratio: 0.1 steps from 0.1 → 0.9, plus 0.95 and 1.0

Closes PLT-354.

## Test plan

- [x] Deploy to a test node and verify `app_block_gas_wanted_bucket` and `app_block_gas_wanted_ratio_bucket` appear in the Prometheus scrape. Can use this p50 query in Grafana by running 
`histogram_quantile(0.5, rate({__name__="sei-chain_app_block_gas_wanted_ratio_bucket"}[10m]))`
- [x] Confirm values are non-zero and ratio stays ≤ 1.0 under normal load