### PR TITLE
Deflake sequential proxy swap GIGA test

### DIFF
--- a/contracts/test/EVMGigaTest.js
+++ b/contracts/test/EVMGigaTest.js
@@ -802,10 +802,10 @@ describe("GIGA EVM Tests", function () {
 
     it("should execute multiple proxy token swaps in sequence", async function () {
       const smallAmount = ethers.parseUnits("100", 18);
+      const totalApproval = smallAmount * 2n;
+      await (await tokenA.approve(await router.getAddress(), totalApproval, { gasPrice: ethers.parseUnits('100', 'gwei') })).wait();
 
       for (let i = 0; i < 2; i++) {
-        await (await tokenA.approve(await router.getAddress(), smallAmount, { gasPrice: ethers.parseUnits('100', 'gwei') })).wait();
-
         const tx = await router.executeMultiHopSwap(
           smallAmount,
           await tokenA.getAddress(),
@@ -915,6 +915,9 @@ describe("GIGA EVM Tests", function () {
         );
         const receipt = await tx.wait();
         expect(receipt.status).to.equal(1);
+        if (i < 1) {
+          await delay();
+        }
       }
     });
   });

--- a/contracts/test/EVMGigaTest.js
+++ b/contracts/test/EVMGigaTest.js
@@ -802,10 +802,10 @@ describe("GIGA EVM Tests", function () {
 
     it("should execute multiple proxy token swaps in sequence", async function () {
       const smallAmount = ethers.parseUnits("100", 18);
+      const totalApproval = smallAmount * 2n;
+      await (await tokenA.approve(await router.getAddress(), totalApproval, { gasPrice: ethers.parseUnits('100', 'gwei') })).wait();
 
       for (let i = 0; i < 2; i++) {
-        await (await tokenA.approve(await router.getAddress(), smallAmount, { gasPrice: ethers.parseUnits('100', 'gwei') })).wait();
-
         const tx = await router.executeMultiHopSwap(
           smallAmount,
           await tokenA.getAddress(),
@@ -819,6 +819,9 @@ describe("GIGA EVM Tests", function () {
         );
         const receipt = await tx.wait();
         expect(receipt.status).to.equal(1);
+        if (i < 1) {
+          await delay();
+        }
       }
     });
 
@@ -915,6 +918,9 @@ describe("GIGA EVM Tests", function () {
         );
         const receipt = await tx.wait();
         expect(receipt.status).to.equal(1);
+        if (i < 1) {
+          await delay();
+        }
       }
     });
   });


### PR DESCRIPTION
The Autobahn EVM GIGA integration job intermittently failed with "incorrect account sequence" on tokenA.approve inside a loop that issued approve+swap pairs back-to-back on the shared owner signer.

Approve once up front (matching the other multi-swap test in this file) and wait between swaps so the live docker cluster's account sequence stays aligned with ethers' nonce tracking. This removes the extra per-iteration approve that widened the CheckTx race window without changing what the test exercises (two sequential multi-hop
proxy swaps).

[Flaked in unrelated changes](https://github.com/sei-protocol/sei-chain/actions/runs/26224027961/job/77166184155?pr=3484).
