### PR TITLE
replaced monotoneMaxPeerHeight with maxPeerHeight (CON-328)

### DIFF
--- a/sei-tendermint/internal/blocksync/pool.go
+++ b/sei-tendermint/internal/blocksync/pool.go
@@ -86,10 +86,9 @@ type BlockPool struct {
 	requesters map[int64]*bpRequester
 	height     int64 // the lowest key in requesters.
 	// peers
-	peers                 map[types.NodeID]*bpPeer
-	router                router
-	maxPeerHeight         int64 // the biggest reported height among current peers
-	monotoneMaxPeerHeight int64 // the biggest reported height observed since the pool started
+	peers         map[types.NodeID]*bpPeer
+	router        router
+	maxPeerHeight int64 // the biggest reported height among current peers
 
 	// atomic
 	numPending atomic.Int32 // number of requests pending assignment or block response
@@ -214,11 +213,9 @@ func (pool *BlockPool) IsCaughtUp() bool {
 		return false
 	}
 
-	// NOTE: we use monotoneMaxPeerHeight - 1 because to sync block H requires
-	// block H+1 to verify the LastCommit. The monotone maximum prevents us from
-	// considering ourselves caught up just because peers later retract their
-	// reported heights.
-	return pool.height >= (pool.monotoneMaxPeerHeight - 1)
+	// To sync block H we require block H+1 to verify the LastCommit, so we are
+	// caught up once we have reached the current maximum peer height minus one.
+	return pool.height >= (pool.maxPeerHeight - 1)
 }
 
 // PeekTwoBlocks returns blocks at pool.height and pool.height+1. We need to
@@ -394,9 +391,6 @@ func (pool *BlockPool) SetPeerRange(peerID types.NodeID, base int64, height int6
 
 	if height > pool.maxPeerHeight {
 		pool.maxPeerHeight = height
-	}
-	if height > pool.monotoneMaxPeerHeight {
-		pool.monotoneMaxPeerHeight = height
 	}
 }
 

--- a/sei-tendermint/internal/blocksync/pool_test.go
+++ b/sei-tendermint/internal/blocksync/pool_test.go
@@ -249,30 +249,25 @@ func TestBlockPoolMaliciousNodeMaxInt64(t *testing.T) {
 	require.Equal(t, int64(initialHeight), pool.maxPeerHeight)
 }
 
-func TestBlockPoolIsCaughtUpUsesMonotoneMaxPeerHeight(t *testing.T) {
-	const startHeight = 7
+func TestBlockPoolIsCaughtUpUsesCurrentMaxPeerHeight(t *testing.T) {
+	const maxHeight = 7
 	goodNodeID := types.NodeID(strings.Repeat("a", 40))
 	badNodeID := types.NodeID(strings.Repeat("b", 40))
 	otherGoodNodeID := types.NodeID(strings.Repeat("c", 40))
 	peers := testPeers{
-		goodNodeID:      {goodNodeID, 1, startHeight, make(chan inputData)},
+		goodNodeID:      {goodNodeID, 1, maxHeight, make(chan inputData)},
 		badNodeID:       {badNodeID, 1, math.MaxInt64, make(chan inputData)},
-		otherGoodNodeID: {otherGoodNodeID, 1, startHeight, make(chan inputData)},
+		otherGoodNodeID: {otherGoodNodeID, 1, maxHeight, make(chan inputData)},
 	}
-	pool := NewBlockPool(1, makeRouter(peers))
+	pool := NewBlockPool(maxHeight-1, makeRouter(peers))
 
-	pool.SetPeerRange(goodNodeID, 1, startHeight)
+	pool.SetPeerRange(goodNodeID, 1, maxHeight)
 	pool.SetPeerRange(badNodeID, 1, math.MaxInt64)
-	pool.SetPeerRange(otherGoodNodeID, 1, startHeight)
-	pool.SetPeerRange(badNodeID, 1, startHeight)
+	pool.SetPeerRange(otherGoodNodeID, 1, maxHeight)
 
-	pool.height = startHeight - 1
 	require.False(t, pool.IsCaughtUp())
 
-	pool.height = startHeight
-	require.False(t, pool.IsCaughtUp())
-
-	pool.height = math.MaxInt64 - 1
+	pool.SetPeerRange(badNodeID, 1, maxHeight)
 	require.True(t, pool.IsCaughtUp())
 }
 


### PR DESCRIPTION
strawman fix to CON-328, marginally increases complexity of stalling blocksync. Currently recommended fix is to explicitly specify a list of trusted blocksync peers in the config.