### PR TITLE
feat(evmrpc): configurable batch request limit and batch response size

### DIFF
--- a/evmrpc/config/config.go
+++ b/evmrpc/config/config.go
@@ -166,6 +166,14 @@ type Config struct {
 
 	// IPRateLimitBurst is the maximum per-IP burst size.
 	IPRateLimitBurst int `mapstructure:"ip_rate_limit_burst"`
+
+	// BatchRequestLimit is the maximum number of requests allowed in a single
+	// JSON-RPC batch (HTTP and WebSocket). Set to 0 to disable the limit.
+	BatchRequestLimit int `mapstructure:"batch_request_limit"`
+
+	// BatchResponseMaxSize is the maximum number of bytes returned from a
+	// batched JSON-RPC call (HTTP and WebSocket). Set to 0 to disable the limit.
+	BatchResponseMaxSize int `mapstructure:"batch_response_max_size"`
 }
 
 var DefaultConfig = Config{
@@ -213,6 +221,8 @@ var DefaultConfig = Config{
 	TraceBakeSnapshotWindow: 64,
 	IPRateLimitRPS:          200,
 	IPRateLimitBurst:        400,
+	BatchRequestLimit:       1000,
+	BatchResponseMaxSize:    25 * 1000 * 1000, // 25MB
 }
 
 const (
@@ -256,6 +266,8 @@ const (
 	flagTraceBakeSnapshotWindow      = "evm.trace_bake_snapshot_window"
 	flagIPRateLimitRPS               = "evm.ip_rate_limit_rps"
 	flagIPRateLimitBurst             = "evm.ip_rate_limit_burst"
+	flagBatchRequestLimit            = "evm.batch_request_limit"
+	flagBatchResponseMaxSize         = "evm.batch_response_max_size"
 )
 
 func ReadConfig(opts servertypes.AppOptions) (Config, error) {
@@ -461,6 +473,16 @@ func ReadConfig(opts servertypes.AppOptions) (Config, error) {
 			return cfg, err
 		}
 	}
+	if v := opts.Get(flagBatchRequestLimit); v != nil {
+		if cfg.BatchRequestLimit, err = cast.ToIntE(v); err != nil {
+			return cfg, err
+		}
+	}
+	if v := opts.Get(flagBatchResponseMaxSize); v != nil {
+		if cfg.BatchResponseMaxSize, err = cast.ToIntE(v); err != nil {
+			return cfg, err
+		}
+	}
 	return cfg, nil
 }
 
@@ -656,5 +678,13 @@ ip_rate_limit_rps = {{ .EVM.IPRateLimitRPS }}
 
 # ip_rate_limit_burst is the maximum per-IP burst above the sustained rate.
 ip_rate_limit_burst = {{ .EVM.IPRateLimitBurst }}
+
+# batch_request_limit is the maximum number of requests allowed in a single
+# JSON-RPC batch (HTTP and WebSocket). Set to 0 to disable the limit.
+batch_request_limit = {{ .EVM.BatchRequestLimit }}
+
+# batch_response_max_size is the maximum number of bytes returned from a
+# batched JSON-RPC call (HTTP and WebSocket). Set to 0 to disable the limit.
+batch_response_max_size = {{ .EVM.BatchResponseMaxSize }}
 
 `

--- a/evmrpc/config/config_test.go
+++ b/evmrpc/config/config_test.go
@@ -42,6 +42,8 @@ type opts struct {
 	workerQueueSize              interface{}
 	ipRateLimitRPS               interface{}
 	ipRateLimitBurst             interface{}
+	batchRequestLimit            interface{}
+	batchResponseMaxSize         interface{}
 }
 
 func (o *opts) Get(k string) interface{} {
@@ -156,6 +158,12 @@ func (o *opts) Get(k string) interface{} {
 	if k == "evm.ip_rate_limit_burst" {
 		return o.ipRateLimitBurst
 	}
+	if k == "evm.batch_request_limit" {
+		return o.batchRequestLimit
+	}
+	if k == "evm.batch_response_max_size" {
+		return o.batchResponseMaxSize
+	}
 	panic("unknown key")
 }
 
@@ -195,6 +203,8 @@ func getDefaultOpts() opts {
 		1000,
 		200.0,
 		400,
+		1000,
+		25 * 1000 * 1000,
 	}
 }
 
@@ -321,6 +331,17 @@ func TestReadConfig(t *testing.T) {
 	_, err = config.ReadConfig(&badOpts)
 	require.NotNil(t, err)
 
+	// Test bad types for batch limit config
+	badOpts = goodOpts
+	badOpts.batchRequestLimit = "bad"
+	_, err = config.ReadConfig(&badOpts)
+	require.NotNil(t, err)
+
+	badOpts = goodOpts
+	badOpts.batchResponseMaxSize = "bad"
+	_, err = config.ReadConfig(&badOpts)
+	require.NotNil(t, err)
+
 }
 
 // Test worker pool configuration values
@@ -378,6 +399,23 @@ func TestReadConfigWorkerPool(t *testing.T) {
 				"WorkerQueueSize mismatch")
 		})
 	}
+}
+
+func TestReadConfigBatchLimits(t *testing.T) {
+	// Defaults flow through when not overridden.
+	cfg, err := config.ReadConfig(&opts{})
+	require.NoError(t, err)
+	require.Equal(t, config.DefaultConfig.BatchRequestLimit, cfg.BatchRequestLimit)
+	require.Equal(t, config.DefaultConfig.BatchResponseMaxSize, cfg.BatchResponseMaxSize)
+
+	// Custom values (including 0 to disable) flow through.
+	o := getDefaultOpts()
+	o.batchRequestLimit = 50
+	o.batchResponseMaxSize = 0
+	cfg, err = config.ReadConfig(&o)
+	require.NoError(t, err)
+	require.Equal(t, 50, cfg.BatchRequestLimit)
+	require.Equal(t, 0, cfg.BatchResponseMaxSize)
 }
 
 func TestReadConfigEnableParallelizedBlockTrace(t *testing.T) {

--- a/evmrpc/server.go
+++ b/evmrpc/server.go
@@ -220,12 +220,15 @@ func NewEVMHTTPServer(
 		logger.Info("Disabling Test EVM APIs", "liveChainID", evmCfg.IsLiveChainID(ctx), "enableTestAPI", config.EnableTestAPI)
 	}
 
-	if err := httpServer.EnableRPC(apis, HTTPConfig{
+	httpConfig := HTTPConfig{
 		CorsAllowedOrigins: strings.Split(config.CORSOrigins, ","),
 		Vhosts:             []string{"*"},
 		DenyList:           config.DenyList,
 		SeiLegacyAllowlist: seiLegacyAllowlist,
-	}); err != nil {
+	}
+	httpConfig.batchItemLimit = config.BatchRequestLimit
+	httpConfig.batchResponseSizeLimit = config.BatchResponseMaxSize
+	if err := httpServer.EnableRPC(apis, httpConfig); err != nil {
 		return nil, err
 	}
 
@@ -329,6 +332,8 @@ func NewEVMWebSocketServer(
 
 	wsConfig := WsConfig{Origins: strings.Split(config.WSOrigins, ",")}
 	wsConfig.readLimit = DefaultWebsocketMaxMessageSize
+	wsConfig.batchItemLimit = config.BatchRequestLimit
+	wsConfig.batchResponseSizeLimit = config.BatchResponseMaxSize
 	if err := httpServer.EnableWS(apis, wsConfig); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Describe your changes and provide context

Adds two new EVM JSON-RPC config fields to bound the size of batched JSON-RPC calls (PLT-703):

- **`evm.batch_request_limit`** — maximum number of requests allowed in a single JSON-RPC batch. Default `1000`.
- **`evm.batch_response_max_size`** — maximum number of bytes returned from a batched JSON-RPC call. Default `25MB` (`25 * 1000 * 1000`).

Both apply to HTTP and WebSocket endpoints, and both can be set to `0` to disable the limit. The values are wired through to go-ethereum's `batchItemLimit` / `batchResponseSizeLimit` on the HTTP and WebSocket server configs in `evmrpc/server.go`.

Changes:
- `evmrpc/config/config.go` — new `Config` fields, defaults, flag names, `ReadConfig` parsing, and `app.toml` template entries with documentation.
- `evmrpc/server.go` — populate `batchItemLimit` / `batchResponseSizeLimit` for both the HTTP and WebSocket servers.

## Testing performed to validate your change

- `evmrpc/config/config_test.go`:
  - Added bad-type cases to `TestReadConfig` for both new fields.
  - Added `TestReadConfigBatchLimits` covering defaults flowing through and custom values (including `0` to disable) being parsed.
- `go test ./evmrpc/config/...`
