### PR TITLE
Release v6.5.1

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v6.5.0"
+  "version": "v6.5.1"
 }


### PR DESCRIPTION
Bump `version.json` to `v6.5.1` in preparation for cutting the release tag.