### PR TITLE
test(giga): self-destruct storage cleanup coverage under OCC giga

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -479,7 +479,8 @@ autobahn-integration-test:
 	@GOWORK=off go test -tags autobahn_integration -v -count=1 -timeout 30m ./integration_test/autobahn/...
 .PHONY: autobahn-integration-test
 
-# Run a mixed-mode cluster: node 0 uses GIGA_EXECUTOR, nodes 1-3 use standard V2.
+# Run a mixed-mode cluster: node 0 uses GIGA_EXECUTOR with OCC, nodes 1-3 use standard V2.
+# (node-level GIGA_EXECUTOR/GIGA_OCC values are pinned in docker-compose.giga-mixed.yml)
 # Any determinism divergence between giga and V2 will cause the giga node to halt.
 docker-cluster-start-giga-mixed: docker-cluster-stop build-docker-node
 	@rm -rf $(PROJECT_HOME)/build/generated
@@ -496,11 +497,11 @@ docker-cluster-start-giga-mixed: docker-cluster-stop build-docker-node
 .PHONY: docker-cluster-start-giga-mixed
 
 # Run the giga mixed-mode integration test.
-# Starts a cluster where only node 0 runs giga (sequential), nodes 1-3 run standard V2.
+# Starts a cluster where only node 0 runs giga (concurrent, OCC), nodes 1-3 run standard V2.
 # Then runs hardhat tests. If giga produces different results, node 0 will halt.
 giga-mixed-integration-test:
 	@echo "=== Starting GIGA Mixed-Mode Integration Tests ==="
-	@echo "=== Node 0: GIGA_EXECUTOR=true, Nodes 1-3: standard V2 ==="
+	@echo "=== Node 0: GIGA_EXECUTOR=true GIGA_OCC=true, Nodes 1-3: standard V2 ==="
 	@$(MAKE) docker-cluster-stop || true
 	@rm -rf $(PROJECT_HOME)/build/generated
 	@DOCKER_DETACH=true $(MAKE) docker-cluster-start-giga-mixed

--- a/contracts/src/SelfDestructTester.sol
+++ b/contracts/src/SelfDestructTester.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * SelfDestructTester
+ *
+ * Exercises the SELFDESTRUCT opcode against a contract that carries on-chain
+ * storage, so there is real account state to clean up. This is a useful
+ * determinism edge case for the GIGA store: if the giga executor's account /
+ * storage deletion diverges from the V2 executor, a mixed-mode cluster will
+ * halt with an AppHash mismatch.
+ *
+ * Note on EIP-6780 (active under the "prague" EVM version configured for this
+ * repo): SELFDESTRUCT only fully deletes the account (code + storage) when it
+ * is executed in the SAME transaction that created the contract. When called in
+ * a later transaction it merely transfers the contract's balance and leaves the
+ * code and storage in place. Both paths are exercised by the tests:
+ *   - destroy() on a previously-deployed instance  -> balance sweep only
+ *   - SelfDestructFactory.createAndDestroy(...)     -> full account cleanup
+ */
+contract SelfDestructTester {
+    address public owner;
+    uint256 public valueA;
+    uint256 public valueB;
+    // mapping storage so there are multiple distinct storage slots to clean up
+    mapping(uint256 => uint256) public data;
+    uint256 public numKeys;
+
+    event Destroyed(address indexed recipient, uint256 balance);
+
+    // Constructor seeds storage so a freshly-created contract has state to clean
+    // up. Payable so the contract can hold a balance that selfdestruct sweeps.
+    constructor(uint256 _numKeys) payable {
+        owner = msg.sender;
+        valueA = 0xA11CE;
+        valueB = 0xB0B;
+        numKeys = _numKeys;
+        for (uint256 i = 0; i < _numKeys; i++) {
+            // non-zero values so the slots are actually written
+            data[i] = i + 1;
+        }
+    }
+
+    function get(uint256 key) external view returns (uint256) {
+        return data[key];
+    }
+
+    // Sum the seeded keys — handy for asserting storage is intact pre-destruct.
+    function sumKeys() external view returns (uint256 total) {
+        for (uint256 i = 0; i < numKeys; i++) {
+            total += data[i];
+        }
+    }
+
+    function destroy(address payable recipient) external {
+        emit Destroyed(recipient, address(this).balance);
+        selfdestruct(recipient);
+    }
+}
+
+/**
+ * SelfDestructFactory
+ *
+ * Creates a SelfDestructTester (seeding its storage) and destroys it within the
+ * same transaction, which under EIP-6780 fully removes the child's code and
+ * storage. This is the path that actually forces the store to clean up the
+ * account state it just wrote.
+ */
+contract SelfDestructFactory {
+    event ChildCreated(address child);
+    event ChildDestroyed(address child);
+
+    function createAndDestroy(uint256 numKeys, address payable recipient)
+        external
+        payable
+        returns (address child)
+    {
+        SelfDestructTester c = new SelfDestructTester{value: msg.value}(numKeys);
+        child = address(c);
+        emit ChildCreated(child);
+        c.destroy(recipient);
+        emit ChildDestroyed(child);
+    }
+}

--- a/contracts/test/EVMGigaTest.js
+++ b/contracts/test/EVMGigaTest.js
@@ -1044,4 +1044,93 @@ describe("GIGA EVM Tests", function () {
       console.log(`        3 rounds of proxy token transfer+verify completed`);
     });
   });
+
+  // ============================================================================
+  // Self-Destruct With Storage Cleanup
+  //
+  // SELFDESTRUCT against a contract that carries real storage exercises the
+  // account/storage deletion path. If the giga executor deletes account state
+  // differently from the V2 executor, a mixed-mode cluster halts with an
+  // AppHash mismatch — so this is a meaningful determinism edge case.
+  //
+  // EIP-6780 (active under the "prague" EVM version) semantics:
+  //   - selfdestruct in a LATER tx than creation: balance sweep only; code and
+  //     storage remain.
+  //   - selfdestruct in the SAME tx as creation: full account removal, which
+  //     forces the store to clean up the storage it just wrote.
+  // ============================================================================
+  describe("Self-Destruct With Storage Cleanup", function () {
+    const NUM_KEYS = 8;
+
+    it("should seed storage on init and sweep balance on later-tx selfdestruct", async function () {
+      // Deploy with seeded storage and a non-zero balance to sweep.
+      const SelfDestructTester = await ethers.getContractFactory("SelfDestructTester");
+      const seedValue = ethers.parseEther("1");
+      const contract = await SelfDestructTester.deploy(NUM_KEYS, {
+        value: seedValue,
+        gasPrice: ethers.parseUnits('100', 'gwei'),
+      });
+      await contract.waitForDeployment();
+      const addr = await contract.getAddress();
+
+      // Constructor seeded storage: data[i] = i + 1, plus valueA/valueB/owner.
+      const code = await ethers.provider.getCode(addr);
+      expect(code.length).to.be.greaterThan(2);
+      expect(await ethers.provider.getBalance(addr)).to.equal(seedValue);
+      expect(await contract.numKeys()).to.equal(BigInt(NUM_KEYS));
+      expect(await contract.valueA()).to.equal(0xA11CEn);
+      // sum of 1..NUM_KEYS
+      const expectedSum = BigInt((NUM_KEYS * (NUM_KEYS + 1)) / 2);
+      expect(await contract.sumKeys()).to.equal(expectedSum);
+
+      // selfdestruct in a separate tx — under EIP-6780 only the balance moves.
+      const recipient = ethers.Wallet.createRandom().connect(ethers.provider);
+      const recipientAddress = await recipient.getAddress();
+      const tx = await contract.destroy(recipientAddress, {
+        gasPrice: ethers.parseUnits('100', 'gwei'),
+      });
+      await tx.wait();
+      await delay();
+
+      // Balance must have been swept to the recipient.
+      expect(await ethers.provider.getBalance(recipientAddress)).to.equal(seedValue);
+      expect(await ethers.provider.getBalance(addr)).to.equal(0n);
+      // Post-EIP-6780: code and storage survive a later-tx selfdestruct.
+      expect(await contract.sumKeys()).to.equal(expectedSum);
+      console.log(`        later-tx selfdestruct swept ${ethers.formatEther(seedValue)} SEI, storage retained`);
+    });
+
+    it("should fully clean up storage when created and destroyed in the same tx", async function () {
+      const Factory = await ethers.getContractFactory("SelfDestructFactory");
+      const factory = await Factory.deploy({ gasPrice: ethers.parseUnits('100', 'gwei') });
+      await factory.waitForDeployment();
+
+      const recipient = ethers.Wallet.createRandom().connect(ethers.provider);
+      const recipientAddress = await recipient.getAddress();
+      const seedValue = ethers.parseEther("0.5");
+
+      // Predict the child address without mutating state, then run the real tx.
+      const childAddr = await factory.createAndDestroy.staticCall(NUM_KEYS, recipientAddress, {
+        value: seedValue,
+        gasPrice: ethers.parseUnits('100', 'gwei'),
+      });
+
+      const tx = await factory.createAndDestroy(NUM_KEYS, recipientAddress, {
+        value: seedValue,
+        gasPrice: ethers.parseUnits('100', 'gwei'),
+      });
+      await tx.wait();
+      await delay();
+
+      // Same-tx create+destroy: child account fully removed (code + storage),
+      // and its balance swept to the recipient.
+      expect(await ethers.provider.getCode(childAddr)).to.equal("0x");
+      expect(await ethers.provider.getBalance(childAddr)).to.equal(0n);
+      expect(await ethers.provider.getBalance(recipientAddress)).to.equal(seedValue);
+      // Storage slot reads on a cleaned-up account return zero.
+      const slot0 = await ethers.provider.getStorage(childAddr, 0);
+      expect(BigInt(slot0)).to.equal(0n);
+      console.log(`        same-tx create+destroy cleaned up child ${childAddr}`);
+    });
+  });
 });

--- a/docker/docker-compose.giga-mixed.yml
+++ b/docker/docker-compose.giga-mixed.yml
@@ -1,7 +1,11 @@
 # Docker Compose override for mixed-mode giga testing.
-# Only node 0 runs with GIGA_EXECUTOR enabled; nodes 1-3 run standard V2.
+# Only node 0 runs with GIGA_EXECUTOR enabled (with OCC); nodes 1-3 run standard V2.
 # This allows testing that giga produces identical results to V2 at the
 # consensus level — any divergence will cause the giga node to halt.
+#
+# Node 0 runs GIGA_OCC=true so this also covers the concurrent giga executor
+# (ProcessTXsWithOCCGiga) path, which uses the multiversion store layered over
+# the giga store — the path V2 must stay byte-for-byte consistent with.
 #
 # Usage:
 #   docker compose -f docker-compose.yml -f docker-compose.giga-mixed.yml up
@@ -13,7 +17,7 @@ services:
   node0:
     environment:
       - GIGA_EXECUTOR=true
-      - GIGA_OCC=false
+      - GIGA_OCC=true
 
   node1:
     environment:

--- a/integration_test/evm_module/scripts/evm_giga_mixed_tests.sh
+++ b/integration_test/evm_module/scripts/evm_giga_mixed_tests.sh
@@ -3,7 +3,7 @@
 # GIGA Mixed-Mode EVM Integration Tests
 #
 # This script replaces the default cluster with a mixed-mode cluster where:
-#   - Node 0: GIGA_EXECUTOR=true (sequential mode)
+#   - Node 0: GIGA_EXECUTOR=true GIGA_OCC=true (concurrent giga executor)
 #   - Nodes 1-3: Standard V2 executor
 #
 # If giga produces different results from V2, the giga node will halt with
@@ -16,7 +16,7 @@
 set -e
 
 echo "=== GIGA Mixed-Mode Integration Test ==="
-echo "=== Node 0: GIGA_EXECUTOR=true, Nodes 1-3: standard V2 ==="
+echo "=== Node 0: GIGA_EXECUTOR=true GIGA_OCC=true, Nodes 1-3: standard V2 ==="
 
 # Stop the default cluster that the workflow started
 echo "Stopping default cluster..."


### PR DESCRIPTION
## Describe your changes and provide context

Adds integration coverage for self-destructing an EVM contract that carries storage under the **concurrent giga executor** (`ProcessTXsWithOCCGiga`).

- New `contracts/src/SelfDestructTester.sol` — seeds storage on init (so there's real account state to clean up), plus a factory that creates + destroys a child in one tx.
- New `EVMGigaTest.js` scenario covering both EIP-6780 paths: later-tx selfdestruct (balance sweep only; code/storage retained) and same-tx create+destroy (full account cleanup).
- Flips node 0 of the mixed-mode determinism cluster to `GIGA_OCC=true` (`docker-compose.giga-mixed.yml`). The previous `GIGA_OCC=false` setting ran node 0 on the synchronous giga path over a plain (iterable) cachekv, so the self-destruct storage-purge path was never exercised. With OCC enabled the purge iterates the giga cachekv store — the path that hit `panic: unexpected iterator call on cachekv store` in production.

This is the regression/repro coverage for the v2-fallback fix in #3560. Without that fix node 0 diverges from V2 (giga returns `ErrPanic`) and halts on an AppHash mismatch; with it, the giga node falls back to V2 for self-destruct txs and the cluster stays consistent.

Test changes only — no production code paths modified.

## Testing performed to validate your change

- `hardhat compile` succeeds (evm target: prague); `node --check` passes on the test file.
- Verified the merged compose config pins node 0 to `GIGA_EXECUTOR=true GIGA_OCC=true` and nodes 1-3 to V2, regardless of host env.
- Runs via the existing `EVM GIGA Mixed (Determinism)` CI job and `make giga-mixed-integration-test`. Expected to fail on `main` (reproduces the panic) and pass once #3560 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)