### PR TITLE
fix(evmrpc): Cap calls in eth_estimateGasAfterCalls

### DIFF
--- a/evmrpc/config/config.go
+++ b/evmrpc/config/config.go
@@ -104,6 +104,9 @@ type Config struct {
 	// max number of blocks to query logs for
 	MaxBlocksForLog int64 `mapstructure:"max_blocks_for_log"`
 
+	// max number of calls allowed in an eth_estimateGasAfterCalls request
+	MaxEstimateGasCalls int `mapstructure:"max_estimate_gas_calls"`
+
 	// max number of concurrent NewHead subscriptions
 	MaxSubscriptionsNewHead uint64 `mapstructure:"max_subscriptions_new_head"`
 
@@ -185,6 +188,7 @@ var DefaultConfig = Config{
 	DenyList:                     make([]string, 0),
 	MaxLogNoBlock:                10000,
 	MaxBlocksForLog:              2000,
+	MaxEstimateGasCalls:          100,
 	MaxSubscriptionsNewHead:      10000,
 	EnableTestAPI:                false,
 	MaxConcurrentTraceCalls:      10,
@@ -231,6 +235,7 @@ const (
 	flagDenyList                     = "evm.deny_list"
 	flagMaxLogNoBlock                = "evm.max_log_no_block"
 	flagMaxBlocksForLog              = "evm.max_blocks_for_log"
+	flagMaxEstimateGasCalls          = "evm.max_estimate_gas_calls"
 	flagMaxSubscriptionsNewHead      = "evm.max_subscriptions_new_head"
 	flagEnableTestAPI                = "evm.enable_test_api"
 	flagMaxConcurrentTraceCalls      = "evm.max_concurrent_trace_calls"
@@ -348,6 +353,11 @@ func ReadConfig(opts servertypes.AppOptions) (Config, error) {
 	}
 	if v := opts.Get(flagMaxBlocksForLog); v != nil {
 		if cfg.MaxBlocksForLog, err = cast.ToInt64E(v); err != nil {
+			return cfg, err
+		}
+	}
+	if v := opts.Get(flagMaxEstimateGasCalls); v != nil {
+		if cfg.MaxEstimateGasCalls, err = cast.ToIntE(v); err != nil {
 			return cfg, err
 		}
 	}
@@ -577,6 +587,9 @@ max_log_no_block = {{ .EVM.MaxLogNoBlock }}
 
 # max number of blocks to query logs for
 max_blocks_for_log = {{ .EVM.MaxBlocksForLog }}
+
+# max number of calls allowed in an eth_estimateGasAfterCalls request
+max_estimate_gas_calls = {{ .EVM.MaxEstimateGasCalls }}
 
 # max number of concurrent NewHead subscriptions
 max_subscriptions_new_head = {{ .EVM.MaxSubscriptionsNewHead }}

--- a/evmrpc/config/config_test.go
+++ b/evmrpc/config/config_test.go
@@ -29,6 +29,7 @@ type opts struct {
 	denyList                     interface{}
 	maxLogNoBlock                interface{}
 	maxBlocksForLog              interface{}
+	maxEstimateGasCalls          interface{}
 	maxSubscriptionsNewHead      interface{}
 	enableTestAPI                interface{}
 	maxConcurrentTraceCalls      interface{}
@@ -104,6 +105,9 @@ func (o *opts) Get(k string) interface{} {
 	if k == "evm.max_blocks_for_log" {
 		return o.maxBlocksForLog
 	}
+	if k == "evm.max_estimate_gas_calls" {
+		return o.maxEstimateGasCalls
+	}
 	if k == "evm.max_subscriptions_new_head" {
 		return o.maxSubscriptionsNewHead
 	}
@@ -178,6 +182,7 @@ func getDefaultOpts() opts {
 		make([]string, 0),
 		20000,
 		1000,
+		100,
 		10000,
 		false,
 		uint64(10),

--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -80,6 +80,7 @@ func NewEVMHTTPServer(
 		GasCap:                       config.SimulationGasLimit,
 		EVMTimeout:                   config.SimulationEVMTimeout,
 		MaxConcurrentSimulationCalls: config.MaxConcurrentSimulationCalls,
+		MaxEstimateGasCalls:          config.MaxEstimateGasCalls,
 	}
 	watermarks := NewWatermarkManager(tmClient, ctxProvider, stateStore, k.ReceiptStore())
 
@@ -265,6 +266,7 @@ func NewEVMWebSocketServer(
 		GasCap:                       config.SimulationGasLimit,
 		EVMTimeout:                   config.SimulationEVMTimeout,
 		MaxConcurrentSimulationCalls: config.MaxConcurrentSimulationCalls,
+		MaxEstimateGasCalls:          config.MaxEstimateGasCalls,
 	}
 	watermarks := NewWatermarkManager(tmClient, ctxProvider, stateStore, k.ReceiptStore())
 	// DB semaphore aligned with worker count

--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -131,6 +131,11 @@ func (s *SimulationAPI) EstimateGasAfterCalls(ctx context.Context, args export.T
 	defer func() {
 		recordMetricsWithError(ctx, "eth_estimateGasAfterCalls", s.connectionType, startTime, returnErr, recover())
 	}()
+	// Reject over-sized requests early, before any state wrapping or resource acquisition.
+	if maxCalls := s.backend.MaxEstimateGasCalls(); maxCalls > 0 && len(calls) > maxCalls {
+		returnErr = fmt.Errorf("eth_estimateGasAfterCalls: too many calls (%d > %d)", len(calls), maxCalls)
+		return
+	}
 	/* ---------- fail‑fast limiter ---------- */
 	if s.requestLimiter != nil {
 		if !s.requestLimiter.TryAcquire(1) {
@@ -220,6 +225,7 @@ type SimulateConfig struct {
 	GasCap                       uint64
 	EVMTimeout                   time.Duration
 	MaxConcurrentSimulationCalls int
+	MaxEstimateGasCalls          int
 }
 
 var _ tracers.Backend = (*Backend)(nil)
@@ -446,6 +452,8 @@ func (b Backend) BlockByHash(ctx context.Context, hash common.Hash) (*ethtypes.B
 func (b *Backend) RPCGasCap() uint64 { return b.config.GasCap }
 
 func (b *Backend) RPCEVMTimeout() time.Duration { return b.config.EVMTimeout }
+
+func (b *Backend) MaxEstimateGasCalls() int { return b.config.MaxEstimateGasCalls }
 
 func (b *Backend) chainConfigForHeight(height int64) *params.ChainConfig {
 	ctx := b.ctxProvider(height)

--- a/evmrpc/simulate_test.go
+++ b/evmrpc/simulate_test.go
@@ -256,7 +256,7 @@ func TestEstimateGasAfterCallsMaxCalls(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "too many calls")
 
-	// At the cap: the size guard is passed (any error must not be the cap error).
+	// At the cap: the size guard is passed.
 	atCap := make([]export.TransactionArgs, maxCalls)
 	for i := range atCap {
 		atCap[i] = call

--- a/evmrpc/simulate_test.go
+++ b/evmrpc/simulate_test.go
@@ -209,6 +209,62 @@ func TestEstimateGasAfterCalls(t *testing.T) {
 	Ctx = Ctx.WithBlockHeight(8)
 }
 
+func TestEstimateGasAfterCallsMaxCalls(t *testing.T) {
+	testCtx := Ctx.WithBlockHeight(1)
+	ctxProvider := func(height int64) sdk.Context {
+		if height == evmrpc.LatestCtxHeight {
+			return testCtx.WithIsTracing(true)
+		}
+		return testCtx.WithBlockHeight(height).WithIsTracing(true)
+	}
+
+	const maxCalls = 2
+	config := &evmrpc.SimulateConfig{
+		GasCap:              1000000,
+		EVMTimeout:          5 * time.Second,
+		MaxEstimateGasCalls: maxCalls,
+	}
+
+	testApp := testkeeper.TestApp(t)
+	watermarks := evmrpc.NewWatermarkManager(&MockClient{}, ctxProvider, nil, EVMKeeper.ReceiptStore())
+	simAPI := evmrpc.NewSimulationAPI(
+		ctxProvider,
+		EVMKeeper,
+		legacyabci.BeginBlockKeepers{},
+		func(int64) client.TxConfig { return TxConfig },
+		&MockClient{},
+		config,
+		testApp.BaseApp,
+		testApp.TracerAnteHandler,
+		evmrpc.ConnectionTypeHTTP,
+		evmrpc.NewBlockCache(3000),
+		&sync.Mutex{},
+		watermarks,
+	)
+
+	_, from := testkeeper.MockAddressPair()
+	_, to := testkeeper.MockAddressPair()
+	args := export.TransactionArgs{From: &from, To: &to}
+	call := export.TransactionArgs{From: &from, To: &to}
+
+	// Over the cap: rejected early with the "too many calls" error.
+	oversized := make([]export.TransactionArgs, maxCalls+1)
+	for i := range oversized {
+		oversized[i] = call
+	}
+	_, err := simAPI.EstimateGasAfterCalls(t.Context(), args, oversized, nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too many calls")
+
+	// At the cap: the size guard is passed (any error must not be the cap error).
+	atCap := make([]export.TransactionArgs, maxCalls)
+	for i := range atCap {
+		atCap[i] = call
+	}
+	_, err = simAPI.EstimateGasAfterCalls(t.Context(), args, atCap, nil, nil)
+	require.Nil(t, err)
+}
+
 func TestCreateAccessList(t *testing.T) {
 	Ctx = Ctx.WithBlockHeight(1)
 


### PR DESCRIPTION
## Describe your changes and provide context

`eth_estimateGasAfterCalls` replays every entry in its `calls` array
through a full EVM execution before estimating gas for the final transaction.
The `calls` slice was previously unbounded, so a single request could drive
`len(calls) × gasCap` of EVM work — an issue that the
per-request rate limiter does not bound.

This PR validates `len(calls) <= max_estimate_gas_calls` at the very top of the
handler, **before** the rate limiter and any state wrapping, so oversized
requests are rejected early without acquiring a limiter token or loading state.

Changes:
- Add `max_estimate_gas_calls` to the EVM RPC config (`mapstructure` tag, flag
  `evm.max_estimate_gas_calls`, parser entry, and `app.toml` template line),
  defaulting to **100**.
- Thread the value through `SimulateConfig` (both constructions in `server.go`)
  and expose it via `Backend.MaxEstimateGasCalls()`.
- Reject over-sized `EstimateGasAfterCalls` requests with
  `eth_estimateGasAfterCalls: too many calls (%d > %d)`. A value of `0` means
  unlimited (explicit opt-out).

Upgrade safety: `ReadConfig` starts from `DefaultConfig` and only overrides a
field when the key is present, so a node upgraded with an existing `app.toml`
that lacks the key keeps the default of 100 — the cap is not silently disabled.

## Testing performed to validate your change

- `TestEstimateGasAfterCallsMaxCalls` (new): over-cap request is rejected with
  the "too many calls" error; an at-cap request passes the size guard.
- Updated `config_test.go` so `TestReadConfig` recognizes the new key.
- `go test ./evmrpc/ ./evmrpc/config/...` passes; `gofmt` clean.
