### PR TITLE
Per-block littidx flush + single shard (gated on #3645)

### DIFF
--- a/sei-db/ledger_db/receipt/litt_receipt_store.go
+++ b/sei-db/ledger_db/receipt/litt_receipt_store.go
@@ -44,11 +44,12 @@ import (
 // metadata (m:latest / m:earliest).
 //
 // Durability: a background flusher bounds litt durability lag to
-// littFlushInterval without putting fsync on the commit path; Close flushes the
-// remainder. Accepted tradeoff: a hard crash can lose up to littFlushInterval
-// of the most recent receipt bodies (litt buffers in memory, no WAL) while the
-// index still lists them — tolerable for auxiliary, non-consensus RPC data,
-// since reads return not-found for a missing body. Retention: receipt values
+// littFlushInterval (~one block) without putting fsync on the commit path;
+// Close flushes the remainder. A hard crash can lose up to littFlushInterval of
+// the most recent receipt bodies while the index still lists them — tolerable
+// for auxiliary, non-consensus RPC data, since reads return not-found for a
+// missing body. The tight interval is only affordable because litt flushes its
+// keymap asynchronously off the control loop. Retention: receipt values
 // expire via litt's per-table TTL (time based), tag keys are pruned by block
 // range, and reads enforce the KeepRecent floor, so visible retention never
 // exceeds KeepRecent regardless of GC timing.
@@ -80,7 +81,12 @@ const (
 	receiptBackendLittIdx = "littidx"
 
 	littReceiptTableName = "receipts"
-	littFlushInterval    = 100 * time.Millisecond
+	// littFlushInterval is roughly one flush per block at Giga throughput (a
+	// block is ~7ms), bounding crash loss to about a single block. Flushing this
+	// often is only cheap because litt flushes its keymap asynchronously, off the
+	// control loop; without that, a per-block flush regresses write throughput
+	// badly (≈-48% observed before the async keymap landed).
+	littFlushInterval = 5 * time.Millisecond
 	// littTTLPerBlock converts the KeepRecent block count into litt's wall-clock
 	// TTL (KeepRecent * littTTLPerBlock). Set above Giga block times so the TTL
 	// over-retains; only a sustained block time above this would expire a body
@@ -123,7 +129,7 @@ func newLittReceiptStore(cfg dbconfig.ReceiptStoreConfig, storeKey sdk.StoreKey)
 		return nil, fmt.Errorf("failed to open littdb: %w", err)
 	}
 	tableConfig := litt.DefaultTableConfig(littReceiptTableName)
-	tableConfig.ShardingFactor = 16 // spread writes across shards (cores spare)
+	tableConfig.ShardingFactor = 1 // single shard: flushing one file is cheaper; sharding mainly helps across multiple disks
 	receipts, err := values.BuildTable(tableConfig)
 	if err != nil {
 		_ = values.Close()


### PR DESCRIPTION
## Description
- NOTE: Only Merge post [3645](https://github.com/sei-protocol/sei-chain/pull/3645): That makes per-block flush affordable, reclaiming near-per-block crash durability for free.
- `littFlushInterval` 100ms -> **5ms** (~one block at Giga throughput) — bounds crash loss to ~a single block (near-WAL durability for receipt bodies).
- `ShardingFactor` 16 -> **1**. flushing one segment file is cheaper; sharding mainly helps across multiple disks.

## Testing
- reads-off write ceiling **167k** (vs 168k prior)
- reads-on **~153–157k** writes / 58k point-reads/s / 520 getLogs/s @ 7ms
- 3h GC soak **flat** (old −27% control-loop step-down gone), 0 panics
