### PR TITLE
ci(PLT-761): cancel superseded integration-test PR runs and defer Autobahn Gov/Mint/Upgrade to merge queue

### DIFF
--- a/.github/workflows/integration-test-matrix.json
+++ b/.github/workflows/integration-test-matrix.json
@@ -94,7 +94,6 @@
   },
   {
     "name": "Autobahn SeiDB State Store",
-    "merge_only": true,
     "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
     "scripts": [
       "docker exec sei-node-0 integration_test/contracts/deploy_wasm_contracts.sh",
@@ -144,7 +143,6 @@
   },
   {
     "name": "Autobahn EVM Module (Compat)",
-    "merge_only": true,
     "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
     "scripts": [
       "./integration_test/evm_module/scripts/evm_compat_tests.sh"
@@ -152,7 +150,6 @@
   },
   {
     "name": "Autobahn EVM Module (Precompile & Endpoints)",
-    "merge_only": true,
     "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
     "scripts": [
       "./integration_test/evm_module/scripts/evm_precompile_tests.sh",
@@ -177,7 +174,6 @@
   },
   {
     "name": "Autobahn EVM Interoperability (Pointer Tests)",
-    "merge_only": true,
     "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
     "scripts": [
       "./integration_test/evm_module/scripts/evm_interoperability_pointer_tests.sh"
@@ -185,7 +181,6 @@
   },
   {
     "name": "Autobahn EVM Interoperability (Misc Tests)",
-    "merge_only": true,
     "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
     "scripts": [
       "./integration_test/evm_module/scripts/evm_interoperability_misc_tests.sh"
@@ -220,7 +215,6 @@
   },
   {
     "name": "Autobahn EVM GIGA Module",
-    "merge_only": true,
     "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
     "scripts": [
       "./integration_test/evm_module/scripts/evm_giga_tests.sh"
@@ -242,7 +236,6 @@
   },
   {
     "name": "Autobahn RPC .io/.iox (spec fixtures)",
-    "merge_only": true,
     "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true",
     "scripts": [
       "./integration_test/evm_module/scripts/evm_rpc_tests.sh"

--- a/.github/workflows/integration-test-matrix.json
+++ b/.github/workflows/integration-test-matrix.json
@@ -1,0 +1,258 @@
+[
+  {
+    "name": "Wasm Module",
+    "scripts": [
+      "docker exec sei-node-0 integration_test/contracts/deploy_timelocked_token_contract.sh",
+      "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestWasmModuleCore",
+      "docker exec sei-node-0 integration_test/contracts/deploy_timelocked_token_contract.sh",
+      "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestWasmModuleEmergencyWithdraw"
+    ]
+  },
+  {
+    "name": "Mint & Staking & Bank Module",
+    "scripts": [
+      "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run \"TestMintModule|TestStakingModule|TestBankModule\""
+    ]
+  },
+  {
+    "name": "Autobahn Mint & Staking & Bank Module",
+    "merge_only": true,
+    "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
+    "scripts": [
+      "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run \"TestMintModule|TestStakingModule|TestAutobahnBankModule\""
+    ]
+  },
+  {
+    "name": "Gov & Oracle & Authz Module",
+    "scripts": [
+      "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run \"TestGovModule|TestOracleModule|TestAuthzModule\""
+    ]
+  },
+  {
+    "name": "Autobahn Gov & Oracle & Authz Module",
+    "merge_only": true,
+    "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
+    "scripts": [
+      "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run \"TestGovModule|TestOracleModule|TestAuthzModule\""
+    ]
+  },
+  {
+    "name": "Chain Operation Test",
+    "env": "GIGA_STORAGE=true",
+    "scripts": [
+      "until [ $(cat build/generated/rpc-launch.complete |wc -l) = 1 ]; do sleep 10; done",
+      "until [[ $(docker exec sei-rpc-node build/seid status |jq -M -r .SyncInfo.latest_block_height) -gt 10 ]]; do sleep 10; done",
+      "echo rpc node started",
+      "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run \"TestChainOperation|TestStateSync\"",
+      "./integration_test/contracts/verify_statesync_flatkv_digest.sh",
+      "./integration_test/contracts/verify_cross_validator_flatkv_digest.sh"
+    ]
+  },
+  {
+    "name": "Distribution Module",
+    "scripts": [
+      "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestDistributionModule"
+    ]
+  },
+  {
+    "name": "Upgrade Module (Major)",
+    "env": "GIGA_STORAGE=true UPGRADE_VERSION_LIST=v1.0.0,v1.0.1,v1.0.2",
+    "scripts": [
+      "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestUpgradeMajor"
+    ]
+  },
+  {
+    "name": "Autobahn Upgrade Module (Major)",
+    "merge_only": true,
+    "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true UPGRADE_VERSION_LIST=v1.0.0,v1.0.1,v1.0.2",
+    "scripts": [
+      "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestUpgradeMajor"
+    ]
+  },
+  {
+    "name": "Upgrade Module (Minor)",
+    "env": "GIGA_STORAGE=true UPGRADE_VERSION_LIST=v1.0.0,v1.0.1,v1.0.2",
+    "scripts": [
+      "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestUpgradeMinor"
+    ]
+  },
+  {
+    "name": "Autobahn Upgrade Module (Minor)",
+    "merge_only": true,
+    "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true UPGRADE_VERSION_LIST=v1.0.0,v1.0.1,v1.0.2",
+    "scripts": [
+      "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestUpgradeMinor"
+    ]
+  },
+  {
+    "name": "SeiDB State Store",
+    "scripts": [
+      "docker exec sei-node-0 integration_test/contracts/deploy_wasm_contracts.sh",
+      "docker exec sei-node-0 integration_test/contracts/create_tokenfactory_denoms.sh",
+      "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestSeiDBStateStore"
+    ]
+  },
+  {
+    "name": "Autobahn SeiDB State Store",
+    "merge_only": true,
+    "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
+    "scripts": [
+      "docker exec sei-node-0 integration_test/contracts/deploy_wasm_contracts.sh",
+      "docker exec sei-node-0 integration_test/contracts/create_tokenfactory_denoms.sh",
+      "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestSeiDBStateStore"
+    ]
+  },
+  {
+    "_comment": "Umbrella job for all FlatKV-specific docker-level coverage. Future FlatKV scenarios (additional bucket layouts, snapshot rotation, etc.) should be appended here rather than added as new matrix rows, so the CI surface stays one row per concern. The cluster boots with GIGA_STORAGE=true, so FlatKV is enabled from genesis (sc-write-mode = test_only_dual_write) and the FlatKV LtHash is folded into every block's AppHash from block 1. No mid-life migration is exercised here; an offline memiavl -> FlatKV import would change the AppHash trajectory at the import boundary and break tendermint replay. Step ordering: 1-3 deploy an EVM fixture, smoke-check EVM RPC reads, and verify the fixture round-tripped through dual_write into physical FlatKV; 4 SIGKILL one validator, restart, and assert 4-node FlatKV digest equality (WAL recovery on a live FlatKV cluster); 5-7 destructive disaster-recovery scenarios, run last because they wipe or damage one validator's local state.",
+    "name": "FlatKV Integration",
+    "env": "GIGA_STORAGE=true",
+    "scripts": [
+      "docker exec sei-node-0 integration_test/contracts/deploy_flatkv_evm_fixture.sh",
+      "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestSeiDBFlatKV",
+      "docker exec sei-node-0 integration_test/contracts/verify_flatkv_evm_store.sh",
+      "./integration_test/contracts/verify_flatkv_crash_recovery.sh",
+      "./integration_test/contracts/verify_flatkv_statesync_crash_recovery.sh",
+      "./integration_test/contracts/verify_flatkv_total_loss_recovery.sh",
+      "./integration_test/contracts/verify_flatkv_partial_loss_fails_loudly.sh"
+    ]
+  },
+  {
+    "_comment": "Post-migration FlatKV-only state-sync coverage. The cluster boots directly in sc-write-mode = flatkv_only, so memiavl is not allocated and all module state is served from FlatKV. The script kills and wipes one validator, configures it for state-sync from the remaining validators, and verifies the recovered FlatKV digest matches the donors at a shared height.",
+    "name": "FlatKV Only State Sync",
+    "env": "GIGA_FLATKV_ONLY=true",
+    "scripts": [
+      "docker exec sei-node-0 integration_test/contracts/deploy_flatkv_evm_fixture.sh",
+      "./integration_test/contracts/verify_flatkv_only_statesync.sh"
+    ]
+  },
+  {
+    "name": "EVM Module (Compat)",
+    "env": "GIGA_STORAGE=true",
+    "scripts": [
+      "./integration_test/evm_module/scripts/evm_compat_tests.sh"
+    ]
+  },
+  {
+    "name": "EVM Module (Precompile & Endpoints)",
+    "env": "GIGA_STORAGE=true",
+    "scripts": [
+      "./integration_test/evm_module/scripts/evm_precompile_tests.sh",
+      "docker exec sei-node-0 integration_test/contracts/deploy_flatkv_evm_fixture.sh",
+      "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestSeiDBFlatKV",
+      "docker exec sei-node-0 integration_test/contracts/verify_flatkv_evm_store.sh"
+    ]
+  },
+  {
+    "name": "Autobahn EVM Module (Compat)",
+    "merge_only": true,
+    "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
+    "scripts": [
+      "./integration_test/evm_module/scripts/evm_compat_tests.sh"
+    ]
+  },
+  {
+    "name": "Autobahn EVM Module (Precompile & Endpoints)",
+    "merge_only": true,
+    "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
+    "scripts": [
+      "./integration_test/evm_module/scripts/evm_precompile_tests.sh",
+      "docker exec sei-node-0 integration_test/contracts/deploy_flatkv_evm_fixture.sh",
+      "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestSeiDBFlatKV",
+      "docker exec sei-node-0 integration_test/contracts/verify_flatkv_evm_store.sh"
+    ]
+  },
+  {
+    "name": "EVM Interoperability (Pointer Tests)",
+    "env": "GIGA_STORAGE=true",
+    "scripts": [
+      "./integration_test/evm_module/scripts/evm_interoperability_pointer_tests.sh"
+    ]
+  },
+  {
+    "name": "EVM Interoperability (Misc Tests)",
+    "env": "GIGA_STORAGE=true",
+    "scripts": [
+      "./integration_test/evm_module/scripts/evm_interoperability_misc_tests.sh"
+    ]
+  },
+  {
+    "name": "Autobahn EVM Interoperability (Pointer Tests)",
+    "merge_only": true,
+    "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
+    "scripts": [
+      "./integration_test/evm_module/scripts/evm_interoperability_pointer_tests.sh"
+    ]
+  },
+  {
+    "name": "Autobahn EVM Interoperability (Misc Tests)",
+    "merge_only": true,
+    "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
+    "scripts": [
+      "./integration_test/evm_module/scripts/evm_interoperability_misc_tests.sh"
+    ]
+  },
+  {
+    "name": "Disable WASM Tests",
+    "scripts": [
+      "./integration_test/evm_module/scripts/disable_wasm.sh"
+    ]
+  },
+  {
+    "name": "dApp Tests (Uniswap)",
+    "env": "GIGA_STORAGE=true",
+    "scripts": [
+      "./integration_test/dapp_tests/dapp_uniswap_tests.sh"
+    ]
+  },
+  {
+    "name": "dApp Tests (NFT & Steak)",
+    "env": "GIGA_STORAGE=true",
+    "scripts": [
+      "./integration_test/dapp_tests/dapp_nft_steak_tests.sh"
+    ]
+  },
+  {
+    "name": "EVM GIGA Module",
+    "env": "GIGA_STORAGE=true GIGA_EXECUTOR=true GIGA_OCC=true",
+    "scripts": [
+      "./integration_test/evm_module/scripts/evm_giga_tests.sh"
+    ]
+  },
+  {
+    "name": "Autobahn EVM GIGA Module",
+    "merge_only": true,
+    "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
+    "scripts": [
+      "./integration_test/evm_module/scripts/evm_giga_tests.sh"
+    ]
+  },
+  {
+    "name": "EVM GIGA Mixed (Determinism)",
+    "env": "GIGA_STORAGE=true",
+    "scripts": [
+      "./integration_test/evm_module/scripts/evm_giga_mixed_tests.sh"
+    ]
+  },
+  {
+    "name": "EVM RPC .io/.iox (spec fixtures)",
+    "env": "GIGA_STORAGE=true",
+    "scripts": [
+      "./integration_test/evm_module/scripts/evm_rpc_tests.sh"
+    ]
+  },
+  {
+    "name": "Autobahn RPC .io/.iox (spec fixtures)",
+    "merge_only": true,
+    "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true",
+    "scripts": [
+      "./integration_test/evm_module/scripts/evm_rpc_tests.sh"
+    ]
+  },
+  {
+    "name": "EVM RPC Parity (geth reference)",
+    "env": "GIGA_STORAGE=true",
+    "scripts": [
+      "./integration_test/rpc_tests/scripts/run-ci.sh"
+    ]
+  }
+]

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,7 +19,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 defaults:
   run:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -17,6 +17,10 @@ on:
       - main
       - release/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -26,6 +26,37 @@ defaults:
     shell: bash
 
 jobs:
+  # Generate the integration-test matrix from integration-test-matrix.json.
+  # On pull_request we drop entries tagged `merge_only: true` (the full Autobahn
+  # GIGA-mode variants) to cut per-PR ubuntu-large fan-out; on push and merge
+  # queue the full matrix runs. The matrix is built here, in a job output,
+  # because the `matrix` context is NOT available to a job-level `if:` — a
+  # per-combination `if` on the test job would fail workflow validation
+  # (startup failure), so the filtering must happen before the matrix expands.
+  set-matrix:
+    name: Resolve integration test matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      tests: ${{ steps.build.outputs.tests }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Build matrix
+        id: build
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          matrix_file=.github/workflows/integration-test-matrix.json
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            # Defer merge_only entries to merge queue / push.
+            tests=$(jq -c '[.[] | select(.merge_only != true)]' "$matrix_file")
+          else
+            tests=$(jq -c '.' "$matrix_file")
+          fi
+          echo "tests=$tests" >> "$GITHUB_OUTPUT"
+          echo "Selected $(echo "$tests" | jq 'length') of $(jq 'length' "$matrix_file") matrix entries for event '$EVENT_NAME'."
+
   # Build localnode/rpcnode images and seid once; matrix jobs pull the images
   # from GHCR (tagged with the run id) and download seid as a small artifact.
   prepare-cluster:
@@ -115,14 +146,11 @@ jobs:
 
   integration-tests:
     name: Integration Test (${{ matrix.test.name }})
-    needs: prepare-cluster
-    # Defer the full Autobahn (GIGA consensus-mode) matrix variants to merge
-    # queue and push events. Entries tagged `merge_only: true` are skipped on
-    # pull_request to cut per-PR ubuntu-large fan-out; a smoke of Autobahn
+    # The merge_only (Autobahn GIGA-mode) variants are filtered out of the
+    # matrix on pull_request by the set-matrix job above; a smoke of Autobahn
     # coverage still runs on PRs via the dedicated autobahn-integration-tests
-    # job below. Job-level `if` is evaluated per matrix combination, so it can
-    # read matrix.test; skipped combinations consume no runner.
-    if: ${{ github.event_name != 'pull_request' || !matrix.test.merge_only }}
+    # job below. On push and merge queue the full matrix runs.
+    needs: [set-matrix, prepare-cluster]
     runs-on: ubuntu-large
     timeout-minutes: 30
     permissions:
@@ -138,293 +166,10 @@ jobs:
     strategy:
       # other jobs should run even if one integration test fails
       fail-fast: false
+      # Matrix is resolved by the set-matrix job from
+      # integration-test-matrix.json (merge_only entries filtered on PRs).
       matrix:
-        test: [
-          {
-            name: "Wasm Module",
-            scripts: [
-              "docker exec sei-node-0 integration_test/contracts/deploy_timelocked_token_contract.sh",
-              "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestWasmModuleCore",
-              "docker exec sei-node-0 integration_test/contracts/deploy_timelocked_token_contract.sh",
-              "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestWasmModuleEmergencyWithdraw"
-            ]
-          },
-          {
-            name: "Mint & Staking & Bank Module",
-            scripts: [
-              "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run \"TestMintModule|TestStakingModule|TestBankModule\""
-            ]
-          },
-          {
-            name: "Autobahn Mint & Staking & Bank Module",
-            # merge_only: skipped on pull_request (see job-level `if`); runs on
-            # merge queue and push.
-            merge_only: true,
-            env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
-            scripts: [
-              "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run \"TestMintModule|TestStakingModule|TestAutobahnBankModule\""
-            ]
-          },
-          {
-            name: "Gov & Oracle & Authz Module",
-            scripts: [
-              "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run \"TestGovModule|TestOracleModule|TestAuthzModule\""
-            ]
-          },
-          {
-            name: "Autobahn Gov & Oracle & Authz Module",
-            merge_only: true,
-            env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
-            scripts: [
-              "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run \"TestGovModule|TestOracleModule|TestAuthzModule\""
-            ]
-          },
-          {
-            name: "Chain Operation Test",
-            env: "GIGA_STORAGE=true",
-            scripts: [
-              "until [ $(cat build/generated/rpc-launch.complete |wc -l) = 1 ]; do sleep 10; done",
-              "until [[ $(docker exec sei-rpc-node build/seid status |jq -M -r .SyncInfo.latest_block_height) -gt 10 ]]; do sleep 10; done",
-              "echo rpc node started",
-              "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run \"TestChainOperation|TestStateSync\"",
-              "./integration_test/contracts/verify_statesync_flatkv_digest.sh",
-              "./integration_test/contracts/verify_cross_validator_flatkv_digest.sh"
-            ]
-          },
-          {
-            name: "Distribution Module",
-            scripts: [
-              "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestDistributionModule"
-            ]
-          },
-          {
-            name: "Upgrade Module (Major)",
-            env: "GIGA_STORAGE=true UPGRADE_VERSION_LIST=v1.0.0,v1.0.1,v1.0.2",
-            scripts: [
-              "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestUpgradeMajor"
-            ]
-          },
-          {
-            name: "Autobahn Upgrade Module (Major)",
-            merge_only: true,
-            env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true UPGRADE_VERSION_LIST=v1.0.0,v1.0.1,v1.0.2",
-            scripts: [
-              "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestUpgradeMajor"
-            ]
-          },
-          {
-            name: "Upgrade Module (Minor)",
-            env: "GIGA_STORAGE=true UPGRADE_VERSION_LIST=v1.0.0,v1.0.1,v1.0.2",
-            scripts: [
-              "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestUpgradeMinor"
-            ]
-          },
-          {
-            name: "Autobahn Upgrade Module (Minor)",
-            merge_only: true,
-            env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true UPGRADE_VERSION_LIST=v1.0.0,v1.0.1,v1.0.2",
-            scripts: [
-              "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestUpgradeMinor"
-            ]
-          },
-          {
-            name: "SeiDB State Store",
-            scripts: [
-              "docker exec sei-node-0 integration_test/contracts/deploy_wasm_contracts.sh",
-              "docker exec sei-node-0 integration_test/contracts/create_tokenfactory_denoms.sh",
-              "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestSeiDBStateStore"
-            ]
-          },
-          {
-            name: "Autobahn SeiDB State Store",
-            merge_only: true,
-            env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
-            scripts: [
-              "docker exec sei-node-0 integration_test/contracts/deploy_wasm_contracts.sh",
-              "docker exec sei-node-0 integration_test/contracts/create_tokenfactory_denoms.sh",
-              "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestSeiDBStateStore"
-            ]
-          },
-          {
-            # Umbrella job for all FlatKV-specific docker-level coverage.
-            # Future FlatKV scenarios (additional bucket layouts, snapshot
-            # rotation, etc.) should be appended here rather than added as
-            # new matrix rows, so the CI surface stays one row per concern.
-            #
-            # The cluster boots with GIGA_STORAGE=true, so FlatKV is enabled
-            # from genesis (sc-write-mode = test_only_dual_write) and the
-            # FlatKV LtHash is folded into every block's AppHash from block 1.
-            # No mid-life migration is exercised here; an offline
-            # memiavl -> FlatKV import would change the AppHash trajectory
-            # at the import boundary and break tendermint replay.
-            #
-            # Step ordering:
-            #   1-3  Deploy an EVM fixture, smoke-check EVM RPC reads, and
-            #        verify the fixture round-tripped through dual_write into
-            #        physical FlatKV.
-            #   4    SIGKILL one validator, restart, and assert 4-node FlatKV
-            #        digest equality. Exercises WAL recovery on a live FlatKV
-            #        cluster.
-            #   5-7  Destructive disaster-recovery scenarios. They run last
-            #        because they wipe or damage one validator's local state.
-            name: "FlatKV Integration",
-            env: "GIGA_STORAGE=true",
-            scripts: [
-              "docker exec sei-node-0 integration_test/contracts/deploy_flatkv_evm_fixture.sh",
-              "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestSeiDBFlatKV",
-              "docker exec sei-node-0 integration_test/contracts/verify_flatkv_evm_store.sh",
-              "./integration_test/contracts/verify_flatkv_crash_recovery.sh",
-              "./integration_test/contracts/verify_flatkv_statesync_crash_recovery.sh",
-              "./integration_test/contracts/verify_flatkv_total_loss_recovery.sh",
-              "./integration_test/contracts/verify_flatkv_partial_loss_fails_loudly.sh"
-            ]
-          },
-          {
-            # Post-migration FlatKV-only state-sync coverage.
-            #
-            # The cluster boots directly in sc-write-mode = flatkv_only, so
-            # memiavl is not allocated and all module state is served from
-            # FlatKV. The script kills and wipes one validator, configures it
-            # for state-sync from the remaining validators, and verifies the
-            # recovered FlatKV digest matches the donors at a shared height.
-            name: "FlatKV Only State Sync",
-            env: "GIGA_FLATKV_ONLY=true",
-            scripts: [
-              "docker exec sei-node-0 integration_test/contracts/deploy_flatkv_evm_fixture.sh",
-              "./integration_test/contracts/verify_flatkv_only_statesync.sh",
-            ],
-          },
-          {
-            name: "EVM Module (Compat)",
-            env: "GIGA_STORAGE=true",
-            scripts: [
-              "./integration_test/evm_module/scripts/evm_compat_tests.sh",
-            ]
-          },
-          {
-            name: "EVM Module (Precompile & Endpoints)",
-            env: "GIGA_STORAGE=true",
-            scripts: [
-              "./integration_test/evm_module/scripts/evm_precompile_tests.sh",
-              "docker exec sei-node-0 integration_test/contracts/deploy_flatkv_evm_fixture.sh",
-              "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestSeiDBFlatKV",
-              "docker exec sei-node-0 integration_test/contracts/verify_flatkv_evm_store.sh"
-            ]
-          },
-          {
-            name: "Autobahn EVM Module (Compat)",
-            merge_only: true,
-            env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
-            scripts: [
-              "./integration_test/evm_module/scripts/evm_compat_tests.sh",
-            ]
-          },
-          {
-            name: "Autobahn EVM Module (Precompile & Endpoints)",
-            merge_only: true,
-            env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
-            scripts: [
-              "./integration_test/evm_module/scripts/evm_precompile_tests.sh",
-              "docker exec sei-node-0 integration_test/contracts/deploy_flatkv_evm_fixture.sh",
-              "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestSeiDBFlatKV",
-              "docker exec sei-node-0 integration_test/contracts/verify_flatkv_evm_store.sh"
-            ]
-          },
-          {
-            name: "EVM Interoperability (Pointer Tests)",
-            env: "GIGA_STORAGE=true",
-            scripts: [
-              "./integration_test/evm_module/scripts/evm_interoperability_pointer_tests.sh"
-            ]
-          },
-          {
-            name: "EVM Interoperability (Misc Tests)",
-            env: "GIGA_STORAGE=true",
-            scripts: [
-              "./integration_test/evm_module/scripts/evm_interoperability_misc_tests.sh"
-            ]
-          },
-          {
-            name: "Autobahn EVM Interoperability (Pointer Tests)",
-            merge_only: true,
-            env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
-            scripts: [
-              "./integration_test/evm_module/scripts/evm_interoperability_pointer_tests.sh"
-            ]
-          },
-          {
-            name: "Autobahn EVM Interoperability (Misc Tests)",
-            merge_only: true,
-            env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
-            scripts: [
-              "./integration_test/evm_module/scripts/evm_interoperability_misc_tests.sh"
-            ]
-          },
-          {
-            name: "Disable WASM Tests",
-            scripts: [
-              "./integration_test/evm_module/scripts/disable_wasm.sh",
-            ]
-          },
-          {
-            name: "dApp Tests (Uniswap)",
-            env: "GIGA_STORAGE=true",
-            scripts: [
-              "./integration_test/dapp_tests/dapp_uniswap_tests.sh"
-            ]
-          },
-          {
-            name: "dApp Tests (NFT & Steak)",
-            env: "GIGA_STORAGE=true",
-            scripts: [
-              "./integration_test/dapp_tests/dapp_nft_steak_tests.sh"
-            ]
-          },
-          {
-            name: "EVM GIGA Module",
-            env: "GIGA_STORAGE=true GIGA_EXECUTOR=true GIGA_OCC=true",
-            scripts: [
-              "./integration_test/evm_module/scripts/evm_giga_tests.sh"
-            ]
-          },
-          {
-            name: "Autobahn EVM GIGA Module",
-            merge_only: true,
-            env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
-            scripts: [
-              "./integration_test/evm_module/scripts/evm_giga_tests.sh"
-            ]
-          },
-          {
-            name: "EVM GIGA Mixed (Determinism)",
-            env: "GIGA_STORAGE=true",
-            scripts: [
-              "./integration_test/evm_module/scripts/evm_giga_mixed_tests.sh"
-            ]
-          },
-          {
-            name: "EVM RPC .io/.iox (spec fixtures)",
-            env: "GIGA_STORAGE=true",
-            scripts: [
-              "./integration_test/evm_module/scripts/evm_rpc_tests.sh"
-            ]
-          },
-          {
-            name: "Autobahn RPC .io/.iox (spec fixtures)",
-            merge_only: true,
-            env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true",
-            scripts: [
-              "./integration_test/evm_module/scripts/evm_rpc_tests.sh"
-            ]
-          },
-          {
-            name: "EVM RPC Parity (geth reference)",
-            env: "GIGA_STORAGE=true",
-            scripts: [
-              "./integration_test/rpc_tests/scripts/run-ci.sh"
-            ]
-          },
-        ]
+        test: ${{ fromJSON(needs.set-matrix.outputs.tests) }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -27,8 +27,8 @@ defaults:
 
 jobs:
   # Generate the integration-test matrix from integration-test-matrix.json.
-  # On pull_request we drop entries tagged `merge_only: true` (the full Autobahn
-  # GIGA-mode variants) to cut per-PR ubuntu-large fan-out; on push and merge
+  # On pull_request we drop entries tagged `merge_only: true` (Autobahn Gov/Mint/
+  # Upgrade GIGA-mode variants) to cut per-PR ubuntu-large fan-out; on push and merge
   # queue the full matrix runs. The matrix is built here, in a job output,
   # because the `matrix` context is NOT available to a job-level `if:` — a
   # per-combination `if` on the test job would fail workflow validation
@@ -49,7 +49,7 @@ jobs:
           set -euo pipefail
           matrix_file=.github/workflows/integration-test-matrix.json
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            # Defer merge_only entries to merge queue / push.
+            # Defer merge_only Autobahn Gov/Mint/Upgrade entries to merge queue / push.
             tests=$(jq -c '[.[] | select(.merge_only != true)]' "$matrix_file")
           else
             tests=$(jq -c '.' "$matrix_file")
@@ -146,7 +146,7 @@ jobs:
 
   integration-tests:
     name: Integration Test (${{ matrix.test.name }})
-    # The merge_only (Autobahn GIGA-mode) variants are filtered out of the
+    # The merge_only Autobahn Gov/Mint/Upgrade variants are filtered out of the
     # matrix on pull_request by the set-matrix job above; a smoke of Autobahn
     # coverage still runs on PRs via the dedicated autobahn-integration-tests
     # job below. On push and merge queue the full matrix runs.

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -116,6 +116,13 @@ jobs:
   integration-tests:
     name: Integration Test (${{ matrix.test.name }})
     needs: prepare-cluster
+    # Defer the full Autobahn (GIGA consensus-mode) matrix variants to merge
+    # queue and push events. Entries tagged `merge_only: true` are skipped on
+    # pull_request to cut per-PR ubuntu-large fan-out; a smoke of Autobahn
+    # coverage still runs on PRs via the dedicated autobahn-integration-tests
+    # job below. Job-level `if` is evaluated per matrix combination, so it can
+    # read matrix.test; skipped combinations consume no runner.
+    if: ${{ github.event_name != 'pull_request' || !matrix.test.merge_only }}
     runs-on: ubuntu-large
     timeout-minutes: 30
     permissions:
@@ -150,6 +157,9 @@ jobs:
           },
           {
             name: "Autobahn Mint & Staking & Bank Module",
+            # merge_only: skipped on pull_request (see job-level `if`); runs on
+            # merge queue and push.
+            merge_only: true,
             env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
             scripts: [
               "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run \"TestMintModule|TestStakingModule|TestAutobahnBankModule\""
@@ -163,6 +173,7 @@ jobs:
           },
           {
             name: "Autobahn Gov & Oracle & Authz Module",
+            merge_only: true,
             env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
             scripts: [
               "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run \"TestGovModule|TestOracleModule|TestAuthzModule\""
@@ -195,6 +206,7 @@ jobs:
           },
           {
             name: "Autobahn Upgrade Module (Major)",
+            merge_only: true,
             env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true UPGRADE_VERSION_LIST=v1.0.0,v1.0.1,v1.0.2",
             scripts: [
               "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestUpgradeMajor"
@@ -209,6 +221,7 @@ jobs:
           },
           {
             name: "Autobahn Upgrade Module (Minor)",
+            merge_only: true,
             env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true UPGRADE_VERSION_LIST=v1.0.0,v1.0.1,v1.0.2",
             scripts: [
               "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestUpgradeMinor"
@@ -224,6 +237,7 @@ jobs:
           },
           {
             name: "Autobahn SeiDB State Store",
+            merge_only: true,
             env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
             scripts: [
               "docker exec sei-node-0 integration_test/contracts/deploy_wasm_contracts.sh",
@@ -299,6 +313,7 @@ jobs:
           },
           {
             name: "Autobahn EVM Module (Compat)",
+            merge_only: true,
             env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
             scripts: [
               "./integration_test/evm_module/scripts/evm_compat_tests.sh",
@@ -306,6 +321,7 @@ jobs:
           },
           {
             name: "Autobahn EVM Module (Precompile & Endpoints)",
+            merge_only: true,
             env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
             scripts: [
               "./integration_test/evm_module/scripts/evm_precompile_tests.sh",
@@ -330,6 +346,7 @@ jobs:
           },
           {
             name: "Autobahn EVM Interoperability (Pointer Tests)",
+            merge_only: true,
             env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
             scripts: [
               "./integration_test/evm_module/scripts/evm_interoperability_pointer_tests.sh"
@@ -337,6 +354,7 @@ jobs:
           },
           {
             name: "Autobahn EVM Interoperability (Misc Tests)",
+            merge_only: true,
             env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
             scripts: [
               "./integration_test/evm_module/scripts/evm_interoperability_misc_tests.sh"
@@ -371,6 +389,7 @@ jobs:
           },
           {
             name: "Autobahn EVM GIGA Module",
+            merge_only: true,
             env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
             scripts: [
               "./integration_test/evm_module/scripts/evm_giga_tests.sh"
@@ -392,6 +411,7 @@ jobs:
           },
           {
             name: "Autobahn RPC .io/.iox (spec fixtures)",
+            merge_only: true,
             env: "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true",
             scripts: [
               "./integration_test/evm_module/scripts/evm_rpc_tests.sh"


### PR DESCRIPTION
## What

Two changes to `integration-test.yml` aimed at reducing CI wall-clock under `ubuntu-large` runner contention (PLT-761):

1. **Cancel superseded PR runs.** Added a `concurrency` block keyed on `github.sha` for `push` and `github.ref` otherwise. `cancel-in-progress` is enabled only for `pull_request`, so a new push to a PR branch cancels the prior matrix instead of leaving it running to completion, while `merge_group` and `push` runs always run to completion.

2. **Defer Autobahn Gov/Mint/Upgrade to the merge queue.** Four Autobahn GIGA-mode matrix entries — Mint & Staking & Bank, Gov & Oracle & Authz, Upgrade (Major), and Upgrade (Minor) — are tagged `merge_only: true` in `integration-test-matrix.json`. A `set-matrix` job loads that file and, on `pull_request` only, strips those entries with `jq` before the matrix expands — PRs run 28 of 32 combinations; `merge_group` and `push` run the full matrix. All other Autobahn matrix jobs (EVM, SeiDB, RPC, etc.) still run on every PR.

## Why

`go-test.yml` already cancels superseded runs, but `integration-test.yml` had no `concurrency` block, so every push to a PR branch left the prior full matrix running. Under `ubuntu-large` contention this starves the queue and inflates everyone's effective wall-clock.

The four deferred Autobahn entries are the slowest governance/state-transition coverage under GIGA consensus mode. Their non-Autobahn siblings already run on every PR; deferring only these four trims ~4 `ubuntu-large` jobs per PR while keeping Autobahn EVM/SeiDB/RPC coverage on the PR path.

## Coverage safety

- A smoke of Autobahn coverage still runs on every PR via the dedicated `autobahn-integration-tests` ("Autobahn Basic") job, which is left untouched.
- Autobahn EVM, SeiDB, RPC, and interoperability matrix jobs still run on every PR.
- The four deferred Autobahn Gov/Mint/Upgrade entries still run in the **merge queue** (`merge_group`) before any code lands on `main`.
- No change needed to `integration-test-check`: `integration-tests`'s aggregate result stays `success` on PRs (28 matrix combinations still run), and the autobahn smoke job still runs.

## Effect

- **PRs:** ~4 fewer `ubuntu-large` jobs per run, plus immediate reclamation of runners from superseded runs.
- **Merge queue / main:** full coverage preserved; merge-queue runs are never cancelled by concurrency.