### PR TITLE
Parallelize littidx eth_getLogs across blocks

### DIFF
--- a/sei-db/config/receipt_config.go
+++ b/sei-db/config/receipt_config.go
@@ -20,7 +20,12 @@ const (
 	flagRSAsyncWriteBuffer     = "receipt-store.async-write-buffer"
 	flagRSPruneIntervalSeconds = "receipt-store.prune-interval-seconds"
 	flagRSReadWriteMetrics     = "receipt-store.enable-read-write-metrics"
+	flagRSLogFilterParallelism = "receipt-store.log-filter-parallelism"
 )
+
+// DefaultReceiptLogFilterParallelism is the default per-query block fan-out for
+// littidx eth_getLogs (see ReceiptStoreConfig.LogFilterParallelism).
+const DefaultReceiptLogFilterParallelism = 16
 
 // ReceiptStoreConfig defines configuration for the receipt store database.
 type ReceiptStoreConfig struct {
@@ -53,6 +58,13 @@ type ReceiptStoreConfig struct {
 	// EnableReadWriteMetrics emits simple estimated read/write counters for Pebble-backed receipt storage.
 	// defaults to false
 	EnableReadWriteMetrics bool `mapstructure:"enable-read-write-metrics"`
+
+	// LogFilterParallelism bounds how many blocks a single eth_getLogs query
+	// scans concurrently in the littidx backend; per-block tag scans and litt
+	// body reads are independent, so a range fans across this many workers.
+	// Applies only to the littidx backend. <= 0 falls back to the default.
+	// defaults to 16
+	LogFilterParallelism int `mapstructure:"log-filter-parallelism"`
 }
 
 // DefaultReceiptStoreConfig returns the default ReceiptStoreConfig.
@@ -64,6 +76,7 @@ func DefaultReceiptStoreConfig() ReceiptStoreConfig {
 		AsyncWriteBuffer:     DefaultSSAsyncBuffer,
 		KeepRecent:           0,
 		PruneIntervalSeconds: DefaultSSPruneInterval,
+		LogFilterParallelism: DefaultReceiptLogFilterParallelism,
 	}
 }
 
@@ -113,6 +126,13 @@ func ReadReceiptConfig(opts AppOptions) (ReceiptStoreConfig, error) {
 			return cfg, err
 		}
 		cfg.EnableReadWriteMetrics = enableReadWriteMetrics
+	}
+	if v := opts.Get(flagRSLogFilterParallelism); v != nil {
+		logFilterParallelism, err := cast.ToIntE(v)
+		if err != nil {
+			return cfg, err
+		}
+		cfg.LogFilterParallelism = logFilterParallelism
 	}
 	return cfg, nil
 }

--- a/sei-db/config/receipt_config_test.go
+++ b/sei-db/config/receipt_config_test.go
@@ -30,3 +30,17 @@ func TestReadReceiptConfigReadWriteMetrics(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, cfg.EnableReadWriteMetrics)
 }
+
+func TestReadReceiptConfigLogFilterParallelism(t *testing.T) {
+	// Defaults when unset.
+	cfg, err := ReadReceiptConfig(mapAppOpts{})
+	require.NoError(t, err)
+	require.Equal(t, DefaultReceiptLogFilterParallelism, cfg.LogFilterParallelism)
+
+	// Override is read through.
+	cfg, err = ReadReceiptConfig(mapAppOpts{
+		"receipt-store.log-filter-parallelism": 32,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 32, cfg.LogFilterParallelism)
+}

--- a/sei-db/config/toml.go
+++ b/sei-db/config/toml.go
@@ -188,6 +188,12 @@ prune-interval-seconds = {{ .ReceiptStore.PruneIntervalSeconds }}
 # receipt storage.
 # Default: false.
 enable-read-write-metrics = {{ .ReceiptStore.EnableReadWriteMetrics }}
+
+# LogFilterParallelism bounds how many blocks a single eth_getLogs query scans
+# concurrently. Applies only when rs-backend = "littidx".
+# Set <= 0 to use the default.
+# defaults to 16
+log-filter-parallelism = {{ .ReceiptStore.LogFilterParallelism }}
 `
 
 // DefaultConfigTemplate combines both templates for backward compatibility

--- a/sei-db/ledger_db/receipt/litt_receipt_store.go
+++ b/sei-db/ledger_db/receipt/litt_receipt_store.go
@@ -61,11 +61,12 @@ type littReceiptStore struct {
 	latestVersion   atomic.Int64
 	earliestVersion atomic.Int64
 
-	keepRecent     int64
-	pruneInterval  int64
-	stopBackground chan struct{}
-	backgroundWg   sync.WaitGroup
-	closeOnce      sync.Once
+	keepRecent           int64
+	pruneInterval        int64
+	logFilterParallelism int
+	stopBackground       chan struct{}
+	backgroundWg         sync.WaitGroup
+	closeOnce            sync.Once
 }
 
 var _ ReceiptStore = (*littReceiptStore)(nil)
@@ -143,14 +144,21 @@ func newLittReceiptStore(cfg dbconfig.ReceiptStoreConfig, storeKey sdk.StoreKey)
 		return nil, fmt.Errorf("failed to open receipt log index: %w", err)
 	}
 
+	// getLogs per-query block fan-out; non-positive config falls back to the default.
+	logFilterParallelism := cfg.LogFilterParallelism
+	if logFilterParallelism <= 0 {
+		logFilterParallelism = dbconfig.DefaultReceiptLogFilterParallelism
+	}
+
 	s := &littReceiptStore{
-		values:         values,
-		receipts:       receipts,
-		index:          index,
-		storeKey:       storeKey,
-		keepRecent:     int64(cfg.KeepRecent),
-		pruneInterval:  int64(cfg.PruneIntervalSeconds),
-		stopBackground: make(chan struct{}),
+		values:               values,
+		receipts:             receipts,
+		index:                index,
+		storeKey:             storeKey,
+		keepRecent:           int64(cfg.KeepRecent),
+		pruneInterval:        int64(cfg.PruneIntervalSeconds),
+		logFilterParallelism: logFilterParallelism,
+		stopBackground:       make(chan struct{}),
 	}
 	s.latestVersion.Store(s.readMeta(receiptLatestVersionKey))
 	s.earliestVersion.Store(s.readMeta(receiptEarliestVersionKey))

--- a/sei-db/ledger_db/receipt/litt_tag_index.go
+++ b/sei-db/ledger_db/receipt/litt_tag_index.go
@@ -207,18 +207,13 @@ func (s *littReceiptStore) filterLogsByTags(fromBlock, toBlock uint64, crit filt
 	groups := criteriaTagGroups(crit)
 	nBlocks := int(toBlock - fromBlock + 1) //nolint:gosec // bounded by the caller's range cap
 
-	par := s.logFilterParallelism
-	if par < 1 {
-		par = 1
-	}
-
 	// One result slot per block, written by exactly one worker, so the merged
 	// output keeps block order regardless of completion order. errgroup caps
-	// concurrency at par and hands the next block to whichever worker frees up,
-	// load-balancing across the skewed per-block cost.
+	// concurrency at the configured limit and hands the next block to whichever
+	// worker frees up, load-balancing across the skewed per-block cost.
 	results := make([][]*ethtypes.Log, nBlocks)
 	var eg errgroup.Group
-	eg.SetLimit(par)
+	eg.SetLimit(s.logFilterParallelism)
 	for i := 0; i < nBlocks; i++ {
 		eg.Go(func() error {
 			blockLogs, err := s.blockLogs(fromBlock+uint64(i), groups, crit) //nolint:gosec // i < nBlocks

--- a/sei-db/ledger_db/receipt/litt_tag_index.go
+++ b/sei-db/ledger_db/receipt/litt_tag_index.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/filters"
 	dbtypes "github.com/sei-protocol/sei-chain/sei-db/db_engine/types"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
+	"golang.org/x/sync/errgroup"
 )
 
 // The tag index is the "littidx" filtering layer. litt holds the receipt
@@ -185,10 +186,13 @@ func (s *littReceiptStore) stageTagKeys(batch dbtypes.Batch, blockNumber uint64,
 	return nil
 }
 
-// filterLogsByTags answers a getLogs query from the tag index: per block,
-// intersect the candidate transactions across criteria dimensions, then
-// point-read only the surviving receipts from litt. Results are exact —
-// matchLog re-verifies after decode.
+// filterLogsByTags answers a getLogs query from the tag index. Each block is
+// independent — its candidate intersection and the point-reads of the surviving
+// receipts touch only that block's keys — so a range is fanned across a bounded
+// worker pool (logFilterParallelism) instead of walked one block at a time.
+// This parallelizes both the per-block index scans and the litt body reads,
+// which dominate wide-range latency. Results are exact (matchLog re-verifies
+// after decode) and stay in (block, txIndex) order via the indexed buffer.
 func (s *littReceiptStore) filterLogsByTags(fromBlock, toBlock uint64, crit filters.FilterCriteria) ([]*ethtypes.Log, error) {
 	if latest := s.latestVersion.Load(); latest >= 0 && toBlock > uint64(latest) { //nolint:gosec // latest is non-negative
 		toBlock = uint64(latest) //nolint:gosec // latest is non-negative
@@ -201,22 +205,52 @@ func (s *littReceiptStore) filterLogsByTags(fromBlock, toBlock uint64, crit filt
 	}
 
 	groups := criteriaTagGroups(crit)
+	nBlocks := int(toBlock - fromBlock + 1) //nolint:gosec // bounded by the caller's range cap
+
+	par := s.logFilterParallelism
+	if par < 1 {
+		par = 1
+	}
+
+	// One result slot per block, written by exactly one worker, so the merged
+	// output keeps block order regardless of completion order. errgroup caps
+	// concurrency at par and hands the next block to whichever worker frees up,
+	// load-balancing across the skewed per-block cost.
+	results := make([][]*ethtypes.Log, nBlocks)
+	var eg errgroup.Group
+	eg.SetLimit(par)
+	for i := 0; i < nBlocks; i++ {
+		eg.Go(func() error {
+			blockLogs, err := s.blockLogs(fromBlock+uint64(i), groups, crit) //nolint:gosec // i < nBlocks
+			if err != nil {
+				return err
+			}
+			results[i] = blockLogs
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
 	var logs []*ethtypes.Log
-	for block := fromBlock; block <= toBlock; block++ {
-		candidates, err := s.blockTagCandidates(block, groups)
-		if err != nil {
-			return nil, err
-		}
-		if len(candidates) == 0 {
-			continue
-		}
-		blockLogs, err := s.candidateBlockLogs(candidates, crit)
-		if err != nil {
-			return nil, err
-		}
+	for _, blockLogs := range results {
 		logs = append(logs, blockLogs...)
 	}
 	return logs, nil
+}
+
+// blockLogs answers the query for one block: intersect the tag candidates, then
+// point-read and match the surviving receipts. Returns nil when nothing matches.
+func (s *littReceiptStore) blockLogs(block uint64, groups [][][]byte, crit filters.FilterCriteria) ([]*ethtypes.Log, error) {
+	candidates, err := s.blockTagCandidates(block, groups)
+	if err != nil {
+		return nil, err
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	return s.candidateBlockLogs(candidates, crit)
 }
 
 // blockTagCandidates returns the block's candidate transactions. With no

--- a/sei-db/ledger_db/receipt/littidx_test.go
+++ b/sei-db/ledger_db/receipt/littidx_test.go
@@ -17,6 +17,12 @@ import (
 
 func setupLittIdx(t *testing.T, dir string) (receipt.ReceiptStore, sdk.Context) {
 	t.Helper()
+	return setupLittIdxPar(t, dir, dbconfig.DefaultReceiptLogFilterParallelism)
+}
+
+// setupLittIdxPar is setupLittIdx with an explicit getLogs parallelism degree.
+func setupLittIdxPar(t *testing.T, dir string, parallelism int) (receipt.ReceiptStore, sdk.Context) {
+	t.Helper()
 	storeKey := storetypes.NewKVStoreKey("evm")
 	tkey := storetypes.NewTransientStoreKey("evm_transient")
 	ctx := testutil.DefaultContext(storeKey, tkey).WithBlockHeight(1)
@@ -24,6 +30,7 @@ func setupLittIdx(t *testing.T, dir string) (receipt.ReceiptStore, sdk.Context) 
 	cfg.Backend = "littidx"
 	cfg.DBDirectory = dir
 	cfg.KeepRecent = 0
+	cfg.LogFilterParallelism = parallelism
 	store, err := receipt.NewReceiptStore(cfg, storeKey)
 	require.NoError(t, err)
 	return store, ctx
@@ -307,4 +314,40 @@ func TestLittIdxPrune(t *testing.T) {
 	logs, err = store.FilterLogs(ctx, 1, 10, filters.FilterCriteria{Addresses: []common.Address{addr}})
 	require.NoError(t, err)
 	require.Len(t, logs, 5)
+}
+
+// TestLittIdxFilterLogsParallelOrder verifies the parallel block fan-out returns
+// logs in strict (block, txIndex) order and yields identical results whether run
+// sequentially (parallelism 1) or in parallel.
+func TestLittIdxFilterLogsParallelOrder(t *testing.T) {
+	addr := common.HexToAddress("0xfeed")
+	topic := common.HexToHash("0x2222")
+	const blocks, txPerBlock = 25, 3
+
+	want := make([]string, 0, blocks*txPerBlock)
+	for b := uint64(1); b <= blocks; b++ {
+		for tx := uint32(0); tx < txPerBlock; tx++ {
+			want = append(want, fmt.Sprintf("%d-%d", b, tx))
+		}
+	}
+
+	for _, parallelism := range []int{1, 8} {
+		store, ctx := setupLittIdxPar(t, t.TempDir(), parallelism)
+		for b := uint64(1); b <= blocks; b++ {
+			recs := make([]receipt.ReceiptRecord, 0, txPerBlock)
+			for tx := uint32(0); tx < txPerBlock; tx++ {
+				recs = append(recs, litReceipt(b, tx, addr, topic))
+			}
+			writeLitBlock(t, store, ctx, b, recs...)
+		}
+
+		logs, err := store.FilterLogs(ctx, 1, blocks, filters.FilterCriteria{Addresses: []common.Address{addr}})
+		require.NoError(t, err)
+		got := make([]string, len(logs))
+		for i, lg := range logs {
+			got[i] = fmt.Sprintf("%d-%d", lg.BlockNumber, lg.TxIndex)
+		}
+		require.Equal(t, want, got, "parallelism=%d should return logs in (block, txIndex) order", parallelism)
+		require.NoError(t, store.Close())
+	}
 }


### PR DESCRIPTION
## Describe your changes and provide context
- previously filterLogsByTags walked its block range one block at a time. 
- Fan them across a bounded errgroup 

## Testing performed to validate your change
- Verified on node filter runs 
- Unit tests
