### PR TITLE
docs: add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,3 +58,33 @@ v2.8.0 and `.github/workflows/go-test.yml` runs `go test -race` on Go 1.25.6.
 
 See [`benchmark/CLAUDE.md`](benchmark/CLAUDE.md) for benchmark usage, environment
 variables, and comparison workflows.
+
+## Cursor Cloud specific instructions
+
+The startup update script only runs `go mod download`. Build the node yourself
+with `make install` (outputs `~/go/bin/seid`); it is not part of the update
+script. Add `~/go/bin` to `PATH` before invoking `seid`.
+
+Run a local single-node chain with `./scripts/initialize_local_chain.sh` (see
+`scripts/initialize_local_chain.sh`). It runs `make install`, wipes `~/.sei`,
+inits chain-id `sei-chain` with a pre-funded `admin` key (keyring backend
+`test`), and then `seid start`. Do not run it in the foreground of a
+short-lived shell — start it in a long-lived tmux session, since `seid start`
+runs until killed.
+
+Gotcha: the script tests `$NO_RUN` unquoted under `set -e`, so `NO_RUN` MUST be
+set or the script errors before starting. Use `NO_RUN=0 ./scripts/initialize_local_chain.sh`
+to init and start, or `NO_RUN=1 ./scripts/initialize_local_chain.sh` to only
+init (then `seid start --chain-id sei-chain` yourself).
+
+Default endpoints after startup: Tendermint RPC `:26657`, Cosmos REST `:1317`,
+gRPC `:9090`, EVM JSON-RPC HTTP `:8545`, EVM WS `:8546`. EVM `eth_chainId`
+returns `0xae3f2`.
+
+Quick smoke test once running: `seid status --node tcp://localhost:26657`,
+`curl -s -X POST http://localhost:8545 -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'`,
+and a bank send `seid tx bank send admin <addr> 1000000usei --chain-id sei-chain --keyring-backend test --fees 20000usei -y`.
+
+`make lint` runs golangci-lint over the whole tree plus `go mod tidy`/`verify`
+(slow); scope to a package with `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0 run ./<pkg>/...`
+while iterating.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the Sei Chain development environment for Cursor Cloud agents, and documents durable, non-obvious startup caveats in `AGENTS.md`.

The only code change is a new `## Cursor Cloud specific instructions` section in `AGENTS.md`. No application code was modified.

## Environment

- Go 1.25.6 (already present), `jq`, `python3`, `node`, `make`, `gcc` all available.
- Update script (startup dependency refresh): `go mod download` (minimal, idempotent). Build (`make install`) and chain startup are performed by the agent, not the update script.

## What was verified

- `make install` → builds `~/go/bin/seid` (`v6.1.6-2275-ga8d35c8a0`).
- `go run .../golangci-lint@v2.8.0 run ./utils/...` → `0 issues`.
- `go test ./utils/...` → all packages pass.
- `./scripts/initialize_local_chain.sh` → single-node chain produces blocks; Tendermint RPC `:26657`, Cosmos REST `:1317`, EVM JSON-RPC `:8545` all respond.
- Hello-world action: `seid tx bank send admin ta0 1000000usei` succeeded (`code 0`) and recipient balance increased by exactly `1000000usei`.

## Non-obvious gotcha documented

`scripts/initialize_local_chain.sh` tests `$NO_RUN` unquoted under `set -e`, so `NO_RUN` must be set (`NO_RUN=0` to start, `NO_RUN=1` to init-only).

[seid_hello_world.log](https://cursor.com/agents/bc-e630eced-1c0a-45ef-a9bb-0e97839f9a94/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseid_hello_world.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e630eced-1c0a-45ef-a9bb-0e97839f9a94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e630eced-1c0a-45ef-a9bb-0e97839f9a94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

