### PR TITLE
Upodate checkout GHA step across all workflows

### DIFF
--- a/.github/workflows/buf-check.yml
+++ b/.github/workflows/buf-check.yml
@@ -16,7 +16,8 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+        # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: bufbuild/buf-action@v1
         with:
           version: 1.58.0

--- a/.github/workflows/cross-arch-build.yml
+++ b/.github/workflows/cross-arch-build.yml
@@ -21,7 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -65,7 +66,8 @@ jobs:
       startsWith(github.event.merge_group.base_ref, 'refs/heads/release/')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       # Build inside Alpine (musl-native): Ubuntu's musl-gcc can't fully static-link
       # on 24.04 (glibc libgcc -> _dl_find_object, absent in musl), and zig cc rejects
@@ -102,7 +104,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           submodules: true
 

--- a/.github/workflows/dapp_tests.yml
+++ b/.github/workflows/dapp_tests.yml
@@ -13,7 +13,8 @@ jobs:
     env:
       DAPP_TESTS_MNEMONIC: ${{ secrets.DAPP_TESTS_MNEMONIC }}
     steps:
-      - uses: actions/checkout@v3
+      # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Install seid
         run: |
@@ -36,7 +37,8 @@ jobs:
     env:
       DAPP_TESTS_MNEMONIC: ${{ secrets.DAPP_TESTS_MNEMONIC }}
     steps:
-      - uses: actions/checkout@v3
+      # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Install seid
         run: |

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -14,7 +14,8 @@ jobs:
     steps:
       -
         name: Check out the repo
-        uses: actions/checkout@v3
+        # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       -
         name: Set up QEMU
         # See: https://github.com/docker/setup-qemu-action/releases/tag/v4.1.0

--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -24,7 +24,8 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: AWS Login

--- a/.github/workflows/eth_blocktests.yml
+++ b/.github/workflows/eth_blocktests.yml
@@ -49,7 +49,8 @@ jobs:
         # generate runner index array from 0 to total-runners
         runner-index: ${{fromJson(needs.runner-indexes.outputs.json)}}
     steps:
-      - uses: actions/checkout@v2
+      # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/forge-test.yml
+++ b/.github/workflows/forge-test.yml
@@ -23,7 +23,8 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           submodules: recursive
 

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -26,7 +26,8 @@ jobs:
     env:
       GOFLAGS: -race -tags=ledger,test_ledger_mock
     steps:
-      - uses: actions/checkout@v5
+      # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 1
 
@@ -68,7 +69,8 @@ jobs:
         if: github.event_name == 'merge_group'
         run: echo 'Coverage skipped in merge queue'
 
-      - uses: actions/checkout@v5
+      # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         if: github.event_name != 'merge_group'
         with:
           # Depth 0 for PRs so merge-base diff against the base branch works.

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -25,7 +25,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.25.6'
-      - uses: actions/checkout@v3
+      # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -40,7 +40,8 @@ jobs:
     outputs:
       tests: ${{ steps.build.outputs.tests }}
     steps:
-      - uses: actions/checkout@v5
+      # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Build matrix
         id: build
         env:
@@ -74,7 +75,8 @@ jobs:
       GHCR_LOCALNODE: ghcr.io/sei-protocol/sei-chain-integration-test-localnode
       GHCR_RPCNODE: ghcr.io/sei-protocol/sei-chain-integration-test-rpcnode
     steps:
-      - uses: actions/checkout@v5
+      # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Login to Docker Hub
         # See: https://github.com/docker/login-action/releases/tag/v4.2.0
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
@@ -150,7 +152,7 @@ jobs:
     # matrix on pull_request by the set-matrix job above; a smoke of Autobahn
     # coverage still runs on PRs via the dedicated autobahn-integration-tests
     # job below. On push and merge queue the full matrix runs.
-    needs: [set-matrix, prepare-cluster]
+    needs: [ set-matrix, prepare-cluster ]
     runs-on: ubuntu-large
     timeout-minutes: 30
     permissions:
@@ -171,7 +173,8 @@ jobs:
       matrix:
         test: ${{ fromJSON(needs.set-matrix.outputs.tests) }}
     steps:
-      - uses: actions/checkout@v3
+      # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -316,7 +319,8 @@ jobs:
       GHCR_LOCALNODE: ghcr.io/sei-protocol/sei-chain-integration-test-localnode
       GHCR_RPCNODE: ghcr.io/sei-protocol/sei-chain-integration-test-rpcnode
     steps:
-      - uses: actions/checkout@v5
+      # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: actions/setup-go@v6
         with:
           go-version: '1.25.6'
@@ -375,7 +379,7 @@ jobs:
   integration-test-check:
     name: Integration Test Check
     runs-on: ubuntu-latest
-    needs: [prepare-cluster, integration-tests, autobahn-integration-tests]
+    needs: [ prepare-cluster, integration-tests, autobahn-integration-tests ]
     if: always()
     steps:
       - name: Verify prepare and test jobs succeeded

--- a/.github/workflows/libwasmvm.yml
+++ b/.github/workflows/libwasmvm.yml
@@ -32,7 +32,8 @@ jobs:
           - release-build-macos
           - release-build-macos-static
     steps:
-      - uses: actions/checkout@v6
+      # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
            ref: ${{ inputs.ref || github.sha }}
       - name: Build

--- a/.github/workflows/mock_balances_build.yml
+++ b/.github/workflows/mock_balances_build.yml
@@ -23,7 +23,8 @@ jobs:
     name: Compile with Mock Balances
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: actions/setup-go@v6
         with:
           go-version: '1.25.6'

--- a/.github/workflows/nightly-ecr.yml
+++ b/.github/workflows/nightly-ecr.yml
@@ -18,7 +18,8 @@ jobs:
       contents: read
     steps:
       - name: Checkout main HEAD
-        uses: actions/checkout@v5
+        # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           ref: main
 

--- a/.github/workflows/pr-to-slack-codex.yml
+++ b/.github/workflows/pr-to-slack-codex.yml
@@ -17,7 +17,8 @@ jobs:
 
     steps:
       - name: Checkout PR HEAD (full history)
-        uses: actions/checkout@v4
+        # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/proto-registry.yml
+++ b/.github/workflows/proto-registry.yml
@@ -13,7 +13,8 @@ jobs:
   push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: bufbuild/buf-setup-action@v1.26.1
       - uses: bufbuild/buf-push-action@v1
         with:

--- a/.github/workflows/rocksdb-unit_tests.yml
+++ b/.github/workflows/rocksdb-unit_tests.yml
@@ -21,7 +21,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.25.6'
-      - uses: actions/checkout@v5
+      # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Install RocksDB dependencies
         run: |

--- a/.github/workflows/sei-db-tests.yml
+++ b/.github/workflows/sei-db-tests.yml
@@ -24,7 +24,8 @@ jobs:
     env:
       GOFLAGS: -race -tags=ledger,test_ledger_mock
     steps:
-      - uses: actions/checkout@v5
+      # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 1
 

--- a/.github/workflows/sei-db-tests.yml
+++ b/.github/workflows/sei-db-tests.yml
@@ -66,7 +66,8 @@ jobs:
         if: github.event_name == 'merge_group'
         run: echo 'Coverage skipped in merge queue'
 
-      - uses: actions/checkout@v5
+      # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         if: github.event_name != 'merge_group'
         with:
           # Depth 0 for PRs so merge-base diff against the base branch works.


### PR DESCRIPTION
We use different versions across the folows. Some version are no longer supported by latest runners.

Update all to consistently use the immutable latest version.
