### PR TITLE
Co-broadcast rich block CW20 transfer with EVM batch

### DIFF
--- a/integration_test/rpc_tests/utils/txUtils.ts
+++ b/integration_test/rpc_tests/utils/txUtils.ts
@@ -456,10 +456,17 @@ export async function buildRichSeiBlock(
                       .then(p => ({ hash: p.hash, wait: p.wait.catch(() => null) }))
                       .catch(() => null)
                 : Promise.resolve(null);
-            const [pendingCosmos, responses] = await Promise.all([
-                cosmosPending,
-                Promise.all(signed.map(raw => provider.broadcastTransaction(raw))),
-            ]);
+            const evmBroadcasts = Promise.all(signed.map(raw => provider.broadcastTransaction(raw)));
+            let pendingCosmos: Awaited<typeof cosmosPending>;
+            let responses: ethers.TransactionResponse[];
+            try {
+                [pendingCosmos, responses] = await Promise.all([cosmosPending, evmBroadcasts]);
+            } catch (e) {
+                pendingCosmos = await cosmosPending;
+                // If the Cosmos tx passed CheckTx, wait for its sequence to settle before retrying.
+                if (pendingCosmos) await pendingCosmos.wait;
+                throw e;
+            }
             // waitForTransaction (unlike resp.wait) does NOT throw on a status-0 receipt, so the
             // two included-but-failed txs resolve to their receipts instead of aborting the batch.
             const receipts = await Promise.all(

--- a/integration_test/rpc_tests/utils/txUtils.ts
+++ b/integration_test/rpc_tests/utils/txUtils.ts
@@ -3,7 +3,8 @@ import { expect } from 'chai';
 import { EvmAccount, abiOf, bytecodeOf, selfAuthorize } from './evmUtils';
 import { RuntimeState, claimPool } from './testUtils';
 import { generateSeiAddress } from './cosmosUtils';
-import { cw20Transfer } from './wasmUtils';
+import { prepareCw20Transfer } from './wasmUtils';
+import { waitUntil } from './chainUtils';
 import { HASH32, BLOOM256, NONCE8, HEX_QUANTITY, HEX_DATA, ADDRESS } from './format';
 import { STAKING_PRECOMPILE_ADDRESS, USEI, ZERO_HASH } from './constants';
 export { STAKING_PRECOMPILE_ADDRESS, USEI, ZERO_HASH };
@@ -230,6 +231,14 @@ async function pricing(
     return { maxFeePerGas, maxPriorityFeePerGas: tip, gasPrice: maxFeePerGas };
 }
 
+async function waitForNextBlock(provider: ethers.JsonRpcProvider, label: string): Promise<void> {
+    const start = await provider.getBlockNumber();
+    await waitUntil(
+        async () => ((await provider.getBlockNumber()) > start ? true : null),
+        { timeoutMs: 10_000, intervalMs: 25, label },
+    );
+}
+
 const TRANSFER_VALUE = ethers.parseEther('0.001');
 const rand = (): string => ethers.Wallet.createRandom().address;
 
@@ -416,23 +425,47 @@ export async function buildRichSeiBlock(
         }
 
         try {
-            const responses = await Promise.all(
-                specs.map(s => s.signer.wallet.sendTransaction(s.req)),
-            );
-            // Fire the Cosmos CW20 transfer right after broadcasting the EVM batch so it
-            // joins the same mempool window. A throw (e.g. a sequence race on retry) just
-            // fails this attempt rather than aborting the build.
-            const cosmosPending = wasm
-                ? cw20Transfer(wasm.cw20, cosmosRecipient!, '1', runtime.funded.adminMnemonic).catch(
-                      () => null,
+            const preparedCosmos = wasm
+                ? await prepareCw20Transfer(
+                      wasm.cw20,
+                      cosmosRecipient!,
+                      '1',
+                      runtime.funded.adminMnemonic,
                   )
+                : undefined;
+            const populated = await Promise.all(
+                specs.map(s => s.signer.wallet.populateTransaction(s.req)),
+            );
+            const signed = await Promise.all(
+                populated.map((tx, i) => specs[i].signer.wallet.signTransaction(tx)),
+            );
+
+            // Stage both sides before a fresh block boundary, then broadcast the pure Cosmos
+            // CW20 transfer and the EVM batch together. Broadcasting the EVM txs first lets a
+            // fast proposer seal them one height before the Cosmos tx, which made the rich-block
+            // fixture flaky.
+            if (wasm) {
+                await waitForNextBlock(
+                    provider,
+                    `next Sei block before rich batch attempt ${attempt + 1}`,
+                );
+            }
+            const cosmosPending = preparedCosmos
+                ? preparedCosmos
+                      .broadcast()
+                      .then(p => ({ hash: p.hash, wait: p.wait.catch(() => null) }))
+                      .catch(() => null)
                 : Promise.resolve(null);
+            const [pendingCosmos, responses] = await Promise.all([
+                cosmosPending,
+                Promise.all(signed.map(raw => provider.broadcastTransaction(raw))),
+            ]);
             // waitForTransaction (unlike resp.wait) does NOT throw on a status-0 receipt, so the
             // two included-but-failed txs resolve to their receipts instead of aborting the batch.
             const receipts = await Promise.all(
                 responses.map(r => provider.waitForTransaction(r.hash, 1, 25_000)),
             );
-            const cosmos = await cosmosPending;
+            const cosmos = pendingCosmos ? await pendingCosmos.wait : null;
             const blockNumbers = receipts.map(r => r!.blockNumber);
             const uniqueBlocks = new Set(blockNumbers);
             const allOk = receipts.every(r => r && (r.status === 1 || r.status === 0));

--- a/integration_test/rpc_tests/utils/wasmUtils.ts
+++ b/integration_test/rpc_tests/utils/wasmUtils.ts
@@ -2,8 +2,10 @@ import util from 'node:util';
 import fs from 'node:fs';
 import { createHash } from 'node:crypto';
 import { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing';
-import { SigningCosmWasmClient } from '@cosmjs/cosmwasm-stargate';
+import { MsgExecuteContractEncodeObject, SigningCosmWasmClient } from '@cosmjs/cosmwasm-stargate';
 import { stringToPath } from '@cosmjs/crypto';
+import { toUtf8 } from '@cosmjs/encoding';
+import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx';
 import { Endpoints } from '../config/endpoints';
 import { waitUntil } from './chainUtils';
 import {
@@ -144,6 +146,59 @@ export interface Cw20ExecResult {
     gasUsed: bigint;
 }
 
+export interface PreparedCw20Transfer {
+    broadcast(): Promise<{ hash: string; wait: Promise<Cw20ExecResult> }>;
+}
+
+const CW20_TRANSFER_MEMO = 'rpc_tests dual-vm cw20 transfer';
+
+async function waitForCw20Exec(
+    client: SigningCosmWasmClient,
+    hash: string,
+): Promise<Cw20ExecResult> {
+    const tx = await waitUntil(
+        async () => client.getTx(hash),
+        { timeoutMs: 60_000, intervalMs: 250, label: `CW20 transfer ${hash}` },
+    );
+    return {
+        hash,
+        height: tx.height,
+        code: tx.code,
+        gasUsed: BigInt(tx.gasUsed),
+    };
+}
+
+/**
+ * Sign a CW20 transfer without broadcasting it. Tests that need a mixed
+ * EVM/Cosmos block use this to stage the Cosmos tx first, then release it in
+ * the same mempool window as their EVM txs.
+ */
+export async function prepareCw20Transfer(
+    cw20Address: string,
+    recipientSei: string,
+    amount: string,
+    adminMnemonic: string,
+): Promise<PreparedCw20Transfer> {
+    const { client, address } = await adminCosmWasm(adminMnemonic);
+    const msg: MsgExecuteContractEncodeObject = {
+        typeUrl: '/cosmwasm.wasm.v1.MsgExecuteContract',
+        value: {
+            sender: address,
+            contract: cw20Address,
+            msg: toUtf8(JSON.stringify({ transfer: { recipient: recipientSei, amount } })),
+            funds: [],
+        },
+    };
+    const txRaw = await client.sign(address, [msg], EXEC_FEE, CW20_TRANSFER_MEMO);
+    const txBytes = TxRaw.encode(txRaw).finish();
+    return {
+        async broadcast() {
+            const hash = await client.broadcastTxSync(txBytes);
+            return { hash, wait: waitForCw20Exec(client, hash) };
+        },
+    };
+}
+
 /**
  * Sign and broadcast a CW20 `transfer` from the admin and wait for inclusion. Returns
  * the block height so the rich-block builder can require it to co-locate with the EVM
@@ -155,18 +210,7 @@ export async function cw20Transfer(
     amount: string,
     adminMnemonic: string,
 ): Promise<Cw20ExecResult> {
-    const { client, address } = await adminCosmWasm(adminMnemonic);
-    const res = await client.execute(
-        address,
-        cw20Address,
-        { transfer: { recipient: recipientSei, amount } },
-        EXEC_FEE,
-        'rpc_tests dual-vm cw20 transfer',
-    );
-    return {
-        hash: res.transactionHash,
-        height: Number(res.height),
-        code: 0,
-        gasUsed: BigInt(res.gasUsed),
-    };
+    const prepared = await prepareCw20Transfer(cw20Address, recipientSei, amount, adminMnemonic);
+    const pending = await prepared.broadcast();
+    return pending.wait;
 }


### PR DESCRIPTION
buildRichSeiBlock broadcast the EVM rich-block batch before starting the pure Cosmos CW20 transfer. On fast CI blocks, the proposer could seal the EVM txs at height N and only include the CW20 transfer at N+1, causing the shared rich block fixture to exhaust retries.

Stage the CW20 execute tx without broadcasting, wait for a fresh block boundary, then broadcast the Cosmos tx and pre-signed EVM batch in the same mempool window. Keep cw20Transfer's existing wait-for-inclusion behavior by layering it on top of the staged broadcast helper.

Flaked on [main](https://github.com/sei-protocol/sei-chain/actions/runs/28020731754/job/82937237940).