### PR TITLE
fix(evmrpc): apply getLogs maxLog cap during merge instead of after (PLT-687)

### DIFF
--- a/evmrpc/filter.go
+++ b/evmrpc/filter.go
@@ -893,12 +893,14 @@ func (f *LogFetcher) GetLogsByFilters(ctx context.Context, crit filters.FilterCr
 		}
 	}()
 
-	res = f.mergeSortedLogs(sortedBatches)
-
-	// Apply rate limit
-	if applyOpenEndedLogLimit && int64(len(res)) >= f.filterConfig.maxLog {
-		res = res[:int(f.filterConfig.maxLog)]
+	// Push the cap into the merge so it stops popping once the limit is reached,
+	// bounding the merged result allocation to O(maxLog) instead of O(total
+	// matching logs). A limit of 0 means no cap.
+	var limit int64
+	if applyOpenEndedLogLimit {
+		limit = f.filterConfig.maxLog
 	}
+	res = f.mergeSortedLogs(sortedBatches, limit)
 
 	// Ensure we never return nil, always return an array (even if empty)
 	if res == nil {
@@ -908,7 +910,11 @@ func (f *LogFetcher) GetLogsByFilters(ctx context.Context, crit filters.FilterCr
 	return res, end, err
 }
 
-func (f *LogFetcher) mergeSortedLogs(batches [][]*ethtypes.Log) []*ethtypes.Log {
+// mergeSortedLogs k-way merges the per-batch sorted slices into a single sorted
+// slice. When limit > 0 it stops once limit logs have been collected, bounding
+// both the result allocation and the work done to O(limit) rather than O(total
+// matching logs). A limit of 0 means no cap.
+func (f *LogFetcher) mergeSortedLogs(batches [][]*ethtypes.Log, limit int64) []*ethtypes.Log {
 	totalSize := 0
 	for _, b := range batches {
 		totalSize += len(b)
@@ -917,7 +923,12 @@ func (f *LogFetcher) mergeSortedLogs(batches [][]*ethtypes.Log) []*ethtypes.Log 
 		return []*ethtypes.Log{}
 	}
 
-	res := make([]*ethtypes.Log, 0, totalSize)
+	capSize := totalSize
+	if limit > 0 && int64(capSize) > limit {
+		capSize = int(limit)
+	}
+
+	res := make([]*ethtypes.Log, 0, capSize)
 	h := &logMergeHeap{}
 
 	// Initialize the heap with the first element from each non-empty batch
@@ -931,8 +942,11 @@ func (f *LogFetcher) mergeSortedLogs(batches [][]*ethtypes.Log) []*ethtypes.Log 
 		}
 	}
 
-	// Process the heap until it's empty
+	// Process the heap until it's empty, or until we've collected `limit` logs.
 	for h.Len() > 0 {
+		if limit > 0 && int64(len(res)) >= limit {
+			break
+		}
 		item := heap.Pop(h).(*kWayMergeItem)
 		res = append(res, item.log)
 

--- a/evmrpc/filter_bounds_test.go
+++ b/evmrpc/filter_bounds_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"testing"
 
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/filters"
 	"github.com/stretchr/testify/require"
 )
@@ -115,4 +116,64 @@ func TestComputeBlockBounds(t *testing.T) {
 			require.Equalf(t, tc.wantEnd, gotEnd, "end mismatch")
 		})
 	}
+}
+
+// TestMergeSortedLogs covers the limit-aware k-way merge: with limit == 0 it
+// merges every batch in global (block, index) order, and with a positive limit
+// it stops early after collecting that many logs while still returning the
+// globally-smallest prefix.
+func TestMergeSortedLogs(t *testing.T) {
+	t.Parallel()
+
+	mkLog := func(block uint64, idx uint) *ethtypes.Log {
+		return &ethtypes.Log{BlockNumber: block, Index: idx}
+	}
+	// Three pre-sorted batches that interleave when merged. Flattened global
+	// order is (1,0)(1,1)(2,0)(2,1)(3,0)(3,1)(4,0)(5,0).
+	batches := [][]*ethtypes.Log{
+		{mkLog(1, 0), mkLog(2, 1), mkLog(4, 0)},
+		{mkLog(1, 1), mkLog(3, 0), mkLog(5, 0)},
+		{mkLog(2, 0), mkLog(3, 1)},
+	}
+	type key struct {
+		block uint64
+		idx   uint
+	}
+	wantOrder := []key{{1, 0}, {1, 1}, {2, 0}, {2, 1}, {3, 0}, {3, 1}, {4, 0}, {5, 0}}
+
+	f := &LogFetcher{}
+
+	assertPrefix := func(t *testing.T, res []*ethtypes.Log, n int) {
+		t.Helper()
+		require.Len(t, res, n)
+		for i := range n {
+			require.Equalf(t, wantOrder[i].block, res[i].BlockNumber, "log %d block", i)
+			require.Equalf(t, wantOrder[i].idx, res[i].Index, "log %d index", i)
+		}
+	}
+
+	t.Run("no limit merges everything in order", func(t *testing.T) {
+		t.Parallel()
+		assertPrefix(t, f.mergeSortedLogs(batches, 0), len(wantOrder))
+	})
+
+	t.Run("limit truncates to global prefix", func(t *testing.T) {
+		t.Parallel()
+		res := f.mergeSortedLogs(batches, 3)
+		assertPrefix(t, res, 3)
+		// Allocation is bounded to the limit, not the total batch size.
+		require.Equal(t, 3, cap(res))
+	})
+
+	t.Run("limit at least total returns everything", func(t *testing.T) {
+		t.Parallel()
+		assertPrefix(t, f.mergeSortedLogs(batches, int64(len(wantOrder)+5)), len(wantOrder))
+	})
+
+	t.Run("empty batches return empty slice", func(t *testing.T) {
+		t.Parallel()
+		res := f.mergeSortedLogs([][]*ethtypes.Log{{}, nil}, 10)
+		require.NotNil(t, res)
+		require.Empty(t, res)
+	})
 }


### PR DESCRIPTION
## Summary
`eth_getLogs` / `sei_getLogs` previously ran the k-way heap merge (`mergeSortedLogs`) to completion and then truncated the result to `maxLog`. The merge had no early exit, so the full merged result set was allocated regardless of the cap value.

This pushes the cap into `mergeSortedLogs` via a `limit` parameter: the merge stops popping the heap once `limit` logs are collected, and the result slice is pre-sized to `min(total, limit)`. Output is identical to before (same `maxLog`, same open-ended gating) — only the wasted allocation and heap work are removed.

## Scope / known limitations
This is a deliberately minimal fix matching the ticket (PLT-687). It does **not** fully bound peak memory for large queries — follow-up scope is tracked separately:

- **Inputs are still fully materialized.** The per-batch sorted slices (`sortedBatches`) hold all matching logs before the merge runs, so peak memory drops from ~`O(2·total)` to `O(total + maxLog)`, not to `O(maxLog)`. What this eliminates is the redundant merged-copy allocation and the wasted heap pops beyond the cap.
- **Only the block-by-block fallback path is affected.** The primary range-query path (`tryFilterLogsRange` → litt `FilterLogs` → `filterLogsByTags`) returns before this code and remains uncapped. A true memory bound requires pushing the limit into that path with ordered/windowed early termination.
- **Only open-ended queries are capped** (`applyOpenEndedLogLimit`, i.e. missing `fromBlock`/`toBlock`); bounded `{fromBlock, toBlock}` queries are not capped on any path. Whether to cap bounded queries — and whether to truncate silently vs. return an error — is an open product decision deferred to the follow-up.

## Test plan
- Added `TestMergeSortedLogs` (`evmrpc/filter_bounds_test.go`, internal package) covering: no-limit full ordered merge; positive limit returns the globally-smallest prefix and bounds `cap(res)` to the limit; `limit >= total`; and empty batches.
- `go test ./evmrpc/ -run 'TestMergeSortedLogs|Logs|GetLogs|Filter'` — pass.

Note: the merge is unit-tested in isolation; there is no new end-to-end test asserting the cap over a live getLogs call, since the HTTP fixtures don't produce enough logs in a single open-ended query to trip `MaxLogNoBlock`. An e2e assertion belongs with the follow-up that reworks the cap semantics.
