### PR TITLE
Fixed parsing of autobahn proposal (CON-325)

### DIFF
--- a/sei-tendermint/internal/autobahn/types/proposal.go
+++ b/sei-tendermint/internal/autobahn/types/proposal.go
@@ -149,6 +149,8 @@ func newProposal(view View, timestamp time.Time, laneRanges []*LaneRange, app ut
 	globalRangeWithoutOffset := GlobalRange{}
 	for _, r := range laneRanges {
 		laneRangesM[r.Lane()] = r
+	}
+	for _, r := range laneRangesM {
 		globalRangeWithoutOffset.First += GlobalBlockNumber(r.First())
 		globalRangeWithoutOffset.Next += GlobalBlockNumber(r.Next())
 	}
@@ -522,12 +524,16 @@ var ProposalConv = protoutils.Conv[*Proposal, *pb.Proposal]{
 		if err != nil {
 			return nil, fmt.Errorf("appQC: %w", err)
 		}
-		return newProposal(
+		proposal := newProposal(
 			view,
 			timestamp,
 			laneRanges,
 			app,
-		), nil
+		)
+		if len(proposal.laneRanges) != len(laneRanges) {
+			return nil, fmt.Errorf("laneRanges: duplicate ranges")
+		}
+		return proposal,nil
 	},
 }
 

--- a/sei-tendermint/internal/autobahn/types/proposal.go
+++ b/sei-tendermint/internal/autobahn/types/proposal.go
@@ -533,7 +533,7 @@ var ProposalConv = protoutils.Conv[*Proposal, *pb.Proposal]{
 		if len(proposal.laneRanges) != len(laneRanges) {
 			return nil, fmt.Errorf("laneRanges: duplicate ranges")
 		}
-		return proposal,nil
+		return proposal, nil
 	},
 }
 

--- a/sei-tendermint/internal/autobahn/types/proposal_test.go
+++ b/sei-tendermint/internal/autobahn/types/proposal_test.go
@@ -469,6 +469,18 @@ func TestProposalVerifyRejectsInvalidLaneQCSignature(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestProposalConvDecode_RejectsDuplicateLaneRanges(t *testing.T) {
+	rng := utils.TestRng()
+	encoded := ProposalConv.Encode(GenProposal(rng))
+	_, err := ProposalConv.Decode(encoded)
+	require.NoError(t, err)
+	// Add a duplicate lane range. Now decoding should fail.
+	require.NotEqual(t, 0, len(encoded.LaneRanges))
+	encoded.LaneRanges = append(encoded.LaneRanges, encoded.LaneRanges[0])
+	_, err = ProposalConv.Decode(encoded)
+	require.Error(t, err)
+}
+
 func makeFullProposal(
 	committee *Committee,
 	keys []SecretKey,


### PR DESCRIPTION
Duplicate laneRanges in Proposal were silently ignored, now parsing will return an error. Also fixed global range parsing in presence of duplicates for defence in-depth.