### PR TITLE
fix(ci/nightly-ecr): role-duration-seconds 7200 → 3600

### DIFF
--- a/.github/workflows/nightly-ecr.yml
+++ b/.github/workflows/nightly-ecr.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::189176372795:role/common/gha
-          role-duration-seconds: 7200
+          role-duration-seconds: 3600
 
       - name: Login to Amazon ECR
         id: login-ecr


### PR DESCRIPTION
The nightly ECR build failed with:
```
Could not assume role with OIDC: The requested DurationSeconds exceeds the MaxSessionDuration set for this role.
```

The previous review bumped from 3600s to 7200s for cold-cache headroom, but `role/common/gha` has `MaxSessionDuration=3600s` (the IAM default). Two sequential Docker builds complete in ~15min on a warm cache, well under 1h. Reverting to 3600s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)