### PR TITLE
Hash Vault Primitive

### DIFF
--- a/sei-db/state_db/sc/hashvault/hashvault.go
+++ b/sei-db/state_db/sc/hashvault/hashvault.go
@@ -22,13 +22,17 @@ type HashVault interface {
 	// Prune deletes all data for blocks below the specified height. Keeps data for the specified block height.
 	// Note that reporting the hash for a block below the pruning boundary will result in an error
 	// (as it is impossible to validate the correctness of the hash for a block below the pruning boundary).
-	//
-	// Actual pruning is asynchronous, and so this method may return before all data is removed from disk.
 	Prune(ctx context.Context, blockHeight uint64) error
 
 	// Close shuts the HashVault down and frees all resources (but does not delete the data from disk).
 	Close(ctx context.Context) error
 }
+
+// BlockHashSize is the required byte length for hashes passed to CommitToHash (CometBFT block ID / header hash).
+const BlockHashSize = 32
+
+// ErrInvalidHashLength is returned when CommitToHash is called with a hash whose length is not BlockHashSize.
+var ErrInvalidHashLength = errors.New("block hash must be 32 bytes")
 
 // ErrHashMismatch is returned by CommitToHash when the caller provides a hash that differs from the
 // hash previously committed for the same block height. This is the primary "node changed its mind"

--- a/sei-db/state_db/sc/hashvault/hashvault.go
+++ b/sei-db/state_db/sc/hashvault/hashvault.go
@@ -50,3 +50,9 @@ var ErrClosed = errors.New("hashvault is closed")
 // fails. This indicates either disk corruption or a bug in the encoding layer. Callers MUST treat
 // this as fatal and require human intervention.
 var ErrCorruption = errors.New("hashvault on-disk integrity check failed")
+
+// ErrRollbackHeightOverflow is returned by HardRollbackPebbleHashVault when blockHeight is
+// math.MaxUint64. The partial-rollback path deletes hashes strictly above blockHeight via
+// DeleteRange(hashKey(blockHeight+1), ...); at MaxUint64 that addition wraps to zero and would
+// delete the entire vault instead of none.
+var ErrRollbackHeightOverflow = errors.New("rollback block height overflows uint64")

--- a/sei-db/state_db/sc/hashvault/hashvault.go
+++ b/sei-db/state_db/sc/hashvault/hashvault.go
@@ -1,0 +1,48 @@
+package hashvault
+
+import (
+	"context"
+	"errors"
+)
+
+// HashVault is a safety mechanism to prevent a validator from "changing its mind" about the hash of a block
+// without human intervention.
+type HashVault interface {
+
+	// CommitToHash takes a provided hash for a block and writes it to disk. This method blocks until the hash is
+	// crash durable.
+	//
+	// This utility may be passed the hash for a block multiple times, but it will refuse to allow the hash to change
+	// for a particular block height. If this method returns nil, then it means that the hash is either the first
+	// one observed by the HashVault, or that the hash is the same as one for this block that was previously reported.
+	//
+	// If this method returns an error, DO NOT ATTEMPT TO RECOVER WITHOUT HUMAN INTERVENTION!
+	CommitToHash(ctx context.Context, blockHeight uint64, hash []byte) error
+
+	// Prune deletes all data for blocks below the specified height. Keeps data for the specified block height.
+	// Note that reporting the hash for a block below the pruning boundary will result in an error
+	// (as it is impossible to validate the correctness of the hash for a block below the pruning boundary).
+	//
+	// Actual pruning is asynchronous, and so this method may return before all data is removed from disk.
+	Prune(ctx context.Context, blockHeight uint64) error
+
+	// Close shuts the HashVault down and frees all resources (but does not delete the data from disk).
+	Close(ctx context.Context) error
+}
+
+// ErrHashMismatch is returned by CommitToHash when the caller provides a hash that differs from the
+// hash previously committed for the same block height. This is the primary "node changed its mind"
+// signal and MUST cause the calling node to halt.
+var ErrHashMismatch = errors.New("block hash mismatch")
+
+// ErrBelowPruneBoundary is returned when an operation targets a block height that has already been
+// pruned. Reporting or rolling back through pruned heights is impossible to validate and so is rejected.
+var ErrBelowPruneBoundary = errors.New("block height below prune boundary")
+
+// ErrClosed is returned when a method is called after Close.
+var ErrClosed = errors.New("hashvault is closed")
+
+// ErrCorruption is returned when the on-disk integrity check (SHA-256 trailer bound to (height, hash))
+// fails. This indicates either disk corruption or a bug in the encoding layer. Callers MUST treat
+// this as fatal and require human intervention.
+var ErrCorruption = errors.New("hashvault on-disk integrity check failed")

--- a/sei-db/state_db/sc/hashvault/hashvault_config.go
+++ b/sei-db/state_db/sc/hashvault/hashvault_config.go
@@ -1,0 +1,43 @@
+package hashvault
+
+import (
+	"fmt"
+)
+
+// HashVaultConfig is the configuration for a HashVault.
+type HashVaultConfig struct {
+	// DataDir is the directory in which the PebbleDB-backed HashVault stores its data.
+	DataDir string
+
+	// Fsync controls whether the underlying Pebble writes are fsynced.
+	//
+	// This field is test-only. Production callers should construct via NewPebbleHashVault, which forces
+	// fsync on regardless of this value. NewUnsafePebbleHashVault honors this flag and is intended for
+	// tests that exercise enough writes that fsync would dominate runtime.
+	Fsync bool
+
+	// CacheSize is the number of recent (height -> verified hash) entries to keep in the in-process LRU cache.
+	// Zero means use the default from DefaultHashVaultConfig.
+	CacheSize uint
+}
+
+// DefaultHashVaultConfig returns a HashVaultConfig populated with sensible defaults. The caller must
+// still set DataDir before passing the config to a constructor.
+func DefaultHashVaultConfig() HashVaultConfig {
+	return HashVaultConfig{
+		Fsync:     false,
+		CacheSize: 1024,
+	}
+}
+
+// Validate returns a non-nil error if the configuration is missing required fields or has values
+// that the HashVault cannot accept.
+func (c *HashVaultConfig) Validate() error {
+	if c.DataDir == "" {
+		return fmt.Errorf("data directory is required")
+	}
+	if c.CacheSize == 0 {
+		return fmt.Errorf("cache size must be greater than zero (start from DefaultHashVaultConfig)")
+	}
+	return nil
+}

--- a/sei-db/state_db/sc/hashvault/hashvault_config.go
+++ b/sei-db/state_db/sc/hashvault/hashvault_config.go
@@ -16,13 +16,11 @@ type HashVaultConfig struct {
 	// tests that exercise enough writes that fsync would dominate runtime.
 	Fsync bool
 
-	// CacheSize is the number of recent (height -> verified hash) entries to keep in the in-process LRU cache.
-	// Zero means use the default from DefaultHashVaultConfig.
-	CacheSize uint
+	// CacheSize is the number of recent (height -> verified hash) entries in the in-process LRU cache.
+	CacheSize int
 }
 
-// DefaultHashVaultConfig returns a HashVaultConfig populated with sensible defaults. The caller must
-// still set DataDir before passing the config to a constructor.
+// DefaultHashVaultConfig returns a HashVaultConfig with production defaults.
 func DefaultHashVaultConfig() HashVaultConfig {
 	return HashVaultConfig{
 		Fsync:     false,
@@ -36,8 +34,8 @@ func (c *HashVaultConfig) Validate() error {
 	if c.DataDir == "" {
 		return fmt.Errorf("data directory is required")
 	}
-	if c.CacheSize == 0 {
-		return fmt.Errorf("cache size must be greater than zero (start from DefaultHashVaultConfig)")
+	if c.CacheSize <= 0 {
+		return fmt.Errorf("cache size must be greater than zero")
 	}
 	return nil
 }

--- a/sei-db/state_db/sc/hashvault/hashvault_test.go
+++ b/sei-db/state_db/sc/hashvault/hashvault_test.go
@@ -23,6 +23,16 @@ func bytesOfLen(b byte, n int) []byte {
 	return out
 }
 
+func TestCommitRejectsInvalidHashLength(t *testing.T) {
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+
+	require.ErrorIs(t, v.CommitToHash(ctx, 1, nil), ErrInvalidHashLength)
+	require.ErrorIs(t, v.CommitToHash(ctx, 1, []byte{}), ErrInvalidHashLength)
+	require.ErrorIs(t, v.CommitToHash(ctx, 1, bytesOfLen(0xAA, 31)), ErrInvalidHashLength)
+	require.ErrorIs(t, v.CommitToHash(ctx, 1, bytesOfLen(0xAA, 33)), ErrInvalidHashLength)
+}
+
 func TestCommitFirstTime(t *testing.T) {
 	ctx := context.Background()
 	v := newTestPebbleVault(t)
@@ -214,4 +224,6 @@ func TestConcurrentCommits(t *testing.T) {
 func TestErrorWrappingIsCompatible(t *testing.T) {
 	wrapped := fmt.Errorf("outer: %w", ErrCorruption)
 	require.ErrorIs(t, wrapped, ErrCorruption)
+	wrappedLen := fmt.Errorf("outer: %w", ErrInvalidHashLength)
+	require.ErrorIs(t, wrappedLen, ErrInvalidHashLength)
 }

--- a/sei-db/state_db/sc/hashvault/hashvault_test.go
+++ b/sei-db/state_db/sc/hashvault/hashvault_test.go
@@ -1,0 +1,217 @@
+package hashvault
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Contract-level tests for HashVault. These exercise the externally-visible behavior promised by
+// the HashVault interface against the PebbleHashVault implementation. Pebble-specific surface
+// (encoding, restart recovery, on-disk inspection, the static rollback function, etc.) is tested
+// per-implementation in pebble_hashvault_test.go and pebble_hashvault_rollback_test.go.
+
+func bytesOfLen(b byte, n int) []byte {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = b
+	}
+	return out
+}
+
+func TestCommitFirstTime(t *testing.T) {
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+	hash := bytesOfLen(0xAA, 32)
+	require.NoError(t, v.CommitToHash(ctx, 7, hash))
+}
+
+func TestCommitIdempotent(t *testing.T) {
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+	hash := bytesOfLen(0xAB, 32)
+	require.NoError(t, v.CommitToHash(ctx, 7, hash))
+	require.NoError(t, v.CommitToHash(ctx, 7, hash))
+	require.NoError(t, v.CommitToHash(ctx, 7, hash))
+}
+
+func TestCommitMismatch(t *testing.T) {
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+	a := bytesOfLen(0x01, 32)
+	b := bytesOfLen(0x02, 32)
+	require.NoError(t, v.CommitToHash(ctx, 42, a))
+
+	err := v.CommitToHash(ctx, 42, b)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrHashMismatch)
+}
+
+func TestCommitMismatchAfterRepeatedCommitIsSticky(t *testing.T) {
+	// Even after re-committing the same hash many times, a single mismatch still surfaces. This
+	// is essentially a regression check that the cache fast path also enforces the mismatch.
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+	a := bytesOfLen(0x55, 32)
+	b := bytesOfLen(0x66, 32)
+	for i := 0; i < 10; i++ {
+		require.NoError(t, v.CommitToHash(ctx, 5, a))
+	}
+	err := v.CommitToHash(ctx, 5, b)
+	require.ErrorIs(t, err, ErrHashMismatch)
+}
+
+func TestPruneRemovesData(t *testing.T) {
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+
+	// Commit a handful of heights, prune below 5, then probe around the boundary.
+	for h := uint64(1); h <= 10; h++ {
+		require.NoError(t, v.CommitToHash(ctx, h, bytesOfLen(byte(h), 32)))
+	}
+	require.NoError(t, v.Prune(ctx, 5))
+
+	// Below the boundary is rejected.
+	require.ErrorIs(t,
+		v.CommitToHash(ctx, 3, bytesOfLen(0x03, 32)),
+		ErrBelowPruneBoundary,
+	)
+	// At the boundary is allowed (and the previously-committed hash is still locked in).
+	require.NoError(t, v.CommitToHash(ctx, 5, bytesOfLen(0x05, 32)))
+	require.ErrorIs(t,
+		v.CommitToHash(ctx, 5, bytesOfLen(0x55, 32)),
+		ErrHashMismatch,
+	)
+	// Above the boundary is allowed and still locked.
+	require.NoError(t, v.CommitToHash(ctx, 7, bytesOfLen(0x07, 32)))
+	require.ErrorIs(t,
+		v.CommitToHash(ctx, 7, bytesOfLen(0x77, 32)),
+		ErrHashMismatch,
+	)
+}
+
+func TestCommitBelowPruneBoundary(t *testing.T) {
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+
+	require.NoError(t, v.Prune(ctx, 100))
+	// Strictly below the boundary is rejected.
+	require.ErrorIs(t,
+		v.CommitToHash(ctx, 99, bytesOfLen(0xAA, 32)),
+		ErrBelowPruneBoundary,
+	)
+	require.ErrorIs(t,
+		v.CommitToHash(ctx, 50, bytesOfLen(0xAA, 32)),
+		ErrBelowPruneBoundary,
+	)
+	// At the boundary is allowed: Prune keeps the boundary block per the godoc.
+	require.NoError(t, v.CommitToHash(ctx, 100, bytesOfLen(0xAA, 32)))
+	// Above is also obviously fine.
+	require.NoError(t, v.CommitToHash(ctx, 101, bytesOfLen(0xAA, 32)))
+}
+
+func TestPruneMonotonic(t *testing.T) {
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+
+	require.NoError(t, v.Prune(ctx, 50))
+	require.NoError(t, v.Prune(ctx, 25)) // no-op
+	// Committing at 30 still errors: the effective boundary is still 50.
+	require.ErrorIs(t,
+		v.CommitToHash(ctx, 30, bytesOfLen(0xAA, 32)),
+		ErrBelowPruneBoundary,
+	)
+	// Just below the boundary still errors.
+	require.ErrorIs(t,
+		v.CommitToHash(ctx, 49, bytesOfLen(0xAA, 32)),
+		ErrBelowPruneBoundary,
+	)
+	// At and above the boundary succeed.
+	require.NoError(t, v.CommitToHash(ctx, 50, bytesOfLen(0x50, 32)))
+	require.NoError(t, v.CommitToHash(ctx, 51, bytesOfLen(0xAA, 32)))
+}
+
+func TestCloseIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+	require.NoError(t, v.Close(ctx))
+	require.NoError(t, v.Close(ctx))
+	require.NoError(t, v.Close(ctx))
+}
+
+func TestCallsAfterCloseError(t *testing.T) {
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+	require.NoError(t, v.Close(ctx))
+	require.ErrorIs(t, v.CommitToHash(ctx, 1, bytesOfLen(0xAA, 32)), ErrClosed)
+	require.ErrorIs(t, v.Prune(ctx, 1), ErrClosed)
+}
+
+func TestConcurrentCommits(t *testing.T) {
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+
+	// 100 goroutines, each commits a distinct height. All should succeed.
+	var wg sync.WaitGroup
+	const N = 100
+	errs := make(chan error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(h uint64) {
+			defer wg.Done()
+			errs <- v.CommitToHash(ctx, h, bytesOfLen(byte(h), 32))
+		}(uint64(i + 1))
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	// Re-committing the same (height, hash) from many goroutines should also all succeed.
+	errs2 := make(chan error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(h uint64) {
+			defer wg.Done()
+			errs2 <- v.CommitToHash(ctx, h, bytesOfLen(byte(h), 32))
+		}(uint64(i + 1))
+	}
+	wg.Wait()
+	close(errs2)
+	for err := range errs2 {
+		require.NoError(t, err)
+	}
+
+	// Committing a *different* hash at any of those heights from many goroutines should yield
+	// at least one mismatch error and never a hidden success.
+	errs3 := make(chan error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(h uint64) {
+			defer wg.Done()
+			errs3 <- v.CommitToHash(ctx, h, bytesOfLen(0xFF, 32))
+		}(uint64(i + 1))
+	}
+	wg.Wait()
+	close(errs3)
+	mismatches := 0
+	for err := range errs3 {
+		require.Error(t, err)
+		if errors.Is(err, ErrHashMismatch) {
+			mismatches++
+		}
+	}
+	require.Equal(t, N, mismatches, "every concurrent different-hash commit must return ErrHashMismatch")
+}
+
+// Sanity check that fmt.Errorf wrapping of our sentinels via %w stays Is-compatible. Defends
+// against accidental future refactors of the codec or handlers that lose the sentinel.
+func TestErrorWrappingIsCompatible(t *testing.T) {
+	wrapped := fmt.Errorf("outer: %w", ErrCorruption)
+	require.ErrorIs(t, wrapped, ErrCorruption)
+}

--- a/sei-db/state_db/sc/hashvault/pebble_hashvault.go
+++ b/sei-db/state_db/sc/hashvault/pebble_hashvault.go
@@ -1,0 +1,222 @@
+package hashvault
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/ethereum/go-ethereum/common/lru"
+	"github.com/sei-protocol/seilog"
+)
+
+var _ HashVault = (*PebbleHashVault)(nil)
+
+var logger = seilog.NewLogger("db", "state-db", "sc", "hashvault")
+
+// PebbleHashVault is a PebbleDB-backed implementation of the HashVault interface.
+type PebbleHashVault struct {
+	config    HashVaultConfig
+	db        *pebble.DB
+	writeOpts *pebble.WriteOptions
+
+	mu sync.Mutex
+	// closed is true after Close. Every other public method returns ErrClosed once set.
+	closed bool
+	// pruneBoundary is the lowest height that may still be committed.
+	pruneBoundary uint64
+	cache         *lru.Cache[uint64, []byte]
+}
+
+// NewPebbleHashVault opens (or creates) a PebbleHashVault rooted at config.DataDir.
+func NewPebbleHashVault(ctx context.Context, config HashVaultConfig) (*PebbleHashVault, error) {
+	if !config.Fsync {
+		logger.Info("forcing fsync on for production PebbleHashVault", "dataDir", config.DataDir)
+	}
+	config.Fsync = true
+	return newPebbleHashVault(ctx, config)
+}
+
+// NewUnsafePebbleHashVault opens (or creates) a PebbleHashVault rooted at config.DataDir. Honors
+// config.Fsync as set; intended for tests only. Never use in production: disabling fsync means a
+// well-timed crash can lose the most recent committed hash and let the node vote a different hash
+// for that block on the next boot.
+func NewUnsafePebbleHashVault(ctx context.Context, config HashVaultConfig) (*PebbleHashVault, error) {
+	return newPebbleHashVault(ctx, config)
+}
+
+func newPebbleHashVault(_ context.Context, config HashVaultConfig) (*PebbleHashVault, error) {
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid hashvault config: %w", err)
+	}
+
+	if err := os.MkdirAll(config.DataDir, 0o750); err != nil {
+		return nil, fmt.Errorf("failed to create hashvault data dir %q: %w", config.DataDir, err)
+	}
+
+	db, err := pebble.Open(config.DataDir, &pebble.Options{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to open hashvault pebble db at %q: %w", config.DataDir, err)
+	}
+
+	writeOpts := pebble.Sync
+	if !config.Fsync {
+		writeOpts = pebble.NoSync
+	}
+
+	p := &PebbleHashVault{
+		config:    config,
+		db:        db,
+		writeOpts: writeOpts,
+		cache:     lru.NewCache[uint64, []byte](int(config.CacheSize)),
+	}
+
+	if err := p.loadPruneBoundary(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+
+	return p, nil
+}
+
+// loadPruneBoundary reads the on-disk prune boundary (if any) and populates p.pruneBoundary.
+func (p *PebbleHashVault) loadPruneBoundary() error {
+	raw, closer, err := p.db.Get(pruneBoundaryKey)
+	if err != nil {
+		if errors.Is(err, pebble.ErrNotFound) {
+			return nil
+		}
+		return fmt.Errorf("failed to read prune boundary: %w", err)
+	}
+	defer func() { _ = closer.Close() }()
+
+	boundary, err := decodeBoundaryValue(raw)
+	if err != nil {
+		logger.Error("hashvault prune boundary is malformed; refusing to start",
+			"dataDir", p.config.DataDir, "rawHex", hex.EncodeToString(raw), "err", err)
+		return err
+	}
+	p.pruneBoundary = boundary
+	return nil
+}
+
+// CommitToHash implements HashVault.
+func (p *PebbleHashVault) CommitToHash(ctx context.Context, blockHeight uint64, hash []byte) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return ErrClosed
+	}
+	if blockHeight < p.pruneBoundary {
+		return ErrBelowPruneBoundary
+	}
+
+	if cached, ok := p.cache.Get(blockHeight); ok {
+		if !bytes.Equal(cached, hash) {
+			p.logHashMismatch(blockHeight, cached, hash)
+			return ErrHashMismatch
+		}
+		return nil
+	}
+
+	key := hashKey(blockHeight)
+	raw, closer, err := p.db.Get(key)
+	switch {
+	case errors.Is(err, pebble.ErrNotFound):
+		// First commit for this height: write it.
+		value := encodeHashValue(blockHeight, hash)
+		if werr := p.db.Set(key, value, p.writeOpts); werr != nil {
+			return fmt.Errorf("failed to persist hash for block %d: %w", blockHeight, werr)
+		}
+		p.cache.Add(blockHeight, bytes.Clone(hash))
+		return nil
+	case err != nil:
+		return fmt.Errorf("failed to read hash for block %d: %w", blockHeight, err)
+	}
+	// Found an existing entry; clone the raw bytes so we can release the closer before doing
+	// further work.
+	cloned := bytes.Clone(raw)
+	_ = closer.Close()
+
+	existing, err := decodeHashValue(blockHeight, cloned)
+	if err != nil {
+		logger.Error("hashvault detected on-disk corruption; DO NOT RESTART WITHOUT HUMAN INVESTIGATION",
+			"blockHeight", blockHeight, "rawHex", hex.EncodeToString(cloned), "err", err)
+		return err
+	}
+	if !bytes.Equal(existing, hash) {
+		p.logHashMismatch(blockHeight, existing, hash)
+		return ErrHashMismatch
+	}
+	p.cache.Add(blockHeight, existing)
+	return nil
+}
+
+// Prune implements HashVault. The boundary advance and range deletion are written in a single
+// atomic Pebble batch: a crash mid-Prune either rolls forward to the new boundary (with the
+// deletions applied) or leaves the old state intact. On return, every height strictly below
+// blockHeight is guaranteed durable-deleted (subject to config.Fsync).
+func (p *PebbleHashVault) Prune(ctx context.Context, blockHeight uint64) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return ErrClosed
+	}
+	if blockHeight <= p.pruneBoundary {
+		return nil
+	}
+
+	batch := p.db.NewBatch()
+	defer func() { _ = batch.Close() }()
+	if err := batch.Set(pruneBoundaryKey, encodeBoundaryValue(blockHeight), nil); err != nil {
+		return fmt.Errorf("failed to stage prune boundary advance to %d: %w", blockHeight, err)
+	}
+	// DeleteRange's upper bound is exclusive, so hashKey(blockHeight) keeps the boundary block
+	// itself per the HashVault.Prune contract.
+	if err := batch.DeleteRange(hashKey(0), hashKey(blockHeight), nil); err != nil {
+		return fmt.Errorf("failed to stage prune deletion below %d: %w", blockHeight, err)
+	}
+	if err := batch.Commit(p.writeOpts); err != nil {
+		return fmt.Errorf("failed to commit prune to %d: %w", blockHeight, err)
+	}
+
+	p.pruneBoundary = blockHeight
+	return nil
+}
+
+// Close implements HashVault. Subsequent calls return nil. After Close, every other public method
+// returns ErrClosed.
+func (p *PebbleHashVault) Close(_ context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return nil
+	}
+	p.closed = true
+	p.cache.Purge()
+	if err := p.db.Close(); err != nil {
+		return fmt.Errorf("failed to close hashvault pebble db: %w", err)
+	}
+	return nil
+}
+
+func (p *PebbleHashVault) logHashMismatch(blockHeight uint64, existing, incoming []byte) {
+	logger.Error("Hashvault detected hash mismatch; node attempted to change its mind. "+
+		"DO NOT RESTART WITHOUT HUMAN INVESTIGATION.",
+		"blockHeight", blockHeight,
+		"existingHex", hex.EncodeToString(existing),
+		"incomingHex", hex.EncodeToString(incoming),
+	)
+}

--- a/sei-db/state_db/sc/hashvault/pebble_hashvault.go
+++ b/sei-db/state_db/sc/hashvault/pebble_hashvault.go
@@ -72,7 +72,7 @@ func newPebbleHashVault(_ context.Context, config HashVaultConfig) (*PebbleHashV
 		config:    config,
 		db:        db,
 		writeOpts: writeOpts,
-		cache:     lru.NewCache[uint64, []byte](int(config.CacheSize)),
+		cache:     lru.NewCache[uint64, []byte](config.CacheSize),
 	}
 
 	if err := p.loadPruneBoundary(); err != nil {
@@ -117,6 +117,9 @@ func (p *PebbleHashVault) CommitToHash(ctx context.Context, blockHeight uint64, 
 	}
 	if blockHeight < p.pruneBoundary {
 		return ErrBelowPruneBoundary
+	}
+	if len(hash) != BlockHashSize {
+		return ErrInvalidHashLength
 	}
 
 	if cached, ok := p.cache.Get(blockHeight); ok {

--- a/sei-db/state_db/sc/hashvault/pebble_hashvault_codec.go
+++ b/sei-db/state_db/sc/hashvault/pebble_hashvault_codec.go
@@ -1,0 +1,160 @@
+package hashvault
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"strconv"
+)
+
+// Wire format
+//
+// Hash entries live under keys "h" <height>, where <height> is fixed-width 20-digit zero-padded
+// ASCII decimal (twenty digits is the exact width of math.MaxUint64). Fixed width is what makes
+// Pebble's lexicographic key order match numeric height order, which is what lets Prune wipe a
+// contiguous range with a single DeleteRange. ASCII (vs binary BE) is chosen so a raw Pebble dump
+// shows recognizable numbers (e.g. "h00000000000000000042") rather than opaque bytes.
+//
+// Each hash entry's value is the raw block hash followed by a 32-byte SHA-256 trailer computed
+// over (be-uint64 height || hash). The trailer is what protects against the validator
+// double-voting after silent corruption: the height is folded into the SHA so a stale entry
+// returned from the wrong key path also fails verification. The trailer's height encoding is
+// binary BE because that representation never appears on disk in raw form (it's consumed entirely
+// by the SHA), so the human-readability argument doesn't apply there.
+//
+// The prune boundary lives under the single key "prune_boundary". Its value is the boundary
+// height as variable-width unpadded ASCII decimal (e.g. "5" or "18446744073709551615"). No
+// padding because there's only one such row and no range scan to satisfy. No checksum: the
+// boundary is GC bookkeeping, a silent flip is not slashable, and Pebble's own block-level CRC
+// catches bit-rot in normal operation.
+//
+// "h" and "prune_boundary" have disjoint first bytes ('h' vs 'p'), so the two namespaces can never
+// alias regardless of what digits follow the hash prefix.
+
+const checksumSize = sha256.Size
+
+// heightDigits is the on-disk width (in ASCII bytes) of every encoded height. math.MaxUint64 is
+// 18446744073709551615, exactly 20 digits.
+const heightDigits = 20
+
+var (
+	hashKeyPrefix    = []byte("h")
+	pruneBoundaryKey = []byte("prune_boundary")
+)
+
+// hashKey returns the Pebble key for the given block height: hashKeyPrefix followed by the height
+// as 20-digit zero-padded ASCII decimal.
+func hashKey(height uint64) []byte {
+	out := make([]byte, 0, len(hashKeyPrefix)+heightDigits)
+	out = append(out, hashKeyPrefix...)
+	return appendHeight(out, height)
+}
+
+// decodeHashKey is the inverse of hashKey: validates the length and prefix, then parses the
+// trailing decimal digits. Returns ErrCorruption on any malformedness.
+func decodeHashKey(key []byte) (uint64, error) {
+	if len(key) != len(hashKeyPrefix)+heightDigits {
+		return 0, fmt.Errorf("%w: unexpected hash key length %d", ErrCorruption, len(key))
+	}
+	if !bytes.HasPrefix(key, hashKeyPrefix) {
+		return 0, fmt.Errorf("%w: hash key missing prefix", ErrCorruption)
+	}
+	return parseHeight(key[len(hashKeyPrefix):])
+}
+
+// hashKeyUpperBound returns an end-exclusive Pebble key that is strictly greater than every key
+// hashKey can produce (i.e. up to and including hashKey(math.MaxUint64)). Safe to use as an
+// IterOptions.UpperBound or as the upper end of a DeleteRange covering the entire hash namespace.
+func hashKeyUpperBound() []byte {
+	// One byte longer than any valid hash key, so lex-greater than all of them.
+	return append(hashKey(math.MaxUint64), 0x00)
+}
+
+// encodeHashValue returns the on-disk value for the given (height, hash) pair: the hash bytes
+// followed by SHA-256(be(height) || hash).
+func encodeHashValue(height uint64, hash []byte) []byte {
+	out := make([]byte, 0, len(hash)+checksumSize)
+	out = append(out, hash...)
+	out = append(out, hashChecksum(height, hash)...)
+	return out
+}
+
+// decodeHashValue verifies the trailing SHA-256 of raw against (height, hash[:len(raw)-32]) and
+// returns the hash bytes on success. Returns ErrCorruption if the trailer is missing or wrong.
+func decodeHashValue(height uint64, raw []byte) ([]byte, error) {
+	if len(raw) < checksumSize {
+		return nil, fmt.Errorf("%w: value too short for height %d (%d bytes)", ErrCorruption, height, len(raw))
+	}
+	split := len(raw) - checksumSize
+	hash := raw[:split]
+	trailer := raw[split:]
+	expected := hashChecksum(height, hash)
+	if !bytes.Equal(trailer, expected) {
+		return nil, fmt.Errorf("%w: checksum mismatch for height %d", ErrCorruption, height)
+	}
+	return bytes.Clone(hash), nil
+}
+
+// encodeBoundaryValue returns the on-disk value for the prune boundary: variable-width unpadded
+// ASCII decimal. There's only one boundary row in the DB and nothing range-scans the value, so
+// fixed-width padding (as used for keys) buys nothing here.
+func encodeBoundaryValue(boundary uint64) []byte {
+	return strconv.AppendUint(nil, boundary, 10)
+}
+
+// decodeBoundaryValue parses an ASCII-decimal boundary value. Empty/oversized/non-digit inputs all
+// trip ErrCorruption; Pebble's own CRC handles bit-rot within an otherwise-valid value.
+func decodeBoundaryValue(raw []byte) (uint64, error) {
+	// math.MaxUint64 is 20 digits; anything longer can't be a valid uint64 and is suspect.
+	if len(raw) == 0 || len(raw) > heightDigits {
+		return 0, fmt.Errorf("%w: unexpected boundary value length %d", ErrCorruption, len(raw))
+	}
+	n, err := strconv.ParseUint(string(raw), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%w: invalid boundary digits %q: %v", ErrCorruption, raw, err)
+	}
+	return n, nil
+}
+
+// hashChecksum returns SHA-256(be(height) || hash). The height is encoded as binary BE here, not
+// ASCII, because the result is hashed in place and never appears on disk in raw form.
+func hashChecksum(height uint64, hash []byte) []byte {
+	h := sha256.New()
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], height)
+	_, _ = h.Write(buf[:])
+	_, _ = h.Write(hash)
+	return h.Sum(nil)
+}
+
+// appendHeight appends 20-digit zero-padded decimal to dst and returns the result.
+func appendHeight(dst []byte, height uint64) []byte {
+	var buf [heightDigits]byte
+	i := len(buf)
+	for height > 0 {
+		i--
+		buf[i] = byte('0' + height%10)
+		height /= 10
+	}
+	for i > 0 {
+		i--
+		buf[i] = '0'
+	}
+	return append(dst, buf[:]...)
+}
+
+// parseHeight parses exactly heightDigits decimal bytes into a uint64. Returns ErrCorruption on
+// any non-digit byte; uint64 cannot overflow because 20 digits is the exact width of math.MaxUint64
+// and ParseUint with bitSize=64 rejects values above MaxUint64.
+func parseHeight(raw []byte) (uint64, error) {
+	if len(raw) != heightDigits {
+		return 0, fmt.Errorf("%w: expected %d digits, got %d", ErrCorruption, heightDigits, len(raw))
+	}
+	n, err := strconv.ParseUint(string(raw), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%w: invalid height digits %q: %v", ErrCorruption, raw, err)
+	}
+	return n, nil
+}

--- a/sei-db/state_db/sc/hashvault/pebble_hashvault_rollback.go
+++ b/sei-db/state_db/sc/hashvault/pebble_hashvault_rollback.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -38,6 +39,12 @@ func HardRollbackPebbleHashVault(_ context.Context, config HashVaultConfig, bloc
 
 	if blockHeight < boundary {
 		return wipeEntireStore(db, config.DataDir, blockHeight, boundary)
+	}
+
+	// Partial rollback uses DeleteRange(hashKey(blockHeight+1), ...). At math.MaxUint64 the +1
+	// wraps to 0, so hashKey(0) becomes the range start and every hash entry is deleted.
+	if blockHeight == math.MaxUint64 {
+		return fmt.Errorf("cannot hard rollback above block %d: %w", blockHeight, ErrRollbackHeightOverflow)
 	}
 
 	return hardRollbackAbove(db, config.DataDir, blockHeight)

--- a/sei-db/state_db/sc/hashvault/pebble_hashvault_rollback.go
+++ b/sei-db/state_db/sc/hashvault/pebble_hashvault_rollback.go
@@ -1,0 +1,91 @@
+package hashvault
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// HardRollbackPebbleHashVault deletes every recorded hash strictly above blockHeight from the
+// on-disk vault rooted at config.DataDir.
+func HardRollbackPebbleHashVault(_ context.Context, config HashVaultConfig, blockHeight uint64) error {
+	if err := config.Validate(); err != nil {
+		return fmt.Errorf("invalid hashvault config: %w", err)
+	}
+
+	// Refuse if the data dir doesn't already exist. pebble.Open would otherwise silently create a
+	// fresh empty DB at a typo'd path and report a "successful" no-op rollback, which is exactly
+	// the kind of operator-error-eaten-by-tooling we want to avoid in a CLI tool.
+	if _, err := os.Stat(config.DataDir); err != nil {
+		return fmt.Errorf("hashvault data dir %q is not accessible: %w", config.DataDir, err)
+	}
+
+	db, err := pebble.Open(config.DataDir, &pebble.Options{})
+	if err != nil {
+		return fmt.Errorf("failed to open hashvault pebble db at %q: %w", config.DataDir, err)
+	}
+	defer func() { _ = db.Close() }()
+
+	boundary, err := readPersistedBoundary(db)
+	if err != nil {
+		return err
+	}
+
+	if blockHeight < boundary {
+		return wipeEntireStore(db, config.DataDir, blockHeight, boundary)
+	}
+
+	from := hashKey(blockHeight + 1)
+	to := hashKeyUpperBound()
+	if err := db.DeleteRange(from, to, pebble.Sync); err != nil {
+		return fmt.Errorf("failed to hard rollback above block %d: %w", blockHeight, err)
+	}
+	logger.Info("hashvault hard rollback completed",
+		"dataDir", config.DataDir, "blockHeight", blockHeight)
+	return nil
+}
+
+// readPersistedBoundary returns the on-disk prune boundary, or zero if none has ever been written.
+// A malformed boundary record is logged and surfaced as ErrCorruption so the operator must
+// investigate before proceeding.
+func readPersistedBoundary(db *pebble.DB) (uint64, error) {
+	raw, closer, err := db.Get(pruneBoundaryKey)
+	if errors.Is(err, pebble.ErrNotFound) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("failed to read prune boundary: %w", err)
+	}
+	defer func() { _ = closer.Close() }()
+
+	boundary, err := decodeBoundaryValue(raw)
+	if err != nil {
+		logger.Error("hashvault prune boundary is malformed; refusing rollback",
+			"rawHex", hex.EncodeToString(raw), "err", err)
+		return 0, err
+	}
+	return boundary, nil
+}
+
+// wipeEntireStore drops every hash entry and the prune boundary record in a single atomic Pebble
+// batch, leaving the store indistinguishable from a freshly-initialized vault.
+func wipeEntireStore(db *pebble.DB, dataDir string, target, boundary uint64) error {
+	batch := db.NewBatch()
+	defer func() { _ = batch.Close() }()
+	if err := batch.DeleteRange(hashKey(0), hashKeyUpperBound(), nil); err != nil {
+		return fmt.Errorf("failed to stage wipe of hash range: %w", err)
+	}
+	if err := batch.Delete(pruneBoundaryKey, nil); err != nil {
+		return fmt.Errorf("failed to stage wipe of prune boundary: %w", err)
+	}
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return fmt.Errorf("failed to wipe hashvault store: %w", err)
+	}
+	logger.Warn("hashvault rollback target is below prune boundary; wiped entire store",
+		"dataDir", dataDir, "rollbackTarget", target, "pruneBoundary", boundary)
+	return nil
+}

--- a/sei-db/state_db/sc/hashvault/pebble_hashvault_rollback.go
+++ b/sei-db/state_db/sc/hashvault/pebble_hashvault_rollback.go
@@ -11,7 +11,8 @@ import (
 )
 
 // HardRollbackPebbleHashVault deletes every recorded hash strictly above blockHeight from the
-// on-disk vault rooted at config.DataDir.
+// on-disk vault rooted at config.DataDir and clears the prune boundary. This is a break-glass
+// operator tool: after it returns, commits at any height are allowed until Prune is run again.
 func HardRollbackPebbleHashVault(_ context.Context, config HashVaultConfig, blockHeight uint64) error {
 	if err := config.Validate(); err != nil {
 		return fmt.Errorf("invalid hashvault config: %w", err)
@@ -39,13 +40,25 @@ func HardRollbackPebbleHashVault(_ context.Context, config HashVaultConfig, bloc
 		return wipeEntireStore(db, config.DataDir, blockHeight, boundary)
 	}
 
-	from := hashKey(blockHeight + 1)
-	to := hashKeyUpperBound()
-	if err := db.DeleteRange(from, to, pebble.Sync); err != nil {
+	return hardRollbackAbove(db, config.DataDir, blockHeight)
+}
+
+// hardRollbackAbove deletes hashes strictly above blockHeight and clears the prune boundary in one
+// atomic batch.
+func hardRollbackAbove(db *pebble.DB, dataDir string, blockHeight uint64) error {
+	batch := db.NewBatch()
+	defer func() { _ = batch.Close() }()
+	if err := batch.DeleteRange(hashKey(blockHeight+1), hashKeyUpperBound(), nil); err != nil {
+		return fmt.Errorf("failed to stage hard rollback above block %d: %w", blockHeight, err)
+	}
+	if err := batch.Delete(pruneBoundaryKey, nil); err != nil {
+		return fmt.Errorf("failed to stage prune boundary clear during hard rollback: %w", err)
+	}
+	if err := batch.Commit(pebble.Sync); err != nil {
 		return fmt.Errorf("failed to hard rollback above block %d: %w", blockHeight, err)
 	}
 	logger.Info("hashvault hard rollback completed",
-		"dataDir", config.DataDir, "blockHeight", blockHeight)
+		"dataDir", dataDir, "blockHeight", blockHeight)
 	return nil
 }
 

--- a/sei-db/state_db/sc/hashvault/pebble_hashvault_rollback_test.go
+++ b/sei-db/state_db/sc/hashvault/pebble_hashvault_rollback_test.go
@@ -64,9 +64,8 @@ func TestHardRollbackPebbleHashVaultBelowPruneBoundaryWipesStore(t *testing.T) {
 }
 
 func TestHardRollbackPebbleHashVaultEqualToPruneBoundary(t *testing.T) {
-	// Rollback target == boundary is the boring case: DeleteRange's lower bound is
-	// hashKey(boundary + 1), so the boundary block itself is kept (consistent with Prune's
-	// "keep the boundary" contract) and the boundary record stays in place.
+	// Rollback target == boundary: hashes above the target are removed, the boundary block is kept,
+	// and the prune boundary record is cleared so commits below the old boundary are allowed again.
 	ctx := context.Background()
 	v := newTestPebbleVault(t)
 	require.NoError(t, v.Prune(ctx, 100))
@@ -78,8 +77,7 @@ func TestHardRollbackPebbleHashVaultEqualToPruneBoundary(t *testing.T) {
 	v2, err := NewUnsafePebbleHashVault(ctx, cfg)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = v2.Close(ctx) })
-	// Boundary survived, so a commit below 100 is still rejected.
-	require.ErrorIs(t, v2.CommitToHash(ctx, 50, bytesOfLen(0xAA, 32)), ErrBelowPruneBoundary)
+	require.NoError(t, v2.CommitToHash(ctx, 50, bytesOfLen(0xAA, 32)))
 }
 
 func TestHardRollbackPebbleHashVaultRejectsLockedDir(t *testing.T) {

--- a/sei-db/state_db/sc/hashvault/pebble_hashvault_rollback_test.go
+++ b/sei-db/state_db/sc/hashvault/pebble_hashvault_rollback_test.go
@@ -2,6 +2,7 @@ package hashvault
 
 import (
 	"context"
+	"math"
 	"path/filepath"
 	"testing"
 
@@ -105,6 +106,26 @@ func TestHardRollbackPebbleHashVaultRefusesMalformedBoundary(t *testing.T) {
 
 	err := HardRollbackPebbleHashVault(ctx, cfg, 100)
 	require.ErrorIs(t, err, ErrCorruption)
+}
+
+func TestHardRollbackPebbleHashVaultRejectsMaxUint64Height(t *testing.T) {
+	// blockHeight+1 must not be used for DeleteRange start keys: at MaxUint64 it wraps to 0 and
+	// would wipe the entire vault. Refuse rather than silently destroy data.
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+	require.NoError(t, v.CommitToHash(ctx, math.MaxUint64, bytesOfLen(0xFF, 32)))
+
+	cfg := v.config
+	require.NoError(t, v.Close(ctx))
+
+	err := HardRollbackPebbleHashVault(ctx, cfg, math.MaxUint64)
+	require.ErrorIs(t, err, ErrRollbackHeightOverflow)
+
+	v2, err := NewUnsafePebbleHashVault(ctx, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = v2.Close(ctx) })
+
+	require.ErrorIs(t, v2.CommitToHash(ctx, math.MaxUint64, bytesOfLen(0xEE, 32)), ErrHashMismatch)
 }
 
 func TestHardRollbackPebbleHashVaultRejectsMissingDir(t *testing.T) {

--- a/sei-db/state_db/sc/hashvault/pebble_hashvault_rollback_test.go
+++ b/sei-db/state_db/sc/hashvault/pebble_hashvault_rollback_test.go
@@ -1,0 +1,122 @@
+package hashvault
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHardRollbackPebbleHashVault covers the happy path: an existing commit at height 10 is
+// removed by rolling back to height 5; a fresh commit at 10 with a different hash then succeeds
+// and is itself locked in. The vault must be closed before invoking the static function (Pebble's
+// directory lock would otherwise refuse).
+func TestHardRollbackPebbleHashVault(t *testing.T) {
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+
+	a := bytesOfLen(0xAA, 32)
+	b := bytesOfLen(0xBB, 32)
+	require.NoError(t, v.CommitToHash(ctx, 10, a))
+
+	cfg := v.config
+	require.NoError(t, v.Close(ctx))
+
+	require.NoError(t, HardRollbackPebbleHashVault(ctx, cfg, 5))
+
+	v2, err := NewUnsafePebbleHashVault(ctx, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = v2.Close(ctx) })
+
+	require.NoError(t, v2.CommitToHash(ctx, 10, b))
+	require.ErrorIs(t, v2.CommitToHash(ctx, 10, a), ErrHashMismatch)
+}
+
+func TestHardRollbackPebbleHashVaultBelowPruneBoundaryWipesStore(t *testing.T) {
+	// When the rollback target is strictly below the boundary, "partial rollback" is incoherent:
+	// every surviving hash has height >= boundary > target, so there is no consistent state to
+	// preserve. The function wipes everything (hashes + boundary record) so the next boot looks
+	// like a freshly-initialized vault.
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+
+	for h := uint64(30); h <= 50; h++ {
+		require.NoError(t, v.CommitToHash(ctx, h, bytesOfLen(byte(h), 32)))
+	}
+	require.NoError(t, v.Prune(ctx, 30))
+
+	cfg := v.config
+	require.NoError(t, v.Close(ctx))
+
+	require.NoError(t, HardRollbackPebbleHashVault(ctx, cfg, 10))
+
+	v2, err := NewUnsafePebbleHashVault(ctx, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = v2.Close(ctx) })
+
+	// Boundary is gone, so commits below the old boundary are now accepted.
+	require.NoError(t, v2.CommitToHash(ctx, 5, bytesOfLen(0xCC, 32)))
+	// Every previously-locked hash is also gone — height 50 used to be 0x32, but the wipe means a
+	// fresh hash there is allowed.
+	require.NoError(t, v2.CommitToHash(ctx, 50, bytesOfLen(0xEE, 32)))
+}
+
+func TestHardRollbackPebbleHashVaultEqualToPruneBoundary(t *testing.T) {
+	// Rollback target == boundary is the boring case: DeleteRange's lower bound is
+	// hashKey(boundary + 1), so the boundary block itself is kept (consistent with Prune's
+	// "keep the boundary" contract) and the boundary record stays in place.
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+	require.NoError(t, v.Prune(ctx, 100))
+	cfg := v.config
+	require.NoError(t, v.Close(ctx))
+
+	require.NoError(t, HardRollbackPebbleHashVault(ctx, cfg, 100))
+
+	v2, err := NewUnsafePebbleHashVault(ctx, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = v2.Close(ctx) })
+	// Boundary survived, so a commit below 100 is still rejected.
+	require.ErrorIs(t, v2.CommitToHash(ctx, 50, bytesOfLen(0xAA, 32)), ErrBelowPruneBoundary)
+}
+
+func TestHardRollbackPebbleHashVaultRejectsLockedDir(t *testing.T) {
+	// Sanity check that the static function fails fast when a live vault still holds the Pebble
+	// directory lock — the whole point of being out-of-process is to make accidental concurrent
+	// use a clean error, not a silent corruption.
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+	cfg := v.config
+
+	err := HardRollbackPebbleHashVault(ctx, cfg, 5)
+	require.Error(t, err, "must refuse to open while the live vault holds the lock")
+}
+
+func TestHardRollbackPebbleHashVaultRefusesMalformedBoundary(t *testing.T) {
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+	cfg := v.config
+	require.NoError(t, v.Close(ctx))
+
+	// Plant a malformed boundary record so the function has to reject before performing any write.
+	directWritePebble(t, cfg.DataDir, func(db *pebble.DB) {
+		require.NoError(t, db.Set(pruneBoundaryKey, []byte{0x00, 0x01}, pebble.Sync))
+	})
+
+	err := HardRollbackPebbleHashVault(ctx, cfg, 100)
+	require.ErrorIs(t, err, ErrCorruption)
+}
+
+func TestHardRollbackPebbleHashVaultRejectsMissingDir(t *testing.T) {
+	ctx := context.Background()
+	cfg := DefaultHashVaultConfig()
+	// Point at a path that definitely doesn't exist; pebble.Open is the source of truth for the
+	// error here — we just want to verify the static function surfaces it rather than silently
+	// creating a fresh empty vault and pretending the rollback succeeded.
+	cfg.DataDir = filepath.Join(t.TempDir(), "does-not-exist", "vault")
+
+	err := HardRollbackPebbleHashVault(ctx, cfg, 5)
+	require.Error(t, err)
+}

--- a/sei-db/state_db/sc/hashvault/pebble_hashvault_test.go
+++ b/sei-db/state_db/sc/hashvault/pebble_hashvault_test.go
@@ -1,0 +1,338 @@
+package hashvault
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestPebbleVault constructs an unsafe Pebble vault rooted in t.TempDir() and arranges for it
+// to be closed at end-of-test.
+func newTestPebbleVault(t *testing.T, configMutators ...func(*HashVaultConfig)) *PebbleHashVault {
+	t.Helper()
+	cfg := DefaultHashVaultConfig()
+	cfg.DataDir = filepath.Join(t.TempDir(), "vault")
+	for _, m := range configMutators {
+		m(&cfg)
+	}
+	v, err := NewUnsafePebbleHashVault(context.Background(), cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = v.Close(context.Background())
+	})
+	return v
+}
+
+// reopenTestPebbleVault closes v then reopens a fresh PebbleHashVault at the same DataDir. The
+// returned vault is cleaned up at end-of-test.
+func reopenTestPebbleVault(t *testing.T, v *PebbleHashVault) *PebbleHashVault {
+	t.Helper()
+	dir := v.config.DataDir
+	require.NoError(t, v.Close(context.Background()))
+	cfg := DefaultHashVaultConfig()
+	cfg.DataDir = dir
+	reopened, err := NewUnsafePebbleHashVault(context.Background(), cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = reopened.Close(context.Background())
+	})
+	return reopened
+}
+
+// directWritePebble opens the Pebble dir at path, applies fn to the db, then closes. Used by
+// corruption tests to poke at on-disk values without going through the HashVault.
+func directWritePebble(t *testing.T, path string, fn func(*pebble.DB)) {
+	t.Helper()
+	db, err := pebble.Open(path, &pebble.Options{})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+	fn(db)
+}
+
+func TestRestartRecoversPruneBoundary(t *testing.T) {
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+
+	require.NoError(t, v.Prune(ctx, 50))
+	v2 := reopenTestPebbleVault(t, v)
+
+	// Strictly below the recovered boundary is rejected.
+	require.ErrorIs(t, v2.CommitToHash(ctx, 25, bytesOfLen(0xAA, 32)), ErrBelowPruneBoundary)
+	require.ErrorIs(t, v2.CommitToHash(ctx, 49, bytesOfLen(0xAA, 32)), ErrBelowPruneBoundary)
+	// At and above the boundary are allowed.
+	require.NoError(t, v2.CommitToHash(ctx, 50, bytesOfLen(0xAA, 32)))
+	require.NoError(t, v2.CommitToHash(ctx, 51, bytesOfLen(0xAA, 32)))
+}
+
+func TestRestartRecoversHashes(t *testing.T) {
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+
+	hash := bytesOfLen(0xCD, 32)
+	require.NoError(t, v.CommitToHash(ctx, 99, hash))
+
+	v2 := reopenTestPebbleVault(t, v)
+
+	// Re-commit the same hash: succeeds.
+	require.NoError(t, v2.CommitToHash(ctx, 99, hash))
+	// Different hash: locked out.
+	require.ErrorIs(t,
+		v2.CommitToHash(ctx, 99, bytesOfLen(0xFF, 32)),
+		ErrHashMismatch,
+	)
+}
+
+func TestPruneRemovesDataOnDisk(t *testing.T) {
+	// The shared suite already covers the externally-visible Prune contract; this test exists to
+	// pin the on-disk effect — i.e. that the deleted heights are actually gone from Pebble (and
+	// not merely shadowed by the in-memory boundary check).
+	ctx := context.Background()
+	const total = uint64(50)
+
+	v := newTestPebbleVault(t)
+	for h := uint64(1); h <= total; h++ {
+		require.NoError(t, v.CommitToHash(ctx, h, bytesOfLen(byte(h), 32)))
+	}
+
+	require.NoError(t, v.Prune(ctx, total))
+
+	dir := v.config.DataDir
+	require.NoError(t, v.Close(ctx))
+
+	var remaining []uint64
+	directWritePebble(t, dir, func(db *pebble.DB) {
+		iter, err := db.NewIter(&pebble.IterOptions{
+			LowerBound: hashKey(0),
+			UpperBound: hashKeyUpperBound(),
+		})
+		require.NoError(t, err)
+		defer func() { _ = iter.Close() }()
+		for iter.First(); iter.Valid(); iter.Next() {
+			h, err := decodeHashKey(iter.Key())
+			require.NoError(t, err)
+			remaining = append(remaining, h)
+		}
+	})
+	// Per the Prune contract the boundary block itself is kept, so only height==total should remain.
+	require.Equal(t, []uint64{total}, remaining,
+		"only the prune-boundary block should remain after Prune")
+}
+
+func TestKeyEncodingRoundtrip(t *testing.T) {
+	cases := []uint64{0, 1, 7, 1 << 30, 1<<63 - 1, ^uint64(0)}
+	for _, h := range cases {
+		k := hashKey(h)
+		require.Len(t, k, len(hashKeyPrefix)+heightDigits)
+		require.True(t, bytes.HasPrefix(k, hashKeyPrefix))
+		got, err := decodeHashKey(k)
+		require.NoError(t, err)
+		require.Equal(t, h, got)
+	}
+}
+
+func TestKeyEncodingOrderingMatchesNumeric(t *testing.T) {
+	// Spot-check that lex order over hashKey() matches numeric order, including non-adjacent
+	// magnitudes. This is the whole reason for zero-padded fixed-width encoding.
+	heights := []uint64{0, 1, 9, 10, 99, 100, 1<<32 - 1, 1 << 32, 1<<63 - 1, ^uint64(0) - 1, ^uint64(0)}
+	for i := 0; i+1 < len(heights); i++ {
+		a, b := hashKey(heights[i]), hashKey(heights[i+1])
+		require.Lessf(t, bytes.Compare(a, b), 0,
+			"hashKey(%d)=%q must sort before hashKey(%d)=%q", heights[i], a, heights[i+1], b)
+	}
+}
+
+func TestKeyEncodingHumanReadable(t *testing.T) {
+	// Pin the on-disk layout so a future "let's switch back to binary BE for size" PR has to
+	// explicitly delete this test.
+	require.Equal(t, "h00000000000000000042", string(hashKey(42)))
+	require.Equal(t, "h18446744073709551615", string(hashKey(^uint64(0))))
+}
+
+func TestDecodeHashKeyRejectsMalformed(t *testing.T) {
+	_, err := decodeHashKey([]byte("h0000000000000000004"))
+	require.ErrorIs(t, err, ErrCorruption, "short length")
+	_, err = decodeHashKey([]byte("x00000000000000000042"))
+	require.ErrorIs(t, err, ErrCorruption, "wrong prefix")
+	_, err = decodeHashKey([]byte("h0000000000000000004x"))
+	require.ErrorIs(t, err, ErrCorruption, "non-digit byte")
+}
+
+func TestValueCodecRoundtrip(t *testing.T) {
+	hash := bytesOfLen(0xAA, 32)
+	for _, h := range []uint64{0, 1, 7, 1 << 30, ^uint64(0)} {
+		raw := encodeHashValue(h, hash)
+		got, err := decodeHashValue(h, raw)
+		require.NoError(t, err)
+		require.Equal(t, hash, got)
+	}
+
+	for _, b := range []uint64{0, 1, 1234567890, ^uint64(0)} {
+		raw := encodeBoundaryValue(b)
+		got, err := decodeBoundaryValue(raw)
+		require.NoError(t, err)
+		require.Equal(t, b, got)
+	}
+}
+
+func TestBoundaryValueIsUnpaddedDecimal(t *testing.T) {
+	// Boundary encoding is variable-width by design (one row, no range scan to satisfy). Pin it
+	// so a future "let's pad for symmetry with keys" change has to explicitly delete this test.
+	require.Equal(t, "0", string(encodeBoundaryValue(0)))
+	require.Equal(t, "42", string(encodeBoundaryValue(42)))
+	require.Equal(t, "18446744073709551615", string(encodeBoundaryValue(^uint64(0))))
+}
+
+func TestDecodeBoundaryValueRejectsMalformed(t *testing.T) {
+	_, err := decodeBoundaryValue(nil)
+	require.ErrorIs(t, err, ErrCorruption, "empty")
+	_, err = decodeBoundaryValue([]byte{})
+	require.ErrorIs(t, err, ErrCorruption, "zero length")
+	_, err = decodeBoundaryValue([]byte("123abc"))
+	require.ErrorIs(t, err, ErrCorruption, "non-digit byte")
+	// 21 digits cannot fit in uint64.
+	_, err = decodeBoundaryValue([]byte("184467440737095516150"))
+	require.ErrorIs(t, err, ErrCorruption, "too long")
+}
+
+func TestValueCodecHeightTamper(t *testing.T) {
+	// The whole reason we feed the height into the SHA is to detect a value that was stored under
+	// a different key from the one we're now reading. Decoding under the wrong height MUST fail.
+	hash := bytesOfLen(0x77, 32)
+	raw := encodeHashValue(100, hash)
+	_, err := decodeHashValue(101, raw)
+	require.ErrorIs(t, err, ErrCorruption)
+}
+
+func TestValueCodecBitFlip(t *testing.T) {
+	hash := bytesOfLen(0x77, 32)
+	raw := encodeHashValue(100, hash)
+
+	// Flip one bit in every byte position and confirm each flip is caught.
+	for i := 0; i < len(raw); i++ {
+		corrupted := bytes.Clone(raw)
+		corrupted[i] ^= 0x01
+		_, err := decodeHashValue(100, corrupted)
+		require.ErrorIsf(t, err, ErrCorruption, "expected ErrCorruption at byte %d", i)
+	}
+}
+
+func TestValueCodecShortValue(t *testing.T) {
+	// A value shorter than the trailer can't carry a valid checksum.
+	for n := 0; n < checksumSize; n++ {
+		_, err := decodeHashValue(0, make([]byte, n))
+		require.ErrorIs(t, err, ErrCorruption)
+	}
+}
+
+func TestCommitDetectsDiskCorruption(t *testing.T) {
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+	hash := bytesOfLen(0xAA, 32)
+	require.NoError(t, v.CommitToHash(ctx, 42, hash))
+
+	dir := v.config.DataDir
+	require.NoError(t, v.Close(ctx))
+
+	// Flip one bit of the stored value via direct Pebble access.
+	directWritePebble(t, dir, func(db *pebble.DB) {
+		key := hashKey(42)
+		raw, closer, err := db.Get(key)
+		require.NoError(t, err)
+		corrupted := bytes.Clone(raw)
+		_ = closer.Close()
+		corrupted[0] ^= 0x01
+		require.NoError(t, db.Set(key, corrupted, pebble.Sync))
+	})
+
+	reopenCfg := DefaultHashVaultConfig()
+	reopenCfg.DataDir = dir
+	v2, err := NewUnsafePebbleHashVault(ctx, reopenCfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = v2.Close(ctx) })
+
+	err = v2.CommitToHash(ctx, 42, hash)
+	require.ErrorIs(t, err, ErrCorruption)
+}
+
+func TestStartupRejectsMalformedBoundary(t *testing.T) {
+	// The boundary value has no checksum (it's just GC bookkeeping), so a flipped byte is
+	// indistinguishable from a legitimately-written boundary and is accepted silently. The only
+	// failure mode startup still catches is a length mismatch, which indicates the record was
+	// truncated/extended outside Pebble's normal write path.
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+	require.NoError(t, v.Prune(ctx, 7))
+
+	dir := v.config.DataDir
+	require.NoError(t, v.Close(ctx))
+
+	directWritePebble(t, dir, func(db *pebble.DB) {
+		require.NoError(t, db.Set(pruneBoundaryKey, []byte{0x00, 0x01, 0x02}, pebble.Sync))
+	})
+
+	reopenCfg := DefaultHashVaultConfig()
+	reopenCfg.DataDir = dir
+	_, err := NewUnsafePebbleHashVault(ctx, reopenCfg)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrCorruption)
+}
+
+func TestProductionConstructorForcesFsync(t *testing.T) {
+	ctx := context.Background()
+	// Caller asks for no fsync, but the production constructor must override that.
+	cfg := DefaultHashVaultConfig()
+	cfg.DataDir = filepath.Join(t.TempDir(), "vault")
+	cfg.Fsync = false
+	v, err := NewPebbleHashVault(ctx, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = v.Close(ctx) })
+
+	require.True(t, v.config.Fsync, "NewPebbleHashVault must force Fsync=true")
+	require.Equal(t, pebble.Sync, v.writeOpts, "writeOpts must be pebble.Sync in production")
+}
+
+func TestUnsafeConstructorHonorsFsync(t *testing.T) {
+	ctx := context.Background()
+	cfg := DefaultHashVaultConfig()
+	cfg.DataDir = filepath.Join(t.TempDir(), "vault")
+	cfg.Fsync = false
+	v, err := NewUnsafePebbleHashVault(ctx, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = v.Close(ctx) })
+
+	require.False(t, v.config.Fsync)
+	require.Equal(t, pebble.NoSync, v.writeOpts)
+}
+
+func TestContextCancelledCommit(t *testing.T) {
+	// A pre-cancelled ctx must short-circuit before we touch any state. We don't otherwise check
+	// the ctx mid-operation (the work is all local, fast, and uninterruptible once started).
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	v := newTestPebbleVault(t)
+	err := v.CommitToHash(ctx, 1, bytesOfLen(0xAA, 32))
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// Cross-check: nothing in the production code accidentally panics on simultaneous Close+Commit.
+func TestCloseConcurrentWithCommits(t *testing.T) {
+	ctx := context.Background()
+	v := newTestPebbleVault(t)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func(h uint64) {
+			defer wg.Done()
+			_ = v.CommitToHash(ctx, h, bytesOfLen(byte(h), 32))
+		}(uint64(i + 1))
+	}
+	// Race Close against the commits.
+	_ = v.Close(ctx)
+	wg.Wait()
+}


### PR DESCRIPTION
## Describe your changes and provide context

Introduces a new storage micro-utility: the `HashVault`. Goal of this utility is to prevent any chain of events from causing a validator to change its mind about the app hash. No matter the circumstances, once a validator commits to an app hash, it should require direct human intervention to change that app hash.

This PR does not integrate the HashVault. In a follow up PR, the HashVault will be added to the `composite.Store`, which will not return app hashes until ensuring they are durable.

## Testing performed to validate your change

unit tests