### PR TITLE
test(evm): retry transient query failures in findProposalByTitle (CON-256)

### DIFF
--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -636,15 +636,32 @@ async function findProposalByTitle(title, maxIdBefore, txHashForError) {
     const deadline = Date.now() + 30000;
     while (Date.now() < deadline) {
         const cur = await maxProposalId();
+        let queryFailed = false;
         for (let id = maxIdBefore + 1; id <= cur; id++) {
-            const detail = JSON.parse(await execute(`seid q gov proposal ${id} -o json`));
+            let detail;
+            try {
+                detail = JSON.parse(await execute(`seid q gov proposal ${id} -o json`));
+            } catch (e) {
+                // Transient query failure (RPC blip, indexer lag, parse
+                // error mid-flight). Leave this id for re-scan next
+                // iteration rather than aborting the whole helper on a
+                // single bad read.
+                queryFailed = true;
+                continue;
+            }
             const observedTitle = detail.content?.title ?? detail.title;
             if (observedTitle === title) return String(id);
         }
-        // Use max so a transient maxProposalId() failure (returns 0) can't
-        // shrink the window and let a prior-run proposal with the same title
-        // re-match on the next iteration.
-        maxIdBefore = Math.max(maxIdBefore, cur);
+        // Only advance the window if every id in the range was
+        // successfully scanned. A transient miss leaves maxIdBefore
+        // unchanged so the failed id is re-checked next iteration —
+        // without this guard, the proposal we just submitted could be
+        // permanently skipped by a single failed query, or (in the
+        // original code) any transient failure threw out of the whole
+        // helper.
+        if (!queryFailed) {
+            maxIdBefore = Math.max(maxIdBefore, cur);
+        }
         await sleep(250);
     }
     throw new Error(`proposal submitted (tx ${txHashForError}) but did not appear in gov state within 30s`);


### PR DESCRIPTION
## Summary

`findProposalByTitle` in `contracts/test/lib.js` aborts the whole helper on any single transient query failure inside its scan loop. A single RPC blip during the scan surfaces as "proposal submitted (tx ...) but did not appear in gov state within 30s" even though it would have appeared on the next iteration.

Symmetric to the bash-side fix amir-deris caught alongside #3469 for `integration_test/utils/_tx_helpers.sh`'s `find_proposal_by_title`.

## Fix

Wrap the inner `seid q gov proposal <id>` query in try/catch; on any error mark `queryFailed` and `continue` to the next id. Only advance `maxIdBefore` to `cur` if every id in the range was scanned successfully, so a failed id is re-checked on the next outer iteration rather than being either permanently skipped (bash bug) or fatally thrown (JS bug).

Preserves the "don't shrink the window" property the original code guarded against (we still never go backwards on success), while closing the abort-on-transient-failure hole.

## Test plan

- [x] CI: existing `EVM Module` / `Autobahn EVM Module` / `EVM Interoperability` / `Autobahn EVM Interoperability` jobs (which exercise this helper via `proposeParamChange` etc.) stay green
- [x] No behavior change on the happy path (clean scan → same result as before)