### PR TITLE
ci(PLT-766): cancel superseded PR runs for remaining workflows

### DIFF
--- a/.github/workflows/buf-check.yml
+++ b/.github/workflows/buf-check.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
   merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -14,6 +14,10 @@ on:
       - main
       - release/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   sei-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/eth_blocktests.yml
+++ b/.github/workflows/eth_blocktests.yml
@@ -14,6 +14,10 @@ on:
       - main
       - release/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 defaults:
  run:
   shell: bash

--- a/.github/workflows/forge-test.yml
+++ b/.github/workflows/forge-test.yml
@@ -8,6 +8,10 @@ on:
       - main
       - release/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   FOUNDRY_PROFILE: ci
 

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -8,6 +8,11 @@ on:
       - release/**
   pull_request:
   merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   # Optional: allow read access to pull request. Use with `only-new-issues` option.

--- a/.github/workflows/mock_balances_build.yml
+++ b/.github/workflows/mock_balances_build.yml
@@ -14,6 +14,10 @@ on:
       - main
       - release/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   mock-balances-build:
     name: Compile with Mock Balances


### PR DESCRIPTION
## What

Adds a `concurrency` block to the six PR-triggered workflows that were still missing one, so pushing a new commit to a PR cancels the prior in-progress run:

- `docker_build.yml` (Build docker image)
- `golangci.yml` (golangci-lint)
- `eth_blocktests.yml` (ETH Blocktests)
- `forge-test.yml` (Forge test)
- `mock_balances_build.yml` (Mock Balances Build Check)
- `buf-check.yml` (Buf)

Each gets the same block already used by `integration-test.yml` and `go-test.yml`:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

## Why

PR #3639 (PLT-761) added cancel-on-supersede, but `concurrency` is **per-workflow** — it only fixed `integration-test.yml`. The workflows above had no `concurrency` block, so superseded runs kept executing to completion and starved the `ubuntu-large` runner queue.

Observed on PR #3648: after pushing a 3rd commit, the 2nd commit's runs were cancelled for workflows that had the block (Docker Integration Test, Go Test, sei-db, Cross-Arch, UCI) but kept running for those that didn't (Build docker image, golangci-lint, ETH Blocktests).

## Behavior

- Keyed on `github.sha` for `push` and `github.ref` otherwise, with `cancel-in-progress` enabled only for `pull_request` — so `push` and `merge_group` runs are never cancelled by concurrency, matching the existing pattern.
- **Skipped** `dapp_tests.yml` (only `workflow_dispatch`, never runs on PRs) and the publish/release workflows (`ecr.yml`, `docker_publish.yml`, `proto-registry.yml`) where cancellation is not wanted.

Follow-up to PLT-761 / #3639. Resolves PLT-766.
