### PR TITLE
ci: pin codecov-action to v7 (fix repo-wide Codecov GPG failure)

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -190,7 +190,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: github.event_name != 'merge_group' && (github.event_name != 'pull_request' || steps.cov-pkgs.outputs.skip != 'true')
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           # Hard-fail on main (full path); soft on PRs (partial data).

--- a/.github/workflows/rocksdb-unit_tests.yml
+++ b/.github/workflows/rocksdb-unit_tests.yml
@@ -59,7 +59,7 @@ jobs:
           export CGO_LDFLAGS="-L/usr/local/lib -lrocksdb -lz -lbz2 -lsnappy -llz4 -lzstd -ljemalloc"
           go test -v -mod=readonly -tags=rocksdbBackend ./sei-db/db_engine/rocksdb/... -covermode=atomic -coverprofile=./rdb-profile.out
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./rdb-profile.out
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/sei-db-tests.yml
+++ b/.github/workflows/sei-db-tests.yml
@@ -181,7 +181,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: github.event_name != 'merge_group' && (github.event_name != 'pull_request' || steps.cov-pkgs.outputs.skip != 'true')
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           # Hard-fail on main (full path); soft on PRs (partial data).


### PR DESCRIPTION
## Problem

The **Upload coverage to Codecov** step has been failing **repo-wide since ~2026-06-06** — red on `main`, the merge queue, and every PR (e.g. the RocksDB Tests check). The tests themselves pass; the job dies at the codecov CLI's GPG integrity check:

```
gpg: no valid OpenPGP data found.
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
Exiting...
```

## Root cause (external — not a repo change)

`codecov/codecov-action@v5`'s bundled script hardcodes:
```sh
curl -s https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import
```
Codecov **migrated its Keybase account `codecovsecurity` → `codecovsecops`**, so that URL now returns **HTTP 404 / 0 bytes**. `curl -s` (no `-f`) pipes the empty body into `gpg --import` → no key imported → `gpg --verify` has no key → exit 1.

- The signing key (`27034E7F…779869`, RSA4096, created 2021) is **unchanged** — only its distribution location moved. It's **not** a key rotation, **not** a CLI-version issue (`version` is unset / the key URL is version-independent), and **not** a repo change.
- Codecov shipped the fix in **v7.0.0** (script now fetches `…/codecovsecops/…`, HTTP 200) at 2026-06-07 01:43 UTC, **but did not backport it to the `v5` tag** — so every `@v5` consumer broke simultaneously. This repo pins `@v5` in all three coverage jobs.

## Fix

Pin all three Codecov steps to **v7.0.0 by commit SHA** `fb8b3582c8e4def4969c97caa2f19720cb33a72f`:
- `go-test.yml`, `sei-db-tests.yml`, `rocksdb-unit_tests.yml`

This restores verification against the genuine key **everywhere, including `main`** (not just unblocking PRs). Pinning by SHA (not a floating tag) prevents a repeat from tag drift. Verified v7 still defines every input these steps use — `files`, `token`, `fail_ci_if_error`, `flags`, `disable_search`, `name` — so no other changes are needed.

**Deliberately not done:** `skip_validation: true` (would run an unverified downloaded binary with `CODECOV_TOKEN` in scope — a supply-chain risk); and `fail_ci_if_error: false` (only masks the failure, coverage still wouldn't upload). The action bump is the actual fix.

### Note (separate, optional cleanup)
`rocksdb-unit_tests.yml` hardcodes `fail_ci_if_error: true` while `go-test.yml`/`sei-db-tests.yml` use `${{ github.event_name != 'pull_request' }}`. That inconsistency is why RocksDB was the check reding PRs while the others stayed green. With this fix the upload works, so it's no longer load-bearing — left as-is here to keep this PR scoped to the root-cause fix; align it in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)