### PR TITLE
Require absolute path for evmone lib

### DIFF
--- a/giga/executor/lib/evmlib.go
+++ b/giga/executor/lib/evmlib.go
@@ -62,6 +62,9 @@ func InitEvmoneVM() (*evmc.VM, error) {
 func resolveLibPath() (string, error) {
 	dirs := make([]string, 0, 3)
 	if dir := os.Getenv(libDirEnv); dir != "" {
+		if !filepath.IsAbs(dir) {
+			return "", fmt.Errorf("%s must be an absolute path, got %q", libDirEnv, dir)
+		}
 		dirs = append(dirs, dir)
 	}
 	dirs = append(dirs, installLibDir)

--- a/giga/executor/lib/evmlib_test.go
+++ b/giga/executor/lib/evmlib_test.go
@@ -28,3 +28,22 @@ func TestLibSHA256MatchesCheckedInLibrary(t *testing.T) {
 	got := hex.EncodeToString(h.Sum(nil))
 	require.Equal(t, libSHA256, got, "checked-in %s digest = %s, want %s", libName, got, libSHA256)
 }
+
+func TestResolveLibPathRejectsRelativeOverrideDir(t *testing.T) {
+	t.Setenv(libDirEnv, ".")
+
+	_, err := resolveLibPath()
+	require.ErrorContains(t, err, libDirEnv+" must be an absolute path")
+}
+
+func TestResolveLibPathUsesAbsoluteOverrideDir(t *testing.T) {
+	dir := t.TempDir()
+	libPath := filepath.Join(dir, libName)
+	require.NoError(t, os.WriteFile(libPath, []byte("test evmone library"), 0o600))
+	t.Setenv(libDirEnv, dir)
+
+	got, err := resolveLibPath()
+	require.NoError(t, err)
+	require.Equal(t, libPath, got)
+	require.True(t, filepath.IsAbs(got))
+}


### PR DESCRIPTION
When supplied via env var, require the path to be absolute to assure that the lib loaded is the same one we check the sha of.
