### PR TITLE
feat(flatkv): fix zero storage pruning during flatkv migration

### DIFF
--- a/sei-db/state_db/sc/composite/store_migration_test.go
+++ b/sei-db/state_db/sc/composite/store_migration_test.go
@@ -367,6 +367,164 @@ func evmStorageTestValue(seed byte) []byte {
 	return value
 }
 
+func zeroStorageTestValue() []byte {
+	return make([]byte, 32)
+}
+
+func isZeroTestValue(v []byte) bool {
+	if len(v) == 0 {
+		return true
+	}
+	for _, b := range v {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func pruneZeroStorageViaRoutedGet(t *testing.T, cs *CompositeCommitStore, limit int) (int, int) {
+	t.Helper()
+	iter, err := cs.Iterator(keys.EVMStoreKey, keys.StateKeyPrefix(), []byte{0x04}, true)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, iter.Close()) }()
+
+	var deletes []*proto.KVPair
+	processed := 0
+	for ; iter.Valid() && processed < limit; iter.Next() {
+		key := append([]byte(nil), iter.Key()...)
+		processed++
+
+		// Match x/evm's migration-safe prune contract: iterator output is only a
+		// candidate source; deletion is decided from the routed logical read path.
+		value, found, err := cs.Get(keys.EVMStoreKey, key)
+		require.NoError(t, err)
+		if found && isZeroTestValue(value) {
+			deletes = append(deletes, &proto.KVPair{Key: key, Delete: true})
+		}
+	}
+	require.NoError(t, iter.Error())
+
+	if len(deletes) > 0 {
+		require.NoError(t, cs.ApplyChangeSets([]*proto.NamedChangeSet{{
+			Name: keys.EVMStoreKey,
+			Changeset: proto.ChangeSet{
+				Pairs: deletes,
+			},
+		}}))
+	} else {
+		require.NoError(t, cs.ApplyChangeSets(nil))
+	}
+	return processed, len(deletes)
+}
+
+func requireEVMStorageKeysAbsentFromIterator(t *testing.T, cs *CompositeCommitStore, absentKeys ...[]byte) {
+	t.Helper()
+	absent := make(map[string]struct{}, len(absentKeys))
+	for _, key := range absentKeys {
+		absent[string(key)] = struct{}{}
+	}
+
+	iter, err := cs.Iterator(keys.EVMStoreKey, keys.StateKeyPrefix(), []byte{0x04}, true)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, iter.Close()) }()
+	for ; iter.Valid(); iter.Next() {
+		_, forbidden := absent[string(iter.Key())]
+		require.Falsef(t, forbidden, "pruned zero-storage key %x must not appear in composite iterator", iter.Key())
+	}
+	require.NoError(t, iter.Error())
+}
+
+func TestComposite_MigrateEVM_PruneZeroStorageSlotsDuringMigration(t *testing.T) {
+	dir := t.TempDir()
+	zeroKeyBeforeBoundary := evmStorageTestKey(0x01)
+	nonZeroKey := evmStorageTestKey(0x02)
+	zeroKeyAfterBoundary := evmStorageTestKey(0x03)
+
+	memCfg := config.DefaultStateCommitConfig()
+	memCfg.WriteMode = config.MemiavlOnly
+	memCfg.MemIAVLConfig.AsyncCommitBuffer = 0
+	cs, err := NewCompositeCommitStore(t.Context(), dir, memCfg)
+	require.NoError(t, err)
+	require.NoError(t, cs.Initialize([]string{keys.BankStoreKey, keys.EVMStoreKey}))
+	_, err = cs.LoadVersion(0, false)
+	require.NoError(t, err)
+	require.NoError(t, cs.ApplyChangeSets([]*proto.NamedChangeSet{{
+		Name: keys.EVMStoreKey,
+		Changeset: proto.ChangeSet{Pairs: []*proto.KVPair{
+			{Key: zeroKeyBeforeBoundary, Value: zeroStorageTestValue()},
+			{Key: nonZeroKey, Value: evmStorageTestValue(0x22)},
+			{Key: zeroKeyAfterBoundary, Value: zeroStorageTestValue()},
+		}},
+	}}))
+	_, err = cs.Commit()
+	require.NoError(t, err)
+	require.NoError(t, cs.Close())
+
+	cs = reopenInMigrateEVM(t, dir, 1)
+
+	processed, deleted := pruneZeroStorageViaRoutedGet(t, cs, 10)
+	require.Equal(t, 3, processed)
+	require.Equal(t, 2, deleted)
+	_, err = cs.Commit()
+	require.NoError(t, err)
+
+	for _, key := range [][]byte{zeroKeyBeforeBoundary, zeroKeyAfterBoundary} {
+		value, found, err := cs.Get(keys.EVMStoreKey, key)
+		require.NoError(t, err)
+		require.Falsef(t, found, "pruned zero-storage key %x must be logically absent", key)
+		require.Nil(t, value)
+	}
+	value, found, err := cs.Get(keys.EVMStoreKey, nonZeroKey)
+	require.NoError(t, err)
+	require.True(t, found, "non-zero storage key must survive prune")
+	require.Equal(t, evmStorageTestValue(0x22), value)
+	requireEVMStorageKeysAbsentFromIterator(t, cs, zeroKeyBeforeBoundary, zeroKeyAfterBoundary)
+
+	workload := newMigrationWorkload(0x5150)
+	runUntilMigrationComplete(t, cs, workload, 20)
+	for _, key := range [][]byte{zeroKeyBeforeBoundary, zeroKeyAfterBoundary} {
+		value, found, err := cs.Get(keys.EVMStoreKey, key)
+		require.NoError(t, err)
+		require.Falsef(t, found, "pruned zero-storage key %x must remain absent after migration completes", key)
+		require.Nil(t, value)
+	}
+	value, found, err = cs.Get(keys.EVMStoreKey, nonZeroKey)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, evmStorageTestValue(0x22), value)
+	requireEVMStorageKeysAbsentFromIterator(t, cs, zeroKeyBeforeBoundary, zeroKeyAfterBoundary)
+	require.NoError(t, flatkv.VerifyLtHash(cs.flatKV))
+
+	preFlipVersion := cs.Version()
+	preFlipHash := append([]byte(nil), cs.flatKV.CommittedRootHash()...)
+	require.NoError(t, cs.Close())
+
+	finalCfg := evmMigratedConfig()
+	finalCfg.MemIAVLConfig.AsyncCommitBuffer = 0
+	cs, err = NewCompositeCommitStore(t.Context(), dir, finalCfg)
+	require.NoError(t, err)
+	require.NoError(t, cs.Initialize([]string{keys.BankStoreKey, keys.EVMStoreKey}))
+	_, err = cs.LoadVersion(0, false)
+	require.NoError(t, err)
+	defer func() { _ = cs.Close() }()
+
+	require.Equal(t, preFlipVersion, cs.Version())
+	require.Equal(t, preFlipHash, cs.flatKV.CommittedRootHash())
+	for _, key := range [][]byte{zeroKeyBeforeBoundary, zeroKeyAfterBoundary} {
+		value, found, err := cs.Get(keys.EVMStoreKey, key)
+		require.NoError(t, err)
+		require.Falsef(t, found, "pruned zero-storage key %x must remain absent after EVMMigrated reopen", key)
+		require.Nil(t, value)
+	}
+	value, found, err = cs.Get(keys.EVMStoreKey, nonZeroKey)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, evmStorageTestValue(0x22), value)
+	requireEVMStorageKeysAbsentFromIterator(t, cs, zeroKeyBeforeBoundary, zeroKeyAfterBoundary)
+	require.NoError(t, flatkv.VerifyLtHash(cs.flatKV))
+}
+
 // runUntilMigrationComplete drives the workload through commits until
 // the flatkv migration-version key reaches Version1_MigrateEVM. Fails
 // the test if completion takes more than maxBlocks (guards against a

--- a/x/evm/keeper/storage_cleanup.go
+++ b/x/evm/keeper/storage_cleanup.go
@@ -60,8 +60,8 @@ func (k *Keeper) PruneZeroStorageSlots(ctx sdk.Context, limit int) (int, int) {
 		processedMetric++
 		lastKey = key
 
-		val := iterator.Value()
-		if isZeroStorageValue(val) {
+		val := store.Get(key)
+		if val != nil && isZeroStorageValue(val) {
 			store.Delete(key)
 			deleted++
 			deletedMetric++

--- a/x/evm/keeper/storage_cleanup_test.go
+++ b/x/evm/keeper/storage_cleanup_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	evmkeeper "github.com/sei-protocol/sei-chain/x/evm/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
@@ -51,4 +52,113 @@ func TestPruneZeroStorageSlots(t *testing.T) {
 	processed, deleted = k.PruneZeroStorageSlots(ctx, evmkeeper.ZeroStorageCleanupBatchSize)
 	require.Equal(t, 1, processed)
 	require.Equal(t, 0, deleted)
+}
+
+// TestPruneZeroStorageSlots_DecidesDeletionFromRoutedGet guards the
+// migration-safety contract: the prune decision must come from the routed
+// logical read (store.Get), not from the iterator's surfaced value. During a
+// flatkv migration the iterator is a merged view across backends and can
+// surface a value that disagrees with the authoritative routed read. We
+// simulate that divergence with a store whose iterator lies about Value()
+// while Get() returns the truth.
+//
+// Without the fix (val := iterator.Value()) this test fails: the live slot is
+// wrongly pruned and the dead slot is wrongly kept.
+func TestPruneZeroStorageSlots_DecidesDeletionFromRoutedGet(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+
+	// liveAddr/liveSlot: authoritative Get is non-zero, but the iterator
+	// surfaces it as zero. It must survive (deleting it would lose live state).
+	liveAddr := common.HexToAddress("0x0100000000000000000000000000000000000000")
+	liveSlot := common.HexToHash("0x01")
+	// deadAddr/deadSlot: authoritative Get is zero, but the iterator surfaces
+	// it as non-zero. It must be pruned (decision follows Get).
+	deadAddr := common.HexToAddress("0x0200000000000000000000000000000000000000")
+	deadSlot := common.HexToHash("0x02")
+
+	zero := common.Hash{}
+	nonZero := common.HexToHash("0x1234")
+
+	liveStore := k.PrefixStore(ctx, types.StateKey(liveAddr))
+	liveStore.Set(liveSlot[:], nonZero[:])
+	deadStore := k.PrefixStore(ctx, types.StateKey(deadAddr))
+	deadStore.Set(deadSlot[:], zero[:])
+
+	liveKey := evmStateFullKey(liveAddr, liveSlot)
+	deadKey := evmStateFullKey(deadAddr, deadSlot)
+	iteratorLies := map[string][]byte{
+		string(liveKey): zero[:],    // iterator pretends the live slot is zero
+		string(deadKey): nonZero[:], // iterator pretends the dead slot is non-zero
+	}
+
+	storeKey := k.GetStoreKey()
+	lying := iteratorValueLyingStore{
+		KVStore: ctx.MultiStore().GetKVStore(storeKey),
+		lies:    iteratorLies,
+	}
+	ctx = ctx.WithMultiStore(kvStoreOverrideMultiStore{
+		MultiStore: ctx.MultiStore(),
+		target:     storeKey,
+		store:      lying,
+	})
+
+	processed, deleted := k.PruneZeroStorageSlots(ctx, evmkeeper.ZeroStorageCleanupBatchSize)
+	require.Equal(t, 2, processed)
+	require.Equal(t, 1, deleted)
+
+	liveStore = k.PrefixStore(ctx, types.StateKey(liveAddr))
+	require.True(t, liveStore.Has(liveSlot[:]), "live slot (routed Get non-zero) must survive despite iterator showing zero")
+	deadStore = k.PrefixStore(ctx, types.StateKey(deadAddr))
+	require.False(t, deadStore.Has(deadSlot[:]), "dead slot (routed Get zero) must be pruned despite iterator showing non-zero")
+}
+
+func evmStateFullKey(addr common.Address, slot common.Hash) []byte {
+	out := make([]byte, 0, len(types.StateKeyPrefix)+len(addr)+len(slot))
+	out = append(out, types.StateKeyPrefix...)
+	out = append(out, addr.Bytes()...)
+	out = append(out, slot[:]...)
+	return out
+}
+
+// kvStoreOverrideMultiStore returns a custom KVStore for a single target store
+// key and delegates everything else to the embedded MultiStore.
+type kvStoreOverrideMultiStore struct {
+	sdk.MultiStore
+	target sdk.StoreKey
+	store  sdk.KVStore
+}
+
+func (m kvStoreOverrideMultiStore) GetKVStore(key sdk.StoreKey) sdk.KVStore {
+	if key.Name() == m.target.Name() {
+		return m.store
+	}
+	return m.MultiStore.GetKVStore(key)
+}
+
+// iteratorValueLyingStore behaves like its underlying KVStore for point reads
+// (Get/Has) but returns iterator values that may disagree with the routed read,
+// mimicking a merged migration iterator.
+type iteratorValueLyingStore struct {
+	sdk.KVStore
+	lies map[string][]byte
+}
+
+func (s iteratorValueLyingStore) Iterator(start, end []byte) sdk.Iterator {
+	return lyingIterator{Iterator: s.KVStore.Iterator(start, end), lies: s.lies}
+}
+
+func (s iteratorValueLyingStore) ReverseIterator(start, end []byte) sdk.Iterator {
+	return lyingIterator{Iterator: s.KVStore.ReverseIterator(start, end), lies: s.lies}
+}
+
+type lyingIterator struct {
+	sdk.Iterator
+	lies map[string][]byte
+}
+
+func (it lyingIterator) Value() []byte {
+	if v, ok := it.lies[string(it.Key())]; ok {
+		return v
+	}
+	return it.Iterator.Value()
 }


### PR DESCRIPTION
## Summary

Make EVM zero-storage-slot pruning safe to run while a flatkv migration is in progress. The prune loop in `PruneZeroStorageSlots` previously decided deletions from the iterator's surfaced value. During a flatkv migration the EVM store is a composite/migration store backed by two engines (memiavl + flatkv): point reads (`Get`/`Has`) are served by the authoritative routed read path, but iteration is a *merged* view stitched across both backends by the owning composite store. These two paths can diverge mid-migration, so trusting `iterator.Value()` could prune a slot that is logically non-zero (live) — corrupting state and producing a storage-digest / apphash mismatch. This change routes the prune decision through the same logical read the EVM itself trusts, so the iterator is used only as a candidate-key source.

- `x/evm/keeper/storage_cleanup.go`: `PruneZeroStorageSlots` now decides deletion from `store.Get(key)` (the routed logical read) instead of `iterator.Value()`. The iterator output is treated purely as a list of candidate keys; the all-zero check is evaluated against the authoritative value. Adds a `val != nil` guard so keys that are logically absent (e.g. a tombstone surfaced by the merged iterator) are skipped rather than re-deleted. This guarantees a slot is pruned only when its authoritative value is all-zero, eliminating the merged-view data-loss path while keeping pruning enabled throughout `migrate_evm`.

## Test plan

- `x/evm/keeper/storage_cleanup_test.go`:
  - `TestPruneZeroStorageSlots_DecidesDeletionFromRoutedGet` (new): drives the real `PruneZeroStorageSlots` against an injected store whose iterator deliberately lies about `Value()` while `Get` returns the truth, reproducing the migration merged-view divergence. Asserts a live slot (routed `Get` non-zero, iterator shows zero) survives, and a dead slot (routed `Get` zero, iterator shows non-zero) is pruned. Verified to fail on the pre-fix code (live slot wrongly pruned) and pass on the fix, so it locks in the production behavior change. Uses `kvStoreOverrideMultiStore` (overrides a single store key), `iteratorValueLyingStore` (truthful point reads, lying iterator values), and `lyingIterator` (per-key `Value()` override).
  - `TestPruneZeroStorageSlots` (existing): unchanged; continues to cover the normal (non-migration) path, batch limits, checkpoint advance, and checkpoint reset on iterator exhaustion.
- `sei-db/state_db/sc/composite/store_migration_test.go`:
  - `TestComposite_MigrateEVM_PruneZeroStorageSlotsDuringMigration` (new): characterizes the composite store the fix relies on. Seeds zero/non-zero slots, reopens in `MigrateEVM`, prunes via routed `Get`, and asserts pruned keys are logically absent (via `Get`) and absent from the composite iterator, while non-zero slots survive. Continues through migration completion and a final `EVMMigrated` reopen, asserting version/root-hash continuity (`preFlipVersion`, `preFlipHash`) and flatkv lt-hash integrity (`VerifyLtHash`) at each stage.
