### PR TITLE
test(evm): migrate evm_rpc_tests.sh off -b block (CON-256)

### DIFF
--- a/integration_test/evm_module/scripts/evm_rpc_tests.sh
+++ b/integration_test/evm_module/scripts/evm_rpc_tests.sh
@@ -25,9 +25,14 @@ run() {
 # Seed chain with block/tx/contract; export SEI_EVM_IO_SEED_BLOCK so .iox __SEED__ tag resolves to deploy block.
 # CLI deploy expects hex file with no whitespace; write trimmed hex to a temp path in the container.
 docker exec "$CONTAINER" /bin/bash -c "tr -d '[:space:]' < \"$CONTRACT_HEX\" > /tmp/minimal_contract.hex"
-run seid tx evm associate-address --from "$FROM" "${KEYRING_ARGS[@]}" --chain-id sei -b block -y 2>/dev/null || true
+# Use -b sync (not -b block): under Autobahn the cosmos KV indexer that
+# -b block polls isn't populated, so -b block hangs to its 60s timeout
+# per call. The deploy's tx hash is in the -b sync JSON response, and
+# downstream eth_getTransactionReceipt polling handles inclusion
+# confirmation independently.
+run seid tx evm associate-address --from "$FROM" "${KEYRING_ARGS[@]}" --chain-id sei -b sync -y 2>/dev/null || true
 run seid tx evm send "$RECIPIENT" 1 --from "$FROM" "${KEYRING_ARGS[@]}" --chain-id sei --evm-rpc "$EVM_RPC_URL" -b sync -y
-DEPLOY_OUT=$(run seid tx evm deploy /tmp/minimal_contract.hex --from "$FROM" "${KEYRING_ARGS[@]}" --chain-id sei --evm-rpc "$EVM_RPC_URL" -b block -y 2>&1) || true
+DEPLOY_OUT=$(run seid tx evm deploy /tmp/minimal_contract.hex --from "$FROM" "${KEYRING_ARGS[@]}" --chain-id sei --evm-rpc "$EVM_RPC_URL" -b sync -y 2>&1) || true
 DEPLOY_TX=$(echo "$DEPLOY_OUT" | grep -oE '0x[a-fA-F0-9]{64}' | head -1)
 if [[ -n "$DEPLOY_TX" ]]; then
   sleep 2
@@ -45,7 +50,7 @@ fi
 
 # Deploy reverter contract (reverts with Error("user error")); export SEI_EVM_IO_REVERTER_ADDRESS for .iox __REVERTER__ tag.
 docker exec "$CONTAINER" /bin/bash -c "tr -d '[:space:]' < \"$REVERTER_HEX\" > /tmp/reverter_contract.hex"
-REVERTER_OUT=$(run seid tx evm deploy /tmp/reverter_contract.hex --from "$FROM" "${KEYRING_ARGS[@]}" --chain-id sei --evm-rpc "$EVM_RPC_URL" -b block -y 2>&1) || true
+REVERTER_OUT=$(run seid tx evm deploy /tmp/reverter_contract.hex --from "$FROM" "${KEYRING_ARGS[@]}" --chain-id sei --evm-rpc "$EVM_RPC_URL" -b sync -y 2>&1) || true
 REVERTER_TX=$(echo "$REVERTER_OUT" | grep -oE '0x[a-fA-F0-9]{64}' | head -1)
 if [[ -n "$REVERTER_TX" ]]; then
   sleep 2

--- a/integration_test/evm_module/scripts/evm_rpc_tests.sh
+++ b/integration_test/evm_module/scripts/evm_rpc_tests.sh
@@ -22,6 +22,41 @@ run() {
     'export PATH=$PATH:/root/go/bin && printf "%s\n" "$SEI_EVM_IO_PASSWORD" | "$@"' bash "$@"
 }
 
+# Resolve sender's cosmos address once. On any failure (transient
+# docker hiccup, container start race, missing key) FROM_ADDR stays
+# empty and the wait helper below becomes a no-op — the script falls
+# back to the original unprotected behavior rather than crashing
+# under set -e.
+FROM_ADDR=$(run seid keys show "$FROM" "${KEYRING_ARGS[@]}" -a 2>/dev/null) || FROM_ADDR=
+
+# Cosmos account sequence for $FROM_ADDR (or empty on any error).
+# Always exits 0 so the calling `local cur=$(get_from_seq)` doesn't
+# trip set -e in command substitution.
+get_from_seq() {
+  if [ -z "$FROM_ADDR" ]; then echo; return 0; fi
+  local s
+  s=$(run seid q account "$FROM_ADDR" -o json 2>/dev/null | jq -r '.sequence // ""' 2>/dev/null) || true
+  echo "$s"
+}
+
+# Wait until $FROM_ADDR's sequence advances past $1, with a 5s timeout.
+# Direct causal "previous tx committed" signal: the sender's sequence
+# advances atomically when its tx is included in a block, so by the
+# time this returns the next CLI's pre-flight `q account` will read
+# the post-tx sequence. No-op if FROM_ADDR resolution failed.
+wait_from_seq_advance() {
+  local prev="$1"
+  if [ -z "$FROM_ADDR" ] || [ -z "$prev" ]; then return 0; fi
+  local deadline=$(($(date +%s) + 5))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    local cur; cur=$(get_from_seq)
+    if [[ "$cur" =~ ^[0-9]+$ ]] && [ "$cur" -gt "$prev" ]; then
+      return 0
+    fi
+    sleep 0.5
+  done
+}
+
 # Seed chain with block/tx/contract; export SEI_EVM_IO_SEED_BLOCK so .iox __SEED__ tag resolves to deploy block.
 # CLI deploy expects hex file with no whitespace; write trimmed hex to a temp path in the container.
 docker exec "$CONTAINER" /bin/bash -c "tr -d '[:space:]' < \"$CONTRACT_HEX\" > /tmp/minimal_contract.hex"
@@ -30,8 +65,26 @@ docker exec "$CONTAINER" /bin/bash -c "tr -d '[:space:]' < \"$CONTRACT_HEX\" > /
 # per call. The deploy's tx hash is in the -b sync JSON response, and
 # downstream eth_getTransactionReceipt polling handles inclusion
 # confirmation independently.
+#
+# Poll the sender's sequence between each pair of consecutive -b sync
+# submissions so the next CLI's pre-flight `q account` doesn't race
+# the mempool's still-pending prior tx (otherwise both sign with the
+# same sequence and the second's CheckTx rejects with "incorrect
+# account sequence"). For the send line that's required because it
+# has no `|| true` and a rejection would crash the script under set -e;
+# for the deploy line it's required because a silent CheckTx rejection
+# leaves SEI_EVM_IO_SEED_BLOCK unset and skips the __SEED__ fixtures.
+# The reverter deploy further down only needs protection if the
+# minimal deploy's receipt-poll loop didn't already wait (which it
+# only skips when DEPLOY_TX is empty — i.e. minimal already failed,
+# in which case reverter racing is no worse).
+SEQ_BEFORE_ASSOC=$(get_from_seq)
 run seid tx evm associate-address --from "$FROM" "${KEYRING_ARGS[@]}" --chain-id sei -b sync -y 2>/dev/null || true
+wait_from_seq_advance "$SEQ_BEFORE_ASSOC"
+SEQ_BEFORE_SEND=$(get_from_seq)
 run seid tx evm send "$RECIPIENT" 1 --from "$FROM" "${KEYRING_ARGS[@]}" --chain-id sei --evm-rpc "$EVM_RPC_URL" -b sync -y
+wait_from_seq_advance "$SEQ_BEFORE_SEND"
+SEQ_BEFORE_MINIMAL=$(get_from_seq)
 DEPLOY_OUT=$(run seid tx evm deploy /tmp/minimal_contract.hex --from "$FROM" "${KEYRING_ARGS[@]}" --chain-id sei --evm-rpc "$EVM_RPC_URL" -b sync -y 2>&1) || true
 DEPLOY_TX=$(echo "$DEPLOY_OUT" | grep -oE '0x[a-fA-F0-9]{64}' | head -1)
 if [[ -n "$DEPLOY_TX" ]]; then
@@ -49,7 +102,13 @@ if [[ -n "$DEPLOY_TX" ]]; then
 fi
 
 # Deploy reverter contract (reverts with Error("user error")); export SEI_EVM_IO_REVERTER_ADDRESS for .iox __REVERTER__ tag.
+# wait_from_seq_advance even though minimal's receipt-poll loop above
+# usually does the same job — when the grep fails to extract DEPLOY_TX
+# from a successful CheckTx response (CLI format quirk, partial output),
+# the receipt poll is skipped entirely and reverter would otherwise
+# fire with a stale sequence.
 docker exec "$CONTAINER" /bin/bash -c "tr -d '[:space:]' < \"$REVERTER_HEX\" > /tmp/reverter_contract.hex"
+wait_from_seq_advance "$SEQ_BEFORE_MINIMAL"
 REVERTER_OUT=$(run seid tx evm deploy /tmp/reverter_contract.hex --from "$FROM" "${KEYRING_ARGS[@]}" --chain-id sei --evm-rpc "$EVM_RPC_URL" -b sync -y 2>&1) || true
 REVERTER_TX=$(echo "$REVERTER_OUT" | grep -oE '0x[a-fA-F0-9]{64}' | head -1)
 if [[ -n "$REVERTER_TX" ]]; then


### PR DESCRIPTION
## Summary

\`evm_rpc_tests.sh\` (run by the \`Autobahn RPC .io/.iox (spec fixtures)\` CI job) seeded the chain with three cosmos txs via \`-b block\`: an \`associate-address\`, a minimal-contract deploy, and a reverter-contract deploy. Each output a tx hash and contract address used by downstream \`.io\`/\`.iox\` spec fixtures.

Under Autobahn the KV indexer that \`-b block\` polls isn't populated, so each of these three calls hung up to its 60s timeout before the trailing \`|| true\` swallowed the failure. The job didn't error out — but the env vars (\`SEI_EVM_IO_SEED_BLOCK\`, \`SEI_EVM_IO_DEPLOY_TX_HASH\`, \`SEI_EVM_IO_REVERTER_ADDRESS\`) were never set, so any spec fixture that referenced the deployed contracts was silently skipped.

## Fix

1. Switch the three submissions to \`-b sync\`. The CLI returns the tx response JSON (including txhash) immediately; the existing downstream \`eth_getTransactionReceipt\` polling loop already handles inclusion confirmation, so no other changes are needed.

2. Poll the sender's cosmos account sequence between consecutive \`-b sync\` submissions (\`wait_from_seq_advance\`, 5s timeout). Required because the next CLI's pre-flight \`q account\` reads from app state (committed view) — if the previous tx hasn't committed yet, the next sign reuses the same sequence and CheckTx rejects with "incorrect account sequence", fatal under \`set -e\` on the \`send\` line which has no \`|| true\`. cursor-bugbot flagged this race; the polling closes it.

## Timing

| | \`Autobahn RPC .io/.iox\` |
|---|---|
| Main (with \`-b block\` hangs) | ~363s avg |
| This PR | ~308s (commit 1, no polling) — polling adds ~1–3s on the happy path |

Net: ~50s faster per Autobahn RPC run **and** the previously-skipped \`__SEED__\` / \`__REVERTER__\` spec fixtures now actually execute.

## Test plan

- [x] CI: \`Autobahn RPC .io/.iox (spec fixtures)\` finishes ~55s faster than main
- [x] CI: \`EVM RPC .io/.iox (spec fixtures)\` (CometBFT) stays green
- [x] All other Autobahn / CometBFT EVM jobs unaffected