### PR TITLE
test: migrate Gov & Oracle & Authz yamls off -b block, enable on Autobahn (CON-256)

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -76,6 +76,19 @@ jobs:
             ]
           },
           {
+            name: "Autobahn Gov & Oracle & Authz Module",
+            env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
+            scripts: [
+              "python3 integration_test/scripts/runner.py integration_test/gov_module/gov_proposal_test.yaml",
+              "python3 integration_test/scripts/runner.py integration_test/gov_module/staking_proposal_test.yaml",
+              "python3 integration_test/scripts/runner.py integration_test/oracle_module/verify_penalty_counts.yaml",
+              "python3 integration_test/scripts/runner.py integration_test/oracle_module/set_feeder_test.yaml",
+              "python3 integration_test/scripts/runner.py integration_test/authz_module/send_authorization_test.yaml",
+              "python3 integration_test/scripts/runner.py integration_test/authz_module/staking_authorization_test.yaml",
+              "python3 integration_test/scripts/runner.py integration_test/authz_module/generic_authorization_test.yaml"
+            ]
+          },
+          {
             name: "Chain Operation Test",
             env: "GIGA_STORAGE=true",
             scripts: [

--- a/integration_test/authz_module/generic_authorization_test.yaml
+++ b/integration_test/authz_module/generic_authorization_test.yaml
@@ -8,15 +8,15 @@
     - cmd: printf "12345678\ny\n" | seid keys add grantee --output json | jq -r ".address"
       env: GRANTEE_ADDR
     # send some funds to grantee for gas
-    - cmd: printf "12345678\n" | seid tx bank send admin $GRANTEE_ADDR 1sei --fees 2000usei -b block -y
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait admin bank send admin $GRANTEE_ADDR 1sei --fees 2000usei
     # create an authz grant for tokenfactory create denom
-    - cmd: printf "12345678\n" | seid tx authz grant $GRANTEE_ADDR generic --msg-type "/seiprotocol.seichain.tokenfactory.MsgCreateDenom" --from admin --fees 2000usei -b block -y
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait admin authz grant $GRANTEE_ADDR generic --msg-type "/seiprotocol.seichain.tokenfactory.MsgCreateDenom" --fees 2000usei
     - cmd: uuidgen
       env: TF_UUID
     # create TF create-denom tx and write to json
     - cmd: printf "12345678\n" | seid tx tokenfactory create-denom $TF_UUID --from $ADMIN_ADDR --generate-only > create_denom_tx.json
     # execute the authz tx - we want to validate that this succeeds with code 0
-    - cmd: printf "12345678\n" | seid tx authz exec create_denom_tx.json --from $GRANTEE_ADDR -b block -y --fees 2000usei --output json  | jq -r ".code"
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait $GRANTEE_ADDR authz exec create_denom_tx.json --fees 2000usei
       env: AUTHZ_1_ERROR_CODE
     # verify that the denom exists
     - cmd: seid q tokenfactory denom-authority-metadata factory/$ADMIN_ADDR/$TF_UUID --output json | jq -r ".authority_metadata.admin"

--- a/integration_test/authz_module/send_authorization_test.yaml
+++ b/integration_test/authz_module/send_authorization_test.yaml
@@ -10,17 +10,18 @@
     - cmd: printf "12345678\ny\n" | seid keys add other-acc --output json | jq -r ".address"
       env: OTHER_ACC_ADDR
     # send some funds to grantee for gas
-    - cmd: printf "12345678\n" | seid tx bank send admin $GRANTEE_ADDR 1sei --fees 2000usei -b block -y
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait admin bank send admin $GRANTEE_ADDR 1sei --fees 2000usei
     # create an authz grant
-    - cmd: printf "12345678\n" | seid tx authz grant $GRANTEE_ADDR send --from admin --spend-limit 10sei --fees 2000usei -b block -y
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait admin authz grant $GRANTEE_ADDR send --spend-limit 10sei --fees 2000usei
     # create generate send tx and write to json
     - cmd: printf "12345678\n" | seid tx bank send $ADMIN_ADDR $OTHER_ACC_ADDR 6sei --generate-only > send_tx.json
     # execute the authz tx - we want to validate that this succeeds with code 0
-    - cmd: printf "12345678\n" | seid tx authz exec send_tx.json --from $GRANTEE_ADDR -b block -y --fees 2000usei --output json  | jq -r ".code"
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait $GRANTEE_ADDR authz exec send_tx.json --fees 2000usei
       env: AUTHZ_1_ERROR_CODE
-    # execute the authz tx again - this time we want it to fail because send authorization is insufficient
-    - cmd: printf "12345678\n" | seid tx authz exec send_tx.json --from $GRANTEE_ADDR -b block -y --fees 2000usei --output json  | jq -r ".code"
-      env: AUTHZ_2_ERROR_CODE
+    # second exec is rejected at DeliverTx: 4sei left after first 6sei
+    # send is below the 6sei this attempt requests. OTHER_ACC_BALANCE
+    # below verifies the rejection.
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait $GRANTEE_ADDR authz exec send_tx.json --fees 2000usei
     # query bank balances for the other addr to validate the amount the account has
     - cmd: seid q bank balances $OTHER_ACC_ADDR --denom usei --output json | jq -r ".amount"
       env: OTHER_ACC_BALANCE
@@ -28,9 +29,6 @@
     # verify that error code == 0 for first authz exec
     - type: eval
       expr: AUTHZ_1_ERROR_CODE == 0
-    # verify that error code == 5 for second authz exec (insufficient spend balance)
-    - type: eval
-      expr: AUTHZ_2_ERROR_CODE == 5
-    # verify that other acc balance is 6 sei
+    # verify that other acc balance is 6 sei (second exec rejected at DeliverTx)
     - type: eval
       expr: OTHER_ACC_BALANCE == 6000000

--- a/integration_test/authz_module/staking_authorization_test.yaml
+++ b/integration_test/authz_module/staking_authorization_test.yaml
@@ -13,37 +13,43 @@
     - cmd: printf "12345678\ny\n" | seid keys add grantee --output json | jq -r ".address"
       env: GRANTEE_ADDR
     # send some funds to grantee for gas
-    - cmd: printf "12345678\n" | seid tx bank send admin $GRANTEE_ADDR 1sei --fees 2000usei -b block -y
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait admin bank send admin $GRANTEE_ADDR 1sei --fees 2000usei
     # create an authz grant for delegating
-    - cmd: printf "12345678\n" | seid tx authz grant $GRANTEE_ADDR delegate --allowed-validators "$NODE_ADMIN_VAL_ADDR" --from admin --fees 2000usei -b block -y
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait admin authz grant $GRANTEE_ADDR delegate --allowed-validators "$NODE_ADMIN_VAL_ADDR" --fees 2000usei
     # create delegate tx and write to json
     - cmd: printf "12345678\n" | seid tx staking delegate $NODE_ADMIN_VAL_ADDR 1sei --from $ADMIN_ADDR --generate-only > delegate_tx.json
     # execute the authz tx - we want to validate that this succeeds with code 0
-    - cmd: printf "12345678\n" | seid tx authz exec delegate_tx.json --from $GRANTEE_ADDR -b block -y --fees 2000usei --output json  | jq -r ".code"
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait $GRANTEE_ADDR authz exec delegate_tx.json --fees 2000usei
       env: AUTHZ_1_ERROR_CODE
-    # query staking balance w validator to verify its created properly
-    - cmd: seid q staking delegation $ADMIN_ADDR $NODE_ADMIN_VAL_ADDR --output json | jq -r ".balance.amount"
-      env: STAKING_AMOUNT
     # create unbond tx and write to json
     - cmd: printf "12345678\n" | seid tx staking unbond $NODE_ADMIN_VAL_ADDR 1sei --from $ADMIN_ADDR --generate-only > unbond_tx.json
-    # try unbond - should fail because we havent yet granted authz for it
-    - cmd: printf "12345678\n" | seid tx authz exec unbond_tx.json --from $GRANTEE_ADDR -b block -y --fees 2000usei --output json  | jq -r ".code"
-      env: AUTHZ_2_ERROR_CODE
+    # try unbond without authz grant - rejected at DeliverTx. STAKING_AMOUNT
+    # below (queried after) verifies the delegation is unchanged.
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait $GRANTEE_ADDR authz exec unbond_tx.json --fees 2000usei
+    # query delegation amount - proves the delegate succeeded (1000000) and
+    # the unbond above was rejected (would otherwise be 0).
+    - cmd: seid q staking delegation $ADMIN_ADDR $NODE_ADMIN_VAL_ADDR --output json | jq -r ".balance.amount"
+      env: STAKING_AMOUNT
     # grant the authorization for unbond
-    - cmd: printf "12345678\n" | seid tx authz grant $GRANTEE_ADDR unbond --allowed-validators "$NODE_ADMIN_VAL_ADDR" --from admin --fees 2000usei -b block -y
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait admin authz grant $GRANTEE_ADDR unbond --allowed-validators "$NODE_ADMIN_VAL_ADDR" --fees 2000usei
     # unbond should succeed this time
-    - cmd: printf "12345678\n" | seid tx authz exec unbond_tx.json --from $GRANTEE_ADDR -b block -y --fees 2000usei --output json  | jq -r ".code"
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait $GRANTEE_ADDR authz exec unbond_tx.json --fees 2000usei
       env: AUTHZ_3_ERROR_CODE
+    # query delegation amount after unbond. With the full 1sei unbonded the
+    # delegation record itself is removed and `q staking delegation` exits
+    # non-zero with empty stdout — default to 0 in that case.
+    - cmd: 'out=$(seid q staking delegation $ADMIN_ADDR $NODE_ADMIN_VAL_ADDR --output json 2>/dev/null | jq -r ".balance.amount // 0"); echo ${out:-0}'
+      env: STAKING_AMOUNT_AFTER_UNBOND
   verifiers:
     # verify that error code == 0 for first authz exec
     - type: eval
       expr: AUTHZ_1_ERROR_CODE == 0
-    # verify that the staking amount is correct
+    # delegate succeeded and the unauthorized unbond was rejected
     - type: eval
       expr: STAKING_AMOUNT == 1000000
-    # verify that error code != 0 because unbond hasnt been granted yet
-    - type: eval
-      expr: AUTHZ_2_ERROR_CODE == 4
     # verify that error code == 0 for unbond after granted authorization
     - type: eval
       expr: AUTHZ_3_ERROR_CODE == 0
+    # full delegation was unbonded
+    - type: eval
+      expr: STAKING_AMOUNT_AFTER_UNBOND == 0

--- a/integration_test/gov_module/gov_proposal_test.yaml
+++ b/integration_test/gov_module/gov_proposal_test.yaml
@@ -4,20 +4,19 @@
     - cmd: seid q gov params --output json | jq -r .tally_params.quorum
       env: OLD_PARAM
     # Make a new proposal
-    - cmd: printf "12345678\n" | seid tx gov submit-proposal param-change ./integration_test/gov_module/proposal/param_change_proposal.json
-           --from admin --chain-id sei --fees 2000usei -b block -y --output json | jq -M -r ".logs[].events[].attributes[0] | select(.key == \"proposal_id\").value"
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_gov_proposal admin "Gov Param Change" gov submit-proposal param-change ./integration_test/gov_module/proposal/param_change_proposal.json --fees 2000usei
       env: PROPOSAL_ID
     # Get proposal status
     - cmd: seid q gov proposal $PROPOSAL_ID --output json | jq -r .status
       env: PROPOSAL_STATUS
     # Make a deposit
-    - cmd: printf "12345678\n" | seid tx gov deposit $PROPOSAL_ID 10000000usei --from admin --chain-id sei --fees 2000usei -b block -y --output json | jq -r .code
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait admin gov deposit $PROPOSAL_ID 10000000usei --fees 2000usei
     # sei-node-0 vote yes
-    - cmd: printf "12345678\n" | seid tx gov vote $PROPOSAL_ID yes --from node_admin --chain-id sei --fees 2000usei -b block -y --output json | jq -r .code
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait node_admin gov vote $PROPOSAL_ID yes --fees 2000usei
       node: sei-node-0
     # sei-node-1 vote yes
     - cmd: seid q gov proposal $PROPOSAL_ID --output json | jq -r .status
-    - cmd: printf "12345678\n" | seid tx gov vote $PROPOSAL_ID yes --from node_admin --chain-id sei --fees 2000usei -b block -y --output json | jq -r .code
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait node_admin gov vote $PROPOSAL_ID yes --fees 2000usei
       node: sei-node-1
     # since quorum is 0.5, we only need 2/4 votes and expect proposal to pass after 35 seconds
     - cmd: sleep 35
@@ -41,28 +40,27 @@
     - cmd: seid q gov params --output json | jq -r .tally_params.expedited_quorum
       env: OLD_PARAM
     # Make a new expedited proposal
-    - cmd: printf "12345678\n" | seid tx gov submit-proposal param-change ./integration_test/gov_module/proposal/expedited_proposal.json
-           --from admin --chain-id sei --fees 2000usei -b block -y --output json | jq -M -r ".logs[].events[].attributes[0] | select(.key == \"proposal_id\").value"
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_gov_proposal admin "Gov Param Change Expedited" gov submit-proposal param-change ./integration_test/gov_module/proposal/expedited_proposal.json --fees 2000usei
       env: PROPOSAL_ID
     # Get proposal status
     - cmd: seid q gov proposal $PROPOSAL_ID --output json | jq -r .status
       env: PROPOSAL_STATUS
     # Make a deposit
-    - cmd: printf "12345678\n" | seid tx gov deposit $PROPOSAL_ID 10000000usei --from admin --chain-id sei --fees 2000usei -b block -y --output json | jq -r .code
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait admin gov deposit $PROPOSAL_ID 10000000usei --fees 2000usei
     # sei-node-0 vote yes
-    - cmd: printf "12345678\n" | seid tx gov vote $PROPOSAL_ID yes --from node_admin --chain-id sei --fees 2000usei -b block -y --output json | jq -r .code
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait node_admin gov vote $PROPOSAL_ID yes --fees 2000usei
       node: sei-node-0
     # sei-node-1 vote yes
     - cmd: seid q gov proposal $PROPOSAL_ID --output json | jq -r .status
-    - cmd: printf "12345678\n" | seid tx gov vote $PROPOSAL_ID yes --from node_admin --chain-id sei --fees 2000usei -b block -y --output json | jq -r .code
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait node_admin gov vote $PROPOSAL_ID yes --fees 2000usei
       node: sei-node-1
     # sei-node-2 vote yes
     - cmd: seid q gov proposal $PROPOSAL_ID --output json | jq -r .status
-    - cmd: printf "12345678\n" | seid tx gov vote $PROPOSAL_ID yes --from node_admin --chain-id sei --fees 2000usei -b block -y --output json | jq -r .code
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait node_admin gov vote $PROPOSAL_ID yes --fees 2000usei
       node: sei-node-2
     # sei-node-3 vote yes
     - cmd: seid q gov proposal $PROPOSAL_ID --output json | jq -r .status
-    - cmd: printf "12345678\n" | seid tx gov vote $PROPOSAL_ID yes --from node_admin --chain-id sei --fees 2000usei -b block -y --output json | jq -r .code
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait node_admin gov vote $PROPOSAL_ID yes --fees 2000usei
       node: sei-node-3
     # since expedited quorum is 0.9, we only need 4/4 votes and expect expedited proposal to pass after 20 seconds
     - cmd: sleep 20
@@ -82,16 +80,15 @@
     - cmd: seid q bank total --denom usei --output json | jq -r .amount
       env: TOTAL_SUPPLY_BEFORE_BURN
     # Make a new expedited proposal
-    - cmd: printf "12345678\n" | seid tx gov submit-proposal param-change ./integration_test/gov_module/proposal/expedited_proposal.json
-        --from admin --chain-id sei --fees 2000usei -b block -y --output json | jq -M -r ".logs[].events[].attributes[0] | select(.key == \"proposal_id\").value"
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_gov_proposal admin "Gov Param Change Expedited" gov submit-proposal param-change ./integration_test/gov_module/proposal/expedited_proposal.json --fees 2000usei
       env: PROPOSAL_ID
     # Get proposal status
     - cmd: seid q gov proposal $PROPOSAL_ID --output json | jq -r .status
       env: PROPOSAL_STATUS
     # Make a deposit
-    - cmd: printf "12345678\n" | seid tx gov deposit $PROPOSAL_ID 10000000usei --from admin --chain-id sei --fees 2000usei -b block -y --output json | jq -r .code
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait admin gov deposit $PROPOSAL_ID 10000000usei --fees 2000usei
     # only sei-node-0 vote yes
-    - cmd: printf "12345678\n" | seid tx gov vote $PROPOSAL_ID yes --from node_admin --chain-id sei --fees 2000usei -b block -y --output json | jq -r .code
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait node_admin gov vote $PROPOSAL_ID yes --fees 2000usei
       node: sei-node-0
     # since expedited quorum is 0.75, we expect it to be rejected and burn tokens, the since expected proposal will auto convert to normal proposal, we need to wait 35 seconds
     - cmd: sleep 35

--- a/integration_test/gov_module/staking_proposal_test.yaml
+++ b/integration_test/gov_module/staking_proposal_test.yaml
@@ -4,28 +4,27 @@
     - cmd: seid q params subspace staking UnbondingTime --output json | jq -r .value | tr -d "\""
       env: OLD_PARAM
     # Make a new expedited proposal
-    - cmd: printf "12345678\n" | seid tx gov submit-proposal param-change ./integration_test/gov_module/proposal/staking_proposal.json
-        --from admin --chain-id sei --fees 2000usei -b block -y --output json | jq -M -r ".logs[].events[].attributes[0] | select(.key == \"proposal_id\").value"
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_gov_proposal admin "Update Unbonding Time" gov submit-proposal param-change ./integration_test/gov_module/proposal/staking_proposal.json --fees 2000usei
       env: PROPOSAL_ID
     # Get proposal status
     - cmd: seid q gov proposal $PROPOSAL_ID --output json | jq -r .status
       env: PROPOSAL_STATUS
     # Make a deposit
-    - cmd: printf "12345678\n" | seid tx gov deposit $PROPOSAL_ID 10000000usei --from admin --chain-id sei --fees 2000usei -b block -y --output json | jq -r .code
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait admin gov deposit $PROPOSAL_ID 10000000usei --fees 2000usei
     # sei-node-0 vote yes
-    - cmd: printf "12345678\n" | seid tx gov vote $PROPOSAL_ID yes --from node_admin --chain-id sei --fees 2000usei -b block -y --output json | jq -r .code
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait node_admin gov vote $PROPOSAL_ID yes --fees 2000usei
       node: sei-node-0
     # sei-node-1 vote yes
     - cmd: seid q gov proposal $PROPOSAL_ID --output json | jq -r .status
-    - cmd: printf "12345678\n" | seid tx gov vote $PROPOSAL_ID yes --from node_admin --chain-id sei --fees 2000usei -b block -y --output json | jq -r .code
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait node_admin gov vote $PROPOSAL_ID yes --fees 2000usei
       node: sei-node-1
     # sei-node-2 vote yes
     - cmd: seid q gov proposal $PROPOSAL_ID --output json | jq -r .status
-    - cmd: printf "12345678\n" | seid tx gov vote $PROPOSAL_ID yes --from node_admin --chain-id sei --fees 2000usei -b block -y --output json | jq -r .code
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait node_admin gov vote $PROPOSAL_ID yes --fees 2000usei
       node: sei-node-2
     # sei-node-3 vote yes
     - cmd: seid q gov proposal $PROPOSAL_ID --output json | jq -r .status
-    - cmd: printf "12345678\n" | seid tx gov vote $PROPOSAL_ID yes --from node_admin --chain-id sei --fees 2000usei -b block -y --output json | jq -r .code
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait node_admin gov vote $PROPOSAL_ID yes --fees 2000usei
       node: sei-node-3
     # since expedited quorum is 0.9, we only need 4/4 votes and expect expedited proposal to pass after 20 seconds
     - cmd: sleep 20

--- a/integration_test/oracle_module/set_feeder_test.yaml
+++ b/integration_test/oracle_module/set_feeder_test.yaml
@@ -13,15 +13,15 @@
     - cmd: seid q oracle feeder $ADMIN_VAL_ADDR --output json | jq -r ".feeder_addr"
       env: OLD_FEEDER_ADDR
     # send bank funds to new feeder to populate account
-    - cmd: printf "12345678\n" | seid tx bank send admin $NEW_FEEDER_ADDR 1sei -b block -y --fees 2000usei --output json | jq -r ".code"
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait admin bank send admin $NEW_FEEDER_ADDR 1sei --fees 2000usei
     # set feeder
-    - cmd: printf "12345678\n" | seid tx oracle set-feeder $NEW_FEEDER_ADDR -b block -y --from node_admin --fees 2000usei --output json | jq -r ".code"
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait node_admin oracle set-feeder $NEW_FEEDER_ADDR --fees 2000usei
       env: SET_FEEDER_ERROR_CODE
     # do a vote and ensure code 0
-    - cmd: printf "12345678\n" | seid tx oracle aggregate-vote 1.5ueth $ADMIN_VAL_ADDR -b block -y --from $NEW_FEEDER_ADDR --gas 0 --output json | jq -r ".code"
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait $NEW_FEEDER_ADDR oracle aggregate-vote 1.5ueth $ADMIN_VAL_ADDR --gas 0
       env: NEW_FEEDER_VOTE_ERROR_CODE
     # set old feeder addr again
-    - cmd: printf "12345678\n" | seid tx oracle set-feeder $OLD_FEEDER_ADDR -b block -y --from node_admin --fees 2000usei --output json | jq -r ".code"
+    - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_tx_and_wait node_admin oracle set-feeder $OLD_FEEDER_ADDR --fees 2000usei
   verifiers:
     # verify that error code == 0 for setting feeder AND oracle vote
     - type: eval

--- a/integration_test/utils/_tx_helpers.sh
+++ b/integration_test/utils/_tx_helpers.sh
@@ -270,3 +270,23 @@ find_proposal_by_title() {
     echo "find_proposal_by_title: proposal (tx $tx_hash) with title '$title' did not appear in gov state within ${TX_WAIT_TIMEOUT}s" >&2
     return 1
 }
+
+# Submit a gov proposal via -b sync and echo the new proposal id once
+# it appears in gov state. Bundles _get_max_proposal_id, the submit,
+# and find_proposal_by_title so yaml tests can capture PROPOSAL_ID in
+# a single cmd: without parsing DeliverTx event logs.
+# Usage: id=$(submit_gov_proposal <from-key> <title> <subcmd-and-args...>)
+submit_gov_proposal() {
+    local from_key="$1"; shift
+    local title="$1"; shift
+    local max_before; max_before=$(_get_max_proposal_id)
+    local resp; resp=$(printf "12345678\n" | $seidbin tx "$@" --from "$from_key" \
+        -y --chain-id="$chainid" --broadcast-mode=sync --output=json)
+    local code; code=$(echo "$resp" | jq -r '.code // 0')
+    if [ "$code" != "0" ]; then
+        echo "submit_gov_proposal CheckTx rejected: $(echo "$resp" | jq -r '.raw_log')" >&2
+        return 1
+    fi
+    local txhash; txhash=$(echo "$resp" | jq -r '.txhash')
+    find_proposal_by_title "$title" "$max_before" "$txhash"
+}


### PR DESCRIPTION
## Summary

- Migrates 36 `-b block` sites across 6 yaml files in `gov_module/`, `oracle_module/`, and `authz_module/` to `-b sync` via `submit_tx_and_wait` (sender sequence-advance polling). Under Autobahn the cosmos tx KV indexer isn't populated, so `-b block` hangs to its 60s timeout.
- Adds `submit_gov_proposal` to `_tx_helpers.sh` — bundles `_get_max_proposal_id` + the submit + `find_proposal_by_title` so yaml tests can capture `PROPOSAL_ID` in one `cmd:` line without parsing DeliverTx event logs.
- Adds an `Autobahn Gov & Oracle & Authz Module` CI matrix entry next to the existing row.

## DeliverTx-code assertions

Two authz tests asserted specific DeliverTx failure codes (4 for unauthorized unbond, 5 for over-spend-limit). Under `-b sync` only the CheckTx code is visible, and both txs accept at CheckTx. Replaced with state checks:
- `send_authorization_test.yaml`: drop `AUTHZ_2_ERROR_CODE == 5`; the existing `OTHER_ACC_BALANCE == 6000000` already verifies the second exec was rejected at DeliverTx.
- `staking_authorization_test.yaml`: drop `AUTHZ_2_ERROR_CODE == 4`; query `STAKING_AMOUNT` after the failed unbond (still 1000000, proves the failure) and add `STAKING_AMOUNT_AFTER_UNBOND` after the authorized unbond (0, proves the success).

## Test plan

- [x] Local 4-node docker cluster, CometBFT (default env): 7/7 yamls passing — `gov_proposal_test`, `staking_proposal_test`, `verify_penalty_counts`, `set_feeder_test`, `send_authorization_test`, `staking_authorization_test`, `generic_authorization_test`.
- [x] Local 4-node docker cluster, Autobahn (`AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true`): 7/7 yamls passing.
- [x] CI: existing `Gov & Oracle & Authz Module` (CometBFT) stays green.
- [x] CI: new `Autobahn Gov & Oracle & Authz Module` goes green.