### PR TITLE
test(evm): cap child_process.exec in lib.js to surface stalled commands

### DIFF
--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -1043,11 +1043,15 @@ function execCommand(command) {
     return new Promise((resolve, reject) => {
         exec(command, { timeout: timeoutMs, killSignal: "SIGKILL" }, (error, stdout, stderr) => {
             if (error) {
-                // error.killed is set only when Node killed the child via the
-                // timeout option; signal-without-killed (external SIGKILL,
-                // OOM, runner cleanup) is a different failure and shouldn't
-                // be mis-attributed as a timeout.
-                if (error.killed) {
+                // Node sets error.killed=true for the two kinds of kill it
+                // initiates: the timeout we configured, and a maxBuffer
+                // overflow. Only the former leaves error.code unset; the
+                // latter sets it to 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER'.
+                // Gate on !error.code so a buffer overflow isn't mis-
+                // attributed as a timeout, and so external signal deaths
+                // (OOM, runner cleanup — error.killed=false) keep their
+                // original error.
+                if (error.killed && !error.code) {
                     const summary = command.length > 200 ? command.slice(0, 197) + "..." : command
                     reject(new Error(`execCommand timed out after ${timeoutMs}ms: ${summary}`))
                     return

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -1052,8 +1052,7 @@ function execCommand(command) {
                 // (OOM, runner cleanup — error.killed=false) keep their
                 // original error.
                 if (error.killed && !error.code) {
-                    const summary = command.length > 200 ? command.slice(0, 197) + "..." : command
-                    reject(new Error(`execCommand timed out after ${timeoutMs}ms: ${summary}`))
+                    reject(new Error(`execCommand timed out after ${timeoutMs}ms: ${command}`))
                     return
                 }
                 reject(error);

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -1032,9 +1032,22 @@ async function execute(command, interaction=`printf "12345678\\n"`){
 }
 
 function execCommand(command) {
+    // Cap shelled-out child processes (typically `docker exec ... seid ...`)
+    // with a timeout so an indefinite stall surfaces as an error with the
+    // command text, instead of consuming the entire job's wall-clock budget.
+    // The Autobahn EVM matrix has hit multiple 30-minute job timeouts where
+    // hardhat went silent between test files; suspect path is a stalled
+    // child here. Override via EXEC_TIMEOUT_MS for tests that legitimately
+    // need longer.
+    const timeoutMs = Number(process.env.EXEC_TIMEOUT_MS || 60000)
     return new Promise((resolve, reject) => {
-        exec(command, (error, stdout, stderr) => {
+        exec(command, { timeout: timeoutMs, killSignal: "SIGKILL" }, (error, stdout, stderr) => {
             if (error) {
+                if (error.killed || error.signal) {
+                    const summary = command.length > 200 ? command.slice(0, 197) + "..." : command
+                    reject(new Error(`execCommand timed out after ${timeoutMs}ms: ${summary}`))
+                    return
+                }
                 reject(error);
                 return;
             }

--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -1043,7 +1043,11 @@ function execCommand(command) {
     return new Promise((resolve, reject) => {
         exec(command, { timeout: timeoutMs, killSignal: "SIGKILL" }, (error, stdout, stderr) => {
             if (error) {
-                if (error.killed || error.signal) {
+                // error.killed is set only when Node killed the child via the
+                // timeout option; signal-without-killed (external SIGKILL,
+                // OOM, runner cleanup) is a different failure and shouldn't
+                // be mis-attributed as a timeout.
+                if (error.killed) {
                     const summary = command.length > 200 ? command.slice(0, 197) + "..." : command
                     reject(new Error(`execCommand timed out after ${timeoutMs}ms: ${summary}`))
                     return


### PR DESCRIPTION
## Summary

`execCommand` in [contracts/test/lib.js](contracts/test/lib.js) wraps `child_process.exec` with no timeout. The Autobahn EVM integration matrix has hit **multiple 30‑minute job timeouts** where the hardhat process went silent at a test boundary, with the orphan‑process listing at cleanup consistently showing a stalled `docker exec ... seid ...` child still alive. The job then consumed its entire wall‑clock budget instead of surfacing a useful error.

This caps `execCommand` with a configurable timeout (default **60s**, `SIGKILL`). On expiry, the rejection includes the offending command so the next occurrence is a 60s actionable error instead of a 30‑minute mystery. Override via `EXEC_TIMEOUT_MS` for tests that legitimately need longer.

## Observed hang pattern (7 occurrences in 3 days)

| Date (UTC) | Run | Affected Autobahn matrix job | Branch |
|---|---|---|---|
| 05‑28 23:48 | [26608835541](https://github.com/sei-protocol/sei-chain/actions/runs/26608835541) | EVM Interoperability | chore branch |
| 05‑29 00:06 | [26609440164](https://github.com/sei-protocol/sei-chain/actions/runs/26609440164) | EVM Interoperability | chore branch |
| 05‑29 06:00 | [26620669539](https://github.com/sei-protocol/sei-chain/actions/runs/26620669539) | EVM Interoperability | chore branch |
| 05‑29 14:19 | [26642258916](https://github.com/sei-protocol/sei-chain/actions/runs/26642258916) | EVM Interoperability | merge_queue #3506 |
| 05‑29 16:22 | [26648904362](https://github.com/sei-protocol/sei-chain/actions/runs/26648904362) | EVM Interoperability | main push |
| 05‑29 16:29 | [26648905384](https://github.com/sei-protocol/sei-chain/actions/runs/26648905384) | EVM Interoperability | merge_queue #3511 |
| 05‑31 01:00 | [26699345153](https://github.com/sei-protocol/sei-chain/actions/runs/26699345153) | EVM Module | PR #3525 |

Each ran for exactly ~30 minutes (job timeout). Investigation of one of the artifacts ([26648905384](https://github.com/sei-protocol/sei-chain/actions/runs/26648905384)): validators were perfectly healthy (continuing to produce blocks) the whole time, no test‑sender activity reached them during the silence — i.e., the hardhat process was alive but never sent another RPC, consistent with a stalled child process here.

## Trade-off

- Healthy `docker exec` calls in the suite complete in ~100–200ms; 60s is comfortably above the worst observed normal case.
- If a specific test legitimately needs longer (e.g. genesis bootstrap), `EXEC_TIMEOUT_MS` overrides per-invocation.

## Test plan

- [x] CI: full integration matrix passes (60s is well above normal).
- [x] The next time this stall pattern hits, the failing job will report a 60s `execCommand timed out … <command>` error instead of a 30‑min cancel — that error itself becomes the diagnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)