### PR TITLE
[codex] Harden multiversion iterator validation

### DIFF
--- a/sei-cosmos/store/multiversion/memiterator.go
+++ b/sei-cosmos/store/multiversion/memiterator.go
@@ -95,9 +95,48 @@ func (store *Store) newMVSValidationIterator(
 	}
 }
 
+func (vi *validationIterator) hasCurrentValue(key []byte) bool {
+	strKey := string(key)
+	if _, ok := vi.writeset[strKey]; ok {
+		return true
+	}
+	if _, ok := vi.readCache[strKey]; ok {
+		return true
+	}
+	return vi.mvStore.GetLatestBeforeIndex(vi.index, key) != nil
+}
+
+func (vi *validationIterator) skipRemovedKeys() {
+	for vi.Iterator.Valid() && !vi.hasCurrentValue(vi.Iterator.Key()) {
+		vi.Iterator.Next()
+	}
+}
+
+func (vi *validationIterator) Valid() bool {
+	vi.skipRemovedKeys()
+	return vi.Iterator.Valid()
+}
+
+func (vi *validationIterator) Next() {
+	vi.Iterator.Next()
+	vi.skipRemovedKeys()
+}
+
+func (vi *validationIterator) Key() []byte {
+	vi.skipRemovedKeys()
+	return vi.Iterator.Key()
+}
+
+func (vi *validationIterator) WriteAbort(abort occtypes.Abort) {
+	select {
+	case vi.abortChannel <- abort:
+	default:
+	}
+}
+
 // try to get value from the writeset, otherwise try to get from multiversion store, otherwise try to get from parent iterator
 func (vi *validationIterator) Value() []byte {
-	key := vi.Key()
+	key := vi.Iterator.Key()
 
 	// try fetch from writeset - return if exists
 	if val, ok := vi.writeset[string(key)]; ok {
@@ -110,10 +149,13 @@ func (vi *validationIterator) Value() []byte {
 
 	// get the value from the multiversion store
 	val := vi.mvStore.GetLatestBeforeIndex(vi.index, key)
+	if val == nil {
+		return nil
+	}
 
 	// if we have an estimate, write to abort channel
 	if val.IsEstimate() {
-		vi.abortChannel <- occtypes.NewEstimateAbort(val.Index())
+		vi.WriteAbort(occtypes.NewEstimateAbort(val.Index()))
 	}
 
 	// if we have a deleted value, return nil

--- a/sei-cosmos/store/multiversion/store.go
+++ b/sei-cosmos/store/multiversion/store.go
@@ -2,13 +2,17 @@ package multiversion
 
 import (
 	"bytes"
+	"runtime/debug"
 	"sort"
 	"sync"
 
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store/types"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/types/occ"
+	"github.com/sei-protocol/seilog"
 	db "github.com/tendermint/tm-db"
 )
+
+var logger = seilog.NewLogger("cosmos", "store", "multiversion")
 
 type MultiVersionStore interface {
 	GetLatest(key []byte) (value MultiVersionValueItem)
@@ -269,51 +273,104 @@ func (s *Store) validateIterator(index int, tracker iterationTracker) bool {
 	validChannel := make(chan bool, 1)
 	abortChannel := make(chan occ.Abort, 1)
 
-	// listen for abort while iterating
+	// Run validation in a goroutine so unexpected iterator panics can be
+	// contained and converted into validation failure.
 	go func(iterationTracker iterationTracker, items *db.MemDB, returnChan chan bool, abortChan chan occ.Abort) {
-		var parentIter types.Iterator
-		expectedKeys := iterationTracker.iteratedKeys
-		foundKeys := 0
-		iter := s.newMVSValidationIterator(index, iterationTracker.startKey, iterationTracker.endKey, items, iterationTracker.ascending, iterationTracker.writeset, abortChan)
-		if iterationTracker.ascending {
-			parentIter = s.parentStore.Iterator(iterationTracker.startKey, iterationTracker.endKey)
-		} else {
-			parentIter = s.parentStore.ReverseIterator(iterationTracker.startKey, iterationTracker.endKey)
-		}
-		// create a new MVSMergeiterator
-		mergeIterator := NewMVSMergeIterator(parentIter, iter, iterationTracker.ascending, NoOpHandler{})
-		defer func() { _ = mergeIterator.Close() }()
-		for ; mergeIterator.Valid(); mergeIterator.Next() {
-			if (len(expectedKeys) - foundKeys) == 0 {
-				// if we have no more expected keys, then the iterator is invalid
-				returnChan <- false
-				return
+		valid := false
+		defer func() {
+			if r := recover(); r != nil {
+				logger.Error(
+					"panic during multiversion iterator validation",
+					"panic", r,
+					"tx_index", index,
+					"start", iterationTracker.startKey,
+					"end", iterationTracker.endKey,
+					"ascending", iterationTracker.ascending,
+					"stack", string(debug.Stack()),
+				)
 			}
-			key := mergeIterator.Key()
-			// TODO: is this ok to not delete the key since we shouldnt have duplicate keys?
-			if _, ok := expectedKeys[string(key)]; !ok {
-				// if key isn't found
-				returnChan <- false
-				return
-			}
-			// remove from expected keys
-			foundKeys += 1
-			// delete(expectedKeys, string(key))
+			returnChan <- valid
+		}()
 
-			// if our iterator key was the early stop, then we can break
-			if bytes.Equal(key, iterationTracker.earlyStopKey) {
-				break
-			}
-		}
-		// return whether we found the exact number of expected keys
-		returnChan <- foundKeys >= len(expectedKeys)
+		valid = s.validateIteratorReplay(index, iterationTracker, items, abortChan)
 	}(tracker, sortedItems, validChannel, abortChannel)
-	select {
-	case <-abortChannel:
-		// if we get an abort, then we know that the iterator is invalid
+
+	return <-validChannel
+}
+
+func (s *Store) validateIteratorReplay(index int, iterationTracker iterationTracker, items *db.MemDB, abortChan chan occ.Abort) bool {
+	var parentIter types.Iterator
+	var iter types.Iterator
+	var mergeIterator *mvsMergeIterator
+	expectedKeys := iterationTracker.iteratedKeys
+	foundKeys := 0
+	defer func() {
+		if mergeIterator != nil {
+			_ = mergeIterator.Close()
+			return
+		}
+		if parentIter != nil {
+			_ = parentIter.Close()
+		}
+		if iter != nil {
+			_ = iter.Close()
+		}
+	}()
+
+	if iterationTracker.ascending {
+		parentIter = s.parentStore.Iterator(iterationTracker.startKey, iterationTracker.endKey)
+	} else {
+		parentIter = s.parentStore.ReverseIterator(iterationTracker.startKey, iterationTracker.endKey)
+	}
+	iter = s.newMVSValidationIterator(index, iterationTracker.startKey, iterationTracker.endKey, items, iterationTracker.ascending, iterationTracker.writeset, abortChan)
+	// create a new MVSMergeiterator
+	mergeIterator = NewMVSMergeIterator(parentIter, iter, iterationTracker.ascending, NoOpHandler{})
+	for {
+		if iteratorValidationAborted(abortChan) {
+			return false
+		}
+		if !mergeIterator.Valid() {
+			break
+		}
+		if iteratorValidationAborted(abortChan) {
+			return false
+		}
+		if (len(expectedKeys) - foundKeys) == 0 {
+			// if we have no more expected keys, then the iterator is invalid
+			return false
+		}
+		key := mergeIterator.Key()
+		if iteratorValidationAborted(abortChan) {
+			return false
+		}
+		// TODO: is this ok to not delete the key since we shouldnt have duplicate keys?
+		if _, ok := expectedKeys[string(key)]; !ok {
+			// if key isn't found
+			return false
+		}
+		// remove from expected keys
+		foundKeys += 1
+		// delete(expectedKeys, string(key))
+
+		// if our iterator key was the early stop, then we can break
+		if bytes.Equal(key, iterationTracker.earlyStopKey) {
+			break
+		}
+		mergeIterator.Next()
+	}
+	if iteratorValidationAborted(abortChan) {
 		return false
-	case valid := <-validChannel:
-		return valid
+	}
+	// return whether we found the exact number of expected keys
+	return foundKeys >= len(expectedKeys)
+}
+
+func iteratorValidationAborted(abortChan <-chan occ.Abort) bool {
+	select {
+	case <-abortChan:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/sei-cosmos/store/multiversion/store_test.go
+++ b/sei-cosmos/store/multiversion/store_test.go
@@ -2,14 +2,104 @@ package multiversion_test
 
 import (
 	"bytes"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store/dbadapter"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store/multiversion"
+	storetypes "github.com/sei-protocol/sei-chain/sei-cosmos/store/types"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/types/occ"
 	"github.com/stretchr/testify/require"
 	dbm "github.com/tendermint/tm-db"
 )
+
+type blockingIteratorStore struct {
+	dbadapter.Store
+
+	mu      sync.Mutex
+	block   bool
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func newBlockingIteratorStore() *blockingIteratorStore {
+	return &blockingIteratorStore{
+		Store:   dbadapter.Store{DB: dbm.NewMemDB()},
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (s *blockingIteratorStore) blockNextIterator() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.block = true
+}
+
+func (s *blockingIteratorStore) maybeBlockIterator() {
+	s.mu.Lock()
+	block := s.block
+	s.block = false
+	s.mu.Unlock()
+	if !block {
+		return
+	}
+	s.once.Do(func() {
+		close(s.entered)
+	})
+	<-s.release
+}
+
+func (s *blockingIteratorStore) Iterator(start, end []byte) storetypes.Iterator {
+	s.maybeBlockIterator()
+	return s.Store.Iterator(start, end)
+}
+
+func (s *blockingIteratorStore) ReverseIterator(start, end []byte) storetypes.Iterator {
+	s.maybeBlockIterator()
+	return s.Store.ReverseIterator(start, end)
+}
+
+type panicIteratorStore struct {
+	dbadapter.Store
+
+	mu            sync.Mutex
+	panicIterator bool
+}
+
+func newPanicIteratorStore() *panicIteratorStore {
+	return &panicIteratorStore{
+		Store: dbadapter.Store{DB: dbm.NewMemDB()},
+	}
+}
+
+func (s *panicIteratorStore) setPanicIterator(panicIterator bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.panicIterator = panicIterator
+}
+
+func (s *panicIteratorStore) shouldPanicIterator() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.panicIterator
+}
+
+func (s *panicIteratorStore) Iterator(start, end []byte) storetypes.Iterator {
+	if s.shouldPanicIterator() {
+		panic("injected iterator panic")
+	}
+	return s.Store.Iterator(start, end)
+}
+
+func (s *panicIteratorStore) ReverseIterator(start, end []byte) storetypes.Iterator {
+	if s.shouldPanicIterator() {
+		panic("injected reverse iterator panic")
+	}
+	return s.Store.ReverseIterator(start, end)
+}
 
 func TestMultiVersionStore(t *testing.T) {
 	store := multiversion.NewMultiVersionStore(nil)
@@ -822,4 +912,128 @@ func TestMVSIteratorValidationEarlyStopIncludedInIterateset(t *testing.T) {
 	valid, conflicts := mvs.ValidateTransactionState(2)
 	require.True(t, valid)
 	require.Empty(t, conflicts)
+}
+
+func TestMVSIteratorValidationLowerIndexRewriteRemovesCapturedKey(t *testing.T) {
+	const validationTimeout = 5 * time.Second
+
+	parentKVStore := newBlockingIteratorStore()
+	mvs := multiversion.NewMultiVersionStore(parentKVStore)
+	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort, 1))
+
+	mvs.SetWriteset(1, 1, multiversion.WriteSet{
+		"balance/denom-a": []byte("100"),
+		"balance/denom-b": []byte("200"),
+	})
+
+	iter := vis.Iterator([]byte("balance/"), []byte("balance0"))
+	for ; iter.Valid(); iter.Next() {
+		iter.Value()
+	}
+	require.NoError(t, iter.Close())
+	vis.WriteToMultiVersionStore()
+
+	parentKVStore.blockNextIterator()
+
+	type validationResult struct {
+		valid     bool
+		conflicts []int
+	}
+	done := make(chan validationResult, 1)
+	go func() {
+		valid, conflicts := mvs.ValidateTransactionState(5)
+		done <- validationResult{valid: valid, conflicts: conflicts}
+	}()
+
+	select {
+	case <-parentKVStore.entered:
+	case <-time.After(validationTimeout):
+		t.Fatal("timed out waiting for iterator validation to capture writeset keys")
+	}
+
+	// Validation has already captured the old writeset keys, so this rewrite
+	// removes denom-b from the multiversion value map while it remains in the
+	// validation iterator's key list.
+	mvs.SetWriteset(1, 2, multiversion.WriteSet{
+		"balance/denom-a": []byte("100"),
+	})
+	close(parentKVStore.release)
+
+	select {
+	case res := <-done:
+		require.False(t, res.valid)
+		require.Empty(t, res.conflicts)
+	case <-time.After(validationTimeout):
+		t.Fatal("timed out waiting for iterator validation")
+	}
+}
+
+func TestMVSIteratorValidationPanicRecovery(t *testing.T) {
+	parentKVStore := newPanicIteratorStore()
+	mvs := multiversion.NewMultiVersionStore(parentKVStore)
+	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort, 1))
+
+	parentKVStore.Set([]byte("balance/denom-a"), []byte("100"))
+
+	iter := vis.Iterator([]byte("balance/"), []byte("balance0"))
+	for ; iter.Valid(); iter.Next() {
+		iter.Value()
+	}
+	require.NoError(t, iter.Close())
+	vis.WriteToMultiVersionStore()
+
+	parentKVStore.setPanicIterator(true)
+
+	var valid bool
+	var conflicts []int
+	require.NotPanics(t, func() {
+		valid, conflicts = mvs.ValidateTransactionState(5)
+	})
+	require.False(t, valid)
+	require.Empty(t, conflicts)
+}
+
+func TestMVSIteratorValidationMultipleEstimatesDoNotBlock(t *testing.T) {
+	const validationTimeout = 5 * time.Second
+
+	parentKVStore := dbadapter.Store{DB: dbm.NewMemDB()}
+	mvs := multiversion.NewMultiVersionStore(parentKVStore)
+	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort, 1))
+
+	mvs.SetWriteset(1, 1, multiversion.WriteSet{
+		"balance/denom-a": []byte("100"),
+		"balance/denom-b": []byte("200"),
+		"balance/denom-c": []byte("300"),
+	})
+
+	iter := vis.Iterator([]byte("balance/"), []byte("balance0"))
+	for ; iter.Valid(); iter.Next() {
+		iter.Value()
+	}
+	require.NoError(t, iter.Close())
+	vis.WriteToMultiVersionStore()
+
+	mvs.SetEstimatedWriteset(1, 2, multiversion.WriteSet{
+		"balance/denom-a": nil,
+		"balance/denom-b": nil,
+		"balance/denom-c": nil,
+	})
+
+	type validationResult struct {
+		valid     bool
+		conflicts []int
+	}
+	done := make(chan validationResult, 1)
+	go func() {
+		valid, conflicts := mvs.ValidateTransactionState(5)
+		done <- validationResult{valid: valid, conflicts: conflicts}
+	}()
+
+	select {
+	case res := <-done:
+		require.False(t, res.valid)
+		require.Equal(t, []int{1}, res.conflicts)
+	case <-time.After(validationTimeout):
+		t.Fatal("timed out waiting for iterator validation with multiple estimates")
+	}
 }


### PR DESCRIPTION
## Summary

- Add a regression test for stale validation iterator keys after a lower-index transaction is re-executed with a smaller writeset.
- Make validation iterators ignore removed multiversion entries without treating real deletes as removed keys.
- Harden iterator validation so recovered panics become validation failures with diagnostic logging, and abort notification cannot leave an ownerless or blocked validation goroutine.

## Root Cause

`validationIterator.Value()` assumed every captured key still had a multiversion value. When a lower-index transaction was re-executed and stopped writing one of those keys, the stale key could remain in the validation iterator's key list while `GetLatestBeforeIndex` returned nil, leading to a nil pointer dereference.

## Validation

- `go test ./sei-cosmos/store/multiversion ./sei-cosmos/tasks ./giga/deps/tasks -count=1`
- `git diff --check`