### PR TITLE
test: use local RPC for eth_accounts empty case

### DIFF
--- a/integration_test/rpc_tests/config/endpoints.ts
+++ b/integration_test/rpc_tests/config/endpoints.ts
@@ -13,7 +13,6 @@ export const Endpoints = {
         geth: env('RPC_ETH_GETH', 'http://127.0.0.1:9547'),
         fork: env('RPC_ETH_FORK', 'http://127.0.0.1:9546'),
     },
-    accountless: env('RPC_ACCOUNTLESS', 'https://evm-rpc.sei-apis.com'),
 } as const;
 
 export const AdminMnemonic = env(

--- a/integration_test/rpc_tests/eth/eth_accounts.spec.ts
+++ b/integration_test/rpc_tests/eth/eth_accounts.spec.ts
@@ -1,8 +1,6 @@
 import { expect } from 'chai';
-import { bothProviders, isReachable } from '../utils/chainUtils';
-import { rawSei, rawGeth, rawAccountless, expectJsonRpcError } from '../utils/chainUtils';
+import { bothProviders, rawSei, rawGeth, expectJsonRpcError } from '../utils/chainUtils';
 import { ADDRESS, ADDRESS_LOWER } from '../utils/format';
-import { Endpoints } from '../config/endpoints';
 
 describe('eth_accounts Tests', function () {
     this.timeout(60 * 1000);
@@ -56,10 +54,10 @@ describe('eth_accounts Tests', function () {
     });
 
     describe('empty / null handling', () => {
-        it('a keyless node returns [] (empty array), never null', async function () {
-            const body = await rawAccountless<string[]>('eth_accounts', []);
+        it('the local Sei node returns [] (empty array), never null', async function () {
+            const body = await rawSei<string[]>('eth_accounts', []);
             expect(body.error, JSON.stringify(body.error)).to.equal(undefined);
-            expect(body.result, 'keyless node must encode the empty set as []').to.deep.equal([]);
+            expect(body.result, 'local Sei node must encode the empty set as []').to.deep.equal([]);
             expect(body.result).to.not.equal(null);
         });
     });

--- a/integration_test/rpc_tests/utils/chainUtils.ts
+++ b/integration_test/rpc_tests/utils/chainUtils.ts
@@ -112,10 +112,6 @@ export const rawSei = <T = unknown>(method: string, params: unknown) =>
 export const rawGeth = <T = unknown>(method: string, params: unknown) =>
     rawJsonRpc<T>(Endpoints.eth.geth, method, params);
 
-/** Raw POST to a keyless node (hosted RPC) — used to observe the empty-account case. */
-export const rawAccountless = <T = unknown>(method: string, params: unknown) =>
-    rawJsonRpc<T>(Endpoints.accountless, method, params);
-
 /**
  * Resolve a promise expected to throw an ethers RPC error and return the underlying
  * JSON-RPC envelope. We unwrap both `e.info.error` (ethers v6 default) and `e.error`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes and provide context

- Verified `eth_accounts` empty/null handling used `rawAccountless`, whose default endpoint was the hosted `https://evm-rpc.sei-apis.com`.
- Switched the empty-set assertion to use `rawSei`, so it targets the local Sei EVM RPC configured by `SEI_EVM_RPC` / `http://localhost:8545`.
- Removed the now-unused accountless raw helper and hosted endpoint config to prevent future accidental external calls.

## Testing performed to validate your change

- `npx tsc -p tsconfig.json --noEmit` (from `integration_test/rpc_tests`) - passed.
- `npx mocha --require tsx --timeout 60000 --exit "eth/eth_accounts.spec.ts"` (from `integration_test/rpc_tests`) - attempted, but local Sei `:8545` and geth `:9547` were not running in this workspace; failures were `ECONNREFUSED`. The empty/null test failure stack now goes through `rawJsonRpc` against the local RPC path rather than the hosted endpoint.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10181384-efb9-44c0-a55f-c1f783427e82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10181384-efb9-44c0-a55f-c1f783427e82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

