### PR TITLE
[codex] Fix Giga V2 fallback cache flush

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1483,6 +1483,15 @@ func (app *App) DeliverTxWithResult(ctx sdk.Context, tx []byte, typedTx sdk.Tx) 
 	}
 }
 
+func (app *App) deliverTxWithV2Fallback(ctx sdk.Context, ms sdk.CacheMultiStore, tx []byte, typedTx sdk.Tx) *abci.ExecTxResult {
+	// Giga and V2 maintain separate block-level caches. Publish the Giga
+	// side before switching, then publish V2 so later Giga txs read it.
+	ctx.GigaMultiStore().WriteGiga()
+	res := app.DeliverTxWithResult(ctx, tx, typedTx)
+	ms.Write()
+	return res
+}
+
 func (app *App) ProcessTxsSynchronousV2(ctx sdk.Context, txs [][]byte, typedTxs []sdk.Tx) []*abci.ExecTxResult {
 	blockProcessStart := time.Now()
 	defer func() {
@@ -1588,18 +1597,16 @@ func (app *App) ProcessTxsSynchronousGiga(ctx sdk.Context, txs [][]byte, typedTx
 		if fallbackToV2 {
 			utilmetrics.IncrGigaFallbackToV2Counter() // TODO(PLT-327): remove once app_giga_fallback_to_v2_total verified
 			appMetrics.gigaFallback.Add(ctx.Context(), 1)
-			res := app.DeliverTxWithResult(ctx, tx, typedTxs[i])
+			res := app.deliverTxWithV2Fallback(ctx, ms, tx, typedTxs[i])
 			txResults[i] = res
-			ms.Write()
 			continue
 		}
 
 		if execErr != nil {
 			// Check if this is a fail-fast error (Cosmos precompile interop detected)
 			if gigautils.ShouldExecutionAbort(execErr) {
-				res := app.DeliverTxWithResult(ctx, tx, typedTxs[i])
+				res := app.deliverTxWithV2Fallback(ctx, ms, tx, typedTxs[i])
 				txResults[i] = res
-				ms.Write()
 				continue
 			}
 			txResults[i] = &abci.ExecTxResult{

--- a/app/app.go
+++ b/app/app.go
@@ -1537,9 +1537,8 @@ func (app *App) ProcessTxsSynchronousGiga(ctx sdk.Context, txs [][]byte, typedTx
 		evmMsg := app.GetEVMMsg(typedTxs[i])
 		// If not an EVM tx, fall back to v2 processing
 		if evmMsg == nil {
-			result := app.DeliverTxWithResult(ctx, tx, typedTxs[i])
+			result := app.deliverTxWithV2Fallback(ctx, ms, tx, typedTxs[i])
 			txResults[i] = result
-			ms.Write()
 			continue
 		}
 

--- a/app/app.go
+++ b/app/app.go
@@ -1492,6 +1492,17 @@ func (app *App) deliverTxWithV2Fallback(ctx sdk.Context, ms sdk.CacheMultiStore,
 	return res
 }
 
+type executeEVMTxWithGigaExecutorAfterValidationHookKey struct{}
+
+func runExecuteEVMTxWithGigaExecutorAfterValidationHook(ctx sdk.Context) {
+	// Tests use this unexported context hook to exercise panic recovery after
+	// Giga validation has populated the block-level cache.
+	hook, _ := ctx.Context().Value(executeEVMTxWithGigaExecutorAfterValidationHookKey{}).(func(sdk.Context))
+	if hook != nil {
+		hook(ctx)
+	}
+}
+
 func (app *App) ProcessTxsSynchronousV2(ctx sdk.Context, txs [][]byte, typedTxs []sdk.Tx) []*abci.ExecTxResult {
 	blockProcessStart := time.Now()
 	defer func() {
@@ -2028,6 +2039,8 @@ func (app *App) executeEVMTxWithGigaExecutor(ctx sdk.Context, msg *evmtypes.MsgE
 		// which giga's cachekv doesn't support. Fall back to v2 for this tx.
 		return nil, gigaprecompiles.ErrBalanceMigrationRequired
 	}
+
+	runExecuteEVMTxWithGigaExecutorAfterValidationHook(ctx)
 
 	// Create state DB for this transaction (only for valid transactions)
 	stateDB := gigaevmstate.NewDBImpl(ctx, &app.GigaEvmKeeper, false)

--- a/app/giga_fallback_test.go
+++ b/app/giga_fallback_test.go
@@ -1,0 +1,201 @@
+package app
+
+import (
+	"crypto/ecdsa"
+	"encoding/hex"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/sei-protocol/sei-chain/sei-cosmos/baseapp"
+	cryptotypes "github.com/sei-protocol/sei-chain/sei-cosmos/crypto/types"
+	"github.com/sei-protocol/sei-chain/sei-cosmos/testutil/testdata"
+	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	abci "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
+	tmproto "github.com/sei-protocol/sei-chain/sei-tendermint/proto/tendermint/types"
+	"github.com/sei-protocol/sei-chain/x/evm/config"
+	evmtypes "github.com/sei-protocol/sei-chain/x/evm/types"
+	"github.com/sei-protocol/sei-chain/x/evm/types/ethtx"
+	"github.com/stretchr/testify/require"
+)
+
+type gigaFallbackTestAcct struct {
+	AccountAddress sdk.AccAddress
+	PublicKey      cryptotypes.PubKey
+	EvmAddress     common.Address
+	EvmSigner      ethtypes.Signer
+	EvmPrivateKey  *ecdsa.PrivateKey
+}
+
+func TestDeliverTxWithV2FallbackFlushesGigaBlockCache(t *testing.T) {
+	blockTime := time.Now()
+	validator := newGigaFallbackTestSigner(t)
+	sender := newGigaFallbackTestSigner(t)
+	recipient1 := newGigaFallbackTestSigner(t)
+	recipient2 := newGigaFallbackTestSigner(t)
+	recipient3 := newGigaFallbackTestSigner(t)
+
+	wrapper := NewGigaTestWrapper(t, blockTime, validator.PublicKey, true, false, func(ba *baseapp.BaseApp) {
+		ba.SetOccEnabled(false)
+		ba.SetConcurrencyWorkers(1)
+	})
+	sei := wrapper.App
+	ctx := wrapper.Ctx.WithBlockHeader(tmproto.Header{
+		Height:  wrapper.Ctx.BlockHeader().Height,
+		ChainID: wrapper.Ctx.BlockHeader().ChainID,
+		Time:    blockTime,
+	})
+
+	initialFundingWei := new(big.Int).Mul(big.NewInt(10), big.NewInt(1_000_000_000_000_000_000))
+	gasPrice := big.NewInt(100_000_000_000)
+	values := []*big.Int{
+		big.NewInt(1_000_000_000_000),
+		big.NewInt(2_000_000_000_000),
+		big.NewInt(3_000_000_000_000),
+	}
+
+	sei.EvmKeeper.SetAddressMapping(ctx, sender.AccountAddress, sender.EvmAddress)
+	fundWeiForGigaFallbackTest(t, sei, ctx, sender.AccountAddress, initialFundingWei)
+
+	sei.GigaEvmKeeper.UseRegularStore = false
+	sei.GigaBankKeeper.UseRegularStore = false
+
+	ms := ctx.MultiStore().CacheMultiStore()
+	blockCtx := ctx.WithMultiStore(ms)
+	cache, err := newGigaBlockCache(blockCtx, &sei.GigaEvmKeeper)
+	require.NoError(t, err)
+
+	preBalance := sei.GigaEvmKeeper.GetBalance(blockCtx, sender.AccountAddress)
+	_, tx1 := buildGigaFallbackTestEVMTx(t, sender, &recipient1.EvmAddress, values[0], nil, 21_000, gasPrice, 0)
+	tx2Bytes, tx2 := buildGigaFallbackTestEVMTx(t, sender, &recipient2.EvmAddress, values[1], nil, 21_000, gasPrice, 1)
+	_, tx3 := buildGigaFallbackTestEVMTx(t, sender, &recipient3.EvmAddress, values[2], nil, 21_000, gasPrice, 2)
+
+	result1 := executeGigaFallbackTestTx(t, sei, blockCtx.WithTxIndex(0), tx1, cache)
+
+	// Tx1 has flushed its tx-level cache into Giga's block-level cache. The
+	// fallback bridge must publish that block-level state before V2 executes tx2.
+	result2 := sei.deliverTxWithV2Fallback(blockCtx.WithTxIndex(1), ms, tx2Bytes, tx2)
+	requireGigaFallbackTestSuccess(t, result2, 1)
+
+	result3 := executeGigaFallbackTestTx(t, sei, blockCtx.WithTxIndex(2), tx3, cache)
+	blockCtx.GigaMultiStore().WriteGiga()
+
+	finalBalance := sei.EvmKeeper.GetBalance(ctx, sender.AccountAddress)
+	expected := expectedGigaFallbackTestBalance(preBalance, values, gasPrice, result1, result2, result3)
+	require.Equal(t, 0, finalBalance.Cmp(expected),
+		"sender balance should include Giga tx1, V2 fallback tx2, and Giga tx3")
+}
+
+func buildGigaFallbackTestEVMTx(
+	t testing.TB,
+	signer gigaFallbackTestAcct,
+	to *common.Address,
+	value *big.Int,
+	data []byte,
+	gasLimit uint64,
+	gasPrice *big.Int,
+	nonce uint64,
+) ([]byte, sdk.Tx) {
+	t.Helper()
+
+	signedTx, err := ethtypes.SignTx(ethtypes.NewTx(&ethtypes.DynamicFeeTx{
+		GasFeeCap: gasPrice,
+		GasTipCap: gasPrice,
+		Gas:       gasLimit,
+		ChainID:   big.NewInt(config.DefaultChainID),
+		To:        to,
+		Value:     value,
+		Data:      data,
+		Nonce:     nonce,
+	}), signer.EvmSigner, signer.EvmPrivateKey)
+	require.NoError(t, err)
+
+	txData, err := ethtx.NewTxDataFromTx(signedTx)
+	require.NoError(t, err)
+
+	msg, err := evmtypes.NewMsgEVMTransaction(txData)
+	require.NoError(t, err)
+
+	txBuilder := MakeEncodingConfig().TxConfig.NewTxBuilder()
+	require.NoError(t, txBuilder.SetMsgs(msg))
+	txBuilder.SetGasLimit(10_000_000_000)
+
+	tx := txBuilder.GetTx()
+	txBytes, err := MakeEncodingConfig().TxConfig.TxEncoder()(tx)
+	require.NoError(t, err)
+
+	return txBytes, tx
+}
+
+func executeGigaFallbackTestTx(
+	t testing.TB,
+	sei *App,
+	ctx sdk.Context,
+	tx sdk.Tx,
+	cache *gigaBlockCache,
+) *abci.ExecTxResult {
+	t.Helper()
+
+	msg := sei.GetEVMMsg(tx)
+	require.NotNil(t, msg)
+	result, err := sei.executeEVMTxWithGigaExecutor(ctx, msg, cache)
+	require.NoError(t, err)
+	requireGigaFallbackTestSuccess(t, result, ctx.TxIndex())
+	return result
+}
+
+func requireGigaFallbackTestSuccess(t testing.TB, result *abci.ExecTxResult, txIndex int) {
+	t.Helper()
+
+	require.NotNil(t, result)
+	require.Equal(t, uint32(0), result.Code, "tx[%d] should succeed: %s", txIndex, result.Log)
+	require.NotNil(t, result.EvmTxInfo, "tx[%d] should include EVM info", txIndex)
+	require.Equal(t, uint64(txIndex), result.EvmTxInfo.Nonce, "tx[%d] nonce", txIndex)
+}
+
+func expectedGigaFallbackTestBalance(
+	preBalance *big.Int,
+	values []*big.Int,
+	gasPrice *big.Int,
+	results ...*abci.ExecTxResult,
+) *big.Int {
+	loss := new(big.Int)
+	for _, value := range values {
+		loss.Add(loss, value)
+	}
+	for _, result := range results {
+		loss.Add(loss, new(big.Int).Mul(big.NewInt(result.GasUsed), gasPrice))
+	}
+	return new(big.Int).Sub(preBalance, loss)
+}
+
+func fundWeiForGigaFallbackTest(t testing.TB, sei *App, ctx sdk.Context, addr sdk.AccAddress, amountWei *big.Int) {
+	t.Helper()
+
+	usei := new(big.Int).Div(new(big.Int).Set(amountWei), big.NewInt(1_000_000_000_000))
+	coins := sdk.NewCoins(sdk.NewCoin("usei", sdk.NewIntFromBigInt(usei)))
+	require.NoError(t, sei.BankKeeper.MintCoins(ctx, "mint", coins))
+	require.NoError(t, sei.BankKeeper.SendCoinsFromModuleToAccount(ctx, "mint", addr, coins))
+}
+
+func newGigaFallbackTestSigner(t testing.TB) gigaFallbackTestAcct {
+	t.Helper()
+
+	priv, pubKey, acct := testdata.KeyTestPubAddr()
+	key, err := crypto.HexToECDSA(hex.EncodeToString(priv.Bytes()))
+	require.NoError(t, err)
+
+	ethCfg := evmtypes.DefaultChainConfig().EthereumConfig(big.NewInt(config.DefaultChainID))
+	signer := ethtypes.MakeSigner(ethCfg, big.NewInt(1), 1)
+
+	return gigaFallbackTestAcct{
+		AccountAddress: acct,
+		PublicKey:      pubKey,
+		EvmAddress:     crypto.PubkeyToAddress(key.PublicKey),
+		EvmSigner:      signer,
+		EvmPrivateKey:  key,
+	}
+}

--- a/app/giga_fallback_test.go
+++ b/app/giga_fallback_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
 	"math/big"
@@ -87,6 +88,67 @@ func TestDeliverTxWithV2FallbackFlushesGigaBlockCache(t *testing.T) {
 	expected := expectedGigaFallbackTestBalance(preBalance, values, gasPrice, result1, result2, result3)
 	require.Equal(t, 0, finalBalance.Cmp(expected),
 		"sender balance should include Giga tx1, V2 fallback tx2, and Giga tx3")
+}
+
+func TestProcessTxsSynchronousGigaFallsBackOnIteratorUnsupported(t *testing.T) {
+	blockTime := time.Now()
+	validator := newGigaFallbackTestSigner(t)
+	sender := newGigaFallbackTestSigner(t)
+	recipient1 := newGigaFallbackTestSigner(t)
+	recipient2 := newGigaFallbackTestSigner(t)
+	recipient3 := newGigaFallbackTestSigner(t)
+
+	wrapper := NewGigaTestWrapper(t, blockTime, validator.PublicKey, true, false, func(ba *baseapp.BaseApp) {
+		ba.SetOccEnabled(false)
+		ba.SetConcurrencyWorkers(1)
+	})
+	sei := wrapper.App
+	ctx := wrapper.Ctx.WithBlockHeader(tmproto.Header{
+		Height:  wrapper.Ctx.BlockHeader().Height,
+		ChainID: wrapper.Ctx.BlockHeader().ChainID,
+		Time:    blockTime,
+	})
+
+	initialFundingWei := new(big.Int).Mul(big.NewInt(10), big.NewInt(1_000_000_000_000_000_000))
+	gasPrice := big.NewInt(100_000_000_000)
+	values := []*big.Int{
+		big.NewInt(1_000_000_000_000),
+		big.NewInt(2_000_000_000_000),
+		big.NewInt(3_000_000_000_000),
+	}
+
+	sei.EvmKeeper.SetAddressMapping(ctx, sender.AccountAddress, sender.EvmAddress)
+	fundWeiForGigaFallbackTest(t, sei, ctx, sender.AccountAddress, initialFundingWei)
+
+	sei.GigaEvmKeeper.UseRegularStore = false
+	sei.GigaBankKeeper.UseRegularStore = false
+
+	preBalance := sei.EvmKeeper.GetBalance(ctx, sender.AccountAddress)
+	tx1Bytes, tx1 := buildGigaFallbackTestEVMTx(t, sender, &recipient1.EvmAddress, values[0], nil, 21_000, gasPrice, 0)
+	tx2Bytes, tx2 := buildGigaFallbackTestEVMTx(t, sender, &recipient2.EvmAddress, values[1], nil, 21_000, gasPrice, 1)
+	tx3Bytes, tx3 := buildGigaFallbackTestEVMTx(t, sender, &recipient3.EvmAddress, values[2], nil, 21_000, gasPrice, 2)
+
+	hookCalls := 0
+	ctx = ctx.WithContext(context.WithValue(ctx.Context(), executeEVMTxWithGigaExecutorAfterValidationHookKey{}, func(execCtx sdk.Context) {
+		if execCtx.TxIndex() != 1 {
+			return
+		}
+		hookCalls++
+		iter := execCtx.GigaKVStore(sei.GetKey(evmtypes.StoreKey)).Iterator(nil, nil)
+		require.NoError(t, iter.Close())
+	}))
+
+	results := sei.ProcessTxsSynchronousGiga(ctx, [][]byte{tx1Bytes, tx2Bytes, tx3Bytes}, []sdk.Tx{tx1, tx2, tx3})
+	require.Len(t, results, 3)
+	require.Equal(t, 1, hookCalls)
+	for i, result := range results {
+		requireGigaFallbackTestSuccess(t, result, i)
+	}
+
+	finalBalance := sei.EvmKeeper.GetBalance(ctx, sender.AccountAddress)
+	expected := expectedGigaFallbackTestBalance(preBalance, values, gasPrice, results...)
+	require.Equal(t, 0, finalBalance.Cmp(expected),
+		"sender balance should include Giga tx1, ErrIteratorUnsupported fallback tx2, and Giga tx3")
 }
 
 func buildGigaFallbackTestEVMTx(

--- a/giga/tests/giga_test.go
+++ b/giga/tests/giga_test.go
@@ -1022,6 +1022,71 @@ func TestGigaVsGeth_SelfDestruct(t *testing.T) {
 	CompareReceipts(t, "SelfDestruct", gethCtx, gethResults, gigaCtx, gigaResults)
 }
 
+func TestGigaSequential_FallbackKeepsCumulativeSenderBalance(t *testing.T) {
+	blockTime := time.Now()
+	accts := utils.NewTestAccounts(3)
+
+	sender := utils.NewSigner()
+	recipient1 := utils.NewSigner()
+	recipient2 := utils.NewSigner()
+
+	initialFundingWei := new(big.Int).Mul(big.NewInt(10), big.NewInt(1_000_000_000_000_000_000))
+	transfer1Value := big.NewInt(1_000_000_000_000)
+	transfer3Value := big.NewInt(2_000_000_000_000)
+	gasPrice := big.NewInt(100_000_000_000)
+
+	prepareCtx := func(mode ExecutorMode) (*GigaTestContext, *big.Int) {
+		tCtx := NewGigaTestContext(t, accts, blockTime, 1, mode)
+		tCtx.TestApp.EvmKeeper.SetAddressMapping(tCtx.Ctx, sender.AccountAddress, sender.EvmAddress)
+		fundAccount(t, tCtx, sender.AccountAddress, initialFundingWei)
+		if mode == ModeGigaSequential {
+			tCtx.TestApp.GigaEvmKeeper.UseRegularStore = false
+			tCtx.TestApp.GigaBankKeeper.UseRegularStore = false
+		}
+		return tCtx, tCtx.TestApp.EvmKeeper.GetBalance(tCtx.Ctx, sender.AccountAddress)
+	}
+
+	buildTxs := func(tCtx *GigaTestContext) [][]byte {
+		return [][]byte{
+			createCustomEVMTx(t, tCtx, sender, &recipient1.EvmAddress, transfer1Value, 21_000, gasPrice, gasPrice, 0),
+			createCustomEVMDataTx(t, tCtx, sender, nil, big.NewInt(0), selfDestructInConstructorBytecode, 1_000_000, gasPrice, gasPrice, 1),
+			createCustomEVMTx(t, tCtx, sender, &recipient2.EvmAddress, transfer3Value, 21_000, gasPrice, gasPrice, 2),
+		}
+	}
+
+	expectedFinalBalance := func(preBalance *big.Int, results []*abci.ExecTxResult) *big.Int {
+		loss := new(big.Int).Add(transfer1Value, transfer3Value)
+		for i, result := range results {
+			require.Equal(t, uint32(0), result.Code, "tx[%d] should succeed: %s", i, result.Log)
+			require.NotNil(t, result.EvmTxInfo, "tx[%d] should include EVM info", i)
+			require.Equal(t, uint64(i), result.EvmTxInfo.Nonce, "tx[%d] nonce", i)
+			gasCost := new(big.Int).Mul(big.NewInt(result.GasUsed), gasPrice)
+			loss.Add(loss, gasCost)
+		}
+		return new(big.Int).Sub(preBalance, loss)
+	}
+
+	v2Ctx, v2PreBalance := prepareCtx(ModeV2Sequential)
+	_, v2Results, v2Err := RunBlock(t, v2Ctx, buildTxs(v2Ctx))
+	require.NoError(t, v2Err)
+	require.Len(t, v2Results, 3)
+	v2FinalBalance := v2Ctx.TestApp.EvmKeeper.GetBalance(v2Ctx.Ctx, sender.AccountAddress)
+	require.Equal(t, 0, v2FinalBalance.Cmp(expectedFinalBalance(v2PreBalance, v2Results)),
+		"V2 sender balance should reflect all three txs")
+
+	gigaCtx, gigaPreBalance := prepareCtx(ModeGigaSequential)
+	require.Equal(t, 0, v2PreBalance.Cmp(gigaPreBalance), "test setup should fund both contexts identically")
+	_, gigaResults, gigaErr := RunBlock(t, gigaCtx, buildTxs(gigaCtx))
+	require.NoError(t, gigaErr)
+	require.Len(t, gigaResults, 3)
+
+	gigaFinalBalance := gigaCtx.TestApp.EvmKeeper.GetBalance(gigaCtx.Ctx, sender.AccountAddress)
+	require.Equal(t, 0, gigaFinalBalance.Cmp(expectedFinalBalance(gigaPreBalance, gigaResults)),
+		"Giga sender balance should reflect tx1, fallback tx2, and tx3 cumulatively")
+	require.Equal(t, 0, v2FinalBalance.Cmp(gigaFinalBalance),
+		"Giga final sender balance should match pure V2 execution")
+}
+
 // TestGigaVsGeth_ContractCallsSequential compares Giga vs Geth for sequential contract calls
 // This test deploys a contract and calls it within the same block
 func TestGigaVsGeth_ContractCallsSequential(t *testing.T) {
@@ -2039,6 +2104,21 @@ func createCustomEVMTx(
 	gasTipCap *big.Int,
 	nonce uint64,
 ) []byte {
+	return createCustomEVMDataTx(t, tCtx, signer, to, value, nil, gasLimit, gasFeeCap, gasTipCap, nonce)
+}
+
+func createCustomEVMDataTx(
+	t testing.TB,
+	tCtx *GigaTestContext,
+	signer utils.TestAcct,
+	to *common.Address,
+	value *big.Int,
+	data []byte,
+	gasLimit uint64,
+	gasFeeCap *big.Int,
+	gasTipCap *big.Int,
+	nonce uint64,
+) []byte {
 	tc := app.MakeEncodingConfig().TxConfig
 	tCtx.TestApp.EvmKeeper.SetAddressMapping(tCtx.Ctx, signer.AccountAddress, signer.EvmAddress)
 
@@ -2049,6 +2129,7 @@ func createCustomEVMTx(
 		ChainID:   big.NewInt(config.DefaultChainID),
 		To:        to,
 		Value:     value,
+		Data:      data,
 		Nonce:     nonce,
 	}), signer.EvmSigner, signer.EvmPrivateKey)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Add a `deliverTxWithV2Fallback` bridge that flushes Giga block-level cache state before running the fallback transaction through V2, then flushes V2 block-level state back for subsequent Giga execution.
- Route both synchronous Giga fallback paths through the shared bridge.
- Add a focused regression test proving V2 sees prior Giga state at the fallback boundary, plus a higher-level three-transaction sender-balance scenario.

## Root Cause

Giga and V2 execution use separate block-level cache paths. The fallback path previously ran the V2 transaction without first publishing already-committed Giga block-level writes, so V2 could observe stale nonce/balance state. After V2 completed, subsequent Giga transactions also needed the V2 block-level writes flushed back to the common base.

## Validation

- `go test ./app -run TestDeliverTxWithV2FallbackFlushesGigaBlockCache -count=1`
- `go test ./giga/tests -run TestGigaSequential_FallbackKeepsCumulativeSenderBalance -count=1 -v`

I also verified the focused app regression fails without the Giga pre-flush: tx2 sees sender nonce `0` instead of `1` and fails with `nonce too high`.