### PR TITLE
Load evmone from a trusted absolute path and verify its SHA-256

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,11 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
 COPY . .
+
+# Install the platform evmone shared library next to the other native libraries
+# so the Giga executor can load it from a fixed, trusted absolute path (/usr/lib)
+# at runtime instead of relying on the dynamic linker's search path.
+RUN cp giga/executor/lib/libevmone.0.12.0_linux_${TARGETARCH}.so /go/lib/
 ENV CGO_ENABLED=1
 ARG SEI_CHAIN_REF=""
 ARG GO_BUILD_TAGS=""
@@ -43,7 +48,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM docker.io/ubuntu:24.04@sha256:104ae83764a5119017b8e8d6218fa0832b09df65aae7d5a6de29a85d813da2fb
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates && \
+    apt-get install -y --no-install-recommends ca-certificates libstdc++6 && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /go/bin/seid /usr/bin/

--- a/giga/executor/lib/evmlib.go
+++ b/giga/executor/lib/evmlib.go
@@ -1,7 +1,11 @@
 package lib
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 	"runtime"
 
@@ -10,19 +14,89 @@ import (
 
 //go:generate go run ./gen/main.go .
 
-// InitEvmoneVM initializes the EVMC VM by loading the platform-specific evmone library.
+// libDirEnv lets operators point at the directory that holds the trusted,
+// integrity-verified evmone shared library. It must be an absolute path to a
+// root-owned, non-writable directory.
+const libDirEnv = "SEI_EVMONE_LIB_DIR"
+
+// installLibDir is the canonical location the evmone library is installed to
+// in release images (see Dockerfile, which copies it alongside the other
+// native libraries that are loaded from /usr/lib).
+const installLibDir = "/usr/lib"
+
+// InitEvmoneVM initializes the EVMC VM by loading the platform-specific evmone
+// library from a trusted, absolute path.
+//
+// Resolution order (first existing file wins):
+//  1. $SEI_EVMONE_LIB_DIR (operator override)
+//  2. /usr/lib (release install location)
+//  3. the source-tree directory (local development and tests)
+//
+// The file's SHA-256 digest is verified against the digest pinned for this
+// platform before it is handed to the dynamic linker. Passing an absolute
+// path to evmc.Load avoids the dynamic linker's search path
+// (LD_LIBRARY_PATH, ld.so.cache, default dirs), so the library cannot be
+// substituted by planting a file earlier in the loader's search order.
+//
 // It does not verify that the loaded version is compatible with evmc version.
 func InitEvmoneVM() (*evmc.VM, error) {
-	_, path, _, ok := runtime.Caller(0)
-	if !ok {
-		return nil, fmt.Errorf("failed to get caller information")
+	libPath, err := resolveLibPath()
+	if err != nil {
+		return nil, err
 	}
 
-	libPath := filepath.Join(filepath.Dir(path), libName)
+	if err := verifyLibDigest(libPath); err != nil {
+		return nil, err
+	}
+
 	vm, err := evmc.Load(libPath)
 	if err != nil {
 		return nil, fmt.Errorf("evmc.Load(%q): %w", libPath, err)
 	}
 
 	return vm, nil
+}
+
+// resolveLibPath returns the absolute path of the platform library, choosing
+// the first candidate directory that actually contains it.
+func resolveLibPath() (string, error) {
+	dirs := make([]string, 0, 3)
+	if dir := os.Getenv(libDirEnv); dir != "" {
+		dirs = append(dirs, dir)
+	}
+	dirs = append(dirs, installLibDir)
+	if _, srcFile, _, ok := runtime.Caller(0); ok {
+		dirs = append(dirs, filepath.Dir(srcFile))
+	}
+
+	for _, dir := range dirs {
+		candidate := filepath.Join(dir, libName)
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate, nil
+		}
+	}
+
+	return "", fmt.Errorf("evmone library %q not found in any of %v", libName, dirs)
+}
+
+// verifyLibDigest computes the SHA-256 of the file at path and compares it
+// against the digest pinned for this platform, mirroring the integrity check
+// the generator performs when downloading the library (see gen/main.go).
+func verifyLibDigest(path string) error {
+	f, err := os.Open(filepath.Clean(path)) //nolint:gosec // path resolved from trusted, fixed locations
+	if err != nil {
+		return fmt.Errorf("open evmone library %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("hash evmone library %q: %w", path, err)
+	}
+
+	if actual := hex.EncodeToString(h.Sum(nil)); actual != libSHA256 {
+		return fmt.Errorf("evmone library %q digest mismatch: expected %s, got %s", path, libSHA256, actual)
+	}
+
+	return nil
 }

--- a/giga/executor/lib/evmlib_test.go
+++ b/giga/executor/lib/evmlib_test.go
@@ -1,0 +1,30 @@
+package lib
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLibSHA256MatchesCheckedInLibrary(t *testing.T) {
+	_, srcFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "failed to determine source path")
+
+	libPath := filepath.Join(filepath.Dir(srcFile), libName)
+	f, err := os.Open(libPath) //nolint:gosec // test reads a fixed, in-tree path
+	require.NoError(t, err, "open %q: %v", libPath, err)
+	defer func() { require.NoError(t, f.Close()) }()
+
+	h := sha256.New()
+	_, err = io.Copy(h, f)
+	require.NoError(t, err, "hash %q: %v", libPath, err)
+
+	got := hex.EncodeToString(h.Sum(nil))
+	require.Equal(t, libSHA256, got, "checked-in %s digest = %s, want %s", libName, got, libSHA256)
+}

--- a/giga/executor/lib/lib_darwin_arm64.go
+++ b/giga/executor/lib/lib_darwin_arm64.go
@@ -3,3 +3,5 @@
 package lib
 
 const libName = "libevmone.0.12.0_darwin_arm64.dylib"
+
+const libSHA256 = "cb1c555b3849a0a6a9402bc907a9a7bfe14e1c08c483c488ec6ba5f19e986847"

--- a/giga/executor/lib/lib_linux_amd64.go
+++ b/giga/executor/lib/lib_linux_amd64.go
@@ -3,3 +3,5 @@
 package lib
 
 const libName = "libevmone.0.12.0_linux_amd64.so"
+
+const libSHA256 = "0fec5d79f4c9a466bb680e8b0b9c770aea38f3dd6d2e4af23535c893d0d18d40"

--- a/giga/executor/lib/lib_linux_arm64.go
+++ b/giga/executor/lib/lib_linux_arm64.go
@@ -3,3 +3,5 @@
 package lib
 
 const libName = "libevmone.0.12.0_linux_arm64.so"
+
+const libSHA256 = "27bf7d3632eb51c3c87234fa29ac70c471af2357898420ddef0da2c5549bac36"

--- a/giga/executor/lib/lib_unsupported.go
+++ b/giga/executor/lib/lib_unsupported.go
@@ -8,3 +8,5 @@ package lib
 // If you see a compile error referencing this file, you are building
 // for an unsupported OS/architecture combination.
 const libName = evmone_unsupported_platform__only_linux_amd64_linux_arm64_and_darwin_arm64_are_supported
+
+const libSHA256 = ""


### PR DESCRIPTION
InitEvmoneVM located the evmone shared library via runtime.Caller(0), which returns the compile-time source path. That path does not exist on a deployed node, so evmc.Load always failed there.

Resolving the library by bare name (as proposed in #3613) would instead hand the lookup to the dynamic linker's search path (LD_LIBRARY_PATH, ld.so.cache, default dirs). For a consensus-critical process that is an untrusted-search-path risk: any library found earlier in that order is loaded and executed, and the load is decoupled from the SHA-256 the generator pins.

Resolve the library to a trusted absolute path instead ($SEI_EVMONE_LIB_DIR, then /usr/lib, then the source tree for local dev/tests) and verify its SHA-256 against a per-platform pinned digest before handing it to evmc.Load; an absolute path makes dlopen open the file directly and skip the search path entirely. Install the library into /usr/lib in the release image so production resolves it, and add a test asserting the checked-in library matches the pinned digest.
