### PR TITLE
[codex] Harden gasless tx raw-byte handling

### DIFF
--- a/app/ante/cosmos_checktx.go
+++ b/app/ante/cosmos_checktx.go
@@ -86,7 +86,11 @@ func CosmosCheckTxAnte(
 	if err != nil {
 		return ctx, err
 	}
-	if !isGasless {
+	if isGasless {
+		if err := antedecorators.ValidateGaslessTxSize(ctx); err != nil {
+			return ctx, err
+		}
+	} else {
 		ctx = SetGasMeter(ctx, tx.(GasTx).GetGas(), pk)
 	}
 
@@ -250,11 +254,14 @@ func SetGasMeter(ctx sdk.Context, gasLimit uint64, paramsKeeper paramskeeper.Kee
 }
 
 func CheckAndChargeFees(ctx sdk.Context, tx sdk.Tx, accountKeeper authkeeper.AccountKeeper, bankKeeper bankkeeper.Keeper, feegrantKeeper *feegrantkeeper.Keeper, paramsKeeper paramskeeper.Keeper, isGasless bool) (priority int64, err error) {
+	feeTx := tx.(sdk.FeeTx)
+	feeCoins := feeTx.GetFee()
+	if err := authante.ValidateFeeAmount(feeCoins); err != nil {
+		return priority, err
+	}
 	if isGasless {
 		return 0, nil
 	}
-	feeTx := tx.(sdk.FeeTx)
-	feeCoins := feeTx.GetFee()
 	feeParams := paramsKeeper.GetFeesParams(ctx)
 	feeCoins = feeCoins.NonZeroAmountsOf(append([]string{sdk.DefaultBondDenom}, feeParams.GetAllowedFeeDenoms()...))
 	gas := feeTx.GetGas()

--- a/app/ante/cosmos_delivertx.go
+++ b/app/ante/cosmos_delivertx.go
@@ -5,6 +5,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/client"
 	storetypes "github.com/sei-protocol/sei-chain/sei-cosmos/store/types"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	authante "github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/ante"
 	authkeeper "github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/keeper"
 	bankkeeper "github.com/sei-protocol/sei-chain/sei-cosmos/x/bank/keeper"
 	feegrantkeeper "github.com/sei-protocol/sei-chain/sei-cosmos/x/feegrant/keeper"
@@ -38,7 +39,11 @@ func CosmosDeliverTxAnte(
 	if err != nil {
 		return ctx, err
 	}
-	if !isGasless {
+	if isGasless {
+		if err := antedecorators.ValidateGaslessTxSize(ctx); err != nil {
+			return ctx, err
+		}
+	} else {
 		ctx = SetGasMeter(ctx, tx.(GasTx).GetGas(), pk)
 	}
 
@@ -77,6 +82,9 @@ func CosmosDeliverTxAnte(
 func ChargeFees(ctx sdk.Context, tx sdk.Tx, accountKeeper authkeeper.AccountKeeper, bankKeeper bankkeeper.Keeper, feegrantKeeper *feegrantkeeper.Keeper, paramsKeeper paramskeeper.Keeper) error {
 	feeTx := tx.(sdk.FeeTx)
 	feeCoins := feeTx.GetFee()
+	if err := authante.ValidateFeeAmount(feeCoins); err != nil {
+		return err
+	}
 	feeParams := paramsKeeper.GetFeesParams(ctx)
 	feeCoins = feeCoins.NonZeroAmountsOf(append([]string{sdk.DefaultBondDenom}, feeParams.GetAllowedFeeDenoms()...))
 	deductFeesFrom, err := chargeFees(ctx, tx, feeCoins, accountKeeper, bankKeeper, feegrantKeeper)

--- a/app/antedecorators/gasless.go
+++ b/app/antedecorators/gasless.go
@@ -15,6 +15,8 @@ import (
 
 var logger = seilog.NewLogger("app", "antedecorators")
 
+const MaxGaslessTxBytes = 16 * 1024
+
 type GaslessDecorator struct {
 	wrapped      []sdk.AnteDecorator
 	oracleKeeper oraclekeeper.Keeper
@@ -34,6 +36,11 @@ func (gd GaslessDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool,
 	if err != nil {
 		return ctx, err
 	}
+	if isGasless {
+		if err := ValidateGaslessTxSize(ctx); err != nil {
+			return ctx, err
+		}
+	}
 	if !isGasless {
 		ctx = ctx.WithGasMeter(originalGasMeter)
 	}
@@ -51,6 +58,14 @@ func (gd GaslessDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool,
 	}
 
 	return next(ctx, tx, simulate)
+}
+
+func ValidateGaslessTxSize(ctx sdk.Context) error {
+	txSize := len(ctx.TxBytes())
+	if txSize > MaxGaslessTxBytes {
+		return sdkerrors.Wrapf(sdkerrors.ErrTxTooLarge, "gasless tx size %d exceeds max %d", txSize, MaxGaslessTxBytes)
+	}
+	return nil
 }
 
 func (gd GaslessDecorator) handleWrapped(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {

--- a/app/antedecorators/gasless_test.go
+++ b/app/antedecorators/gasless_test.go
@@ -140,3 +140,13 @@ func TestNonGaslessMsg(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, gasless)
 }
+
+func TestValidateGaslessTxSize(t *testing.T) {
+	ctx := sdk.NewContext(nil, tmproto.Header{}, false)
+
+	require.NoError(t, antedecorators.ValidateGaslessTxSize(ctx.WithTxBytes(make([]byte, antedecorators.MaxGaslessTxBytes))))
+
+	err := antedecorators.ValidateGaslessTxSize(ctx.WithTxBytes(make([]byte, antedecorators.MaxGaslessTxBytes+1)))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "gasless tx size")
+}

--- a/sei-cosmos/types/tx/types.go
+++ b/sei-cosmos/types/tx/types.go
@@ -77,6 +77,11 @@ func (t *Tx) ValidateBasic() error {
 			"invalid fee provided: %s", fee.Amount,
 		)
 	}
+	for _, coin := range fee.Amount {
+		if err := sdk.ValidateDenom(coin.Denom); err != nil {
+			return sdkerrors.Wrap(sdkerrors.ErrInsufficientFee, "invalid fee denom")
+		}
+	}
 
 	if fee.Payer != "" {
 		_, err := sdk.AccAddressFromBech32(fee.Payer)

--- a/sei-cosmos/x/auth/ante/fee.go
+++ b/sei-cosmos/x/auth/ante/fee.go
@@ -113,6 +113,21 @@ func (dfd DeductFeeDecorator) checkDeductFee(ctx sdk.Context, sdkTx sdk.Tx, fee 
 	return nil
 }
 
+func ValidateFeeAmount(fees sdk.Coins) error {
+	if fees.IsAnyNil() {
+		return sdkerrors.Wrap(sdkerrors.ErrInsufficientFee, "invalid fee provided: null")
+	}
+	if fees.IsAnyNegative() {
+		return sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, "invalid fee provided: %s", fees)
+	}
+	for _, fee := range fees {
+		if err := sdk.ValidateDenom(fee.Denom); err != nil {
+			return sdkerrors.Wrap(sdkerrors.ErrInsufficientFee, "invalid fee denom")
+		}
+	}
+	return nil
+}
+
 // DeductFees deducts fees from the given account.
 func DeductFees(bankKeeper types.BankKeeper, ctx sdk.Context, acc types.AccountI, fees sdk.Coins) error {
 	if !fees.IsValid() {

--- a/sei-cosmos/x/auth/ante/validator_tx_fee.go
+++ b/sei-cosmos/x/auth/ante/validator_tx_fee.go
@@ -19,6 +19,9 @@ func CheckTxFeeWithValidatorMinGasPrices(ctx sdk.Context, tx sdk.Tx, simulate bo
 	}
 
 	feeCoins := feeTx.GetFee()
+	if err := ValidateFeeAmount(feeCoins); err != nil {
+		return nil, 0, err
+	}
 	feeParams := paramsKeeper.GetFeesParams(ctx)
 	feeCoins = feeCoins.NonZeroAmountsOf(append([]string{sdk.DefaultBondDenom}, feeParams.GetAllowedFeeDenoms()...))
 	gas := feeTx.GetGas()

--- a/sei-cosmos/x/auth/ante/validator_tx_fee_test.go
+++ b/sei-cosmos/x/auth/ante/validator_tx_fee_test.go
@@ -1,12 +1,21 @@
 package ante_test
 
 import (
+	"strings"
 	"testing"
 
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/ante"
 	"github.com/stretchr/testify/require"
 )
+
+func TestValidateFeeAmount(t *testing.T) {
+	require.NoError(t, ante.ValidateFeeAmount(sdk.Coins{sdk.NewInt64Coin("usei", 0)}))
+
+	err := ante.ValidateFeeAmount(sdk.Coins{{Denom: strings.Repeat("x", 129), Amount: sdk.OneInt()}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid fee denom")
+}
 
 func TestGetMinimumGasWanted(t *testing.T) {
 	// Test case 1: Both global and validator minimum gas prices are empty.

--- a/sei-cosmos/x/auth/tx/builder_test.go
+++ b/sei-cosmos/x/auth/tx/builder_test.go
@@ -1,6 +1,7 @@
 package tx
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -166,6 +167,14 @@ func TestBuilderValidateBasic(t *testing.T) {
 	err = txBuilder.ValidateBasic()
 	require.Error(t, err)
 	_, code, _ := sdkerrors.ABCIInfo(err, false)
+	require.Equal(t, sdkerrors.ErrInsufficientFee.ABCICode(), code)
+
+	badFeeDenom := sdk.Coins{{Denom: strings.Repeat("x", 129), Amount: sdk.OneInt()}}
+	txBuilder.SetFeeAmount(badFeeDenom)
+	err = txBuilder.ValidateBasic()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid fee denom")
+	_, code, _ = sdkerrors.ABCIInfo(err, false)
 	require.Equal(t, sdkerrors.ErrInsufficientFee.ABCICode(), code)
 
 	// require to fail validation when no signatures exist

--- a/sei-cosmos/x/auth/tx/decoder.go
+++ b/sei-cosmos/x/auth/tx/decoder.go
@@ -1,6 +1,7 @@
 package tx
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/gogo/protobuf/proto"
@@ -13,22 +14,33 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/types/tx"
 )
 
+type txDecoderOptions struct {
+	rejectRootCanonical     bool
+	rejectBodyCanonical     bool
+	rejectAuthInfoCanonical bool
+}
+
 // DefaultTxDecoder returns a default protobuf TxDecoder using the provided Marshaler.
 func DefaultTxDecoder(cdc codec.ProtoCodecMarshaler) sdk.TxDecoder {
-	return defaultTxDecoder(cdc, true)
+	return defaultTxDecoder(cdc, txDecoderOptions{
+		rejectRootCanonical:     true,
+		rejectBodyCanonical:     true,
+		rejectAuthInfoCanonical: true,
+	})
 }
 
 // DefaultTxDecoderWithoutBodyBloatRejection returns a protobuf TxDecoder that
-// preserves pre-v6.5 decode behavior for historical tooling. Do not use this for
-// mempool, CheckTx, or DeliverTx paths.
+// preserves pre-v6.5 decode behavior for historical tooling by disabling
+// canonical bloat rejection for TxRaw, TxBody, and AuthInfo. Do not use this for
+// mempool, CheckTx, DeliverTx, or proposal-validation paths.
 func DefaultTxDecoderWithoutBodyBloatRejection(cdc codec.ProtoCodecMarshaler) sdk.TxDecoder {
-	return defaultTxDecoder(cdc, false)
+	return defaultTxDecoder(cdc, txDecoderOptions{})
 }
 
-func defaultTxDecoder(cdc codec.ProtoCodecMarshaler, rejectBodyBloat bool) sdk.TxDecoder {
+func defaultTxDecoder(cdc codec.ProtoCodecMarshaler, options txDecoderOptions) sdk.TxDecoder {
 	return func(txBytes []byte) (sdk.Tx, error) {
 		// Make sure txBytes follow ADR-027.
-		err := rejectNonADR027TxRaw(txBytes)
+		err := rejectNonADR027TxRaw(txBytes, options.rejectRootCanonical)
 		if err != nil {
 			return nil, sdkerrors.Wrap(sdkerrors.ErrTxDecode, err.Error())
 		}
@@ -46,6 +58,12 @@ func defaultTxDecoder(cdc codec.ProtoCodecMarshaler, rejectBodyBloat bool) sdk.T
 			return nil, err
 		}
 
+		if options.rejectRootCanonical {
+			if err := rejectNonCanonicalTxRaw(txBytes, &raw); err != nil {
+				return nil, sdkerrors.Wrap(sdkerrors.ErrTxDecode, err.Error())
+			}
+		}
+
 		var body tx.TxBody
 
 		// allow non-critical unknown fields in TxBody
@@ -59,8 +77,8 @@ func defaultTxDecoder(cdc codec.ProtoCodecMarshaler, rejectBodyBloat bool) sdk.T
 			return nil, sdkerrors.Wrap(sdkerrors.ErrTxDecode, err.Error())
 		}
 
-		if rejectBodyBloat {
-			if err := rejectBloatedBody(raw.BodyBytes, &body); err != nil {
+		if options.rejectBodyCanonical {
+			if err := rejectNonCanonicalBody(raw.BodyBytes, &body); err != nil {
 				return nil, sdkerrors.Wrap(sdkerrors.ErrTxDecode, err.Error())
 			}
 		}
@@ -76,6 +94,12 @@ func defaultTxDecoder(cdc codec.ProtoCodecMarshaler, rejectBodyBloat bool) sdk.T
 		err = cdc.Unmarshal(raw.AuthInfoBytes, &authInfo)
 		if err != nil {
 			return nil, sdkerrors.Wrap(sdkerrors.ErrTxDecode, err.Error())
+		}
+
+		if options.rejectAuthInfoCanonical {
+			if err := rejectNonCanonicalAuthInfo(raw.AuthInfoBytes, &authInfo); err != nil {
+				return nil, sdkerrors.Wrap(sdkerrors.ErrTxDecode, err.Error())
+			}
 		}
 
 		theTx := &tx.Tx{
@@ -115,9 +139,11 @@ func DefaultJSONTxDecoder(cdc codec.ProtoCodecMarshaler) sdk.TxDecoder {
 // - and varints are as short as possible.
 // All other ADR-027 edge cases (e.g. default values) are not applicable with
 // TxRaw.
-func rejectNonADR027TxRaw(txBytes []byte) error {
+func rejectNonADR027TxRaw(txBytes []byte, rejectDuplicateRootSingulars bool) error {
 	// Make sure all fields are ordered in ascending order with this variable.
 	prevTagNum := protowire.Number(0)
+	seenBodyBytes := false
+	seenAuthInfoBytes := false
 
 	for len(txBytes) > 0 {
 		tagNum, wireType, m := protowire.ConsumeTag(txBytes)
@@ -131,6 +157,20 @@ func rejectNonADR027TxRaw(txBytes []byte) error {
 		// Make sure fields are ordered in ascending order.
 		if tagNum < prevTagNum {
 			return fmt.Errorf("txRaw must follow ADR-027, got tagNum %d after tagNum %d", tagNum, prevTagNum)
+		}
+		if rejectDuplicateRootSingulars {
+			switch tagNum {
+			case 1:
+				if seenBodyBytes {
+					return fmt.Errorf("txRaw must not contain duplicate body_bytes fields")
+				}
+				seenBodyBytes = true
+			case 2:
+				if seenAuthInfoBytes {
+					return fmt.Errorf("txRaw must not contain duplicate auth_info_bytes fields")
+				}
+				seenAuthInfoBytes = true
+			}
 		}
 		prevTagNum = tagNum
 
@@ -159,17 +199,45 @@ func rejectNonADR027TxRaw(txBytes []byte) error {
 	return nil
 }
 
-// rejectBloatedBody rejects tx bodies where the raw wire encoding is larger
-// than the canonical re-marshal of the decoded struct. This catches protobuf-level
+func rejectNonCanonicalTxRaw(rawTxBytes []byte, raw *tx.TxRaw) error {
+	canonicalBytes, err := proto.Marshal(raw)
+	if err != nil {
+		return fmt.Errorf("failed to re-marshal tx raw: %w", err)
+	}
+	if !bytes.Equal(rawTxBytes, canonicalBytes) {
+		return fmt.Errorf("tx raw bytes are not canonical")
+	}
+	return nil
+}
+
+// rejectNonCanonicalBody rejects tx bodies where the raw wire encoding differs
+// from the canonical re-marshal of the decoded struct. This catches protobuf-level
 // bloat (e.g. padded sdk.Int fields, oversized Any.Value) that UnpackAny would
 // otherwise silently canonicalize away before validation runs.
-func rejectBloatedBody(rawBodyBytes []byte, body *tx.TxBody) error {
+func rejectNonCanonicalBody(rawBodyBytes []byte, body *tx.TxBody) error {
 	canonicalBytes, err := proto.Marshal(body)
 	if err != nil {
 		return fmt.Errorf("failed to re-marshal tx body: %w", err)
 	}
-	if len(rawBodyBytes) != len(canonicalBytes) {
-		return fmt.Errorf("tx body wire size (%d) exceeds canonical size (%d)", len(rawBodyBytes), len(canonicalBytes))
+	if !bytes.Equal(rawBodyBytes, canonicalBytes) {
+		if len(rawBodyBytes) != len(canonicalBytes) {
+			return fmt.Errorf("tx body wire size (%d) exceeds canonical size (%d)", len(rawBodyBytes), len(canonicalBytes))
+		}
+		return fmt.Errorf("tx body bytes are not canonical")
+	}
+	return nil
+}
+
+func rejectNonCanonicalAuthInfo(rawAuthInfoBytes []byte, authInfo *tx.AuthInfo) error {
+	canonicalBytes, err := proto.Marshal(authInfo)
+	if err != nil {
+		return fmt.Errorf("failed to re-marshal auth info: %w", err)
+	}
+	if !bytes.Equal(rawAuthInfoBytes, canonicalBytes) {
+		if len(rawAuthInfoBytes) != len(canonicalBytes) {
+			return fmt.Errorf("auth info wire size (%d) exceeds canonical size (%d)", len(rawAuthInfoBytes), len(canonicalBytes))
+		}
+		return fmt.Errorf("auth info bytes are not canonical")
 	}
 	return nil
 }

--- a/sei-cosmos/x/auth/tx/encode_decode_test.go
+++ b/sei-cosmos/x/auth/tx/encode_decode_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"testing"
 
+	gogoproto "github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protowire"
 
@@ -17,6 +18,11 @@ import (
 	signingtypes "github.com/sei-protocol/sei-chain/sei-cosmos/types/tx/signing"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/signing"
 )
+
+func appendProtoBytesField(dst []byte, field protowire.Number, value []byte) []byte {
+	dst = protowire.AppendTag(dst, field, protowire.BytesType)
+	return protowire.AppendBytes(dst, value)
+}
 
 func TestDefaultTxDecoderError(t *testing.T) {
 	registry := codectypes.NewInterfaceRegistry()
@@ -90,6 +96,94 @@ func TestDefaultTxDecoderWithoutBodyBloatRejection(t *testing.T) {
 			decoded, err := DefaultTxDecoderWithoutBodyBloatRejection(cdc)(bloatedTxBz)
 			require.NoError(t, err)
 			tt.assert(t, decoded.(*wrapper))
+		})
+	}
+}
+
+func TestDefaultTxDecoderCanonicalRejectionAndCompat(t *testing.T) {
+	registry := codectypes.NewInterfaceRegistry()
+	testdata.RegisterInterfaces(registry)
+	cdc := codec.NewProtoCodec(registry)
+
+	builder := newBuilder()
+	require.NoError(t, builder.SetMsgs(testdata.NewTestMsg()))
+
+	txBz, err := DefaultTxEncoder()(builder.GetTx())
+	require.NoError(t, err)
+
+	var raw tx.TxRaw
+	require.NoError(t, raw.Unmarshal(txBz))
+
+	emptyFeeBz, err := gogoproto.Marshal(&tx.Fee{})
+	require.NoError(t, err)
+	bloatedFeeBz, err := gogoproto.Marshal(&tx.Fee{Payer: "sei1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq4qvh7h"})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		mutate      func(tx.TxRaw) []byte
+		strictError string
+	}{
+		{
+			name: "same length non-canonical body field order",
+			mutate: func(raw tx.TxRaw) []byte {
+				raw.BodyBytes = []byte{0x18, 0x01, 0x12, 0x01, 'a'}
+				bz, err := raw.Marshal()
+				require.NoError(t, err)
+				return bz
+			},
+			strictError: "tx body bytes are not canonical",
+		},
+		{
+			name: "duplicate auth info fee field",
+			mutate: func(raw tx.TxRaw) []byte {
+				authInfoBz := appendProtoBytesField(nil, 2, bloatedFeeBz)
+				authInfoBz = appendProtoBytesField(authInfoBz, 2, emptyFeeBz)
+				raw.AuthInfoBytes = authInfoBz
+				bz, err := raw.Marshal()
+				require.NoError(t, err)
+				return bz
+			},
+			strictError: "auth info wire size",
+		},
+		{
+			name: "duplicate root body bytes",
+			mutate: func(raw tx.TxRaw) []byte {
+				txRawBz := appendProtoBytesField(nil, 1, []byte("junk"))
+				txRawBz = appendProtoBytesField(txRawBz, 1, raw.BodyBytes)
+				txRawBz = appendProtoBytesField(txRawBz, 2, raw.AuthInfoBytes)
+				for _, sig := range raw.Signatures {
+					txRawBz = appendProtoBytesField(txRawBz, 3, sig)
+				}
+				return txRawBz
+			},
+			strictError: "duplicate body_bytes",
+		},
+		{
+			name: "duplicate root auth info bytes",
+			mutate: func(raw tx.TxRaw) []byte {
+				txRawBz := appendProtoBytesField(nil, 1, raw.BodyBytes)
+				txRawBz = appendProtoBytesField(txRawBz, 2, []byte("junk"))
+				txRawBz = appendProtoBytesField(txRawBz, 2, raw.AuthInfoBytes)
+				for _, sig := range raw.Signatures {
+					txRawBz = appendProtoBytesField(txRawBz, 3, sig)
+				}
+				return txRawBz
+			},
+			strictError: "duplicate auth_info_bytes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mutatedTxBz := tt.mutate(raw)
+
+			_, err := DefaultTxDecoder(cdc)(mutatedTxBz)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.strictError)
+
+			_, err = DefaultTxDecoderWithoutBodyBloatRejection(cdc)(mutatedTxBz)
+			require.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

This PR closes the raw protobuf bloat routes for gasless transactions by making decoded transaction bytes canonical, validating fee data before denom filtering, and adding a hard raw-size cap for gasless txs.

## Changes

- Enforce canonical `TxRaw`, `TxBody`, and `AuthInfo` bytes in the default tx decoder.
- Reject duplicate root `TxRaw.body_bytes` and `TxRaw.auth_info_bytes`.
- Preserve the relaxed historical decoder for pre-v6.5 tracing compatibility.
- Add `MaxGaslessTxBytes = 16 KiB` and enforce it in normal gasless ante plus custom CheckTx/DeliverTx paths.
- Validate original decoded fee amounts before allowed-denom filtering.
- Validate fee denoms in `Tx.ValidateBasic` while preserving existing zero-fee behavior.
- Add regression coverage for canonical decoder rejection, compatibility decoding, gasless size cap, and invalid fee denoms.

## Out of scope

- Proposal-level block gas accounting for gasless txs is intentionally unchanged in this PR.

## Tests

- `go test ./sei-cosmos/x/auth/tx`
- `go test ./sei-cosmos/x/auth/ante`
- `go test ./app/antedecorators`
- `go test ./app/ante`
- `go test ./sei-cosmos/types/tx`
- `go test ./evmrpc -run TestTraceBlockByNumberUsesCompatDecoderForHistoricalCosmosTx`
- `go test ./app -run TestCheckTotalBlockGas_AssociateTxIsGasless`
- `git diff --check`
