### PR TITLE
Don't use hardcoded path to the evmc lib

### DIFF
--- a/giga/executor/lib/evmlib.go
+++ b/giga/executor/lib/evmlib.go
@@ -2,8 +2,6 @@ package lib
 
 import (
 	"fmt"
-	"path/filepath"
-	"runtime"
 
 	"github.com/ethereum/evmc/v12/bindings/go/evmc"
 )
@@ -13,15 +11,9 @@ import (
 // InitEvmoneVM initializes the EVMC VM by loading the platform-specific evmone library.
 // It does not verify that the loaded version is compatible with evmc version.
 func InitEvmoneVM() (*evmc.VM, error) {
-	_, path, _, ok := runtime.Caller(0)
-	if !ok {
-		return nil, fmt.Errorf("failed to get caller information")
-	}
-
-	libPath := filepath.Join(filepath.Dir(path), libName)
-	vm, err := evmc.Load(libPath)
+	vm, err := evmc.Load(libName)
 	if err != nil {
-		return nil, fmt.Errorf("evmc.Load(%q): %w", libPath, err)
+		return nil, fmt.Errorf("evmc.Load(%q): %w", libName, err)
 	}
 
 	return vm, nil


### PR DESCRIPTION
## Describe your changes and provide context

The runtime.Caller(0) returns paths to the source code, not picking them up during runtime.

## Testing performed to validate your change

The nodes are starting with giga executor enabled, instead of crashing trying to pick up the wrong hardcoded path to the .so file.

`panic: failed to load evmone: evmc.Load("/go/src/github.com/sei-protocol/sei/giga/executor/lib/libevmone.0.12.0_linux_amd64.so"): EVMC loading error: /go/src/github.com/sei-protocol/sei/giga/executor/lib/libevmone.0.12.0_linux_amd64.so: cannot open shared object file: No such file or directory`