### PR TITLE
conditional deactivation of consensus timeout overrides in config

### DIFF
--- a/sei-tendermint/config/config.go
+++ b/sei-tendermint/config/config.go
@@ -1158,6 +1158,9 @@ type ConsensusConfig struct {
 	// removed in the v0.37 release of Tendermint.
 	// See: https://github.com/tendermint/tendermint/issues/8188
 
+	// If false, all the Unsafe<..>TimeoutOverride fields are ignored.
+	// Defaults to false.
+	UnsafeOverridesEnabled bool `mapstructure:"unsafe-overrides-enabled"`
 	// UnsafeProposeTimeoutOverride provides an unsafe override of the Propose
 	// timeout consensus parameter. It configures how long the consensus engine
 	// will wait to receive a proposal block before prevoting nil.
@@ -1199,6 +1202,43 @@ type ConsensusConfig struct {
 	DeprecatedTimeoutPrecommitDelta *any `mapstructure:"timeout-precommit-delta"`
 	DeprecatedTimeoutCommit         *any `mapstructure:"timeout-commit"`
 	DeprecatedSkipTimeoutCommit     *any `mapstructure:"skip-timeout-commit"`
+}
+
+// Timeout params on Sei pacific-1, as of 2026-06-16.
+// Overrides will be disabled by default in release 6.6,
+// but only after the onchain timeout params are set
+// to correct values via gov proposal. Until then
+// (i.e. while onchain timeout params are still equal to badParams)
+// overrides are still enabled by default.
+var badParams = types.TimeoutParams{
+	Propose:             1000 * time.Millisecond,
+	ProposeDelta:        500 * time.Millisecond,
+	Vote:                50 * time.Millisecond,
+	VoteDelta:           500 * time.Millisecond,
+	Commit:              50 * time.Millisecond,
+	BypassCommitTimeout: false,
+}
+
+func (c *ConsensusConfig) ResolveTimeouts(t types.TimeoutParams) types.TimeoutParams {
+	t = t.Or(types.DefaultTimeoutParams())
+	// Overrides are effective iff UnsafeOverridesEnabled OR t == badParams:
+	// see doc on badParams.
+	if !c.UnsafeOverridesEnabled && t != badParams {
+		return t
+	}
+	overrides := types.TimeoutParams{
+		Propose:      c.UnsafeProposeTimeoutOverride,
+		ProposeDelta: c.UnsafeProposeTimeoutDeltaOverride,
+		Vote:         c.UnsafeVoteTimeoutOverride,
+		VoteDelta:    c.UnsafeVoteTimeoutDeltaOverride,
+		Commit:       c.UnsafeCommitTimeoutOverride,
+	}
+	t = overrides.Or(t)
+	// BypassCommitTimeout is special because it can be overriden to false.
+	if bcto := c.UnsafeBypassCommitTimeoutOverride; bcto != nil {
+		t.BypassCommitTimeout = *bcto
+	}
+	return t
 }
 
 // DefaultConsensusConfig returns a default configuration for the consensus service

--- a/sei-tendermint/config/config.go
+++ b/sei-tendermint/config/config.go
@@ -1234,7 +1234,7 @@ func (c *ConsensusConfig) ResolveTimeouts(t types.TimeoutParams) types.TimeoutPa
 		Commit:       c.UnsafeCommitTimeoutOverride,
 	}
 	t = overrides.Or(t)
-	// BypassCommitTimeout is special because it can be overriden to false.
+	// BypassCommitTimeout is special because it can be overridden to false.
 	if bcto := c.UnsafeBypassCommitTimeoutOverride; bcto != nil {
 		t.BypassCommitTimeout = *bcto
 	}

--- a/sei-tendermint/config/config.go
+++ b/sei-tendermint/config/config.go
@@ -1211,7 +1211,7 @@ type ConsensusConfig struct {
 // (i.e. while onchain timeout params are still equal to badParams)
 // overrides are still enabled by default.
 var badParams = types.TimeoutParams{
-	Propose:             1000 * time.Millisecond,
+	Propose:             1 * time.Second,
 	ProposeDelta:        500 * time.Millisecond,
 	Vote:                50 * time.Millisecond,
 	VoteDelta:           500 * time.Millisecond,
@@ -1221,7 +1221,7 @@ var badParams = types.TimeoutParams{
 
 func (c *ConsensusConfig) ResolveTimeouts(t types.TimeoutParams) types.TimeoutParams {
 	t = t.Or(types.DefaultTimeoutParams())
-	// Overrides are effective iff UnsafeOverridesEnabled OR t == badParams:
+	// Overrides are ineffective iff !UnsafeOverridesEnabled AND t != badParams:
 	// see doc on badParams.
 	if !c.UnsafeOverridesEnabled && t != badParams {
 		return t

--- a/sei-tendermint/config/config_test.go
+++ b/sei-tendermint/config/config_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -147,6 +149,62 @@ func TestConsensusConfig_ValidateBasic(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestConsensusConfigResolveTimeouts(t *testing.T) {
+	overrides := func(enabled bool, bypass *bool) *ConsensusConfig {
+		cfg := DefaultConsensusConfig()
+		cfg.UnsafeOverridesEnabled = enabled
+		cfg.UnsafeProposeTimeoutOverride = 9 * time.Second
+		cfg.UnsafeProposeTimeoutDeltaOverride = 8 * time.Second
+		cfg.UnsafeVoteTimeoutOverride = 7 * time.Second
+		cfg.UnsafeVoteTimeoutDeltaOverride = 6 * time.Second
+		cfg.UnsafeCommitTimeoutOverride = 5 * time.Second
+		cfg.UnsafeBypassCommitTimeoutOverride = bypass
+		return cfg
+	}
+
+	onchain := func(bypass bool) types.TimeoutParams {
+		return types.TimeoutParams{
+			Propose:             2 * time.Second,
+			ProposeDelta:        250 * time.Millisecond,
+			Vote:                3 * time.Second,
+			VoteDelta:           350 * time.Millisecond,
+			Commit:              4 * time.Second,
+			BypassCommitTimeout: bypass,
+		}
+	}
+	overridden := func(bypass bool) types.TimeoutParams {
+		return types.TimeoutParams{
+			Propose:             9 * time.Second,
+			ProposeDelta:        8 * time.Second,
+			Vote:                7 * time.Second,
+			VoteDelta:           6 * time.Second,
+			Commit:              5 * time.Second,
+			BypassCommitTimeout: bypass,
+		}
+	}
+
+	testCases := []struct {
+		name     string
+		cfg      *ConsensusConfig
+		params   types.TimeoutParams
+		expected types.TimeoutParams
+	}{
+		{"fills defaults", DefaultConsensusConfig(), types.TimeoutParams{}, types.DefaultTimeoutParams()},
+		{"disabled ignores overrides for non-legacy params", overrides(false, utils.Alloc(true)), onchain(false), onchain(false)},
+		{"disabled preserves legacy override behavior", overrides(false, utils.Alloc(true)), badParams, overridden(true)},
+		{"enabled applies overrides", overrides(true, utils.Alloc(false)), onchain(false), overridden(false)},
+		{"nil bypass override keeps resolved false", overrides(true, nil), onchain(false), overridden(false)},
+		{"nil bypass override keeps resolved true", overrides(true, nil), onchain(true), overridden(true)},
+		{"false bypass override clears true", overrides(true, utils.Alloc(false)), onchain(true), overridden(false)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.cfg.ResolveTimeouts(tc.params))
 		})
 	}
 }

--- a/sei-tendermint/internal/consensus/state.go
+++ b/sei-tendermint/internal/consensus/state.go
@@ -2736,11 +2736,7 @@ func (cs *State) voteTimeout(round int32) time.Duration {
 }
 
 func (cs *State) commitTime(t time.Time) time.Time {
-	c := cs.state.ConsensusParams.Timeout.Commit
-	if cs.config.UnsafeCommitTimeoutOverride != 0 {
-		c = cs.config.UnsafeCommitTimeoutOverride
-	}
-	return t.Add(c)
+	return t.Add(cs.config.ResolveTimeouts(cs.state.ConsensusParams.Timeout).Commit)
 }
 
 func (cs *State) bypassCommitTimeout() bool {

--- a/sei-tendermint/internal/consensus/state.go
+++ b/sei-tendermint/internal/consensus/state.go
@@ -2724,31 +2724,15 @@ func (cs *State) calculatePrevoteMessageDelayMetrics() {
 //---------------------------------------------------------
 
 func (cs *State) proposeTimeout(round int32) time.Duration {
-	tp := cs.state.ConsensusParams.Timeout.TimeoutParamsOrDefaults()
-	p := tp.Propose
-	if cs.config.UnsafeProposeTimeoutOverride != 0 {
-		p = cs.config.UnsafeProposeTimeoutOverride
-	}
-	pd := tp.ProposeDelta
-	if cs.config.UnsafeProposeTimeoutDeltaOverride != 0 {
-		pd = cs.config.UnsafeProposeTimeoutDeltaOverride
-	}
+	t := cs.config.ResolveTimeouts(cs.state.ConsensusParams.Timeout)
 	return time.Duration(
-		p.Nanoseconds()+pd.Nanoseconds()*int64(round),
+		t.Propose.Nanoseconds()+t.ProposeDelta.Nanoseconds()*int64(round),
 	) * time.Nanosecond
 }
 
 func (cs *State) voteTimeout(round int32) time.Duration {
-	tp := cs.state.ConsensusParams.Timeout.TimeoutParamsOrDefaults()
-	v := tp.Vote
-	if cs.config.UnsafeVoteTimeoutOverride != 0 {
-		v = cs.config.UnsafeVoteTimeoutOverride
-	}
-	vd := tp.VoteDelta
-	if cs.config.UnsafeVoteTimeoutDeltaOverride != 0 {
-		vd = cs.config.UnsafeVoteTimeoutDeltaOverride
-	}
-	return v + vd*time.Duration(round)
+	t := cs.config.ResolveTimeouts(cs.state.ConsensusParams.Timeout)
+	return t.Vote + t.VoteDelta*time.Duration(round)
 }
 
 func (cs *State) commitTime(t time.Time) time.Time {
@@ -2760,10 +2744,7 @@ func (cs *State) commitTime(t time.Time) time.Time {
 }
 
 func (cs *State) bypassCommitTimeout() bool {
-	if cs.config.UnsafeBypassCommitTimeoutOverride != nil {
-		return *cs.config.UnsafeBypassCommitTimeoutOverride
-	}
-	return cs.state.ConsensusParams.Timeout.BypassCommitTimeout
+	return cs.config.ResolveTimeouts(cs.state.ConsensusParams.Timeout).BypassCommitTimeout
 }
 
 func (cs *State) calculateProposalTimestampDifferenceMetric() {

--- a/sei-tendermint/internal/consensus/state_test.go
+++ b/sei-tendermint/internal/consensus/state_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/abci/example/kvstore"
 	abci "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
 	abcimocks "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types/mocks"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/config"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/crypto"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/crypto/ed25519"
 	cstypes "github.com/sei-protocol/sei-chain/sei-tendermint/internal/consensus/types"
@@ -21,6 +22,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/proxy"
 	tmpubsub "github.com/sei-protocol/sei-chain/sei-tendermint/internal/pubsub"
 	tmquery "github.com/sei-protocol/sei-chain/sei-tendermint/internal/pubsub/query"
+	sm "github.com/sei-protocol/sei-chain/sei-tendermint/internal/state"
 	tmbytes "github.com/sei-protocol/sei-chain/sei-tendermint/libs/bytes"
 	tmrand "github.com/sei-protocol/sei-chain/sei-tendermint/libs/rand"
 	tmtime "github.com/sei-protocol/sei-chain/sei-tendermint/libs/time"
@@ -2912,4 +2914,88 @@ func TestAddProposalBlockPartNilProposalBlockParts(t *testing.T) {
 	// Should not add the part and should not return an error (just a debug log)
 	require.False(t, added, "Part should not be added when ProposalBlockParts is nil")
 	require.NoError(t, err, "No error expected when ProposalBlockParts is nil, just debug logging")
+}
+
+func TestStateTimeoutResolution(t *testing.T) {
+	baseTime := time.Unix(100, 0)
+
+	newState := func(cfg *config.ConsensusConfig, params types.TimeoutParams) *State {
+		return &State{
+			config: cfg,
+			state: sm.State{
+				ConsensusParams: types.ConsensusParams{
+					Timeout: params,
+				},
+			},
+		}
+	}
+
+	cfgWithOverrides := func(enabled bool, bypass bool) *config.ConsensusConfig {
+		cfg := config.DefaultConsensusConfig()
+		cfg.UnsafeOverridesEnabled = enabled
+		cfg.UnsafeProposeTimeoutOverride = 9 * time.Second
+		cfg.UnsafeProposeTimeoutDeltaOverride = 8 * time.Second
+		cfg.UnsafeVoteTimeoutOverride = 7 * time.Second
+		cfg.UnsafeVoteTimeoutDeltaOverride = 6 * time.Second
+		cfg.UnsafeCommitTimeoutOverride = 5 * time.Second
+		cfg.UnsafeBypassCommitTimeoutOverride = utils.Alloc(bypass)
+		return cfg
+	}
+
+	onchain := types.TimeoutParams{
+		Propose:             2 * time.Second,
+		ProposeDelta:        250 * time.Millisecond,
+		Vote:                3 * time.Second,
+		VoteDelta:           350 * time.Millisecond,
+		Commit:              4 * time.Second,
+		BypassCommitTimeout: false,
+	}
+	overridden := types.TimeoutParams{
+		Propose:             9 * time.Second,
+		ProposeDelta:        8 * time.Second,
+		Vote:                7 * time.Second,
+		VoteDelta:           6 * time.Second,
+		Commit:              5 * time.Second,
+		BypassCommitTimeout: true,
+	}
+	overriddenFalseBypass := overridden
+	overriddenFalseBypass.BypassCommitTimeout = false
+
+	testCases := []struct {
+		name     string
+		cfg      *config.ConsensusConfig
+		params   types.TimeoutParams
+		expected types.TimeoutParams
+	}{
+		{"disabled uses onchain params", cfgWithOverrides(false, true), onchain, onchain},
+		{"disabled keeps legacy behavior", cfgWithOverrides(false, true), types.DefaultTimeoutParams(), overridden},
+		{"enabled applies overrides", cfgWithOverrides(true, false), onchain, overriddenFalseBypass},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := newState(tc.cfg, tc.params)
+
+			require.Equal(t, tc.expected.ProposeTimeout(1), cs.proposeTimeout(1))
+			require.Equal(t, tc.expected.VoteTimeout(2), cs.voteTimeout(2))
+			require.Equal(t, baseTime.Add(tc.expected.Commit), cs.commitTime(baseTime))
+			require.Equal(t, tc.expected.BypassCommitTimeout, cs.bypassCommitTimeout())
+		})
+	}
+
+	t.Run("nil bypass override differs from false pointer", func(t *testing.T) {
+		params := onchain
+		params.BypassCommitTimeout = true
+
+		cfgNil := config.DefaultConsensusConfig()
+		cfgNil.UnsafeOverridesEnabled = true
+		cfgNil.UnsafeBypassCommitTimeoutOverride = nil
+
+		cfgFalse := config.DefaultConsensusConfig()
+		cfgFalse.UnsafeOverridesEnabled = true
+		cfgFalse.UnsafeBypassCommitTimeoutOverride = utils.Alloc(false)
+
+		require.True(t, newState(cfgNil, params).bypassCommitTimeout())
+		require.False(t, newState(cfgFalse, params).bypassCommitTimeout())
+	})
 }

--- a/sei-tendermint/internal/rpc/core/consensus.go
+++ b/sei-tendermint/internal/rpc/core/consensus.go
@@ -170,7 +170,7 @@ func (env *Environment) ConsensusParams(ctx context.Context, req *coretypes.Requ
 	}
 
 	consensusParams.Synchrony = consensusParams.Synchrony.SynchronyParamsOrDefaults()
-	consensusParams.Timeout = consensusParams.Timeout.TimeoutParamsOrDefaults()
+	consensusParams.Timeout = consensusParams.Timeout.Or(types.DefaultTimeoutParams())
 
 	return &coretypes.ResultConsensusParams{
 		BlockHeight:     height,

--- a/sei-tendermint/types/params.go
+++ b/sei-tendermint/types/params.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"cmp"
 	"crypto/sha256"
 	"errors"
 	"fmt"
@@ -211,29 +212,16 @@ func DefaultABCIParams() ABCIParams {
 	}
 }
 
-// TimeoutParamsOrDefaults returns the SynchronyParams, filling in any zero values
-// with the Tendermint defined default values.
-func (t TimeoutParams) TimeoutParamsOrDefaults() TimeoutParams {
-	// TODO: Remove this method and all uses once development on v0.37 begins.
-	// See: https://github.com/tendermint/tendermint/issues/8187
-
-	defaults := DefaultTimeoutParams()
-	if t.Propose == 0 {
-		t.Propose = defaults.Propose
+// replaces zeros in t with values in defaults.
+func (t TimeoutParams) Or(defaults TimeoutParams) TimeoutParams {
+	return TimeoutParams{
+		Propose:             cmp.Or(t.Propose, defaults.Propose),
+		ProposeDelta:        cmp.Or(t.ProposeDelta, defaults.ProposeDelta),
+		Vote:                cmp.Or(t.Vote, defaults.Vote),
+		VoteDelta:           cmp.Or(t.VoteDelta, defaults.VoteDelta),
+		Commit:              cmp.Or(t.Commit, defaults.Commit),
+		BypassCommitTimeout: cmp.Or(t.BypassCommitTimeout, defaults.BypassCommitTimeout),
 	}
-	if t.ProposeDelta == 0 {
-		t.ProposeDelta = defaults.ProposeDelta
-	}
-	if t.Vote == 0 {
-		t.Vote = defaults.Vote
-	}
-	if t.VoteDelta == 0 {
-		t.VoteDelta = defaults.VoteDelta
-	}
-	if t.Commit == 0 {
-		t.Commit = defaults.Commit
-	}
-	return t
 }
 
 // ProposeTimeout returns the amount of time to wait for a proposal.

--- a/sei-tendermint/types/params_test.go
+++ b/sei-tendermint/types/params_test.go
@@ -429,6 +429,81 @@ func TestConsensusParamsUpdate_VoteExtensionsEnableHeight(t *testing.T) {
 	})
 }
 
+func TestTimeoutParamsOr(t *testing.T) {
+	first := TimeoutParams{
+		Propose:             1 * time.Second,
+		ProposeDelta:        2 * time.Second,
+		Vote:                3 * time.Second,
+		VoteDelta:           4 * time.Second,
+		Commit:              5 * time.Second,
+		BypassCommitTimeout: true,
+	}
+	second := TimeoutParams{
+		Propose:             11 * time.Second,
+		ProposeDelta:        12 * time.Second,
+		Vote:                13 * time.Second,
+		VoteDelta:           14 * time.Second,
+		Commit:              15 * time.Second,
+		BypassCommitTimeout: false,
+	}
+
+	durationFields := []struct {
+		name  string
+		field func(*TimeoutParams) *time.Duration
+	}{
+		{
+			name:  "propose",
+			field: func(tp *TimeoutParams) *time.Duration { return &tp.Propose },
+		},
+		{
+			name:  "propose delta",
+			field: func(tp *TimeoutParams) *time.Duration { return &tp.ProposeDelta },
+		},
+		{
+			name:  "vote",
+			field: func(tp *TimeoutParams) *time.Duration { return &tp.Vote },
+		},
+		{
+			name:  "vote delta",
+			field: func(tp *TimeoutParams) *time.Duration { return &tp.VoteDelta },
+		},
+		{
+			name:  "commit",
+			field: func(tp *TimeoutParams) *time.Duration { return &tp.Commit },
+		},
+	}
+
+	for _, tc := range durationFields {
+		t.Run(tc.name, func(t *testing.T) {
+			left := first
+			*tc.field(&left) = 0
+			expected := first
+			*tc.field(&expected) = *tc.field(&second)
+			require.Equal(t, expected, left.Or(second))
+
+			left = first
+			right := second
+			*tc.field(&left) = 0
+			*tc.field(&right) = 0
+			expected = first
+			*tc.field(&expected) = 0
+			require.Equal(t, expected, left.Or(right))
+		})
+	}
+
+	t.Run("bypass commit timeout", func(t *testing.T) {
+		left := first
+		left.BypassCommitTimeout = false
+		expected := first
+		expected.BypassCommitTimeout = second.BypassCommitTimeout
+		require.Equal(t, expected, left.Or(second))
+
+		right := second
+		right.BypassCommitTimeout = false
+		require.Equal(t, expected, left.Or(right))
+	})
+}
+
 func TestProto(t *testing.T) {
 	params := []ConsensusParams{
 		makeParams(makeParamsArgs{blockBytes: 4, blockGas: 2, evidenceAge: 3, maxEvidenceBytes: 1}),


### PR DESCRIPTION
In 6.6 release we want to disable the overrides support.
Overrides can only be disabled AFTER onchain params are updated via government proposal.
Govenment proposal needs to wait for changes deployed in 6.6.
Disabling overrides needs to be synchronized across the network.
We need ability to reenable overrides for disaster recovery (chain halt).

To achieve that we:
* add a unsafeOverridesEnabled flag
* unsafeOverridesEnabled defaults to true BEFORE the government proposal goes through, and to false AFTERWARDS