### PR TITLE
ci: use Docker Buildx + ECR registry cache for integration-test prepare-cluster

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -27,11 +27,14 @@ jobs:
     name: Prepare integration test cluster
     runs-on: ubuntu-large
     timeout-minutes: 45
+    # OIDC token required for ECR cache push. Fork PRs cannot obtain it;
+    # aws-login uses continue-on-error so cold builds still succeed.
+    # cache-to is restricted to push events to avoid cache thrashing on PRs.
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v6
-        with:
-          go-version: '1.25.6'
+      - uses: actions/checkout@v5
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         if: env.DOCKERHUB_USERNAME != ''
@@ -40,10 +43,50 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build Docker images and seid binary
+      - name: AWS Login
+        id: aws-login
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::189176372795:role/common/gha
+          role-duration-seconds: 900
+      - name: Login to Amazon ECR
+        id: login-ecr
+        if: steps.aws-login.outcome == 'success'
+        continue-on-error: true
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build localnode image (cached)
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/localnode
+          file: docker/localnode/Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: sei-chain/localnode
+          cache-from: ${{ steps.login-ecr.outputs.registry != '' && format('type=registry,ref={0}/sei/build-cache:integration-localnode', steps.login-ecr.outputs.registry) || '' }}
+          cache-to: ${{ steps.login-ecr.outputs.registry != '' && github.event_name == 'push' && format('type=registry,ref={0}/sei/build-cache:integration-localnode,mode=max', steps.login-ecr.outputs.registry) || '' }}
+      - name: Build rpcnode image (cached)
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/rpcnode
+          file: docker/rpcnode/Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: sei-chain/rpcnode
+          cache-from: ${{ steps.login-ecr.outputs.registry != '' && format('type=registry,ref={0}/sei/build-cache:integration-rpcnode', steps.login-ecr.outputs.registry) || '' }}
+          cache-to: ${{ steps.login-ecr.outputs.registry != '' && github.event_name == 'push' && format('type=registry,ref={0}/sei/build-cache:integration-rpcnode,mode=max', steps.login-ecr.outputs.registry) || '' }}
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.25.6'
+      - name: Build seid binary in localnode container
         env:
           DOCKER_PLATFORM: linux/amd64
-        run: make build-integration-ci-artifacts
+        run: make build-seid-in-localnode-ci
       - name: Package CI artifacts
         run: |
           tar -czf integration-build.tar.gz build/seid

--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,21 @@ build-seid-in-localnode: build-docker-node
 		bash -c 'export PATH=/usr/local/go/bin:$$PATH && make clean && make build-linux && mkdir -p build/generated && echo DONE > build/generated/build.complete'
 .PHONY: build-seid-in-localnode
 
+# CI variant: assumes localnode image already built by Buildx in prepare-cluster (skips docker build).
+build-seid-in-localnode-ci: ensure-integration-ci-images
+	@mkdir -p build $(shell go env GOPATH)/pkg/mod $(shell go env GOCACHE)
+	@docker run --rm \
+		--user="$(shell id -u):$(shell id -g)" \
+		-v $(PROJECT_HOME):/sei-protocol/sei-chain:Z \
+		-v $(GO_PKG_PATH)/mod:/root/go/pkg/mod:Z \
+		-v $(shell go env GOCACHE):/root/.cache/go-build:Z \
+		--platform $(DOCKER_PLATFORM) \
+		-w /sei-protocol/sei-chain \
+		-e LEDGER_ENABLED=false \
+		sei-chain/localnode \
+		bash -c 'export PATH=/usr/local/go/bin:$$PATH && make clean && make build-linux && mkdir -p build/generated && echo DONE > build/generated/build.complete'
+.PHONY: build-seid-in-localnode-ci
+
 # Images + seid binary for integration-test CI (see .github/workflows/integration-test.yml).
 # build-seid-in-localnode already depends on build-docker-node, so omit it here to avoid building localnode twice.
 build-integration-ci-artifacts: build-rpc-node build-seid-in-localnode


### PR DESCRIPTION
## Summary
- Replace uncached `docker build` in `prepare-cluster` with Docker Buildx + ECR registry-backed layer cache, using dedicated cache tags (`build-cache:integration-localnode`, `build-cache:integration-rpcnode`) separate from the release `build-cache:shared`.
- Add `build-seid-in-localnode-ci` Makefile target that compiles `seid` inside an already-loaded `localnode` container, avoiding a redundant image rebuild.
- Fork PRs degrade gracefully to a cold build: AWS OIDC login uses `continue-on-error`, and cache refs are conditionally empty when auth fails. Cache writes (`cache-to`) are further restricted to `push` events to avoid cache thrashing on PRs.

## Expected impact

| Step | Cold build | Warm (Dockerfiles unchanged) |
|------|-----------|------------------------------|
| `localnode` image | ~10–20+ min | ~1–3 min |
| `rpcnode` image | ~2–5 min | ~30s–1 min |
| `seid` compile | unchanged | unchanged |

