### PR TITLE
test(evm): retry signer.sendTransaction on incorrect-account-sequence (CON-256)

### DIFF
--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -828,9 +828,39 @@ async function deployEvmContract(name, args=[]) {
     return contract;
 }
 
+// Wrap a signer's sendTransaction with retry on "incorrect account
+// sequence". Under Autobahn the post-commit window in which
+// eth_getTransactionCount may briefly return a stale nonce is wider
+// than under CometBFT, so an ethers-managed send right after an
+// awaited prior tx can hit a one-off nonce mismatch even though the
+// chain has fully processed the previous tx. The retry refetches a
+// fresh nonce on the next attempt; the happy path is unaffected.
+function _wrapSignerWithNonceRetry(signer) {
+    if (signer.__nonceRetryWrapped) return signer
+    const TX_NONCE_RETRIES = 5
+    const TX_NONCE_RETRY_DELAY_MS = 500
+    const original = signer.sendTransaction.bind(signer)
+    signer.sendTransaction = async function(...args) {
+        let lastErr
+        for (let i = 0; i <= TX_NONCE_RETRIES; i++) {
+            try {
+                return await original(...args)
+            } catch (e) {
+                lastErr = e
+                if (!/incorrect account sequence/i.test(e?.message || '')) throw e
+                await new Promise(r => setTimeout(r, TX_NONCE_RETRY_DELAY_MS))
+            }
+        }
+        throw lastErr
+    }
+    signer.__nonceRetryWrapped = true
+    return signer
+}
+
 async function setupSigners(signers) {
     const result = []
     for(let signer of signers) {
+        _wrapSignerWithNonceRetry(signer)
         const evmAddress = await signer.getAddress();
         await fundAddress(evmAddress);
         const resp = await signer.sendTransaction({


### PR DESCRIPTION
## Summary

Fixes the Autobahn EVM Interoperability / GIGA / Module CI flake hit on PR #3480 ([example run](https://github.com/sei-protocol/sei-chain/actions/runs/26209300235/job/77116161153)):

```
ProviderError: eth_sendRawTransaction(...): : incorrect account sequence
  at ContractFactory.deploy (...)
  at Context.<anonymous> (contracts/test/TransientStorageTest.js)
```

The race: under Autobahn's async execution, after a tx commits at consensus, there's a window during which the chain's account sequence has advanced (commit-level) but the mempool's CheckTx view of state hasn't caught up. A follow-up ethers send during that window can read a stale nonce from `eth_getTransactionCount`, submit with that value, and get rejected with "incorrect account sequence."

## Fix

`setupSigners` (in `contracts/test/lib.js`) wraps each hardhat-default signer's `sendTransaction` with up to 5 retries × 500ms delay (~2.5s total budget) on the specific `incorrect account sequence` error. Each retry waits for execution-state to catch up to consensus-state, then ethers re-reads a fresh nonce on the next attempt — eventually the mempool's view matches and the submit succeeds. Happy path is unaffected (first-call success returns immediately).

## Why not local nonce tracking

Tried bypassing the RPC read entirely by tracking nonce locally in the wrap (`__localNonceWrapped`). That was *strictly worse* because of a two-sided race:

- **My cached value** advances to N+1 as soon as the previous `sendTransaction` returns CheckTx-accepted
- **Mempool's view** stays at N until execution catches up (the same lag this PR works around)
- Local tracking submits N+1 → mempool says "expected N, got N+1" → reject
- Reset-on-error refetches: mempool returns stale N → local cache is N → submit N → consensus already advanced past N → reject
- Both directions fail; retry doesn't help because the local cache and the mempool view never reconcile in the same direction

Retry naturally tolerates this because it doesn't pre-commit to a nonce — each retry refetches whatever the mempool currently thinks, and the mempool eventually catches up.

## Test plan

- [x] CI: `Autobahn EVM Interoperability` / `Autobahn EVM GIGA Module` / `Autobahn EVM Module` green across multiple runs
- [x] No regression on CometBFT EVM jobs — wrap is a no-op on the happy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)