### PR TITLE
evmrpc: return null on above-watermark for spec-compliant endpoints

### DIFF
--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -299,16 +299,16 @@ func (a *BlockAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.Block
 	if blockNrOrHash.BlockNumber != nil && *blockNrOrHash.BlockNumber == 0 {
 		return []map[string]any{}, nil
 	}
-	// Get height from params. GetBlockNumberByNrOrHash resolves a hash through
-	// blockByHashRespectingWatermarks internally, so an above-watermark height
-	// surfaces here as ErrBlockHeightNotYetAvailable — convert to null per
-	// spec, alongside the not-found-by-hash case.
+	// Get height from params. GetBlockNumberByNrOrHash already maps both
+	// unknown-hash and above-watermark to (nil, nil) for the by-hash path,
+	// matching Ethereum JSON-RPC null semantics; by-number propagates other
+	// errors normally.
 	heightPtr, err := GetBlockNumberByNrOrHash(ctx, a.tmClient, a.watermarks, blockNrOrHash)
-	if errors.Is(err, ErrBlockNotFoundByHash) || errors.Is(err, ErrBlockHeightNotYetAvailable) {
-		return nil, nil
-	}
 	if err != nil {
 		return nil, err
+	}
+	if heightPtr == nil {
+		return nil, nil
 	}
 
 	// Ethereum JSON-RPC: non-existent / above-watermark block => null, not an error.

--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -271,13 +270,13 @@ func (a *BlockAPI) getBlockByNumber(
 		}
 	}
 
-	block, err := blockByNumberRespectingWatermarks(ctx, a.tmClient, a.watermarks, numberPtr, 1)
 	// Ethereum JSON-RPC: non-existent / future numeric block => null, not an error.
-	if errors.Is(err, ErrBlockHeightNotYetAvailable) {
-		return nil, nil
-	}
+	block, err := blockByNumberOrNullForJSONRPC(ctx, a.tmClient, a.watermarks, numberPtr, 1)
 	if err != nil {
 		return nil, err
+	}
+	if block == nil {
+		return nil, nil
 	}
 	return EncodeTmBlock(a.ctxProvider, a.txConfigProvider, block, a.keeper, fullTx, a.includeBankTransfers, includeSyntheticTxs, excludeUntraceable, a.globalBlockCache, a.cacheCreationMutex)
 }

--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -303,23 +303,20 @@ func (a *BlockAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.Block
 	// (the "latest"/"safe"/"finalized"/"pending" tags) resolves to the safe-latest
 	// height via blockByNumberOrNullForJSONRPC rather than being misread as
 	// "block doesn't exist".
-	var block *coretypes.ResultBlock
+	var (
+		block *coretypes.ResultBlock
+		err   error
+	)
 	if blockNrOrHash.BlockHash != nil {
-		b, err := blockByHashOrNullForJSONRPC(ctx, a.tmClient, a.watermarks, blockNrOrHash.BlockHash[:], 1)
-		if err != nil {
-			return nil, err
-		}
-		block = b
+		block, err = blockByHashOrNullForJSONRPC(ctx, a.tmClient, a.watermarks, blockNrOrHash.BlockHash[:], 1)
 	} else {
-		numberPtr, err := getBlockNumber(ctx, a.tmClient, *blockNrOrHash.BlockNumber)
-		if err != nil {
-			return nil, err
+		var numberPtr *int64
+		if numberPtr, err = getBlockNumber(ctx, a.tmClient, *blockNrOrHash.BlockNumber); err == nil {
+			block, err = blockByNumberOrNullForJSONRPC(ctx, a.tmClient, a.watermarks, numberPtr, 1)
 		}
-		b, err := blockByNumberOrNullForJSONRPC(ctx, a.tmClient, a.watermarks, numberPtr, 1)
-		if err != nil {
-			return nil, err
-		}
-		block = b
+	}
+	if err != nil {
+		return nil, err
 	}
 	if block == nil {
 		return nil, nil

--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -302,9 +302,12 @@ func (a *BlockAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.Block
 	if blockNrOrHash.BlockNumber != nil && *blockNrOrHash.BlockNumber == 0 {
 		return []map[string]any{}, nil
 	}
-	// Get height from params
+	// Get height from params. GetBlockNumberByNrOrHash resolves a hash through
+	// blockByHashRespectingWatermarks internally, so an above-watermark height
+	// surfaces here as ErrBlockHeightNotYetAvailable — convert to null per
+	// spec, alongside the not-found-by-hash case.
 	heightPtr, err := GetBlockNumberByNrOrHash(ctx, a.tmClient, a.watermarks, blockNrOrHash)
-	if errors.Is(err, ErrBlockNotFoundByHash) {
+	if errors.Is(err, ErrBlockNotFoundByHash) || errors.Is(err, ErrBlockHeightNotYetAvailable) {
 		return nil, nil
 	}
 	if err != nil {

--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -172,9 +172,13 @@ func (a *BlockAPI) GetBlockTransactionCountByNumber(ctx context.Context, number 
 	if err != nil {
 		return nil, err
 	}
-	block, err := blockByNumberRespectingWatermarks(ctx, a.tmClient, a.watermarks, numberPtr, 1)
+	// Ethereum JSON-RPC: non-existent / future numeric block => null, not an error.
+	block, err := blockByNumberOrNullForJSONRPC(ctx, a.tmClient, a.watermarks, numberPtr, 1)
 	if err != nil {
 		return nil, err
+	}
+	if block == nil {
+		return nil, nil
 	}
 	return a.getEvmTxCount(block), nil
 }
@@ -187,9 +191,13 @@ func (a *BlockAPI) GetBlockTransactionCountByHash(ctx context.Context, blockHash
 	if blockHash == genesisBlockHash {
 		return genesisBlockTxCount, nil
 	}
-	block, err := blockByHashRespectingWatermarks(ctx, a.tmClient, a.watermarks, blockHash[:], 1)
+	// Ethereum JSON-RPC: non-existent block hash => null, not an error.
+	block, err := blockByHashOrNullForJSONRPC(ctx, a.tmClient, a.watermarks, blockHash[:], 1)
 	if err != nil {
 		return nil, err
+	}
+	if block == nil {
+		return nil, nil
 	}
 	return a.getEvmTxCount(block), nil
 }
@@ -212,12 +220,17 @@ func (a *BlockAPI) getBlockByHash(ctx context.Context, blockHash common.Hash, fu
 	if blockHash == genesisBlockHash {
 		return encodeGenesisBlock(), nil
 	}
-	block, err := blockByHashRespectingWatermarks(ctx, a.tmClient, a.watermarks, blockHash[:], 1)
+	// Ethereum JSON-RPC: non-existent block hash (unknown OR above safe latest)
+	// => null, not an error.
+	block, err := blockByHashOrNullForJSONRPC(ctx, a.tmClient, a.watermarks, blockHash[:], 1)
 	if errors.Is(err, ErrBlockNotFoundByHash) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, err
+	}
+	if block == nil {
+		return nil, nil
 	}
 
 	// Validate EVM block height for pacific-1 chain
@@ -298,9 +311,13 @@ func (a *BlockAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.Block
 		return nil, err
 	}
 
-	block, err := blockByNumberRespectingWatermarks(ctx, a.tmClient, a.watermarks, heightPtr, 1)
+	// Ethereum JSON-RPC: non-existent / above-watermark block => null, not an error.
+	block, err := blockByNumberOrNullForJSONRPC(ctx, a.tmClient, a.watermarks, heightPtr, 1)
 	if err != nil {
 		return nil, err
+	}
+	if block == nil {
+		return nil, nil
 	}
 
 	// Get all tx hashes for the block

--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -221,11 +221,8 @@ func (a *BlockAPI) getBlockByHash(ctx context.Context, blockHash common.Hash, fu
 		return encodeGenesisBlock(), nil
 	}
 	// Ethereum JSON-RPC: non-existent block hash (unknown OR above safe latest)
-	// => null, not an error.
+	// => null, not an error. The helper handles both cases.
 	block, err := blockByHashOrNullForJSONRPC(ctx, a.tmClient, a.watermarks, blockHash[:], 1)
-	if errors.Is(err, ErrBlockNotFoundByHash) {
-		return nil, nil
-	}
 	if err != nil {
 		return nil, err
 	}

--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -298,22 +298,28 @@ func (a *BlockAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.Block
 	if blockNrOrHash.BlockNumber != nil && *blockNrOrHash.BlockNumber == 0 {
 		return []map[string]any{}, nil
 	}
-	// Get height from params. GetBlockNumberByNrOrHash already maps both
-	// unknown-hash and above-watermark to (nil, nil) for the by-hash path,
-	// matching Ethereum JSON-RPC null semantics; by-number propagates other
-	// errors normally.
-	heightPtr, err := GetBlockNumberByNrOrHash(ctx, a.tmClient, a.watermarks, blockNrOrHash)
-	if err != nil {
-		return nil, err
-	}
-	if heightPtr == nil {
-		return nil, nil
-	}
-
 	// Ethereum JSON-RPC: non-existent / above-watermark block => null, not an error.
-	block, err := blockByNumberOrNullForJSONRPC(ctx, a.tmClient, a.watermarks, heightPtr, 1)
-	if err != nil {
-		return nil, err
+	// Dispatch on hash vs number directly so a nil heightPtr from getBlockNumber
+	// (the "latest"/"safe"/"finalized"/"pending" tags) resolves to the safe-latest
+	// height via blockByNumberOrNullForJSONRPC rather than being misread as
+	// "block doesn't exist".
+	var block *coretypes.ResultBlock
+	if blockNrOrHash.BlockHash != nil {
+		b, err := blockByHashOrNullForJSONRPC(ctx, a.tmClient, a.watermarks, blockNrOrHash.BlockHash[:], 1)
+		if err != nil {
+			return nil, err
+		}
+		block = b
+	} else {
+		numberPtr, err := getBlockNumber(ctx, a.tmClient, *blockNrOrHash.BlockNumber)
+		if err != nil {
+			return nil, err
+		}
+		b, err := blockByNumberOrNullForJSONRPC(ctx, a.tmClient, a.watermarks, numberPtr, 1)
+		if err != nil {
+			return nil, err
+		}
+		block = b
 	}
 	if block == nil {
 		return nil, nil

--- a/evmrpc/height_availability_test.go
+++ b/evmrpc/height_availability_test.go
@@ -107,7 +107,11 @@ func testTxConfigProvider(int64) client.TxConfig { return nil }
 
 func testCtxProvider(int64) sdk.Context { return sdk.Context{} }
 
-func TestBlockAPIEnsureHeightUnavailable(t *testing.T) {
+// GetBlockByHash for a block whose height sits above safe latest must return
+// JSON null per the Ethereum JSON-RPC spec (the block doesn't exist from the
+// caller's perspective), matching get-block-by-empty-hash.iox / get-block-by-
+// notfound-hash.iox semantics.
+func TestBlockAPIAboveWatermarkReturnsNull(t *testing.T) {
 	t.Parallel()
 
 	earliest := int64(1)
@@ -117,9 +121,9 @@ func TestBlockAPIEnsureHeightUnavailable(t *testing.T) {
 	watermarks := NewWatermarkManager(client, testCtxProvider, nil, nil)
 	api := NewBlockAPI(client, nil, testCtxProvider, testTxConfigProvider, ConnectionTypeHTTP, watermarks, nil, nil)
 
-	_, err := api.GetBlockByHash(context.Background(), common.HexToHash(highBlockHashHex), false)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "requested height")
+	result, err := api.GetBlockByHash(context.Background(), common.HexToHash(highBlockHashHex), false)
+	require.NoError(t, err)
+	require.Nil(t, result)
 }
 
 // TestGetBlockByHashNotFoundReturnsNull verifies Ethereum-compatible behavior: empty or non-existent block hash

--- a/evmrpc/height_availability_test.go
+++ b/evmrpc/height_availability_test.go
@@ -182,6 +182,42 @@ func TestGetBlockReceiptsNotFoundReturnsNull(t *testing.T) {
 	require.Nil(t, receipts)
 }
 
+// TestBlockAPILatestTagResolves verifies that block endpoints accepting
+// "latest"/"safe"/"finalized"/"pending" tags resolve to the safe-latest height
+// rather than returning JSON null. The tag arrives as numberPtr=nil from
+// getBlockNumber; the by-number helper must route it through wm.LatestHeight.
+//
+// GetBlockByNumber and getTransactionByBlockNumberAndIndex use the identical
+// (getBlockNumber → blockByNumberOrNullForJSONRPC → if block == nil) pattern
+// but require a real keeper for downstream encoding so they're not exercised
+// directly here.
+func TestBlockAPILatestTagResolves(t *testing.T) {
+	t.Parallel()
+
+	earliest := int64(1)
+	latest := int64(100)
+	client := newHeightTestClient(latest+5, earliest, latest)
+	watermarks := NewWatermarkManager(client, testCtxProvider, nil, nil)
+	api := NewBlockAPI(client, nil, testCtxProvider, testTxConfigProvider, ConnectionTypeHTTP, watermarks, nil, nil)
+	ctx := context.Background()
+
+	tags := []rpc.BlockNumber{
+		rpc.LatestBlockNumber,
+		rpc.SafeBlockNumber,
+		rpc.FinalizedBlockNumber,
+		rpc.PendingBlockNumber,
+	}
+	for _, tag := range tags {
+		receipts, err := api.GetBlockReceipts(ctx, rpc.BlockNumberOrHashWithNumber(tag))
+		require.NoError(t, err)
+		require.NotNil(t, receipts, "GetBlockReceipts tag %v must resolve, not null", tag)
+
+		count, err := api.GetBlockTransactionCountByNumber(ctx, tag)
+		require.NoError(t, err)
+		require.NotNil(t, count, "GetBlockTransactionCountByNumber tag %v must resolve, not null", tag)
+	}
+}
+
 // TestGetBlockTransactionCountByHashGenesis verifies that the genesis block hash returned by
 // eth_getBlockByNumber("0x0") is accepted by eth_getBlockTransactionCountByHash (consistency).
 func TestGetBlockTransactionCountByHashGenesis(t *testing.T) {

--- a/evmrpc/setup_test.go
+++ b/evmrpc/setup_test.go
@@ -371,7 +371,10 @@ func (c *MockClient) BlockByHash(_ context.Context, hash bytes.HexBytes) (*coret
 		return c.mockBlock(MockHeight2), nil
 	}
 	if strings.ToLower(hash.String()) == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" {
-		return nil, errors.New("not found")
+		// Match real Tendermint behavior for unknown hashes: ResultBlock with
+		// Block: nil + no error. blockByHashWithRetry wraps this as
+		// ErrBlockNotFoundByHash, which JSON-RPC endpoints convert to null.
+		return &coretypes.ResultBlock{Block: nil}, nil
 	}
 	return c.mockBlock(MockHeight8), nil
 }

--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -136,13 +136,13 @@ func getTransactionReceipt(
 	}
 	// Fetch block once — used both for ante-failure receipt population and encoding.
 	height := int64(receipt.BlockNumber) //nolint:gosec
-	block, err := blockByNumberRespectingWatermarks(ctx, t.tmClient, t.watermarks, &height, 1)
 	// Ethereum JSON-RPC: receipt for a block above safe latest => null, not an error.
-	if errors.Is(err, ErrBlockHeightNotYetAvailable) {
-		return nil, nil
-	}
+	block, err := blockByNumberOrNullForJSONRPC(ctx, t.tmClient, t.watermarks, &height, 1)
 	if err != nil {
 		return nil, err
+	}
+	if block == nil {
+		return nil, nil
 	}
 
 	// Fill in the receipt if the transaction has failed and used 0 gas

--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -213,9 +213,13 @@ func (t *TransactionAPI) getTransactionByBlockNumberAndIndex(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	block, err := blockByNumberRespectingWatermarks(ctx, t.tmClient, t.watermarks, blockNumber, 1)
+	// Ethereum JSON-RPC: non-existent block => null, not an error.
+	block, err := blockByNumberOrNullForJSONRPC(ctx, t.tmClient, t.watermarks, blockNumber, 1)
 	if err != nil {
 		return nil, err
+	}
+	if block == nil {
+		return nil, nil
 	}
 	return t.getTransactionWithBlock(block, txIndex, t.includeSynthetic)
 }
@@ -229,9 +233,13 @@ func (t *TransactionAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, 
 			_err = nil //not returning error for invalid tx index for complying with Ethereum JSON-RPC spec
 		}
 	}()
-	block, err := blockByHashRespectingWatermarks(ctx, t.tmClient, t.watermarks, blockHash[:], 1)
+	// Ethereum JSON-RPC: non-existent / above-watermark block => null, not an error.
+	block, err := blockByHashOrNullForJSONRPC(ctx, t.tmClient, t.watermarks, blockHash[:], 1)
 	if err != nil {
 		return nil, err
+	}
+	if block == nil {
+		return nil, nil
 	}
 	var idx uint32
 	idx, err = txIndexToUint32(txIndex)
@@ -290,9 +298,16 @@ func (t *TransactionAPI) GetTransactionByHash(ctx context.Context, hash common.H
 		return nil, err
 	}
 	blockNumber := int64(receipt.BlockNumber) //nolint:gosec
-	block, err := blockByNumberRespectingWatermarks(ctx, t.tmClient, t.watermarks, &blockNumber, 1)
+	// Ethereum JSON-RPC: tx whose block isn't safe-latest yet => null (not yet
+	// mined from the caller's perspective). The watermark race here mirrors
+	// the one fixed in getTransactionReceipt; ethers' tx.wait() and similar
+	// flows can call getTransactionByHash and propagate the error otherwise.
+	block, err := blockByNumberOrNullForJSONRPC(ctx, t.tmClient, t.watermarks, &blockNumber, 1)
 	if err != nil {
 		return nil, err
+	}
+	if block == nil {
+		return nil, nil
 	}
 	filteredMsgs := t.getFilteredMsgs(block)
 	txIndex, found, ethtx, _ := GetEvmTxIndex(t.ctxProvider(LatestCtxHeight), block, filteredMsgs, receipt.TransactionIndex, t.keeper, t.cacheCreationMutex, t.globalBlockCache)

--- a/evmrpc/tx_test.go
+++ b/evmrpc/tx_test.go
@@ -471,9 +471,9 @@ func TestGetTransactionByBlockHashAndIndexErrors(t *testing.T) {
 	resObj := map[string]interface{}{}
 	require.Nil(t, json.Unmarshal(resBody, &resObj))
 
-	// Should get an error for non-existent block hash
-	errMap := resObj["error"].(map[string]interface{})
-	require.NotNil(t, errMap["message"])
+	// Non-existent block hash returns null result (Ethereum JSON-RPC spec).
+	require.Nil(t, resObj["error"])
+	require.Nil(t, resObj["result"])
 
 	body = fmt.Sprintf(`{"jsonrpc": "2.0","method": "eth_getTransactionByBlockHashAndIndex","params":["%s","0xFFFFFFFFFF"],"id":"test"}`, TestBlockHash)
 	req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s:%d", TestAddr, TestPort), strings.NewReader(body))

--- a/evmrpc/tx_test.go
+++ b/evmrpc/tx_test.go
@@ -453,9 +453,9 @@ func TestGetTransactionByBlockNumberAndIndexErrors(t *testing.T) {
 	resObj = map[string]interface{}{}
 	require.Nil(t, json.Unmarshal(resBody, &resObj))
 
-	// Should get an error for non-existent block
-	errMap := resObj["error"].(map[string]interface{})
-	require.NotNil(t, errMap["message"])
+	// Non-existent block returns null result (Ethereum JSON-RPC spec).
+	require.Nil(t, resObj["error"])
+	require.Nil(t, resObj["result"])
 }
 
 func TestGetTransactionByBlockHashAndIndexErrors(t *testing.T) {

--- a/evmrpc/utils.go
+++ b/evmrpc/utils.go
@@ -45,7 +45,11 @@ const Pacific1EVMLaunchHeight int64 = 79123881
 // Ethereum-compatible RPCs should return result: null for this case instead of an error.
 var ErrBlockNotFoundByHash = errors.New("block not found by hash")
 
-// GetBlockNumberByNrOrHash returns the height of the block with the given number or hash.
+// GetBlockNumberByNrOrHash returns the height of the block with the given
+// number or hash. For the hash path it uses the JSON-RPC-aligned helper so
+// that "block doesn't exist" (unknown hash) and "block not yet safe-latest"
+// (above watermark) both surface as (nil, nil) rather than distinct errors —
+// callers serving Ethereum JSON-RPC endpoints can map either to a null result.
 func GetBlockNumberByNrOrHash(ctx context.Context, tmClient client.LocalClient, wm *WatermarkManager, blockNrOrHash rpc.BlockNumberOrHash) (*int64, error) {
 	if blockNrOrHash.BlockHash != nil {
 		// Synthetic genesis from eth_getBlockByNumber("0x0") is not stored under this hash in Tendermint.
@@ -53,9 +57,12 @@ func GetBlockNumberByNrOrHash(ctx context.Context, tmClient client.LocalClient, 
 			z := int64(0)
 			return &z, nil
 		}
-		block, err := blockByHashRespectingWatermarks(ctx, tmClient, wm, blockNrOrHash.BlockHash[:], 1)
+		block, err := blockByHashOrNullForJSONRPC(ctx, tmClient, wm, blockNrOrHash.BlockHash[:], 1)
 		if err != nil {
 			return nil, err
+		}
+		if block == nil {
+			return nil, nil
 		}
 		height := block.Block.Height
 		return &height, nil

--- a/evmrpc/utils.go
+++ b/evmrpc/utils.go
@@ -45,11 +45,7 @@ const Pacific1EVMLaunchHeight int64 = 79123881
 // Ethereum-compatible RPCs should return result: null for this case instead of an error.
 var ErrBlockNotFoundByHash = errors.New("block not found by hash")
 
-// GetBlockNumberByNrOrHash returns the height of the block with the given
-// number or hash. For the hash path it uses the JSON-RPC-aligned helper so
-// that "block doesn't exist" (unknown hash) and "block not yet safe-latest"
-// (above watermark) both surface as (nil, nil) rather than distinct errors —
-// callers serving Ethereum JSON-RPC endpoints can map either to a null result.
+// GetBlockNumberByNrOrHash returns the height of the block with the given number or hash.
 func GetBlockNumberByNrOrHash(ctx context.Context, tmClient client.LocalClient, wm *WatermarkManager, blockNrOrHash rpc.BlockNumberOrHash) (*int64, error) {
 	if blockNrOrHash.BlockHash != nil {
 		// Synthetic genesis from eth_getBlockByNumber("0x0") is not stored under this hash in Tendermint.
@@ -57,12 +53,9 @@ func GetBlockNumberByNrOrHash(ctx context.Context, tmClient client.LocalClient, 
 			z := int64(0)
 			return &z, nil
 		}
-		block, err := blockByHashOrNullForJSONRPC(ctx, tmClient, wm, blockNrOrHash.BlockHash[:], 1)
+		block, err := blockByHashRespectingWatermarks(ctx, tmClient, wm, blockNrOrHash.BlockHash[:], 1)
 		if err != nil {
 			return nil, err
-		}
-		if block == nil {
-			return nil, nil
 		}
 		height := block.Block.Height
 		return &height, nil

--- a/evmrpc/watermark_manager.go
+++ b/evmrpc/watermark_manager.go
@@ -296,7 +296,10 @@ func blockByNumberOrNullForJSONRPC(
 }
 
 // blockByHashOrNullForJSONRPC is the by-hash counterpart of
-// blockByNumberOrNullForJSONRPC. See that function for spec rationale.
+// blockByNumberOrNullForJSONRPC. In addition to the above-watermark case it
+// also converts ErrBlockNotFoundByHash to (nil, nil) — both are forms of
+// "block doesn't exist from the caller's perspective" and the Ethereum
+// JSON-RPC spec maps both to null.
 func blockByHashOrNullForJSONRPC(
 	ctx context.Context,
 	c client.LocalClient,
@@ -305,7 +308,7 @@ func blockByHashOrNullForJSONRPC(
 	maxRetries int,
 ) (*coretypes.ResultBlock, error) {
 	block, err := blockByHashRespectingWatermarks(ctx, c, wm, hash, maxRetries)
-	if errors.Is(err, ErrBlockHeightNotYetAvailable) {
+	if errors.Is(err, ErrBlockHeightNotYetAvailable) || errors.Is(err, ErrBlockNotFoundByHash) {
 		return nil, nil
 	}
 	return block, err

--- a/evmrpc/watermark_manager.go
+++ b/evmrpc/watermark_manager.go
@@ -270,6 +270,47 @@ func blockByHashRespectingWatermarks(
 	return block, nil
 }
 
+// blockByNumberOrNullForJSONRPC wraps blockByNumberRespectingWatermarks for
+// Ethereum JSON-RPC endpoints that must return null (not an error) when the
+// requested block sits above the safe-latest watermark — i.e. the block does
+// not yet exist from the caller's perspective. This is the spec contract for
+// endpoints that take a block identifier and return null for non-existent
+// blocks (eth_getBlockByNumber, eth_getBlockByHash, eth_getBlockReceipts,
+// eth_getTransactionByHash, eth_getTransactionByBlock*AndIndex, etc.).
+//
+// Internal call sites that genuinely need the error (state queries that must
+// reject invalid heights, simulation paths bound to a specific block) keep
+// using blockByNumberRespectingWatermarks directly.
+func blockByNumberOrNullForJSONRPC(
+	ctx context.Context,
+	c client.LocalClient,
+	wm *WatermarkManager,
+	heightPtr *int64,
+	maxRetries int,
+) (*coretypes.ResultBlock, error) {
+	block, err := blockByNumberRespectingWatermarks(ctx, c, wm, heightPtr, maxRetries)
+	if errors.Is(err, ErrBlockHeightNotYetAvailable) {
+		return nil, nil
+	}
+	return block, err
+}
+
+// blockByHashOrNullForJSONRPC is the by-hash counterpart of
+// blockByNumberOrNullForJSONRPC. See that function for spec rationale.
+func blockByHashOrNullForJSONRPC(
+	ctx context.Context,
+	c client.LocalClient,
+	wm *WatermarkManager,
+	hash []byte,
+	maxRetries int,
+) (*coretypes.ResultBlock, error) {
+	block, err := blockByHashRespectingWatermarks(ctx, c, wm, hash, maxRetries)
+	if errors.Is(err, ErrBlockHeightNotYetAvailable) {
+		return nil, nil
+	}
+	return block, err
+}
+
 func (m *WatermarkManager) fetchTendermintWatermarks(ctx context.Context) (int64, int64, error) {
 	if m.tmClient == nil {
 		return 0, 0, errNoHeightSource

--- a/evmrpc/watermark_manager_test.go
+++ b/evmrpc/watermark_manager_test.go
@@ -317,3 +317,84 @@ func makeBlockResult(height int64) *coretypes.ResultBlock {
 		},
 	}
 }
+
+// blockByNumberOrNullForJSONRPC: above-watermark height returns (nil, nil);
+// in-range height returns the block; non-watermark errors propagate.
+func TestBlockByNumberOrNullForJSONRPC(t *testing.T) {
+	t.Parallel()
+
+	stat := &coretypes.ResultStatus{SyncInfo: coretypes.SyncInfo{LatestBlockHeight: 100, EarliestBlockHeight: 1}}
+
+	t.Run("above watermark returns (nil, nil)", func(t *testing.T) {
+		c := &fakeTMClient{status: stat, blocksByHeight: map[int64]*coretypes.ResultBlock{150: makeBlockResult(150)}}
+		wm := NewWatermarkManager(c, nil, nil, nil)
+		h := int64(150) // above latest=100
+		block, err := blockByNumberOrNullForJSONRPC(context.Background(), c, wm, &h, 0)
+		require.NoError(t, err)
+		require.Nil(t, block)
+	})
+
+	t.Run("in-range height returns block", func(t *testing.T) {
+		c := &fakeTMClient{status: stat, blocksByHeight: map[int64]*coretypes.ResultBlock{50: makeBlockResult(50)}}
+		wm := NewWatermarkManager(c, nil, nil, nil)
+		h := int64(50)
+		block, err := blockByNumberOrNullForJSONRPC(context.Background(), c, wm, &h, 0)
+		require.NoError(t, err)
+		require.NotNil(t, block)
+		require.Equal(t, int64(50), block.Block.Height)
+	})
+
+	t.Run("non-watermark error propagates", func(t *testing.T) {
+		// Watermark itself fails (no sources) — error is errNoHeightSource,
+		// which must NOT be silently converted to null.
+		wm := NewWatermarkManager(nil, nil, nil, nil)
+		h := int64(50)
+		_, err := blockByNumberOrNullForJSONRPC(context.Background(), nil, wm, &h, 0)
+		require.Error(t, err)
+		require.False(t, errors.Is(err, ErrBlockHeightNotYetAvailable))
+	})
+}
+
+// blockByHashOrNullForJSONRPC: above-watermark AND unknown-hash both return
+// (nil, nil); in-range hash returns the block; other errors propagate.
+func TestBlockByHashOrNullForJSONRPC(t *testing.T) {
+	t.Parallel()
+
+	stat := &coretypes.ResultStatus{SyncInfo: coretypes.SyncInfo{LatestBlockHeight: 100, EarliestBlockHeight: 1}}
+
+	t.Run("above watermark returns (nil, nil)", func(t *testing.T) {
+		c := &fakeTMClient{status: stat, blockByHash: makeBlockResult(150)} // height above latest=100
+		wm := NewWatermarkManager(c, nil, nil, nil)
+		block, err := blockByHashOrNullForJSONRPC(context.Background(), c, wm, []byte{0xaa}, 0)
+		require.NoError(t, err)
+		require.Nil(t, block)
+	})
+
+	t.Run("unknown hash (Block: nil) returns (nil, nil)", func(t *testing.T) {
+		// blockByHashWithRetry wraps Block:nil as ErrBlockNotFoundByHash;
+		// the helper must catch that sentinel too.
+		c := &fakeTMClient{status: stat, blockByHash: &coretypes.ResultBlock{Block: nil}}
+		wm := NewWatermarkManager(c, nil, nil, nil)
+		block, err := blockByHashOrNullForJSONRPC(context.Background(), c, wm, []byte{0xbb}, 0)
+		require.NoError(t, err)
+		require.Nil(t, block)
+	})
+
+	t.Run("in-range hash returns block", func(t *testing.T) {
+		c := &fakeTMClient{status: stat, blockByHash: makeBlockResult(50)}
+		wm := NewWatermarkManager(c, nil, nil, nil)
+		block, err := blockByHashOrNullForJSONRPC(context.Background(), c, wm, []byte{0xcc}, 0)
+		require.NoError(t, err)
+		require.NotNil(t, block)
+		require.Equal(t, int64(50), block.Block.Height)
+	})
+
+	t.Run("transport error propagates", func(t *testing.T) {
+		// A non-sentinel error from the TM client (e.g. RPC transport
+		// failure) must NOT be silently swallowed into null.
+		c := &fakeTMClient{status: stat, blockByHashErr: io.ErrUnexpectedEOF}
+		wm := NewWatermarkManager(c, nil, nil, nil)
+		_, err := blockByHashOrNullForJSONRPC(context.Background(), c, wm, []byte{0xdd}, 0)
+		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	})
+}


### PR DESCRIPTION
## Summary

Several Ethereum JSON-RPC endpoints that take a block identifier currently surface the watermark race (`"requested height N is not yet available; safe latest is N-1"`) as an error, where the Ethereum JSON-RPC spec says they should return JSON `null` (block doesn't exist *yet* from the caller's perspective). Wallets, indexers, and similar tools see this as a transient failure exactly when a tx has just been mined and the safe-latest watermark hasn't caught up.

#3119 fixed `eth_getBlockByNumber` and #3501 fixed `eth_getTransactionReceipt` with the same `if errors.Is(err, ErrBlockHeightNotYetAvailable) { return nil, nil }` pattern. This PR generalizes the pattern into two helpers and applies it to the remaining user‑facing endpoints.

## Endpoints converted

| RPC method | File:line |
|---|---|
| `eth_getBlockReceipts` | `block.go` |
| `eth_getBlockTransactionCountByNumber` | `block.go` |
| `eth_getBlockTransactionCountByHash` | `block.go` |
| `eth_getBlockByHash` + `sei_getBlockByHashExcludeTraceFail` (shared `getBlockByHash`) | `block.go` |
| `eth_getTransactionByBlockNumberAndIndex` | `tx.go` |
| `eth_getTransactionByBlockHashAndIndex` | `tx.go` |
| `eth_getTransactionByHash` | `tx.go` |

## Historic context (why propagation was the previous default)

The watermark integration (#2465) deliberately propagated the error so clients would know "data not yet ready — retry later" rather than getting a misleading null. That was the original conservative default across **all** evmrpc endpoints that touched a height.

Since then, subsequent PRs have progressively chosen JSON `null` per Ethereum spec on a per‑endpoint basis:

| PR | Endpoint | Rationale |
|---|---|---|
| #3067 (Moji) | `eth_getBlockByHash` (unknown hash) | PLT‑162: "return result null for non‑existent hashes" |
| #3119 (Moji) | `eth_getBlockByNumber` (above watermark) | "Align with expectations" (Ethereum spec) |
| #3320 (Wen) | `eth_getTransactionByBlock*AndIndex` (out‑of‑range index) | "Per Ethereum JSON‑RPC spec, these methods must return null" |
| #3501 | `eth_getTransactionReceipt` (above watermark) | spec |
| **#3530** (this) | the **remaining 7** user‑facing endpoints | continues the same pattern |

So the propagation on these 7 endpoints wasn't a deliberate "this endpoint should error" choice — it's historical inertia from #2465 that subsequent PRs have been chipping away one endpoint at a time. #3530 finishes the same job; nothing about the original watermark intent is being reversed where it still serves users (see *out of scope* below).

## Out of scope

State queries (`eth_getBalance`/`Code`/`StorageAt`/`Proof`), simulation paths, filter internals, and `info.go`/`association.go` helpers keep using `blockByNumberRespectingWatermarks` directly. These are where the original #2465 design still applies:

- The spec is fuzzier (some clients expect error for invalid blocks).
- The "data not ready" semantic is more meaningful — a wallet showing `balance: 0` for a not‑yet‑ready block would mislead users.
- Internal call sites validate heights and rely on the error path.

Tests covering those error paths (`TestStateAPIGetProofUnavailableHeight`, the filter‑cache test) are intentionally unchanged.

**Pruned-block path also unchanged.** Explicit numeric requests for heights below the earliest watermark (`height < earliest`) still return `"requested height N has been pruned"`. The helpers only convert `ErrBlockHeightNotYetAvailable` (and `ErrBlockNotFoundByHash` for the by-hash variant). Pre-PR behavior is preserved here — pruned is a different (permanent, not transient) failure class from the watermark race this PR addresses, and changing it would touch a different set of test assertions (`watermark_manager_test.go:106,135`). Hash-based requests for pruned blocks already return null in production because Tendermint returns `Block: nil` for unknown hashes, which `blockByHashWithRetry` wraps as `ErrBlockNotFoundByHash`.

## Helpers

```go
// blockByNumberOrNullForJSONRPC: wraps blockByNumberRespectingWatermarks
// and converts ErrBlockHeightNotYetAvailable to (nil, nil) so callers can
// return JSON null per the Ethereum spec.

// blockByHashOrNullForJSONRPC: same, by-hash variant. Also catches
// ErrBlockNotFoundByHash — both are "block doesn't exist" per spec.
```

Internal call sites that want the error keep using the originals.

## Operational impact (broader than tests)

This is a production-correctness fix. Currently a wallet polling for a freshly-mined tx, or an indexer doing `eth_getBlockReceipts` near the chain head, can intermittently get a `"block height not yet available"` error response instead of `null` — they then surface that as a transient failure to users. With this change, those endpoints behave per Ethereum JSON-RPC spec.

## Test plan

- [x] `go test ./evmrpc/ -count=1` passes (21s, includes the updated above-watermark tests).
- [x] `golangci-lint run ./evmrpc/`: 0 issues.
- [x] `gofmt -s -l` clean.
- [ ] CI integration matrix passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
