### PR TITLE
test(flatkv): wait for catchup before partial-loss digest compare

### DIFF
--- a/integration_test/contracts/verify_flatkv_partial_loss_fails_loudly.sh
+++ b/integration_test/contracts/verify_flatkv_partial_loss_fails_loudly.sh
@@ -15,6 +15,14 @@ FLATKV_DIR=${FLATKV_DIR:-/root/.sei/data/state_commit/flatkv}
 GO_BIN=${GO_BIN:-/usr/local/go/bin/go}
 RESTART_OBSERVE_SECS=${FLATKV_PARTIAL_LOSS_RESTART_OBSERVE_SECS:-20}
 COMPARE_BUFFER=${FLATKV_PARTIAL_LOSS_COMPARE_BUFFER:-2}
+# Cap on how long we wait for the victim to catch up to the other validators
+# before comparing FlatKV digests. The dump-flatkv tool clones a snapshot +
+# WAL into a temp dir and only retries a small number of times if a live
+# writer rolls a new snapshot and truncates the WAL mid-clone; running the
+# digest comparison while the victim is still actively blocksyncing
+# reliably loses that race on busy CI runners.
+CATCHUP_TIMEOUT=${FLATKV_PARTIAL_LOSS_CATCHUP_TIMEOUT:-240}
+CATCHUP_TOLERANCE=${FLATKV_PARTIAL_LOSS_CATCHUP_TOLERANCE:-10}
 
 echo "verify_flatkv_partial_loss_fails_loudly: victim=$VICTIM_NODE flatkv_dir=$FLATKV_DIR"
 
@@ -40,6 +48,55 @@ node_height() {
   docker exec "$node" build/seid status 2>/dev/null \
     | jq -r '.SyncInfo.latest_block_height // "0"' 2>/dev/null \
     || echo 0
+}
+
+# wait_for_catchup polls until the victim's height is within $tolerance of the
+# maximum height across the other (non-victim) validators, or until $timeout
+# seconds elapse. This must run before dump-flatkv: while the victim is
+# blocksyncing it rolls new FlatKV snapshots and truncates the WAL, which the
+# dump tool can only ride out for a small fixed number of retries before
+# panicking with "source kept churning".
+wait_for_catchup() {
+  local victim=$1
+  local timeout=$2
+  local tolerance=$3
+  local elapsed=0
+  while [ "$elapsed" -lt "$timeout" ]; do
+    local max_other_h=0 victim_h gap
+    for i in $(seq 0 $((NODE_COUNT - 1))); do
+      if [ "$i" = "$VICTIM_INDEX" ]; then
+        continue
+      fi
+      local h
+      h=$(node_height "sei-node-$i")
+      if [ "$h" -gt "$max_other_h" ]; then
+        max_other_h=$h
+      fi
+    done
+    victim_h=$(node_height "$victim")
+    gap=$((max_other_h - victim_h))
+    if [ "$victim_h" -gt 0 ] && [ "$gap" -le "$tolerance" ]; then
+      echo "$victim caught up: others_max=$max_other_h victim=$victim_h gap=$gap"
+      return 0
+    fi
+    echo "Waiting for $victim to catch up: others_max=$max_other_h victim=$victim_h gap=$gap (elapsed=${elapsed}s/${timeout}s)"
+    sleep 5
+    elapsed=$((elapsed + 5))
+  done
+  echo "ERROR: $victim failed to catch up within ${timeout}s" >&2
+  echo "Height snapshot at timeout:" >&2
+  for i in $(seq 0 $((NODE_COUNT - 1))); do
+    local node h
+    node="sei-node-$i"
+    h=$(node_height "$node")
+    if [ "$i" = "$VICTIM_INDEX" ]; then
+      echo "  $node (victim): $h" >&2
+    else
+      echo "  $node: $h" >&2
+    fi
+  done
+  dump_node_log "$victim"
+  return 1
 }
 
 ensure_seidb() {
@@ -165,6 +222,11 @@ if ! docker exec "$VICTIM_NODE" build/seid status >/dev/null 2>&1; then
   dump_node_log "$VICTIM_NODE"
   exit 1
 fi
+
+# Wait for the victim to catch up before dumping FlatKV; see CATCHUP_TIMEOUT
+# comment at the top of this script for why running dump-flatkv against an
+# actively-syncing node is unreliable.
+wait_for_catchup "$VICTIM_NODE" "$CATCHUP_TIMEOUT" "$CATCHUP_TOLERANCE"
 
 assert_flatkv_digests_match
 echo "PASS: $VICTIM_NODE self-healed after FlatKV-only loss and matches FlatKV digests"


### PR DESCRIPTION
The dump-flatkv tool clones a snapshot + WAL into a temp dir and only retries 3 times if a live writer rolls a new snapshot and truncates the WAL mid-clone. Running the digest comparison right after a 20s sleep while the victim is still blocksyncing reliably loses that race on busy CI runners, panicking with "source kept churning".

- increase default catchup timeout/tolerance
- print per-node heights on catchup timeout for diagnosis

## Describe your changes and provide context

## Testing performed to validate your change

