### PR TITLE
feat(mempool): observability for the TxMempool rewrite invariants

### DIFF
--- a/sei-tendermint/internal/mempool/mempool.go
+++ b/sei-tendermint/internal/mempool/mempool.go
@@ -397,7 +397,6 @@ func (txmp *TxMempool) CheckTx(ctx context.Context, tx types.Tx) (*abci.Response
 	txmp.metrics.Size.Set(float64(txmp.NumTxsNotPending()))
 	txmp.metrics.PendingSize.Set(float64(txmp.PendingSize()))
 	txmp.metrics.TotalTxsSizeBytes.Set(float64(txmp.TotalTxsBytesSize()))
-	txmp.metrics.Utilisation.Set(txmp.utilisation())
 
 	txmp.notifyTxsAvailable()
 	return res.ResponseCheckTx, nil
@@ -413,7 +412,6 @@ func (txmp *TxMempool) Flush() {
 	txmp.metrics.Size.Set(0)
 	txmp.metrics.PendingSize.Set(0)
 	txmp.metrics.TotalTxsSizeBytes.Set(0)
-	txmp.metrics.Utilisation.Set(0)
 }
 
 // ReapTxs returns a list of transactions within the provided constraints and their total gas estimate.
@@ -434,7 +432,6 @@ func (txmp *TxMempool) ReapTxs(limits ReapLimits, remove bool) (types.Txs, int64
 		txmp.metrics.Size.Set(float64(txmp.NumTxsNotPending()))
 		txmp.metrics.PendingSize.Set(float64(txmp.PendingSize()))
 		txmp.metrics.TotalTxsSizeBytes.Set(float64(txmp.TotalTxsBytesSize()))
-		txmp.metrics.Utilisation.Set(txmp.utilisation())
 	}
 	return txs, gasEstimate
 }
@@ -499,7 +496,6 @@ func (txmp *TxMempool) Update(
 	txmp.metrics.Size.Set(float64(txmp.NumTxsNotPending()))
 	txmp.metrics.TotalTxsSizeBytes.Set(float64(txmp.TotalTxsBytesSize()))
 	txmp.metrics.PendingSize.Set(float64(txmp.PendingSize()))
-	txmp.metrics.Utilisation.Set(txmp.utilisation())
 	return nil
 }
 

--- a/sei-tendermint/internal/mempool/mempool.go
+++ b/sei-tendermint/internal/mempool/mempool.go
@@ -410,6 +410,10 @@ func (txmp *TxMempool) SafeGetTxsForHashes(txHashes []types.TxHash) (types.Txs, 
 // Flush empties the mempool.
 func (txmp *TxMempool) Flush() {
 	txmp.txStore.Clear()
+	txmp.metrics.Size.Set(0)
+	txmp.metrics.PendingSize.Set(0)
+	txmp.metrics.TotalTxsSizeBytes.Set(0)
+	txmp.metrics.Utilisation.Set(0)
 }
 
 // ReapTxs returns a list of transactions within the provided constraints and their total gas estimate.
@@ -425,7 +429,14 @@ func (txmp *TxMempool) Flush() {
 // NOTE: Transactions are removed from the mempool iff remove == true.
 // Either way, the transactions stay in the LRU cache.
 func (txmp *TxMempool) ReapTxs(limits ReapLimits, remove bool) (types.Txs, int64) {
-	return txmp.txStore.Reap(limits, remove)
+	txs, gasEstimate := txmp.txStore.Reap(limits, remove)
+	if remove {
+		txmp.metrics.Size.Set(float64(txmp.NumTxsNotPending()))
+		txmp.metrics.PendingSize.Set(float64(txmp.PendingSize()))
+		txmp.metrics.TotalTxsSizeBytes.Set(float64(txmp.TotalTxsBytesSize()))
+		txmp.metrics.Utilisation.Set(txmp.utilisation())
+	}
+	return txs, gasEstimate
 }
 
 // Update iterates over all the transactions provided by the block producer,

--- a/sei-tendermint/internal/mempool/mempool.go
+++ b/sei-tendermint/internal/mempool/mempool.go
@@ -397,6 +397,7 @@ func (txmp *TxMempool) CheckTx(ctx context.Context, tx types.Tx) (*abci.Response
 	txmp.metrics.Size.Set(float64(txmp.NumTxsNotPending()))
 	txmp.metrics.PendingSize.Set(float64(txmp.PendingSize()))
 	txmp.metrics.TotalTxsSizeBytes.Set(float64(txmp.TotalTxsBytesSize()))
+	txmp.metrics.Utilisation.Set(txmp.utilisation())
 
 	txmp.notifyTxsAvailable()
 	return res.ResponseCheckTx, nil
@@ -487,6 +488,7 @@ func (txmp *TxMempool) Update(
 	txmp.metrics.Size.Set(float64(txmp.NumTxsNotPending()))
 	txmp.metrics.TotalTxsSizeBytes.Set(float64(txmp.TotalTxsBytesSize()))
 	txmp.metrics.PendingSize.Set(float64(txmp.PendingSize()))
+	txmp.metrics.Utilisation.Set(txmp.utilisation())
 	return nil
 }
 

--- a/sei-tendermint/internal/mempool/metrics.gen.go
+++ b/sei-tendermint/internal/mempool/metrics.gen.go
@@ -152,13 +152,13 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "compact_total",
-			Help:      "CompactTotal counts invocations of the txStore compact path, labeled by the triggering call site. trigger=insert_overflow fires when Insert pushes total past hardLimit; trigger=update fires on every Update recompute pass; trigger=reap fires when Reap is called with remove=true. Rate of trigger=insert_overflow is the capacity-pressure signal.",
+			Help:      "Number of compact() invocations, labeled by call site (insert_overflow, update, reap).",
 		}, append(labels, "trigger")).With(labelsAndValues...),
 		CompactDurationSeconds: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "compact_duration_seconds",
-			Help:      "CompactDurationSeconds observes wall-clock duration of compact() — which re-sorts the mempool in priority order and rebuilds the byHash/byNonce indices. Complexity is O(m log m) over the full mempool, so the upper buckets accommodate large mempools (100k entries → 1-3s typical, 5-10s under GC pressure; +20s and +30s preserve quantile signal past that).",
+			Help:      "Wall-clock duration of compact(), which re-sorts and rebuilds indices over the full mempool (O(m log m)).",
 
 			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30},
 		}, labels).With(labelsAndValues...),
@@ -166,7 +166,7 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "promotion_total",
-			Help:      "PromotionTotal counts pending-to-ready transitions, labeled by the transaction lane that promoted (tx_type=evm — counted once per EVM nonce advance in the inline promotion loop in txStore.insert). Cosmos txs are auto-ready on insert and not counted here; future cosmos-side counts would add tx_type=cosmos without renaming.",
+			Help:      "Number of pending-to-ready transitions, labeled by tx_type. Cosmos txs are auto-ready on insert and not counted.",
 		}, append(labels, "tx_type")).With(labelsAndValues...),
 	}
 }

--- a/sei-tendermint/internal/mempool/metrics.gen.go
+++ b/sei-tendermint/internal/mempool/metrics.gen.go
@@ -148,26 +148,6 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "check_tx_met_drop_utilisation_threshold",
 			Help:      "CheckTxMetDropUtilisationThreshold is the number of transactions for which CheckTx was executed while the mempool utilisation was above the configured threshold. Note that not all such transactions are dropped, only those that also have a low priority.",
 		}, labels).With(labelsAndValues...),
-		CompactTotal: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: MetricsSubsystem,
-			Name:      "compact_total",
-			Help:      "Number of compact() invocations, labeled by call site (insert_overflow, update, reap).",
-		}, append(labels, "trigger")).With(labelsAndValues...),
-		CompactDurationSeconds: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
-			Namespace: namespace,
-			Subsystem: MetricsSubsystem,
-			Name:      "compact_duration_seconds",
-			Help:      "Wall-clock duration of compact(), which re-sorts and rebuilds indices over the full mempool (O(m log m)).",
-
-			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30},
-		}, labels).With(labelsAndValues...),
-		PromotionTotal: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: MetricsSubsystem,
-			Name:      "promotion_total",
-			Help:      "Number of pending-to-ready transitions, labeled by tx_type. Cosmos txs are auto-ready on insert and not counted.",
-		}, append(labels, "tx_type")).With(labelsAndValues...),
 	}
 }
 
@@ -195,8 +175,5 @@ func NopMetrics() *Metrics {
 		CheckTxPriorityDistribution:        discard.NewHistogram(),
 		CheckTxDroppedByPriorityHint:       discard.NewCounter(),
 		CheckTxMetDropUtilisationThreshold: discard.NewCounter(),
-		CompactTotal:                       discard.NewCounter(),
-		CompactDurationSeconds:             discard.NewHistogram(),
-		PromotionTotal:                     discard.NewCounter(),
 	}
 }

--- a/sei-tendermint/internal/mempool/metrics.gen.go
+++ b/sei-tendermint/internal/mempool/metrics.gen.go
@@ -148,6 +148,32 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "check_tx_met_drop_utilisation_threshold",
 			Help:      "CheckTxMetDropUtilisationThreshold is the number of transactions for which CheckTx was executed while the mempool utilisation was above the configured threshold. Note that not all such transactions are dropped, only those that also have a low priority.",
 		}, labels).With(labelsAndValues...),
+		CompactTotal: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "compact_total",
+			Help:      "CompactTotal counts invocations of the txStore compact path, labeled by the triggering call site. reason=insert_overflow fires when Insert pushes total past hardLimit; reason=update fires on every Update recompute pass; reason=reap fires when Reap is called with remove=true. Rate of reason=insert_overflow is the capacity-pressure signal.",
+		}, append(labels, "reason")).With(labelsAndValues...),
+		CompactDurationSeconds: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "compact_duration_seconds",
+			Help:      "CompactDurationSeconds observes wall-clock duration of compact() — which re-sorts the mempool in priority order and rebuilds the byHash/byNonce indices. Complexity is O(m log m) over the full mempool, so the upper buckets must accommodate large mempools (100k entries → 1-3s typical, 5-10s under GC pressure).",
+
+			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		}, labels).With(labelsAndValues...),
+		PromotionTotal: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "promotion_total",
+			Help:      "PromotionTotal counts pending-to-ready transitions. Incremented once per nonce advance inside the inline promotion loop in txStore.insert (EVM path). Cosmos txs are auto-ready on insert and are not counted.",
+		}, labels).With(labelsAndValues...),
+		Utilisation: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "utilisation",
+			Help:      "Utilisation mirrors the same ratio the CheckTx drop gate evaluates: total count / (cfg.Size + cfg.PendingSize). Exposed as a gauge so recording rules don't need to re-derive it from Size+PendingSize.",
+		}, labels).With(labelsAndValues...),
 	}
 }
 
@@ -175,5 +201,9 @@ func NopMetrics() *Metrics {
 		CheckTxPriorityDistribution:        discard.NewHistogram(),
 		CheckTxDroppedByPriorityHint:       discard.NewCounter(),
 		CheckTxMetDropUtilisationThreshold: discard.NewCounter(),
+		CompactTotal:                       discard.NewCounter(),
+		CompactDurationSeconds:             discard.NewHistogram(),
+		PromotionTotal:                     discard.NewCounter(),
+		Utilisation:                        discard.NewGauge(),
 	}
 }

--- a/sei-tendermint/internal/mempool/metrics.gen.go
+++ b/sei-tendermint/internal/mempool/metrics.gen.go
@@ -152,22 +152,22 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "compact_total",
-			Help:      "CompactTotal counts invocations of the txStore compact path, labeled by the triggering call site. reason=insert_overflow fires when Insert pushes total past hardLimit; reason=update fires on every Update recompute pass; reason=reap fires when Reap is called with remove=true. Rate of reason=insert_overflow is the capacity-pressure signal.",
-		}, append(labels, "reason")).With(labelsAndValues...),
+			Help:      "CompactTotal counts invocations of the txStore compact path, labeled by the triggering call site. trigger=insert_overflow fires when Insert pushes total past hardLimit; trigger=update fires on every Update recompute pass; trigger=reap fires when Reap is called with remove=true. Rate of trigger=insert_overflow is the capacity-pressure signal.",
+		}, append(labels, "trigger")).With(labelsAndValues...),
 		CompactDurationSeconds: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "compact_duration_seconds",
-			Help:      "CompactDurationSeconds observes wall-clock duration of compact() — which re-sorts the mempool in priority order and rebuilds the byHash/byNonce indices. Complexity is O(m log m) over the full mempool, so the upper buckets must accommodate large mempools (100k entries → 1-3s typical, 5-10s under GC pressure).",
+			Help:      "CompactDurationSeconds observes wall-clock duration of compact() — which re-sorts the mempool in priority order and rebuilds the byHash/byNonce indices. Complexity is O(m log m) over the full mempool, so the upper buckets accommodate large mempools (100k entries → 1-3s typical, 5-10s under GC pressure; +20s and +30s preserve quantile signal past that).",
 
-			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30},
 		}, labels).With(labelsAndValues...),
 		PromotionTotal: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "promotion_total",
-			Help:      "PromotionTotal counts pending-to-ready transitions. Incremented once per nonce advance inside the inline promotion loop in txStore.insert (EVM path). Cosmos txs are auto-ready on insert and are not counted.",
-		}, labels).With(labelsAndValues...),
+			Help:      "PromotionTotal counts pending-to-ready transitions, labeled by the transaction lane that promoted (tx_type=evm — counted once per EVM nonce advance in the inline promotion loop in txStore.insert). Cosmos txs are auto-ready on insert and not counted here; future cosmos-side counts would add tx_type=cosmos without renaming.",
+		}, append(labels, "tx_type")).With(labelsAndValues...),
 		Utilisation: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,

--- a/sei-tendermint/internal/mempool/metrics.gen.go
+++ b/sei-tendermint/internal/mempool/metrics.gen.go
@@ -168,12 +168,6 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "promotion_total",
 			Help:      "PromotionTotal counts pending-to-ready transitions, labeled by the transaction lane that promoted (tx_type=evm — counted once per EVM nonce advance in the inline promotion loop in txStore.insert). Cosmos txs are auto-ready on insert and not counted here; future cosmos-side counts would add tx_type=cosmos without renaming.",
 		}, append(labels, "tx_type")).With(labelsAndValues...),
-		Utilisation: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: MetricsSubsystem,
-			Name:      "utilisation",
-			Help:      "Utilisation mirrors the same ratio the CheckTx drop gate evaluates: total count / (cfg.Size + cfg.PendingSize). Exposed as a gauge so recording rules don't need to re-derive it from Size+PendingSize.",
-		}, labels).With(labelsAndValues...),
 	}
 }
 
@@ -204,6 +198,5 @@ func NopMetrics() *Metrics {
 		CompactTotal:                       discard.NewCounter(),
 		CompactDurationSeconds:             discard.NewHistogram(),
 		PromotionTotal:                     discard.NewCounter(),
-		Utilisation:                        discard.NewGauge(),
 	}
 }

--- a/sei-tendermint/internal/mempool/metrics.go
+++ b/sei-tendermint/internal/mempool/metrics.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 
 	"github.com/go-kit/kit/metrics"
+	stdprometheus "github.com/prometheus/client_golang/prometheus"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -24,15 +26,15 @@ var (
 		compactTotal           metric.Int64Counter
 		compactDurationSeconds metric.Float64Histogram
 	}{
-		compactTotal: must(mempoolMeter.Int64Counter(
+		compactTotal: utils.OrPanic1(mempoolMeter.Int64Counter(
 			"tendermint_mempool_compact_total",
 			metric.WithDescription("Number of compact() invocations, labeled by call site (insert_overflow, update, reap)."),
 		)),
-		compactDurationSeconds: must(mempoolMeter.Float64Histogram(
+		compactDurationSeconds: utils.OrPanic1(mempoolMeter.Float64Histogram(
 			"tendermint_mempool_compact_duration_seconds",
 			metric.WithDescription("Wall-clock duration of compact(), which re-sorts and rebuilds indices over the full mempool (O(m log m))."),
 			metric.WithUnit("s"),
-			metric.WithExplicitBucketBoundaries(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30),
+			metric.WithExplicitBucketBoundaries(stdprometheus.ExponentialBucketsRange(0.001, 30, 14)...),
 		)),
 	}
 
@@ -40,13 +42,6 @@ var (
 	triggerUpdateAttr         = metric.WithAttributes(attribute.String("trigger", "update"))
 	triggerReapAttr           = metric.WithAttributes(attribute.String("trigger", "reap"))
 )
-
-func must[V any](v V, err error) V {
-	if err != nil {
-		panic(err)
-	}
-	return v
-}
 
 //go:generate go run ../../scripts/metricsgen -struct=Metrics
 

--- a/sei-tendermint/internal/mempool/metrics.go
+++ b/sei-tendermint/internal/mempool/metrics.go
@@ -113,25 +113,16 @@ type Metrics struct {
 	// utilisation was above the configured threshold. Note that not all such transactions are dropped, only those that also have a low priority.
 	CheckTxMetDropUtilisationThreshold metrics.Counter
 
-	// CompactTotal counts invocations of the txStore compact path, labeled by
-	// the triggering call site. trigger=insert_overflow fires when Insert pushes
-	// total past hardLimit; trigger=update fires on every Update recompute
-	// pass; trigger=reap fires when Reap is called with remove=true. Rate of
-	// trigger=insert_overflow is the capacity-pressure signal.
+	// Number of compact() invocations, labeled by call site
+	// (insert_overflow, update, reap).
 	CompactTotal metrics.Counter `metrics_labels:"trigger"`
 
-	// CompactDurationSeconds observes wall-clock duration of compact() — which
-	// re-sorts the mempool in priority order and rebuilds the byHash/byNonce
-	// indices. Complexity is O(m log m) over the full mempool, so the upper
-	// buckets accommodate large mempools (100k entries → 1-3s typical, 5-10s
-	// under GC pressure; +20s and +30s preserve quantile signal past that).
+	// Wall-clock duration of compact(), which re-sorts and rebuilds indices
+	// over the full mempool (O(m log m)).
 	CompactDurationSeconds metrics.Histogram `metrics_bucketsizes:"0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30"`
 
-	// PromotionTotal counts pending-to-ready transitions, labeled by the
-	// transaction lane that promoted (tx_type=evm — counted once per EVM nonce
-	// advance in the inline promotion loop in txStore.insert). Cosmos txs are
-	// auto-ready on insert and not counted here; future cosmos-side counts
-	// would add tx_type=cosmos without renaming.
+	// Number of pending-to-ready transitions, labeled by tx_type.
+	// Cosmos txs are auto-ready on insert and not counted.
 	PromotionTotal metrics.Counter `metrics_labels:"tx_type"`
 }
 

--- a/sei-tendermint/internal/mempool/metrics.go
+++ b/sei-tendermint/internal/mempool/metrics.go
@@ -6,22 +6,58 @@ import (
 
 	"github.com/go-kit/kit/metrics"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 )
 
 const (
 	// MetricsSubsystem is a subsystem shared by all metrics exposed by this
 	// package.
 	MetricsSubsystem = "mempool"
-
-	labelTrigger = "trigger"
-	labelTxType  = "tx_type"
-
-	triggerInsertOverflow = "insert_overflow"
-	triggerUpdate         = "update"
-	triggerReap           = "reap"
-
-	txTypeEVM = "evm"
 )
+
+// New metrics for the TxMempool rewrite are emitted via OpenTelemetry rather
+// than go-kit; go-kit is unmaintained and OTel is the strategic direction
+// across the sei-protocol monorepo (sei-db has been on OTel for some time).
+// The existing 22 Metrics fields above remain go-kit until a follow-up PR
+// migrates the whole package.
+var (
+	mempoolMeter = otel.Meter("tendermint_mempool")
+
+	otelMetrics = struct {
+		compactTotal           metric.Int64Counter
+		compactDurationSeconds metric.Float64Histogram
+		promotionTotal         metric.Int64Counter
+	}{
+		compactTotal: must(mempoolMeter.Int64Counter(
+			"compact_total",
+			metric.WithDescription("Number of compact() invocations, labeled by call site (insert_overflow, update, reap)."),
+		)),
+		compactDurationSeconds: must(mempoolMeter.Float64Histogram(
+			"compact_duration_seconds",
+			metric.WithDescription("Wall-clock duration of compact(), which re-sorts and rebuilds indices over the full mempool (O(m log m))."),
+			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30),
+		)),
+		promotionTotal: must(mempoolMeter.Int64Counter(
+			"promotion_total",
+			metric.WithDescription("Number of pending-to-ready transitions, labeled by tx_type. Cosmos txs are auto-ready on insert and not counted."),
+		)),
+	}
+
+	triggerInsertOverflowAttr = metric.WithAttributes(attribute.String("trigger", "insert_overflow"))
+	triggerUpdateAttr         = metric.WithAttributes(attribute.String("trigger", "update"))
+	triggerReapAttr           = metric.WithAttributes(attribute.String("trigger", "reap"))
+	txTypeEVMAttr             = metric.WithAttributes(attribute.String("tx_type", "evm"))
+)
+
+func must[V any](v V, err error) V {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
 
 //go:generate go run ../../scripts/metricsgen -struct=Metrics
 
@@ -112,18 +148,6 @@ type Metrics struct {
 	// CheckTxMetDropUtilisationThreshold is the number of transactions for which CheckTx was executed while the mempool
 	// utilisation was above the configured threshold. Note that not all such transactions are dropped, only those that also have a low priority.
 	CheckTxMetDropUtilisationThreshold metrics.Counter
-
-	// Number of compact() invocations, labeled by call site
-	// (insert_overflow, update, reap).
-	CompactTotal metrics.Counter `metrics_labels:"trigger"`
-
-	// Wall-clock duration of compact(), which re-sorts and rebuilds indices
-	// over the full mempool (O(m log m)).
-	CompactDurationSeconds metrics.Histogram `metrics_bucketsizes:"0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30"`
-
-	// Number of pending-to-ready transitions, labeled by tx_type.
-	// Cosmos txs are auto-ready on insert and not counted.
-	PromotionTotal metrics.Counter `metrics_labels:"tx_type"`
 }
 
 func (m *Metrics) observeCheckTxPriorityDistribution(priority int64, hint bool, senderNodeID types.NodeID, isError bool) {

--- a/sei-tendermint/internal/mempool/metrics.go
+++ b/sei-tendermint/internal/mempool/metrics.go
@@ -28,7 +28,6 @@ var (
 	otelMetrics = struct {
 		compactTotal           metric.Int64Counter
 		compactDurationSeconds metric.Float64Histogram
-		promotionTotal         metric.Int64Counter
 	}{
 		compactTotal: must(mempoolMeter.Int64Counter(
 			"compact_total",
@@ -40,16 +39,11 @@ var (
 			metric.WithUnit("s"),
 			metric.WithExplicitBucketBoundaries(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30),
 		)),
-		promotionTotal: must(mempoolMeter.Int64Counter(
-			"promotion_total",
-			metric.WithDescription("Number of pending-to-ready transitions, labeled by tx_type. Cosmos txs are auto-ready on insert and not counted."),
-		)),
 	}
 
 	triggerInsertOverflowAttr = metric.WithAttributes(attribute.String("trigger", "insert_overflow"))
 	triggerUpdateAttr         = metric.WithAttributes(attribute.String("trigger", "update"))
 	triggerReapAttr           = metric.WithAttributes(attribute.String("trigger", "reap"))
-	txTypeEVMAttr             = metric.WithAttributes(attribute.String("tx_type", "evm"))
 )
 
 func must[V any](v V, err error) V {

--- a/sei-tendermint/internal/mempool/metrics.go
+++ b/sei-tendermint/internal/mempool/metrics.go
@@ -17,11 +17,6 @@ const (
 	MetricsSubsystem = "mempool"
 )
 
-// New metrics for the TxMempool rewrite are emitted via OpenTelemetry rather
-// than go-kit; go-kit is unmaintained and OTel is the strategic direction
-// across the sei-protocol monorepo (sei-db has been on OTel for some time).
-// The existing 22 Metrics fields above remain go-kit until a follow-up PR
-// migrates the whole package.
 var (
 	mempoolMeter = otel.Meter("tendermint_mempool")
 

--- a/sei-tendermint/internal/mempool/metrics.go
+++ b/sei-tendermint/internal/mempool/metrics.go
@@ -103,6 +103,30 @@ type Metrics struct {
 	// CheckTxMetDropUtilisationThreshold is the number of transactions for which CheckTx was executed while the mempool
 	// utilisation was above the configured threshold. Note that not all such transactions are dropped, only those that also have a low priority.
 	CheckTxMetDropUtilisationThreshold metrics.Counter
+
+	// CompactTotal counts invocations of the txStore compact path, labeled by the
+	// triggering call site. reason=insert_overflow fires when Insert pushes total
+	// past hardLimit; reason=update fires on every Update recompute pass;
+	// reason=reap fires when Reap is called with remove=true. Rate of
+	// reason=insert_overflow is the capacity-pressure signal.
+	CompactTotal metrics.Counter `metrics_labels:"reason"`
+
+	// CompactDurationSeconds observes wall-clock duration of compact() — which
+	// re-sorts the mempool in priority order and rebuilds the byHash/byNonce
+	// indices. Complexity is O(m log m) over the full mempool, so the upper
+	// buckets must accommodate large mempools (100k entries → 1-3s typical,
+	// 5-10s under GC pressure).
+	CompactDurationSeconds metrics.Histogram `metrics_bucketsizes:"0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10"`
+
+	// PromotionTotal counts pending-to-ready transitions. Incremented once per
+	// nonce advance inside the inline promotion loop in txStore.insert (EVM
+	// path). Cosmos txs are auto-ready on insert and are not counted.
+	PromotionTotal metrics.Counter
+
+	// Utilisation mirrors the same ratio the CheckTx drop gate evaluates:
+	// total count / (cfg.Size + cfg.PendingSize). Exposed as a gauge so
+	// recording rules don't need to re-derive it from Size+PendingSize.
+	Utilisation metrics.Gauge
 }
 
 func (m *Metrics) observeCheckTxPriorityDistribution(priority int64, hint bool, senderNodeID types.NodeID, isError bool) {

--- a/sei-tendermint/internal/mempool/metrics.go
+++ b/sei-tendermint/internal/mempool/metrics.go
@@ -104,24 +104,26 @@ type Metrics struct {
 	// utilisation was above the configured threshold. Note that not all such transactions are dropped, only those that also have a low priority.
 	CheckTxMetDropUtilisationThreshold metrics.Counter
 
-	// CompactTotal counts invocations of the txStore compact path, labeled by the
-	// triggering call site. reason=insert_overflow fires when Insert pushes total
-	// past hardLimit; reason=update fires on every Update recompute pass;
-	// reason=reap fires when Reap is called with remove=true. Rate of
-	// reason=insert_overflow is the capacity-pressure signal.
-	CompactTotal metrics.Counter `metrics_labels:"reason"`
+	// CompactTotal counts invocations of the txStore compact path, labeled by
+	// the triggering call site. trigger=insert_overflow fires when Insert pushes
+	// total past hardLimit; trigger=update fires on every Update recompute
+	// pass; trigger=reap fires when Reap is called with remove=true. Rate of
+	// trigger=insert_overflow is the capacity-pressure signal.
+	CompactTotal metrics.Counter `metrics_labels:"trigger"`
 
 	// CompactDurationSeconds observes wall-clock duration of compact() — which
 	// re-sorts the mempool in priority order and rebuilds the byHash/byNonce
 	// indices. Complexity is O(m log m) over the full mempool, so the upper
-	// buckets must accommodate large mempools (100k entries → 1-3s typical,
-	// 5-10s under GC pressure).
-	CompactDurationSeconds metrics.Histogram `metrics_bucketsizes:"0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10"`
+	// buckets accommodate large mempools (100k entries → 1-3s typical, 5-10s
+	// under GC pressure; +20s and +30s preserve quantile signal past that).
+	CompactDurationSeconds metrics.Histogram `metrics_bucketsizes:"0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30"`
 
-	// PromotionTotal counts pending-to-ready transitions. Incremented once per
-	// nonce advance inside the inline promotion loop in txStore.insert (EVM
-	// path). Cosmos txs are auto-ready on insert and are not counted.
-	PromotionTotal metrics.Counter
+	// PromotionTotal counts pending-to-ready transitions, labeled by the
+	// transaction lane that promoted (tx_type=evm — counted once per EVM nonce
+	// advance in the inline promotion loop in txStore.insert). Cosmos txs are
+	// auto-ready on insert and not counted here; future cosmos-side counts
+	// would add tx_type=cosmos without renaming.
+	PromotionTotal metrics.Counter `metrics_labels:"tx_type"`
 
 	// Utilisation mirrors the same ratio the CheckTx drop gate evaluates:
 	// total count / (cfg.Size + cfg.PendingSize). Exposed as a gauge so

--- a/sei-tendermint/internal/mempool/metrics.go
+++ b/sei-tendermint/internal/mempool/metrics.go
@@ -12,6 +12,15 @@ const (
 	// MetricsSubsystem is a subsystem shared by all metrics exposed by this
 	// package.
 	MetricsSubsystem = "mempool"
+
+	labelTrigger = "trigger"
+	labelTxType  = "tx_type"
+
+	triggerInsertOverflow = "insert_overflow"
+	triggerUpdate         = "update"
+	triggerReap           = "reap"
+
+	txTypeEVM = "evm"
 )
 
 //go:generate go run ../../scripts/metricsgen -struct=Metrics
@@ -124,11 +133,6 @@ type Metrics struct {
 	// auto-ready on insert and not counted here; future cosmos-side counts
 	// would add tx_type=cosmos without renaming.
 	PromotionTotal metrics.Counter `metrics_labels:"tx_type"`
-
-	// Utilisation mirrors the same ratio the CheckTx drop gate evaluates:
-	// total count / (cfg.Size + cfg.PendingSize). Exposed as a gauge so
-	// recording rules don't need to re-derive it from Size+PendingSize.
-	Utilisation metrics.Gauge
 }
 
 func (m *Metrics) observeCheckTxPriorityDistribution(priority int64, hint bool, senderNodeID types.NodeID, isError bool) {

--- a/sei-tendermint/internal/mempool/metrics.go
+++ b/sei-tendermint/internal/mempool/metrics.go
@@ -25,11 +25,11 @@ var (
 		compactDurationSeconds metric.Float64Histogram
 	}{
 		compactTotal: must(mempoolMeter.Int64Counter(
-			"compact_total",
+			"tendermint_mempool_compact_total",
 			metric.WithDescription("Number of compact() invocations, labeled by call site (insert_overflow, update, reap)."),
 		)),
 		compactDurationSeconds: must(mempoolMeter.Float64Histogram(
-			"compact_duration_seconds",
+			"tendermint_mempool_compact_duration_seconds",
 			metric.WithDescription("Wall-clock duration of compact(), which re-sorts and rebuilds indices over the full mempool (O(m log m))."),
 			metric.WithUnit("s"),
 			metric.WithExplicitBucketBoundaries(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30),

--- a/sei-tendermint/internal/mempool/tx.go
+++ b/sei-tendermint/internal/mempool/tx.go
@@ -346,7 +346,7 @@ func (s *txStore) insert(inner *txStoreInner, wtx *WrappedTx) error {
 			}
 			account.nextNonce += 1
 			state.ready.Inc(wtx.Size())
-			s.metrics.PromotionTotal.With("tx_type", "evm").Add(1)
+			s.metrics.PromotionTotal.With(labelTxType, txTypeEVM).Add(1)
 			if !wtx.readyEl.IsPresent() {
 				wtx.readyEl = utils.Some(s.readyTxs.PushBack(wtx.Tx()))
 			}
@@ -423,7 +423,7 @@ func (s *txStore) Insert(wtx *WrappedTx) error {
 		if total := inner.state.Load().total; !total.LessEqual(&inner.hardLimit) {
 			start := time.Now()
 			s.compact(inner, false)
-			s.metrics.CompactTotal.With("trigger", "insert_overflow").Add(1)
+			s.metrics.CompactTotal.With(labelTrigger, triggerInsertOverflow).Add(1)
 			s.metrics.CompactDurationSeconds.Observe(time.Since(start).Seconds())
 			if _, ok := inner.byHash[wtx.Hash()]; !ok {
 				return errMempoolFull
@@ -531,7 +531,7 @@ func (s *txStore) Update(spec updateSpec) {
 		}
 		start := time.Now()
 		s.compact(inner, true)
-		s.metrics.CompactTotal.With("trigger", "update").Add(1)
+		s.metrics.CompactTotal.With(labelTrigger, triggerUpdate).Add(1)
 		s.metrics.CompactDurationSeconds.Observe(time.Since(start).Seconds())
 	}
 }
@@ -598,7 +598,7 @@ func (s *txStore) Reap(l ReapLimits, remove bool) (types.Txs, int64) {
 			}
 			start := time.Now()
 			s.compact(inner, false)
-			s.metrics.CompactTotal.With("trigger", "reap").Add(1)
+			s.metrics.CompactTotal.With(labelTrigger, triggerReap).Add(1)
 			s.metrics.CompactDurationSeconds.Observe(time.Since(start).Seconds())
 		}
 	}

--- a/sei-tendermint/internal/mempool/tx.go
+++ b/sei-tendermint/internal/mempool/tx.go
@@ -346,7 +346,7 @@ func (s *txStore) insert(inner *txStoreInner, wtx *WrappedTx) error {
 			}
 			account.nextNonce += 1
 			state.ready.Inc(wtx.Size())
-			s.metrics.PromotionTotal.Add(1)
+			s.metrics.PromotionTotal.With("tx_type", "evm").Add(1)
 			if !wtx.readyEl.IsPresent() {
 				wtx.readyEl = utils.Some(s.readyTxs.PushBack(wtx.Tx()))
 			}
@@ -433,12 +433,12 @@ func (s *txStore) Insert(wtx *WrappedTx) error {
 }
 
 // O(m log m), prunes transactions above softLimit and recomputes all the indices.
-// reason labels the triggering call site for the compact_total counter
+// trigger labels the call site for the compact_total counter
 // (insert_overflow | update | reap).
-func (s *txStore) compact(inner *txStoreInner, clearAccounts bool, reason string) {
+func (s *txStore) compact(inner *txStoreInner, clearAccounts bool, trigger string) {
 	start := time.Now()
 	defer func() {
-		s.metrics.CompactTotal.With("reason", reason).Add(1)
+		s.metrics.CompactTotal.With("trigger", trigger).Add(1)
 		s.metrics.CompactDurationSeconds.Observe(time.Since(start).Seconds())
 	}()
 	// Order all txs by priority.

--- a/sei-tendermint/internal/mempool/tx.go
+++ b/sei-tendermint/internal/mempool/tx.go
@@ -290,9 +290,6 @@ func (s *txStore) SafeGetTxsForHashes(txHashes []types.TxHash) (types.Txs, []typ
 	return got, missing
 }
 
-// countPromotion is true for user-driven inserts and false for compact()'s
-// re-insertion path, which would otherwise double-count every already-ready
-// EVM tx on every block.
 func (s *txStore) insert(inner *txStoreInner, wtx *WrappedTx, countPromotion bool) error {
 	if _, ok := inner.byHash[wtx.Hash()]; ok {
 		return errDuplicateTx

--- a/sei-tendermint/internal/mempool/tx.go
+++ b/sei-tendermint/internal/mempool/tx.go
@@ -346,6 +346,7 @@ func (s *txStore) insert(inner *txStoreInner, wtx *WrappedTx) error {
 			}
 			account.nextNonce += 1
 			state.ready.Inc(wtx.Size())
+			s.metrics.PromotionTotal.Add(1)
 			if !wtx.readyEl.IsPresent() {
 				wtx.readyEl = utils.Some(s.readyTxs.PushBack(wtx.Tx()))
 			}
@@ -420,7 +421,7 @@ func (s *txStore) Insert(wtx *WrappedTx) error {
 			s.priorityReservoir.Add(wtx.priority)
 		}
 		if total := inner.state.Load().total; !total.LessEqual(&inner.hardLimit) {
-			s.compact(inner, false)
+			s.compact(inner, false, "insert_overflow")
 			if _, ok := inner.byHash[wtx.Hash()]; !ok {
 				return errMempoolFull
 			}
@@ -432,7 +433,14 @@ func (s *txStore) Insert(wtx *WrappedTx) error {
 }
 
 // O(m log m), prunes transactions above softLimit and recomputes all the indices.
-func (s *txStore) compact(inner *txStoreInner, clearAccounts bool) {
+// reason labels the triggering call site for the compact_total counter
+// (insert_overflow | update | reap).
+func (s *txStore) compact(inner *txStoreInner, clearAccounts bool, reason string) {
+	start := time.Now()
+	defer func() {
+		s.metrics.CompactTotal.With("reason", reason).Add(1)
+		s.metrics.CompactDurationSeconds.Observe(time.Since(start).Seconds())
+	}()
 	// Order all txs by priority.
 	wtxs := inner.inInclusionOrder()
 	// Reset internal state.
@@ -525,7 +533,7 @@ func (s *txStore) Update(spec updateSpec) {
 				wtx.priority = newPriority
 			}
 		}
-		s.compact(inner, true)
+		s.compact(inner, true, "update")
 	}
 }
 
@@ -589,7 +597,7 @@ func (s *txStore) Reap(l ReapLimits, remove bool) (types.Txs, int64) {
 					s.readyTxs.Remove(el)
 				}
 			}
-			s.compact(inner, false)
+			s.compact(inner, false, "reap")
 		}
 	}
 

--- a/sei-tendermint/internal/mempool/tx.go
+++ b/sei-tendermint/internal/mempool/tx.go
@@ -421,7 +421,10 @@ func (s *txStore) Insert(wtx *WrappedTx) error {
 			s.priorityReservoir.Add(wtx.priority)
 		}
 		if total := inner.state.Load().total; !total.LessEqual(&inner.hardLimit) {
-			s.compact(inner, false, "insert_overflow")
+			start := time.Now()
+			s.compact(inner, false)
+			s.metrics.CompactTotal.With("trigger", "insert_overflow").Add(1)
+			s.metrics.CompactDurationSeconds.Observe(time.Since(start).Seconds())
 			if _, ok := inner.byHash[wtx.Hash()]; !ok {
 				return errMempoolFull
 			}
@@ -433,14 +436,7 @@ func (s *txStore) Insert(wtx *WrappedTx) error {
 }
 
 // O(m log m), prunes transactions above softLimit and recomputes all the indices.
-// trigger labels the call site for the compact_total counter
-// (insert_overflow | update | reap).
-func (s *txStore) compact(inner *txStoreInner, clearAccounts bool, trigger string) {
-	start := time.Now()
-	defer func() {
-		s.metrics.CompactTotal.With("trigger", trigger).Add(1)
-		s.metrics.CompactDurationSeconds.Observe(time.Since(start).Seconds())
-	}()
+func (s *txStore) compact(inner *txStoreInner, clearAccounts bool) {
 	// Order all txs by priority.
 	wtxs := inner.inInclusionOrder()
 	// Reset internal state.
@@ -533,7 +529,10 @@ func (s *txStore) Update(spec updateSpec) {
 				wtx.priority = newPriority
 			}
 		}
-		s.compact(inner, true, "update")
+		start := time.Now()
+		s.compact(inner, true)
+		s.metrics.CompactTotal.With("trigger", "update").Add(1)
+		s.metrics.CompactDurationSeconds.Observe(time.Since(start).Seconds())
 	}
 }
 
@@ -597,7 +596,10 @@ func (s *txStore) Reap(l ReapLimits, remove bool) (types.Txs, int64) {
 					s.readyTxs.Remove(el)
 				}
 			}
-			s.compact(inner, false, "reap")
+			start := time.Now()
+			s.compact(inner, false)
+			s.metrics.CompactTotal.With("trigger", "reap").Add(1)
+			s.metrics.CompactDurationSeconds.Observe(time.Since(start).Seconds())
 		}
 	}
 

--- a/sei-tendermint/internal/mempool/tx.go
+++ b/sei-tendermint/internal/mempool/tx.go
@@ -290,7 +290,7 @@ func (s *txStore) SafeGetTxsForHashes(txHashes []types.TxHash) (types.Txs, []typ
 	return got, missing
 }
 
-func (s *txStore) insert(inner *txStoreInner, wtx *WrappedTx, countPromotion bool) error {
+func (s *txStore) insert(inner *txStoreInner, wtx *WrappedTx) error {
 	if _, ok := inner.byHash[wtx.Hash()]; ok {
 		return errDuplicateTx
 	}
@@ -346,9 +346,6 @@ func (s *txStore) insert(inner *txStoreInner, wtx *WrappedTx, countPromotion boo
 			}
 			account.nextNonce += 1
 			state.ready.Inc(wtx.Size())
-			if countPromotion {
-				otelMetrics.promotionTotal.Add(context.Background(), 1, txTypeEVMAttr)
-			}
 			if !wtx.readyEl.IsPresent() {
 				wtx.readyEl = utils.Some(s.readyTxs.PushBack(wtx.Tx()))
 			}
@@ -416,7 +413,7 @@ func (inner *txStoreInner) inInclusionOrder() []*WrappedTx {
 // txStore takes ownership of wtx.
 func (s *txStore) Insert(wtx *WrappedTx) error {
 	for inner := range s.inner.Lock() {
-		if err := s.insert(inner, wtx, true); err != nil {
+		if err := s.insert(inner, wtx); err != nil {
 			return err
 		}
 		if inner.isReady(wtx) {
@@ -456,7 +453,7 @@ func (s *txStore) compact(inner *txStoreInner, clearAccounts bool) {
 		total.Inc(wtx.Size())
 		limitOk := total.LessEqual(&inner.softLimit)
 		// NOTE: insertion is lazily evaluated here.
-		if !limitOk || s.insert(inner, wtx, false) != nil {
+		if !limitOk || s.insert(inner, wtx) != nil {
 			// NOTE: evicted txs are not cached unconditionally
 			if !limitOk || !s.config.KeepInvalidTxsInCache {
 				inner.cache.Remove(wtx.Hash())

--- a/sei-tendermint/internal/mempool/tx.go
+++ b/sei-tendermint/internal/mempool/tx.go
@@ -347,7 +347,7 @@ func (s *txStore) insert(inner *txStoreInner, wtx *WrappedTx, countPromotion boo
 			account.nextNonce += 1
 			state.ready.Inc(wtx.Size())
 			if countPromotion {
-				s.metrics.PromotionTotal.With(labelTxType, txTypeEVM).Add(1)
+				otelMetrics.promotionTotal.Add(context.Background(), 1, txTypeEVMAttr)
 			}
 			if !wtx.readyEl.IsPresent() {
 				wtx.readyEl = utils.Some(s.readyTxs.PushBack(wtx.Tx()))
@@ -425,8 +425,8 @@ func (s *txStore) Insert(wtx *WrappedTx) error {
 		if total := inner.state.Load().total; !total.LessEqual(&inner.hardLimit) {
 			start := time.Now()
 			s.compact(inner, false)
-			s.metrics.CompactTotal.With(labelTrigger, triggerInsertOverflow).Add(1)
-			s.metrics.CompactDurationSeconds.Observe(time.Since(start).Seconds())
+			otelMetrics.compactTotal.Add(context.Background(), 1, triggerInsertOverflowAttr)
+			otelMetrics.compactDurationSeconds.Record(context.Background(), time.Since(start).Seconds())
 			if _, ok := inner.byHash[wtx.Hash()]; !ok {
 				return errMempoolFull
 			}
@@ -533,8 +533,8 @@ func (s *txStore) Update(spec updateSpec) {
 		}
 		start := time.Now()
 		s.compact(inner, true)
-		s.metrics.CompactTotal.With(labelTrigger, triggerUpdate).Add(1)
-		s.metrics.CompactDurationSeconds.Observe(time.Since(start).Seconds())
+		otelMetrics.compactTotal.Add(context.Background(), 1, triggerUpdateAttr)
+		otelMetrics.compactDurationSeconds.Record(context.Background(), time.Since(start).Seconds())
 	}
 }
 
@@ -600,8 +600,8 @@ func (s *txStore) Reap(l ReapLimits, remove bool) (types.Txs, int64) {
 			}
 			start := time.Now()
 			s.compact(inner, false)
-			s.metrics.CompactTotal.With(labelTrigger, triggerReap).Add(1)
-			s.metrics.CompactDurationSeconds.Observe(time.Since(start).Seconds())
+			otelMetrics.compactTotal.Add(context.Background(), 1, triggerReapAttr)
+			otelMetrics.compactDurationSeconds.Record(context.Background(), time.Since(start).Seconds())
 		}
 	}
 

--- a/sei-tendermint/internal/mempool/tx.go
+++ b/sei-tendermint/internal/mempool/tx.go
@@ -290,7 +290,10 @@ func (s *txStore) SafeGetTxsForHashes(txHashes []types.TxHash) (types.Txs, []typ
 	return got, missing
 }
 
-func (s *txStore) insert(inner *txStoreInner, wtx *WrappedTx) error {
+// countPromotion is true for user-driven inserts and false for compact()'s
+// re-insertion path, which would otherwise double-count every already-ready
+// EVM tx on every block.
+func (s *txStore) insert(inner *txStoreInner, wtx *WrappedTx, countPromotion bool) error {
 	if _, ok := inner.byHash[wtx.Hash()]; ok {
 		return errDuplicateTx
 	}
@@ -346,7 +349,9 @@ func (s *txStore) insert(inner *txStoreInner, wtx *WrappedTx) error {
 			}
 			account.nextNonce += 1
 			state.ready.Inc(wtx.Size())
-			s.metrics.PromotionTotal.With(labelTxType, txTypeEVM).Add(1)
+			if countPromotion {
+				s.metrics.PromotionTotal.With(labelTxType, txTypeEVM).Add(1)
+			}
 			if !wtx.readyEl.IsPresent() {
 				wtx.readyEl = utils.Some(s.readyTxs.PushBack(wtx.Tx()))
 			}
@@ -414,7 +419,7 @@ func (inner *txStoreInner) inInclusionOrder() []*WrappedTx {
 // txStore takes ownership of wtx.
 func (s *txStore) Insert(wtx *WrappedTx) error {
 	for inner := range s.inner.Lock() {
-		if err := s.insert(inner, wtx); err != nil {
+		if err := s.insert(inner, wtx, true); err != nil {
 			return err
 		}
 		if inner.isReady(wtx) {
@@ -454,7 +459,7 @@ func (s *txStore) compact(inner *txStoreInner, clearAccounts bool) {
 		total.Inc(wtx.Size())
 		limitOk := total.LessEqual(&inner.softLimit)
 		// NOTE: insertion is lazily evaluated here.
-		if !limitOk || s.insert(inner, wtx) != nil {
+		if !limitOk || s.insert(inner, wtx, false) != nil {
 			// NOTE: evicted txs are not cached unconditionally
 			if !limitOk || !s.config.KeepInvalidTxsInCache {
 				inner.cache.Remove(wtx.Hash())


### PR DESCRIPTION
Adds two metrics that expose the TxMempool rewrite's compaction behavior without changing logic: `tendermint_mempool_compact_total{trigger}` and `tendermint_mempool_compact_duration_seconds`. The `trigger` label distinguishes the three call sites of `compact()` (`insert_overflow`, `update`, `reap`); rate-of-`insert_overflow` is the capacity-pressure signal. Emitted via OpenTelemetry (`otel.Meter("tendermint_mempool")`) following the sei-db convention.

Companion to platform sei-protocol/platform#743 (recording rules, dashboard panels, alerts). The reactor-side gossip-bytes counter and any pending→ready promotion signal are separate followups — the latter is already directly tested by `mempool_pending_promotion_test.js` in the release-test suite, so a metric for it isn't yet pulling weight.

## Metric rationale

These metrics let us answer four questions about the rewrite that we couldn't ask cleanly before.

### What each metric is for, when stress-testing

**`compact_total{trigger="insert_overflow"}` is the capacity-pressure signal.** When this counter ticks, the mempool was momentarily over `hardLimit` (= 2× softLimit). A non-zero rate means ingress is outpacing block consumption — the only operational question is whether admission control is supposed to be catching it. If both `check_tx_met_drop_utilisation_threshold` *and* `insert_overflow` are rising, pressure escaped the gate.

**`compact_total{trigger="update"}` is the block heartbeat.** It fires once per Update, so its rate is a block-rate proxy. If it flatlines while seiload is still pushing, the consensus loop is stuck — different signal from `block_height_delta` because it's measured at the mempool, not the indexer.

**`compact_total{trigger="reap"}` is this node's proposer share.** Validators that propose blocks Reap; followers don't. Useful for telling "is this node doing block-proposal work?" without consulting Tendermint internals.

**`compact_duration_seconds` is where we'll catch the rewrite's real failure mode.** `compact()` is O(m log m) over the full mempool. As load grows, this latency grows. The number we'll watch is `rate(compact_total[5m]) × avg(compact_duration_seconds)` — wall-time-fraction spent inside compact. Once that approaches ~50%, compact is now blocking block production. The histogram lets us see this coming long before p99 actually hits block-interval (~200ms).

### The composite questions only these together can answer

1. **Does the rewrite's amortization actually hold under load?** `rate(insert_overflow) / rate(inserted_txs)` should stay sub-linear as throughput rises. If the ratio goes to 1, the 2× hardLimit amortization broke and we're back to per-insert prune.
2. **Is compact CPU-bound or block-bound?** Compare per-call duration to per-block compact rate. `compact_duration_p99` rising independently of `insert_overflow` rate means individual compacts got expensive (likely GC pressure on 100k+ entries); both rising means we're pruning more often AND each prune is slower — the failure mode.
3. **Is admission control doing its job or just delaying the problem?** `rate(check_tx_met_drop_utilisation_threshold) / rate(insert_overflow)` — if it's high, the gate is absorbing the spike. If it's near zero while overflow is high, the gate's threshold is mistuned.

### What we're still blind to

These metrics don't tell us *why* a compact was slow (sort vs. map-rebuild vs. GC) — that needs pprof or per-phase timing inside `compact()`. Per-peer gossip bandwidth is the next PR. The pending→ready promotion behavior is directly tested by `mempool_pending_promotion_test.js`; a continuous prod signal for it can be added later if operational need surfaces.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/mempool/ -count=1` passes
- [ ] Validate emissions in a nightly chaos run
- [ ] Wire up platform-side recording rules + dashboard panels per #743

References: design doc sei-protocol/platform#743, TxMempool rewrite #3476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)