### PR TITLE
docs: remove empty parens from testnet description

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ All these features combine to unlock a brand new, scalable design space for the 
 # Testnet
 ## Get started
 **How to validate on the Sei Testnet**
-*This is the Sei Atlantic-2 Testnet ()*
+*This is the Sei Atlantic-2 Testnet*
 
 > Genesis [Published](https://github.com/sei-protocol/testnet/blob/main/atlantic-2/genesis.json)
 


### PR DESCRIPTION
Tiny fix: empty trailing parens '()' on the testnet description line.