### PR TITLE
test(evm): wrap TransientStorageTest contracts with nonce-retry signer

### DIFF
--- a/contracts/test/TransientStorageTest.js
+++ b/contracts/test/TransientStorageTest.js
@@ -13,10 +13,16 @@ describe("Transient Storage Tests", function () {
         let signers = await ethers.getSigners();
         [owner, addr1, addr2] = await setupSigners(signers);
 
-        const TransientStorageTester = await ethers.getContractFactory("TransientStorageTester");
+        // Connect contracts to the retry-wrapped signer from setupSigners so
+        // deploys and method calls inherit the incorrect-account-sequence retry.
+        // Under Autobahn the pending-nonce read briefly lags a just-committed tx
+        // (rpc sharding routes the read to the sender's lane owner), so an
+        // ethers-managed send right after an awaited tx can hit a one-off nonce
+        // mismatch; the wrapper refetches and retries.
+        const TransientStorageTester = await ethers.getContractFactory("TransientStorageTester", owner.signer);
         transientStorageTester = await TransientStorageTester.deploy({ gasLimit: 10000000 });
 
-        const SnapshotRevertTester = await ethers.getContractFactory("SnapshotRevertTester");
+        const SnapshotRevertTester = await ethers.getContractFactory("SnapshotRevertTester", owner.signer);
         snapshotRevertTester = await SnapshotRevertTester.deploy({ gasLimit: 10000000 });
     });
 


### PR DESCRIPTION
## Summary

`contracts/test/TransientStorageTest.js` deployed and called its contracts through the contract factory's **default (unwrapped) signer**, bypassing the `incorrect-account-sequence` retry that `setupSigners` (`_wrapSignerWithNonceRetry`, #3482) installs on the test signers. This connects both contracts to `owner.signer` so deploys and all `runX()` method calls inherit the retry — matching how `ERC20toNativePointerTest` and the other pointer tests already work.

## Why it flakes (Autobahn only)

Under Autobahn, `eth_sendRawTransaction` and `eth_getTransactionCount("pending")` for a given sender are **proxied to that sender's lane owner** (rpc sharding, #3438). The lane owner's pending-nonce view can briefly lag a just-committed tx, so an ethers-managed send issued immediately after an awaited prior tx intermittently gets a too-low nonce and is rejected with `incorrect account sequence`. The wrapper refetches a fresh nonce and retries; the happy path is unaffected.

Observed on main (Autobahn EVM Interoperability), e.g. runs [26458615608](https://github.com/sei-protocol/sei-chain/actions/runs/26458615608) and [26475364459](https://github.com/sei-protocol/sei-chain/actions/runs/26475364459), failing at different `TransientStorageTest.js` cases — consistent with a file-wide unwrapped-signer gap. The non-Autobahn `EVM Interoperability` row passes the same code.

## Test plan

- [x] CI: Autobahn EVM Interoperability stays green across runs (this is the real verification venue — the exact race needs CI-scale inter-node skew and does not reproduce reliably on a single-host local cluster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)