### PR TITLE
fix(giga): robust handling of unsupported iterators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -479,7 +479,8 @@ autobahn-integration-test:
 	@GOWORK=off go test -tags autobahn_integration -v -count=1 -timeout 30m ./integration_test/autobahn/...
 .PHONY: autobahn-integration-test
 
-# Run a mixed-mode cluster: node 0 uses GIGA_EXECUTOR, nodes 1-3 use standard V2.
+# Run a mixed-mode cluster: node 0 uses GIGA_EXECUTOR with OCC, nodes 1-3 use standard V2.
+# (node-level GIGA_EXECUTOR/GIGA_OCC values are pinned in docker-compose.giga-mixed.yml)
 # Any determinism divergence between giga and V2 will cause the giga node to halt.
 docker-cluster-start-giga-mixed: docker-cluster-stop build-docker-node
 	@rm -rf $(PROJECT_HOME)/build/generated
@@ -496,11 +497,11 @@ docker-cluster-start-giga-mixed: docker-cluster-stop build-docker-node
 .PHONY: docker-cluster-start-giga-mixed
 
 # Run the giga mixed-mode integration test.
-# Starts a cluster where only node 0 runs giga (sequential), nodes 1-3 run standard V2.
+# Starts a cluster where only node 0 runs giga (concurrent, OCC), nodes 1-3 run standard V2.
 # Then runs hardhat tests. If giga produces different results, node 0 will halt.
 giga-mixed-integration-test:
 	@echo "=== Starting GIGA Mixed-Mode Integration Tests ==="
-	@echo "=== Node 0: GIGA_EXECUTOR=true, Nodes 1-3: standard V2 ==="
+	@echo "=== Node 0: GIGA_EXECUTOR=true GIGA_OCC=true, Nodes 1-3: standard V2 ==="
 	@$(MAKE) docker-cluster-stop || true
 	@rm -rf $(PROJECT_HOME)/build/generated
 	@DOCKER_DETACH=true $(MAKE) docker-cluster-start-giga-mixed

--- a/app/app.go
+++ b/app/app.go
@@ -182,6 +182,7 @@ import (
 	_ "github.com/sei-protocol/sei-chain/docs/swagger"
 	receipt "github.com/sei-protocol/sei-chain/sei-db/ledger_db/receipt"
 
+	gigastore "github.com/sei-protocol/sei-chain/giga/deps/store"
 	gigabankkeeper "github.com/sei-protocol/sei-chain/giga/deps/xbank/keeper"
 	gigaevmkeeper "github.com/sei-protocol/sei-chain/giga/deps/xevm/keeper"
 	gigaevmstate "github.com/sei-protocol/sei-chain/giga/deps/xevm/state"
@@ -2054,6 +2055,12 @@ func (app *App) executeEVMTxWithGigaExecutor(ctx sdk.Context, msg *evmtypes.MsgE
 
 	// Execute with feeAlreadyCharged=true — matching V2's msg_server behavior
 	execResult, execErr := gigaExecutor.ExecuteTransactionFeeCharged(ethTx, sender, cache.baseFee, &gp)
+
+	// Self-destruct requires iterating the store, unsupported by giga. Fallback to v2.
+	if stateDB.AnySelfDestructed() {
+		return nil, gigaprecompiles.ErrSelfDestructUnsupported
+	}
+
 	if execErr != nil {
 		// Match V2 error handling: bump nonce, commit fee deduction, track surplus
 		stateDB.SetNonce(sender, stateDB.GetNonce(sender)+1, tracing.NonceChangeEoACall)
@@ -2244,6 +2251,16 @@ func (app *App) makeGigaDeliverTx(cache *gigaBlockCache) func(sdk.Context, abci.
 						Codespace: sdkerrors.RootCodespace,
 						Code:      sdkerrors.ErrOutOfGas.ABCICode(),
 						Log:       fmt.Sprintf("out of gas in location: %v", oogErr.Descriptor),
+					}
+					return
+				}
+				// Any store-iteration panic means giga can't handle this tx: fall back to v2.
+				if err, ok := r.(error); ok && errors.Is(err, gigastore.ErrIteratorUnsupported) {
+					resp = abci.ResponseDeliverTx{
+						Code:      gigautils.GigaAbortCode,
+						Codespace: gigautils.GigaAbortCodespace,
+						Info:      gigautils.GigaAbortInfo,
+						Log:       "giga executor abort: store iteration unsupported, fall back to v2",
 					}
 					return
 				}

--- a/contracts/src/SelfDestructTester.sol
+++ b/contracts/src/SelfDestructTester.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * SelfDestructTester
+ *
+ * Exercises the SELFDESTRUCT opcode against a contract that carries on-chain
+ * storage, so there is real account state to clean up. This is a useful
+ * determinism edge case for the GIGA store: if the giga executor's account /
+ * storage deletion diverges from the V2 executor, a mixed-mode cluster will
+ * halt with an AppHash mismatch.
+ *
+ * Note on EIP-6780 (active under the "prague" EVM version configured for this
+ * repo): SELFDESTRUCT only fully deletes the account (code + storage) when it
+ * is executed in the SAME transaction that created the contract. When called in
+ * a later transaction it merely transfers the contract's balance and leaves the
+ * code and storage in place. Both paths are exercised by the tests:
+ *   - destroy() on a previously-deployed instance  -> balance sweep only
+ *   - SelfDestructFactory.createAndDestroy(...)     -> full account cleanup
+ */
+contract SelfDestructTester {
+    address public owner;
+    uint256 public valueA;
+    uint256 public valueB;
+    // mapping storage so there are multiple distinct storage slots to clean up
+    mapping(uint256 => uint256) public data;
+    uint256 public numKeys;
+
+    event Destroyed(address indexed recipient, uint256 balance);
+
+    // Constructor seeds storage so a freshly-created contract has state to clean
+    // up. Payable so the contract can hold a balance that selfdestruct sweeps.
+    constructor(uint256 _numKeys) payable {
+        owner = msg.sender;
+        valueA = 0xA11CE;
+        valueB = 0xB0B;
+        numKeys = _numKeys;
+        for (uint256 i = 0; i < _numKeys; i++) {
+            // non-zero values so the slots are actually written
+            data[i] = i + 1;
+        }
+    }
+
+    function get(uint256 key) external view returns (uint256) {
+        return data[key];
+    }
+
+    // Sum the seeded keys — handy for asserting storage is intact pre-destruct.
+    function sumKeys() external view returns (uint256 total) {
+        for (uint256 i = 0; i < numKeys; i++) {
+            total += data[i];
+        }
+    }
+
+    function destroy(address payable recipient) external {
+        emit Destroyed(recipient, address(this).balance);
+        selfdestruct(recipient);
+    }
+}
+
+/**
+ * SelfDestructFactory
+ *
+ * Creates a SelfDestructTester (seeding its storage) and destroys it within the
+ * same transaction, which under EIP-6780 fully removes the child's code and
+ * storage. This is the path that actually forces the store to clean up the
+ * account state it just wrote.
+ */
+contract SelfDestructFactory {
+    event ChildCreated(address child);
+    event ChildDestroyed(address child);
+
+    function createAndDestroy(uint256 numKeys, address payable recipient)
+        external
+        payable
+        returns (address child)
+    {
+        SelfDestructTester c = new SelfDestructTester{value: msg.value}(numKeys);
+        child = address(c);
+        emit ChildCreated(child);
+        c.destroy(recipient);
+        emit ChildDestroyed(child);
+    }
+}

--- a/contracts/test/EVMGigaTest.js
+++ b/contracts/test/EVMGigaTest.js
@@ -1044,4 +1044,93 @@ describe("GIGA EVM Tests", function () {
       console.log(`        3 rounds of proxy token transfer+verify completed`);
     });
   });
+
+  // ============================================================================
+  // Self-Destruct With Storage Cleanup
+  //
+  // SELFDESTRUCT against a contract that carries real storage exercises the
+  // account/storage deletion path. If the giga executor deletes account state
+  // differently from the V2 executor, a mixed-mode cluster halts with an
+  // AppHash mismatch — so this is a meaningful determinism edge case.
+  //
+  // EIP-6780 (active under the "prague" EVM version) semantics:
+  //   - selfdestruct in a LATER tx than creation: balance sweep only; code and
+  //     storage remain.
+  //   - selfdestruct in the SAME tx as creation: full account removal, which
+  //     forces the store to clean up the storage it just wrote.
+  // ============================================================================
+  describe("Self-Destruct With Storage Cleanup", function () {
+    const NUM_KEYS = 8;
+
+    it("should seed storage on init and sweep balance on later-tx selfdestruct", async function () {
+      // Deploy with seeded storage and a non-zero balance to sweep.
+      const SelfDestructTester = await ethers.getContractFactory("SelfDestructTester");
+      const seedValue = ethers.parseEther("1");
+      const contract = await SelfDestructTester.deploy(NUM_KEYS, {
+        value: seedValue,
+        gasPrice: ethers.parseUnits('100', 'gwei'),
+      });
+      await contract.waitForDeployment();
+      const addr = await contract.getAddress();
+
+      // Constructor seeded storage: data[i] = i + 1, plus valueA/valueB/owner.
+      const code = await ethers.provider.getCode(addr);
+      expect(code.length).to.be.greaterThan(2);
+      expect(await ethers.provider.getBalance(addr)).to.equal(seedValue);
+      expect(await contract.numKeys()).to.equal(BigInt(NUM_KEYS));
+      expect(await contract.valueA()).to.equal(0xA11CEn);
+      // sum of 1..NUM_KEYS
+      const expectedSum = BigInt((NUM_KEYS * (NUM_KEYS + 1)) / 2);
+      expect(await contract.sumKeys()).to.equal(expectedSum);
+
+      // selfdestruct in a separate tx — under EIP-6780 only the balance moves.
+      const recipient = ethers.Wallet.createRandom().connect(ethers.provider);
+      const recipientAddress = await recipient.getAddress();
+      const tx = await contract.destroy(recipientAddress, {
+        gasPrice: ethers.parseUnits('100', 'gwei'),
+      });
+      await tx.wait();
+      await delay();
+
+      // Balance must have been swept to the recipient.
+      expect(await ethers.provider.getBalance(recipientAddress)).to.equal(seedValue);
+      expect(await ethers.provider.getBalance(addr)).to.equal(0n);
+      // Post-EIP-6780: code and storage survive a later-tx selfdestruct.
+      expect(await contract.sumKeys()).to.equal(expectedSum);
+      console.log(`        later-tx selfdestruct swept ${ethers.formatEther(seedValue)} SEI, storage retained`);
+    });
+
+    it("should fully clean up storage when created and destroyed in the same tx", async function () {
+      const Factory = await ethers.getContractFactory("SelfDestructFactory");
+      const factory = await Factory.deploy({ gasPrice: ethers.parseUnits('100', 'gwei') });
+      await factory.waitForDeployment();
+
+      const recipient = ethers.Wallet.createRandom().connect(ethers.provider);
+      const recipientAddress = await recipient.getAddress();
+      const seedValue = ethers.parseEther("0.5");
+
+      // Predict the child address without mutating state, then run the real tx.
+      const childAddr = await factory.createAndDestroy.staticCall(NUM_KEYS, recipientAddress, {
+        value: seedValue,
+        gasPrice: ethers.parseUnits('100', 'gwei'),
+      });
+
+      const tx = await factory.createAndDestroy(NUM_KEYS, recipientAddress, {
+        value: seedValue,
+        gasPrice: ethers.parseUnits('100', 'gwei'),
+      });
+      await tx.wait();
+      await delay();
+
+      // Same-tx create+destroy: child account fully removed (code + storage),
+      // and its balance swept to the recipient.
+      expect(await ethers.provider.getCode(childAddr)).to.equal("0x");
+      expect(await ethers.provider.getBalance(childAddr)).to.equal(0n);
+      expect(await ethers.provider.getBalance(recipientAddress)).to.equal(seedValue);
+      // Storage slot reads on a cleaned-up account return zero.
+      const slot0 = await ethers.provider.getStorage(childAddr, 0);
+      expect(BigInt(slot0)).to.equal(0n);
+      console.log(`        same-tx create+destroy cleaned up child ${childAddr}`);
+    });
+  });
 });

--- a/docker/docker-compose.giga-mixed.yml
+++ b/docker/docker-compose.giga-mixed.yml
@@ -1,7 +1,11 @@
 # Docker Compose override for mixed-mode giga testing.
-# Only node 0 runs with GIGA_EXECUTOR enabled; nodes 1-3 run standard V2.
+# Only node 0 runs with GIGA_EXECUTOR enabled (with OCC); nodes 1-3 run standard V2.
 # This allows testing that giga produces identical results to V2 at the
 # consensus level — any divergence will cause the giga node to halt.
+#
+# Node 0 runs GIGA_OCC=true so this also covers the concurrent giga executor
+# (ProcessTXsWithOCCGiga) path, which uses the multiversion store layered over
+# the giga store — the path V2 must stay byte-for-byte consistent with.
 #
 # Usage:
 #   docker compose -f docker-compose.yml -f docker-compose.giga-mixed.yml up
@@ -13,7 +17,7 @@ services:
   node0:
     environment:
       - GIGA_EXECUTOR=true
-      - GIGA_OCC=false
+      - GIGA_OCC=true
 
   node1:
     environment:

--- a/giga/deps/store/cachekv.go
+++ b/giga/deps/store/cachekv.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"sort"
 	"sync"
@@ -9,6 +10,8 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store/tracekv"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store/types"
 )
+
+var ErrIteratorUnsupported = errors.New("unexpected iterator call on cachekv store")
 
 // Store wraps an in-memory cache around an underlying types.KVStore.
 type Store struct {
@@ -183,10 +186,10 @@ func (store *Store) GetAllKeyStrsInRange(start, end []byte) (res []string) {
 }
 
 func (store *Store) Iterator(start, end []byte) types.Iterator {
-	panic("unexpected iterator call on cachekv store")
+	panic(ErrIteratorUnsupported)
 }
 
 // ReverseIterator implements types.KVStore.
 func (store *Store) ReverseIterator(start, end []byte) types.Iterator {
-	panic("unexpected reverse iterator call on cachekv store")
+	panic(ErrIteratorUnsupported)
 }

--- a/giga/deps/store/cachekv_test.go
+++ b/giga/deps/store/cachekv_test.go
@@ -1,0 +1,39 @@
+package store_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	gigastore "github.com/sei-protocol/sei-chain/giga/deps/store"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIteratorPanicsWithSentinel(t *testing.T) {
+	s := gigastore.NewStore(nil, nil, 0)
+
+	require.PanicsWithValue(t, gigastore.ErrIteratorUnsupported, func() {
+		_ = s.Iterator(nil, nil)
+	})
+	require.PanicsWithValue(t, gigastore.ErrIteratorUnsupported, func() {
+		_ = s.ReverseIterator(nil, nil)
+	})
+}
+
+// TestIteratorPanicDetectableViaErrorsIs mirrors the recover net in app.go: the
+// recovered panic value must be detectable as the sentinel via errors.Is, even
+// once wrapped, so the giga executor can fall back to v2 instead of diverging.
+func TestIteratorPanicDetectableViaErrorsIs(t *testing.T) {
+	s := gigastore.NewStore(nil, nil, 0)
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		_ = s.Iterator(nil, nil)
+	}()
+
+	err, ok := recovered.(error)
+	require.True(t, ok)
+	require.True(t, errors.Is(err, gigastore.ErrIteratorUnsupported))
+	require.True(t, errors.Is(fmt.Errorf("wrapped: %w", err), gigastore.ErrIteratorUnsupported))
+}

--- a/giga/deps/xevm/state/state.go
+++ b/giga/deps/xevm/state/state.go
@@ -105,6 +105,17 @@ func (s *DBImpl) HasSelfDestructed(acc common.Address) bool {
 	return bytes.Equal(val, AccountDeleted)
 }
 
+// AnySelfDestructed reports whether any account was self-destructed in this tx,
+// letting callers fall back to v2 before Finalize iterates the store and panics.
+func (s *DBImpl) AnySelfDestructed() bool {
+	for _, status := range s.tempState.transientAccounts {
+		if bytes.Equal(status, AccountDeleted) {
+			return true
+		}
+	}
+	return false
+}
+
 // Snapshot records the current journal length as a revision and pushes the current
 // EventManager onto the stack, creating a fresh one for subsequent events.
 func (s *DBImpl) Snapshot() int {

--- a/giga/deps/xevm/state/state_test.go
+++ b/giga/deps/xevm/state/state_test.go
@@ -66,6 +66,33 @@ func TestState(t *testing.T) {
 	require.Equal(t, common.Hash{}, statedb.GetState(evmAddr, common.Hash{}))
 }
 
+func TestAnySelfDestructed(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	_, evmAddr := testkeeper.MockAddressPair()
+	statedb := state.NewDBImpl(ctx, k, false)
+
+	// no marked accounts yet
+	require.False(t, statedb.AnySelfDestructed())
+
+	// creating an account marks it AccountCreated, not AccountDeleted
+	statedb.CreateAccount(evmAddr)
+	require.False(t, statedb.AnySelfDestructed())
+
+	// self-destructing flips the flag
+	statedb.SelfDestruct(evmAddr)
+	require.True(t, statedb.AnySelfDestructed())
+
+	// reverting the self-destruct via snapshot should clear it again
+	statedb2 := state.NewDBImpl(ctx, k, false)
+	statedb2.CreateAccount(evmAddr)
+	rev := statedb2.Snapshot()
+	statedb2.SelfDestruct(evmAddr)
+	require.True(t, statedb2.AnySelfDestructed())
+	statedb2.RevertToSnapshot(rev)
+	require.False(t, statedb2.AnySelfDestructed())
+}
+
 func TestCreate(t *testing.T) {
 	k, ctx := testkeeper.MockEVMKeeper(t)
 	ctx = ctx.WithBlockTime(time.Now())

--- a/giga/executor/precompiles/failfast.go
+++ b/giga/executor/precompiles/failfast.go
@@ -71,6 +71,20 @@ func (e *BalanceMigrationAbortError) IsAbortError() bool {
 
 var ErrBalanceMigrationRequired error = &BalanceMigrationAbortError{}
 
+// SelfDestructAbortError signals a self-destruct, whose storage clearing needs
+// store iteration giga can't do; the caller should fall back to v2.
+type SelfDestructAbortError struct{}
+
+func (e *SelfDestructAbortError) Error() string {
+	return "self-destruct storage clearing requires store iteration unsupported by giga"
+}
+
+func (e *SelfDestructAbortError) IsAbortError() bool {
+	return true
+}
+
+var ErrSelfDestructUnsupported error = &SelfDestructAbortError{}
+
 type FailFastPrecompile struct{}
 
 var FailFastSingleton vm.PrecompiledContract = &FailFastPrecompile{}

--- a/giga/executor/precompiles/failfast_test.go
+++ b/giga/executor/precompiles/failfast_test.go
@@ -1,0 +1,20 @@
+package precompiles_test
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core/vm"
+	gigaprecompiles "github.com/sei-protocol/sei-chain/giga/executor/precompiles"
+	gigautils "github.com/sei-protocol/sei-chain/giga/executor/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelfDestructAbortError(t *testing.T) {
+	abortErr, ok := gigaprecompiles.ErrSelfDestructUnsupported.(vm.AbortError)
+	require.True(t, ok, "ErrSelfDestructUnsupported must implement vm.AbortError")
+	require.True(t, abortErr.IsAbortError())
+	require.NotEmpty(t, gigaprecompiles.ErrSelfDestructUnsupported.Error())
+
+	// ShouldExecutionAbort must recognize it so the giga executor falls back to v2.
+	require.True(t, gigautils.ShouldExecutionAbort(gigaprecompiles.ErrSelfDestructUnsupported))
+}

--- a/giga/tests/giga_test.go
+++ b/giga/tests/giga_test.go
@@ -984,6 +984,44 @@ func TestGigaVsGeth_ContractDeployAndCall(t *testing.T) {
 	t.Logf("Giga deploy gas used: %d", gigaDeployResults[0].GasUsed)
 }
 
+// selfDestructInConstructorBytecode is init code (CALLER; SELFDESTRUCT) that
+// destroys the contract within the same tx it is created. This makes the giga
+// executor detect the self-destruct (AnySelfDestructed) and fall back to v2,
+// since giga's cachekv cannot iterate to clear a destructed account's storage.
+var selfDestructInConstructorBytecode = common.Hex2Bytes("33ff")
+
+// TestGigaVsGeth_SelfDestruct verifies a self-destructing tx yields identical
+// consensus results under v2 and giga. Giga must fall back to v2 (it cannot
+// clear destructed storage), so this guards that the two stay interoperable.
+func TestGigaVsGeth_SelfDestruct(t *testing.T) {
+	blockTime := time.Now()
+	accts := utils.NewTestAccounts(5)
+	deployer := utils.NewSigner()
+
+	// ---- Geth (v2) ----
+	gethCtx := NewGigaTestContext(t, accts, blockTime, 1, ModeV2withOCC)
+	gethTxs := CreateContractDeployTxs(t, gethCtx, []EVMContractDeploy{
+		{Signer: deployer, Bytecode: selfDestructInConstructorBytecode, Nonce: 0},
+	}, false)
+	_, gethResults, gethErr := RunBlock(t, gethCtx, gethTxs)
+	require.NoError(t, gethErr)
+	require.Len(t, gethResults, 1)
+
+	// ---- Giga (OCC) — must fall back to v2 on the self-destruct ----
+	gigaCtx := NewGigaTestContext(t, accts, blockTime, 1, ModeGigaOCC)
+	gigaTxs := CreateContractDeployTxs(t, gigaCtx, []EVMContractDeploy{
+		{Signer: deployer, Bytecode: selfDestructInConstructorBytecode, Nonce: 0},
+	}, true)
+	_, gigaResults, gigaErr := RunBlock(t, gigaCtx, gigaTxs)
+	require.NoError(t, gigaErr)
+	require.Len(t, gigaResults, 1)
+
+	// Consensus-critical parity: LastResultsHash covers Code/Data/GasWanted/GasUsed.
+	CompareResultsNoGas(t, "SelfDestruct", gethResults, gigaResults)
+	CompareLastResultsHash(t, "SelfDestruct", gethResults, gigaResults)
+	CompareReceipts(t, "SelfDestruct", gethCtx, gethResults, gigaCtx, gigaResults)
+}
+
 // TestGigaVsGeth_ContractCallsSequential compares Giga vs Geth for sequential contract calls
 // This test deploys a contract and calls it within the same block
 func TestGigaVsGeth_ContractCallsSequential(t *testing.T) {

--- a/integration_test/evm_module/scripts/evm_giga_mixed_tests.sh
+++ b/integration_test/evm_module/scripts/evm_giga_mixed_tests.sh
@@ -3,7 +3,7 @@
 # GIGA Mixed-Mode EVM Integration Tests
 #
 # This script replaces the default cluster with a mixed-mode cluster where:
-#   - Node 0: GIGA_EXECUTOR=true (sequential mode)
+#   - Node 0: GIGA_EXECUTOR=true GIGA_OCC=true (concurrent giga executor)
 #   - Nodes 1-3: Standard V2 executor
 #
 # If giga produces different results from V2, the giga node will halt with
@@ -16,7 +16,7 @@
 set -e
 
 echo "=== GIGA Mixed-Mode Integration Test ==="
-echo "=== Node 0: GIGA_EXECUTOR=true, Nodes 1-3: standard V2 ==="
+echo "=== Node 0: GIGA_EXECUTOR=true GIGA_OCC=true, Nodes 1-3: standard V2 ==="
 
 # Stop the default cluster that the workflow started
 echo "Stopping default cluster..."


### PR DESCRIPTION
## Describe your changes and provide context

Since the giga cachekv doesn't support iterations, https://github.com/sei-protocol/sei-chain/pull/3103 changed the giga executor to fall back to v2 for associations and migrations, which are the primary triggers for iteration. There are (at least) 2 others, however:
- self-destructs (triggered by stateDB.Finalize)
- CreateAccount-over-existing-code (panics mid-execution).

This PR adds a lightweight check for self-destructs, falling back to v2 in that case. It also robust-ifies unsupported iteration handling by adding a special error for that case, which upon being detected triggers a v2 fallback.

In theory _all_ we need is the unsupported iteration detection, but it is more optimal to special-case associations and migrations (as in #3103) and self-destructs (as in this PR).

## Testing performed to validate your change

New tests from Cursor pass. Will confirm this fixes the pacific issue.

