### PR TITLE
UnconfirmedTxs improvements (CON-322)

### DIFF
--- a/app/abci.go
+++ b/app/abci.go
@@ -125,6 +125,7 @@ func (app *App) CheckTx(ctx context.Context, req *abci.RequestCheckTxV2) *abci.R
 			GasEstimated: int64(gInfo.GasEstimate), //nolint:gosec
 		},
 		EVMNonce:           txCtx.EVMNonce(),
+		EVMHash:            txCtx.EVMTxHash(),
 		EVMSenderAddress:   txCtx.EVMSenderAddress(),
 		SeiSenderAddress:   txCtx.SeiSenderAddress(),
 		IsEVM:              txCtx.IsEVM(),
@@ -194,7 +195,7 @@ func (app *App) DeliverTx(ctx sdk.Context, req abci.RequestDeliverTxV2, tx sdk.T
 		res.EvmTxInfo = &abci.EvmTxInfo{
 			SenderAddress: resCtx.EVMSenderAddress().Hex(),
 			Nonce:         resCtx.EVMNonce(),
-			TxHash:        resCtx.EVMTxHash(),
+			TxHash:        resCtx.EVMTxHash().Hex(),
 			VmError:       result.EvmError,
 		}
 		// TODO: populate error data for EVM err

--- a/app/ante/evm_checktx.go
+++ b/app/ante/evm_checktx.go
@@ -161,7 +161,7 @@ func DecorateContext(ctx sdk.Context, ek *evmkeeper.Keeper, tx sdk.Tx, txData et
 	ctx = ctx.WithEVMNonce(etx.Nonce())
 	ctx = ctx.WithEVMSenderAddress(sender)
 	ctx = ctx.WithSeiSenderAddress(seiSender)
-	ctx = ctx.WithEVMTxHash(etx.Hash().Hex())
+	ctx = ctx.WithEVMTxHash(etx.Hash())
 	adjustedGasLimit := ek.GetPriorityNormalizer(ctx).MulInt64(int64(txData.GetGas())) //nolint:gosec
 	gasMeter := sdk.NewGasMeterWithMultiplier(ctx, adjustedGasLimit.TruncateInt().Uint64())
 	ctx = ctx.WithGasMeter(gasMeter)

--- a/app/legacyabci/deliver_tx.go
+++ b/app/legacyabci/deliver_tx.go
@@ -142,7 +142,7 @@ func DeliverTx(
 			evmTxInfo = &abci.EvmTxInfo{
 				SenderAddress: ctx.EVMSenderAddress().Hex(),
 				Nonce:         ctx.EVMNonce(),
-				TxHash:        ctx.EVMTxHash(),
+				TxHash:        ctx.EVMTxHash().Hex(),
 				VmError:       result.EvmError,
 			}
 		}

--- a/evmrpc/block_txcount_parity_test.go
+++ b/evmrpc/block_txcount_parity_test.go
@@ -36,6 +36,10 @@ func (*parityTxCountTMClient) EvmNextPendingNonce(common.Address) uint64 {
 	return 0
 }
 
+func (*parityTxCountTMClient) EvmTxByHash(common.Hash) (tmtypes.Tx, bool) {
+	return nil, false
+}
+
 func (*parityTxCountTMClient) EvmProxy(common.Address) (*url.URL, bool) {
 	return nil, false
 }

--- a/evmrpc/height_availability_test.go
+++ b/evmrpc/height_availability_test.go
@@ -34,6 +34,10 @@ func (*heightTestClient) EvmNextPendingNonce(common.Address) uint64 {
 	return 0
 }
 
+func (*heightTestClient) EvmTxByHash(common.Hash) (tmtypes.Tx, bool) {
+	return nil, false
+}
+
 func (*heightTestClient) EvmProxy(common.Address) (*url.URL, bool) {
 	return nil, false
 }

--- a/evmrpc/setup_test.go
+++ b/evmrpc/setup_test.go
@@ -146,6 +146,18 @@ func (*MockClient) EvmNextPendingNonce(common.Address) uint64 {
 	return 0
 }
 
+func (*MockClient) EvmTxByHash(hash common.Hash) (tmtypes.Tx, bool) {
+	tx, err := Encoder(UnconfirmedTx)
+	if err != nil {
+		return nil, false
+	}
+	ethTx, _ := UnconfirmedTx.GetMsgs()[0].(*types.MsgEVMTransaction).AsTransaction()
+	if ethTx == nil || ethTx.Hash() != hash {
+		return nil, false
+	}
+	return tx, true
+}
+
 func (*MockClient) EvmProxy(common.Address) (*url.URL, bool) {
 	return nil, false
 }

--- a/evmrpc/simulate_test.go
+++ b/evmrpc/simulate_test.go
@@ -873,6 +873,10 @@ func (c *fixedBlockClient) EvmNextPendingNonce(common.Address) uint64 {
 	return 0
 }
 
+func (c *fixedBlockClient) EvmTxByHash(common.Hash) (tmtypes.Tx, bool) {
+	return nil, false
+}
+
 func (c *fixedBlockClient) EvmProxy(common.Address) (*url.URL, bool) {
 	return nil, false
 }

--- a/evmrpc/tests/mock_client.go
+++ b/evmrpc/tests/mock_client.go
@@ -41,6 +41,10 @@ func (c *MockClient) EvmNextPendingNonce(_ common.Address) uint64 {
 	return 0
 }
 
+func (*MockClient) EvmTxByHash(common.Hash) (tmtypes.Tx, bool) {
+	return nil, false
+}
+
 func (c *MockClient) EvmProxy(common.Address) (*url.URL, bool) {
 	return nil, false
 }

--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -31,9 +31,6 @@ import (
 
 var ErrPanicTx = errors.New("transaction is panic tx")
 
-const UnconfirmedTxQueryMaxPage = 20
-const UnconfirmedTxQueryPerPage = 30
-
 type TransactionAPI struct {
 	tmClient           client.LocalClient
 	keeper             *keeper.Keeper
@@ -256,36 +253,30 @@ func (t *TransactionAPI) GetTransactionByHash(ctx context.Context, hash common.H
 	}()
 	sdkCtx := t.ctxProvider(LatestCtxHeight)
 	// first try get from mempool
-	for page := 1; page <= UnconfirmedTxQueryMaxPage; page++ {
-		res, err := t.tmClient.UnconfirmedTxs(ctx, &page, nil)
-		if err != nil || len(res.Txs) == 0 {
-			break
-		}
-		for _, tx := range res.Txs {
-			etx := getEthTxForTxBz(tx, t.txConfigProvider(LatestCtxHeight).TxDecoder())
-			if etx != nil && etx.Hash() == hash {
-				from, err := rpcutils.RecoverEVMSenderWithContext(sdkCtx, etx)
-				if err != nil { // codecov:ignore - defensive error handling for invalid signatures
-					logger.Error("failed to recover sender", "err", err, "tx", etx.Hash()) // codecov:ignore
-					return nil, err                                                        // codecov:ignore
-				}
-				v, r, s := etx.RawSignatureValues()
-				res := export.RPCTransaction{
-					Type:     hexutil.Uint64(etx.Type()),
-					From:     from,
-					Gas:      hexutil.Uint64(etx.Gas()),
-					GasPrice: (*hexutil.Big)(etx.GasPrice()),
-					Hash:     etx.Hash(),
-					Input:    hexutil.Bytes(etx.Data()),
-					Nonce:    hexutil.Uint64(etx.Nonce()),
-					To:       etx.To(),
-					Value:    (*hexutil.Big)(etx.Value()),
-					V:        (*hexutil.Big)(v),
-					R:        (*hexutil.Big)(r),
-					S:        (*hexutil.Big)(s),
-				}
-				return &res, nil
+	if tx, ok := t.tmClient.EvmTxByHash(hash); ok {
+		etx := getEthTxForTxBz(tx, t.txConfigProvider(LatestCtxHeight).TxDecoder())
+		if etx != nil {
+			from, err := rpcutils.RecoverEVMSenderWithContext(sdkCtx, etx)
+			if err != nil { // codecov:ignore - defensive error handling for invalid signatures
+				logger.Error("failed to recover sender", "err", err, "tx", etx.Hash()) // codecov:ignore
+				return nil, err                                                        // codecov:ignore
 			}
+			v, r, s := etx.RawSignatureValues()
+			res := export.RPCTransaction{
+				Type:     hexutil.Uint64(etx.Type()),
+				From:     from,
+				Gas:      hexutil.Uint64(etx.Gas()),
+				GasPrice: (*hexutil.Big)(etx.GasPrice()),
+				Hash:     etx.Hash(),
+				Input:    hexutil.Bytes(etx.Data()),
+				Nonce:    hexutil.Uint64(etx.Nonce()),
+				To:       etx.To(),
+				Value:    (*hexutil.Big)(etx.Value()),
+				V:        (*hexutil.Big)(v),
+				R:        (*hexutil.Big)(r),
+				S:        (*hexutil.Big)(s),
+			}
+			return &res, nil
 		}
 	}
 

--- a/evmrpc/tx_test.go
+++ b/evmrpc/tx_test.go
@@ -29,6 +29,7 @@ import (
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/rpc/client/mock"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/rpc/coretypes"
+	tmtypes "github.com/sei-protocol/sei-chain/sei-tendermint/types"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
@@ -300,6 +301,8 @@ type lowLatestTMClient struct {
 }
 
 func (c *lowLatestTMClient) EvmNextPendingNonce(common.Address) uint64 { return 0 }
+
+func (c *lowLatestTMClient) EvmTxByHash(common.Hash) (tmtypes.Tx, bool) { return nil, false }
 
 func (c *lowLatestTMClient) EvmProxy(common.Address) (*url.URL, bool) { return nil, false }
 

--- a/evmrpc/watermark_manager_test.go
+++ b/evmrpc/watermark_manager_test.go
@@ -168,6 +168,10 @@ func (*fakeTMClient) EvmNextPendingNonce(common.Address) uint64 {
 	return 0
 }
 
+func (*fakeTMClient) EvmTxByHash(common.Hash) (tmtypes.Tx, bool) {
+	return nil, false
+}
+
 func (*fakeTMClient) EvmProxy(common.Address) (*url.URL, bool) {
 	return nil, false
 }

--- a/sei-cosmos/baseapp/abci.go
+++ b/sei-cosmos/baseapp/abci.go
@@ -223,7 +223,7 @@ func (app *BaseApp) DeliverTx(ctx sdk.Context, req abci.RequestDeliverTxV2, tx s
 		res.EvmTxInfo = &abci.EvmTxInfo{
 			SenderAddress: runTxRes.ctx.EVMSenderAddress().Hex(),
 			Nonce:         runTxRes.ctx.EVMNonce(),
-			TxHash:        runTxRes.ctx.EVMTxHash(),
+			TxHash:        runTxRes.ctx.EVMTxHash().Hex(),
 			VmError:       result.EvmError,
 		}
 		// TODO: populate error data for EVM err

--- a/sei-cosmos/baseapp/baseapp.go
+++ b/sei-cosmos/baseapp/baseapp.go
@@ -978,7 +978,7 @@ func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, tx sdk.Tx, checksum [
 			evmTxInfo = &abci.EvmTxInfo{
 				SenderAddress: ctx.EVMSenderAddress().Hex(),
 				Nonce:         ctx.EVMNonce(),
-				TxHash:        ctx.EVMTxHash(),
+				TxHash:        ctx.EVMTxHash().Hex(),
 				VmError:       runTxRes.result.EvmError,
 			}
 		}

--- a/sei-cosmos/baseapp/deliver_tx_test.go
+++ b/sei-cosmos/baseapp/deliver_tx_test.go
@@ -1486,7 +1486,7 @@ func TestDeliverTx(t *testing.T) {
 
 			if isEvm {
 				require.Equal(t, uint64(12345), res.EvmTxInfo.Nonce)
-				require.Equal(t, "hash", res.EvmTxInfo.TxHash)
+				require.Equal(t, common.HexToHash("0x1234").Hex(), res.EvmTxInfo.TxHash)
 				require.Equal(t, "0x00000000000000000000000000000000000000AA", res.EvmTxInfo.SenderAddress)
 			} else {
 				require.Nil(t, res.EvmTxInfo)

--- a/sei-cosmos/baseapp/deliver_tx_test.go
+++ b/sei-cosmos/baseapp/deliver_tx_test.go
@@ -1473,7 +1473,7 @@ func TestDeliverTx(t *testing.T) {
 			if isEvm {
 				ctx = ctx.WithIsEVM(true)
 				ctx = ctx.WithEVMNonce(12345)
-				ctx = ctx.WithEVMTxHash("hash")
+				ctx = ctx.WithEVMTxHash(common.HexToHash("0x1234"))
 				ctx = ctx.WithEVMSenderAddress(common.HexToAddress("0x00000000000000000000000000000000000000aa"))
 			}
 

--- a/sei-cosmos/client/context.go
+++ b/sei-cosmos/client/context.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 	rpcclient "github.com/sei-protocol/sei-chain/sei-tendermint/rpc/client"
+	tmtypes "github.com/sei-protocol/sei-chain/sei-tendermint/types"
 
 	"github.com/sei-protocol/sei-chain/sei-cosmos/codec"
 	codectypes "github.com/sei-protocol/sei-chain/sei-cosmos/codec/types"
@@ -27,6 +28,7 @@ type Client = rpcclient.Client
 type LocalClient interface {
 	Client
 	EvmNextPendingNonce(addr common.Address) uint64
+	EvmTxByHash(hash common.Hash) (tmtypes.Tx, bool)
 	EvmProxy(sender common.Address) (*url.URL, bool)
 }
 

--- a/sei-cosmos/types/context.go
+++ b/sei-cosmos/types/context.go
@@ -55,10 +55,10 @@ type Context struct {
 	evmNonce                            uint64 // EVM Transaction nonce
 	evmSenderAddress                    common.Address
 	seiSenderAddress                    AccAddress
-	evmTxHash                           string // EVM TX hash
-	evmVmError                          string // EVM VM error during execution
-	evmEntryViaWasmdPrecompile          bool   // EVM is entered via wasmd precompile directly
-	evmPrecompileCalledFromDelegateCall bool   // EVM precompile is called from a delegate call
+	evmTxHash                           common.Hash // EVM TX hash
+	evmVmError                          string      // EVM VM error during execution
+	evmEntryViaWasmdPrecompile          bool        // EVM is entered via wasmd precompile directly
+	evmPrecompileCalledFromDelegateCall bool        // EVM precompile is called from a delegate call
 
 	messageIndex int // Used to track current message being processed
 	txIndex      int
@@ -164,7 +164,7 @@ func (c Context) SeiSenderAddress() AccAddress {
 	return c.seiSenderAddress
 }
 
-func (c Context) EVMTxHash() string {
+func (c Context) EVMTxHash() common.Hash {
 	return c.evmTxHash
 }
 
@@ -439,7 +439,7 @@ func (c Context) WithIsEVM(isEVM bool) Context {
 	return c
 }
 
-func (c Context) WithEVMTxHash(txHash string) Context {
+func (c Context) WithEVMTxHash(txHash common.Hash) Context {
 	c.evmTxHash = txHash
 	return c
 }

--- a/sei-tendermint/abci/types/types.go
+++ b/sei-tendermint/abci/types/types.go
@@ -233,6 +233,7 @@ type ResponseCheckTxV2 struct {
 
 	// helper properties for prioritization in mempool
 	EVMNonce uint64
+	EVMHash  common.Hash
 	// EVM and sei addresses are both derived from the sender's public key.
 	// TODO(gprusak): include just the secp256k1 public key and let the CheckTx caller derive evm/sei address on their own.
 	EVMSenderAddress   common.Address

--- a/sei-tendermint/internal/mempool/mempool.go
+++ b/sei-tendermint/internal/mempool/mempool.go
@@ -242,6 +242,10 @@ func (txmp *TxMempool) EvmNextPendingNonce(addr common.Address) uint64 {
 	return txmp.txStore.NextNonce(addr)
 }
 
+func (txmp *TxMempool) EvmTxByHash(hash common.Hash) (types.Tx, bool) {
+	return txmp.txStore.ByEvmHash(hash)
+}
+
 // Relatively fresh snapshot of the mempool.
 // NOTE: it is NOT the current state of the mempool most of the time.
 func (txmp *TxMempool) RecentSnapshot() types.Txs { return txmp.txStore.RecentSnapshot() }
@@ -378,6 +382,7 @@ func (txmp *TxMempool) CheckTx(ctx context.Context, tx types.Tx) (*abci.Response
 		wtx.evm = utils.Some(evmTx{
 			address:         res.EVMSenderAddress,
 			seiAddress:      res.SeiSenderAddress,
+			hash:            res.EVMHash,
 			nonce:           res.EVMNonce,
 			requiredBalance: res.EVMRequiredBalance,
 		})

--- a/sei-tendermint/internal/mempool/mempool.go
+++ b/sei-tendermint/internal/mempool/mempool.go
@@ -242,6 +242,10 @@ func (txmp *TxMempool) EvmNextPendingNonce(addr common.Address) uint64 {
 	return txmp.txStore.NextNonce(addr)
 }
 
+// Relatively fresh snapshot of the mempool.
+// NOTE: it is NOT the current state of the mempool most of the time.
+func (txmp *TxMempool) RecentSnapshot() types.Txs { return txmp.txStore.RecentSnapshot() }
+
 func (txmp *TxMempool) WaitForTxs(ctx context.Context) error {
 	return txmp.txStore.WaitForTxs(ctx)
 }

--- a/sei-tendermint/internal/mempool/mempool_test.go
+++ b/sei-tendermint/internal/mempool/mempool_test.go
@@ -96,6 +96,7 @@ func (app *application) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) *
 				GasWanted:    gasWanted,
 				GasEstimated: gasEstimated,
 			},
+			EVMHash:            common.BytesToHash(req.Tx),
 			EVMNonce:           nonce,
 			EVMSenderAddress:   common.HexToAddress(account),
 			SeiSenderAddress:   sdk.AccAddress(common.HexToAddress(account).Bytes()),

--- a/sei-tendermint/internal/mempool/mempool_test.go
+++ b/sei-tendermint/internal/mempool/mempool_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
+	"crypto/sha256"
 	"sort"
 	"strconv"
 	"strings"
@@ -96,7 +97,7 @@ func (app *application) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) *
 				GasWanted:    gasWanted,
 				GasEstimated: gasEstimated,
 			},
-			EVMHash:            common.BytesToHash(req.Tx),
+			EVMHash:            common.Hash(sha256.Sum256(req.Tx)),
 			EVMNonce:           nonce,
 			EVMSenderAddress:   common.HexToAddress(account),
 			SeiSenderAddress:   sdk.AccAddress(common.HexToAddress(account).Bytes()),

--- a/sei-tendermint/internal/mempool/mempool_test.go
+++ b/sei-tendermint/internal/mempool/mempool_test.go
@@ -3,10 +3,10 @@ package mempool
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"math/big"
 	"math/rand"
-	"crypto/sha256"
 	"sort"
 	"strconv"
 	"strings"

--- a/sei-tendermint/internal/mempool/recheck_drain_test.go
+++ b/sei-tendermint/internal/mempool/recheck_drain_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"crypto/sha256"
 	"strconv"
 	"sync"
 	"testing"
@@ -107,7 +108,7 @@ func (a *evmNonceApp) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) *ab
 			GasWanted:    DefaultGasWanted,
 			GasEstimated: DefaultGasEstimated,
 		},
-		EVMHash:            common.BytesToHash(req.Tx),
+		EVMHash:            common.Hash(sha256.Sum256(req.Tx)),
 		EVMNonce:           nonce,
 		EVMSenderAddress:   senderAddr,
 		SeiSenderAddress:   sdk.AccAddress(senderAddr.Bytes()),

--- a/sei-tendermint/internal/mempool/recheck_drain_test.go
+++ b/sei-tendermint/internal/mempool/recheck_drain_test.go
@@ -3,9 +3,9 @@ package mempool
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"math/big"
-	"crypto/sha256"
 	"strconv"
 	"sync"
 	"testing"

--- a/sei-tendermint/internal/mempool/recheck_drain_test.go
+++ b/sei-tendermint/internal/mempool/recheck_drain_test.go
@@ -107,6 +107,7 @@ func (a *evmNonceApp) CheckTx(_ context.Context, req *abci.RequestCheckTxV2) *ab
 			GasWanted:    DefaultGasWanted,
 			GasEstimated: DefaultGasEstimated,
 		},
+		EVMHash:            common.BytesToHash(req.Tx),
 		EVMNonce:           nonce,
 		EVMSenderAddress:   senderAddr,
 		SeiSenderAddress:   sdk.AccAddress(senderAddr.Bytes()),

--- a/sei-tendermint/internal/mempool/tx.go
+++ b/sei-tendermint/internal/mempool/tx.go
@@ -87,13 +87,6 @@ func (wtx *WrappedTx) EVMNonce() uint64 {
 	return 0
 }
 
-func (wtx *WrappedTx) EVMHash() common.Hash {
-	if evm, ok := wtx.evm.Get(); ok {
-		return evm.hash
-	}
-	return common.Hash{}
-}
-
 type evmAccount struct {
 	balance    *big.Int
 	firstNonce uint64

--- a/sei-tendermint/internal/mempool/tx.go
+++ b/sei-tendermint/internal/mempool/tx.go
@@ -244,7 +244,7 @@ func (s *txStore) State() txStoreState { return s.state.Load() }
 
 // Recent snapshot of the mempool.
 func (s *txStore) RecentSnapshot() types.Txs {
-	for inner := range s.inner.Lock() {
+	for inner := range s.inner.RLock() {
 		return inner.snapshot
 	}
 	panic("unreachable")
@@ -314,22 +314,6 @@ func (s *txStore) SafeGetTxsForHashes(txHashes []types.TxHash) (types.Txs, []typ
 	return got, missing
 }
 
-func (s *txStore) deleteTx(inner *txStoreInner, wtx *WrappedTx) {
-	state := inner.state.Load()
-	delete(inner.byHash, wtx.Hash())
-	if evm, ok := wtx.evm.Get(); ok {
-		delete(inner.byEvmHash, evm.hash)
-		delete(inner.byNonce, evmAddrNonce{Address: evm.address, Nonce: evm.nonce})
-	}
-	s.metrics.RemovedTxs.Add(1)
-	state.total.Dec(wtx.Size())
-	if el, ok := wtx.readyEl.Get(); ok {
-		s.readyTxs.Remove(el)
-		state.ready.Dec(wtx.Size())
-	}
-	inner.state.Store(state)
-}
-
 func (s *txStore) insert(inner *txStoreInner, wtx *WrappedTx) error {
 	if _, ok := inner.byHash[wtx.Hash()]; ok {
 		return errDuplicateTx
@@ -354,7 +338,8 @@ func (s *txStore) insert(inner *txStoreInner, wtx *WrappedTx) error {
 		}
 		an := evmAddrNonce{evm.address, evm.nonce}
 		if old, ok := inner.byNonce[an]; ok {
-			oldReady := old.evm.OrPanic("non-evm tx").nonce < account.nextNonce
+			oldEvm := old.evm.OrPanic("non-evm tx")
+			oldReady := oldEvm.nonce < account.nextNonce
 			// If the old tx is ready but the new tx is not, then reject the new tx.
 			if oldReady && account.balance.Cmp(evm.requiredBalance) < 0 {
 				return errSameNonce
@@ -366,9 +351,15 @@ func (s *txStore) insert(inner *txStoreInner, wtx *WrappedTx) error {
 			// Remove the old transaction.
 			inner.cache.Remove(old.Hash()) // evicted txs are not cached
 			s.metrics.CacheSize.Set(float64(inner.cache.Size()))
-			s.deleteTx(inner, old)
-			state = inner.state.Load()
+			delete(inner.byHash, old.Hash())
+			delete(inner.byEvmHash, oldEvm.hash)
+			s.metrics.RemovedTxs.Add(1)
+			state.total.Dec(old.Size())
+			if el, ok := old.readyEl.Get(); ok {
+				s.readyTxs.Remove(el)
+			}
 			if oldReady {
+				state.ready.Dec(old.Size())
 				state.ready.Inc(wtx.Size())
 				wtx.readyEl = utils.Some(s.readyTxs.PushBack(wtx.Tx()))
 			}
@@ -565,7 +556,11 @@ func (s *txStore) Update(spec updateSpec) {
 						inner.failedTxs.Remove(txHash)
 					}
 				}
-				s.deleteTx(inner, wtx)
+				delete(inner.byHash, txHash)
+				s.metrics.RemovedTxs.Add(1)
+				if el, ok := wtx.readyEl.Get(); ok {
+					s.readyTxs.Remove(el)
+				}
 			} else if newPriority, ok := spec.NewPriorities[wtx.Hash()]; ok {
 				wtx.priority = newPriority
 			}
@@ -631,7 +626,11 @@ func (s *txStore) Reap(l ReapLimits, remove bool) (types.Txs, int64) {
 		}
 		if remove {
 			for _, wtx := range wtxs {
-				s.deleteTx(inner, wtx)
+				delete(inner.byHash, wtx.Hash())
+				s.metrics.RemovedTxs.Add(1)
+				if el, ok := wtx.readyEl.Get(); ok {
+					s.readyTxs.Remove(el)
+				}
 			}
 			start := time.Now()
 			s.compact(inner, false)

--- a/sei-tendermint/internal/mempool/tx.go
+++ b/sei-tendermint/internal/mempool/tx.go
@@ -72,6 +72,7 @@ func (wtx *WrappedTx) check(c TxConstraints) error {
 type evmTx struct {
 	address    common.Address
 	seiAddress []byte
+	hash       common.Hash
 	nonce      uint64
 	// requiredBalance is the sender balance threshold for this EVM tx to become ready.
 	requiredBalance *big.Int
@@ -84,6 +85,13 @@ func (wtx *WrappedTx) EVMNonce() uint64 {
 		return evm.nonce
 	}
 	return 0
+}
+
+func (wtx *WrappedTx) EVMHash() common.Hash {
+	if evm, ok := wtx.evm.Get(); ok {
+		return evm.hash
+	}
+	return common.Hash{}
 }
 
 type evmAccount struct {
@@ -121,9 +129,10 @@ func (s txStoreState) PendingBytes() uint64 { return s.total.bytes - s.ready.byt
 func (s txStoreState) PendingCount() int    { return s.total.count - s.ready.count }
 
 type txStoreInner struct {
-	byHash   map[types.TxHash]*WrappedTx
-	byNonce  map[evmAddrNonce]*WrappedTx
-	accounts map[common.Address]*evmAccount
+	byHash    map[types.TxHash]*WrappedTx
+	byEvmHash map[common.Hash]*WrappedTx
+	byNonce   map[evmAddrNonce]*WrappedTx
+	accounts  map[common.Address]*evmAccount
 
 	softLimit txCounter
 	hardLimit txCounter
@@ -177,6 +186,7 @@ func NewTxStore(cfg *Config, app *proxy.Proxy, metrics *Metrics) *txStore {
 	hardLimit := txCounter{count: 2 * softLimit.count, bytes: 2 * softLimit.bytes}
 	inner := &txStoreInner{
 		byHash:    map[types.TxHash]*WrappedTx{},
+		byEvmHash: map[common.Hash]*WrappedTx{},
 		byNonce:   map[evmAddrNonce]*WrappedTx{},
 		accounts:  map[common.Address]*evmAccount{},
 		softLimit: softLimit,
@@ -202,6 +212,7 @@ func (s *txStore) Clear() {
 		s.metrics.CacheSize.Set(float64(inner.cache.Size()))
 		inner.failedTxs.Reset()
 		inner.byHash = map[types.TxHash]*WrappedTx{}
+		inner.byEvmHash = map[common.Hash]*WrappedTx{}
 		inner.byNonce = map[evmAddrNonce]*WrappedTx{}
 		inner.accounts = map[common.Address]*evmAccount{}
 		inner.state.Store(txStoreState{})
@@ -286,6 +297,15 @@ func (s *txStore) ByHash(key types.TxHash) (types.Tx, bool) {
 	return nil, false
 }
 
+func (s *txStore) ByEvmHash(key common.Hash) (types.Tx, bool) {
+	for inner := range s.inner.RLock() {
+		if wtx, ok := inner.byEvmHash[key]; ok {
+			return wtx.Tx(), true
+		}
+	}
+	return nil, false
+}
+
 func (s *txStore) SafeGetTxsForHashes(txHashes []types.TxHash) (types.Txs, []types.TxHash) {
 	got := make([]types.Tx, 0, len(txHashes))
 	missing := make([]types.TxHash, 0)
@@ -301,12 +321,31 @@ func (s *txStore) SafeGetTxsForHashes(txHashes []types.TxHash) (types.Txs, []typ
 	return got, missing
 }
 
+func (s *txStore) deleteTx(inner *txStoreInner, wtx *WrappedTx) {
+	state := inner.state.Load()
+	delete(inner.byHash, wtx.Hash())
+	if evm, ok := wtx.evm.Get(); ok {
+		delete(inner.byEvmHash, evm.hash)
+		delete(inner.byNonce, evmAddrNonce{Address: evm.address, Nonce: evm.nonce})
+	}
+	s.metrics.RemovedTxs.Add(1)
+	state.total.Dec(wtx.Size())
+	if el, ok := wtx.readyEl.Get(); ok {
+		s.readyTxs.Remove(el)
+		state.ready.Dec(wtx.Size())
+	}
+	inner.state.Store(state)
+}
+
 func (s *txStore) insert(inner *txStoreInner, wtx *WrappedTx) error {
 	if _, ok := inner.byHash[wtx.Hash()]; ok {
 		return errDuplicateTx
 	}
 	state := inner.state.Load()
 	if evm, ok := wtx.evm.Get(); ok {
+		if _, ok := inner.byEvmHash[evm.hash]; ok {
+			return errDuplicateTx
+		}
 		// Fetch the evm account state.
 		account, ok := inner.accounts[evm.address]
 		if !ok {
@@ -334,19 +373,15 @@ func (s *txStore) insert(inner *txStoreInner, wtx *WrappedTx) error {
 			// Remove the old transaction.
 			inner.cache.Remove(old.Hash()) // evicted txs are not cached
 			s.metrics.CacheSize.Set(float64(inner.cache.Size()))
-			delete(inner.byHash, old.Hash())
-			s.metrics.RemovedTxs.Add(1)
-			state.total.Dec(old.Size())
-			if el, ok := old.readyEl.Get(); ok {
-				s.readyTxs.Remove(el)
-			}
+			s.deleteTx(inner, old)
+			state = inner.state.Load()
 			if oldReady {
-				state.ready.Dec(old.Size())
 				state.ready.Inc(wtx.Size())
 				wtx.readyEl = utils.Some(s.readyTxs.PushBack(wtx.Tx()))
 			}
 		}
 		state.total.Inc(wtx.Size())
+		inner.byEvmHash[evm.hash] = wtx
 		inner.byNonce[an] = wtx
 		// Update account ready txs.
 		for {
@@ -458,6 +493,7 @@ func (s *txStore) compact(inner *txStoreInner, clearAccounts bool) {
 	// Reset internal state.
 	inner.state.Store(txStoreState{})
 	inner.byHash = map[types.TxHash]*WrappedTx{}
+	inner.byEvmHash = map[common.Hash]*WrappedTx{}
 	inner.byNonce = map[evmAddrNonce]*WrappedTx{}
 	if clearAccounts {
 		inner.accounts = map[common.Address]*evmAccount{}
@@ -536,11 +572,7 @@ func (s *txStore) Update(spec updateSpec) {
 						inner.failedTxs.Remove(txHash)
 					}
 				}
-				delete(inner.byHash, txHash)
-				s.metrics.RemovedTxs.Add(1)
-				if el, ok := wtx.readyEl.Get(); ok {
-					s.readyTxs.Remove(el)
-				}
+				s.deleteTx(inner, wtx)
 			} else if newPriority, ok := spec.NewPriorities[wtx.Hash()]; ok {
 				wtx.priority = newPriority
 			}
@@ -606,11 +638,7 @@ func (s *txStore) Reap(l ReapLimits, remove bool) (types.Txs, int64) {
 		}
 		if remove {
 			for _, wtx := range wtxs {
-				delete(inner.byHash, wtx.Hash())
-				s.metrics.RemovedTxs.Add(1)
-				if el, ok := wtx.readyEl.Get(); ok {
-					s.readyTxs.Remove(el)
-				}
+				s.deleteTx(inner, wtx)
 			}
 			start := time.Now()
 			s.compact(inner, false)

--- a/sei-tendermint/internal/mempool/tx.go
+++ b/sei-tendermint/internal/mempool/tx.go
@@ -129,6 +129,9 @@ type txStoreInner struct {
 	hardLimit txCounter
 	state     utils.AtomicSend[txStoreState]
 
+	// Snapshot of the mempool state: transactions in inclusion order.
+	// Recomputed every time inInclusionOrder is called.
+	snapshot types.Txs
 	// Cache of already seen txs, reducess pressure on app.
 	// It is a superset of transactions in txStore.
 	// * successfully inserted transactions are automatically added to cache.
@@ -234,6 +237,14 @@ func (s *txStore) CacheRemove(txHash types.TxHash) {
 
 // Size returns the total number of transactions in the store.
 func (s *txStore) State() txStoreState { return s.state.Load() }
+
+// Recent snapshot of the mempool.
+func (s *txStore) RecentSnapshot() types.Txs {
+	for inner := range s.inner.Lock() {
+		return inner.snapshot
+	}
+	panic("unreachable")
+}
 
 // WaitForTxs waits until there is >0 ready txs.
 func (s *txStore) WaitForTxs(ctx context.Context) error {
@@ -406,7 +417,13 @@ func (inner *txStoreInner) inInclusionOrder() []*WrappedTx {
 		// Stable sort by capped priority - it preserves the nonce ordering.
 		slices.SortStableFunc(txs, func(a, b *WrappedTx) int { return -cmp.Compare(txPrio[a], txPrio[b]) })
 	}
-	return append(ready, pending...)
+	res := append(ready, pending...)
+	// Update the snapshot.
+	inner.snapshot = make(types.Txs, len(res))
+	for i := range inner.snapshot {
+		inner.snapshot[i] = res[i].Tx()
+	}
+	return res
 }
 
 // Inserts a new transaction to txStore.

--- a/sei-tendermint/internal/mempool/tx_test.go
+++ b/sei-tendermint/internal/mempool/tx_test.go
@@ -155,6 +155,14 @@ func toTxs(wtxs []*WrappedTx) types.Txs {
 	return txs
 }
 
+func genEvmHash(rng utils.Rng) common.Hash {
+	return common.BytesToHash(utils.GenBytes(rng, common.HashLength))
+}
+
+func genEvmAddress(rng utils.Rng) common.Address {
+	return common.BytesToAddress(utils.GenBytes(rng, common.AddressLength))
+}
+
 func makeEvmTxForTest(
 	rng utils.Rng,
 	address common.Address,
@@ -171,7 +179,7 @@ func makeEvmTxForTest(
 		evm: utils.Some(evmTx{
 			address:         address,
 			seiAddress:      address.Bytes(),
-			hash:            common.BytesToHash(utils.GenBytes(rng, common.HashLength)),
+			hash:            genEvmHash(rng),
 			nonce:           nonce,
 			requiredBalance: big.NewInt(int64(requiredBalance)),
 		}),
@@ -231,16 +239,16 @@ func TestTxStore_GetTxByHash(t *testing.T) {
 }
 
 func TestTxStore_GetTxByEvmHash(t *testing.T) {
+	rng := utils.TestRng()
 	txs := newTxStoreForTest()
-	wtx := makeEvmTxForTest(utils.TestRng(), common.HexToAddress("0x1"), 7, 1, 0)
+	wtx := makeEvmTxForTest(rng, genEvmAddress(rng), 7, 1, 0)
+	hash := wtx.evm.OrPanic("evm tx").hash
 
-	res, ok := txs.ByEvmHash(wtx.EVMHash())
+	res, ok := txs.ByEvmHash(hash)
 	require.False(t, ok)
-	require.Nil(t, res)
 
 	require.NoError(t, txs.Insert(wtx))
-
-	res, ok = txs.ByEvmHash(wtx.EVMHash())
+	res, ok = txs.ByEvmHash(hash)
 	require.True(t, ok)
 	require.Equal(t, wtx.Tx(), res)
 }
@@ -292,7 +300,7 @@ func TestTxStore_RejectsAndEvictsTransactionsBelowAccountNonce(t *testing.T) {
 			evm: utils.Some(evmTx{
 				address:         address,
 				seiAddress:      address.Bytes(),
-				hash:            common.BytesToHash(utils.GenBytes(rng, common.HashLength)),
+				hash:            genEvmHash(rng),
 				nonce:           nonce,
 				requiredBalance: requiredBalance,
 			}),
@@ -378,7 +386,7 @@ func testTxStoreUpdateExpiresTransactions(t *testing.T, removeExpiredTxsFromQueu
 			evm: utils.Some(evmTx{
 				address:         address,
 				seiAddress:      address.Bytes(),
-				hash:            common.BytesToHash(utils.GenBytes(rng, common.HashLength)),
+				hash:            genEvmHash(rng),
 				nonce:           nonce,
 				requiredBalance: big.NewInt(0),
 			}),
@@ -526,7 +534,7 @@ func TestTxStore_ExpiredTxCacheBehavior(t *testing.T) {
 				evm: utils.Some(evmTx{
 					address:         address,
 					seiAddress:      address.Bytes(),
-					hash:            common.BytesToHash(utils.GenBytes(rng, common.HashLength)),
+					hash:            genEvmHash(rng),
 					nonce:           7,
 					requiredBalance: big.NewInt(0),
 				}),
@@ -540,7 +548,7 @@ func TestTxStore_ExpiredTxCacheBehavior(t *testing.T) {
 				evm: utils.Some(evmTx{
 					address:         address,
 					seiAddress:      address.Bytes(),
-					hash:            common.BytesToHash(utils.GenBytes(rng, common.HashLength)),
+					hash:            genEvmHash(rng),
 					nonce:           8,
 					requiredBalance: big.NewInt(200),
 				}),
@@ -647,12 +655,12 @@ func TestTxStore_ReplacesReadyTxByHigherPriority(t *testing.T) {
 	env.assertState(t)
 	_, ok := env.txStore.ByHash(old.Hash())
 	require.False(t, ok)
-	_, ok = env.txStore.ByEvmHash(old.EVMHash())
+	_, ok = env.txStore.ByEvmHash(old.evm.OrPanic("evm tx").hash)
 	require.False(t, ok)
 	got, ok := env.txStore.ByHash(replacement.Hash())
 	require.True(t, ok)
 	require.Equal(t, replacement.Tx(), got)
-	got, ok = env.txStore.ByEvmHash(replacement.EVMHash())
+	got, ok = env.txStore.ByEvmHash(replacement.evm.OrPanic("evm tx").hash)
 	require.True(t, ok)
 	require.Equal(t, replacement.Tx(), got)
 
@@ -673,22 +681,22 @@ func TestTxStore_RejectsDuplicateEvmHash(t *testing.T) {
 	rng := utils.TestRng()
 	app := newEVMNonceApp()
 	txStore := NewTxStore(TestConfig(), proxy.New(app, proxy.NopMetrics()), NopMetrics())
-	address := common.HexToAddress("0x1")
+	address := genEvmAddress(rng)
 	app.setNonce(address, 7)
 	app.setBalance(address, 100)
 
 	first := makeEvmTxForTest(rng, address, 7, 10, 0)
 	second := makeEvmTxForTest(rng, address, 8, 20, 0)
 	second.evm = utils.Some(func() evmTx {
-		evm := second.evm.OrPanic("evm tx")
-		evm.hash = first.EVMHash()
+		evm := second.evm.OrPanic("")
+		evm.hash = first.evm.OrPanic("").hash
 		return evm
 	}())
 
 	require.NoError(t, txStore.Insert(first))
 	require.ErrorIs(t, txStore.Insert(second), errDuplicateTx)
 
-	got, ok := txStore.ByEvmHash(first.EVMHash())
+	got, ok := txStore.ByEvmHash(first.evm.OrPanic("evm tx").hash)
 	require.True(t, ok)
 	require.Equal(t, first.Tx(), got)
 	_, ok = txStore.ByHash(second.Hash())

--- a/sei-tendermint/internal/mempool/tx_test.go
+++ b/sei-tendermint/internal/mempool/tx_test.go
@@ -171,6 +171,7 @@ func makeEvmTxForTest(
 		evm: utils.Some(evmTx{
 			address:         address,
 			seiAddress:      address.Bytes(),
+			hash:            common.BytesToHash(utils.GenBytes(rng, common.HashLength)),
 			nonce:           nonce,
 			requiredBalance: big.NewInt(int64(requiredBalance)),
 		}),
@@ -229,6 +230,21 @@ func TestTxStore_GetTxByHash(t *testing.T) {
 	require.Equal(t, wtx.Tx(), res)
 }
 
+func TestTxStore_GetTxByEvmHash(t *testing.T) {
+	txs := newTxStoreForTest()
+	wtx := makeEvmTxForTest(utils.TestRng(), common.HexToAddress("0x1"), 7, 1, 0)
+
+	res, ok := txs.ByEvmHash(wtx.EVMHash())
+	require.False(t, ok)
+	require.Nil(t, res)
+
+	require.NoError(t, txs.Insert(wtx))
+
+	res, ok = txs.ByEvmHash(wtx.EVMHash())
+	require.True(t, ok)
+	require.Equal(t, wtx.Tx(), res)
+}
+
 func TestTxStore_SetTx(t *testing.T) {
 	txs := newTxStoreForTest()
 	wtx := &WrappedTx{
@@ -276,6 +292,7 @@ func TestTxStore_RejectsAndEvictsTransactionsBelowAccountNonce(t *testing.T) {
 			evm: utils.Some(evmTx{
 				address:         address,
 				seiAddress:      address.Bytes(),
+				hash:            common.BytesToHash(utils.GenBytes(rng, common.HashLength)),
 				nonce:           nonce,
 				requiredBalance: requiredBalance,
 			}),
@@ -361,6 +378,7 @@ func testTxStoreUpdateExpiresTransactions(t *testing.T, removeExpiredTxsFromQueu
 			evm: utils.Some(evmTx{
 				address:         address,
 				seiAddress:      address.Bytes(),
+				hash:            common.BytesToHash(utils.GenBytes(rng, common.HashLength)),
 				nonce:           nonce,
 				requiredBalance: big.NewInt(0),
 			}),
@@ -508,6 +526,7 @@ func TestTxStore_ExpiredTxCacheBehavior(t *testing.T) {
 				evm: utils.Some(evmTx{
 					address:         address,
 					seiAddress:      address.Bytes(),
+					hash:            common.BytesToHash(utils.GenBytes(rng, common.HashLength)),
 					nonce:           7,
 					requiredBalance: big.NewInt(0),
 				}),
@@ -521,6 +540,7 @@ func TestTxStore_ExpiredTxCacheBehavior(t *testing.T) {
 				evm: utils.Some(evmTx{
 					address:         address,
 					seiAddress:      address.Bytes(),
+					hash:            common.BytesToHash(utils.GenBytes(rng, common.HashLength)),
 					nonce:           8,
 					requiredBalance: big.NewInt(200),
 				}),
@@ -627,7 +647,12 @@ func TestTxStore_ReplacesReadyTxByHigherPriority(t *testing.T) {
 	env.assertState(t)
 	_, ok := env.txStore.ByHash(old.Hash())
 	require.False(t, ok)
+	_, ok = env.txStore.ByEvmHash(old.EVMHash())
+	require.False(t, ok)
 	got, ok := env.txStore.ByHash(replacement.Hash())
+	require.True(t, ok)
+	require.Equal(t, replacement.Tx(), got)
+	got, ok = env.txStore.ByEvmHash(replacement.EVMHash())
 	require.True(t, ok)
 	require.Equal(t, replacement.Tx(), got)
 
@@ -641,6 +666,32 @@ func TestTxStore_ReplacesReadyTxByHigherPriority(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, replacement.Tx(), got)
 	_, ok = env.txStore.ByHash(blocked.Hash())
+	require.False(t, ok)
+}
+
+func TestTxStore_RejectsDuplicateEvmHash(t *testing.T) {
+	rng := utils.TestRng()
+	app := newEVMNonceApp()
+	txStore := NewTxStore(TestConfig(), proxy.New(app, proxy.NopMetrics()), NopMetrics())
+	address := common.HexToAddress("0x1")
+	app.setNonce(address, 7)
+	app.setBalance(address, 100)
+
+	first := makeEvmTxForTest(rng, address, 7, 10, 0)
+	second := makeEvmTxForTest(rng, address, 8, 20, 0)
+	second.evm = utils.Some(func() evmTx {
+		evm := second.evm.OrPanic("evm tx")
+		evm.hash = first.EVMHash()
+		return evm
+	}())
+
+	require.NoError(t, txStore.Insert(first))
+	require.ErrorIs(t, txStore.Insert(second), errDuplicateTx)
+
+	got, ok := txStore.ByEvmHash(first.EVMHash())
+	require.True(t, ok)
+	require.Equal(t, first.Tx(), got)
+	_, ok = txStore.ByHash(second.Hash())
 	require.False(t, ok)
 }
 

--- a/sei-tendermint/internal/p2p/pex/reactor_test.go
+++ b/sei-tendermint/internal/p2p/pex/reactor_test.go
@@ -281,7 +281,7 @@ func (r *reactorTestSuite) listenForPeerDown(
 	onNode, withNode int,
 ) {
 	on, with := r.checkNodePair(t, onNode, withNode)
-	r.network.Node(on).WaitForConn(t.Context(), with, false)
+	require.NoError(t, r.network.Node(on).WaitForConn(t.Context(), with, false))
 }
 
 func (r *reactorTestSuite) getAddressesFor(nodes []int) []*pb.PexAddress {

--- a/sei-tendermint/internal/p2p/router_test.go
+++ b/sei-tendermint/internal/p2p/router_test.go
@@ -239,7 +239,7 @@ func TestRouter_PexOnHandshake_DialerDisabled(t *testing.T) {
 
 	// Add a node with PexOnHandshake = false and connect it to nodes[0]
 	newNode := network.MakeNode(t, TestNodeOptions{PexOnHandshake: false})
-	newNode.Connect(ctx, nodes[0])
+	require.NoError(t, newNode.Connect(ctx, nodes[0]))
 
 	// newNode should NOT learn about nodes[1] during handshake.
 	require.True(t, slices.Index(
@@ -256,11 +256,11 @@ func TestRouter_PexOnHandshake_ListenerPeersPropagated(t *testing.T) {
 	nodes := network.Nodes()
 
 	t.Log("Connect nodes 1,2 to 0.")
-	nodes[1].Connect(ctx, nodes[0])
-	nodes[2].Connect(ctx, nodes[0])
+	require.NoError(t, nodes[1].Connect(ctx, nodes[0]))
+	require.NoError(t, nodes[2].Connect(ctx, nodes[0]))
 
 	t.Log("Node 2 should learn about node 1 during handshake with 0, and connect to it eventually.")
-	nodes[2].WaitForConn(ctx, nodes[1].NodeID, true)
+	require.NoError(t, nodes[2].WaitForConn(ctx, nodes[1].NodeID, true))
 }
 
 func makeRouterWithOptionsAndKey(opts *RouterOptions, key NodeSecretKey) *Router {

--- a/sei-tendermint/internal/p2p/testonly.go
+++ b/sei-tendermint/internal/p2p/testonly.go
@@ -97,8 +97,8 @@ func (n *TestNetwork) ConnectCycle(ctx context.Context, t *testing.T) {
 		require.NoError(t, err)
 	}
 	for i := range n.Nodes() {
-		nodes[i].WaitForConn(ctx, nodes[(i+1)%N].NodeID, true)
-		nodes[i].WaitForConn(ctx, nodes[(i+N-1)%N].NodeID, true)
+		require.NoError(t, nodes[i].WaitForConn(ctx, nodes[(i+1)%N].NodeID, true))
+		require.NoError(t, nodes[i].WaitForConn(ctx, nodes[(i+N-1)%N].NodeID, true))
 	}
 }
 
@@ -213,7 +213,7 @@ func (n *TestNetwork) Remove(t *testing.T, id types.NodeID) {
 	}
 	node.Router.Stop()
 	for _, peer := range peers {
-		peer.WaitForConn(t.Context(), id, false)
+		require.NoError(t, peer.WaitForConn(t.Context(), id, false))
 	}
 }
 
@@ -265,8 +265,12 @@ func (n *TestNode) WaitForConn(ctx context.Context, target types.NodeID, status 
 
 func (n *TestNode) Connect(ctx context.Context, target *TestNode) error {
 	_ = n.Router.peerManager.PushPex(utils.Some(target.NodeID), utils.Slice(target.NodeAddress))
-	if err := n.WaitForConn(ctx, target.NodeID, true); err!=nil { return err }
-	if err := target.WaitForConn(ctx, n.NodeID, true); err!=nil { return err }
+	if err := n.WaitForConn(ctx, target.NodeID, true); err != nil {
+		return err
+	}
+	if err := target.WaitForConn(ctx, n.NodeID, true); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -274,7 +278,7 @@ func (n *TestNode) Disconnect(ctx context.Context, target types.NodeID) {
 	for _, conn := range GetAll(n.Router.peerManager.Conns(), target) {
 		conn.Close()
 	}
-	n.WaitForConn(ctx, target, false)
+	utils.OrPanic(n.WaitForConn(ctx, target, false))
 }
 
 // MakeNode creates a new Node configured for the network with a

--- a/sei-tendermint/internal/p2p/testonly.go
+++ b/sei-tendermint/internal/p2p/testonly.go
@@ -255,19 +255,19 @@ func (n *TestNode) WaitForConnAndGet(ctx context.Context, target types.NodeID) (
 	return
 }
 
-func (n *TestNode) WaitForConn(ctx context.Context, target types.NodeID, status bool) {
-	if _, err := n.Router.peerManager.conns.Wait(ctx, func(conns ConnSet) bool {
+func (n *TestNode) WaitForConn(ctx context.Context, target types.NodeID, status bool) error {
+	_, err := n.Router.peerManager.conns.Wait(ctx, func(conns ConnSet) bool {
 		_, ok := GetAny(conns, target)
 		return ok == status
-	}); err != nil {
-		panic(err)
-	}
+	})
+	return err
 }
 
-func (n *TestNode) Connect(ctx context.Context, target *TestNode) {
+func (n *TestNode) Connect(ctx context.Context, target *TestNode) error {
 	_ = n.Router.peerManager.PushPex(utils.Some(target.NodeID), utils.Slice(target.NodeAddress))
-	n.WaitForConn(ctx, target.NodeID, true)
-	target.WaitForConn(ctx, n.NodeID, true)
+	if err := n.WaitForConn(ctx, target.NodeID, true); err!=nil { return err }
+	if err := target.WaitForConn(ctx, n.NodeID, true); err!=nil { return err }
+	return nil
 }
 
 func (n *TestNode) Disconnect(ctx context.Context, target types.NodeID) {

--- a/sei-tendermint/internal/proxy/proxy.go
+++ b/sei-tendermint/internal/proxy/proxy.go
@@ -71,6 +71,9 @@ func (app *Proxy) CheckTxSafe(ctx context.Context, req *types.RequestCheckTxV2) 
 		return nil, fmt.Errorf("nil response")
 	}
 	if res.IsEVM {
+		if res.EVMHash == (common.Hash{}) {
+			return nil, fmt.Errorf("EVM response missing EVMHash")
+		}
 		if res.EVMRequiredBalance == nil {
 			return nil, fmt.Errorf("EVM response missing EVMRequiredBalance")
 		}

--- a/sei-tendermint/internal/proxy/proxy_test.go
+++ b/sei-tendermint/internal/proxy/proxy_test.go
@@ -11,49 +11,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type panicCheckTxApp struct {
+type testApp struct {
 	types.BaseApplication
+	checkTx func(context.Context, *types.RequestCheckTxV2) *types.ResponseCheckTxV2
 }
 
-func (panicCheckTxApp) CheckTx(_ context.Context, _ *types.RequestCheckTxV2) *types.ResponseCheckTxV2 {
-	panic("boom")
+func (app testApp) CheckTx(ctx context.Context, req *types.RequestCheckTxV2) *types.ResponseCheckTxV2 {
+	return app.checkTx(ctx, req)
 }
 
 func TestCheckTxSafeReturnsErrorOnPanic(t *testing.T) {
-	proxyApp := New(panicCheckTxApp{}, NopMetrics())
+	proxyApp := New(testApp{
+		checkTx: func(context.Context, *types.RequestCheckTxV2) *types.ResponseCheckTxV2 {
+			panic("boom")
+		},
+	}, NopMetrics())
 	_, err := proxyApp.CheckTxSafe(t.Context(), &types.RequestCheckTxV2{Tx: []byte("tx")})
 	require.Error(t, err)
 }
 
-type invalidEVMCheckTxApp struct {
-	types.BaseApplication
-}
-
-func (invalidEVMCheckTxApp) CheckTx(_ context.Context, _ *types.RequestCheckTxV2) *types.ResponseCheckTxV2 {
-	return &types.ResponseCheckTxV2{
-		ResponseCheckTx: &types.ResponseCheckTx{Code: types.CodeTypeOK},
-		IsEVM:           true,
-	}
-}
-
-type invalidEVMCheckTxAppMissingRequiredBalance struct {
-	types.BaseApplication
-}
-
-func (invalidEVMCheckTxAppMissingRequiredBalance) CheckTx(_ context.Context, _ *types.RequestCheckTxV2) *types.ResponseCheckTxV2 {
-	return &types.ResponseCheckTxV2{
-		ResponseCheckTx:  &types.ResponseCheckTx{Code: types.CodeTypeOK},
-		EVMHash:          common.HexToHash("0x123"),
-		IsEVM:            true,
-		SeiSenderAddress: sdk.AccAddress("sender"),
-	}
-}
-
-type validEVMCheckTxApp struct {
-	types.BaseApplication
-}
-
-func (validEVMCheckTxApp) CheckTx(_ context.Context, _ *types.RequestCheckTxV2) *types.ResponseCheckTxV2 {
+func validEVMResponse() *types.ResponseCheckTxV2 {
 	return &types.ResponseCheckTxV2{
 		ResponseCheckTx:    &types.ResponseCheckTx{Code: types.CodeTypeOK},
 		EVMHash:            common.HexToHash("0x123"),
@@ -64,38 +41,47 @@ func (validEVMCheckTxApp) CheckTx(_ context.Context, _ *types.RequestCheckTxV2) 
 }
 
 func TestCheckTxSafeReturnsErrorOnMissingEVMHash(t *testing.T) {
-	proxyApp := New(invalidEVMCheckTxApp{}, NopMetrics())
+	proxyApp := New(testApp{
+		checkTx: func(context.Context, *types.RequestCheckTxV2) *types.ResponseCheckTxV2 {
+			res := validEVMResponse()
+			res.EVMHash = common.Hash{}
+			return res
+		},
+	}, NopMetrics())
 	_, err := proxyApp.CheckTxSafe(t.Context(), &types.RequestCheckTxV2{Tx: []byte("tx")})
 	require.Error(t, err)
 }
 
 func TestCheckTxSafeReturnsErrorOnMissingEVMRequiredBalance(t *testing.T) {
-	proxyApp := New(invalidEVMCheckTxAppMissingRequiredBalance{}, NopMetrics())
+	proxyApp := New(testApp{
+		checkTx: func(context.Context, *types.RequestCheckTxV2) *types.ResponseCheckTxV2 {
+			res := validEVMResponse()
+			res.EVMRequiredBalance = nil
+			return res
+		},
+	}, NopMetrics())
 	_, err := proxyApp.CheckTxSafe(t.Context(), &types.RequestCheckTxV2{Tx: []byte("tx")})
 	require.Error(t, err)
 }
 
 func TestCheckTxSafeReturnsErrorOnMissingSeiSenderAddress(t *testing.T) {
-	proxyApp := New(validEVMCheckTxAppMissingSeiSenderAddress{}, NopMetrics())
+	proxyApp := New(testApp{
+		checkTx: func(context.Context, *types.RequestCheckTxV2) *types.ResponseCheckTxV2 {
+			res := validEVMResponse()
+			res.SeiSenderAddress = nil
+			return res
+		},
+	}, NopMetrics())
 	_, err := proxyApp.CheckTxSafe(t.Context(), &types.RequestCheckTxV2{Tx: []byte("tx")})
 	require.Error(t, err)
 }
 
 func TestCheckTxSafeAllowsValidEVMResponse(t *testing.T) {
-	proxyApp := New(validEVMCheckTxApp{}, NopMetrics())
+	proxyApp := New(testApp{
+		checkTx: func(context.Context, *types.RequestCheckTxV2) *types.ResponseCheckTxV2 {
+			return validEVMResponse()
+		},
+	}, NopMetrics())
 	_, err := proxyApp.CheckTxSafe(t.Context(), &types.RequestCheckTxV2{Tx: []byte("tx")})
 	require.NoError(t, err)
-}
-
-type validEVMCheckTxAppMissingSeiSenderAddress struct {
-	types.BaseApplication
-}
-
-func (validEVMCheckTxAppMissingSeiSenderAddress) CheckTx(_ context.Context, _ *types.RequestCheckTxV2) *types.ResponseCheckTxV2 {
-	return &types.ResponseCheckTxV2{
-		ResponseCheckTx:    &types.ResponseCheckTx{Code: types.CodeTypeOK},
-		EVMHash:            common.HexToHash("0x123"),
-		IsEVM:              true,
-		EVMRequiredBalance: big.NewInt(1),
-	}
 }

--- a/sei-tendermint/internal/proxy/proxy_test.go
+++ b/sei-tendermint/internal/proxy/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
 	"github.com/stretchr/testify/require"
@@ -35,6 +36,19 @@ func (invalidEVMCheckTxApp) CheckTx(_ context.Context, _ *types.RequestCheckTxV2
 	}
 }
 
+type invalidEVMCheckTxAppMissingRequiredBalance struct {
+	types.BaseApplication
+}
+
+func (invalidEVMCheckTxAppMissingRequiredBalance) CheckTx(_ context.Context, _ *types.RequestCheckTxV2) *types.ResponseCheckTxV2 {
+	return &types.ResponseCheckTxV2{
+		ResponseCheckTx:  &types.ResponseCheckTx{Code: types.CodeTypeOK},
+		EVMHash:          common.HexToHash("0x123"),
+		IsEVM:            true,
+		SeiSenderAddress: sdk.AccAddress("sender"),
+	}
+}
+
 type validEVMCheckTxApp struct {
 	types.BaseApplication
 }
@@ -42,14 +56,21 @@ type validEVMCheckTxApp struct {
 func (validEVMCheckTxApp) CheckTx(_ context.Context, _ *types.RequestCheckTxV2) *types.ResponseCheckTxV2 {
 	return &types.ResponseCheckTxV2{
 		ResponseCheckTx:    &types.ResponseCheckTx{Code: types.CodeTypeOK},
+		EVMHash:            common.HexToHash("0x123"),
 		IsEVM:              true,
 		SeiSenderAddress:   sdk.AccAddress("sender"),
 		EVMRequiredBalance: big.NewInt(1),
 	}
 }
 
-func TestCheckTxSafeReturnsErrorOnMissingEVMRequiredBalance(t *testing.T) {
+func TestCheckTxSafeReturnsErrorOnMissingEVMHash(t *testing.T) {
 	proxyApp := New(invalidEVMCheckTxApp{}, NopMetrics())
+	_, err := proxyApp.CheckTxSafe(t.Context(), &types.RequestCheckTxV2{Tx: []byte("tx")})
+	require.Error(t, err)
+}
+
+func TestCheckTxSafeReturnsErrorOnMissingEVMRequiredBalance(t *testing.T) {
+	proxyApp := New(invalidEVMCheckTxAppMissingRequiredBalance{}, NopMetrics())
 	_, err := proxyApp.CheckTxSafe(t.Context(), &types.RequestCheckTxV2{Tx: []byte("tx")})
 	require.Error(t, err)
 }
@@ -73,6 +94,7 @@ type validEVMCheckTxAppMissingSeiSenderAddress struct {
 func (validEVMCheckTxAppMissingSeiSenderAddress) CheckTx(_ context.Context, _ *types.RequestCheckTxV2) *types.ResponseCheckTxV2 {
 	return &types.ResponseCheckTxV2{
 		ResponseCheckTx:    &types.ResponseCheckTx{Code: types.CodeTypeOK},
+		EVMHash:            common.HexToHash("0x123"),
 		IsEVM:              true,
 		EVMRequiredBalance: big.NewInt(1),
 	}

--- a/sei-tendermint/internal/rpc/core/mempool.go
+++ b/sei-tendermint/internal/rpc/core/mempool.go
@@ -125,14 +125,13 @@ func (env *Environment) BroadcastTxCommit(ctx context.Context, req *coretypes.Re
 // UnconfirmedTxs gets unconfirmed transactions from the mempool in order of priority
 // More: https://docs.tendermint.com/master/rpc/#/Info/unconfirmed_txs
 func (env *Environment) UnconfirmedTxs(ctx context.Context, req *coretypes.RequestUnconfirmedTxs) (*coretypes.ResultUnconfirmedTxs, error) {
-	totalCount := env.Mempool.Size()
+	txs := env.Mempool.RecentSnapshot()
 	perPage := env.validatePerPage(req.PerPage.IntPtr())
-	page, err := validatePage(req.Page.IntPtr(), perPage, totalCount)
+	page, err := validatePage(req.Page.IntPtr(), perPage, len(txs))
 	if err != nil {
 		return nil, err
 	}
 
-	txs := env.Mempool.RecentSnapshot()
 	first := min(len(txs), validateSkipCount(page, perPage))
 	next := first + min(len(txs)-first, perPage)
 	result := txs[first:next]

--- a/sei-tendermint/internal/rpc/core/mempool.go
+++ b/sei-tendermint/internal/rpc/core/mempool.go
@@ -10,9 +10,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	abci "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
-	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/mempool"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/state/indexer"
-	tmmath "github.com/sei-protocol/sei-chain/sei-tendermint/libs/math"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/rpc/coretypes"
 )
@@ -136,13 +134,8 @@ func (env *Environment) UnconfirmedTxs(ctx context.Context, req *coretypes.Reque
 
 	skipCount := validateSkipCount(page, perPage)
 
-	txs, _ := env.Mempool.ReapTxs(mempool.ReapLimits{
-		MaxTxs: utils.Some(uint64(skipCount + tmmath.MinInt(perPage, totalCount-skipCount))), //nolint:gosec // guaranteed to be non-negative
-	}, false)
-	if skipCount > len(txs) {
-		skipCount = len(txs)
-	}
-	result := txs[skipCount:]
+	txs := env.Mempool.RecentSnapshot()
+	result := txs[min(len(txs), skipCount):min(len(txs), skipCount+perPage)]
 
 	return &coretypes.ResultUnconfirmedTxs{
 		Count:      len(result),

--- a/sei-tendermint/internal/rpc/core/mempool.go
+++ b/sei-tendermint/internal/rpc/core/mempool.go
@@ -136,11 +136,15 @@ func (env *Environment) UnconfirmedTxs(ctx context.Context, req *coretypes.Reque
 	first := min(len(txs), validateSkipCount(page, perPage))
 	next := first + min(len(txs)-first, perPage)
 	result := txs[first:next]
+	totalBytes := 0
+	for _, tx := range txs {
+		totalBytes += len(tx)
+	}
 
 	return &coretypes.ResultUnconfirmedTxs{
 		Count:      len(result),
-		Total:      totalCount,
-		TotalBytes: utils.Clamp[int64](env.Mempool.SizeBytes()),
+		Total:      len(txs),
+		TotalBytes: int64(totalBytes),
 		Txs:        result,
 	}, nil
 }
@@ -148,9 +152,10 @@ func (env *Environment) UnconfirmedTxs(ctx context.Context, req *coretypes.Reque
 // NumUnconfirmedTxs gets number of unconfirmed transactions.
 // More: https://docs.tendermint.com/master/rpc/#/Info/num_unconfirmed_txs
 func (env *Environment) NumUnconfirmedTxs(ctx context.Context) (*coretypes.ResultUnconfirmedTxs, error) {
+	total := env.Mempool.Size()
 	return &coretypes.ResultUnconfirmedTxs{
-		Count:      env.Mempool.Size(),
-		Total:      env.Mempool.Size(),
+		Count:      total,
+		Total:      total,
 		TotalBytes: utils.Clamp[int64](env.Mempool.SizeBytes()),
 	}, nil
 }

--- a/sei-tendermint/internal/rpc/core/mempool.go
+++ b/sei-tendermint/internal/rpc/core/mempool.go
@@ -132,10 +132,10 @@ func (env *Environment) UnconfirmedTxs(ctx context.Context, req *coretypes.Reque
 		return nil, err
 	}
 
-	skipCount := validateSkipCount(page, perPage)
-
 	txs := env.Mempool.RecentSnapshot()
-	result := txs[min(len(txs), skipCount):min(len(txs), skipCount+perPage)]
+	first := min(len(txs), validateSkipCount(page, perPage))
+	next := first + min(len(txs)-first, perPage)
+	result := txs[first:next]
 
 	return &coretypes.ResultUnconfirmedTxs{
 		Count:      len(result),

--- a/sei-tendermint/internal/statesync/dispatcher_test.go
+++ b/sei-tendermint/internal/statesync/dispatcher_test.go
@@ -69,7 +69,7 @@ func (ts *dispatcherTestSuite) AddPeer(t *testing.T) *DispatcherNode {
 		TestNode: testNode,
 		blockCh:  blockCh,
 	}
-	ts.node.Connect(t.Context(), testNode)
+	require.NoError(t, ts.node.Connect(t.Context(), testNode))
 	return n
 }
 

--- a/sei-tendermint/internal/statesync/reactor_test.go
+++ b/sei-tendermint/internal/statesync/reactor_test.go
@@ -136,19 +136,23 @@ func (rts *reactorTestSuite) AddPeerWithoutWaiting(ctx context.Context, t *testi
 		blockCh:    orPanic(p2p.OpenChannel(testNode.Router, GetLightBlockChannelDescriptor())),
 		paramsCh:   orPanic(p2p.OpenChannel(testNode.Router, GetParamsChannelDescriptor())),
 	}
-	if err := testNode.Connect(ctx, rts.node); err!=nil { return nil, err }
-	return n,nil
+	if err := testNode.Connect(ctx, rts.node); err != nil {
+		return nil, err
+	}
+	return n, nil
 }
 
-func (rts *reactorTestSuite) AddPeer(ctx context.Context, t *testing.T) (*Node,error) {
-	n,err := rts.AddPeerWithoutWaiting(ctx,t)
-	if err!=nil { return nil, err }
+func (rts *reactorTestSuite) AddPeer(ctx context.Context, t *testing.T) (*Node, error) {
+	n, err := rts.AddPeerWithoutWaiting(ctx, t)
+	if err != nil {
+		return nil, err
+	}
 	// Peer registration in the reactor is asynchronous, so block until this peer
 	// is visible before returning to callers that may assert on peer counts.
-	if err:=rts.reactor.peers.WaitUntilContains(ctx, n.TestNode.NodeID); err!=nil {
-		return nil,err
+	if err := rts.reactor.peers.WaitUntilContains(ctx, n.TestNode.NodeID); err != nil {
+		return nil, err
 	}
-	return n,nil
+	return n, nil
 }
 
 func TestReactor_Sync(t *testing.T) {
@@ -177,12 +181,12 @@ func TestReactor_Sync(t *testing.T) {
 		s.SpawnBg(func() error {
 			return utils.IgnoreCancel(scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
 				for {
-					if err:=utils.Sleep(ctx, time.Second); err!=nil {
+					if err := utils.Sleep(ctx, time.Second); err != nil {
 						return err
 					}
-					n,err := rts.AddPeerWithoutWaiting(ctx,t)
-					if err!=nil {
-						return fmt.Errorf("rtx.AddPeerWithoutWaiting(): %w",err)
+					n, err := rts.AddPeerWithoutWaiting(ctx, t)
+					if err != nil {
+						return fmt.Errorf("rtx.AddPeerWithoutWaiting(): %w", err)
 					}
 					s.SpawnBg(func() error { return n.handleLightBlockRequests(ctx, chain, false) })
 					s.SpawnBg(func() error { return n.handleChunkRequests(ctx, []byte("abc")) })
@@ -255,7 +259,7 @@ func TestReactor_ChunkRequest(t *testing.T) {
 			conn.loadSnapshotChunk.Push(mkHandler(expected, &abci.ResponseLoadSnapshotChunk{Chunk: tc.chunk}))
 
 			rts := setup(t, conn, nil, false)
-			n := utils.OrPanic1(rts.AddPeer(ctx,t))
+			n := utils.OrPanic1(rts.AddPeer(ctx, t))
 			// Send the actual message.
 			n.chunkCh.Broadcast(wrap(tc.request))
 			m, err := n.chunkCh.Recv(ctx)
@@ -320,7 +324,7 @@ func TestReactor_SnapshotsRequest(t *testing.T) {
 			conn.listSnapshots.Set(mkHandler(&abci.RequestListSnapshots{}, &abci.ResponseListSnapshots{Snapshots: snapshots}))
 
 			rts := setup(t, conn, nil, false)
-			n := utils.OrPanic1(rts.AddPeer(ctx,t))
+			n := utils.OrPanic1(rts.AddPeer(ctx, t))
 			// Send the actual message.
 			n.snapshotCh.Broadcast(wrap(&pb.SnapshotsRequest{}))
 
@@ -391,7 +395,7 @@ func TestReactor_LightBlockResponse(t *testing.T) {
 	require.NoError(t, rts.blockStore.SaveSignedHeader(sh, blockID))
 
 	rts.stateStore.On("LoadValidators", height).Return(vals, nil)
-	n := utils.OrPanic1(rts.AddPeer(ctx,t))
+	n := utils.OrPanic1(rts.AddPeer(ctx, t))
 	n.blockCh.Broadcast(wrap(&pb.LightBlockRequest{Height: 10}))
 	m, err := n.blockCh.Recv(ctx)
 	require.NoError(t, err)
@@ -406,8 +410,8 @@ func TestReactor_BlockProviders(t *testing.T) {
 	defer cancel()
 
 	rts := setup(t, nil, nil, false)
-	a := utils.OrPanic1(rts.AddPeer(ctx,t))
-	b := utils.OrPanic1(rts.AddPeer(ctx,t))
+	a := utils.OrPanic1(rts.AddPeer(ctx, t))
+	b := utils.OrPanic1(rts.AddPeer(ctx, t))
 
 	chain := buildLightBlockChain(ctx, t, 1, 10, time.Now())
 	go a.handleLightBlockRequests(t.Context(), chain, false)
@@ -452,9 +456,9 @@ func TestReactor_StateProviderP2P(t *testing.T) {
 	ctx := t.Context()
 
 	rts := setup(t, nil, nil, true)
-	peerA := utils.OrPanic1(rts.AddPeer(ctx,t))
-	peerB := utils.OrPanic1(rts.AddPeer(ctx,t))
-	peerC := utils.OrPanic1(rts.AddPeer(ctx,t))
+	peerA := utils.OrPanic1(rts.AddPeer(ctx, t))
+	peerB := utils.OrPanic1(rts.AddPeer(ctx, t))
+	peerC := utils.OrPanic1(rts.AddPeer(ctx, t))
 	chain := buildLightBlockChain(ctx, t, 1, 10, time.Now())
 	for _, peer := range utils.Slice(peerA, peerB, peerC) {
 		go peer.handleLightBlockRequests(t.Context(), chain, false)
@@ -545,7 +549,7 @@ func TestReactor_Backfill(t *testing.T) {
 
 			var peers []*Node
 			for range 10 {
-				peers = append(peers, utils.OrPanic1(rts.AddPeer(ctx,t)))
+				peers = append(peers, utils.OrPanic1(rts.AddPeer(ctx, t)))
 			}
 			chain := buildLightBlockChain(ctx, t, stopHeight-1, startHeight+1, stopTime)
 			for i, peer := range peers {

--- a/sei-tendermint/internal/statesync/reactor_test.go
+++ b/sei-tendermint/internal/statesync/reactor_test.go
@@ -125,7 +125,7 @@ func orPanic[T any](v T, err error) T {
 	return v
 }
 
-func (rts *reactorTestSuite) AddPeerWithoutWaiting(t *testing.T) *Node {
+func (rts *reactorTestSuite) AddPeerWithoutWaiting(ctx context.Context, t *testing.T) (*Node, error) {
 	testNode := rts.network.MakeNode(t, p2p.TestNodeOptions{
 		MaxConnected: utils.Some(1),
 	})
@@ -136,16 +136,19 @@ func (rts *reactorTestSuite) AddPeerWithoutWaiting(t *testing.T) *Node {
 		blockCh:    orPanic(p2p.OpenChannel(testNode.Router, GetLightBlockChannelDescriptor())),
 		paramsCh:   orPanic(p2p.OpenChannel(testNode.Router, GetParamsChannelDescriptor())),
 	}
-	testNode.Connect(t.Context(), rts.node)
-	return n
+	if err := testNode.Connect(ctx, rts.node); err!=nil { return nil, err }
+	return n,nil
 }
 
-func (rts *reactorTestSuite) AddPeer(t *testing.T) *Node {
-	n := rts.AddPeerWithoutWaiting(t)
+func (rts *reactorTestSuite) AddPeer(ctx context.Context, t *testing.T) (*Node,error) {
+	n,err := rts.AddPeerWithoutWaiting(ctx,t)
+	if err!=nil { return nil, err }
 	// Peer registration in the reactor is asynchronous, so block until this peer
 	// is visible before returning to callers that may assert on peer counts.
-	utils.OrPanic(rts.reactor.peers.WaitUntilContains(t.Context(), n.TestNode.NodeID))
-	return n
+	if err:=rts.reactor.peers.WaitUntilContains(ctx, n.TestNode.NodeID); err!=nil {
+		return nil,err
+	}
+	return n,nil
 }
 
 func TestReactor_Sync(t *testing.T) {
@@ -172,37 +175,29 @@ func TestReactor_Sync(t *testing.T) {
 			mock.AnythingOfType("*types.ValidatorSet")).Return(nil)
 
 		s.SpawnBg(func() error {
-			ticker := time.NewTicker(time.Second)
-			defer ticker.Stop()
-
-			for {
-				if err:=utils.Sleep(ctx, time.Second); err!=nil {
-					return err
-				}
-				n := rts.AddPeerWithoutWaiting(t)
-				s.SpawnBg(func() error {
-					n.handleLightBlockRequests(ctx, t, chain, false)
-					return nil
-				})
-				s.SpawnBg(func() error {
-					n.handleChunkRequests(ctx, t, []byte("abc"))
-					return nil
-				})
-				s.SpawnBg(func() error {
-					n.handleConsensusParamsRequest(ctx, t)
-					return nil
-				})
-				s.SpawnBg(func() error {
-					n.handleSnapshotRequests(ctx, t, []snapshot{
-						{
-							Height: uint64(snapshotHeight),
-							Format: 1,
-							Chunks: 1,
-						},
+			return utils.IgnoreCancel(scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
+				for {
+					if err:=utils.Sleep(ctx, time.Second); err!=nil {
+						return err
+					}
+					n,err := rts.AddPeerWithoutWaiting(ctx,t)
+					if err!=nil {
+						return fmt.Errorf("rtx.AddPeerWithoutWaiting(): %w",err)
+					}
+					s.SpawnBg(func() error { return n.handleLightBlockRequests(ctx, chain, false) })
+					s.SpawnBg(func() error { return n.handleChunkRequests(ctx, []byte("abc")) })
+					s.SpawnBg(func() error { return n.handleConsensusParamsRequest(ctx) })
+					s.SpawnBg(func() error {
+						return n.handleSnapshotRequests(ctx, []snapshot{
+							{
+								Height: uint64(snapshotHeight),
+								Format: 1,
+								Chunks: 1,
+							},
+						})
 					})
-					return nil
-				})
-			}
+				}
+			}))
 		})
 
 		// update the config to use the p2p provider
@@ -260,7 +255,7 @@ func TestReactor_ChunkRequest(t *testing.T) {
 			conn.loadSnapshotChunk.Push(mkHandler(expected, &abci.ResponseLoadSnapshotChunk{Chunk: tc.chunk}))
 
 			rts := setup(t, conn, nil, false)
-			n := rts.AddPeer(t)
+			n := utils.OrPanic1(rts.AddPeer(ctx,t))
 			// Send the actual message.
 			n.chunkCh.Broadcast(wrap(tc.request))
 			m, err := n.chunkCh.Recv(ctx)
@@ -325,7 +320,7 @@ func TestReactor_SnapshotsRequest(t *testing.T) {
 			conn.listSnapshots.Set(mkHandler(&abci.RequestListSnapshots{}, &abci.ResponseListSnapshots{Snapshots: snapshots}))
 
 			rts := setup(t, conn, nil, false)
-			n := rts.AddPeer(t)
+			n := utils.OrPanic1(rts.AddPeer(ctx,t))
 			// Send the actual message.
 			n.snapshotCh.Broadcast(wrap(&pb.SnapshotsRequest{}))
 
@@ -396,7 +391,7 @@ func TestReactor_LightBlockResponse(t *testing.T) {
 	require.NoError(t, rts.blockStore.SaveSignedHeader(sh, blockID))
 
 	rts.stateStore.On("LoadValidators", height).Return(vals, nil)
-	n := rts.AddPeer(t)
+	n := utils.OrPanic1(rts.AddPeer(ctx,t))
 	n.blockCh.Broadcast(wrap(&pb.LightBlockRequest{Height: 10}))
 	m, err := n.blockCh.Recv(ctx)
 	require.NoError(t, err)
@@ -411,12 +406,12 @@ func TestReactor_BlockProviders(t *testing.T) {
 	defer cancel()
 
 	rts := setup(t, nil, nil, false)
-	a := rts.AddPeer(t)
-	b := rts.AddPeer(t)
+	a := utils.OrPanic1(rts.AddPeer(ctx,t))
+	b := utils.OrPanic1(rts.AddPeer(ctx,t))
 
 	chain := buildLightBlockChain(ctx, t, 1, 10, time.Now())
-	go a.handleLightBlockRequests(t.Context(), t, chain, false)
-	go b.handleLightBlockRequests(t.Context(), t, chain, false)
+	go a.handleLightBlockRequests(t.Context(), chain, false)
+	go b.handleLightBlockRequests(t.Context(), chain, false)
 
 	peers := rts.reactor.peers.All()
 	require.Len(t, peers, 2)
@@ -457,13 +452,13 @@ func TestReactor_StateProviderP2P(t *testing.T) {
 	ctx := t.Context()
 
 	rts := setup(t, nil, nil, true)
-	peerA := rts.AddPeer(t)
-	peerB := rts.AddPeer(t)
-	peerC := rts.AddPeer(t)
+	peerA := utils.OrPanic1(rts.AddPeer(ctx,t))
+	peerB := utils.OrPanic1(rts.AddPeer(ctx,t))
+	peerC := utils.OrPanic1(rts.AddPeer(ctx,t))
 	chain := buildLightBlockChain(ctx, t, 1, 10, time.Now())
 	for _, peer := range utils.Slice(peerA, peerB, peerC) {
-		go peer.handleLightBlockRequests(t.Context(), t, chain, false)
-		go peer.handleConsensusParamsRequest(t.Context(), t)
+		go peer.handleLightBlockRequests(t.Context(), chain, false)
+		go peer.handleConsensusParamsRequest(t.Context())
 	}
 
 	rts.reactor.cfg.UseP2P = true
@@ -550,11 +545,11 @@ func TestReactor_Backfill(t *testing.T) {
 
 			var peers []*Node
 			for range 10 {
-				peers = append(peers, rts.AddPeer(t))
+				peers = append(peers, utils.OrPanic1(rts.AddPeer(ctx,t)))
 			}
 			chain := buildLightBlockChain(ctx, t, stopHeight-1, startHeight+1, stopTime)
 			for i, peer := range peers {
-				go peer.handleLightBlockRequests(t.Context(), t, chain, i < failureRate)
+				go peer.handleLightBlockRequests(t.Context(), chain, i < failureRate)
 			}
 
 			trackingHeight := startHeight
@@ -618,15 +613,14 @@ type Node struct {
 
 func (n *Node) handleLightBlockRequests(
 	ctx context.Context,
-	t *testing.T,
 	chain map[int64]*types.LightBlock,
 	shouldFail bool,
-) {
+) error {
 	errorCount := 0
 	for requests := 0; ; requests++ {
 		m, err := n.blockCh.Recv(ctx)
 		if err != nil {
-			return
+			return err
 		}
 		wmsg, ok := m.Message.Sum.(*pb.Message_LightBlockRequest)
 		if !ok {
@@ -634,18 +628,14 @@ func (n *Node) handleLightBlockRequests(
 		}
 		msg := wmsg.LightBlockRequest
 		if !shouldFail {
-			lb, err := chain[int64(msg.Height)].ToProto()
-			require.NoError(t, err)
+			lb := utils.OrPanic1(chain[int64(msg.Height)].ToProto())
 			n.blockCh.Send(wrap(&pb.LightBlockResponse{LightBlock: lb}), m.From)
 		} else {
 			switch errorCount % 3 {
 			case 0: // send a different block
 				vals, pv := factory.ValidatorSet(ctx, 3, 10)
 				_, _, lb := mockLB(ctx, int64(msg.Height), factory.DefaultTestTime, factory.MakeBlockID(), vals, pv)
-				differntLB, err := lb.ToProto()
-				if err != nil {
-					panic(err)
-				}
+				differntLB := utils.OrPanic1(lb.ToProto())
 				n.blockCh.Send(wrap(&pb.LightBlockResponse{LightBlock: differntLB}), m.From)
 			case 1: // send nil block i.e. pretend we don't have it
 				n.blockCh.Send(wrap(&pb.LightBlockResponse{LightBlock: nil}), m.From)
@@ -656,14 +646,13 @@ func (n *Node) handleLightBlockRequests(
 	}
 }
 
-func (n *Node) handleConsensusParamsRequest(ctx context.Context, t *testing.T) {
-	t.Helper()
+func (n *Node) handleConsensusParamsRequest(ctx context.Context) error {
 	params := types.DefaultConsensusParams()
 	paramsProto := params.ToProto()
 	for {
 		m, err := n.paramsCh.Recv(ctx)
 		if err != nil {
-			return
+			return err
 		}
 		msg := m.Message.Sum.(*pb.Message_ParamsRequest).ParamsRequest
 		n.paramsCh.Send(wrap(&pb.ParamsResponse{
@@ -673,12 +662,11 @@ func (n *Node) handleConsensusParamsRequest(ctx context.Context, t *testing.T) {
 	}
 }
 
-func (n *Node) handleSnapshotRequests(ctx context.Context, t *testing.T, snapshots []snapshot) {
-	t.Helper()
+func (n *Node) handleSnapshotRequests(ctx context.Context, snapshots []snapshot) error {
 	for {
 		m, err := n.snapshotCh.Recv(ctx)
 		if err != nil {
-			return
+			return err
 		}
 		_ = m.Message.Sum.(*pb.Message_SnapshotsRequest)
 		for _, snapshot := range snapshots {
@@ -693,12 +681,11 @@ func (n *Node) handleSnapshotRequests(ctx context.Context, t *testing.T, snapsho
 	}
 }
 
-func (n *Node) handleChunkRequests(ctx context.Context, t *testing.T, chunk []byte) {
-	t.Helper()
+func (n *Node) handleChunkRequests(ctx context.Context, chunk []byte) error {
 	for {
 		m, err := n.chunkCh.Recv(ctx)
 		if err != nil {
-			return
+			return err
 		}
 		msg := m.Message.Sum.(*pb.Message_ChunkRequest).ChunkRequest
 		n.chunkCh.Send(wrap(&pb.ChunkResponse{

--- a/sei-tendermint/internal/statesync/reactor_test.go
+++ b/sei-tendermint/internal/statesync/reactor_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/test/factory"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/require"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/scope"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/light/provider"
 	pb "github.com/sei-protocol/sei-chain/sei-tendermint/proto/tendermint/statesync"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
@@ -148,58 +149,72 @@ func (rts *reactorTestSuite) AddPeer(t *testing.T) *Node {
 }
 
 func TestReactor_Sync(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
-	defer cancel()
+	err := scope.Run(t.Context(), func(ctx context.Context, s scope.Scope) error {
+		const snapshotHeight = 7
+		rts := setup(t, nil, nil, false)
+		chain := buildLightBlockChain(ctx, t, 1, 10, time.Now())
+		appConn := rts.conn
+		appConn.offerSnapshot.Set(func(context.Context, *abci.RequestOfferSnapshot) (*abci.ResponseOfferSnapshot, error) {
+			return &abci.ResponseOfferSnapshot{Result: abci.ResponseOfferSnapshot_ACCEPT}, nil
+		})
+		appConn.applySnapshotChunk.Set(func(context.Context, *abci.RequestApplySnapshotChunk) (*abci.ResponseApplySnapshotChunk, error) {
+			return &abci.ResponseApplySnapshotChunk{Result: abci.ResponseApplySnapshotChunk_ACCEPT}, nil
+		})
+		appConn.info.Push(mkHandler(&version.RequestInfo, &abci.ResponseInfo{
+			AppVersion:       testAppVersion,
+			LastBlockHeight:  snapshotHeight,
+			LastBlockAppHash: chain[snapshotHeight+1].AppHash,
+		}))
 
-	const snapshotHeight = 7
-	rts := setup(t, nil, nil, false)
-	chain := buildLightBlockChain(ctx, t, 1, 10, time.Now())
-	appConn := rts.conn
-	appConn.offerSnapshot.Set(func(context.Context, *abci.RequestOfferSnapshot) (*abci.ResponseOfferSnapshot, error) {
-		return &abci.ResponseOfferSnapshot{Result: abci.ResponseOfferSnapshot_ACCEPT}, nil
-	})
-	appConn.applySnapshotChunk.Set(func(context.Context, *abci.RequestApplySnapshotChunk) (*abci.ResponseApplySnapshotChunk, error) {
-		return &abci.ResponseApplySnapshotChunk{Result: abci.ResponseApplySnapshotChunk_ACCEPT}, nil
-	})
-	appConn.info.Push(mkHandler(&version.RequestInfo, &abci.ResponseInfo{
-		AppVersion:       testAppVersion,
-		LastBlockHeight:  snapshotHeight,
-		LastBlockAppHash: chain[snapshotHeight+1].AppHash,
-	}))
+		// store accepts state and validator sets
+		rts.stateStore.On("Bootstrap", mock.AnythingOfType("state.State")).Return(nil)
+		rts.stateStore.On("SaveValidatorSets", mock.AnythingOfType("int64"), mock.AnythingOfType("int64"),
+			mock.AnythingOfType("*types.ValidatorSet")).Return(nil)
 
-	// store accepts state and validator sets
-	rts.stateStore.On("Bootstrap", mock.AnythingOfType("state.State")).Return(nil)
-	rts.stateStore.On("SaveValidatorSets", mock.AnythingOfType("int64"), mock.AnythingOfType("int64"),
-		mock.AnythingOfType("*types.ValidatorSet")).Return(nil)
+		s.SpawnBg(func() error {
+			ticker := time.NewTicker(time.Second)
+			defer ticker.Stop()
 
-	go func() {
-		ticker := time.NewTicker(time.Second)
-		for {
-			if _, err := utils.Recv(ctx, ticker.C); err != nil {
-				return
+			for {
+				if err:=utils.Sleep(ctx, time.Second); err!=nil {
+					return err
+				}
+				n := rts.AddPeerWithoutWaiting(t)
+				s.SpawnBg(func() error {
+					n.handleLightBlockRequests(ctx, t, chain, false)
+					return nil
+				})
+				s.SpawnBg(func() error {
+					n.handleChunkRequests(ctx, t, []byte("abc"))
+					return nil
+				})
+				s.SpawnBg(func() error {
+					n.handleConsensusParamsRequest(ctx, t)
+					return nil
+				})
+				s.SpawnBg(func() error {
+					n.handleSnapshotRequests(ctx, t, []snapshot{
+						{
+							Height: uint64(snapshotHeight),
+							Format: 1,
+							Chunks: 1,
+						},
+					})
+					return nil
+				})
 			}
-			n := rts.AddPeerWithoutWaiting(t)
-			go n.handleLightBlockRequests(t, chain, false)
-			go n.handleChunkRequests(t, []byte("abc"))
-			go n.handleConsensusParamsRequest(t)
-			go n.handleSnapshotRequests(t, []snapshot{
-				{
-					Height: uint64(snapshotHeight),
-					Format: 1,
-					Chunks: 1,
-				},
-			})
-		}
-	}()
+		})
 
-	// update the config to use the p2p provider
-	rts.reactor.cfg.UseP2P = true
-	rts.reactor.cfg.TrustHeight = 1
-	rts.reactor.cfg.TrustHash = fmt.Sprintf("%X", chain[1].Hash())
-	rts.reactor.cfg.DiscoveryTime = 1 * time.Second
+		// update the config to use the p2p provider
+		rts.reactor.cfg.UseP2P = true
+		rts.reactor.cfg.TrustHeight = 1
+		rts.reactor.cfg.TrustHash = fmt.Sprintf("%X", chain[1].Hash())
+		rts.reactor.cfg.DiscoveryTime = 1 * time.Second
 
-	// Run state sync
-	_, err := rts.reactor.Sync(ctx)
+		// Run state sync
+		_, err := rts.reactor.Sync(ctx)
+		return err
+	})
 	require.NoError(t, err)
 }
 
@@ -400,8 +415,8 @@ func TestReactor_BlockProviders(t *testing.T) {
 	b := rts.AddPeer(t)
 
 	chain := buildLightBlockChain(ctx, t, 1, 10, time.Now())
-	go a.handleLightBlockRequests(t, chain, false)
-	go b.handleLightBlockRequests(t, chain, false)
+	go a.handleLightBlockRequests(t.Context(), t, chain, false)
+	go b.handleLightBlockRequests(t.Context(), t, chain, false)
 
 	peers := rts.reactor.peers.All()
 	require.Len(t, peers, 2)
@@ -447,8 +462,8 @@ func TestReactor_StateProviderP2P(t *testing.T) {
 	peerC := rts.AddPeer(t)
 	chain := buildLightBlockChain(ctx, t, 1, 10, time.Now())
 	for _, peer := range utils.Slice(peerA, peerB, peerC) {
-		go peer.handleLightBlockRequests(t, chain, false)
-		go peer.handleConsensusParamsRequest(t)
+		go peer.handleLightBlockRequests(t.Context(), t, chain, false)
+		go peer.handleConsensusParamsRequest(t.Context(), t)
 	}
 
 	rts.reactor.cfg.UseP2P = true
@@ -539,7 +554,7 @@ func TestReactor_Backfill(t *testing.T) {
 			}
 			chain := buildLightBlockChain(ctx, t, stopHeight-1, startHeight+1, stopTime)
 			for i, peer := range peers {
-				go peer.handleLightBlockRequests(t, chain, i < failureRate)
+				go peer.handleLightBlockRequests(t.Context(), t, chain, i < failureRate)
 			}
 
 			trackingHeight := startHeight
@@ -602,11 +617,11 @@ type Node struct {
 }
 
 func (n *Node) handleLightBlockRequests(
+	ctx context.Context,
 	t *testing.T,
 	chain map[int64]*types.LightBlock,
 	shouldFail bool,
 ) {
-	ctx := t.Context()
 	errorCount := 0
 	for requests := 0; ; requests++ {
 		m, err := n.blockCh.Recv(ctx)
@@ -641,9 +656,8 @@ func (n *Node) handleLightBlockRequests(
 	}
 }
 
-func (n *Node) handleConsensusParamsRequest(t *testing.T) {
+func (n *Node) handleConsensusParamsRequest(ctx context.Context, t *testing.T) {
 	t.Helper()
-	ctx := t.Context()
 	params := types.DefaultConsensusParams()
 	paramsProto := params.ToProto()
 	for {
@@ -659,9 +673,8 @@ func (n *Node) handleConsensusParamsRequest(t *testing.T) {
 	}
 }
 
-func (n *Node) handleSnapshotRequests(t *testing.T, snapshots []snapshot) {
+func (n *Node) handleSnapshotRequests(ctx context.Context, t *testing.T, snapshots []snapshot) {
 	t.Helper()
-	ctx := t.Context()
 	for {
 		m, err := n.snapshotCh.Recv(ctx)
 		if err != nil {
@@ -680,9 +693,8 @@ func (n *Node) handleSnapshotRequests(t *testing.T, snapshots []snapshot) {
 	}
 }
 
-func (n *Node) handleChunkRequests(t *testing.T, chunk []byte) {
+func (n *Node) handleChunkRequests(ctx context.Context, t *testing.T, chunk []byte) {
 	t.Helper()
-	ctx := t.Context()
 	for {
 		m, err := n.chunkCh.Recv(ctx)
 		if err != nil {

--- a/sei-tendermint/internal/statesync/syncer_test.go
+++ b/sei-tendermint/internal/statesync/syncer_test.go
@@ -95,9 +95,9 @@ func TestSyncer_SyncAny(t *testing.T) {
 	}
 
 	rts := setup(t, app, stateProvider, true)
-	peerA := rts.AddPeer(t)
-	peerB := rts.AddPeer(t)
-	peerC := rts.AddPeer(t)
+	peerA := utils.OrPanic1(rts.AddPeer(t.Context(), t))
+	peerB := utils.OrPanic1(rts.AddPeer(t.Context(), t))
+	peerC := utils.OrPanic1(rts.AddPeer(t.Context(), t))
 
 	// Adding a chunk should error when no sync is in progress
 	_, err := rts.reactor.syncer.AddChunk(&chunk{Height: 1, Format: 1, Index: 0, Chunk: []byte{1}})
@@ -375,9 +375,9 @@ func TestSyncer_SyncAny_reject_sender(t *testing.T) {
 	rts := setup(t, nil, stateProvider, true)
 	app := rts.conn
 
-	peerA := rts.AddPeer(t)
-	peerB := rts.AddPeer(t)
-	peerC := rts.AddPeer(t)
+	peerA := utils.OrPanic1(rts.AddPeer(t.Context(), t))
+	peerB := utils.OrPanic1(rts.AddPeer(t.Context(), t))
+	peerC := utils.OrPanic1(rts.AddPeer(t.Context(), t))
 
 	// sbc will be offered first, which will be rejected with reject_sender, causing all snapshots
 	// submitted by both b and c (i.e. sb, sc, sbc) to be rejected. Finally, sa will reject and

--- a/sei-tendermint/rpc/client/local/local.go
+++ b/sei-tendermint/rpc/client/local/local.go
@@ -110,6 +110,10 @@ func (c *Local) EvmNextPendingNonce(addr common.Address) uint64 {
 	return c.Mempool.EvmNextPendingNonce(addr)
 }
 
+func (c *Local) EvmTxByHash(hash common.Hash) (types.Tx, bool) {
+	return c.Mempool.EvmTxByHash(hash)
+}
+
 func (c *Local) EvmProxy(sender common.Address) (*url.URL, bool) {
 	return c.Environment.EvmProxy(sender)
 }

--- a/sei-tendermint/rpc/client/main_test.go
+++ b/sei-tendermint/rpc/client/main_test.go
@@ -16,10 +16,23 @@ import (
 func NodeSuite(ctx context.Context, t *testing.T) (service.Service, *config.Config) {
 	t.Helper()
 
+	return nodeSuiteWithMode(ctx, t, config.ModeValidator)
+}
+
+func FullNodeSuite(ctx context.Context, t *testing.T) (service.Service, *config.Config) {
+	t.Helper()
+
+	return nodeSuiteWithMode(ctx, t, config.ModeFull)
+}
+
+func nodeSuiteWithMode(ctx context.Context, t *testing.T, mode string) (service.Service, *config.Config) {
+	t.Helper()
+
 	ctx, cancel := context.WithCancel(ctx)
 
 	conf, err := rpctest.CreateConfig(t, t.Name())
 	require.NoError(t, err)
+	conf.Mode = mode
 
 	app := kvstore.NewApplication()
 

--- a/sei-tendermint/rpc/client/rpc_test.go
+++ b/sei-tendermint/rpc/client/rpc_test.go
@@ -144,28 +144,21 @@ func TestClientOperations(t *testing.T) {
 			require.Equal(t, 0, batch.Count())
 		})
 		t.Run("SendingEmptyRequest", func(t *testing.T) {
-
 			c := getHTTPClient(t, conf)
 			batch := c.NewBatch()
 			_, err := batch.Send(ctx)
 			require.Error(t, err, "sending an empty batch of JSON RPC requests should result in an error")
 		})
 		t.Run("ClearingEmptyRequest", func(t *testing.T) {
-
 			c := getHTTPClient(t, conf)
 			batch := c.NewBatch()
 			require.Zero(t, batch.Clear(), "clearing an empty batch of JSON RPC requests should result in a 0 result")
 		})
 		t.Run("ConcurrentJSONRPC", func(t *testing.T) {
-
 			var wg sync.WaitGroup
 			c := getHTTPClient(t, conf)
 			for range 50 {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-					testBatchedJSONRPCCalls(ctx, c)
-				}()
+				wg.Go(func() { testBatchedJSONRPCCalls(ctx, c) })
 			}
 			wg.Wait()
 		})
@@ -585,30 +578,18 @@ func TestClientMethodCallsAdvanced(t *testing.T) {
 	t.Run("UnconfirmedTxs", func(t *testing.T) {
 		// populate mempool with 5 tx
 		txs := make([]types.Tx, 5)
-		ch := make(chan error, 5)
-		for i := range 5 {
+		for i := range txs {
 			_, _, tx := MakeTxKV()
-
 			txs[i] = tx
 			_, err := pool.CheckTx(ctx, tx)
 			require.NoError(t, err)
-			ch <- nil
 		}
-		// wait for tx to arrive in mempoool.
-		for range 5 {
-			select {
-			case <-ch:
-			case <-time.After(5 * time.Second):
-				t.Error("Timed out waiting for CheckTx callback")
-			}
-		}
-		close(ch)
-
+		// Trigger snapshot recomputation.
+		pool.ReapTxs(mempool.ReapLimits{},false)
 		for _, c := range GetClients(t, n, conf) {
 			for i := 1; i <= 2; i++ {
-				mc := c.(client.MempoolClient)
 				page, perPage := i, 3
-				res, err := mc.UnconfirmedTxs(ctx, &page, &perPage)
+				res, err := c.UnconfirmedTxs(ctx, &page, &perPage)
 				require.NoError(t, err)
 
 				if i == 2 {
@@ -626,22 +607,10 @@ func TestClientMethodCallsAdvanced(t *testing.T) {
 		pool.Flush()
 	})
 	t.Run("NumUnconfirmedTxs", func(t *testing.T) {
-		ch := make(chan struct{})
-
 		pool := getMempool(t, n)
-
 		_, _, tx := MakeTxKV()
-
 		_, err := pool.CheckTx(ctx, tx)
 		require.NoError(t, err)
-		close(ch)
-
-		// wait for tx to arrive in mempoool.
-		select {
-		case <-ch:
-		case <-time.After(5 * time.Second):
-			t.Error("Timed out waiting for CheckTx callback")
-		}
 
 		mempoolSize := pool.Size()
 		for i, c := range GetClients(t, n, conf) {

--- a/sei-tendermint/rpc/client/rpc_test.go
+++ b/sei-tendermint/rpc/client/rpc_test.go
@@ -573,59 +573,6 @@ func TestClientMethodCallsAdvanced(t *testing.T) {
 	ctx := t.Context()
 
 	n, conf := NodeSuite(ctx, t)
-	pool := getMempool(t, n)
-
-	t.Run("UnconfirmedTxs", func(t *testing.T) {
-		// populate mempool with 5 tx
-		txs := make([]types.Tx, 5)
-		for i := range txs {
-			_, _, tx := MakeTxKV()
-			txs[i] = tx
-			_, err := pool.CheckTx(ctx, tx)
-			require.NoError(t, err)
-		}
-		// Trigger snapshot recomputation.
-		pool.ReapTxs(mempool.ReapLimits{},false)
-		for _, c := range GetClients(t, n, conf) {
-			for i := 1; i <= 2; i++ {
-				page, perPage := i, 3
-				res, err := c.UnconfirmedTxs(ctx, &page, &perPage)
-				require.NoError(t, err)
-
-				if i == 2 {
-					perPage = 2
-				}
-				require.Equal(t, perPage, int(res.Count))
-				require.Equal(t, 5, int(res.Total))
-				require.Equal(t, pool.SizeBytes(), uint64(res.TotalBytes))
-				for _, tx := range res.Txs {
-					require.Contains(t, txs, tx)
-				}
-			}
-		}
-
-		pool.Flush()
-	})
-	t.Run("NumUnconfirmedTxs", func(t *testing.T) {
-		pool := getMempool(t, n)
-		_, _, tx := MakeTxKV()
-		_, err := pool.CheckTx(ctx, tx)
-		require.NoError(t, err)
-
-		mempoolSize := pool.Size()
-		for i, c := range GetClients(t, n, conf) {
-			mc, ok := c.(client.MempoolClient)
-			require.True(t, ok, "%d", i)
-			res, err := mc.NumUnconfirmedTxs(ctx)
-			require.NoError(t, err, "%d: %+v", i, err)
-
-			require.Equal(t, mempoolSize, int(res.Count))
-			require.Equal(t, mempoolSize, int(res.Total))
-			require.Equal(t, pool.SizeBytes(), uint64(res.TotalBytes))
-		}
-
-		pool.Flush()
-	})
 	t.Run("Tx", func(t *testing.T) {
 
 		c := getHTTPClient(t, conf)
@@ -819,6 +766,71 @@ func TestClientMethodCallsAdvanced(t *testing.T) {
 				require.Len(t, seen, txCount)
 			})
 		}
+	})
+}
+
+func TestMempoolRPCOnFullNode(t *testing.T) {
+	ctx := t.Context()
+
+	// Use a full node so background consensus does not consume mempool
+	// transactions while these RPC assertions are running.
+	n, conf := FullNodeSuite(ctx, t)
+	pool := getMempool(t, n)
+
+	t.Run("UnconfirmedTxs", func(t *testing.T) {
+		txs := make([]types.Tx, 5)
+		for i := range txs {
+			_, _, tx := MakeTxKV()
+			txs[i] = tx
+			_, err := pool.CheckTx(ctx, tx)
+			require.NoError(t, err)
+		}
+
+		// UnconfirmedTxs reads from the mempool's recent snapshot, so force a
+		// snapshot recomputation after inserting the test transactions.
+		pool.ReapTxs(mempool.ReapLimits{}, false)
+
+		for _, c := range GetClients(t, n, conf) {
+			mc, ok := c.(client.MempoolClient)
+			require.True(t, ok)
+			for i := 1; i <= 2; i++ {
+				page, perPage := i, 3
+				res, err := mc.UnconfirmedTxs(ctx, &page, &perPage)
+				require.NoError(t, err)
+
+				if i == 2 {
+					perPage = 2
+				}
+				require.Equal(t, perPage, int(res.Count))
+				require.Equal(t, 5, int(res.Total))
+				require.Equal(t, pool.SizeBytes(), uint64(res.TotalBytes))
+				for _, tx := range res.Txs {
+					require.Contains(t, txs, tx)
+				}
+			}
+		}
+
+		pool.Flush()
+	})
+
+	t.Run("NumUnconfirmedTxs", func(t *testing.T) {
+		_, _, tx := MakeTxKV()
+		_, err := pool.CheckTx(ctx, tx)
+		require.NoError(t, err)
+
+		mempoolSize := pool.Size()
+		for i, c := range GetClients(t, n, conf) {
+			mc, ok := c.(client.MempoolClient)
+			require.True(t, ok, "%d", i)
+			res, err := mc.NumUnconfirmedTxs(ctx)
+			require.NoError(t, err, "%d: %+v", i, err)
+
+			require.Equal(t, mempoolSize, int(res.Count))
+			require.Equal(t, mempoolSize, int(res.Total))
+			require.Equal(t, pool.SizeBytes(), uint64(res.TotalBytes))
+		}
+
+		pool.Flush()
 	})
 }
 

--- a/x/evm/ante/sig.go
+++ b/x/evm/ante/sig.go
@@ -41,7 +41,7 @@ func (svd *EVMSigVerifyDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulat
 	ctx = ctx.WithEVMNonce(txNonce)
 	ctx = ctx.WithEVMSenderAddress(evmAddr)
 	ctx = ctx.WithSeiSenderAddress(types.MustGetEVMTransactionMessage(tx).Derived.SenderSeiAddr)
-	ctx = ctx.WithEVMTxHash(ethTx.Hash().Hex())
+	ctx = ctx.WithEVMTxHash(ethTx.Hash())
 
 	chainID := svd.evmKeeper.ChainID(ctx)
 	txChainID := ethTx.ChainId()

--- a/x/evm/ante/sig_test.go
+++ b/x/evm/ante/sig_test.go
@@ -62,7 +62,7 @@ func TestEVMSigVerifyDecorator(t *testing.T) {
 
 	require.Equal(t, uint64(1), resCtx.EVMNonce())
 	require.Equal(t, sender, resCtx.EVMSenderAddress())
-	require.Equal(t, tx.Hash().Hex(), resCtx.EVMTxHash())
+	require.Equal(t, tx.Hash(), resCtx.EVMTxHash())
 	require.Equal(t, true, resCtx.IsEVM())
 
 	// should return error if acc is not found (i.e. preprocess not called)


### PR DESCRIPTION
* UnconfirmedTxs was computationally expensive, because it did scan of the whole mempool. I have made it access a recent mempool snapshot, since the original semantics was not giving any useful guarantees anyway
* Made eth_getTransactionByHash access the mempool directly (O(1) lookup) instead of first dumping the mempool via UnconfirmedTxs and then scanning its content.
