### PR TITLE
ci: add retry/backoff to GHCR docker pull in integration-test workflow (PLT-753)

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -462,8 +462,17 @@ jobs:
       - name: Load prebuilt seid and pull Docker images
         run: |
           tar -xzf integration-build.tar.gz
-          docker pull "${GHCR_LOCALNODE}:${{ github.run_id }}"
-          docker pull "${GHCR_RPCNODE}:${{ github.run_id }}"
+          pull_with_retry() {
+            local ref="$1"
+            for attempt in 1 2 3 4 5; do
+              if docker pull "$ref"; then return 0; fi
+              echo "docker pull $ref failed (attempt $attempt), retrying in $((attempt*5))s..."
+              sleep $((attempt*5))
+            done
+            echo "docker pull $ref failed after 5 attempts"; return 1
+          }
+          pull_with_retry "${GHCR_LOCALNODE}:${{ github.run_id }}"
+          pull_with_retry "${GHCR_RPCNODE}:${{ github.run_id }}"
           docker tag "${GHCR_LOCALNODE}:${{ github.run_id }}" sei-chain/localnode
           docker tag "${GHCR_RPCNODE}:${{ github.run_id }}" sei-chain/rpcnode
       - name: Start 4 node docker cluster


### PR DESCRIPTION
## Problem

The `Integration Test` matrix jobs intermittently fail at the **"Load prebuilt seid and pull Docker images"** step with transient GHCR errors, before any test runs:

```
Get "https://ghcr.io/token?...&scope=...rpcnode:pull...":
  context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

```
Head "https://ghcr.io/v2/.../localnode/manifests/...":
  net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

## Root cause

PR #3582 switched image distribution from a 1 GB artifact download to GHCR `docker pull`. That pull step used a **bare** `docker pull` with no retry wrapper. The docker client only retries **layer blob downloads** automatically — it does NOT retry the initial **auth-token fetch / manifest HEAD** request, which is exactly where the failures occur. When ~40 matrix jobs start simultaneously and hammer `ghcr.io/token`, a briefly-slow auth response times out, `docker pull` exits 1, and with no retry loop the whole step (and job) fails.

## Fix

Wrap the pulls in a retry-with-backoff loop so the token/manifest request is also retried (5 attempts, linear backoff 5/10/15/20s):

```bash
pull_with_retry() {
  local ref="$1"
  for attempt in 1 2 3 4 5; do
    if docker pull "$ref"; then return 0; fi
    echo "docker pull $ref failed (attempt $attempt), retrying in $((attempt*5))s..."
    sleep $((attempt*5))
  done
  echo "docker pull $ref failed after 5 attempts"; return 1
}
pull_with_retry "${GHCR_LOCALNODE}:${{ github.run_id }}"
pull_with_retry "${GHCR_RPCNODE}:${{ github.run_id }}"
```

Tagging logic is unchanged.

## References

- Closes PLT-753
- Introduced by #3582 (ci: fix flaky integration tests by distributing images via GHCR)
