### PR TITLE
downgrading logging levels in p2p

### DIFF
--- a/sei-tendermint/internal/p2p/router.go
+++ b/sei-tendermint/internal/p2p/router.go
@@ -241,7 +241,7 @@ func (r *Router) acceptPeersRoutine(ctx context.Context) error {
 					release()
 					return r.runConn(ctx, hConn, info, utils.None[NodeAddress]())
 				})
-				logger.Error("r.runConn(inbound)", "addr", addr, "err", err)
+				logger.Info("r.runConn(inbound)", "addr", addr, "err", err)
 				return nil
 			})
 		}
@@ -319,7 +319,7 @@ func (r *Router) dialPeersRoutine(ctx context.Context) error {
 					}
 					return nil
 				})
-				logger.Error("r.runConn(outbound)", "id", id, "err", err)
+				logger.Warn("r.runConn(outbound)", "id", id, "err", err)
 				return nil
 			})
 		}
@@ -364,7 +364,7 @@ func (r *Router) metricsRoutine(ctx context.Context) error {
 
 // Evict reports a peer misbehavior and forces peer to be disconnected.
 func (r *Router) Evict(id types.NodeID, err error) {
-	logger.Error("evicting", "peer", id, "err", err)
+	logger.Warn("evicting", "peer", id, "err", err)
 	r.peerManager.Evict(id)
 }
 


### PR DESCRIPTION
* inbound connection errors will be logged as Info
* outbound connection errors will be logged as Warn
* eviction will be logged as Warn
* configuration issues stay logged as Error