### PR TITLE
fix(sei-tendermint): default HTTP write timeout to 30s on CometBFT RPC server (SEI-10199)

### DIFF
--- a/sei-tendermint/cmd/tendermint/commands/light.go
+++ b/sei-tendermint/cmd/tendermint/commands/light.go
@@ -170,14 +170,7 @@ for applications built w/ Cosmos SDK).
 			cfg.MaxBodyBytes = conf.RPC.MaxBodyBytes
 			cfg.MaxHeaderBytes = conf.RPC.MaxHeaderBytes
 			cfg.MaxOpenConnections = maxOpenConnections
-			if conf.RPC.TimeoutWrite == 0 {
-				cfg.WriteTimeout = 0
-			} else {
-				cfg.WriteTimeout = conf.RPC.TimeoutWrite
-				if cfg.WriteTimeout <= conf.RPC.TimeoutBroadcastTxCommit {
-					cfg.WriteTimeout = conf.RPC.TimeoutBroadcastTxCommit + 1*time.Second
-				}
-			}
+			cfg.WriteTimeout = conf.RPC.TimeoutWrite
 
 			p, err := lproxy.NewProxy(c, listenAddr, primaryAddr, cfg, lrpc.KeyPathFn(lrpc.DefaultMerkleKeyPathFn()))
 			if err != nil {

--- a/sei-tendermint/cmd/tendermint/commands/light.go
+++ b/sei-tendermint/cmd/tendermint/commands/light.go
@@ -170,12 +170,13 @@ for applications built w/ Cosmos SDK).
 			cfg.MaxBodyBytes = conf.RPC.MaxBodyBytes
 			cfg.MaxHeaderBytes = conf.RPC.MaxHeaderBytes
 			cfg.MaxOpenConnections = maxOpenConnections
-			// If necessary adjust global WriteTimeout to ensure it's greater than
-			// TimeoutBroadcastTxCommit.
-			// See https://github.com/tendermint/tendermint/issues/3435
-			// Note we don't need to adjust anything if the timeout is already unlimited.
-			if cfg.WriteTimeout > 0 && cfg.WriteTimeout <= conf.RPC.TimeoutBroadcastTxCommit {
-				cfg.WriteTimeout = conf.RPC.TimeoutBroadcastTxCommit + 1*time.Second
+			if conf.RPC.TimeoutWrite == 0 {
+				cfg.WriteTimeout = 0
+			} else {
+				cfg.WriteTimeout = conf.RPC.TimeoutWrite
+				if cfg.WriteTimeout <= conf.RPC.TimeoutBroadcastTxCommit {
+					cfg.WriteTimeout = conf.RPC.TimeoutBroadcastTxCommit + 1*time.Second
+				}
 			}
 
 			p, err := lproxy.NewProxy(c, listenAddr, primaryAddr, cfg, lrpc.KeyPathFn(lrpc.DefaultMerkleKeyPathFn()))

--- a/sei-tendermint/config/config.go
+++ b/sei-tendermint/config/config.go
@@ -514,6 +514,10 @@ type RPCConfig struct {
 
 	// Timeout for any read request
 	TimeoutRead time.Duration `mapstructure:"timeout-read"`
+
+	// HTTP write timeout. Acts as a hard backstop for all handlers.
+	// 0 disables the timeout, not recommended
+	TimeoutWrite time.Duration `mapstructure:"timeout-write"`
 }
 
 // DefaultRPCConfig returns a default configuration for the RPC server
@@ -543,7 +547,8 @@ func DefaultRPCConfig() *RPCConfig {
 		TLSKeyFile:   "",
 		LagThreshold: 300,
 
-		TimeoutRead: 10 * time.Second,
+		TimeoutRead:  10 * time.Second,
+		TimeoutWrite: 30 * time.Second,
 	}
 }
 
@@ -585,6 +590,9 @@ func (cfg *RPCConfig) ValidateBasic() error {
 	}
 	if cfg.LagThreshold < 0 {
 		return errors.New("lag-threshold can't be negative")
+	}
+	if cfg.TimeoutWrite < 0 {
+		return errors.New("timeout-write can't be negative")
 	}
 	return nil
 }

--- a/sei-tendermint/config/config.go
+++ b/sei-tendermint/config/config.go
@@ -594,6 +594,10 @@ func (cfg *RPCConfig) ValidateBasic() error {
 	if cfg.TimeoutWrite < 0 {
 		return errors.New("timeout-write can't be negative")
 	}
+	if cfg.TimeoutWrite > 0 && cfg.TimeoutWrite <= cfg.TimeoutBroadcastTxCommit {
+		return fmt.Errorf("timeout-write (%s) must be greater than timeout-broadcast-tx-commit (%s)",
+			cfg.TimeoutWrite, cfg.TimeoutBroadcastTxCommit)
+	}
 	return nil
 }
 

--- a/sei-tendermint/config/config_test.go
+++ b/sei-tendermint/config/config_test.go
@@ -80,6 +80,16 @@ func TestRPCConfigValidateBasic(t *testing.T) {
 		assert.Error(t, cfg.ValidateBasic())
 		reflect.ValueOf(cfg).Elem().FieldByName(fieldName).SetInt(0)
 	}
+
+	// Cross-field: timeout-write must be greater than timeout-broadcast-tx-commit when non-zero.
+	cfg2 := TestRPCConfig()
+	cfg2.TimeoutBroadcastTxCommit = 20 * time.Second
+	cfg2.TimeoutWrite = 20 * time.Second
+	assert.Error(t, cfg2.ValidateBasic())
+	cfg2.TimeoutWrite = 21 * time.Second
+	assert.NoError(t, cfg2.ValidateBasic())
+	cfg2.TimeoutWrite = 0 // 0 disables; constraint does not apply
+	assert.NoError(t, cfg2.ValidateBasic())
 }
 
 func TestMempoolConfigValidateBasic(t *testing.T) {

--- a/sei-tendermint/config/config_test.go
+++ b/sei-tendermint/config/config_test.go
@@ -72,6 +72,7 @@ func TestRPCConfigValidateBasic(t *testing.T) {
 		"MaxBodyBytes",
 		"MaxHeaderBytes",
 		"LagThreshold",
+		"TimeoutWrite",
 	}
 
 	for _, fieldName := range fieldsToTest {

--- a/sei-tendermint/config/toml.go
+++ b/sei-tendermint/config/toml.go
@@ -245,6 +245,10 @@ pprof-laddr = "{{ .RPC.PprofListenAddress }}"
 # timeout for any read request
 timeout-read = "{{ .RPC.TimeoutRead }}"
 
+# HTTP write timeout; acts as a hard backstop for all handlers.
+# Set to "0s" to disable (not recommended).
+timeout-write = "{{ .RPC.TimeoutWrite }}"
+
 #######################################################################
 ###           P2P Configuration Options                             ###
 #######################################################################

--- a/sei-tendermint/internal/inspect/rpc/rpc.go
+++ b/sei-tendermint/internal/inspect/rpc/rpc.go
@@ -3,7 +3,6 @@ package rpc
 import (
 	"context"
 	"net/http"
-	"time"
 
 	"github.com/rs/cors"
 	"github.com/sei-protocol/seilog"
@@ -121,13 +120,6 @@ func serverRPCConfig(r *config.RPCConfig) *server.Config {
 	cfg := server.DefaultConfig()
 	cfg.MaxBodyBytes = r.MaxBodyBytes
 	cfg.MaxHeaderBytes = r.MaxHeaderBytes
-	if r.TimeoutWrite == 0 {
-		cfg.WriteTimeout = 0
-	} else {
-		cfg.WriteTimeout = r.TimeoutWrite
-		if cfg.WriteTimeout <= r.TimeoutBroadcastTxCommit {
-			cfg.WriteTimeout = r.TimeoutBroadcastTxCommit + 1*time.Second
-		}
-	}
+	cfg.WriteTimeout = r.TimeoutWrite
 	return cfg
 }

--- a/sei-tendermint/internal/inspect/rpc/rpc.go
+++ b/sei-tendermint/internal/inspect/rpc/rpc.go
@@ -121,12 +121,13 @@ func serverRPCConfig(r *config.RPCConfig) *server.Config {
 	cfg := server.DefaultConfig()
 	cfg.MaxBodyBytes = r.MaxBodyBytes
 	cfg.MaxHeaderBytes = r.MaxHeaderBytes
-	// If necessary adjust global WriteTimeout to ensure it's greater than
-	// TimeoutBroadcastTxCommit.
-	// See https://github.com/tendermint/tendermint/issues/3435
-	// Note we don't need to adjust anything if the timeout is already unlimited.
-	if cfg.WriteTimeout > 0 && cfg.WriteTimeout <= r.TimeoutBroadcastTxCommit {
-		cfg.WriteTimeout = r.TimeoutBroadcastTxCommit + 1*time.Second
+	if r.TimeoutWrite == 0 {
+		cfg.WriteTimeout = 0
+	} else {
+		cfg.WriteTimeout = r.TimeoutWrite
+		if cfg.WriteTimeout <= r.TimeoutBroadcastTxCommit {
+			cfg.WriteTimeout = r.TimeoutBroadcastTxCommit + 1*time.Second
+		}
 	}
 	return cfg
 }

--- a/sei-tendermint/internal/rpc/core/env.go
+++ b/sei-tendermint/internal/rpc/core/env.go
@@ -279,16 +279,21 @@ func (env *Environment) StartService(ctx context.Context, conf *config.Config) (
 	cfg.MaxBodyBytes = conf.RPC.MaxBodyBytes
 	cfg.MaxHeaderBytes = conf.RPC.MaxHeaderBytes
 	cfg.MaxOpenConnections = conf.RPC.MaxOpenConnections
-	// If necessary adjust global WriteTimeout to ensure it's greater than
-	// TimeoutBroadcastTxCommit.
-	// See https://github.com/tendermint/tendermint/issues/3435
-	// Note we don't need to adjust anything if the timeout is already unlimited.
-	if cfg.WriteTimeout > 0 && cfg.WriteTimeout <= conf.RPC.TimeoutBroadcastTxCommit {
-		cfg.WriteTimeout = conf.RPC.TimeoutBroadcastTxCommit + 1*time.Second
-	}
 
 	if conf.RPC.TimeoutRead > 0 {
 		cfg.ReadTimeout = conf.RPC.TimeoutRead
+	}
+
+	// TimeoutWrite of 0 disables the write timeout; otherwise use the configured
+	// value, but ensure it is always greater than TimeoutBroadcastTxCommit.
+	// See https://github.com/tendermint/tendermint/issues/3435
+	if conf.RPC.TimeoutWrite == 0 {
+		cfg.WriteTimeout = 0
+	} else {
+		cfg.WriteTimeout = conf.RPC.TimeoutWrite
+		if cfg.WriteTimeout <= conf.RPC.TimeoutBroadcastTxCommit {
+			cfg.WriteTimeout = conf.RPC.TimeoutBroadcastTxCommit + 1*time.Second
+		}
 	}
 
 	// If the event log is enabled, subscribe to all events published to the

--- a/sei-tendermint/internal/rpc/core/env.go
+++ b/sei-tendermint/internal/rpc/core/env.go
@@ -284,16 +284,7 @@ func (env *Environment) StartService(ctx context.Context, conf *config.Config) (
 		cfg.ReadTimeout = conf.RPC.TimeoutRead
 	}
 
-	// TimeoutWrite of 0 disables the write timeout; otherwise use the configured
-	// value but ensure it is always greater than TimeoutBroadcastTxCommit.
-	if conf.RPC.TimeoutWrite == 0 {
-		cfg.WriteTimeout = 0
-	} else {
-		cfg.WriteTimeout = conf.RPC.TimeoutWrite
-		if cfg.WriteTimeout <= conf.RPC.TimeoutBroadcastTxCommit {
-			cfg.WriteTimeout = conf.RPC.TimeoutBroadcastTxCommit + 1*time.Second
-		}
-	}
+	cfg.WriteTimeout = conf.RPC.TimeoutWrite
 
 	// If the event log is enabled, subscribe to all events published to the
 	// event bus, and forward them to the event log.

--- a/sei-tendermint/internal/rpc/core/env.go
+++ b/sei-tendermint/internal/rpc/core/env.go
@@ -285,14 +285,13 @@ func (env *Environment) StartService(ctx context.Context, conf *config.Config) (
 	}
 
 	// TimeoutWrite of 0 disables the write timeout; otherwise use the configured
-	// value, but ensure it is always greater than TimeoutBroadcastTxCommit.
-	// See https://github.com/tendermint/tendermint/issues/3435
+	// value but ensure it is always greater than TimeoutBroadcastTxCommit.
 	if conf.RPC.TimeoutWrite == 0 {
 		cfg.WriteTimeout = 0
 	} else {
 		cfg.WriteTimeout = conf.RPC.TimeoutWrite
 		if cfg.WriteTimeout <= conf.RPC.TimeoutBroadcastTxCommit {
-			cfg.WriteTimeout = conf.RPC.TimeoutBroadcastTxCommit + 1*time.Second
+			cfg.WriteTimeout = conf.RPC.TimeoutBroadcastTxCommit + 5*time.Second
 		}
 	}
 

--- a/sei-tendermint/internal/rpc/core/env.go
+++ b/sei-tendermint/internal/rpc/core/env.go
@@ -291,7 +291,7 @@ func (env *Environment) StartService(ctx context.Context, conf *config.Config) (
 	} else {
 		cfg.WriteTimeout = conf.RPC.TimeoutWrite
 		if cfg.WriteTimeout <= conf.RPC.TimeoutBroadcastTxCommit {
-			cfg.WriteTimeout = conf.RPC.TimeoutBroadcastTxCommit + 5*time.Second
+			cfg.WriteTimeout = conf.RPC.TimeoutBroadcastTxCommit + 1*time.Second
 		}
 	}
 

--- a/sei-tendermint/rpc/jsonrpc/server/http_server.go
+++ b/sei-tendermint/rpc/jsonrpc/server/http_server.go
@@ -51,7 +51,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		MaxOpenConnections: 0, // unlimited
 		ReadTimeout:        10 * time.Second,
-		WriteTimeout:       0,       // no default timeout
+		WriteTimeout:       30 * time.Second,
 		MaxBodyBytes:       1000000, // 1MB
 		MaxHeaderBytes:     1 << 20, // same as the net/http default
 	}


### PR DESCRIPTION
## Summary

- `WriteTimeout` on the CometBFT JSON-RPC HTTP server was `0` (disabled), allowing clients to hold connections open indefinitely and exhaust server memory (SEI-10199).
- Default `WriteTimeout` is now **30s**, enforced as a hard backstop across all handlers.
- Exposed as `timeout-write` in `RPCConfig` and the generated `config.toml` so operators can tune or disable it (`0s`).
- Instead of silently bumping `WriteTimeout` at runtime, `ValidateBasic` now returns a descriptive error when `timeout-write` is positive but not greater than `timeout-broadcast-tx-commit`, making misconfiguration explicit at startup.

## Changes

| File | Change |
|------|--------|
| `sei-tendermint/rpc/jsonrpc/server/http_server.go` | `WriteTimeout: 0` → `30s` in `DefaultConfig()` |
| `sei-tendermint/config/config.go` | Added `TimeoutWrite` field to `RPCConfig`; default `30s`; validated non-negative and greater than `TimeoutBroadcastTxCommit` |
| `sei-tendermint/internal/rpc/core/env.go` | Assigns `conf.RPC.TimeoutWrite` directly; removes silent runtime bump |
| `sei-tendermint/cmd/tendermint/commands/light.go` | Same — assigns `TimeoutWrite` directly |
| `sei-tendermint/internal/inspect/rpc/rpc.go` | Same — assigns `TimeoutWrite` directly |
| `sei-tendermint/config/toml.go` | Added `timeout-write` template entry |
| `sei-tendermint/config/config_test.go` | Extended `TestRPCConfigValidateBasic` to cover `TimeoutWrite` negative and cross-field cases |

## Risk

`broadcast_tx_commit` waits at most ~400ms on Sei — well within 30s. Setting `timeout-write = "0s"` restores the previous behaviour. If `timeout-write` is set to a value ≤ `timeout-broadcast-tx-commit`, node startup will fail with a descriptive error rather than silently adjusting the value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)