### PR TITLE
feat(ci): nightly ECR publish for harbor nightly job freshness

### DIFF
--- a/.github/workflows/nightly-ecr.yml
+++ b/.github/workflows/nightly-ecr.yml
@@ -56,6 +56,8 @@ jobs:
           tags: ${{ steps.login-ecr.outputs.registry }}/sei/sei-chain:${{ steps.tag.outputs.nightly }}
           cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:shared
           cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:shared,mode=max
+          build-args: |
+            SEI_CHAIN_REF=${{ github.sha }}
 
       # mock_balances -- consumed by nightly-load SEID_IMAGE (pre-funded EVM accounts).
       - name: Build and push mock-nightly (mock_balances)
@@ -68,6 +70,7 @@ jobs:
           cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:shared
           cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:shared,mode=max
           build-args: |
+            SEI_CHAIN_REF=${{ github.sha }}
             GO_BUILD_TAGS=mock_balances
 
       - name: Summary

--- a/.github/workflows/nightly-ecr.yml
+++ b/.github/workflows/nightly-ecr.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout main HEAD
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           ref: main
 
@@ -39,7 +39,7 @@ jobs:
         with:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::189176372795:role/common/gha
-          role-duration-seconds: 1800
+          role-duration-seconds: 3600
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -56,8 +56,8 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ steps.login-ecr.outputs.registry }}/sei/sei-chain:${{ steps.tag.outputs.nightly }}
-          cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:shared
-          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:shared,mode=max
+          cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:nightly-regular
+          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:nightly-regular,mode=max
           build-args: |
             SEI_CHAIN_REF=${{ steps.tag.outputs.sha }}
 
@@ -69,8 +69,8 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ steps.login-ecr.outputs.registry }}/sei/sei-chain:${{ steps.tag.outputs.mock }}
-          cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:shared
-          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:shared,mode=max
+          cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:nightly-mock
+          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:nightly-mock,mode=max
           build-args: |
             SEI_CHAIN_REF=${{ steps.tag.outputs.sha }}
             GO_BUILD_TAGS=mock_balances

--- a/.github/workflows/nightly-ecr.yml
+++ b/.github/workflows/nightly-ecr.yml
@@ -1,16 +1,10 @@
 name: Nightly ECR
 
 on:
-  # Runs at 01:00 UTC daily. Downstream consumers (Flux ImagePolicy) scan
-  # every 5m and commit the bump within ~17m of this workflow completing.
   schedule:
     - cron: '0 1 * * *'
-  # workflow_dispatch allows first-run bootstrap and manual re-triggers.
   workflow_dispatch:
 
-# One nightly build at a time. If a manual trigger fires while the schedule
-# is still running, the manual run queues rather than cancels — we want the
-# full build, not a partial overwrite.
 concurrency:
   group: nightly-ecr
   cancel-in-progress: false
@@ -35,8 +29,8 @@ jobs:
           SHA7=$(git rev-parse --short=7 HEAD)
           echo "date=${DATE}"   >> "$GITHUB_OUTPUT"
           echo "sha7=${SHA7}"   >> "$GITHUB_OUTPUT"
-          echo "nightly=nightly-${DATE}-${SHA7}"           >> "$GITHUB_OUTPUT"
-          echo "mock=mock-nightly-${DATE}-${SHA7}"         >> "$GITHUB_OUTPUT"
+          echo "nightly=nightly-${DATE}-${SHA7}"   >> "$GITHUB_OUTPUT"
+          echo "mock=mock-nightly-${DATE}-${SHA7}" >> "$GITHUB_OUTPUT"
 
       - name: AWS Login
         uses: aws-actions/configure-aws-credentials@v4
@@ -52,7 +46,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Regular build — consumed by release-test SEID_IMAGE.
+      # Regular build -- consumed by release-test SEID_IMAGE.
       - name: Build and push nightly (regular)
         uses: docker/build-push-action@v6
         with:
@@ -63,8 +57,7 @@ jobs:
           cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:shared
           cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:shared,mode=max
 
-      # Mock-balances build — consumed by nightly-load SEID_IMAGE (pre-funded
-      # accounts required for the EVM-transfer benchmark workload).
+      # mock_balances -- consumed by nightly-load SEID_IMAGE (pre-funded EVM accounts).
       - name: Build and push mock-nightly (mock_balances)
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/nightly-ecr.yml
+++ b/.github/workflows/nightly-ecr.yml
@@ -1,0 +1,87 @@
+name: Nightly ECR
+
+on:
+  # Runs at 01:00 UTC daily. Downstream consumers (Flux ImagePolicy) scan
+  # every 5m and commit the bump within ~17m of this workflow completing.
+  schedule:
+    - cron: '0 1 * * *'
+  # workflow_dispatch allows first-run bootstrap and manual re-triggers.
+  workflow_dispatch:
+
+# One nightly build at a time. If a manual trigger fires while the schedule
+# is still running, the manual run queues rather than cancels — we want the
+# full build, not a partial overwrite.
+concurrency:
+  group: nightly-ecr
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish nightly containers
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout main HEAD
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - name: Compute tag components
+        id: tag
+        run: |
+          DATE=$(date -u +%Y%m%d)
+          SHA7=$(git rev-parse --short=7 HEAD)
+          echo "date=${DATE}"   >> "$GITHUB_OUTPUT"
+          echo "sha7=${SHA7}"   >> "$GITHUB_OUTPUT"
+          echo "nightly=nightly-${DATE}-${SHA7}"           >> "$GITHUB_OUTPUT"
+          echo "mock=mock-nightly-${DATE}-${SHA7}"         >> "$GITHUB_OUTPUT"
+
+      - name: AWS Login
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::189176372795:role/common/gha
+          role-duration-seconds: 1800
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Regular build — consumed by release-test SEID_IMAGE.
+      - name: Build and push nightly (regular)
+        uses: docker/build-push-action@v6
+        with:
+          context: '.'
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.login-ecr.outputs.registry }}/sei/sei-chain:${{ steps.tag.outputs.nightly }}
+          cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:shared
+          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:shared,mode=max
+
+      # Mock-balances build — consumed by nightly-load SEID_IMAGE (pre-funded
+      # accounts required for the EVM-transfer benchmark workload).
+      - name: Build and push mock-nightly (mock_balances)
+        uses: docker/build-push-action@v6
+        with:
+          context: '.'
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.login-ecr.outputs.registry }}/sei/sei-chain:${{ steps.tag.outputs.mock }}
+          cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:shared
+          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:shared,mode=max
+          build-args: |
+            GO_BUILD_TAGS=mock_balances
+
+      - name: Summary
+        run: |
+          echo "### Nightly ECR publish" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Tag | Variant |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-----|---------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`${{ steps.tag.outputs.nightly }}\` | regular |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`${{ steps.tag.outputs.mock }}\` | mock_balances |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/nightly-ecr.yml
+++ b/.github/workflows/nightly-ecr.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout main HEAD
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
 
@@ -39,7 +39,7 @@ jobs:
         with:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::189176372795:role/common/gha
-          role-duration-seconds: 3600
+          role-duration-seconds: 7200
 
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.github/workflows/nightly-ecr.yml
+++ b/.github/workflows/nightly-ecr.yml
@@ -25,10 +25,12 @@ jobs:
       - name: Compute tag components
         id: tag
         run: |
-          DATE=$(date -u +%Y%m%d)
+          SHA=$(git rev-parse HEAD)
           SHA7=$(git rev-parse --short=7 HEAD)
-          echo "date=${DATE}"   >> "$GITHUB_OUTPUT"
+          DATE=$(date -u +%Y%m%d)
+          echo "sha=${SHA}"     >> "$GITHUB_OUTPUT"
           echo "sha7=${SHA7}"   >> "$GITHUB_OUTPUT"
+          echo "date=${DATE}"   >> "$GITHUB_OUTPUT"
           echo "nightly=nightly-${DATE}-${SHA7}"   >> "$GITHUB_OUTPUT"
           echo "mock=mock-nightly-${DATE}-${SHA7}" >> "$GITHUB_OUTPUT"
 
@@ -57,7 +59,7 @@ jobs:
           cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:shared
           cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:shared,mode=max
           build-args: |
-            SEI_CHAIN_REF=${{ github.sha }}
+            SEI_CHAIN_REF=${{ steps.tag.outputs.sha }}
 
       # mock_balances -- consumed by nightly-load SEID_IMAGE (pre-funded EVM accounts).
       - name: Build and push mock-nightly (mock_balances)
@@ -70,7 +72,7 @@ jobs:
           cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:shared
           cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/sei/build-cache:shared,mode=max
           build-args: |
-            SEI_CHAIN_REF=${{ github.sha }}
+            SEI_CHAIN_REF=${{ steps.tag.outputs.sha }}
             GO_BUILD_TAGS=mock_balances
 
       - name: Summary


### PR DESCRIPTION
## Summary

Adds a scheduled GHA workflow that builds and publishes two sei-chain container variants to ECR every day at 01:00 UTC, using a Flux-sortable tag format that enables automated image freshness on harbor's nightly test infrastructure.

## Tags produced

| Tag | Example | Consumer |
|---|---|---|
| `nightly-YYYYMMDD-<sha7>` | `nightly-20260527-2667d96` | release-test `SEID_IMAGE` |
| `mock-nightly-YYYYMMDD-<sha7>` | `mock-nightly-20260527-2667d96` | nightly-load `SEID_IMAGE` (mock_balances for pre-funded EVM accounts) |

## Why this format

`nightly-YYYYMMDD-<sha7>` is numerically sortable on the date prefix — Flux's `ImagePolicy.filterTags` can extract `$date` and sort descending to always resolve to the latest nightly. The `<sha7>` suffix gives provenance so a broken nightly is trivially `git log`-able back to a sei-chain commit.

## Downstream

Once this merges and the first tags land in ECR, the platform repo will follow with:
1. Terraform: IRSA for Flux's `image-reflector-controller` SA + enable `image-reflector-controller` and `image-automation-controller` on harbor
2. Flux objects: `ImageRepository` + 2× `ImagePolicy` + `ImageUpdateAutomation` + marker comments on the two `SEID_IMAGE` env lines in `clusters/harbor/nightly/{release,load}/workflow.yaml`

See sei-protocol/platform#518 for the full design.

## Notes

- `concurrency: {cancel-in-progress: false}` — a queued manual trigger won't interrupt a running scheduled build
- Reuses the `role/common/gha` OIDC role and build-cache pattern from `ecr.yml`
- `workflow_dispatch` enables first-run bootstrap (trigger manually to seed ECR before Flux starts scanning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)