### PR TITLE
fix(evmrpc): acquire requestLimiter in eth_createAccessList

### DIFF
--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -88,6 +88,14 @@ func (s *SimulationAPI) CreateAccessList(ctx context.Context, args export.Transa
 	defer func() {
 		recordMetricsWithError(ctx, "eth_createAccessList", s.connectionType, startTime, returnErr, recover())
 	}()
+	/* ---------- fail‑fast limiter ---------- */
+	if s.requestLimiter != nil {
+		if !s.requestLimiter.TryAcquire(1) {
+			returnErr = errors.New("eth_createAccessList rejected due to rate limit: server busy")
+			return
+		}
+		defer s.requestLimiter.Release(1)
+	}
 	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
 	if blockNrOrHash != nil {
 		bNrOrHash = *blockNrOrHash

--- a/evmrpc/simulate_test.go
+++ b/evmrpc/simulate_test.go
@@ -720,6 +720,48 @@ func TestSimulationAPIRequestLimiter(t *testing.T) {
 		t.Logf("eth_estimateGas rate limiting: %d successful, %d rejected out of %d total", successCount, rejectedCount, numRequests)
 	})
 
+	t.Run("TestCreateAccessListRateLimiting", func(t *testing.T) {
+		tEnv := newTestEnv(t)
+		// Test eth_createAccessList rate limiting
+		numRequests := 8
+		results := make(chan error, numRequests)
+
+		// Start all requests concurrently
+		for i := 0; i < numRequests; i++ {
+			go func() {
+				_, err := tEnv.simAPI.CreateAccessList(t.Context(), tEnv.args, nil)
+				results <- err
+			}()
+		}
+
+		// Collect all results
+		var errors []error
+		for i := 0; i < numRequests; i++ {
+			errors = append(errors, <-results)
+		}
+
+		// Count successful vs rejected requests
+		successCount := 0
+		rejectedCount := 0
+		for _, err := range errors {
+			if err == nil {
+				successCount++
+			} else if strings.Contains(err.Error(), "eth_createAccessList rejected due to rate limit: server busy") {
+				rejectedCount++
+			} else {
+				t.Logf("Unexpected createAccessList error: %v", err)
+			}
+		}
+
+		// Under constrained scheduling these requests can serialize and avoid
+		// rejections. The stable invariant is that every response is either success or
+		// rate-limited.
+		require.Greater(t, successCount, 0, "Should have at least one successful createAccessList request")
+		require.Equal(t, numRequests, successCount+rejectedCount, "All createAccessList requests should be accounted for")
+
+		t.Logf("eth_createAccessList rate limiting: %d successful, %d rejected out of %d total", successCount, rejectedCount, numRequests)
+	})
+
 	t.Run("TestEstimateGasAfterCallsRateLimiting", func(t *testing.T) {
 		tEnv := newTestEnv(t)
 		// Test eth_estimateGasAfterCalls rate limiting


### PR DESCRIPTION
## Summary

Acquire the simulation `requestLimiter` at the top of `eth_createAccessList` (`evmrpc/simulate.go`), matching the existing fail-fast pattern already used in `eth_call`, `eth_estimateGas`, and `eth_estimateGasAfterCalls`.

`CreateAccessList` runs the same simulation-style execution path as those methods but was not gated by the shared concurrency limiter. This makes it consistent: when no slot is available it fails fast with `eth_createAccessList rejected due to rate limit: server busy` instead of contending for simulation resources.

## Changes

- `evmrpc/simulate.go` — `CreateAccessList` now does `TryAcquire(1)` on `requestLimiter` (when configured), returns a "server busy" error on rejection, and defers `Release(1)`.
- `evmrpc/simulate_test.go` — add `TestCreateAccessListRateLimiting` subtest under `TestSimulationAPIRequestLimiter`, mirroring the existing per-method limiter subtests (fires concurrent requests against a limiter sized at 2 and asserts every response is either a success or the exact rate-limit rejection).

## Notes

This is scoped to closing the limiter gap for `eth_createAccessList`. Applying simulation limiting *before* JSON decode (to bound decode/buffering memory) is a separate, transport-layer concern and is tracked independently.

## Testing

`go test ./evmrpc/ -run 'TestSimulationAPIRequestLimiter|TestCreateAccessList'` passes.
