### PR TITLE
sharding rpc fixes (CON-320)

### DIFF
--- a/evmrpc/endpoints.go
+++ b/evmrpc/endpoints.go
@@ -17,41 +17,10 @@
 package evmrpc
 
 import (
-	"fmt"
-	"net"
-	"net/http"
 	"time"
 
 	"github.com/ethereum/go-ethereum/rpc"
 )
-
-// StartHTTPEndpoint starts the HTTP RPC endpoint.
-func StartHTTPEndpoint(endpoint string, timeouts rpc.HTTPTimeouts, handler http.Handler) (*http.Server, net.Addr, error) {
-	// start the HTTP listener
-	var (
-		listener net.Listener
-		err      error
-	)
-	if listener, err = net.Listen("tcp", endpoint); err != nil {
-		return nil, nil, err
-	}
-	// make sure timeout values are meaningful
-	CheckTimeouts(&timeouts)
-	// Bundle and start the HTTP server
-	httpSrv := &http.Server{
-		Handler:           handler,
-		ReadTimeout:       timeouts.ReadTimeout,
-		ReadHeaderTimeout: timeouts.ReadHeaderTimeout,
-		WriteTimeout:      timeouts.WriteTimeout,
-		IdleTimeout:       timeouts.IdleTimeout,
-	}
-	go func() {
-		if err := httpSrv.Serve(listener); err != nil {
-			fmt.Printf("server exiting due to %s\n", err)
-		}
-	}()
-	return httpSrv, listener.Addr(), err
-}
 
 // checkModuleAvailability checks that all names given in modules are actually
 // available API services. It assumes that the MetadataApi module ("rpc") is always available;

--- a/evmrpc/rpcstack.go
+++ b/evmrpc/rpcstack.go
@@ -100,6 +100,7 @@ const (
 )
 
 func NewHTTPServer(timeouts rpc.HTTPTimeouts) *HTTPServer {
+	CheckTimeouts(&timeouts)
 	h := &HTTPServer{timeouts: timeouts, handlerNames: make(map[string]string)}
 
 	h.httpHandler.Store((*rpcHandler)(nil))
@@ -143,7 +144,6 @@ func (h *HTTPServer) Start() error {
 	}
 
 	// Initialize the server.
-	CheckTimeouts(&h.timeouts)
 	h.server = &http.Server{
 		Handler:           h,
 		ReadTimeout:       h.timeouts.ReadTimeout,
@@ -357,20 +357,6 @@ func (h *HTTPServer) EnableWS(apis []rpc.API, config WsConfig) error {
 	return nil
 }
 
-// stopWS disables JSON-RPC over WebSocket and also stops the server if it only serves WebSocket.
-//
-//lint:ignore U1000 lifecycle method retained for completeness
-func (h *HTTPServer) stopWS() {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	if h.disableWS() {
-		if !h.rpcAllowed() {
-			h.doStop()
-		}
-	}
-}
-
 // disableWS disables the WebSocket handler. This is internal, the caller must hold h.mu.
 func (h *HTTPServer) disableWS() bool {
 	ws := h.wsHandler.Load().(*rpcHandler)
@@ -472,7 +458,7 @@ func (h *virtualHostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 var gzPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		w := gzip.NewWriter(io.Discard)
 		return w
 	},

--- a/evmrpc/send.go
+++ b/evmrpc/send.go
@@ -95,7 +95,8 @@ func (s *SendAPI) SendRawTransaction(ctx context.Context, input hexutil.Bytes) (
 			defer client.Close()
 
 			if err := client.CallContext(ctx, &hash, "eth_sendRawTransaction", input); err != nil {
-				return hash, fmt.Errorf("eth_sendRawTransaction(%q): %w", url.String(), err)
+				// No error wrapping, because evm server is too dumb to handle wrapped error.
+				return hash, err
 			}
 			return hash, nil
 		}

--- a/evmrpc/send.go
+++ b/evmrpc/send.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/client"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 	"github.com/sei-protocol/sei-chain/x/evm/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 	"github.com/sei-protocol/sei-chain/x/evm/types/ethtx"
@@ -34,6 +35,7 @@ type SendAPI struct {
 	homeDir          string
 	backend          *Backend
 	connectionType   ConnectionType
+	methodTimeout    utils.Option[time.Duration]
 }
 
 type SendConfig struct {
@@ -52,6 +54,7 @@ func NewSendAPI(
 	app *baseapp.BaseApp,
 	antehandler sdk.AnteHandler,
 	connectionType ConnectionType,
+	methodTimeout utils.Option[time.Duration],
 	globalBlockCache BlockCache,
 	cacheCreationMutex *sync.Mutex,
 	watermarks *WatermarkManager,
@@ -65,10 +68,17 @@ func NewSendAPI(
 		homeDir:          homeDir,
 		backend:          NewBackend(ctxProvider, k, beginBlockKeepers, txConfigProvider, tmClient, simulateConfig, app, antehandler, globalBlockCache, cacheCreationMutex, watermarks),
 		connectionType:   connectionType,
+		methodTimeout:    methodTimeout,
 	}
 }
 
 func (s *SendAPI) SendRawTransaction(ctx context.Context, input hexutil.Bytes) (hash common.Hash, err error) {
+	if timeout, ok := s.methodTimeout.Get(); ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
 	startTime := time.Now()
 	defer func() {
 		recordMetricsWithError(ctx, "eth_sendRawTransaction", s.connectionType, startTime, err, recover())

--- a/evmrpc/send_test.go
+++ b/evmrpc/send_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -19,6 +20,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/client"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/crypto/hd"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 	"github.com/stretchr/testify/require"
 )
@@ -137,6 +139,7 @@ func TestSendRawTransactionUsesProxy(t *testing.T) {
 		nil,
 		nil,
 		evmrpc.ConnectionTypeHTTP,
+		utils.None[time.Duration](),
 		evmrpc.NewBlockCache(1),
 		nil,
 		nil,

--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/client"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	"github.com/sei-protocol/sei-chain/sei-db/db_engine/types"
+	tmutils "github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 	evmCfg "github.com/sei-protocol/sei-chain/x/evm/config"
 	"github.com/sei-protocol/sei-chain/x/evm/keeper"
 )
@@ -71,6 +72,7 @@ func NewEVMHTTPServer(
 		WriteTimeout:      config.WriteTimeout,
 		IdleTimeout:       config.IdleTimeout,
 	})
+	methodTimeout := tmutils.Some(httpServer.timeouts.WriteTimeout)
 	if err := httpServer.SetListenAddr(LocalAddress, config.HTTPPort); err != nil {
 		return nil, err
 	}
@@ -83,14 +85,14 @@ func NewEVMHTTPServer(
 
 	globalBlockCache := NewBlockCache(3000)
 	cacheCreationMutex := &sync.Mutex{}
-	sendAPI := NewSendAPI(tmClient, txConfigProvider, &SendConfig{slow: config.Slow}, k, beginBlockKeepers, ctxProvider, homeDir, simulateConfig, app, antehandler, ConnectionTypeHTTP, globalBlockCache, cacheCreationMutex, watermarks)
+	sendAPI := NewSendAPI(tmClient, txConfigProvider, &SendConfig{slow: config.Slow}, k, beginBlockKeepers, ctxProvider, homeDir, simulateConfig, app, antehandler, ConnectionTypeHTTP, methodTimeout, globalBlockCache, cacheCreationMutex, watermarks)
 
 	ctx := ctxProvider(LatestCtxHeight)
 	traceCtxProvider := defaultTraceContextProvider(ctxProvider)
 	if len(traceCtxProviders) > 0 && traceCtxProviders[0] != nil {
 		traceCtxProvider = traceCtxProviders[0]
 	}
-	txAPI := NewTransactionAPI(tmClient, k, ctxProvider, txConfigProvider, homeDir, ConnectionTypeHTTP, watermarks, globalBlockCache, cacheCreationMutex)
+	txAPI := NewTransactionAPI(tmClient, k, ctxProvider, txConfigProvider, homeDir, ConnectionTypeHTTP, methodTimeout, watermarks, globalBlockCache, cacheCreationMutex)
 	debugAPI := NewDebugAPI(tmClient, k, beginBlockKeepers, ctxProvider, txConfigProvider, simulateConfig, app, antehandler, ConnectionTypeHTTP, config, globalBlockCache, cacheCreationMutex, watermarks)
 	debugAPI.backend.SetTraceContextProvider(traceCtxProvider)
 	if config.TraceBakeEnabled {
@@ -105,7 +107,7 @@ func NewEVMHTTPServer(
 	isPanicOrSyntheticTxFunc := debugAPI.isPanicOrSyntheticTx
 	seiLegacyAllowlist := BuildSeiLegacyEnabledSet(config.EnabledLegacySeiApis)
 
-	seiTxAPI := NewSeiTransactionAPI(tmClient, k, ctxProvider, txConfigProvider, homeDir, ConnectionTypeHTTP, isPanicOrSyntheticTxFunc, watermarks, globalBlockCache, cacheCreationMutex)
+	seiTxAPI := NewSeiTransactionAPI(tmClient, k, ctxProvider, txConfigProvider, homeDir, ConnectionTypeHTTP, methodTimeout, isPanicOrSyntheticTxFunc, watermarks, globalBlockCache, cacheCreationMutex)
 	seiDebugAPI := NewSeiDebugAPI(tmClient, k, beginBlockKeepers, ctxProvider, txConfigProvider, simulateConfig, app, antehandler, ConnectionTypeHTTP, config, globalBlockCache, cacheCreationMutex, watermarks)
 	seiDebugAPI.backend.SetTraceContextProvider(traceCtxProvider)
 
@@ -261,6 +263,7 @@ func NewEVMWebSocketServer(
 		WriteTimeout:      config.WriteTimeout,
 		IdleTimeout:       config.IdleTimeout,
 	})
+	methodTimeout := tmutils.Some(httpServer.timeouts.WriteTimeout)
 	if err := httpServer.SetListenAddr(LocalAddress, config.WSPort); err != nil {
 		return nil, err
 	}
@@ -286,7 +289,7 @@ func NewEVMWebSocketServer(
 		},
 		{
 			Namespace: "eth",
-			Service:   NewTransactionAPI(tmClient, k, ctxProvider, txConfigProvider, homeDir, ConnectionTypeWS, watermarks, globalBlockCache, cacheCreationMutex),
+			Service:   NewTransactionAPI(tmClient, k, ctxProvider, txConfigProvider, homeDir, ConnectionTypeWS, methodTimeout, watermarks, globalBlockCache, cacheCreationMutex),
 		},
 		{
 			Namespace: "eth",
@@ -298,7 +301,7 @@ func NewEVMWebSocketServer(
 		},
 		{
 			Namespace: "eth",
-			Service:   NewSendAPI(tmClient, txConfigProvider, &SendConfig{slow: config.Slow}, k, beginBlockKeepers, ctxProvider, homeDir, simulateConfig, app, antehandler, ConnectionTypeWS, globalBlockCache, cacheCreationMutex, watermarks),
+			Service:   NewSendAPI(tmClient, txConfigProvider, &SendConfig{slow: config.Slow}, k, beginBlockKeepers, ctxProvider, homeDir, simulateConfig, app, antehandler, ConnectionTypeWS, methodTimeout, globalBlockCache, cacheCreationMutex, watermarks),
 		},
 		{
 			Namespace: "eth",

--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -93,11 +93,11 @@ func NewSeiTransactionAPI(
 	return &SeiTransactionAPI{TransactionAPI: baseAPI, isPanicTx: isPanicTx}
 }
 
-func (t *SeiTransactionAPI) GetTransactionReceiptExcludeTraceFail(ctx context.Context, hash common.Hash) (result map[string]interface{}, returnErr error) {
+func (t *SeiTransactionAPI) GetTransactionReceiptExcludeTraceFail(ctx context.Context, hash common.Hash) (result map[string]any, returnErr error) {
 	return getTransactionReceipt(ctx, t.TransactionAPI, hash, true, t.isPanicTx, true)
 }
 
-func (t *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (result map[string]interface{}, returnErr error) {
+func (t *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (result map[string]any, returnErr error) {
 	return getTransactionReceipt(ctx, t, hash, false, nil, t.includeSynthetic)
 }
 
@@ -108,7 +108,7 @@ func getTransactionReceipt(
 	excludePanicTxs bool,
 	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error),
 	includeSynthetic bool,
-) (result map[string]interface{}, returnErr error) {
+) (result map[string]any, returnErr error) {
 	startTime := time.Now()
 	defer func() {
 		recordMetricsWithError(ctx, "eth_getTransactionReceipt", t.connectionType, startTime, returnErr, recover())
@@ -249,6 +249,8 @@ func (t *TransactionAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, 
 	return t.getTransactionWithBlock(block, idx, t.includeSynthetic)
 }
 
+// TODO(gprusak): for autobahn txs sharding, we might need to proxy this rpc as well,
+// since it checks if the given tx is in the local mempool.
 func (t *TransactionAPI) GetTransactionByHash(ctx context.Context, hash common.Hash) (result *export.RPCTransaction, returnErr error) {
 	startTime := time.Now()
 	defer func() {
@@ -357,7 +359,8 @@ func (t *TransactionAPI) GetTransactionCount(ctx context.Context, address common
 
 			var nonce hexutil.Uint64
 			if err := client.CallContext(ctx, &nonce, "eth_getTransactionCount", address, rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)); err != nil {
-				return nil, fmt.Errorf("eth_getTransactionCount(%q): %w", url.String(), err)
+				// No error wrapping, because evm server is too dumb to handle wrapped error.
+				return nil, err
 			}
 			return &nonce, nil
 		}
@@ -504,7 +507,7 @@ func encodeReceipt(
 	includeSynthetic bool,
 	globalBlockCache BlockCache,
 	cacheCreationMutex *sync.Mutex,
-) (map[string]interface{}, error) {
+) (map[string]any, error) {
 	blockHash := block.BlockID.Hash
 	bh := common.HexToHash(blockHash.String())
 	ctx := ctxProvider(block.Block.Height)
@@ -522,7 +525,7 @@ func encodeReceipt(
 	}
 	bloom := ethtypes.Bloom{}
 	bloom.SetBytes(receipt.LogsBloom)
-	fields := map[string]interface{}{
+	fields := map[string]any{
 		"blockHash":         bh,
 		"blockNumber":       hexutil.Uint64(receipt.BlockNumber),
 		"transactionHash":   common.HexToHash(receipt.TxHashHex),

--- a/evmrpc/tx.go
+++ b/evmrpc/tx.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/client"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	receiptpkg "github.com/sei-protocol/sei-chain/sei-db/ledger_db/receipt"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/rpc/coretypes"
 	tmtypes "github.com/sei-protocol/sei-chain/sei-tendermint/types"
 	wasmtypes "github.com/sei-protocol/sei-chain/sei-wasmd/x/wasm/types"
@@ -41,6 +42,7 @@ type TransactionAPI struct {
 	txConfigProvider   func(int64) client.TxConfig
 	homeDir            string
 	connectionType     ConnectionType
+	methodTimeout      utils.Option[time.Duration]
 	includeSynthetic   bool
 	watermarks         *WatermarkManager
 	globalBlockCache   BlockCache
@@ -59,6 +61,7 @@ func NewTransactionAPI(
 	txConfigProvider func(int64) client.TxConfig,
 	homeDir string,
 	connectionType ConnectionType,
+	methodTimeout utils.Option[time.Duration],
 	watermarks *WatermarkManager,
 	globalBlockCache BlockCache,
 	cacheCreationMutex *sync.Mutex,
@@ -70,6 +73,7 @@ func NewTransactionAPI(
 		txConfigProvider:   txConfigProvider,
 		homeDir:            homeDir,
 		connectionType:     connectionType,
+		methodTimeout:      methodTimeout,
 		watermarks:         watermarks,
 		globalBlockCache:   globalBlockCache,
 		cacheCreationMutex: cacheCreationMutex,
@@ -83,12 +87,13 @@ func NewSeiTransactionAPI(
 	txConfigProvider func(int64) client.TxConfig,
 	homeDir string,
 	connectionType ConnectionType,
+	methodTimeout utils.Option[time.Duration],
 	isPanicTx func(ctx context.Context, hash common.Hash) (bool, error),
 	watermarks *WatermarkManager,
 	globalBlockCache BlockCache,
 	cacheCreationMutex *sync.Mutex,
 ) *SeiTransactionAPI {
-	baseAPI := NewTransactionAPI(tmClient, k, ctxProvider, txConfigProvider, homeDir, connectionType, watermarks, globalBlockCache, cacheCreationMutex)
+	baseAPI := NewTransactionAPI(tmClient, k, ctxProvider, txConfigProvider, homeDir, connectionType, methodTimeout, watermarks, globalBlockCache, cacheCreationMutex)
 	baseAPI.includeSynthetic = true
 	return &SeiTransactionAPI{TransactionAPI: baseAPI, isPanicTx: isPanicTx}
 }
@@ -338,6 +343,12 @@ func (t *TransactionAPI) GetTransactionErrorByHash(ctx context.Context, hash com
 }
 
 func (t *TransactionAPI) GetTransactionCount(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (result *hexutil.Uint64, returnErr error) {
+	if timeout, ok := t.methodTimeout.Get(); ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
 	startTime := time.Now()
 	defer func() {
 		recordMetricsWithError(ctx, "eth_getTransactionCount", t.connectionType, startTime, returnErr, recover())

--- a/evmrpc/tx_test.go
+++ b/evmrpc/tx_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/crypto/hd"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/crypto/keyring"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/rpc/client/mock"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/rpc/coretypes"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
@@ -132,7 +133,7 @@ func TestGetTransactionError(t *testing.T) {
 
 func TestSign(t *testing.T) {
 	homeDir := t.TempDir()
-	txApi := evmrpc.NewTransactionAPI(nil, nil, nil, nil, homeDir, evmrpc.ConnectionTypeHTTP, &evmrpc.WatermarkManager{}, evmrpc.NewBlockCache(3000), &sync.Mutex{})
+	txApi := evmrpc.NewTransactionAPI(nil, nil, nil, nil, homeDir, evmrpc.ConnectionTypeHTTP, utils.None[time.Duration](), &evmrpc.WatermarkManager{}, evmrpc.NewBlockCache(3000), &sync.Mutex{})
 	infoApi := evmrpc.NewInfoAPI(nil, nil, nil, nil, homeDir, 1024, evmrpc.ConnectionTypeHTTP, nil, nil)
 	clientCtx := client.Context{}.WithViper("").WithHomeDir(homeDir)
 	clientCtx, err := config.ReadFromClientConfig(clientCtx)
@@ -330,7 +331,7 @@ func TestGetTransactionReceiptReturnsNullAboveWatermark(t *testing.T) {
 	tmClient := &lowLatestTMClient{latest: MockHeight8}
 	ctxProvider := func(int64) sdk.Context { return Ctx.WithBlockHeight(MockHeight8) }
 	watermarks := evmrpc.NewWatermarkManager(tmClient, ctxProvider, nil, nil)
-	txAPI := evmrpc.NewTransactionAPI(tmClient, EVMKeeper, ctxProvider, nil, t.TempDir(), evmrpc.ConnectionTypeHTTP, watermarks, evmrpc.NewBlockCache(8), &sync.Mutex{})
+	txAPI := evmrpc.NewTransactionAPI(tmClient, EVMKeeper, ctxProvider, nil, t.TempDir(), evmrpc.ConnectionTypeHTTP, utils.None[time.Duration](), watermarks, evmrpc.NewBlockCache(8), &sync.Mutex{})
 
 	result, err := txAPI.GetTransactionReceipt(context.Background(), hash)
 	require.NoError(t, err)
@@ -996,6 +997,7 @@ func TestGetTransactionCountPendingUsesProxy(t *testing.T) {
 		nil,
 		"",
 		evmrpc.ConnectionTypeHTTP,
+		utils.None[time.Duration](),
 		&evmrpc.WatermarkManager{},
 		evmrpc.NewBlockCache(1),
 		&sync.Mutex{},
@@ -1018,6 +1020,7 @@ func TestGetTransactionCountPendingFallsBackToLocalNonce(t *testing.T) {
 		nil,
 		"",
 		evmrpc.ConnectionTypeHTTP,
+		utils.None[time.Duration](),
 		&evmrpc.WatermarkManager{},
 		evmrpc.NewBlockCache(1),
 		&sync.Mutex{},


### PR DESCRIPTION
* apparently WS RPC server does not have any timeouts by default, so I have added an explicit timeout for the proxying calls (so that proxy is not waiting forever if server is unresponsive) consistent HTTP RPC server - httpServer.timeouts.WriteTimeout
* I have removed the error wrapping of proxied rpc calls, because evm server is unable to handle the wrapped errors
* removed some deadcode