### PR TITLE
Revise the repository security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Security researchers are essential in identifying vulnerabilities that may impac
 
 - [Sei Bug Bounty on Immunefi](https://immunefi.com/bug-bounty/sei/information/)
 
-Please do not report security vulnerabilities through public channels, including GitHub issues, pull requests, public chats, or social media. Reports submitted outside the Immunefi program may not be eligible for a bounty.
+Please do not report security vulnerabilities through public channels, including GitHub issues, pull requests, public chats, or social media. Reports submitted outside the Immunefi program will not be eligible for a bounty.
 
 The Immunefi program page is the authoritative source for:
 
@@ -21,11 +21,11 @@ The Immunefi program page is the authoritative source for:
 
 All vulnerability research must follow the rules and scope published in the Sei Immunefi program. In particular:
 
-- Do not test vulnerabilities on Sei mainnet `pacific-1`, public testnets, public frontends, or other publicly accessible Sei environments unless the Immunefi program explicitly allows it.
+- Do not test vulnerabilities on Sei mainnet `pacific-1`, public testnets, public frontends, or other publicly accessible Sei environments. The Sei Immunefi program requires vulnerability testing to be performed in permitted local environments.
 - Use local forks, local testnets, or other permitted local environments for proof-of-concept development.
 - Do not attempt phishing, social engineering, denial-of-service attacks, or automated testing that generates significant traffic.
 - Do not access, modify, delete, exfiltrate, or degrade data that does not belong to you.
-- Do not publicly disclose an unpatched vulnerability unless and until disclosure has been approved under the Immunefi program rules.
+- Do not publicly disclose any vulnerability or vulnerability report details unless and until disclosure has been explicitly approved under the Immunefi program rules.
 
 ## What to Include in a Report
 
@@ -47,7 +47,7 @@ Submit reports through Immunefi with enough detail for the issue to be reproduce
 4. **Resolution**: Once fixed, you may be contacted to verify the solution.
 5. **Disclosure**: Public disclosure must follow the Immunefi program's responsible publication rules.
 
-During the vulnerability disclosure process, keep vulnerabilities and communications around vulnerability submissions private and confidential until disclosure is approved. If a security issue requires a network upgrade, additional time may be needed to raise a governance proposal and complete the upgrade.
+During the vulnerability disclosure process, keep vulnerabilities and communications around vulnerability submissions private and confidential unless and until disclosure is explicitly approved. If a security issue requires a network upgrade, additional time may be needed to raise a governance proposal and complete the upgrade.
 
 During this time:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,68 +1,63 @@
 # Security Policy
 
-## Introduction
+## Reporting Security Vulnerabilities
 
-Security researchers are essential in identifying vulnerabilities that may impact the Sei ecosystem. If you have discovered a security vulnerability in the Sei chain or any repository managed by Sei, we encourage you to notify us using one of the methods outlined below.
+Security researchers are essential in identifying vulnerabilities that may impact the Sei ecosystem. If you believe you have discovered a security vulnerability in Sei Chain or another asset covered by Sei's bug bounty program, submit your report through the Sei Immunefi program:
 
-### Guidelines for Responsible Vulnerability Testing and Reporting
+- [Sei Bug Bounty on Immunefi](https://immunefi.com/bug-bounty/sei/information/)
 
-1. **Refrain from testing vulnerabilities on our publicly accessible environments**, including but not limited to:
+Please do not report security vulnerabilities through public channels, including GitHub issues, pull requests, public chats, or social media. Reports submitted outside the Immunefi program may not be eligible for a bounty.
 
-- Sei mainnet `pacific-1`
-- Sei frontend
-- Sei public testnets
-- Sei testnet frontend
+The Immunefi program page is the authoritative source for:
 
-2. **Avoid reporting security vulnerabilities through public channels, including GitHub issues**
+- Assets and impacts in scope
+- Reward amounts and eligibility requirements
+- Severity classification
+- Proof-of-concept requirements
+- Disclosure rules and prohibited activities
+- KYC and payout requirements
 
-To privately report a security vulnerability, please choose one of the following options:
+## Responsible Vulnerability Testing
 
-### 1. Email
+All vulnerability research must follow the rules and scope published in the Sei Immunefi program. In particular:
 
-Send your detailed vulnerability report to `protocol-eng@seinetwork.io`.
+- Do not test vulnerabilities on Sei mainnet `pacific-1`, public testnets, public frontends, or other publicly accessible Sei environments unless the Immunefi program explicitly allows it.
+- Use local forks, local testnets, or other permitted local environments for proof-of-concept development.
+- Do not attempt phishing, social engineering, denial-of-service attacks, or automated testing that generates significant traffic.
+- Do not access, modify, delete, exfiltrate, or degrade data that does not belong to you.
+- Do not publicly disclose an unpatched vulnerability unless and until disclosure has been approved under the Immunefi program rules.
 
-### 2. GitHub Private Vulnerability Reporting
+## What to Include in a Report
 
-Utilize [GitHub's Private Vulnerability Reporting](https://github.com/sei-protocol/sei-chain/security/advisories/new) for confidential disclosure.
-
-## Submit Vulnerability Report
-
-When reporting a vulnerability through either method, please include the following details to aid in our assessment:
+Submit reports through Immunefi with enough detail for the issue to be reproduced and assessed. Include:
 
 - Type of vulnerability
+- Affected component, asset, version, commit, or configuration
 - Description of the vulnerability
 - Steps to reproduce the issue
+- Proof of concept, when required by the Immunefi program
 - Impact of the issue
-- Explanation on how an attacker could exploit it
+- Explanation of how an attacker could exploit it
 
 ## Vulnerability Disclosure Process
 
-1. **Initial Report**: Submit the vulnerability via one of the above channels.
-2. **Confirmation**: We will confirm receipt of your report within 48 hours.
-3. **Assessment**: Our security team will evaluate the vulnerability and inform you of its severity and the estimated time frame for resolution.
-4. **Resolution**: Once fixed, you will be contacted to verify the solution.
-5. **Public Disclosure**: Details of the vulnerability may be publicly disclosed after ensuring it poses no further risk.
+1. **Submission**: Submit the vulnerability through the Sei Immunefi program.
+2. **Triage**: Immunefi and the Sei security team will triage the report according to the program rules.
+3. **Assessment**: The issue will be evaluated for validity, scope, severity, impact, and reward eligibility.
+4. **Resolution**: Once fixed, you may be contacted to verify the solution.
+5. **Disclosure**: Public disclosure must follow the Immunefi program's responsible publication rules.
 
-During the vulnerability disclosure process, we ask security researchers to keep vulnerabilities and communications around vulnerability submissions private and confidential until a patch is developed. Should a security issue require a network upgrade, additional time may be needed to raise a governance proposal and complete the upgrade.
+During the vulnerability disclosure process, keep vulnerabilities and communications around vulnerability submissions private and confidential until disclosure is approved. If a security issue requires a network upgrade, additional time may be needed to raise a governance proposal and complete the upgrade.
 
 During this time:
 
 - Avoid exploiting any vulnerabilities you discover.
 - Demonstrate good faith by not disrupting or degrading Sei's services.
 
-## Feature request
+## Feature Requests
 
 For a feature request, e.g. module inclusion, please make a GitHub issue. Clearly state your use case and what value it will bring to other users or developers on Sei.
 
-## Severity Characterization
-
-| Severity     | Description                                                             |
-| ------------ | ----------------------------------------------------------------------- |
-| **CRITICAL** | Immediate threat to critical systems (e.g., chain halts, funds at risk) |
-| **HIGH**     | Significant impact on major functionality                               |
-| **MEDIUM**   | Impacts minor features or exposes non-sensitive data                    |
-| **LOW**      | Minimal impact                                                          |
-
 ## Feedback on this Policy
 
-For recommendations on how to improve this policy, either submit a pull request or email `protocol-eng@seinetwork.io`.
+For non-sensitive recommendations on how to improve this policy, submit a pull request. Do not include vulnerability details in public pull requests.


### PR DESCRIPTION
Revise SECURITY.md to make the Sei Immunefi bug bounty program the authoritative channel for security vulnerability reports.

The updated policy removes the prior email and GitHub private reporting paths, points researchers to the Immunefi program page, and clarifies that scope, rewards, severity, PoC requirements, disclosure rules, prohibited activities, KYC, and payout terms are governed by Immunefi.

This keeps reporter guidance aligned with the active bug bounty program and reduces ambiguity about where security researchers should submit reports.

