### PR TITLE
Wait for address association before balance assertions

### DIFF
--- a/contracts/test/lib.js
+++ b/contracts/test/lib.js
@@ -280,8 +280,12 @@ async function associateKey(keyName) {
 
 // Strict helper for tests that are explicitly asserting association behavior.
 async function associateKeyStrict(keyName) {
+    const seiAddress = await getKeySeiAddress(keyName)
     await execute(`seid tx evm associate-address --from ${keyName} -b sync`)
-    await waitForBlocks()
+    await waitForCondition(
+        async () => (await getEvmAddressAssociation(seiAddress)).associated === true,
+        `${seiAddress} to have an associated EVM address`,
+    )
 }
 
 function getEventAttribute(response, type, attribute) {
@@ -836,10 +840,13 @@ async function getSeiAddress(evmAddress) {
 }
 
 async function getEvmAddress(seiAddress) {
+    return (await getEvmAddressAssociation(seiAddress)).evm_address
+}
+
+async function getEvmAddressAssociation(seiAddress) {
     const command = `seid q evm evm-addr ${seiAddress} -o json`
     const output = await execute(command);
-    const response = JSON.parse(output)
-    return response.evm_address
+    return JSON.parse(output)
 }
 
 function generateWallet() {


### PR DESCRIPTION
The Autobahn associate-balance test was flaky because `associateKeyStrict` returned after submitting `seid tx evm associate-address` and waiting a fixed number of blocks. In the failing run, the associate transaction had returned, but the EVM/Sei address association was not visible to the balance query yet, so the test read the pre-association EVM balance (`200`) instead of the expected converted Sei balance.

Fix this by waiting on the causal post-state: query `seid q evm evm-addr` until it reports `associated: true` for the Sei address. This makes the test proceed only once the association side effect is observable, instead of relying on block timing.

Flaked [here](https://github.com/sei-protocol/sei-chain/actions/runs/27301809780/job/80650521620).
