### PR TITLE
feat(seid): ConfigManager selection seam (PLT-775 PR1)

### DIFF
--- a/cmd/seid/cmd/configmanager/configmanager.go
+++ b/cmd/seid/cmd/configmanager/configmanager.go
@@ -1,0 +1,64 @@
+// Package configmanager is the selection seam between the legacy config
+// loader and the (forthcoming) sei-config-backed manager, gated by the
+// SEI_CONFIG_MANAGER environment variable.
+//
+// PR1 ships the seam only: LegacyConfigManager re-enters the unchanged
+// legacy handler verbatim (the default), and SeiConfigManager is a
+// not-yet-implemented stub that does not import the sei-config library.
+// The v2 body lands in a follow-up PR. See PLT-775 and the canonical
+// design (bdchatham-designs designs/config-manager/DESIGN.md).
+package configmanager
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sei-protocol/sei-chain/sei-cosmos/server"
+)
+
+// EnvVar is the experimental gate that selects the configuration manager.
+const EnvVar = "SEI_CONFIG_MANAGER"
+
+// ConfigManager resolves a seid node's configuration during
+// PersistentPreRunE. An implementation must populate both channels the app
+// consumes — serverCtx.Config and serverCtx.Viper — exactly as the legacy
+// path does. The signature mirrors server.InterceptConfigsPreRunHandler.
+type ConfigManager interface {
+	Apply(cmd *cobra.Command, customAppConfigTemplate string, customAppConfig any) error
+}
+
+// LegacyConfigManager is the default manager: it re-enters the unchanged
+// legacy handler verbatim, so the legacy path stays byte-for-byte unaffected.
+type LegacyConfigManager struct{}
+
+// Apply delegates to the legacy interception handler unchanged.
+func (LegacyConfigManager) Apply(cmd *cobra.Command, customAppConfigTemplate string, customAppConfig any) error {
+	return server.InterceptConfigsPreRunHandler(cmd, customAppConfigTemplate, customAppConfig)
+}
+
+// SeiConfigManager will resolve configuration through the sei-config library
+// behind SEI_CONFIG_MANAGER=v2. PR1 ships the seam only; the real body lands
+// in a follow-up PR. It intentionally does not import sei-config.
+type SeiConfigManager struct{}
+
+// Apply is not yet implemented in PR1. It returns a hard error rather than
+// silently falling back to the legacy path, so a v2 invocation is observable.
+func (SeiConfigManager) Apply(_ *cobra.Command, _ string, _ any) error {
+	return fmt.Errorf("%s=v2 not yet implemented (PR1 seam only)", EnvVar)
+}
+
+// Select returns the ConfigManager chosen by the SEI_CONFIG_MANAGER value:
+// unset or "legacy" -> LegacyConfigManager (the default); "v2" ->
+// SeiConfigManager; any other value -> error (never a silent fallback).
+// getenv is injected for testability; production callers pass os.Getenv.
+func Select(getenv func(string) string) (ConfigManager, error) {
+	switch v := getenv(EnvVar); v {
+	case "", "legacy":
+		return LegacyConfigManager{}, nil
+	case "v2":
+		return SeiConfigManager{}, nil
+	default:
+		return nil, fmt.Errorf("invalid %s=%q (want unset, \"legacy\", or \"v2\")", EnvVar, v)
+	}
+}

--- a/cmd/seid/cmd/configmanager/configmanager.go
+++ b/cmd/seid/cmd/configmanager/configmanager.go
@@ -20,10 +20,22 @@ import (
 // EnvVar is the experimental gate that selects the configuration manager.
 const EnvVar = "SEI_CONFIG_MANAGER"
 
-// ConfigManager resolves a seid node's configuration during
-// PersistentPreRunE. An implementation must populate both channels the app
-// consumes — serverCtx.Config and serverCtx.Viper — exactly as the legacy
-// path does. The signature mirrors server.InterceptConfigsPreRunHandler.
+// ConfigManager resolves a seid node's configuration during PersistentPreRunE.
+//
+// Load-bearing contract: an implementation must leave both channels the app
+// consumes — serverCtx.Config and serverCtx.Viper — populated exactly as the
+// legacy path does, and must be all-or-nothing with respect to on-disk state
+// (no partial config.toml/app.toml materialization on error). A v2 manager
+// that authors the two files from the sei-config library must write BOTH
+// atomically and then re-enter the legacy read tail so the channels are
+// produced identically — it must not feed app.New from an in-memory struct.
+//
+// The Apply signature matches server.InterceptConfigsPreRunHandler so the
+// legacy implementation forwards verbatim. This is an internal,
+// single-consumer contract (only root.go calls it) and is free to grow — an
+// explicit home dir or a Prepare/Apply split — when the v2 write-then-re-enter
+// body lands in a follow-up PR; the node dir is resolvable from cmd, so the
+// signature is sufficient for PR1's seam.
 type ConfigManager interface {
 	Apply(cmd *cobra.Command, customAppConfigTemplate string, customAppConfig any) error
 }
@@ -52,6 +64,10 @@ func (SeiConfigManager) Apply(_ *cobra.Command, _ string, _ any) error {
 // unset or "legacy" -> LegacyConfigManager (the default); "v2" ->
 // SeiConfigManager; any other value -> error (never a silent fallback).
 // getenv is injected for testability; production callers pass os.Getenv.
+//
+// The value is matched exactly — no trimming or case-folding. This is
+// deliberate: normalizing would broaden the gate, and the error names the
+// legal tokens so an operator can self-correct.
 func Select(getenv func(string) string) (ConfigManager, error) {
 	switch v := getenv(EnvVar); v {
 	case "", "legacy":

--- a/cmd/seid/cmd/configmanager/configmanager_test.go
+++ b/cmd/seid/cmd/configmanager/configmanager_test.go
@@ -1,0 +1,48 @@
+package configmanager
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestSelect covers the dispatch table: unset and "legacy" select the
+// LegacyConfigManager, "v2" selects the SeiConfigManager, and any other
+// value is a hard error (no silent fallback).
+func TestSelect(t *testing.T) {
+	cases := []struct {
+		name    string
+		val     string
+		want    ConfigManager
+		wantErr bool
+	}{
+		{name: "unset", val: "", want: LegacyConfigManager{}},
+		{name: "legacy", val: "legacy", want: LegacyConfigManager{}},
+		{name: "v2", val: "v2", want: SeiConfigManager{}},
+		{name: "garbage", val: "v3", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr, err := Select(func(string) string { return tc.val })
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("Select(%q): want error, got nil", tc.val)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Select(%q): unexpected error: %v", tc.val, err)
+			}
+			if got, want := fmt.Sprintf("%T", mgr), fmt.Sprintf("%T", tc.want); got != want {
+				t.Errorf("Select(%q) = %s, want %s", tc.val, got, want)
+			}
+		})
+	}
+}
+
+// TestSeiConfigManagerNotImplemented asserts the v2 stub fails hard rather
+// than silently behaving like legacy (PR1 ships the seam only).
+func TestSeiConfigManagerNotImplemented(t *testing.T) {
+	if err := (SeiConfigManager{}).Apply(nil, "", nil); err == nil {
+		t.Fatal("SeiConfigManager.Apply: want not-implemented error, got nil")
+	}
+}

--- a/cmd/seid/cmd/configmanager/configmanager_test.go
+++ b/cmd/seid/cmd/configmanager/configmanager_test.go
@@ -1,8 +1,9 @@
 package configmanager
 
 import (
-	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestSelect covers the dispatch table: unset and "legacy" select the
@@ -24,17 +25,11 @@ func TestSelect(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mgr, err := Select(func(string) string { return tc.val })
 			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("Select(%q): want error, got nil", tc.val)
-				}
+				require.Error(t, err)
 				return
 			}
-			if err != nil {
-				t.Fatalf("Select(%q): unexpected error: %v", tc.val, err)
-			}
-			if got, want := fmt.Sprintf("%T", mgr), fmt.Sprintf("%T", tc.want); got != want {
-				t.Errorf("Select(%q) = %s, want %s", tc.val, got, want)
-			}
+			require.NoError(t, err)
+			require.IsType(t, tc.want, mgr)
 		})
 	}
 }
@@ -42,7 +37,5 @@ func TestSelect(t *testing.T) {
 // TestSeiConfigManagerNotImplemented asserts the v2 stub fails hard rather
 // than silently behaving like legacy (PR1 ships the seam only).
 func TestSeiConfigManagerNotImplemented(t *testing.T) {
-	if err := (SeiConfigManager{}).Apply(nil, "", nil); err == nil {
-		t.Fatal("SeiConfigManager.Apply: want not-implemented error, got nil")
-	}
+	require.Error(t, (SeiConfigManager{}).Apply(nil, "", nil))
 }

--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -100,6 +100,10 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 
 			customAppTemplate, customAppConfig := initAppConfig()
 
+			// SEI_CONFIG_MANAGER is read once per PersistentPreRunE invocation
+			// (a clean two-way door). When PR2 adds the `seid config ...` subtree
+			// (which skips PersistentPreRunE), it must own single-read discipline
+			// so one process cannot select two different managers.
 			mgr, err := configmanager.Select(os.Getenv)
 			if err != nil {
 				return err

--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sei-protocol/sei-chain/admin"
 	"github.com/sei-protocol/sei-chain/app"
 	"github.com/sei-protocol/sei-chain/app/params"
+	"github.com/sei-protocol/sei-chain/cmd/seid/cmd/configmanager"
 	evmrpcconfig "github.com/sei-protocol/sei-chain/evmrpc/config"
 	gigaconfig "github.com/sei-protocol/sei-chain/giga/executor/config"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/baseapp"
@@ -99,7 +100,11 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 
 			customAppTemplate, customAppConfig := initAppConfig()
 
-			return server.InterceptConfigsPreRunHandler(cmd, customAppTemplate, customAppConfig)
+			mgr, err := configmanager.Select(os.Getenv)
+			if err != nil {
+				return err
+			}
+			return mgr.Apply(cmd, customAppTemplate, customAppConfig)
 		},
 	}
 


### PR DESCRIPTION
## What

PR1 of the ConfigManager MVP (**PLT-775**): the **logical seam** between the legacy config loader and the forthcoming sei-config-backed manager, gated by `SEI_CONFIG_MANAGER`. This PR ships the seam only — no behavior change on the default path.

New package `cmd/seid/cmd/configmanager`:
- `ConfigManager` interface — `Apply(cmd, customAppConfigTemplate, customAppConfig)` mirrors `server.InterceptConfigsPreRunHandler`.
- `LegacyConfigManager` — re-enters the legacy handler **verbatim** (the default).
- `SeiConfigManager` — PR1 **stub**: returns a hard error `SEI_CONFIG_MANAGER=v2 not yet implemented (PR1 seam only)`; **does not import sei-config**.
- `Select(getenv)` — `unset`/`legacy` → Legacy; `v2` → Sei; **any other value → hard error** (no silent fallback).

`root.go` `PersistentPreRunE` now routes through `Select`+`Apply` instead of calling `InterceptConfigsPreRunHandler` directly. The `init` skip is untouched.

## Scope / constraints

- **Zero edits to the vendored `sei-cosmos` fork.** Diff is confined to `cmd/seid/cmd/` (the new package + a 6-line wiring change in `root.go`).
- One-day seam slice; the v2 body (sei-config wiring) is a follow-up PR.

## Acceptance-criteria drift contract

Per the canonical design (the design doc [`designs/config-manager/DESIGN.md`](https://github.com/sei-protocol/bdchatham-designs/blob/main/designs/config-manager/DESIGN.md) — *The selection seam* / *MVP scope*), this PR:

**Satisfies:**
- **Legacy untouched** (structural) — when `SEI_CONFIG_MANAGER` is unset, dispatch routes to the unmodified `InterceptConfigsPreRunHandler`.
- **No silent fallback** — any value other than unset/`legacy`/`v2` is a hard startup error.

**Explicitly deferred to PR2+** (all require sei-config as a live dependency):
- v2 parity (legacy-vs-v2 differential on parsed semantics)
- fresh/mixed-home matrix
- `SEI_` collision audit
- `sc-write-mode` failure-parity (the PLT-775 incident class, extending into `app.New()`)
- `KNOWN_UNMAPPED_FIELDS` enumeration

## Tests

`cmd/seid/cmd/configmanager` table test: dispatch (unset / legacy / v2 / garbage→error) + the v2-stub-errors assertion. `go build ./cmd/seid/...` green.

## Lineage

- Issue: **PLT-775** (rides the issue directly; this is the first slice of the single MVP deliverable).
- Design: [`designs/config-manager/DESIGN.md`](https://github.com/sei-protocol/bdchatham-designs/blob/main/designs/config-manager/DESIGN.md) (bdchatham-designs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
