### PR TITLE
chore(ci/nightly-ecr): reschedule to 0 6 * * * (10pm PST)

### DIFF
--- a/.github/workflows/nightly-ecr.yml
+++ b/.github/workflows/nightly-ecr.yml
@@ -2,7 +2,7 @@ name: Nightly ECR
 
 on:
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 6 * * *'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Moves nightly ECR build to 06:00 UTC (10pm PST), 2 hours before harbor nightly test jobs at 08:00 UTC (midnight PST). 🤖