### PR TITLE
fix(sei-tendermint): prevent readRoutine goroutine leak on /websocket when writeChan is full (PLT-707)

### DIFF
--- a/sei-tendermint/rpc/jsonrpc/server/ws_handler.go
+++ b/sei-tendermint/rpc/jsonrpc/server/ws_handler.go
@@ -180,6 +180,10 @@ func ReadLimit(readLimit int64) func(*wsConnection) {
 func (wsc *wsConnection) Start(ctx context.Context) error {
 	wsc.writeChan = make(chan rpctypes.RPCResponse, defaultWSWriteChanCapacity)
 
+	// Derive a connection-scoped context that is canceled as soon as Start returns.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	// Read subscriptions/unsubscriptions to events
 	go wsc.readRoutine(ctx)
 	// Write responses, BLOCKING.
@@ -243,8 +247,10 @@ func (wsc *wsConnection) Context() context.Context {
 
 // Read from the socket and subscribe to or unsubscribe from events
 func (wsc *wsConnection) readRoutine(ctx context.Context) {
-	// readRoutine will block until response is written or WS connection is closed
-	writeCtx := context.Background()
+	// readRoutine will block until response is written or the connection's
+	// context is canceled. Using ctx here ensures a send blocked on a full writeChan is released when writeRoutine
+	// exits, instead of leaking this goroutine.
+	writeCtx := ctx
 
 	defer func() {
 		if r := recover(); r != nil {

--- a/sei-tendermint/rpc/jsonrpc/server/ws_handler_test.go
+++ b/sei-tendermint/rpc/jsonrpc/server/ws_handler_test.go
@@ -81,6 +81,50 @@ func TestWebsocketReadRoutineNoLeakOnFullWriteChan(t *testing.T) {
 	require.NoError(t, c.Close())
 }
 
+// TestWebsocketReadRoutineNoLeakOnPanicWithFullWriteChan exercises the panic
+// recovery path in readRoutine. When a handler panics, recover() writes an error
+// response into writeChan and then relaunches readRoutine. If writeChan is full
+// and writeRoutine has stopped draining it, that recovery send must not block
+// forever, and neither the recovering goroutine nor its relaunched successor may
+// leak.
+func TestWebsocketReadRoutineNoLeakOnPanicWithFullWriteChan(t *testing.T) {
+	s := newEchoWSServer(t)
+	defer s.Close()
+
+	t.Cleanup(leaktest.Check(t))
+
+	d := websocket.Dialer{}
+	c, dialResp, err := d.Dial("ws://"+s.Listener.Addr().String()+"/websocket", nil)
+	require.NoError(t, err)
+	dialResp.Body.Close()
+
+	// As in the full-writeChan test, never read responses. The huge first
+	// response makes writeRoutine block on the socket write and stop draining.
+	bigReq := rpctypes.NewRequest(1)
+	require.NoError(t, bigReq.SetMethodAndParams("echo", map[string]any{"size": 32 * 1024 * 1024}))
+	require.NoError(t, c.WriteJSON(bigReq))
+
+	// Exactly fill writeChan with tiny responses. writeRoutine pulls only the
+	// big response (then blocks), so these defaultWSWriteChanCapacity sends all
+	// succeed and leave writeChan full when readRoutine reads the next request.
+	for i := range defaultWSWriteChanCapacity {
+		req := rpctypes.NewRequest(i + 2)
+		require.NoError(t, req.SetMethodAndParams("echo", map[string]any{"size": 0}))
+		require.NoError(t, c.WriteJSON(req))
+	}
+
+	// The next request panics in the handler. readRoutine's recover() then tries
+	// to push an error response into the already-full writeChan.
+	panicReq := rpctypes.NewRequest(defaultWSWriteChanCapacity + 2)
+	require.NoError(t, panicReq.SetMethodAndParams("panic", map[string]any{"size": 0}))
+	require.NoError(t, c.WriteJSON(panicReq))
+
+	// Closing the client makes writeRoutine's blocked write fail, cancelling the
+	// connection context. That must release the recovery send and let any
+	// relaunched readRoutine exit instead of leaking.
+	require.NoError(t, c.Close())
+}
+
 func newEchoWSServer(t *testing.T) *httptest.Server {
 	type sizeArgs struct {
 		Size json.Number `json:"size"`
@@ -92,6 +136,9 @@ func newEchoWSServer(t *testing.T) *httptest.Server {
 				return "", err
 			}
 			return strings.Repeat("x", int(n)), nil
+		}),
+		"panic": NewWSRPCFunc(func(_ context.Context, _ *sizeArgs) (string, error) {
+			panic("boom in WSJSONRPC handler")
 		}),
 	}
 	wm := NewWebsocketManager(funcMap)

--- a/sei-tendermint/rpc/jsonrpc/server/ws_handler_test.go
+++ b/sei-tendermint/rpc/jsonrpc/server/ws_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/fortytw2/leaktest"
@@ -40,6 +41,68 @@ func TestWebsocketManagerHandler(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, resp.Error)
 	dialResp.Body.Close()
+}
+
+// TestWebsocketReadRoutineNoLeakOnFullWriteChan reproduces a goroutine leak in
+// readRoutine: when writeChan is full and the writeRoutine has stopped draining
+// it, readRoutine blocks forever in WriteRPCResponse because it pushes responses
+// using a non-cancelable context. The connection then tears down (writeRoutine
+// exits, the handler returns) but readRoutine is stranded on the channel send.
+func TestWebsocketReadRoutineNoLeakOnFullWriteChan(t *testing.T) {
+	s := newEchoWSServer(t)
+	defer s.Close()
+
+	t.Cleanup(leaktest.Check(t))
+
+	d := websocket.Dialer{}
+	c, dialResp, err := d.Dial("ws://"+s.Listener.Addr().String()+"/websocket", nil)
+	require.NoError(t, err)
+	require.NoError(t, dialResp.Body.Close())
+
+	// We deliberately never read any response from c. The first request asks for
+	// a response far larger than any socket buffer; the server's writeRoutine
+	// pulls that response first and blocks on the socket write, so it stops
+	// draining writeChan.
+	bigReq := rpctypes.NewRequest(1)
+	require.NoError(t, bigReq.SetMethodAndParams("echo", map[string]any{"size": 32 * 1024 * 1024}))
+	require.NoError(t, c.WriteJSON(bigReq))
+
+	// The follow-up tiny requests produce responses that fill writeChan to
+	// capacity. readRoutine then blocks on the next send with no drainer.
+	for i := range defaultWSWriteChanCapacity + 5 {
+		req := rpctypes.NewRequest(i + 2)
+		require.NoError(t, req.SetMethodAndParams("echo", map[string]any{"size": 0}))
+		require.NoError(t, c.WriteJSON(req))
+	}
+
+	// Closing the client makes the writeRoutine's blocked socket write fail, so
+	// it exits and the handler returns. A correct readRoutine must also unwind;
+	// the buggy one stays blocked on the full writeChan -> leak.
+	require.NoError(t, c.Close())
+}
+
+func newEchoWSServer(t *testing.T) *httptest.Server {
+	type sizeArgs struct {
+		Size json.Number `json:"size"`
+	}
+	funcMap := map[string]*RPCFunc{
+		"echo": NewWSRPCFunc(func(_ context.Context, a *sizeArgs) (string, error) {
+			n, err := a.Size.Int64()
+			if err != nil {
+				return "", err
+			}
+			return strings.Repeat("x", int(n)), nil
+		}),
+	}
+	wm := NewWebsocketManager(funcMap)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/websocket", wm.WebsocketHandler)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return srv
 }
 
 func newWSServer(t *testing.T) *httptest.Server {


### PR DESCRIPTION
## Problem

`readRoutine` on the JSON-RPC `/websocket` endpoint could leak permanently when `writeChan` is full.

`readRoutine` pushes every response through `WriteRPCResponse`, which does a **blocking** send on `writeChan` (capacity `defaultWSWriteChanCapacity = 100`), guarded only by a context:

```go
select {
case <-ctx.Done():
    return ctx.Err()
case wsc.writeChan <- resp:
    return nil
}
```

The context passed was hardcoded to `context.Background()`, so the `<-ctx.Done()` branch could never fire. `writeChan` is the only consumer's input, drained solely by `writeRoutine`. When `writeRoutine` exits independently of `readRoutine` — a socket write/ping failure against a slow or dead client, or context cancellation — nothing drains `writeChan` anymore. Once full, `readRoutine`'s next `WriteRPCResponse` blocks forever:

- `Stop()`/`cancel()` only cancel `wsc.ctx`, which the blocked send doesn't observe.
- Closing the underlying connection only affects socket reads, not a channel send.
- `writeChan` is intentionally never closed.

The same defect existed on the panic-recovery path, which also called `WriteRPCResponse(context.Background(), ...)` before relaunching `readRoutine`.

## Fix

Give `readRoutine` a context that is cancelled when the write side goes away:

- `Start` derives a connection-scoped, cancellable context with `defer cancel()`, so it is cancelled the moment `Start` returns (i.e. once `writeRoutine` exits).
- `readRoutine` uses that context (instead of `context.Background()`) for its `WriteRPCResponse` calls, including the panic-recovery path.

When `writeRoutine` exits for any reason, the context cancels, a blocked `WriteRPCResponse` returns `ctx.Err()`, and `readRoutine` unwinds via its `<-ctx.Done()` case instead of leaking. The relaunched `readRoutine` on the panic path inherits the same cancellable context and terminates on teardown as well.

## Tests

Two `leaktest`-based regression tests in `ws_handler_test.go`, both deterministic (a 32 MB response blocks `writeRoutine` on the socket write; tiny follow-up requests fill `writeChan` to capacity):

- `TestWebsocketReadRoutineNoLeakOnFullWriteChan` — readRoutine blocked on a full `writeChan` after `writeRoutine` exits.
- `TestWebsocketReadRoutineNoLeakOnPanicWithFullWriteChan` — the panic→`recover()` path with a full `writeChan`.

Both were verified to **fail** against the pre-fix code (leaked goroutine reported by `leaktest`) and **pass** after the fix. Full package passes with `-race`; `gofmt -s` and `go vet` are clean.
