### PR TITLE
fix(metrics): OTel exporter namespace sei-chain -> sei_chain so sei_chain_* metrics are queryable

### DIFF
--- a/utils/metrics/metrics_util.go
+++ b/utils/metrics/metrics_util.go
@@ -17,7 +17,7 @@ import (
 )
 
 func SetupOtelMetricsProvider() error {
-	metricsExporter, err := prometheus.New(prometheus.WithNamespace("sei-chain"))
+	metricsExporter, err := prometheus.New(prometheus.WithNamespace("sei_chain"))
 	if err != nil {
 		return fmt.Errorf("failed to create Prometheus exporter: %w", err)
 	}


### PR DESCRIPTION
Closes #3555.

## Scope (intentionally narrow)

**This PR changes exactly one thing: the OTel exporter namespace `sei-chain` → `sei_chain`.** It is the single-line root-cause fix that makes the entire OTel `sei_chain_*` metric family emit under a legal, queryable name. It does **not** touch consumers or instrument modeling — those are tracked as separate follow-ups in #3555 (interim chaos-suite TPS repoint for the deploy lag; an `absent()` guardrail for silently-empty recording rules; the `_total`-gauge-vs-counter smell). No dashboard/recording-rule change is needed — they already query `sei_chain_*` and light up once a fixed seid deploys.

## Problem

The OTel-instrumented metrics (`evmrpc_*`, cosmos `app_*`/`abci_*`) land in prod as `sei-chain_*` (**hyphen**). A hyphen is not a legal legacy Prometheus base name; the series ingest only under `metric_name_validation_scheme: utf8`, and a normal selector `sei-chain_evmrpc_x` **parses the `-` as subtraction** → silently empty, `status: success`, no error. The whole family is invisible to every `sei_chain_*` (underscore) consumer: the EVM-RPC dashboards and the chaos-suite committed-TPS recording rule are blind.

## Root cause

`SetupOtelMetricsProvider()` configures the exporter `WithNamespace("sei-chain")`. Under the pinned deps (`exporters/prometheus v0.60.0`, `prometheus/common v0.66.1`, `otlptranslator v0.0.2`), the default `UTF8Validation` scheme selects `NoUTF8EscapingWithSuffixes`, and `otlptranslator.buildMetricName` joins `namespace + "_" + name` **verbatim with no escaping** — so the hyphen survives. This metric surface has been born-broken since the OTel instruments landed (PLT-353 / PLT-326); legacy armon metrics (`tx_count`, `abci_*`, `sei_*`) are a separate pipeline and are unaffected.

## Fix

```diff
- prometheus.New(prometheus.WithNamespace("sei-chain"))
+ prometheus.New(prometheus.WithNamespace("sei_chain"))
```

Metrics emit as `sei_chain_*`. An all-underscore namespace is also forward-stable if the exporter later flips its default to `UnderscoreEscapingWithSuffixes`.

## Validation

Cross-reviewed by opentelemetry-expert (online, against the pinned exporter/otlptranslator source) and observability-platform-engineer (prod Thanos + scrape config): hyphen originates from the namespace (zero `__name__` relabelings in the pipeline), prod Prometheus 3.10 ingests it via UTF-8 names, no consumer depends on the hyphen spelling (whole-repo grep = 0), and the `_seconds`/`_total` suffix concerns are pre-existing and unaffected by this change.

## Why local validation didn't catch it

The in-repo local stack (`docker/docker-compose.monitoring.yml`) runs `prom/prometheus:latest`, which uses UTF-8 name validation — so the hyphenated names ingest without error and appear populated in the Prometheus/Grafana metric browser. It provisions only a datasource (no dashboards or recording rules), so the `sei_chain_*` underscore queries that actually break are never exercised. Net: the local check confirms "the metric is emitted and scraped," not "it resolves under the name consumers query" — and a namespace typo only surfaces under the second check, which nothing in-package performs.

## Caveats

- **Metric rename** — no historical continuity between `sei-chain_*` and `sei_chain_*` in Thanos; the old family ages out at raw retention.
- **Deploy lag** — consumers populate only after a seid build with this change reaches the relevant (EVM-RPC-serving) nodes.
