### PR TITLE
Fix race condition for memiavl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ Ref: https://keepachangelog.com/en/1.0.0/
 # Changelog
 ## v6.6
 sei-chain
+* [#3679](https://github.com/sei-protocol/sei-chain/pull/3679) Backport `release/v6.6`: State Store: Compact pruned key range after each prune
+* [#3673](https://github.com/sei-protocol/sei-chain/pull/3673) Backport `release/v6.6`: fix(metrics): Prometheus metrics output
+* [#3672](https://github.com/sei-protocol/sei-chain/pull/3672) Backport `release/v6.6`: [codex] Harden multiversion iterator validation
+* [#3669](https://github.com/sei-protocol/sei-chain/pull/3669) Backport `release/v6.6`: Require absolute path for evmone lib
+* [#3662](https://github.com/sei-protocol/sei-chain/pull/3662) Backport `release/v6.6`: [codex] bump go-ethereum to v1.15.7-sei-17
+* [#3661](https://github.com/sei-protocol/sei-chain/pull/3661) Update checkout GHA step across all workflows
+* [#3635](https://github.com/sei-protocol/sei-chain/pull/3635) Backport `release/v6.6`: Generate v6.6 CHANGELOG
+* [#3627](https://github.com/sei-protocol/sei-chain/pull/3627) Backport `release/v6.6`: Co-broadcast rich block CW20 transfer with EVM batch
 * [#3625](https://github.com/sei-protocol/sei-chain/pull/3625) Generate v6.6 pre-compiles in prep to freeze feature releases
 * [#3624](https://github.com/sei-protocol/sei-chain/pull/3624) Load evmone from a trusted absolute path and verify its SHA-256
 * [#3622](https://github.com/sei-protocol/sei-chain/pull/3622) ci: add retry/backoff to GHCR docker pull in integration-test workflow (PLT-753)

--- a/app/app.go
+++ b/app/app.go
@@ -519,7 +519,7 @@ func New(
 	bApp.SetInterfaceRegistry(interfaceRegistry)
 
 	// Bind OTEL metrics provider once at application construction
-	if err := utilmetrics.SetupOtelMetricsProvider(); err != nil {
+	if err := utilmetrics.SetupOtelMetricsProvider(bApp.ChainID); err != nil {
 		logger.Error(err.Error())
 	}
 

--- a/integration_test/evm_module/scripts/disable_wasm.sh
+++ b/integration_test/evm_module/scripts/disable_wasm.sh
@@ -3,5 +3,19 @@
 set -e
 
 cd contracts
-npm ci
+
+for attempt in 1 2 3; do
+  if npm ci; then
+    break
+  fi
+
+  if [ "$attempt" -eq 3 ]; then
+    exit 1
+  fi
+
+  echo "npm ci failed; retrying in $((attempt * 5)) seconds..."
+  rm -rf node_modules
+  sleep $((attempt * 5))
+done
+
 npx hardhat test --network seilocal test/DisableWasmTest.js

--- a/integration_test/rpc_tests/eth/eth_gasPrice.spec.ts
+++ b/integration_test/rpc_tests/eth/eth_gasPrice.spec.ts
@@ -4,7 +4,14 @@ import { readRuntimeState, RuntimeState, expectSameError, claimPool } from '../u
 import { EvmAccount } from '../utils/evmUtils';
 import { burnGasBurst } from '../utils/txUtils';
 import { HEX_QUANTITY } from '../utils/format';
-import { gasPrice, gasPriceAtStableBlock, assertSeiGasPriceTracks } from '../utils/gasPriceUtils';
+import {
+    gasPrice,
+    gasPriceAtStableBlock,
+    assertSeiGasPriceTracks,
+    DEFAULT_PRIORITY_FEE_WEI,
+    isCongested,
+    maxPriorityFeePerGasAtStableBlock,
+} from '../utils/gasPriceUtils';
 
 describe('eth_gasPrice', function () {
     this.timeout(240 * 1000);
@@ -68,9 +75,14 @@ describe('eth_gasPrice', function () {
         });
 
         it('[Sei] maxPriorityFeePerGas defaults to 1 gwei while the chain is uncongested', async () => {
-            // Quiescent runs sit well under the 80% congestion threshold.
-            const tip = BigInt(await sei.send('eth_maxPriorityFeePerGas', []));
-            expect(tip).to.equal(1_000_000_000n);
+            const sample = await waitUntil(
+                async () => {
+                    const stable = await maxPriorityFeePerGasAtStableBlock(sei);
+                    return isCongested(stable) ? null : stable;
+                },
+                { timeoutMs: 60_000, intervalMs: 250, label: 'EVM-uncongested gas-price head' },
+            );
+            expect(sample.tip).to.equal(DEFAULT_PRIORITY_FEE_WEI);
         });
     });
 

--- a/integration_test/rpc_tests/eth/eth_maxPriorityFeePerGas.spec.ts
+++ b/integration_test/rpc_tests/eth/eth_maxPriorityFeePerGas.spec.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers';
 import { expect } from 'chai';
-import { bothProviders, rawSei, rawGeth, expectJsonRpcError, blockGasInfo } from '../utils/chainUtils';
+import { bothProviders, rawSei, rawGeth, expectJsonRpcError, blockGasInfo, waitUntil } from '../utils/chainUtils';
 import { readRuntimeState, RuntimeState, claimPool } from '../utils/testUtils';
 import { EvmAccount } from '../utils/evmUtils';
 import { burnGasBurst } from '../utils/txUtils';
@@ -11,6 +11,8 @@ import {
     gasPrice,
     DEFAULT_PRIORITY_FEE_WEI,
     CONGESTION_THRESHOLD,
+    isCongested,
+    maxPriorityFeePerGasAtStableBlock,
 } from '../utils/gasPriceUtils';
 
 describe('eth_maxPriorityFeePerGas', function () {
@@ -43,26 +45,27 @@ describe('eth_maxPriorityFeePerGas', function () {
         });
 
         it('falls back to the 1-gwei default while the latest block is uncongested', async () => {
-            const head = await blockGasInfo(sei, 'latest');
-            // EVM-only gas (what the node measures) <= total block gas, so a sub-threshold
-            // gasUsed/gasLimit here guarantees the node also sees the block as uncongested.
-            const ratio = Number(head.gasUsed) / Number(head.gasLimit);
-            if (ratio >= CONGESTION_THRESHOLD) return; // congested sample; the default does not apply
-            const tip = await maxPriorityFeePerGas(sei);
-            expect(tip, 'uncongested tip == 1 gwei default').to.equal(DEFAULT_PRIORITY_FEE_WEI);
+            const sample = await waitUntil(
+                async () => {
+                    const stable = await maxPriorityFeePerGasAtStableBlock(sei);
+                    return isCongested(stable) ? null : stable;
+                },
+                { timeoutMs: 60_000, intervalMs: 250, label: 'EVM-uncongested priority-fee head' },
+            );
+            expect(sample.tip, 'uncongested tip == 1 gwei default').to.equal(
+                DEFAULT_PRIORITY_FEE_WEI,
+            );
         });
 
         it('returns either the 1-gwei default or the latest-block 50th-pct tip (congestion rule)', async () => {
-            const [tip, fh] = await Promise.all([
-                maxPriorityFeePerGas(sei),
-                feeHistory(sei, 1, 'latest', [50]),
-            ]);
+            const sample = await maxPriorityFeePerGasAtStableBlock(sei);
+            const fh = await feeHistory(sei, 1, ethers.toQuantity(sample.block), [50]);
             const reward = fh.reward?.[0]?.[0];
             const congestedTip = reward ? BigInt(reward) : 0n;
             expect(
-                tip === DEFAULT_PRIORITY_FEE_WEI || tip === congestedTip,
-                `tip ${tip} must be the 1-gwei default (${DEFAULT_PRIORITY_FEE_WEI}) ` +
-                    `or the latest-block 50th-pct tip (${congestedTip})`,
+                sample.tip === DEFAULT_PRIORITY_FEE_WEI || sample.tip === congestedTip,
+                `tip ${sample.tip} from block ${sample.block} must be the 1-gwei default ` +
+                    `(${DEFAULT_PRIORITY_FEE_WEI}) or that block's 50th-pct tip (${congestedTip})`,
             ).to.equal(true);
         });
 

--- a/integration_test/rpc_tests/utils/gasPriceUtils.ts
+++ b/integration_test/rpc_tests/utils/gasPriceUtils.ts
@@ -14,11 +14,65 @@ export async function gasPrice(provider: ethers.JsonRpcProvider): Promise<bigint
 /** Sei's idle-chain default priority fee (1 gwei), returned when the latest block is uncongested. */
 export const DEFAULT_PRIORITY_FEE_WEI = ethers.parseUnits('1', 'gwei');
 
-/** Sei treats a block as congested once it burns > 80% of the block gas limit. */
+/** Sei treats a block as congested once EVM receipt gas burns > 80% of the block gas limit. */
 export const CONGESTION_THRESHOLD = 0.8;
 
 export async function maxPriorityFeePerGas(provider: ethers.JsonRpcProvider): Promise<bigint> {
     return BigInt(await provider.send('eth_maxPriorityFeePerGas', []));
+}
+
+export interface PriorityFeeSample {
+    tip: bigint;
+    block: number;
+    gasUsed: bigint;
+    evmGasUsed: bigint;
+    gasLimit: bigint;
+    ratio: number;
+    evmRatio: number;
+}
+
+/**
+ * Read eth_maxPriorityFeePerGas and the latest block it was derived from without
+ * crossing a block boundary. The fee RPC has no block tag, so callers that assert
+ * against latest-block gas usage must pin a stable head themselves.
+ */
+export async function maxPriorityFeePerGasAtStableBlock(
+    provider: ethers.JsonRpcProvider,
+): Promise<PriorityFeeSample> {
+    for (let i = 0; i < 20; i++) {
+        const b1 = await provider.getBlockNumber();
+        const tip = await maxPriorityFeePerGas(provider);
+        const info = await blockGasInfo(provider, 'latest');
+        const evmGasUsed = await evmGasUsedForBlock(provider, info.number);
+        const b2 = await provider.getBlockNumber();
+        if (b1 === b2 && info.number === b1) {
+            return {
+                tip,
+                block: info.number,
+                gasUsed: info.gasUsed,
+                evmGasUsed,
+                gasLimit: info.gasLimit,
+                ratio: Number(info.gasUsed) / Number(info.gasLimit),
+                evmRatio: Number(evmGasUsed) / Number(info.gasLimit),
+            };
+        }
+    }
+    throw new Error('maxPriorityFeePerGasAtStableBlock: block kept advancing across the sample');
+}
+
+export async function evmGasUsedForBlock(
+    provider: ethers.JsonRpcProvider,
+    block: number,
+): Promise<bigint> {
+    const receipts = await provider.send('eth_getBlockReceipts', [ethers.toQuantity(block)]);
+    return (receipts ?? []).reduce(
+        (sum: bigint, receipt: { gasUsed: string }) => sum + BigInt(receipt.gasUsed),
+        0n,
+    );
+}
+
+export function isCongested(sample: { evmGasUsed: bigint; gasLimit: bigint }): boolean {
+    return sample.evmGasUsed > (sample.gasLimit * 80n) / 100n;
 }
 
 /**
@@ -55,10 +109,11 @@ export async function assertSeiGasPriceTracks(
     const head = await provider.getBlockNumber();
     const heights = [block - 1, block, block + 1, block + 2].filter(h => h >= 0 && h <= head);
     const infos = await Promise.all(heights.map(h => blockGasInfo(provider, h)));
+    const evmGasUsed = await Promise.all(heights.map(h => evmGasUsedForBlock(provider, h)));
 
     if (infos.some(b => (b.baseFee * 110n) / 100n === gasPriceWei)) return;
 
-    const congested = infos.some(b => b.gasUsed > (b.gasLimit * 80n) / 100n);
+    const congested = infos.some((b, i) => evmGasUsed[i] > (b.gasLimit * 80n) / 100n);
     const minBase = infos.reduce((m, b) => (b.baseFee < m ? b.baseFee : m), infos[0].baseFee);
     expect(
         congested && gasPriceWei >= minBase,

--- a/sei-db/db_engine/pebbledb/mvcc/db.go
+++ b/sei-db/db_engine/pebbledb/mvcc/db.go
@@ -51,6 +51,13 @@ const (
 	PruneCommitBatchSize  = 50
 	DeleteCommitBatchSize = 50
 	MinWALEntriesToKeep   = 1000
+
+	// maxConcurrentCompactions is the upper bound for the number of compactions
+	// Pebble may run in parallel. Pebble's default range is {1,1}, but a single
+	// compactor cannot keep up with the tombstone churn that pruning generates,
+	// so deleted data accumulates and slows every subsequent prune scan. Allowing
+	// Pebble to burst up to a few compactions clears that backlog.
+	maxConcurrentCompactions = 4
 )
 
 var (
@@ -125,6 +132,9 @@ func OpenDB(dataDir string, config config.StateStoreConfig) (types.StateStore, e
 		LBaseMaxBytes:               64 << 20, // 64 MB
 		MemTableSize:                64 << 20,
 		MemTableStopWritesThreshold: 4,
+		// Let Pebble run several compactions in parallel so it can keep up with
+		// the tombstone churn produced by pruning. See maxConcurrentCompactions.
+		CompactionConcurrencyRange: func() (int, int) { return 1, maxConcurrentCompactions },
 	}
 
 	// Configure L0 with explicit settings
@@ -507,6 +517,26 @@ func (db *Database) Prune(version int64) error {
 	return db.pruneAscending(version)
 }
 
+// compactPrunedRange compacts only the span of keys that a prune pass deleted so
+// Pebble reclaims the tombstoned space right away. Without it, deleted keys pile
+// up as un-compacted tombstones and every subsequent full-DB prune scan has to
+// read through them, which makes prune latency creep upward the longer a node
+// stays up (and is why restarting a node temporarily relieves head-lag: the
+// reopen triggers compaction). first and last are the smallest and largest
+// encoded keys deleted during the pass, in Pebble comparer order; both are nil
+// when nothing was deleted, in which case compaction is skipped entirely.
+func (db *Database) compactPrunedRange(first, last []byte) error {
+	if first == nil {
+		return nil
+	}
+	// Pebble's Compact treats [start, end] as an inclusive range but requires
+	// start < end. Appending a zero byte extends the user-key portion of last,
+	// yielding a key strictly greater than it under both the MVCC and default
+	// comparers, so the entire deleted span is covered.
+	end := append(slices.Clone(last), 0)
+	return db.storage.Compact(context.Background(), first, end, true)
+}
+
 // Iterator dispatches between descending- and ascending-mode implementations
 // depending on the on-disk encoding detected at open time.
 func (db *Database) Iterator(storeKey string, version int64, start, end []byte) (dbm.Iterator, error) {
@@ -611,11 +641,12 @@ func (db *Database) pruneDescending(version int64) (_err error) {
 	defer func() { _ = batch.Close() }()
 
 	var (
-		counter        int
-		prevKey        []byte
-		keptBelowPrune bool
-		prevStore      string
-		scanReads      int64
+		counter                         int
+		prevKey                         []byte
+		keptBelowPrune                  bool
+		prevStore                       string
+		scanReads                       int64
+		firstDeletedKey, lastDeletedKey []byte
 	)
 
 	for itr.First(); itr.Valid(); {
@@ -683,6 +714,13 @@ func (db *Database) pruneDescending(version int64) (_err error) {
 				if err := batch.Delete(currKeyEncoded, nil); err != nil {
 					return err
 				}
+				// Track the deleted span (keys are visited in comparer order, so
+				// the first delete is the smallest and the last is the largest)
+				// to compact just that range once pruning completes.
+				if firstDeletedKey == nil {
+					firstDeletedKey = currKeyEncoded
+				}
+				lastDeletedKey = currKeyEncoded
 				counter++
 				if counter >= PruneCommitBatchSize {
 					writeCount := int64(batch.Count())
@@ -710,7 +748,10 @@ func (db *Database) pruneDescending(version int64) (_err error) {
 	}
 	db.operationMetrics.AddRead(scanReads)
 
-	return db.SetEarliestVersion(earliestVersion, false)
+	if err := db.SetEarliestVersion(earliestVersion, false); err != nil {
+		return err
+	}
+	return db.compactPrunedRange(firstDeletedKey, lastDeletedKey)
 }
 
 func (db *Database) iteratorDescending(storeKey string, version int64, start, end []byte) (dbm.Iterator, error) {

--- a/sei-db/db_engine/pebbledb/mvcc/db_ascending.go
+++ b/sei-db/db_engine/pebbledb/mvcc/db_ascending.go
@@ -124,6 +124,7 @@ func (db *Database) pruneAscending(version int64) (_err error) {
 		prevVersionDecoded                      int64
 		prevStore                               string
 		scanReads                               int64
+		firstDeletedKey, lastDeletedKey         []byte
 	)
 
 	for itr.First(); itr.Valid(); {
@@ -181,6 +182,14 @@ func (db *Database) pruneAscending(version int64) (_err error) {
 				return err
 			}
 
+			// Track the deleted span (keys are visited in comparer order, so the
+			// first delete is the smallest and the last is the largest) to compact
+			// just that range once pruning completes.
+			if firstDeletedKey == nil {
+				firstDeletedKey = prevKeyEncoded
+			}
+			lastDeletedKey = prevKeyEncoded
+
 			counter++
 			if counter >= PruneCommitBatchSize {
 				writeCount := int64(batch.Count())
@@ -215,7 +224,10 @@ func (db *Database) pruneAscending(version int64) (_err error) {
 	}
 	db.operationMetrics.AddRead(scanReads)
 
-	return db.SetEarliestVersion(earliestVersion, false)
+	if err := db.SetEarliestVersion(earliestVersion, false); err != nil {
+		return err
+	}
+	return db.compactPrunedRange(firstDeletedKey, lastDeletedKey)
 }
 
 func (db *Database) iteratorAscending(storeKey string, version int64, start, end []byte) (dbm.Iterator, error) {

--- a/sei-db/db_engine/pebbledb/mvcc/prune_compaction_test.go
+++ b/sei-db/db_engine/pebbledb/mvcc/prune_compaction_test.go
@@ -1,0 +1,141 @@
+package mvcc
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+
+	"github.com/sei-protocol/sei-chain/sei-db/config"
+	sstest "github.com/sei-protocol/sei-chain/sei-db/db_engine/test"
+)
+
+const compactionTestStore = "store1" // matches the store key used by sstest.FillData
+
+func newCompactionTestDB(t *testing.T) *Database {
+	t.Helper()
+
+	cfg := config.DefaultStateStoreConfig()
+	cfg.Backend = "pebbledb"
+
+	store, err := OpenDB(t.TempDir(), cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	return store.(*Database)
+}
+
+// TestPruneCompactsDeletedRange verifies that a prune which deletes keys triggers
+// a compaction of the pruned range, and that live data survives it. Without the
+// post-prune compaction the deleted keys would linger as tombstones and make
+// every later prune scan progressively slower (the root cause of the head-lag
+// that creeps in with node uptime).
+func TestPruneCompactsDeletedRange(t *testing.T) {
+	db := newCompactionTestDB(t)
+
+	require.NoError(t, sstest.FillData(db, 10, 50))
+
+	// Push the data into SSTables so the post-prune compaction has files to act on.
+	require.NoError(t, db.storage.Flush())
+	compactionsBefore := db.storage.Metrics().Compact.Count
+
+	require.NoError(t, db.Prune(25))
+
+	compactionsAfter := db.storage.Metrics().Compact.Count
+	require.Greater(t, compactionsAfter, compactionsBefore,
+		"a prune that deletes keys should compact the range it pruned")
+
+	// Live data is preserved: versions <= 25 are gone, later versions remain.
+	bz, err := db.Get(compactionTestStore, 25, []byte("key000"))
+	require.NoError(t, err)
+	require.Nil(t, bz)
+
+	bz, err = db.Get(compactionTestStore, 50, []byte("key000"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("val000-050"), bz)
+}
+
+// TestPruneWithoutDeletionsSkipsCompaction verifies the guard that skips
+// compaction entirely when a prune pass deleted nothing, so idle prunes stay
+// cheap. The data is deliberately left in the memtable (no flush) so no
+// background compaction can be scheduled and pollute the count.
+func TestPruneWithoutDeletionsSkipsCompaction(t *testing.T) {
+	db := newCompactionTestDB(t)
+
+	require.NoError(t, sstest.FillData(db, 4, 4))
+
+	compactionsBefore := db.storage.Metrics().Compact.Count
+	// No version is <= 0, so this prune deletes nothing and must not compact.
+	require.NoError(t, db.Prune(0))
+	require.Equal(t, compactionsBefore, db.storage.Metrics().Compact.Count,
+		"a prune that deletes nothing must not trigger a compaction")
+}
+
+// TestCompactPrunedRangeSingleKey verifies the inclusive-bound math for the
+// degenerate case where a prune deleted exactly one key (first == last). Pebble
+// rejects Compact unless start < end, so the helper must derive an end bound
+// strictly greater than the single deleted key.
+func TestCompactPrunedRangeSingleKey(t *testing.T) {
+	db := newCompactionTestDB(t)
+
+	key := db.mvccEncode([]byte("s/k:store1/key000"), 1)
+
+	// The derived end bound must sort strictly after the deleted key under the
+	// MVCC comparer (the default for this config).
+	end := append(slices.Clone(key), 0)
+	require.Equal(t, -1, MVCCKeyCompare(key, end))
+
+	// And the compaction itself must not be rejected.
+	require.NoError(t, db.compactPrunedRange(key, key))
+}
+
+// TestPruneAscendingCompactsDeletedRange covers the legacy ascending-encoding
+// prune path end to end: a prune that deletes keys must compact the pruned
+// range while preserving live data. New DBs use the descending path, so the
+// directory is first seeded with a legacy-style DB to force ascending mode.
+func TestPruneAscendingCompactsDeletedRange(t *testing.T) {
+	dir := t.TempDir()
+
+	// Seed a legacy-style DB: ascending-encoded data plus a latestVersionKey but
+	// no descending marker, so OpenDB selects ascending mode.
+	{
+		raw, err := pebble.Open(dir, &pebble.Options{Comparer: MVCCComparer})
+		require.NoError(t, err)
+		seedKey := MVCCEncodeAscending(prependStoreKey(compactionTestStore, []byte("seed")), 1)
+		require.NoError(t, raw.Set(seedKey, MVCCEncodeAscending([]byte("v"), 0), pebble.Sync))
+		var ts [VersionSize]byte
+		ts[0] = 1
+		require.NoError(t, raw.Set([]byte(latestVersionKey), ts[:], pebble.Sync))
+		require.NoError(t, raw.Close())
+	}
+
+	cfg := config.DefaultStateStoreConfig()
+	cfg.Backend = "pebbledb"
+	store, err := OpenDB(dir, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	db := store.(*Database)
+	require.False(t, db.descending, "seeded legacy DB must open in ascending mode")
+
+	require.NoError(t, sstest.FillData(db, 10, 50))
+
+	// Push the data into SSTables so the post-prune compaction has files to act on.
+	require.NoError(t, db.storage.Flush())
+	compactionsBefore := db.storage.Metrics().Compact.Count
+
+	require.NoError(t, db.Prune(25))
+
+	require.Greater(t, db.storage.Metrics().Compact.Count, compactionsBefore,
+		"an ascending prune that deletes keys should compact the range it pruned")
+
+	// Live data is preserved: versions <= 25 are gone, later versions remain.
+	bz, err := db.Get(compactionTestStore, 25, []byte("key000"))
+	require.NoError(t, err)
+	require.Nil(t, bz)
+
+	bz, err = db.Get(compactionTestStore, 50, []byte("key000"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("val000-050"), bz)
+}

--- a/sei-ibc-go/modules/core/04-channel/types/msgs_test.go
+++ b/sei-ibc-go/modules/core/04-channel/types/msgs_test.go
@@ -75,6 +75,9 @@ func (suite *TypesTestSuite) SetupTest() {
 	scConfig.MemIAVLConfig.SnapshotMinTimeInterval = 0
 	ssConfig := seidbconfig.StateStoreConfig{}
 	store := storev2rootmulti.NewStore(suite.T().TempDir(), scConfig, ssConfig, nil)
+	defer func() {
+		suite.Require().NoError(store.Close())
+	}()
 	storeKey := storetypes.NewKVStoreKey("iavlStoreKey")
 
 	store.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, nil)

--- a/utils/metrics/metrics_util.go
+++ b/utils/metrics/metrics_util.go
@@ -13,19 +13,42 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	sdk "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
 )
 
-func SetupOtelMetricsProvider() error {
+func SetupOtelMetricsProvider(chainID string) error {
+	if chainID == "" {
+		return fmt.Errorf("chainID must not be empty")
+	}
+
+	res, err := resource.Merge(
+		resource.Default(),
+		resource.NewWithAttributes(
+			"",
+			attribute.String("chain_id", chainID),
+		),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create OTel resource: %w", err)
+	}
+
 	metricsExporter, err := prometheus.New(
 		prometheus.WithNamespace("sei_chain"),
 		prometheus.WithTranslationStrategy(otlptranslator.UnderscoreEscapingWithSuffixes),
+		prometheus.WithResourceAsConstantLabels(
+			attribute.NewAllowKeysFilter("chain_id"),
+		),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create Prometheus exporter: %w", err)
 	}
-	otel.SetMeterProvider(sdk.NewMeterProvider(sdk.WithReader(metricsExporter)))
+	otel.SetMeterProvider(sdk.NewMeterProvider(
+		sdk.WithResource(res),
+		sdk.WithReader(metricsExporter),
+	))
 	return nil
 }
 

--- a/utils/metrics/metrics_util_test.go
+++ b/utils/metrics/metrics_util_test.go
@@ -1,0 +1,46 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+)
+
+func TestSetupOtelMetricsProviderRequiresChainID(t *testing.T) {
+	require.Error(t, SetupOtelMetricsProvider(""))
+}
+
+// TestSetupOtelMetricsProviderAttachesChainID verifies that chain_id is emitted
+// as a constant label on every OTel metric series scraped via Prometheus
+func TestSetupOtelMetricsProviderAttachesChainID(t *testing.T) {
+	const chainID = "test-chain-1"
+	require.NoError(t, SetupOtelMetricsProvider(chainID))
+
+	// Emit a measurement through the global provider the setup just installed.
+	counter, err := otel.Meter("meter_test").Int64Counter("meter_chain_id_probe")
+	require.NoError(t, err)
+	counter.Add(t.Context(), 1)
+
+	// Gathering triggers the exporter's pull-based collection.
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	var found bool
+	for _, mf := range families {
+		if !strings.Contains(mf.GetName(), "meter_chain_id_probe") {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "chain_id" {
+					require.Equal(t, chainID, l.GetValue())
+					found = true
+				}
+			}
+		}
+	}
+	require.True(t, found, "expected chain_id label on the emitted OTel metric")
+}


### PR DESCRIPTION

## Fix
Serialize the hash-mutating operations on each memIAVL tree with the tree's
**write** lock, and add no-lock internal helpers so the public entry points
don't re-acquire the lock recursively.
`sei-db/state_db/sc/memiavl/tree.go`
- `RootHash()` now takes `t.mtx.Lock()` (it mutates `MemNode.hash`), delegating to a new `rootHashNoLock()`.
- `GetProof()` now takes `t.mtx.Lock()` for the whole proof build, delegating to `getProofNoLock()`.
- Added no-lock read helpers used by the proof builders: `getWithIndexNoLock()`, `getByIndexNoLock()`, `hasNoLock()`.
`sei-db/state_db/sc/memiavl/proof.go`
- `GetMembershipProof()` / `GetNonMembershipProof()` now take the write lock and delegate to `getMembershipProofNoLock()` / `getNonMembershipProofNoLock()`.
- `createExistenceProof()` documented as "caller must hold the write lock".
The read-only fast paths (`Get`, `GetWithIndex`, `GetByIndex`, `Has`, `Iterator`)
are unchanged and still use `RLock`. Locking is **per-tree (per-store)**.
### Lock-ordering safety
- Commit path acquires `db.mtx` then per-tree `t.mtx`; the query path acquires
  only `t.mtx`. No inversion, no new deadlock.
- No in-package caller invokes the now-locking methods while already holding
  `t.mtx` (verified); internal callers use the `*NoLock` helpers.
## Performance impact
- **Validators (no queries):** the write lock is uncontended, so `Lock()` costs
  the same as the previous `RLock()` (a single atomic op). `RootHash` runs
  ~once/twice per store per block → single-digit microseconds per block. No
  measurable impact on block/consensus/tx-execution time.
- **Tx execution:** unaffected — reads go through cache stores (`RLock`,
  unchanged); `GetProof` is not on the execution path.
- **RPC nodes under heavy `prove=true`:** a commit's `RootHash` and a proof build
  now serialize **per store**. This is bounded (proof build is O(tree height))
  and per-store (committing store A never blocks proofs on store B). It is the
  necessary cost of correctness — the previous "cheaper" path was the bug.
## Testing
Added `sei-db/state_db/sc/memiavl/tree_race_test.go`:
- `TestTreeProofRaceWithCommit` — commit (`Set` + `RootHash`) concurrent with
  membership/non-membership `GetProof` and `RootHash`.
- `TestTreeConcurrentRootHash` — concurrent `RootHash` over a tree with unfilled
  hash caches; asserts all callers agree.
Verification:
- The tests were confirmed to **reproduce** the bug: reverting the two locks back
  to `RLock` makes `go test -race` report `DATA RACE` on `MemNode.hash`.
- With the fix, `go test -race ./sei-db/state_db/sc/memiavl/...` passes clean
  (0 data races), as do the `commitment` and `rootmulti` suites.
## Risk & rollout
- Read-path behavior and hash outputs are unchanged; this is a locking-only fix.
- Safe to roll out without coordination (not AppHash-format changing). It
  *prevents* divergence rather than changing committed state.
