### PR TITLE
fix(scripts): preserve node_key.json across state sync (PLT-415)

### DIFF
--- a/scripts/state_sync.sh
+++ b/scripts/state_sync.sh
@@ -13,8 +13,9 @@ echo
 # Create a backup directory for keys
 mkdir -p $HOME/key_backup
 
-# Backup the validator key and state files
+# Backup the validator key, node key, and state files
 cp $HOME/.sei/config/priv_validator_key.json $HOME/key_backup
+cp $HOME/.sei/config/node_key.json $HOME/key_backup
 cp $HOME/.sei/data/priv_validator_state.json $HOME/key_backup
 
 # Create a backup directory for the entire .sei configuration
@@ -28,10 +29,11 @@ mv $HOME/.sei/wasm $HOME/.sei_backup
 # Remove the data and wasm folder
 cd $HOME/.sei && ls | grep -xv "cosmovisor" | xargs rm -rf
 
-# Restore the validator key and state files from the backup
+# Restore the validator key, node key, and state files from the backup
 mkdir -p $HOME/.sei/config
 mkdir -p $HOME/.sei/data
 cp $HOME/key_backup/priv_validator_key.json $HOME/.sei/config/
+cp $HOME/key_backup/node_key.json $HOME/.sei/config/
 cp $HOME/key_backup/priv_validator_state.json $HOME/.sei/data/
 
 # Set up /tmp as a 12G RAM disk to allow for more than 400 state sync chunks


### PR DESCRIPTION
## Summary

- [scripts/state_sync.sh](https://github.com/sei-protocol/sei-chain/blob/main/scripts/state_sync.sh) backed up `priv_validator_key.json` before wiping `~/.sei/config`, but not `node_key.json` — which lives in the same directory. The whole `config/` dir is moved to `~/.sei_backup` and only the validator key is copied back, so `node_key.json` never returns.
- On the next start, `LoadOrGenNodeKey` finds no key and generates a fresh Ed25519 keypair, giving the node a brand-new NodeID (`hex(sha256(pubkey)[:20])`). Any peer that has the old `NodeID@host:port` in `persistent_peers` then silently fails to connect, because Tendermint rejects the handshake when the advertised NodeID doesn't match.
- This bites hardest during upgrades / incident recovery — exactly when operators reach for state sync — and churns the NodeID on every run for teams using state sync for disk management. State sync has no dependency on a fresh node key, so there's no reason to regenerate it.
- Fix: back up and restore `node_key.json` alongside `priv_validator_key.json`, preserving node identity across a sync.

## Test plan

- [x] `bash -n scripts/state_sync.sh` — syntax clean
- [x] Verified backup/restore symmetry: `node_key.json` is now copied to `$HOME/key_backup` before the config wipe and copied back to `$HOME/.sei/config/` afterward, mirroring the existing `priv_validator_key.json` handling
- [ ] Operator validation on a non-prod node: run state sync on an existing node and confirm the NodeID (`seid tendermint show-node-id`) is unchanged afterward

## Notes

- The copy of this script deployed on some EC2 instances is reportedly out of date with the version in `sei-infra`. This PR fixes the in-repo script; the `sei-infra` copy should be patched and redeployed separately so existing nodes actually pick up the fix.