### PR TITLE
clean up littDB config

### DIFF
--- a/sei-db/db_engine/litt/benchmark/benchmark_engine.go
+++ b/sei-db/db_engine/litt/benchmark/benchmark_engine.go
@@ -62,9 +62,7 @@ func NewBenchmarkEngine(configPath string) (*BenchmarkEngine, error) {
 		return nil, fmt.Errorf("failed to load config file %s: %w", configPath, err)
 	}
 
-	if cfg.LittConfig.Logger == nil {
-		cfg.LittConfig.Logger = slog.Default()
-	}
+	runtimeConfig := litt.DefaultRuntimeConfig()
 
 	if len(cfg.LittConfig.Paths) > litt.MaxShardingFactor {
 		return nil, fmt.Errorf("too many paths configured (%d), max is %d",
@@ -72,7 +70,7 @@ func NewBenchmarkEngine(configPath string) (*BenchmarkEngine, error) {
 	}
 	cfg.LittConfig.ShardingFactor = uint8(len(cfg.LittConfig.Paths)) //nolint:gosec // bounded above by MaxShardingFactor
 
-	db, err := littbuilder.NewDB(cfg.LittConfig)
+	db, err := littbuilder.NewDB(cfg.LittConfig, runtimeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create db: %w", err)
 	}
@@ -90,7 +88,7 @@ func NewBenchmarkEngine(configPath string) (*BenchmarkEngine, error) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	errorMonitor := util.NewErrorMonitor(ctx, cfg.LittConfig.Logger, nil)
+	errorMonitor := util.NewErrorMonitor(ctx, runtimeConfig.Logger, nil)
 
 	dataTracker, err := NewDataTracker(ctx, cfg, errorMonitor)
 	if err != nil {
@@ -117,7 +115,7 @@ func NewBenchmarkEngine(configPath string) (*BenchmarkEngine, error) {
 	return &BenchmarkEngine{
 		ctx:                          ctx,
 		cancel:                       cancel,
-		logger:                       cfg.LittConfig.Logger,
+		logger:                       runtimeConfig.Logger,
 		config:                       cfg,
 		db:                           db,
 		table:                        table,
@@ -126,7 +124,7 @@ func NewBenchmarkEngine(configPath string) (*BenchmarkEngine, error) {
 		readBytesPerSecondPerThread:  readBytesPerSecondPerThread,
 		writeBurstSize:               writeBurstSize,
 		readBurstSize:                readBurstSize,
-		metrics:                      newMetrics(ctx, cfg.LittConfig.Logger, cfg),
+		metrics:                      newMetrics(ctx, runtimeConfig.Logger, cfg),
 		errorMonitor:                 errorMonitor,
 	}, nil
 }

--- a/sei-db/db_engine/litt/benchmark/data_tracker_test.go
+++ b/sei-db/db_engine/litt/benchmark/data_tracker_test.go
@@ -1,6 +1,7 @@
 package benchmark
 
 import (
+	"log/slog"
 	"os"
 	"testing"
 	"time"
@@ -27,7 +28,7 @@ func TestTrackerDeterminism(t *testing.T) {
 	// Generate enough data to fill 10ish cohorts.
 	keyCount := 10*config.CohortSize + rand.Uint64Range(0, 10)
 
-	errorMonitor := util.NewErrorMonitor(ctx, config.LittConfig.Logger, nil)
+	errorMonitor := util.NewErrorMonitor(ctx, slog.Default(), nil)
 
 	dataTracker, err := NewDataTracker(ctx, config, errorMonitor)
 	require.NoError(t, err)
@@ -91,7 +92,7 @@ func TestTrackerRestart(t *testing.T) {
 	// Generate enough data to fill 10ish cohorts.
 	keyCount := 10*config.CohortSize + rand.Uint64Range(0, 10)
 
-	errorMonitor := util.NewErrorMonitor(ctx, config.LittConfig.Logger, nil)
+	errorMonitor := util.NewErrorMonitor(ctx, slog.Default(), nil)
 
 	dataTracker, err := NewDataTracker(ctx, config, errorMonitor)
 	require.NoError(t, err)
@@ -149,7 +150,7 @@ func TestTrackReads(t *testing.T) {
 	// Generate enough data to fill exactly 10 cohorts.
 	keyCount := 10 * config.CohortSize
 
-	errorMonitor := util.NewErrorMonitor(ctx, config.LittConfig.Logger, nil)
+	errorMonitor := util.NewErrorMonitor(ctx, slog.Default(), nil)
 
 	dataTracker, err := NewDataTracker(ctx, config, errorMonitor)
 	require.NoError(t, err)

--- a/sei-db/db_engine/litt/disktable/disk_table.go
+++ b/sei-db/db_engine/litt/disktable/disk_table.go
@@ -97,6 +97,7 @@ type DiskTable struct {
 // NewDiskTable creates a new DiskTable.
 func NewDiskTable(
 	config *litt.Config,
+	runtimeConfig *litt.RuntimeConfig,
 	name string,
 	keymap keymap.Keymap,
 	keymapPath string,
@@ -158,7 +159,7 @@ func NewDiskTable(
 		// No metadata file exists yet. Create a new one in the first root.
 		var err error
 		metadataDir := qualifiedRoots[0]
-		metadata, err = newTableMetadata(config.Logger, metadataDir, config.TTL, config.ShardingFactor, config.Fsync)
+		metadata, err = newTableMetadata(runtimeConfig.Logger, metadataDir, config.TTL, config.ShardingFactor, config.Fsync)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create table metadata: %w", err)
 		}
@@ -166,18 +167,18 @@ func NewDiskTable(
 		// Metadata file exists, so we need to load it.
 		var err error
 		metadataDir := path.Dir(metadataFilePath)
-		metadata, err = loadTableMetadata(config.Logger, metadataDir)
+		metadata, err = loadTableMetadata(runtimeConfig.Logger, metadataDir)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load table metadata: %w", err)
 		}
 	}
 
-	errorMonitor := util.NewErrorMonitor(config.CTX, config.Logger, config.FatalErrorCallback)
+	errorMonitor := util.NewErrorMonitor(runtimeConfig.CTX, runtimeConfig.Logger, runtimeConfig.FatalErrorCallback)
 
 	table := &DiskTable{
-		logger:         config.Logger,
+		logger:         runtimeConfig.Logger,
 		errorMonitor:   errorMonitor,
-		clock:          config.Clock,
+		clock:          runtimeConfig.Clock,
 		roots:          qualifiedRoots,
 		segmentPaths:   segmentPaths,
 		name:           name,
@@ -195,11 +196,11 @@ func NewDiskTable(
 	// Load segments.
 	lowestSegmentIndex, highestSegmentIndex, segments, err :=
 		segment.GatherSegmentFiles(
-			config.Logger,
+			runtimeConfig.Logger,
 			errorMonitor,
 			table.segmentPaths,
 			snapshottingEnabled,
-			config.Clock(),
+			runtimeConfig.Clock(),
 			true,
 			config.Fsync)
 	if err != nil {
@@ -227,7 +228,7 @@ func NewDiskTable(
 		nextSegmentIndex = highestSegmentIndex + 1
 	}
 	mutableSegment, err := segment.CreateSegment(
-		config.Logger,
+		runtimeConfig.Logger,
 		errorMonitor,
 		nextSegmentIndex,
 		segmentPaths,
@@ -244,7 +245,7 @@ func NewDiskTable(
 	segments[nextSegmentIndex] = mutableSegment
 
 	if reloadKeymap {
-		config.Logger.Info("reloading keymap from segments")
+		runtimeConfig.Logger.Info("reloading keymap from segments")
 		err = table.reloadKeymap(segments, lowestSegmentIndex, highestSegmentIndex)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load keymap from segments: %w", err)
@@ -266,12 +267,12 @@ func NewDiskTable(
 
 	// Start the flush loop.
 	fLoop := &flushLoop{
-		logger:                 config.Logger,
+		logger:                 runtimeConfig.Logger,
 		diskTable:              table,
 		errorMonitor:           errorMonitor,
 		flushChannel:           make(chan any, tableFlushChannelCapacity),
 		metrics:                metrics,
-		clock:                  config.Clock,
+		clock:                  runtimeConfig.Clock,
 		name:                   name,
 		upperBoundSnapshotFile: upperBoundSnapshotFile,
 	}
@@ -280,7 +281,7 @@ func NewDiskTable(
 
 	// Start the control loop.
 	cLoop := &controlLoop{
-		logger:                  config.Logger,
+		logger:                  runtimeConfig.Logger,
 		diskTable:               table,
 		errorMonitor:            errorMonitor,
 		controllerChannel:       make(chan any, config.ControlChannelSize),
@@ -292,7 +293,7 @@ func NewDiskTable(
 		targetFileSize:          config.TargetSegmentFileSize,
 		targetKeyFileSize:       config.TargetSegmentKeyFileSize,
 		maxKeyCount:             config.MaxSegmentKeyCount,
-		clock:                   config.Clock,
+		clock:                   runtimeConfig.Clock,
 		segmentPaths:            segmentPaths,
 		snapshottingEnabled:     snapshottingEnabled,
 		metadata:                metadata,

--- a/sei-db/db_engine/litt/disktable/disk_table_secondary_keys_test.go
+++ b/sei-db/db_engine/litt/disktable/disk_table_secondary_keys_test.go
@@ -40,18 +40,21 @@ func buildOneShardMemKeyDiskTable(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create config: %w", err)
 	}
-	config.Clock = clock
 	config.GCPeriod = time.Millisecond
 	config.Fsync = false
-	config.Logger = logger
 	config.ShardingFactor = 1
 	// Pick a target file size large enough that several Puts can co-exist in one segment without
 	// rotation; the recovery test specifically wants the torn group to share a segment with the
 	// surviving groups so the all-or-nothing behavior is observable.
 	config.TargetSegmentFileSize = 1 << 20
 
+	runtimeConfig := litt.DefaultRuntimeConfig()
+	runtimeConfig.Clock = clock
+	runtimeConfig.Logger = logger
+
 	table, err := NewDiskTable(
 		config,
+		runtimeConfig,
 		name,
 		keys,
 		keymapPath,

--- a/sei-db/db_engine/litt/disktable/disk_table_test.go
+++ b/sei-db/db_engine/litt/disktable/disk_table_test.go
@@ -100,14 +100,17 @@ func buildMemKeyDiskTableSingleShard(
 		return nil, fmt.Errorf("failed to create config: %w", err)
 	}
 
-	config.Clock = clock
 	config.TargetSegmentFileSize = 100 // intentionally use a very small segment size
 	config.GCPeriod = time.Millisecond
 	config.Fsync = false
-	config.Logger = logger
+
+	runtimeConfig := litt.DefaultRuntimeConfig()
+	runtimeConfig.Clock = clock
+	runtimeConfig.Logger = logger
 
 	table, err := NewDiskTable(
 		config,
+		runtimeConfig,
 		name,
 		keys,
 		keymapPath,
@@ -146,15 +149,18 @@ func buildMemKeyDiskTableMultiShard(
 		return nil, fmt.Errorf("failed to create config: %w", err)
 	}
 
-	config.Clock = clock
 	config.TargetSegmentFileSize = 100 // intentionally use a very small segment size
 	config.GCPeriod = time.Millisecond
 	config.Fsync = false
 	config.ShardingFactor = 4
-	config.Logger = logger
+
+	runtimeConfig := litt.DefaultRuntimeConfig()
+	runtimeConfig.Clock = clock
+	runtimeConfig.Logger = logger
 
 	table, err := NewDiskTable(
 		config,
+		runtimeConfig,
 		name,
 		keys,
 		keymapPath,
@@ -192,14 +198,17 @@ func buildPebbleDBKeyDiskTableSingleShard(
 		return nil, fmt.Errorf("failed to create config: %w", err)
 	}
 
-	config.Clock = clock
 	config.TargetSegmentFileSize = 100 // intentionally use a very small segment size
 	config.GCPeriod = time.Millisecond
 	config.Fsync = false
-	config.Logger = logger
+
+	runtimeConfig := litt.DefaultRuntimeConfig()
+	runtimeConfig.Clock = clock
+	runtimeConfig.Logger = logger
 
 	table, err := NewDiskTable(
 		config,
+		runtimeConfig,
 		name,
 		keys,
 		keymapPath,
@@ -237,15 +246,18 @@ func buildPebbleDBKeyDiskTableMultiShard(
 		return nil, fmt.Errorf("failed to create config: %w", err)
 	}
 
-	config.Clock = clock
 	config.TargetSegmentFileSize = 100 // intentionally use a very small segment size
 	config.GCPeriod = time.Millisecond
 	config.Fsync = false
 	config.ShardingFactor = 4
-	config.Logger = logger
+
+	runtimeConfig := litt.DefaultRuntimeConfig()
+	runtimeConfig.Clock = clock
+	runtimeConfig.Logger = logger
 
 	table, err := NewDiskTable(
 		config,
+		runtimeConfig,
 		name,
 		keys,
 		keymapPath,

--- a/sei-db/db_engine/litt/littbuilder/build_utils.go
+++ b/sei-db/db_engine/litt/littbuilder/build_utils.go
@@ -191,7 +191,7 @@ func buildKeymap(
 // buildTable creates a new table based on the configuration.
 func buildTable(
 	config *litt.Config,
-	logger *slog.Logger,
+	runtimeConfig *litt.RuntimeConfig,
 	name string,
 	metrics *metrics.LittDBMetrics) (litt.ManagedTable, error) {
 
@@ -201,13 +201,14 @@ func buildTable(
 		return nil, fmt.Errorf("sharding factor must be at least 1")
 	}
 
-	kmap, keymapDirectory, keymapTypeFile, requiresReload, err := buildKeymap(config, logger, name)
+	kmap, keymapDirectory, keymapTypeFile, requiresReload, err := buildKeymap(config, runtimeConfig.Logger, name)
 	if err != nil {
 		return nil, fmt.Errorf("error creating keymap: %w", err)
 	}
 
 	table, err = disktable.NewDiskTable(
 		config,
+		runtimeConfig,
 		name,
 		kmap,
 		keymapDirectory,
@@ -231,34 +232,29 @@ func buildTable(
 	return cachedTable, nil
 }
 
-// buildLogger returns the configured logger or slog.Default() if none was provided.
-func buildLogger(config *litt.Config) *slog.Logger {
-	if config.Logger != nil {
-		return config.Logger
-	}
-	return slog.Default()
-}
-
 // buildMetrics creates a new metrics object backed by the global OTel
 // MeterProvider. When MetricsEnabled is true, this configures the global
 // provider with a Prometheus exporter and starts an HTTP server on
 // MetricsPort that serves /metrics. The returned shutdown function flushes
 // the provider; it is the responsibility of the caller to invoke it during
 // teardown.
-func buildMetrics(config *litt.Config, logger *slog.Logger) (*metrics.LittDBMetrics, func(context.Context) error) {
+func buildMetrics(
+	config *litt.Config,
+	runtimeConfig *litt.RuntimeConfig,
+) (*metrics.LittDBMetrics, func(context.Context) error) {
 	if !config.MetricsEnabled {
 		return nil, nil
 	}
 
 	reg, shutdown, err := commonmetrics.SetupOtelPrometheus()
 	if err != nil {
-		logger.Error("failed to set up OTel Prometheus exporter", "error", err)
+		runtimeConfig.Logger.Error("failed to set up OTel Prometheus exporter", "error", err)
 		return nil, nil
 	}
 
 	addr := fmt.Sprintf(":%d", config.MetricsPort)
-	logger.Info("Starting metrics server", "port", config.MetricsPort)
-	commonmetrics.StartMetricsServer(config.CTX, reg, addr)
+	runtimeConfig.Logger.Info("Starting metrics server", "port", config.MetricsPort)
+	commonmetrics.StartMetricsServer(runtimeConfig.CTX, reg, addr)
 
 	return metrics.NewLittDBMetrics(), shutdown
 }

--- a/sei-db/db_engine/litt/littbuilder/db_impl.go
+++ b/sei-db/db_engine/litt/littbuilder/db_impl.go
@@ -3,7 +3,6 @@ package littbuilder
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -18,18 +17,14 @@ var _ litt.DB = &db{}
 
 // TableBuilderFunc is a function that creates a new table.
 type TableBuilderFunc func(
-	ctx context.Context,
-	logger *slog.Logger,
+	runtimeConfig *litt.RuntimeConfig,
 	name string,
 	metrics *metrics.LittDBMetrics) (litt.ManagedTable, error)
 
 // db is an implementation of DB.
 type db struct {
-	ctx    context.Context
-	logger *slog.Logger
-
-	// A function that returns the current time.
-	clock func() time.Time
+	// The non-serializable runtime dependencies for the database.
+	runtimeConfig *litt.RuntimeConfig
 
 	// The default time-to-live for new tables. Once created, the TTL for a table can be changed.
 	ttl time.Duration
@@ -63,10 +58,21 @@ type db struct {
 }
 
 // NewDB creates a new DB instance. After this method is called, the config object should not be modified.
-func NewDB(config *litt.Config) (litt.DB, error) {
-	config.Logger = buildLogger(config)
+// At most one RuntimeConfig may be provided. If none is provided, a default RuntimeConfig is used.
+func NewDB(config *litt.Config, runtimeConfig ...*litt.RuntimeConfig) (litt.DB, error) {
+	if len(runtimeConfig) > 1 {
+		return nil, fmt.Errorf("at most one RuntimeConfig may be provided, got %d", len(runtimeConfig))
+	}
 
-	err := config.SanityCheck()
+	rc := litt.DefaultRuntimeConfig()
+	if len(runtimeConfig) == 1 && runtimeConfig[0] != nil {
+		rc = runtimeConfig[0]
+	}
+	if err := rc.Validate(); err != nil {
+		return nil, fmt.Errorf("error validating runtime config: %w", err)
+	}
+
+	err := config.Validate()
 	if err != nil {
 		return nil, fmt.Errorf("error checking config: %w", err)
 	}
@@ -77,25 +83,35 @@ func NewDB(config *litt.Config) (litt.DB, error) {
 	}
 
 	if !config.Fsync {
-		config.Logger.Warn(
+		rc.Logger.Warn(
 			"Fsync is disabled. Ok for unit tests that need to run fast, NOT OK FOR PRODUCTION USE.")
 	}
 
 	tableBuilder := func(
-		ctx context.Context,
-		logger *slog.Logger,
+		runtimeConfig *litt.RuntimeConfig,
 		name string,
 		metrics *metrics.LittDBMetrics) (litt.ManagedTable, error) {
 
-		return buildTable(config, logger, name, metrics)
+		return buildTable(config, runtimeConfig, name, metrics)
 	}
 
-	return NewDBUnsafe(config, tableBuilder)
+	return NewDBUnsafe(config, rc, tableBuilder)
 }
 
 // NewDBUnsafe creates a new DB instance with a custom table builder. This is intended for unit test use,
-// and should not be considered a stable API.
-func NewDBUnsafe(config *litt.Config, tableBuilder TableBuilderFunc) (litt.DB, error) {
+// and should not be considered a stable API. If runtimeConfig is nil, a default RuntimeConfig is used.
+func NewDBUnsafe(
+	config *litt.Config,
+	runtimeConfig *litt.RuntimeConfig,
+	tableBuilder TableBuilderFunc,
+) (litt.DB, error) {
+	if runtimeConfig == nil {
+		runtimeConfig = litt.DefaultRuntimeConfig()
+	}
+	if err := runtimeConfig.Validate(); err != nil {
+		return nil, fmt.Errorf("error validating runtime config: %w", err)
+	}
+
 	for _, rootPath := range config.Paths {
 		err := util.EnsureDirectoryExists(rootPath, config.Fsync)
 		if err != nil {
@@ -104,40 +120,34 @@ func NewDBUnsafe(config *litt.Config, tableBuilder TableBuilderFunc) (litt.DB, e
 	}
 
 	if config.PurgeLocks {
-		config.Logger.Warn("Purging LittDB locks", "paths", config.Paths)
-		err := disktable.Unlock(config.Logger, config.Paths)
+		runtimeConfig.Logger.Warn("Purging LittDB locks", "paths", config.Paths)
+		err := disktable.Unlock(runtimeConfig.Logger, config.Paths)
 		if err != nil {
 			return nil, fmt.Errorf("error purging locks: %w", err)
 		}
-		config.Logger.Info("Locks purged successfully")
+		runtimeConfig.Logger.Info("Locks purged successfully")
 	} else {
-		config.Logger.Info("Not purging locks, continuing with existing locks")
+		runtimeConfig.Logger.Info("Not purging locks, continuing with existing locks")
 	}
 
-	releaseLocks, err := util.LockDirectories(config.Logger, config.Paths, util.LockfileName, config.Fsync)
+	releaseLocks, err := util.LockDirectories(runtimeConfig.Logger, config.Paths, util.LockfileName, config.Fsync)
 	if err != nil {
 		return nil, fmt.Errorf("error acquiring locks on paths %v: %w", config.Paths, err)
-	}
-
-	if config.Logger == nil {
-		config.Logger = buildLogger(config)
 	}
 
 	var dbMetrics *metrics.LittDBMetrics
 	var metricsShutdown func(context.Context) error
 	if config.MetricsEnabled {
-		dbMetrics, metricsShutdown = buildMetrics(config, config.Logger)
+		dbMetrics, metricsShutdown = buildMetrics(config, runtimeConfig)
 	}
 
 	if config.SnapshotDirectory != "" {
-		config.Logger.Info("LittDB rolling snapshots enabled",
+		runtimeConfig.Logger.Info("LittDB rolling snapshots enabled",
 			"directory", config.SnapshotDirectory)
 	}
 
 	database := &db{
-		ctx:             config.CTX,
-		logger:          config.Logger,
-		clock:           config.Clock,
+		runtimeConfig:   runtimeConfig,
 		ttl:             config.TTL,
 		gcPeriod:        config.GCPeriod,
 		tableBuilder:    tableBuilder,
@@ -195,11 +205,11 @@ func (d *db) GetTable(name string) (litt.Table, error) {
 		}
 
 		var err error
-		table, err = d.tableBuilder(d.ctx, d.logger, name, d.metrics)
+		table, err = d.tableBuilder(d.runtimeConfig, name, d.metrics)
 		if err != nil {
 			return nil, fmt.Errorf("error creating table: %w", err)
 		}
-		d.logger.Info("Table initialized",
+		d.runtimeConfig.Logger.Info("Table initialized",
 			"table", name,
 			"keys", table.KeyCount(),
 			"size", util.PrettyPrintBytes(table.Size()),
@@ -218,11 +228,11 @@ func (d *db) DropTable(name string) error {
 	table, ok := d.tables[name]
 	if !ok {
 		// Table does not exist, nothing to do.
-		d.logger.Info("table does not exist, cannot drop", "table", name)
+		d.runtimeConfig.Logger.Info("table does not exist, cannot drop", "table", name)
 		return nil
 	}
 
-	d.logger.Info("dropping table", "table", name)
+	d.runtimeConfig.Logger.Info("dropping table", "table", name)
 	err := table.Destroy()
 	if err != nil {
 		return fmt.Errorf("error destroying table: %w", err)
@@ -244,7 +254,7 @@ func (d *db) closeUnsafe() error {
 		return nil
 	}
 
-	d.logger.Info("Stopping LittDB", "size", d.lockFreeSize())
+	d.runtimeConfig.Logger.Info("Stopping LittDB", "size", d.lockFreeSize())
 	d.stopped.Store(true)
 
 	for name, table := range d.tables {
@@ -286,7 +296,7 @@ func (d *db) gatherMetrics(interval time.Duration) {
 			defer cancel()
 			err := d.metricsShutdown(shutdownCtx)
 			if err != nil {
-				d.logger.Error("error shutting down metrics provider", "error", err)
+				d.runtimeConfig.Logger.Error("error shutting down metrics provider", "error", err)
 			}
 		}()
 	}
@@ -296,7 +306,7 @@ func (d *db) gatherMetrics(interval time.Duration) {
 
 	for !d.stopped.Load() {
 		select {
-		case <-d.ctx.Done():
+		case <-d.runtimeConfig.CTX.Done():
 			return
 		case <-ticker.C:
 			d.lock.Lock()

--- a/sei-db/db_engine/litt/littdb_config.go
+++ b/sei-db/db_engine/litt/littdb_config.go
@@ -1,9 +1,7 @@
 package litt
 
 import (
-	"context"
 	"fmt"
-	"log/slog"
 	"math"
 	"time"
 
@@ -19,9 +17,6 @@ const MaxShardingFactor = 255
 
 // Config is configuration for a litt.DB.
 type Config struct {
-	// The context for the database. If nil, context.Background() is used.
-	CTX context.Context
-
 	// The paths where the database will store its files. If the path does not exist, it will be created.
 	// If more than one path is provided, then the database will do its best to spread out the data across
 	// the paths. If the database is restarted, it will attempt to load data from all paths. Note: the number
@@ -33,9 +28,6 @@ type Config struct {
 	//
 	// Providing zero paths will cause the DB to return an error at startup.
 	Paths []string
-
-	// The logger for the database. If nil, slog.Default() is used.
-	Logger *slog.Logger
 
 	// The type of the keymap. Choices are keymap.MemKeymapType and keymap.PebbleDBKeymapType.
 	// Default is keymap.PebbleDBKeymapType.
@@ -94,10 +86,6 @@ type Config struct {
 	// individually on each table by calling Table.SetReadCacheSize().
 	ReadCacheSize uint64
 
-	// The time source used by the database. This can be substituted for an artificial time source
-	// for testing purposes. The default is time.Now.
-	Clock func() time.Time
-
 	// If true, then flush operations will call fsync on the underlying file to ensure data is flushed out of the
 	// operating system's buffer and onto disk. Setting this to false means that even after flushing data,
 	// there may be data loss in the advent of an OS/hardware crash.
@@ -126,11 +114,6 @@ type Config struct {
 
 	// The interval at which various DB metrics are updated. The default is 1 second.
 	MetricsUpdateInterval time.Duration
-
-	// A function that is called if the database experiences a non-recoverable error (e.g. data corruption,
-	// a crashed goroutine, a full disk, etc.). If nil (the default), no callback is called. If called at all,
-	// this method is called exactly once.
-	FatalErrorCallback func(error)
 
 	// If empty, snapshotting is disabled. If not empty, then this directory is used by the database to publish a
 	// rolling sequence of "snapshots". Using the data in the snapshot directory, an external process can safely
@@ -174,9 +157,6 @@ func DefaultConfig(paths ...string) (*Config, error) {
 // If paths are not set prior to use, then the DB will return an error at startup.
 func DefaultConfigNoPaths() *Config {
 	return &Config{
-		CTX:                      context.Background(),
-		Logger:                   slog.Default(),
-		Clock:                    time.Now,
 		GCPeriod:                 5 * time.Minute,
 		GCBatchSize:              10_000,
 		ShardingFactor:           8,
@@ -215,20 +195,11 @@ func (c *Config) SanitizePaths() error {
 	return nil
 }
 
-// SanityCheck performs a sanity check on the configuration, returning an error if any of the configuration
+// Validate performs a sanity check on the configuration, returning an error if any of the configuration
 // settings are invalid. The config returned by DefaultConfig() is guaranteed to pass this check if unmodified.
-func (c *Config) SanityCheck() error {
-	if c.CTX == nil {
-		return fmt.Errorf("context cannot be nil")
-	}
+func (c *Config) Validate() error {
 	if len(c.Paths) == 0 {
 		return fmt.Errorf("at least one path must be provided")
-	}
-	if c.Logger == nil {
-		return fmt.Errorf("logger must be provided")
-	}
-	if c.Clock == nil {
-		return fmt.Errorf("time source cannot be nil")
 	}
 	if c.GCBatchSize == 0 {
 		return fmt.Errorf("gc batch size must be at least 1")

--- a/sei-db/db_engine/litt/littdb_config_test.go
+++ b/sei-db/db_engine/litt/littdb_config_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSanityCheckShardingFactorBounds(t *testing.T) {
+func TestValidateShardingFactorBounds(t *testing.T) {
 	t.Parallel()
 
 	t.Run("zero is rejected", func(t *testing.T) {
@@ -14,7 +14,7 @@ func TestSanityCheckShardingFactorBounds(t *testing.T) {
 		config, err := DefaultConfig("/tmp/litt-test")
 		require.NoError(t, err)
 		config.ShardingFactor = 0
-		require.Error(t, config.SanityCheck())
+		require.Error(t, config.Validate())
 	})
 
 	t.Run("MaxShardingFactor is accepted", func(t *testing.T) {
@@ -22,7 +22,7 @@ func TestSanityCheckShardingFactorBounds(t *testing.T) {
 		config, err := DefaultConfig("/tmp/litt-test")
 		require.NoError(t, err)
 		config.ShardingFactor = MaxShardingFactor
-		require.NoError(t, config.SanityCheck())
+		require.NoError(t, config.Validate())
 	})
 
 }

--- a/sei-db/db_engine/litt/memtable/mem_table.go
+++ b/sei-db/db_engine/litt/memtable/mem_table.go
@@ -49,10 +49,10 @@ type memTable struct {
 }
 
 // NewMemTable creates a new in-memory table.
-func NewMemTable(config *litt.Config, name string) litt.ManagedTable {
+func NewMemTable(config *litt.Config, runtimeConfig *litt.RuntimeConfig, name string) litt.ManagedTable {
 
 	table := &memTable{
-		clock:           config.Clock,
+		clock:           runtimeConfig.Clock,
 		name:            name,
 		ttl:             config.TTL,
 		data:            make(map[string][]byte),

--- a/sei-db/db_engine/litt/runtime_config.go
+++ b/sei-db/db_engine/litt/runtime_config.go
@@ -1,0 +1,52 @@
+package litt
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// RuntimeConfig holds the non-serializable runtime dependencies for a litt.DB. These are kept separate from
+// Config so that Config can be safely deserialized from a config file. Callers that do not want to set every
+// field should start from DefaultRuntimeConfig() and override as needed, as the required fields must be set.
+type RuntimeConfig struct {
+	// The context for the database.
+	CTX context.Context
+
+	// The logger for the database.
+	Logger *slog.Logger
+
+	// The time source used by the database. This can be substituted for an artificial time source
+	// for testing purposes.
+	Clock func() time.Time
+
+	// A function that is called if the database experiences a non-recoverable error (e.g. data corruption,
+	// a crashed goroutine, a full disk, etc.). This field is optional; if nil, no callback is called. If
+	// called at all, this method is called exactly once.
+	FatalErrorCallback func(error)
+}
+
+// DefaultRuntimeConfig returns a RuntimeConfig with sane default values. Callers that do not want to set
+// every field themselves should generally start from this.
+func DefaultRuntimeConfig() *RuntimeConfig {
+	return &RuntimeConfig{
+		CTX:    context.Background(),
+		Logger: slog.Default(),
+		Clock:  time.Now,
+	}
+}
+
+// Validate returns an error if any required field is unset. FatalErrorCallback is optional and may be nil.
+func (r *RuntimeConfig) Validate() error {
+	if r.CTX == nil {
+		return fmt.Errorf("context cannot be nil")
+	}
+	if r.Logger == nil {
+		return fmt.Errorf("logger cannot be nil")
+	}
+	if r.Clock == nil {
+		return fmt.Errorf("clock cannot be nil")
+	}
+	return nil
+}

--- a/sei-db/db_engine/litt/test/db_test.go
+++ b/sei-db/db_engine/litt/test/db_test.go
@@ -1,9 +1,7 @@
 package test
 
 import (
-	"context"
 	"fmt"
-	"log/slog"
 	"os"
 	"testing"
 	"time"
@@ -59,18 +57,18 @@ func buildMemDB(t *testing.T, path string) (litt.DB, error) {
 	require.NoError(t, err)
 
 	config.GCPeriod = 50 * time.Millisecond
-	config.Logger = slog.Default()
+
+	runtimeConfig := litt.DefaultRuntimeConfig()
 
 	tb := func(
-		ctx context.Context,
-		logger *slog.Logger,
+		runtimeConfig *litt.RuntimeConfig,
 		name string,
 		metrics *metrics.LittDBMetrics,
 	) (litt.ManagedTable, error) {
-		return memtable.NewMemTable(config, name), nil
+		return memtable.NewMemTable(config, runtimeConfig, name), nil
 	}
 
-	return littbuilder.NewDBUnsafe(config, tb)
+	return littbuilder.NewDBUnsafe(config, runtimeConfig, tb)
 }
 
 func buildMemKeyDiskDB(t *testing.T, path string) (litt.DB, error) {

--- a/sei-db/db_engine/litt/test/table_test.go
+++ b/sei-db/db_engine/litt/test/table_test.go
@@ -74,14 +74,16 @@ func buildMemTable(
 	path string) (litt.ManagedTable, error) {
 
 	config, err := litt.DefaultConfig(path)
-	config.Clock = clock
 	config.GCPeriod = time.Millisecond
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create config: %w", err)
 	}
 
-	return memtable.NewMemTable(config, name), nil
+	runtimeConfig := litt.DefaultRuntimeConfig()
+	runtimeConfig.Clock = clock
+
+	return memtable.NewMemTable(config, runtimeConfig, name), nil
 }
 
 func setupKeymapTypeFile(keymapPath string, keymapType keymap.KeymapType) (*keymap.KeymapTypeFile, error) {
@@ -133,14 +135,17 @@ func buildMemKeyDiskTable(
 		return nil, fmt.Errorf("failed to create config: %w", err)
 	}
 	config.GCPeriod = time.Millisecond
-	config.Clock = clock
 	config.Fsync = false
 	config.DoubleWriteProtection = true
 	config.TargetSegmentFileSize = 100 // intentionally use a very small segment size
-	config.Logger = logger
+
+	runtimeConfig := litt.DefaultRuntimeConfig()
+	runtimeConfig.Clock = clock
+	runtimeConfig.Logger = logger
 
 	table, err := disktable.NewDiskTable(
 		config,
+		runtimeConfig,
 		name,
 		keys,
 		keymapPath,
@@ -179,14 +184,17 @@ func buildPebbleDBKeyDiskTable(
 		return nil, fmt.Errorf("failed to create config: %w", err)
 	}
 	config.GCPeriod = time.Millisecond
-	config.Clock = clock
 	config.Fsync = false
 	config.DoubleWriteProtection = true
 	config.TargetSegmentFileSize = 100 // intentionally use a very small segment size
-	config.Logger = logger
+
+	runtimeConfig := litt.DefaultRuntimeConfig()
+	runtimeConfig.Clock = clock
+	runtimeConfig.Logger = logger
 
 	table, err := disktable.NewDiskTable(
 		config,
+		runtimeConfig,
 		name,
 		keys,
 		keymapPath,

--- a/sei-db/db_engine/litt/test/unlock_test.go
+++ b/sei-db/db_engine/litt/test/unlock_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"log/slog"
 	"os"
 	"path"
 	"path/filepath"
@@ -65,7 +66,7 @@ func TestUnlock(t *testing.T) {
 	require.Equal(t, 3, lockFileCount)
 
 	// Unlock the DB. This should remove all lock files, but leave other files intact.
-	err = disktable.Unlock(config.Logger, volumes)
+	err = disktable.Unlock(slog.Default(), volumes)
 	require.NoError(t, err, "Failed to unlock the database")
 
 	// There should be no lock files left.
@@ -88,7 +89,7 @@ func TestUnlock(t *testing.T) {
 	require.Equal(t, 0, lockFileCount, "There should be no lock files left after unlocking")
 
 	// Calling unlock again should not cause any issues.
-	err = disktable.Unlock(config.Logger, volumes)
+	err = disktable.Unlock(slog.Default(), volumes)
 	require.NoError(t, err, "Failed to unlock the database again")
 
 	// Verify that the data is still intact.


### PR DESCRIPTION
## Describe your changes and provide context

Cleans up LittDB config so that non-serializable fields are not in the config struct

## Testing performed to validate your change

unit tests