### PR TITLE
autobahn: feed persistent_state_dir into data WAL (CON-256)

### DIFF
--- a/sei-tendermint/cmd/tendermint/commands/gen_autobahn_config.go
+++ b/sei-tendermint/cmd/tendermint/commands/gen_autobahn_config.go
@@ -33,6 +33,7 @@ Output is written to the file specified by --output.`,
 			if output == "" {
 				return fmt.Errorf("--output flag is required")
 			}
+			persistentStateDir, _ := cmd.Flags().GetString("persistent-state-dir")
 
 			var validators []config.AutobahnValidator
 			for _, dir := range args {
@@ -89,6 +90,14 @@ Output is written to the file specified by --output.`,
 				ViewTimeout:      utils.Duration(1500 * time.Millisecond),
 				DialInterval:     utils.Duration(10 * time.Second),
 			}
+			// The flag defaults to "data/autobahn" so persistence is on without
+			// operator action. node/setup.go rootifies the relative path against
+			// cfg.RootDir at load time. Passing --persistent-state-dir= (empty)
+			// disables persistence and runs both consensus and data layers
+			// in-memory only.
+			if persistentStateDir != "" {
+				cfg.PersistentStateDir = utils.Some(persistentStateDir)
+			}
 
 			data, err := json.MarshalIndent(cfg, "", "  ")
 			if err != nil {
@@ -102,5 +111,6 @@ Output is written to the file specified by --output.`,
 		},
 	}
 	cmd.Flags().StringP("output", "o", "", "output file path for the autobahn config")
+	cmd.Flags().String("persistent-state-dir", "data/autobahn", "directory to persist autobahn consensus and data WALs across restarts; relative paths are resolved against the node's --home dir; pass --persistent-state-dir= (empty) to disable persistence and run in-memory only")
 	return cmd
 }

--- a/sei-tendermint/internal/p2p/giga_router.go
+++ b/sei-tendermint/internal/p2p/giga_router.go
@@ -83,7 +83,17 @@ func NewGigaRouter(cfg *GigaRouterConfig, key NodeSecretKey) (*GigaRouter, error
 		return nil, fmt.Errorf("atypes.NewRoundRobinElection(): %w", err)
 	}
 	// Automated pruning is disabled, because it is controlled by the application.
-	dataWAL, err := data.NewDataWAL(utils.None[string](), committee)
+	// The data WAL piggybacks on Consensus.PersistentStateDir: the two layers
+	// share the same on-disk root and write to distinct subdirectories under
+	// it (inner / blocks / commitqcs for consensus, globalblocks /
+	// fullcommitqcs for data).
+	//
+	// TODO(autobahn): once sei-db/ledger_db/block.BlockDB has a writer wired
+	// (see BlockByNumber's TODO), the data layer's WAL is redundant —
+	// BlockDB is the long-term home for the block read path and survives
+	// process restarts on its own. At that point this NewDataWAL call can
+	// drop the directory and become a no-op.
+	dataWAL, err := data.NewDataWAL(cfg.Consensus.PersistentStateDir, committee)
 	if err != nil {
 		return nil, fmt.Errorf("data.NewDataWAL(): %w", err)
 	}

--- a/sei-tendermint/node/setup.go
+++ b/sei-tendermint/node/setup.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	_ "net/http/pprof" // nolint: gosec // securely exposed on separate, optional port
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -369,6 +370,13 @@ func createRouter(
 		gigaCfg, err := buildGigaConfig(cfg.AutobahnConfigFile, nodeKey, valKey, mp, genDoc)
 		if err != nil {
 			return nil, closer, fmt.Errorf("buildGigaConfig: %w", err)
+		}
+		// Resolve a relative persistent_state_dir against the node's --home dir,
+		// matching how other paths in the tendermint config are handled
+		// (config.go's rootify). Absolute paths pass through unchanged. None
+		// means the operator opted into in-memory-only mode and stays None.
+		if dir, ok := gigaCfg.Consensus.PersistentStateDir.Get(); ok && !filepath.IsAbs(dir) {
+			gigaCfg.Consensus.PersistentStateDir = utils.Some(filepath.Join(cfg.RootDir, dir))
 		}
 		logger.Info("Autobahn config loaded", "validators", len(gigaCfg.ValidatorAddrs))
 		options.Giga = utils.Some(gigaCfg)


### PR DESCRIPTION
## Summary

The data layer's block and commitqc WALs were constructed with `utils.None[string]()`, making them no-ops: writes returned success but nothing landed on disk, and `NewState` loaded an empty WAL on every restart.

The autobahn config file already has `persistent_state_dir` and it was already wired into the consensus layer. Reuse the same value for the data layer's WAL (via `cfg.Consensus.PersistentStateDir`) — the two layers write to distinct subdirs under the same root. No new struct field; once BlockDB has a writer the data WAL will go away entirely (TODO in code).

This will enable Upgrade (Major) test for Autobahn. Right now it's stuck because the previous states are lost upon restart.

## Visible changes

- `gen-autobahn-config` `--persistent-state-dir` flag now defaults to `data/autobahn` (was: field absent, persistence off). Pass `--persistent-state-dir=` to disable.
- A relative `persistent_state_dir` in `autobahn.json` is now rootified against `--home` at load time, matching other tendermint config paths.

## Test plan

- [x] Autobahn Upgrade Module (Major) passes (was deadlocking before)
- [x] Autobahn Upgrade Module (Minor) passes
- [x] CometBFT Upgrade Module Major/Minor still pass