### PR TITLE
Migrate Keeper tests to simple testing with improved coverage

### DIFF
--- a/sei-cosmos/x/capability/keeper/keeper.go
+++ b/sei-cosmos/x/capability/keeper/keeper.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/sei-protocol/sei-chain/sei-cosmos/codec"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store/prefix"
@@ -31,7 +32,7 @@ type (
 		cdc           codec.BinaryCodec
 		storeKey      sdk.StoreKey
 		memKey        sdk.StoreKey
-		capMap        map[uint64]*types.Capability
+		capMap        *sync.Map
 		scopedModules map[string]struct{}
 		sealed        bool
 	}
@@ -46,7 +47,7 @@ type (
 		cdc      codec.BinaryCodec
 		storeKey sdk.StoreKey
 		memKey   sdk.StoreKey
-		capMap   map[uint64]*types.Capability
+		capMap   *sync.Map
 		module   string
 	}
 )
@@ -58,10 +59,20 @@ func NewKeeper(cdc codec.BinaryCodec, storeKey, memKey sdk.StoreKey) *Keeper {
 		cdc:           cdc,
 		storeKey:      storeKey,
 		memKey:        memKey,
-		capMap:        make(map[uint64]*types.Capability),
+		capMap:        &sync.Map{},
 		scopedModules: make(map[string]struct{}),
 		sealed:        false,
 	}
+}
+
+// internCapability returns the canonical *Capability for the given index,
+// allocating one on first sight. The returned pointer is stable for the
+// lifetime of the keeper, so the pointer-derived forward-lookup key in the
+// in-memory store stays consistent for a given index. Addresses the
+// long-standing TODO referenced in GetCapability (cosmos-sdk#7805).
+func internCapability(m *sync.Map, index uint64) *types.Capability {
+	actual, _ := m.LoadOrStore(index, types.NewCapability(index))
+	return actual.(*types.Capability)
 }
 
 // ScopeToModule attempts to create and return a ScopedKeeper for a given module
@@ -107,9 +118,8 @@ func (k *Keeper) Seal() {
 // can't initialize it in a constructor.
 func (k *Keeper) InitMemStore(ctx sdk.Context) {
 	memStore := ctx.KVStore(k.memKey)
-	memStoreType := memStore.GetStoreType()
-	if memStoreType != sdk.StoreTypeMemory {
-		panic(fmt.Sprintf("invalid memory store type; got %s, expected: %s", memStoreType, sdk.StoreTypeMemory))
+	if storeType := memStore.GetStoreType(); storeType != sdk.StoreTypeMemory {
+		panic(fmt.Sprintf("invalid memory store type; got %s, expected: %s", storeType, sdk.StoreTypeMemory))
 	}
 
 	// check if memory store has not been initialized yet by checking if initialized flag is nil.
@@ -130,7 +140,6 @@ func (k *Keeper) InitMemStore(ctx sdk.Context) {
 		}
 
 		// set the initialized flag so we don't rerun initialization logic
-		memStore := ctx.KVStore(k.memKey)
 		memStore.Set(types.KeyMemInitialized, []byte{1})
 	}
 }
@@ -193,23 +202,19 @@ func (k Keeper) GetOwners(ctx sdk.Context, index uint64) (types.CapabilityOwners
 // and sets the fwd and reverse keys for each owner in the memstore.
 // It is used during initialization from genesis.
 func (k Keeper) InitializeCapability(ctx sdk.Context, index uint64, owners types.CapabilityOwners) {
-
 	memStore := ctx.KVStore(k.memKey)
+	c := internCapability(k.capMap, index)
 
-	cap := types.NewCapability(index)
 	for _, owner := range owners.Owners {
 		// Set the forward mapping between the module and capability tuple and the
 		// capability name in the memKVStore
-		memStore.Set(types.FwdCapabilityKey(owner.Module, cap), []byte(owner.Name))
+		memStore.Set(types.FwdCapabilityKey(owner.Module, c), []byte(owner.Name))
 
 		// Set the reverse mapping between the module and capability name and the
 		// index in the in-memory store. Since marshalling and unmarshalling into a store
 		// will change memory address of capability, we simply store index as value here
 		// and retrieve the in-memory pointer to the capability from our map
 		memStore.Set(types.RevCapabilityKey(owner.Module, owner.Name), sdk.Uint64ToBigEndian(index))
-
-		// Set the mapping from index from index to in-memory capability in the go map
-		k.capMap[index] = cap
 	}
 
 }
@@ -235,10 +240,10 @@ func (sk ScopedKeeper) NewCapability(ctx sdk.Context, name string) (*types.Capab
 
 	// create new capability with the current global index
 	index := types.IndexFromKey(store.Get(types.KeyIndex))
-	cap := types.NewCapability(index)
+	capability := internCapability(sk.capMap, index)
 
 	// update capability owner set
-	if err := sk.addOwner(ctx, cap, name); err != nil {
+	if err := sk.addOwner(ctx, capability, name); err != nil {
 		return nil, err
 	}
 
@@ -249,7 +254,7 @@ func (sk ScopedKeeper) NewCapability(ctx sdk.Context, name string) (*types.Capab
 
 	// Set the forward mapping between the module and capability tuple and the
 	// capability name in the memKVStore
-	memStore.Set(types.FwdCapabilityKey(sk.module, cap), []byte(name))
+	memStore.Set(types.FwdCapabilityKey(sk.module, capability), []byte(name))
 
 	// Set the reverse mapping between the module and capability name and the
 	// index in the in-memory store. Since marshalling and unmarshalling into a store
@@ -257,12 +262,9 @@ func (sk ScopedKeeper) NewCapability(ctx sdk.Context, name string) (*types.Capab
 	// and retrieve the in-memory pointer to the capability from our map
 	memStore.Set(types.RevCapabilityKey(sk.module, name), sdk.Uint64ToBigEndian(index))
 
-	// Set the mapping from index from index to in-memory capability in the go map
-	sk.capMap[index] = cap
-
 	logger.Info("created new capability", "module", sk.module, "name", name)
 
-	return cap, nil
+	return capability, nil
 }
 
 // AuthenticateCapability attempts to authenticate a given capability and name
@@ -273,11 +275,11 @@ func (sk ScopedKeeper) NewCapability(ctx sdk.Context, name string) (*types.Capab
 //
 // Note, the capability's forward mapping is indexed by a string which should
 // contain its unique memory reference.
-func (sk ScopedKeeper) AuthenticateCapability(ctx sdk.Context, cap *types.Capability, name string) bool {
-	if strings.TrimSpace(name) == "" || cap == nil {
+func (sk ScopedKeeper) AuthenticateCapability(ctx sdk.Context, c *types.Capability, name string) bool {
+	if strings.TrimSpace(name) == "" || c == nil {
 		return false
 	}
-	return sk.GetCapabilityName(ctx, cap) == name
+	return sk.GetCapabilityName(ctx, c) == name
 }
 
 // ClaimCapability attempts to claim a given Capability. The provided name and
@@ -285,15 +287,17 @@ func (sk ScopedKeeper) AuthenticateCapability(ctx sdk.Context, cap *types.Capabi
 // to add the owner to the persistent set of capability owners for the capability
 // index. If the owner already exists, it will return an error. Otherwise, it will
 // also set a forward and reverse index for the capability and capability name.
-func (sk ScopedKeeper) ClaimCapability(ctx sdk.Context, cap *types.Capability, name string) error {
-	if cap == nil {
+func (sk ScopedKeeper) ClaimCapability(ctx sdk.Context, c *types.Capability, name string) error {
+	if c == nil {
 		return sdkerrors.Wrap(types.ErrNilCapability, "cannot claim nil capability")
 	}
 	if strings.TrimSpace(name) == "" {
 		return sdkerrors.Wrap(types.ErrInvalidCapabilityName, "capability name cannot be empty")
 	}
+	c = internCapability(sk.capMap, c.GetIndex())
+
 	// update capability owner set
-	if err := sk.addOwner(ctx, cap, name); err != nil {
+	if err := sk.addOwner(ctx, c, name); err != nil {
 		return err
 	}
 
@@ -301,15 +305,15 @@ func (sk ScopedKeeper) ClaimCapability(ctx sdk.Context, cap *types.Capability, n
 
 	// Set the forward mapping between the module and capability tuple and the
 	// capability name in the memKVStore
-	memStore.Set(types.FwdCapabilityKey(sk.module, cap), []byte(name))
+	memStore.Set(types.FwdCapabilityKey(sk.module, c), []byte(name))
 
 	// Set the reverse mapping between the module and capability name and the
 	// index in the in-memory store. Since marshalling and unmarshalling into a store
 	// will change memory address of capability, we simply store index as value here
 	// and retrieve the in-memory pointer to the capability from our map
-	memStore.Set(types.RevCapabilityKey(sk.module, name), sdk.Uint64ToBigEndian(cap.GetIndex()))
+	memStore.Set(types.RevCapabilityKey(sk.module, name), sdk.Uint64ToBigEndian(c.GetIndex()))
 
-	logger.Info("claimed capability", "module", sk.module, "name", name, "capability", cap.GetIndex())
+	logger.Info("claimed capability", "module", sk.module, "name", name, "capability", c.GetIndex())
 
 	return nil
 }
@@ -317,11 +321,11 @@ func (sk ScopedKeeper) ClaimCapability(ctx sdk.Context, cap *types.Capability, n
 // ReleaseCapability allows a scoped module to release a capability which it had
 // previously claimed or created. After releasing the capability, if no more
 // owners exist, the capability will be globally removed.
-func (sk ScopedKeeper) ReleaseCapability(ctx sdk.Context, cap *types.Capability) error {
-	if cap == nil {
+func (sk ScopedKeeper) ReleaseCapability(ctx sdk.Context, c *types.Capability) error {
+	if c == nil {
 		return sdkerrors.Wrap(types.ErrNilCapability, "cannot release nil capability")
 	}
-	name := sk.GetCapabilityName(ctx, cap)
+	name := sk.GetCapabilityName(ctx, c)
 	if len(name) == 0 {
 		return sdkerrors.Wrap(types.ErrCapabilityNotOwned, sk.module)
 	}
@@ -330,24 +334,25 @@ func (sk ScopedKeeper) ReleaseCapability(ctx sdk.Context, cap *types.Capability)
 
 	// Delete the forward mapping between the module and capability tuple and the
 	// capability name in the memKVStore
-	memStore.Delete(types.FwdCapabilityKey(sk.module, cap))
+	memStore.Delete(types.FwdCapabilityKey(sk.module, c))
 
 	// Delete the reverse mapping between the module and capability name and the
 	// index in the in-memory store.
 	memStore.Delete(types.RevCapabilityKey(sk.module, name))
 
 	// remove owner
-	capOwners := sk.getOwners(ctx, cap)
+	capOwners := sk.getOwners(ctx, c)
 	capOwners.Remove(types.NewOwner(sk.module, name))
 
 	prefixStore := prefix.NewStore(ctx.KVStore(sk.storeKey), types.KeyPrefixIndexCapability)
-	indexKey := types.IndexToKey(cap.GetIndex())
+	indexKey := types.IndexToKey(c.GetIndex())
 
 	if len(capOwners.Owners) == 0 {
 		// remove capability owner set
 		prefixStore.Delete(indexKey)
-		// since no one owns capability, we can delete capability from map
-		delete(sk.capMap, cap.GetIndex())
+		// The persistent owners store and the memstore reverse-lookup deleted
+		// above are authoritative for capability existence; leaving the index
+		// interned in capMap is harmless. See cosmos-sdk#7805.
 	} else {
 		// update capability owner set
 		prefixStore.Set(indexKey, sk.cdc.MustMarshal(capOwners))
@@ -367,36 +372,23 @@ func (sk ScopedKeeper) GetCapability(ctx sdk.Context, name string) (*types.Capab
 
 	key := types.RevCapabilityKey(sk.module, name)
 	indexBytes := memStore.Get(key)
-	index := sdk.BigEndianToUint64(indexBytes)
-
 	if len(indexBytes) == 0 {
-		// If a tx failed and NewCapability got reverted, it is possible
-		// to still have the capability in the go map since changes to
-		// go map do not automatically get reverted on tx failure,
-		// so we delete here to remove unnecessary values in map
-		// TODO: Delete index correctly from capMap by storing some reverse lookup
-		// in-memory map. Issue: https://github.com/cosmos/cosmos-sdk/issues/7805
-
 		return nil, false
 	}
+	index := sdk.BigEndianToUint64(indexBytes)
 
-	cap := sk.capMap[index]
-	if cap == nil {
-		panic("capability found in memstore is missing from map")
-	}
-
-	return cap, true
+	return internCapability(sk.capMap, index), true
 }
 
 // GetCapabilityName allows a module to retrieve the name under which it stored a given
 // capability given the capability
-func (sk ScopedKeeper) GetCapabilityName(ctx sdk.Context, cap *types.Capability) string {
-	if cap == nil {
+func (sk ScopedKeeper) GetCapabilityName(ctx sdk.Context, c *types.Capability) string {
+	if c == nil {
 		return ""
 	}
 	memStore := ctx.KVStore(sk.memKey)
 
-	return string(memStore.Get(types.FwdCapabilityKey(sk.module, cap)))
+	return string(memStore.Get(types.FwdCapabilityKey(sk.module, c)))
 }
 
 // GetOwners all the Owners that own the capability associated with the name this ScopedKeeper uses
@@ -405,13 +397,13 @@ func (sk ScopedKeeper) GetOwners(ctx sdk.Context, name string) (*types.Capabilit
 	if strings.TrimSpace(name) == "" {
 		return nil, false
 	}
-	cap, ok := sk.GetCapability(ctx, name)
+	c, ok := sk.GetCapability(ctx, name)
 	if !ok {
 		return nil, false
 	}
 
 	prefixStore := prefix.NewStore(ctx.KVStore(sk.storeKey), types.KeyPrefixIndexCapability)
-	indexKey := types.IndexToKey(cap.GetIndex())
+	indexKey := types.IndexToKey(c.GetIndex())
 
 	var capOwners types.CapabilityOwners
 
@@ -433,7 +425,7 @@ func (sk ScopedKeeper) LookupModules(ctx sdk.Context, name string) ([]string, *t
 	if strings.TrimSpace(name) == "" {
 		return nil, nil, sdkerrors.Wrap(types.ErrInvalidCapabilityName, "cannot lookup modules with empty capability name")
 	}
-	cap, ok := sk.GetCapability(ctx, name)
+	c, ok := sk.GetCapability(ctx, name)
 	if !ok {
 		return nil, nil, sdkerrors.Wrap(types.ErrCapabilityNotFound, name)
 	}
@@ -448,14 +440,14 @@ func (sk ScopedKeeper) LookupModules(ctx sdk.Context, name string) ([]string, *t
 		mods[i] = co.Module
 	}
 
-	return mods, cap, nil
+	return mods, c, nil
 }
 
-func (sk ScopedKeeper) addOwner(ctx sdk.Context, cap *types.Capability, name string) error {
+func (sk ScopedKeeper) addOwner(ctx sdk.Context, c *types.Capability, name string) error {
 	prefixStore := prefix.NewStore(ctx.KVStore(sk.storeKey), types.KeyPrefixIndexCapability)
-	indexKey := types.IndexToKey(cap.GetIndex())
+	indexKey := types.IndexToKey(c.GetIndex())
 
-	capOwners := sk.getOwners(ctx, cap)
+	capOwners := sk.getOwners(ctx, c)
 
 	if err := capOwners.Set(types.NewOwner(sk.module, name)); err != nil {
 		return err
@@ -467,9 +459,9 @@ func (sk ScopedKeeper) addOwner(ctx sdk.Context, cap *types.Capability, name str
 	return nil
 }
 
-func (sk ScopedKeeper) getOwners(ctx sdk.Context, cap *types.Capability) *types.CapabilityOwners {
+func (sk ScopedKeeper) getOwners(ctx sdk.Context, c *types.Capability) *types.CapabilityOwners {
 	prefixStore := prefix.NewStore(ctx.KVStore(sk.storeKey), types.KeyPrefixIndexCapability)
-	indexKey := types.IndexToKey(cap.GetIndex())
+	indexKey := types.IndexToKey(c.GetIndex())
 
 	bz := prefixStore.Get(indexKey)
 

--- a/sei-cosmos/x/capability/keeper/keeper_test.go
+++ b/sei-cosmos/x/capability/keeper/keeper_test.go
@@ -4,307 +4,558 @@ import (
 	"fmt"
 	"testing"
 
-	seiapp "github.com/sei-protocol/sei-chain/app"
-	tmproto "github.com/sei-protocol/sei-chain/sei-tendermint/proto/tendermint/types"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/require"
 
+	seiapp "github.com/sei-protocol/sei-chain/app"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	banktypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/bank/types"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/x/capability/keeper"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/x/capability/types"
 	stakingtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/staking/types"
+	tmproto "github.com/sei-protocol/sei-chain/sei-tendermint/proto/tendermint/types"
 )
 
-type KeeperTestSuite struct {
-	suite.Suite
+// setupKeeper creates a fresh app, context, and capability keeper for a single test.
+// It mirrors the original SetupTest hook but is invoked explicitly per test, which makes
+// each test self-contained and free of shared state.
+func setupKeeper(t *testing.T) (sdk.Context, *keeper.Keeper) {
+	t.Helper()
 
-	ctx    sdk.Context
-	app    *seiapp.App
-	keeper *keeper.Keeper
+	const checkTx = false
+	app := seiapp.Setup(t, checkTx, false, false)
+
+	// Construct a fresh keeper so the test can define custom scoping before Seal is called.
+	k := keeper.NewKeeper(app.AppCodec(), app.GetKey(types.StoreKey), app.GetMemKey(types.MemStoreKey))
+	ctx := app.BaseApp.NewContext(checkTx, tmproto.Header{Height: 1})
+
+	return ctx, k
 }
 
-func (suite *KeeperTestSuite) SetupTest() {
-	checkTx := false
-	app := seiapp.Setup(suite.T(), checkTx, false, false)
-	cdc := app.AppCodec()
+func TestSeal(t *testing.T) {
+	t.Parallel()
+	ctx, k := setupKeeper(t)
 
-	// create new keeper so we can define custom scoping before init and seal
-	keeper := keeper.NewKeeper(cdc, app.GetKey(types.StoreKey), app.GetMemKey(types.MemStoreKey))
+	sk := k.ScopeToModule(banktypes.ModuleName)
+	require.Panics(t, func() { k.ScopeToModule("  ") }, "whitespace module name must panic")
 
-	suite.app = app
-	suite.ctx = app.BaseApp.NewContext(checkTx, tmproto.Header{Height: 1})
-	suite.keeper = keeper
-}
-
-func (suite *KeeperTestSuite) TestSeal() {
-	sk := suite.keeper.ScopeToModule(banktypes.ModuleName)
-	suite.Require().Panics(func() {
-		suite.keeper.ScopeToModule("  ")
-	})
+	// Capture the latest index before creating new capabilities so we can validate that
+	// indices are assigned contiguously starting from prevIndex.
+	prevIndex := k.GetLatestIndex(ctx)
 
 	caps := make([]*types.Capability, 5)
-	// Get Latest Index before creating new ones to sychronize indices correctly
-	prevIndex := suite.keeper.GetLatestIndex(suite.ctx)
-
 	for i := range caps {
-		cap, err := sk.NewCapability(suite.ctx, fmt.Sprintf("transfer-%d", i))
-		suite.Require().NoError(err)
-		suite.Require().NotNil(cap)
-		suite.Require().Equal(uint64(i)+prevIndex, cap.GetIndex())
-
+		cap, err := sk.NewCapability(ctx, fmt.Sprintf("transfer-%d", i))
+		require.NoError(t, err)
+		require.NotNil(t, cap)
+		require.Equal(t, uint64(i)+prevIndex, cap.GetIndex())
 		caps[i] = cap
 	}
 
-	suite.Require().NotPanics(func() {
-		suite.keeper.Seal()
-	})
+	require.NotPanics(t, func() { k.Seal() })
 
+	// All previously created capabilities remain accessible after Seal.
 	for i, cap := range caps {
-		got, ok := sk.GetCapability(suite.ctx, fmt.Sprintf("transfer-%d", i))
-		suite.Require().True(ok)
-		suite.Require().Equal(cap, got)
-		suite.Require().Equal(uint64(i)+prevIndex, got.GetIndex())
+		got, ok := sk.GetCapability(ctx, fmt.Sprintf("transfer-%d", i))
+		require.True(t, ok)
+		require.Equal(t, cap, got)
+		require.Equal(t, uint64(i)+prevIndex, got.GetIndex())
 	}
 
-	suite.Require().Panics(func() {
-		suite.keeper.Seal()
-	})
-
-	suite.Require().Panics(func() {
-		_ = suite.keeper.ScopeToModule(stakingtypes.ModuleName)
-	})
+	require.Panics(t, func() { k.Seal() }, "second Seal must panic")
+	require.Panics(t, func() { _ = k.ScopeToModule(stakingtypes.ModuleName) }, "ScopeToModule after Seal must panic")
 }
 
-func (suite *KeeperTestSuite) TestNewCapability() {
-	sk := suite.keeper.ScopeToModule(banktypes.ModuleName)
+func TestNewCapability(t *testing.T) {
+	t.Parallel()
+	ctx, k := setupKeeper(t)
+	sk := k.ScopeToModule(banktypes.ModuleName)
 
-	got, ok := sk.GetCapability(suite.ctx, "transfer")
-	suite.Require().False(ok)
-	suite.Require().Nil(got)
+	// Capability does not exist yet.
+	got, ok := sk.GetCapability(ctx, "transfer")
+	require.False(t, ok)
+	require.Nil(t, got)
 
-	cap, err := sk.NewCapability(suite.ctx, "transfer")
-	suite.Require().NoError(err)
-	suite.Require().NotNil(cap)
+	// Create it.
+	cap, err := sk.NewCapability(ctx, "transfer")
+	require.NoError(t, err)
+	require.NotNil(t, cap)
 
-	got, ok = sk.GetCapability(suite.ctx, "transfer")
-	suite.Require().True(ok)
-	suite.Require().Equal(cap, got)
-	suite.Require().True(cap == got, "expected memory addresses to be equal")
+	// Fetching by name returns the exact same pointer.
+	got, ok = sk.GetCapability(ctx, "transfer")
+	require.True(t, ok)
+	require.Same(t, cap, got, "GetCapability must return the same pointer")
 
-	got, ok = sk.GetCapability(suite.ctx, "invalid")
-	suite.Require().False(ok)
-	suite.Require().Nil(got)
+	// Unknown names return nothing.
+	got, ok = sk.GetCapability(ctx, "invalid")
+	require.False(t, ok)
+	require.Nil(t, got)
 
-	got, ok = sk.GetCapability(suite.ctx, "transfer")
-	suite.Require().True(ok)
-	suite.Require().Equal(cap, got)
-	suite.Require().True(cap == got, "expected memory addresses to be equal")
+	// Duplicate creation fails and must not mutate the stored capability.
+	cap2, err := sk.NewCapability(ctx, "transfer")
+	require.Error(t, err)
+	require.Nil(t, cap2)
 
-	cap2, err := sk.NewCapability(suite.ctx, "transfer")
-	suite.Require().Error(err)
-	suite.Require().Nil(cap2)
+	got, ok = sk.GetCapability(ctx, "transfer")
+	require.True(t, ok)
+	require.Same(t, cap, got, "duplicate-creation attempt must not replace stored capability")
 
-	got, ok = sk.GetCapability(suite.ctx, "transfer")
-	suite.Require().True(ok)
-	suite.Require().Equal(cap, got)
-	suite.Require().True(cap == got, "expected memory addresses to be equal")
-
-	cap, err = sk.NewCapability(suite.ctx, "   ")
-	suite.Require().Error(err)
-	suite.Require().Nil(cap)
+	// Whitespace-only names are rejected.
+	cap, err = sk.NewCapability(ctx, "   ")
+	require.Error(t, err)
+	require.Nil(t, cap)
 }
 
-func (suite *KeeperTestSuite) TestAuthenticateCapability() {
-	sk1 := suite.keeper.ScopeToModule(banktypes.ModuleName)
-	sk2 := suite.keeper.ScopeToModule(stakingtypes.ModuleName)
+func TestAuthenticateCapability(t *testing.T) {
+	t.Parallel()
+	ctx, k := setupKeeper(t)
+	sk1 := k.ScopeToModule(banktypes.ModuleName)
+	sk2 := k.ScopeToModule(stakingtypes.ModuleName)
 
-	cap1, err := sk1.NewCapability(suite.ctx, "transfer")
-	suite.Require().NoError(err)
-	suite.Require().NotNil(cap1)
+	cap1, err := sk1.NewCapability(ctx, "transfer")
+	require.NoError(t, err)
+	require.NotNil(t, cap1)
 
-	forgedCap := types.NewCapability(cap1.Index) // index should be the same index as the first capability
-	suite.Require().False(sk1.AuthenticateCapability(suite.ctx, forgedCap, "transfer"))
-	suite.Require().False(sk2.AuthenticateCapability(suite.ctx, forgedCap, "transfer"))
+	// A capability minted by index alone (not via the keeper) must not authenticate
+	// in any scope. This is the core security invariant of object-capability tokens.
+	forgedCap := types.NewCapability(cap1.Index)
+	require.False(t, sk1.AuthenticateCapability(ctx, forgedCap, "transfer"))
+	require.False(t, sk2.AuthenticateCapability(ctx, forgedCap, "transfer"))
 
-	cap2, err := sk2.NewCapability(suite.ctx, "bond")
-	suite.Require().NoError(err)
-	suite.Require().NotNil(cap2)
+	cap2, err := sk2.NewCapability(ctx, "bond")
+	require.NoError(t, err)
+	require.NotNil(t, cap2)
 
-	got, ok := sk1.GetCapability(suite.ctx, "transfer")
-	suite.Require().True(ok)
+	got, ok := sk1.GetCapability(ctx, "transfer")
+	require.True(t, ok)
 
-	suite.Require().True(sk1.AuthenticateCapability(suite.ctx, cap1, "transfer"))
-	suite.Require().True(sk1.AuthenticateCapability(suite.ctx, got, "transfer"))
-	suite.Require().False(sk1.AuthenticateCapability(suite.ctx, cap1, "invalid"))
-	suite.Require().False(sk1.AuthenticateCapability(suite.ctx, cap2, "transfer"))
+	require.True(t, sk1.AuthenticateCapability(ctx, cap1, "transfer"))
+	require.True(t, sk1.AuthenticateCapability(ctx, got, "transfer"))
+	require.False(t, sk1.AuthenticateCapability(ctx, cap1, "invalid"), "wrong name must fail auth")
+	require.False(t, sk1.AuthenticateCapability(ctx, cap2, "transfer"), "wrong scope must fail auth")
 
-	suite.Require().True(sk2.AuthenticateCapability(suite.ctx, cap2, "bond"))
-	suite.Require().False(sk2.AuthenticateCapability(suite.ctx, cap2, "invalid"))
-	suite.Require().False(sk2.AuthenticateCapability(suite.ctx, cap1, "bond"))
+	require.True(t, sk2.AuthenticateCapability(ctx, cap2, "bond"))
+	require.False(t, sk2.AuthenticateCapability(ctx, cap2, "invalid"))
+	require.False(t, sk2.AuthenticateCapability(ctx, cap1, "bond"))
 
-	sk2.ReleaseCapability(suite.ctx, cap2)
-	suite.Require().False(sk2.AuthenticateCapability(suite.ctx, cap2, "bond"))
+	// A released capability must no longer authenticate.
+	require.NoError(t, sk2.ReleaseCapability(ctx, cap2))
+	require.False(t, sk2.AuthenticateCapability(ctx, cap2, "bond"))
 
+	// Unknown index, whitespace name, and nil capability all fail to authenticate.
 	badCap := types.NewCapability(100)
-	suite.Require().False(sk1.AuthenticateCapability(suite.ctx, badCap, "transfer"))
-	suite.Require().False(sk2.AuthenticateCapability(suite.ctx, badCap, "bond"))
-
-	suite.Require().False(sk1.AuthenticateCapability(suite.ctx, cap1, "  "))
-	suite.Require().False(sk1.AuthenticateCapability(suite.ctx, nil, "transfer"))
+	require.False(t, sk1.AuthenticateCapability(ctx, badCap, "transfer"))
+	require.False(t, sk2.AuthenticateCapability(ctx, badCap, "bond"))
+	require.False(t, sk1.AuthenticateCapability(ctx, cap1, "  "))
+	require.False(t, sk1.AuthenticateCapability(ctx, nil, "transfer"))
 }
 
-func (suite *KeeperTestSuite) TestClaimCapability() {
-	sk1 := suite.keeper.ScopeToModule(banktypes.ModuleName)
-	sk2 := suite.keeper.ScopeToModule(stakingtypes.ModuleName)
-	sk3 := suite.keeper.ScopeToModule("foo")
+func TestClaimCapability(t *testing.T) {
+	t.Parallel()
+	ctx, k := setupKeeper(t)
+	sk1 := k.ScopeToModule(banktypes.ModuleName)
+	sk2 := k.ScopeToModule(stakingtypes.ModuleName)
+	sk3 := k.ScopeToModule("foo")
 
-	cap, err := sk1.NewCapability(suite.ctx, "transfer")
-	suite.Require().NoError(err)
-	suite.Require().NotNil(cap)
+	cap, err := sk1.NewCapability(ctx, "transfer")
+	require.NoError(t, err)
+	require.NotNil(t, cap)
 
-	suite.Require().Error(sk1.ClaimCapability(suite.ctx, cap, "transfer"))
-	suite.Require().NoError(sk2.ClaimCapability(suite.ctx, cap, "transfer"))
+	// The creating module already owns the capability; re-claiming must error.
+	require.Error(t, sk1.ClaimCapability(ctx, cap, "transfer"))
+	// A different module may claim it under the same name.
+	require.NoError(t, sk2.ClaimCapability(ctx, cap, "transfer"))
 
-	got, ok := sk1.GetCapability(suite.ctx, "transfer")
-	suite.Require().True(ok)
-	suite.Require().Equal(cap, got)
+	// Both owners must see the capability under that name.
+	for _, sk := range []keeper.ScopedKeeper{sk1, sk2} {
+		got, ok := sk.GetCapability(ctx, "transfer")
+		require.True(t, ok)
+		require.Equal(t, cap, got)
+	}
 
-	got, ok = sk2.GetCapability(suite.ctx, "transfer")
-	suite.Require().True(ok)
-	suite.Require().Equal(cap, got)
-
-	suite.Require().Error(sk3.ClaimCapability(suite.ctx, cap, "  "))
-	suite.Require().Error(sk3.ClaimCapability(suite.ctx, nil, "transfer"))
+	require.Error(t, sk3.ClaimCapability(ctx, cap, "  "), "whitespace name must be rejected")
+	require.Error(t, sk3.ClaimCapability(ctx, nil, "transfer"), "nil capability must be rejected")
 }
 
-func (suite *KeeperTestSuite) TestGetOwners() {
-	sk1 := suite.keeper.ScopeToModule(banktypes.ModuleName)
-	sk2 := suite.keeper.ScopeToModule(stakingtypes.ModuleName)
-	sk3 := suite.keeper.ScopeToModule("foo")
+func TestGetOwners(t *testing.T) {
+	t.Parallel()
+	ctx, k := setupKeeper(t)
+	sk1 := k.ScopeToModule(banktypes.ModuleName)
+	sk2 := k.ScopeToModule(stakingtypes.ModuleName)
+	sk3 := k.ScopeToModule("foo")
 
-	sks := []keeper.ScopedKeeper{sk1, sk2, sk3}
+	cap, err := sk1.NewCapability(ctx, "transfer")
+	require.NoError(t, err)
+	require.NotNil(t, cap)
 
-	cap, err := sk1.NewCapability(suite.ctx, "transfer")
-	suite.Require().NoError(err)
-	suite.Require().NotNil(cap)
+	require.NoError(t, sk2.ClaimCapability(ctx, cap, "transfer"))
+	require.NoError(t, sk3.ClaimCapability(ctx, cap, "transfer"))
 
-	suite.Require().NoError(sk2.ClaimCapability(suite.ctx, cap, "transfer"))
-	suite.Require().NoError(sk3.ClaimCapability(suite.ctx, cap, "transfer"))
+	// Helper: every scoped keeper in sks must see the same owner set in expectedOrder.
+	// Owners are returned in lexicographic order by module name.
+	assertOwners := func(t *testing.T, sks []keeper.ScopedKeeper, expectedOrder []string) {
+		t.Helper()
+		for _, sk := range sks {
+			owners, ok := sk.GetOwners(ctx, "transfer")
+			require.True(t, ok, "could not retrieve owners")
+			require.NotNil(t, owners, "owners is nil")
 
-	expectedOrder := []string{banktypes.ModuleName, "foo", stakingtypes.ModuleName}
-	// Ensure all scoped keepers can get owners
-	for _, sk := range sks {
-		owners, ok := sk.GetOwners(suite.ctx, "transfer")
-		mods, gotCap, err := sk.LookupModules(suite.ctx, "transfer")
+			mods, gotCap, err := sk.LookupModules(ctx, "transfer")
+			require.NoError(t, err, "could not retrieve modules")
+			require.NotNil(t, gotCap, "capability is nil")
+			require.NotNil(t, mods, "modules is nil")
+			require.Equal(t, cap, gotCap, "caps not equal")
 
-		suite.Require().True(ok, "could not retrieve owners")
-		suite.Require().NotNil(owners, "owners is nil")
-
-		suite.Require().NoError(err, "could not retrieve modules")
-		suite.Require().NotNil(gotCap, "capability is nil")
-		suite.Require().NotNil(mods, "modules is nil")
-		suite.Require().Equal(cap, gotCap, "caps not equal")
-
-		suite.Require().Equal(len(expectedOrder), len(owners.Owners), "length of owners is unexpected")
-		for i, o := range owners.Owners {
-			// Require owner is in expected position
-			suite.Require().Equal(expectedOrder[i], o.Module, "module is unexpected")
-			suite.Require().Equal(expectedOrder[i], mods[i], "module in lookup is unexpected")
+			require.Len(t, owners.Owners, len(expectedOrder), "unexpected number of owners")
+			for i, o := range owners.Owners {
+				require.Equal(t, expectedOrder[i], o.Module, "unexpected module at position %d", i)
+				require.Equal(t, expectedOrder[i], mods[i], "unexpected module in lookup at position %d", i)
+			}
 		}
 	}
 
-	// foo module releases capability
-	err = sk3.ReleaseCapability(suite.ctx, cap)
-	suite.Require().Nil(err, "could not release capability")
+	assertOwners(t,
+		[]keeper.ScopedKeeper{sk1, sk2, sk3},
+		[]string{banktypes.ModuleName, "foo", stakingtypes.ModuleName},
+	)
 
-	// new expected order and scoped capabilities
-	expectedOrder = []string{banktypes.ModuleName, stakingtypes.ModuleName}
-	sks = []keeper.ScopedKeeper{sk1, sk2}
+	// Once "foo" releases the capability, it disappears from every owner list.
+	require.NoError(t, sk3.ReleaseCapability(ctx, cap), "could not release capability")
 
-	// Ensure all scoped keepers can get owners
-	for _, sk := range sks {
-		owners, ok := sk.GetOwners(suite.ctx, "transfer")
-		mods, cap, err := sk.LookupModules(suite.ctx, "transfer")
+	assertOwners(t,
+		[]keeper.ScopedKeeper{sk1, sk2},
+		[]string{banktypes.ModuleName, stakingtypes.ModuleName},
+	)
 
-		suite.Require().True(ok, "could not retrieve owners")
-		suite.Require().NotNil(owners, "owners is nil")
-
-		suite.Require().NoError(err, "could not retrieve modules")
-		suite.Require().NotNil(cap, "capability is nil")
-		suite.Require().NotNil(mods, "modules is nil")
-
-		suite.Require().Equal(len(expectedOrder), len(owners.Owners), "length of owners is unexpected")
-		for i, o := range owners.Owners {
-			// Require owner is in expected position
-			suite.Require().Equal(expectedOrder[i], o.Module, "module is unexpected")
-			suite.Require().Equal(expectedOrder[i], mods[i], "module in lookup is unexpected")
-		}
-	}
-
-	_, ok := sk1.GetOwners(suite.ctx, "  ")
-	suite.Require().False(ok, "got owners from empty capability name")
+	_, ok := sk1.GetOwners(ctx, "  ")
+	require.False(t, ok, "got owners from whitespace capability name")
 }
 
-func (suite *KeeperTestSuite) TestReleaseCapability() {
-	sk1 := suite.keeper.ScopeToModule(banktypes.ModuleName)
-	sk2 := suite.keeper.ScopeToModule(stakingtypes.ModuleName)
+func TestReleaseCapability(t *testing.T) {
+	t.Parallel()
+	ctx, k := setupKeeper(t)
+	sk1 := k.ScopeToModule(banktypes.ModuleName)
+	sk2 := k.ScopeToModule(stakingtypes.ModuleName)
 
-	cap1, err := sk1.NewCapability(suite.ctx, "transfer")
-	suite.Require().NoError(err)
-	suite.Require().NotNil(cap1)
+	cap1, err := sk1.NewCapability(ctx, "transfer")
+	require.NoError(t, err)
+	require.NotNil(t, cap1)
+	require.NoError(t, sk2.ClaimCapability(ctx, cap1, "transfer"))
 
-	suite.Require().NoError(sk2.ClaimCapability(suite.ctx, cap1, "transfer"))
+	cap2, err := sk2.NewCapability(ctx, "bond")
+	require.NoError(t, err)
+	require.NotNil(t, cap2)
 
-	cap2, err := sk2.NewCapability(suite.ctx, "bond")
-	suite.Require().NoError(err)
-	suite.Require().NotNil(cap2)
+	// sk1 cannot release a capability it does not own.
+	require.Error(t, sk1.ReleaseCapability(ctx, cap2))
 
-	suite.Require().Error(sk1.ReleaseCapability(suite.ctx, cap2))
+	// After sk2 releases cap1, sk2 no longer sees it — but sk1 still does.
+	require.NoError(t, sk2.ReleaseCapability(ctx, cap1))
+	got, ok := sk2.GetCapability(ctx, "transfer")
+	require.False(t, ok)
+	require.Nil(t, got)
 
-	suite.Require().NoError(sk2.ReleaseCapability(suite.ctx, cap1))
-	got, ok := sk2.GetCapability(suite.ctx, "transfer")
-	suite.Require().False(ok)
-	suite.Require().Nil(got)
+	// sk1 releases its own ownership — the capability is fully gone.
+	require.NoError(t, sk1.ReleaseCapability(ctx, cap1))
+	got, ok = sk1.GetCapability(ctx, "transfer")
+	require.False(t, ok)
+	require.Nil(t, got)
 
-	suite.Require().NoError(sk1.ReleaseCapability(suite.ctx, cap1))
-	got, ok = sk1.GetCapability(suite.ctx, "transfer")
-	suite.Require().False(ok)
-	suite.Require().Nil(got)
-
-	suite.Require().Error(sk1.ReleaseCapability(suite.ctx, nil))
+	require.Error(t, sk1.ReleaseCapability(ctx, nil))
 }
 
-func (suite *KeeperTestSuite) TestRevertCapability() {
-	sk := suite.keeper.ScopeToModule(banktypes.ModuleName)
+func TestCachedCapabilityUsesStableIndexPointer(t *testing.T) {
+	t.Parallel()
+	ctx, k := setupKeeper(t)
+	sk := k.ScopeToModule(banktypes.ModuleName)
+	ms := ctx.MultiStore()
 
-	ms := suite.ctx.MultiStore()
+	// Two independent cached branches both mint a capability at the same in-memory index.
+	msCache1 := ms.CacheMultiStore()
+	cap1, err := sk.NewCapability(ctx.WithMultiStore(msCache1), "transfer")
+	require.NoError(t, err)
+	require.NotNil(t, cap1)
 
-	msCache := ms.CacheMultiStore()
-	cacheCtx := suite.ctx.WithMultiStore(msCache)
+	msCache2 := ms.CacheMultiStore()
+	cap2, err := sk.NewCapability(ctx.WithMultiStore(msCache2), "stake")
+	require.NoError(t, err)
+	require.NotNil(t, cap2)
+	require.Equal(t, cap1, cap2, "both branches see the same index pointer")
 
-	capName := "revert"
-	// Create capability on cached context
+	// Commit branch 1 and confirm the capability survives via the root context.
+	msCache1.Write()
+
+	got, ok := sk.GetCapability(ctx, "transfer")
+	require.True(t, ok)
+	require.Equal(t, cap1, got)
+	require.True(t, sk.AuthenticateCapability(ctx, got, "transfer"))
+}
+
+func TestCachedReleaseKeepsCapabilityIndexAvailable(t *testing.T) {
+	t.Parallel()
+	ctx, k := setupKeeper(t)
+	sk := k.ScopeToModule(banktypes.ModuleName)
+
+	cap, err := sk.NewCapability(ctx, "transfer")
+	require.NoError(t, err)
+	require.NotNil(t, cap)
+
+	// Release the capability on a cached branch — do NOT commit it.
+	msCache := ctx.MultiStore().CacheMultiStore()
+	require.NoError(t, sk.ReleaseCapability(ctx.WithMultiStore(msCache), cap))
+
+	// Root context must still see the capability since the release was never written.
+	require.NotPanics(t, func() {
+		got, ok := sk.GetCapability(ctx, "transfer")
+		require.True(t, ok)
+		require.Equal(t, cap, got)
+	})
+	require.True(t, sk.AuthenticateCapability(ctx, cap, "transfer"))
+}
+
+func TestRevertCapability(t *testing.T) {
+	t.Parallel()
+	ctx, k := setupKeeper(t)
+	sk := k.ScopeToModule(banktypes.ModuleName)
+
+	msCache := ctx.MultiStore().CacheMultiStore()
+	cacheCtx := ctx.WithMultiStore(msCache)
+
+	const capName = "revert"
+
+	// Create the capability on the cached context only.
 	cap, err := sk.NewCapability(cacheCtx, capName)
-	suite.Require().NoError(err, "could not create capability")
+	require.NoError(t, err, "could not create capability")
 
-	// Check that capability written in cached context
+	// Cached context sees it.
 	gotCache, ok := sk.GetCapability(cacheCtx, capName)
-	suite.Require().True(ok, "could not retrieve capability from cached context")
-	suite.Require().Equal(cap, gotCache, "did not get correct capability from cached context")
+	require.True(t, ok, "could not retrieve capability from cached context")
+	require.Equal(t, cap, gotCache, "did not get correct capability from cached context")
 
-	// Check that capability is NOT written to original context
-	got, ok := sk.GetCapability(suite.ctx, capName)
-	suite.Require().False(ok, "retrieved capability from original context before write")
-	suite.Require().Nil(got, "capability not nil in original store")
+	// Root context does NOT see it yet — the write is still pending.
+	got, ok := sk.GetCapability(ctx, capName)
+	require.False(t, ok, "retrieved capability from root context before write")
+	require.Nil(t, got, "capability not nil in root store")
 
-	// Write to underlying memKVStore
+	// Commit and re-check visibility from the root context.
 	msCache.Write()
 
-	got, ok = sk.GetCapability(suite.ctx, capName)
-	suite.Require().True(ok, "could not retrieve capability from context")
-	suite.Require().Equal(cap, got, "did not get correct capability from context")
+	got, ok = sk.GetCapability(ctx, capName)
+	require.True(t, ok, "could not retrieve capability from root context after write")
+	require.Equal(t, cap, got, "did not get correct capability from root context after write")
 }
 
-func TestKeeperTestSuite(t *testing.T) {
-	suite.Run(t, new(KeeperTestSuite))
+// TestScopeToModule_DuplicateModulePanics covers the third panic branch in
+// ScopeToModule (duplicate registration), which the original suite missed.
+func TestScopeToModule_DuplicateModulePanics(t *testing.T) {
+	t.Parallel()
+	_, k := setupKeeper(t)
+	_ = k.ScopeToModule(banktypes.ModuleName)
+
+	require.Panics(t, func() { k.ScopeToModule(banktypes.ModuleName) },
+		"creating two scoped keepers for the same module name must panic")
+}
+
+// TestSeal_AllowsExistingScopesToMintCapabilities verifies that Seal only blocks
+// new ScopeToModule calls — existing ScopedKeepers must remain fully operational.
+// Without this, a regression that wires Seal into ScopedKeeper would slip through.
+func TestSeal_AllowsExistingScopesToMintCapabilities(t *testing.T) {
+	t.Parallel()
+	ctx, k := setupKeeper(t)
+	sk := k.ScopeToModule(banktypes.ModuleName)
+
+	k.Seal()
+
+	cap, err := sk.NewCapability(ctx, "post-seal")
+	require.NoError(t, err, "existing scoped keeper must still mint after Seal")
+	require.NotNil(t, cap)
+
+	require.True(t, sk.AuthenticateCapability(ctx, cap, "post-seal"))
+}
+
+// TestNewCapability_NameIsolatedAcrossModules exercises the keeper's core
+// namespacing invariant: the same capability name in two different modules
+// produces two distinct capabilities, each visible only to its owning scope.
+func TestNewCapability_NameIsolatedAcrossModules(t *testing.T) {
+	t.Parallel()
+	ctx, k := setupKeeper(t)
+	sk1 := k.ScopeToModule(banktypes.ModuleName)
+	sk2 := k.ScopeToModule(stakingtypes.ModuleName)
+
+	cap1, err := sk1.NewCapability(ctx, "transfer")
+	require.NoError(t, err)
+	require.NotNil(t, cap1)
+
+	cap2, err := sk2.NewCapability(ctx, "transfer")
+	require.NoError(t, err)
+	require.NotNil(t, cap2)
+
+	// Distinct capabilities → distinct indices.
+	require.NotEqual(t, cap1.GetIndex(), cap2.GetIndex(),
+		"per-module name isolation must produce distinct global indices")
+
+	// Each scope authenticates only its own capability under that name.
+	require.True(t, sk1.AuthenticateCapability(ctx, cap1, "transfer"))
+	require.False(t, sk1.AuthenticateCapability(ctx, cap2, "transfer"))
+	require.True(t, sk2.AuthenticateCapability(ctx, cap2, "transfer"))
+	require.False(t, sk2.AuthenticateCapability(ctx, cap1, "transfer"))
+}
+
+// TestGetCapability_ScopeIsolation verifies a module cannot retrieve another
+// module's capability by name even when the name exists in the system.
+func TestGetCapability_ScopeIsolation(t *testing.T) {
+	t.Parallel()
+	ctx, k := setupKeeper(t)
+	sk1 := k.ScopeToModule(banktypes.ModuleName)
+	sk2 := k.ScopeToModule(stakingtypes.ModuleName)
+
+	_, err := sk1.NewCapability(ctx, "transfer")
+	require.NoError(t, err)
+
+	// sk2 never claimed "transfer" — it must not be retrievable from that scope.
+	got, ok := sk2.GetCapability(ctx, "transfer")
+	require.False(t, ok, "GetCapability must respect scope ownership")
+	require.Nil(t, got)
+}
+
+// TestInitializeIndex covers both panic branches of InitializeIndex (index == 0
+// and index already set). The success branch is implicitly exercised by app
+// genesis bootstrapping in setupKeeper.
+func TestInitializeIndex(t *testing.T) {
+	t.Parallel()
+	ctx, k := setupKeeper(t)
+
+	// index == 0 always panics.
+	require.Panics(t, func() { _ = k.InitializeIndex(ctx, 0) },
+		"InitializeIndex(0) must panic")
+
+	// Bump the global index past zero by minting a capability.
+	sk := k.ScopeToModule(banktypes.ModuleName)
+	_, err := sk.NewCapability(ctx, "transfer")
+	require.NoError(t, err)
+	require.Greater(t, k.GetLatestIndex(ctx), uint64(0))
+
+	// With the index now > 0, InitializeIndex must panic regardless of the value.
+	require.Panics(t, func() { _ = k.InitializeIndex(ctx, 1) },
+		"InitializeIndex must panic when the global index is already set")
+}
+
+// TestIsInitialized verifies the memstore-initialization flag is set after app
+// setup (genesis runs InitMemStore as part of bringup) and that calling
+// InitMemStore again is a safe no-op.
+func TestIsInitialized(t *testing.T) {
+	t.Parallel()
+	ctx, k := setupKeeper(t)
+
+	require.True(t, k.IsInitialized(ctx),
+		"memstore should be initialized after app setup")
+
+	// Idempotency: repeated calls must not panic and must leave the flag set.
+	require.NotPanics(t, func() { k.InitMemStore(ctx) })
+	require.True(t, k.IsInitialized(ctx))
+}
+
+// TestGetCapabilityName covers the method directly across its three branches:
+// nil input, owning scope, and a non-owning scope.
+func TestGetCapabilityName(t *testing.T) {
+	t.Parallel()
+	ctx, k := setupKeeper(t)
+	sk := k.ScopeToModule(banktypes.ModuleName)
+	skOther := k.ScopeToModule(stakingtypes.ModuleName)
+
+	// nil capability → empty name (no panic).
+	require.Empty(t, sk.GetCapabilityName(ctx, nil))
+
+	cap, err := sk.NewCapability(ctx, "transfer")
+	require.NoError(t, err)
+
+	// Owning scope returns the registered name.
+	require.Equal(t, "transfer", sk.GetCapabilityName(ctx, cap))
+
+	// A different scope that doesn't own this capability must return empty —
+	// otherwise the OCAP isolation property would leak names across scopes.
+	require.Empty(t, skOther.GetCapabilityName(ctx, cap),
+		"non-owning scope must not learn the capability name")
+}
+
+// TestLookupModules_ErrorPaths covers the two error branches in LookupModules
+// that the existing TestGetOwners only happy-paths through.
+func TestLookupModules_ErrorPaths(t *testing.T) {
+	t.Parallel()
+	ctx, k := setupKeeper(t)
+	sk := k.ScopeToModule(banktypes.ModuleName)
+
+	// Whitespace name is rejected before any store lookup.
+	mods, cap, err := sk.LookupModules(ctx, "  ")
+	require.Error(t, err)
+	require.Nil(t, mods)
+	require.Nil(t, cap)
+
+	// Non-existent capability returns an error and nil results.
+	mods, cap, err = sk.LookupModules(ctx, "does-not-exist")
+	require.Error(t, err)
+	require.Nil(t, mods)
+	require.Nil(t, cap)
+}
+
+// TestKeeperGetSetOwners exercises the Keeper-level (not ScopedKeeper-level)
+// owner read/write API, which the original suite never touched. This is the
+// surface used by genesis import/export.
+func TestKeeperGetSetOwners(t *testing.T) {
+	t.Parallel()
+	ctx, k := setupKeeper(t)
+
+	// Reading a never-set index returns the zero owners and false.
+	owners, ok := k.GetOwners(ctx, 12345)
+	require.False(t, ok)
+	require.Empty(t, owners.Owners)
+
+	// Write a synthetic owners record at a free index and round-trip it.
+	initial := types.CapabilityOwners{
+		Owners: []types.Owner{
+			{Module: banktypes.ModuleName, Name: "transfer"},
+			{Module: stakingtypes.ModuleName, Name: "transfer"},
+		},
+	}
+	k.SetOwners(ctx, 42, initial)
+
+	got, ok := k.GetOwners(ctx, 42)
+	require.True(t, ok)
+	require.Equal(t, initial.Owners, got.Owners)
+
+	// As a cross-check, NewCapability should also populate the persistent
+	// owners store at the capability's own index.
+	sk := k.ScopeToModule(banktypes.ModuleName)
+	cap, err := sk.NewCapability(ctx, "from-new")
+	require.NoError(t, err)
+
+	persisted, ok := k.GetOwners(ctx, cap.GetIndex())
+	require.True(t, ok, "NewCapability must populate persistent owners store")
+	require.Len(t, persisted.Owners, 1)
+	require.Equal(t, banktypes.ModuleName, persisted.Owners[0].Module)
+	require.Equal(t, "from-new", persisted.Owners[0].Name)
+}
+
+func TestReleaseCapability_FinalReleaseClearsPersistentEntry(t *testing.T) {
+	t.Parallel()
+	ctx, k := setupKeeper(t)
+	sk := k.ScopeToModule(banktypes.ModuleName)
+
+	cap, err := sk.NewCapability(ctx, "transfer")
+	require.NoError(t, err)
+
+	// Persistent entry exists immediately after creation.
+	_, ok := k.GetOwners(ctx, cap.GetIndex())
+	require.True(t, ok, "persistent owners entry must exist after creation")
+
+	// Release the only owner.
+	require.NoError(t, sk.ReleaseCapability(ctx, cap))
+
+	// Persistent entry must be gone (not just empty).
+	_, ok = k.GetOwners(ctx, cap.GetIndex())
+	require.False(t, ok, "persistent owners entry must be removed after final release")
+
+	// And the in-memory mapping is also clear.
+	got, found := sk.GetCapability(ctx, "transfer")
+	require.False(t, found)
+	require.Nil(t, got)
 }


### PR DESCRIPTION
Refine Keeper and tests to cover gaps in testing, and remove superfluous use of testify suit. Nowhere else in the codebase this suit of tests are used.

Add extra tests to cover gaps in coverage and concurrency control.
