### PR TITLE
Pin priority-fee assertions to stable heads

### DIFF
--- a/integration_test/rpc_tests/eth/eth_gasPrice.spec.ts
+++ b/integration_test/rpc_tests/eth/eth_gasPrice.spec.ts
@@ -80,7 +80,7 @@ describe('eth_gasPrice', function () {
                     const stable = await maxPriorityFeePerGasAtStableBlock(sei);
                     return isCongested(stable) ? null : stable;
                 },
-                { timeoutMs: 60_000, intervalMs: 250, label: 'uncongested gas-price head' },
+                { timeoutMs: 60_000, intervalMs: 250, label: 'EVM-uncongested gas-price head' },
             );
             expect(sample.tip).to.equal(DEFAULT_PRIORITY_FEE_WEI);
         });

--- a/integration_test/rpc_tests/eth/eth_gasPrice.spec.ts
+++ b/integration_test/rpc_tests/eth/eth_gasPrice.spec.ts
@@ -4,7 +4,14 @@ import { readRuntimeState, RuntimeState, expectSameError, claimPool } from '../u
 import { EvmAccount } from '../utils/evmUtils';
 import { burnGasBurst } from '../utils/txUtils';
 import { HEX_QUANTITY } from '../utils/format';
-import { gasPrice, gasPriceAtStableBlock, assertSeiGasPriceTracks } from '../utils/gasPriceUtils';
+import {
+    gasPrice,
+    gasPriceAtStableBlock,
+    assertSeiGasPriceTracks,
+    DEFAULT_PRIORITY_FEE_WEI,
+    isCongested,
+    maxPriorityFeePerGasAtStableBlock,
+} from '../utils/gasPriceUtils';
 
 describe('eth_gasPrice', function () {
     this.timeout(240 * 1000);
@@ -68,9 +75,14 @@ describe('eth_gasPrice', function () {
         });
 
         it('[Sei] maxPriorityFeePerGas defaults to 1 gwei while the chain is uncongested', async () => {
-            // Quiescent runs sit well under the 80% congestion threshold.
-            const tip = BigInt(await sei.send('eth_maxPriorityFeePerGas', []));
-            expect(tip).to.equal(1_000_000_000n);
+            const sample = await waitUntil(
+                async () => {
+                    const stable = await maxPriorityFeePerGasAtStableBlock(sei);
+                    return isCongested(stable) ? null : stable;
+                },
+                { timeoutMs: 60_000, intervalMs: 250, label: 'uncongested gas-price head' },
+            );
+            expect(sample.tip).to.equal(DEFAULT_PRIORITY_FEE_WEI);
         });
     });
 

--- a/integration_test/rpc_tests/eth/eth_maxPriorityFeePerGas.spec.ts
+++ b/integration_test/rpc_tests/eth/eth_maxPriorityFeePerGas.spec.ts
@@ -50,7 +50,7 @@ describe('eth_maxPriorityFeePerGas', function () {
                     const stable = await maxPriorityFeePerGasAtStableBlock(sei);
                     return isCongested(stable) ? null : stable;
                 },
-                { timeoutMs: 60_000, intervalMs: 250, label: 'uncongested priority-fee head' },
+                { timeoutMs: 60_000, intervalMs: 250, label: 'EVM-uncongested priority-fee head' },
             );
             expect(sample.tip, 'uncongested tip == 1 gwei default').to.equal(
                 DEFAULT_PRIORITY_FEE_WEI,

--- a/integration_test/rpc_tests/eth/eth_maxPriorityFeePerGas.spec.ts
+++ b/integration_test/rpc_tests/eth/eth_maxPriorityFeePerGas.spec.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers';
 import { expect } from 'chai';
-import { bothProviders, rawSei, rawGeth, expectJsonRpcError, blockGasInfo } from '../utils/chainUtils';
+import { bothProviders, rawSei, rawGeth, expectJsonRpcError, blockGasInfo, waitUntil } from '../utils/chainUtils';
 import { readRuntimeState, RuntimeState, claimPool } from '../utils/testUtils';
 import { EvmAccount } from '../utils/evmUtils';
 import { burnGasBurst } from '../utils/txUtils';
@@ -11,6 +11,8 @@ import {
     gasPrice,
     DEFAULT_PRIORITY_FEE_WEI,
     CONGESTION_THRESHOLD,
+    isCongested,
+    maxPriorityFeePerGasAtStableBlock,
 } from '../utils/gasPriceUtils';
 
 describe('eth_maxPriorityFeePerGas', function () {
@@ -43,26 +45,27 @@ describe('eth_maxPriorityFeePerGas', function () {
         });
 
         it('falls back to the 1-gwei default while the latest block is uncongested', async () => {
-            const head = await blockGasInfo(sei, 'latest');
-            // EVM-only gas (what the node measures) <= total block gas, so a sub-threshold
-            // gasUsed/gasLimit here guarantees the node also sees the block as uncongested.
-            const ratio = Number(head.gasUsed) / Number(head.gasLimit);
-            if (ratio >= CONGESTION_THRESHOLD) return; // congested sample; the default does not apply
-            const tip = await maxPriorityFeePerGas(sei);
-            expect(tip, 'uncongested tip == 1 gwei default').to.equal(DEFAULT_PRIORITY_FEE_WEI);
+            const sample = await waitUntil(
+                async () => {
+                    const stable = await maxPriorityFeePerGasAtStableBlock(sei);
+                    return isCongested(stable) ? null : stable;
+                },
+                { timeoutMs: 60_000, intervalMs: 250, label: 'uncongested priority-fee head' },
+            );
+            expect(sample.tip, 'uncongested tip == 1 gwei default').to.equal(
+                DEFAULT_PRIORITY_FEE_WEI,
+            );
         });
 
         it('returns either the 1-gwei default or the latest-block 50th-pct tip (congestion rule)', async () => {
-            const [tip, fh] = await Promise.all([
-                maxPriorityFeePerGas(sei),
-                feeHistory(sei, 1, 'latest', [50]),
-            ]);
+            const sample = await maxPriorityFeePerGasAtStableBlock(sei);
+            const fh = await feeHistory(sei, 1, ethers.toQuantity(sample.block), [50]);
             const reward = fh.reward?.[0]?.[0];
             const congestedTip = reward ? BigInt(reward) : 0n;
             expect(
-                tip === DEFAULT_PRIORITY_FEE_WEI || tip === congestedTip,
-                `tip ${tip} must be the 1-gwei default (${DEFAULT_PRIORITY_FEE_WEI}) ` +
-                    `or the latest-block 50th-pct tip (${congestedTip})`,
+                sample.tip === DEFAULT_PRIORITY_FEE_WEI || sample.tip === congestedTip,
+                `tip ${sample.tip} from block ${sample.block} must be the 1-gwei default ` +
+                    `(${DEFAULT_PRIORITY_FEE_WEI}) or that block's 50th-pct tip (${congestedTip})`,
             ).to.equal(true);
         });
 

--- a/integration_test/rpc_tests/utils/gasPriceUtils.ts
+++ b/integration_test/rpc_tests/utils/gasPriceUtils.ts
@@ -21,6 +21,44 @@ export async function maxPriorityFeePerGas(provider: ethers.JsonRpcProvider): Pr
     return BigInt(await provider.send('eth_maxPriorityFeePerGas', []));
 }
 
+export interface PriorityFeeSample {
+    tip: bigint;
+    block: number;
+    gasUsed: bigint;
+    gasLimit: bigint;
+    ratio: number;
+}
+
+/**
+ * Read eth_maxPriorityFeePerGas and the latest block it was derived from without
+ * crossing a block boundary. The fee RPC has no block tag, so callers that assert
+ * against latest-block gas usage must pin a stable head themselves.
+ */
+export async function maxPriorityFeePerGasAtStableBlock(
+    provider: ethers.JsonRpcProvider,
+): Promise<PriorityFeeSample> {
+    for (let i = 0; i < 20; i++) {
+        const b1 = await provider.getBlockNumber();
+        const tip = await maxPriorityFeePerGas(provider);
+        const info = await blockGasInfo(provider, 'latest');
+        const b2 = await provider.getBlockNumber();
+        if (b1 === b2 && info.number === b1) {
+            return {
+                tip,
+                block: info.number,
+                gasUsed: info.gasUsed,
+                gasLimit: info.gasLimit,
+                ratio: Number(info.gasUsed) / Number(info.gasLimit),
+            };
+        }
+    }
+    throw new Error('maxPriorityFeePerGasAtStableBlock: block kept advancing across the sample');
+}
+
+export function isCongested(sample: { gasUsed: bigint; gasLimit: bigint }): boolean {
+    return sample.gasUsed > (sample.gasLimit * 80n) / 100n;
+}
+
 /**
  * Read eth_gasPrice with the latest height pinned: only accept a reading where no new
  * block landed across the call, so the returned price provably derives from

--- a/integration_test/rpc_tests/utils/gasPriceUtils.ts
+++ b/integration_test/rpc_tests/utils/gasPriceUtils.ts
@@ -14,7 +14,7 @@ export async function gasPrice(provider: ethers.JsonRpcProvider): Promise<bigint
 /** Sei's idle-chain default priority fee (1 gwei), returned when the latest block is uncongested. */
 export const DEFAULT_PRIORITY_FEE_WEI = ethers.parseUnits('1', 'gwei');
 
-/** Sei treats a block as congested once it burns > 80% of the block gas limit. */
+/** Sei treats a block as congested once EVM receipt gas burns > 80% of the block gas limit. */
 export const CONGESTION_THRESHOLD = 0.8;
 
 export async function maxPriorityFeePerGas(provider: ethers.JsonRpcProvider): Promise<bigint> {
@@ -25,8 +25,10 @@ export interface PriorityFeeSample {
     tip: bigint;
     block: number;
     gasUsed: bigint;
+    evmGasUsed: bigint;
     gasLimit: bigint;
     ratio: number;
+    evmRatio: number;
 }
 
 /**
@@ -41,22 +43,36 @@ export async function maxPriorityFeePerGasAtStableBlock(
         const b1 = await provider.getBlockNumber();
         const tip = await maxPriorityFeePerGas(provider);
         const info = await blockGasInfo(provider, 'latest');
+        const evmGasUsed = await evmGasUsedForBlock(provider, info.number);
         const b2 = await provider.getBlockNumber();
         if (b1 === b2 && info.number === b1) {
             return {
                 tip,
                 block: info.number,
                 gasUsed: info.gasUsed,
+                evmGasUsed,
                 gasLimit: info.gasLimit,
                 ratio: Number(info.gasUsed) / Number(info.gasLimit),
+                evmRatio: Number(evmGasUsed) / Number(info.gasLimit),
             };
         }
     }
     throw new Error('maxPriorityFeePerGasAtStableBlock: block kept advancing across the sample');
 }
 
-export function isCongested(sample: { gasUsed: bigint; gasLimit: bigint }): boolean {
-    return sample.gasUsed > (sample.gasLimit * 80n) / 100n;
+export async function evmGasUsedForBlock(
+    provider: ethers.JsonRpcProvider,
+    block: number,
+): Promise<bigint> {
+    const receipts = await provider.send('eth_getBlockReceipts', [ethers.toQuantity(block)]);
+    return (receipts ?? []).reduce(
+        (sum: bigint, receipt: { gasUsed: string }) => sum + BigInt(receipt.gasUsed),
+        0n,
+    );
+}
+
+export function isCongested(sample: { evmGasUsed: bigint; gasLimit: bigint }): boolean {
+    return sample.evmGasUsed > (sample.gasLimit * 80n) / 100n;
 }
 
 /**
@@ -93,10 +109,11 @@ export async function assertSeiGasPriceTracks(
     const head = await provider.getBlockNumber();
     const heights = [block - 1, block, block + 1, block + 2].filter(h => h >= 0 && h <= head);
     const infos = await Promise.all(heights.map(h => blockGasInfo(provider, h)));
+    const evmGasUsed = await Promise.all(heights.map(h => evmGasUsedForBlock(provider, h)));
 
     if (infos.some(b => (b.baseFee * 110n) / 100n === gasPriceWei)) return;
 
-    const congested = infos.some(b => b.gasUsed > (b.gasLimit * 80n) / 100n);
+    const congested = infos.some((b, i) => evmGasUsed[i] > (b.gasLimit * 80n) / 100n);
     const minBase = infos.reduce((m, b) => (b.baseFee < m ? b.baseFee : m), infos[0].baseFee);
     expect(
         congested && gasPriceWei >= minBase,


### PR DESCRIPTION
The EVM RPC parity tests sampled eth_maxPriorityFeePerGas against "latest" while the devnet was still producing blocks and other fee-market tests could leave a congested block at the head. A new empty block could land between the priority-fee RPC and the eth_feeHistory/latest-block read, or the test could assume the 1 gwei idle default while the sampled head was still congested.

Add a stable-head sampler for eth_maxPriorityFeePerGas, query fee history by the pinned block height, and wait for a stable uncongested head before asserting the default priority fee.

Flaked in [unrelated changes](https://github.com/sei-protocol/sei-chain/actions/runs/28464992080/job/84364444593).
