### PR TITLE
feat(indexer): push result cap and ordering into KV block search (PLT-748)

### DIFF
--- a/sei-tendermint/internal/inspect/inspect_test.go
+++ b/sei-tendermint/internal/inspect/inspect_test.go
@@ -121,7 +121,7 @@ func TestTxSearch(t *testing.T) {
 	eventSinkMock.On("Stop").Return(nil)
 	eventSinkMock.On("Type").Return(indexer.KV)
 	eventSinkMock.On("SearchTxEvents", mock.Anything,
-		mock.MatchedBy(func(q *query.Query) bool { return testQuery == q.String() })).
+		mock.MatchedBy(func(q *query.Query) bool { return testQuery == q.String() }), mock.Anything).
 		Return([]*abcitypes.TxResultV2{testTxResult}, nil)
 
 	rpcConfig := config.TestRPCConfig()
@@ -535,7 +535,7 @@ func TestBlockSearch(t *testing.T) {
 		},
 	})
 	eventSinkMock.On("SearchBlockEvents", mock.Anything,
-		mock.MatchedBy(func(q *query.Query) bool { return testQuery == q.String() })).
+		mock.MatchedBy(func(q *query.Query) bool { return testQuery == q.String() }), mock.Anything).
 		Return([]int64{testHeight}, nil)
 	rpcConfig := config.TestRPCConfig()
 	d := inspect.New(rpcConfig, blockStoreMock, stateStoreMock, []indexer.EventSink{eventSinkMock})

--- a/sei-tendermint/internal/rpc/core/block_search_test.go
+++ b/sei-tendermint/internal/rpc/core/block_search_test.go
@@ -25,7 +25,7 @@ func blockSearchEnv(t *testing.T, maxResults int, heights []int64) *Environment 
 	t.Helper()
 	sink := indexermocks.NewEventSink(t)
 	sink.On("Type").Return(indexer.KV)
-	sink.On("SearchBlockEvents", mock.Anything, mock.Anything).Return(heights, nil)
+	sink.On("SearchBlockEvents", mock.Anything, mock.Anything, mock.Anything).Return(heights, nil)
 
 	// LoadBlock returns nil so the page loop skips materialisation; TotalCount
 	// is set before the loop and reflects the cap correctly regardless.
@@ -51,7 +51,7 @@ func TestBlockSearchCapAppliedAfterSort(t *testing.T) {
 
 	sink := indexermocks.NewEventSink(t)
 	sink.On("Type").Return(indexer.KV)
-	sink.On("SearchBlockEvents", mock.Anything, mock.Anything).Return(makeBlockHeights(total), nil)
+	sink.On("SearchBlockEvents", mock.Anything, mock.Anything, mock.Anything).Return(makeBlockHeights(total), nil)
 
 	var loadedHeights []int64
 	bs := statemocks.NewBlockStore(t)

--- a/sei-tendermint/internal/rpc/core/blocks.go
+++ b/sei-tendermint/internal/rpc/core/blocks.go
@@ -301,6 +301,9 @@ func (env *Environment) BlockResults(ctx context.Context, req *coretypes.Request
 	}, nil
 }
 
+const AscendingOrder = "asc"
+const DescendingOrder = "desc"
+
 // BlockSearch searches for a paginated set of blocks matching the provided query.
 func (env *Environment) BlockSearch(ctx context.Context, req *coretypes.RequestBlockSearch) (*coretypes.ResultBlockSearch, error) {
 	if !indexer.KVSinkEnabled(env.EventSinks) {
@@ -324,10 +327,10 @@ func (env *Environment) BlockSearch(ctx context.Context, req *coretypes.RequestB
 	// path rather than after materializing and sorting the full match set.
 	var orderDesc bool
 	switch req.OrderBy {
-	case "desc", "":
+	case DescendingOrder, "":
 		orderDesc = true
 
-	case "asc":
+	case AscendingOrder:
 		orderDesc = false
 
 	default:

--- a/sei-tendermint/internal/rpc/core/blocks.go
+++ b/sei-tendermint/internal/rpc/core/blocks.go
@@ -319,25 +319,40 @@ func (env *Environment) BlockSearch(ctx context.Context, req *coretypes.RequestB
 		}
 	}
 
-	results, err := kvsink.SearchBlockEvents(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-
-	// sort results (must be done before cap and pagination)
+	// Validate order_by up front so we can push the ordering (and the result
+	// cap) down into the indexer; a broad query is then bounded at the scan
+	// path rather than after materializing and sorting the full match set.
+	var orderDesc bool
 	switch req.OrderBy {
 	case "desc", "":
-		sort.Slice(results, func(i, j int) bool { return results[i] > results[j] })
+		orderDesc = true
 
 	case "asc":
-		sort.Slice(results, func(i, j int) bool { return results[i] < results[j] })
+		orderDesc = false
 
 	default:
 		return nil, fmt.Errorf("expected order_by to be either `asc` or `desc` or empty: %w", coretypes.ErrInvalidRequest)
 	}
 
-	if max := env.Config.MaxTxSearchResults; max > 0 && len(results) > max {
-		results = results[:max]
+	results, err := kvsink.SearchBlockEvents(ctx, q, indexer.SearchOptions{
+		Limit:     env.Config.MaxTxSearchResults,
+		OrderDesc: orderDesc,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// sort results (must be done before cap and pagination)
+	if orderDesc {
+		sort.Slice(results, func(i, j int) bool { return results[i] > results[j] })
+	} else {
+		sort.Slice(results, func(i, j int) bool { return results[i] < results[j] })
+	}
+
+	// Safety net: the kv indexer already bounds to MaxTxSearchResults, but keep
+	// the cap so the response stays bounded for any sink that ignores the limit.
+	if maxResults := env.Config.MaxTxSearchResults; maxResults > 0 && len(results) > maxResults {
+		results = results[:maxResults]
 	}
 
 	// paginate results

--- a/sei-tendermint/internal/rpc/core/tx.go
+++ b/sei-tendermint/internal/rpc/core/tx.go
@@ -73,7 +73,7 @@ func (env *Environment) TxSearch(ctx context.Context, req *coretypes.RequestTxSe
 			// and ordering down to the scan.
 			results, err := sink.SearchTxEvents(ctx, q, indexer.SearchOptions{
 				Limit:     env.Config.MaxTxSearchResults,
-				OrderDesc: req.OrderBy != "asc",
+				OrderDesc: req.OrderBy != AscendingOrder,
 			})
 			if err != nil {
 				return nil, err
@@ -81,14 +81,14 @@ func (env *Environment) TxSearch(ctx context.Context, req *coretypes.RequestTxSe
 
 			// sort results (must be done before cap and pagination)
 			switch req.OrderBy {
-			case "desc", "":
+			case DescendingOrder, "":
 				sort.Slice(results, func(i, j int) bool {
 					if results[i].Height == results[j].Height {
 						return results[i].Index > results[j].Index
 					}
 					return results[i].Height > results[j].Height
 				})
-			case "asc":
+			case AscendingOrder:
 				sort.Slice(results, func(i, j int) bool {
 					if results[i].Height == results[j].Height {
 						return results[i].Index < results[j].Index

--- a/sei-tendermint/internal/rpc/core/tx.go
+++ b/sei-tendermint/internal/rpc/core/tx.go
@@ -67,7 +67,14 @@ func (env *Environment) TxSearch(ctx context.Context, req *coretypes.RequestTxSe
 
 	for _, sink := range env.EventSinks {
 		if sink.Type() == indexer.KV {
-			results, err := sink.SearchTxEvents(ctx, q)
+			// TODO(PLT-748): the kv tx indexer currently ignores these opts and
+			// the cap below still applies after sort (PLT-700). Once the tx
+			// scan path is bounded like the block indexer, this pushes the cap
+			// and ordering down to the scan.
+			results, err := sink.SearchTxEvents(ctx, q, indexer.SearchOptions{
+				Limit:     env.Config.MaxTxSearchResults,
+				OrderDesc: req.OrderBy != "asc",
+			})
 			if err != nil {
 				return nil, err
 			}

--- a/sei-tendermint/internal/rpc/core/tx_test.go
+++ b/sei-tendermint/internal/rpc/core/tx_test.go
@@ -25,7 +25,7 @@ func txSearchEnv(t *testing.T, maxResults int, txs []*abci.TxResultV2) *Environm
 	t.Helper()
 	sink := indexermocks.NewEventSink(t)
 	sink.On("Type").Return(indexer.KV)
-	sink.On("SearchTxEvents", mock.Anything, mock.Anything).Return(txs, nil)
+	sink.On("SearchTxEvents", mock.Anything, mock.Anything, mock.Anything).Return(txs, nil)
 	return &Environment{
 		EventSinks: []indexer.EventSink{sink},
 		Config:     config.RPCConfig{MaxTxSearchResults: maxResults},

--- a/sei-tendermint/internal/state/indexer/block/kv/kv.go
+++ b/sei-tendermint/internal/state/indexer/block/kv/kv.go
@@ -126,8 +126,10 @@ func (idx *BlockerIndexer) Search(ctx context.Context, q *query.Query, opts inde
 	return idx.collectBounded(ctx, filteredHeights, opts)
 }
 
-// intersect reproduces the historical match/intersect behavior, returning the
-// set of height-encoded values that satisfy every condition (implicit AND).
+// intersect returns the set of height-encoded values that satisfy every
+// condition (implicit AND). It seeds the set from the first condition's index
+// matches, then intersects each remaining condition against it, so a height
+// survives only if it matches all of them.
 func (idx *BlockerIndexer) intersect(
 	ctx context.Context,
 	conditions []syntax.Condition,

--- a/sei-tendermint/internal/state/indexer/block/kv/kv.go
+++ b/sei-tendermint/internal/state/indexer/block/kv/kv.go
@@ -363,12 +363,9 @@ func (idx *BlockerIndexer) hasEvent(compositeKey, eventValue string, height int6
 // rather than materializing and sorting the full match set.
 type boundedPlan struct {
 	// driverEquality, when non-nil, is the equality condition whose event-key
-	// prefix is scanned in height order. Exactly one of driverEquality /
-	// driverHeightRange is set.
+	// prefix is scanned in height order. When nil, the scan is driven off the
+	// primary block.height key range instead.
 	driverEquality *syntax.Condition
-	// driverHeightRange, when non-nil, drives the scan off the primary
-	// block.height key range.
-	driverHeightRange *indexer.QueryRange
 	// equalityProbes are the remaining equality conditions, tested per
 	// candidate height with a point lookup.
 	equalityProbes []syntax.Condition
@@ -416,12 +413,9 @@ func planBounded(conditions []syntax.Condition, ranges indexer.QueryRanges, rang
 		plan.driverEquality = &equalities[0]
 		plan.equalityProbes = equalities[1:]
 	case len(plan.heightRanges) > 0:
-		// No equality to drive off; drive off the primary block.height range.
-		// LookForRanges merges all block.height bounds into a single range, so
-		// heightRanges has exactly one element here, which also filters
-		// candidates during the scan.
-		qr := plan.heightRanges[0]
-		plan.driverHeightRange = &qr
+		// No equality to drive off; searchBounded drives off the primary
+		// block.height key range. heightRanges (populated above) already
+		// filters candidates during the scan.
 	default:
 		// No sorted driver (e.g. an empty query); fall back.
 		return boundedPlan{}, false

--- a/sei-tendermint/internal/state/indexer/block/kv/kv.go
+++ b/sei-tendermint/internal/state/indexer/block/kv/kv.go
@@ -78,13 +78,10 @@ func (idx *BlockerIndexer) Index(bh types.EventDataNewBlockHeader) error {
 // of height queries, i.e. block.height=H, if the height is indexed, that height
 // alone will be returned. An error and nil slice is returned. Otherwise, a
 // non-nil slice and nil error is returned.
-func (idx *BlockerIndexer) Search(ctx context.Context, q *query.Query) ([]int64, error) {
+func (idx *BlockerIndexer) Search(ctx context.Context, q *query.Query, opts indexer.SearchOptions) ([]int64, error) {
 	results := make([]int64, 0)
-	select {
-	case <-ctx.Done():
+	if ctx.Err() != nil {
 		return results, nil
-
-	default:
 	}
 
 	conditions := q.Syntax()
@@ -105,15 +102,44 @@ func (idx *BlockerIndexer) Search(ctx context.Context, q *query.Query) ([]int64,
 		return results, nil
 	}
 
+	// Extract ranges. If both upper and lower bounds exist, it's better to get
+	// them in order as to not iterate over kvs that are not within range.
+	ranges, rangeIndexes := indexer.LookForRanges(conditions)
+
+	// Fast path: when every condition can be driven by a single height-ordered
+	// scan and point-probed, stream candidates in order_by order and stop at
+	// the limit, so a broad query does not materialize and sort the full match
+	// set.
+	if plan, ok := planBounded(conditions, ranges, rangeIndexes); ok {
+		return idx.searchBounded(ctx, plan, opts)
+	}
+
+	// Fallback: queries containing CONTAINS/MATCHES/EXISTS or non-height ranges
+	// cannot be point-probed against a candidate height (the block's events
+	// live only in the index, so there is nothing cheap to fetch). Materialize
+	// the intersection as before, then bound and order the result set.
+	filteredHeights, err := idx.intersect(ctx, conditions, ranges, rangeIndexes)
+	if err != nil {
+		return nil, err
+	}
+
+	return idx.collectBounded(ctx, filteredHeights, opts)
+}
+
+// intersect reproduces the historical match/intersect behavior, returning the
+// set of height-encoded values that satisfy every condition (implicit AND).
+func (idx *BlockerIndexer) intersect(
+	ctx context.Context,
+	conditions []syntax.Condition,
+	ranges indexer.QueryRanges,
+	rangeIndexes []int,
+) (map[string][]byte, error) {
 	var heightsInitialized bool
 	filteredHeights := make(map[string][]byte)
 
 	// conditions to skip because they're handled before "everything else"
 	skipIndexes := make([]int, 0)
 
-	// Extract ranges. If both upper and lower bounds exist, it's better to get
-	// them in order as to not iterate over kvs that are not within range.
-	ranges, rangeIndexes := indexer.LookForRanges(conditions)
 	if len(ranges) > 0 {
 		skipIndexes = append(skipIndexes, rangeIndexes...)
 
@@ -177,9 +203,15 @@ func (idx *BlockerIndexer) Search(ctx context.Context, q *query.Query) ([]int64,
 		}
 	}
 
-	// fetch matching heights
-	results = make([]int64, 0, len(filteredHeights))
-heights:
+	return filteredHeights, nil
+}
+
+// collectBounded materializes filteredHeights into heights, orders them per
+// opts.OrderDesc and truncates to opts.Limit. The intermediate match set is
+// still fully materialized by intersect; only the returned slice and the sort
+// cost are bounded here.
+func (idx *BlockerIndexer) collectBounded(ctx context.Context, filteredHeights map[string][]byte, opts indexer.SearchOptions) ([]int64, error) {
+	results := make([]int64, 0, len(filteredHeights))
 	for _, hBz := range filteredHeights {
 		h := int64FromBytes(hBz)
 
@@ -191,17 +223,209 @@ heights:
 			results = append(results, h)
 		}
 
-		select {
-		case <-ctx.Done():
-			break heights
-
-		default:
+		if ctx.Err() != nil {
+			break
 		}
 	}
 
-	sort.Slice(results, func(i, j int) bool { return results[i] < results[j] })
+	if opts.OrderDesc {
+		sort.Slice(results, func(i, j int) bool { return results[i] > results[j] })
+	} else {
+		sort.Slice(results, func(i, j int) bool { return results[i] < results[j] })
+	}
+
+	if opts.Limit > 0 && len(results) > opts.Limit {
+		results = results[:opts.Limit]
+	}
 
 	return results, nil
+}
+
+// searchBounded executes a boundedPlan: it scans the driver prefix in
+// order_by order, point-probes the remaining conditions per candidate height,
+// and stops as soon as opts.Limit matches are collected. Memory is bounded by
+// the number of results kept rather than by the full match cardinality.
+func (idx *BlockerIndexer) searchBounded(ctx context.Context, plan boundedPlan, opts indexer.SearchOptions) ([]int64, error) {
+	var (
+		prefix []byte
+		err    error
+	)
+	if plan.driverEquality != nil {
+		prefix, err = orderedcode.Append(nil, plan.driverEquality.Tag, plan.driverEquality.Arg.Value())
+	} else {
+		// Drive off the primary block.height key range.
+		prefix, err = orderedcode.Append(nil, types.BlockHeightKey)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to create driver prefix key: %w", err)
+	}
+
+	it, err := idx.prefixIterator(prefix, opts.OrderDesc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create driver iterator: %w", err)
+	}
+	defer func() { _ = it.Close() }()
+
+	results := make([]int64, 0, boundedCap(opts.Limit))
+	seen := make(map[int64]struct{})
+
+	for ; it.Valid(); it.Next() {
+		if ctx.Err() != nil {
+			break
+		}
+
+		h := int64FromBytes(it.Value())
+		if _, dup := seen[h]; dup {
+			continue
+		}
+
+		match, err := idx.candidateMatches(h, plan)
+		if err != nil {
+			return nil, err
+		}
+		if !match {
+			continue
+		}
+
+		seen[h] = struct{}{}
+		results = append(results, h)
+
+		if opts.Limit > 0 && len(results) >= opts.Limit {
+			break
+		}
+	}
+
+	if err := it.Error(); err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// candidateMatches reports whether the block at height h satisfies every
+// non-driver condition in the plan: height-range bounds are evaluated directly
+// from h, and equality probes are tested with a single point lookup against the
+// event index.
+func (idx *BlockerIndexer) candidateMatches(h int64, plan boundedPlan) (bool, error) {
+	for i := range plan.heightRanges {
+		if !heightInRange(h, plan.heightRanges[i]) {
+			return false, nil
+		}
+	}
+
+	for i := range plan.equalityProbes {
+		c := plan.equalityProbes[i]
+		ok, err := idx.hasEvent(c.Tag, c.Arg.Value(), h)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			return false, nil
+		}
+	}
+
+	// Confirm the height is indexed. Events and the height key are written in
+	// the same atomic batch, so this is normally redundant, but it preserves
+	// the historical guarantee and guards against partially written state.
+	return idx.Has(h)
+}
+
+// prefixIterator returns an iterator over the given key prefix. When desc is
+// true it iterates in descending (most-recent-height-first) order.
+func (idx *BlockerIndexer) prefixIterator(prefix []byte, desc bool) (dbm.Iterator, error) {
+	if !desc {
+		return dbm.IteratePrefix(idx.store, prefix)
+	}
+	return idx.store.ReverseIterator(prefix, prefixUpperBound(prefix))
+}
+
+// hasEvent reports whether the block at the given height has an indexed event
+// matching compositeKey=eventValue, regardless of the event type suffix.
+func (idx *BlockerIndexer) hasEvent(compositeKey, eventValue string, height int64) (bool, error) {
+	prefix, err := orderedcode.Append(nil, compositeKey, eventValue, height)
+	if err != nil {
+		return false, err
+	}
+
+	it, err := dbm.IteratePrefix(idx.store, prefix)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = it.Close() }()
+
+	return it.Valid(), it.Error()
+}
+
+// boundedPlan describes a fast-path execution that bounds memory by driving a
+// single height-ordered scan and point-probing the remaining conditions,
+// rather than materializing and sorting the full match set.
+type boundedPlan struct {
+	// driverEquality, when non-nil, is the equality condition whose event-key
+	// prefix is scanned in height order. Exactly one of driverEquality /
+	// driverHeightRange is set.
+	driverEquality *syntax.Condition
+	// driverHeightRange, when non-nil, drives the scan off the primary
+	// block.height key range.
+	driverHeightRange *indexer.QueryRange
+	// equalityProbes are the remaining equality conditions, tested per
+	// candidate height with a point lookup.
+	equalityProbes []syntax.Condition
+	// heightRanges are block.height bounds evaluated directly from a candidate
+	// height. When driving off the height range it is included here too so it
+	// also filters candidates.
+	heightRanges []indexer.QueryRange
+}
+
+// planBounded decides whether a query is eligible for the bounded fast path and
+// builds its plan. A query qualifies only when every condition is either an
+// equality (point-probeable) or a block.height range (evaluable from the
+// candidate height), and there is at least one such condition to drive a
+// height-ordered scan.
+func planBounded(conditions []syntax.Condition, ranges indexer.QueryRanges, rangeIndexes []int) (boundedPlan, bool) {
+	var plan boundedPlan
+
+	// Every range must be a numeric block.height range; any other range needs
+	// the attribute's value, which cannot be derived from the height alone.
+	for key, qr := range ranges {
+		if key != types.BlockHeightKey {
+			return boundedPlan{}, false
+		}
+		if _, ok := qr.AnyBound().(int64); !ok {
+			return boundedPlan{}, false
+		}
+		plan.heightRanges = append(plan.heightRanges, qr)
+	}
+
+	// Every non-range condition must be an equality to be point-probeable.
+	var equalities []syntax.Condition
+	for i, c := range conditions {
+		if intInSlice(i, rangeIndexes) {
+			continue
+		}
+		if c.Op != syntax.TEq {
+			return boundedPlan{}, false
+		}
+		equalities = append(equalities, c)
+	}
+
+	switch {
+	case len(equalities) > 0:
+		// Drive off the first equality; its event-key prefix is height-ordered.
+		plan.driverEquality = &equalities[0]
+		plan.equalityProbes = equalities[1:]
+	case len(plan.heightRanges) > 0:
+		// No equality to drive off; drive off the primary block.height range.
+		// LookForRanges merges all block.height bounds into a single range, so
+		// heightRanges has exactly one element here, which also filters
+		// candidates during the scan.
+		qr := plan.heightRanges[0]
+		plan.driverHeightRange = &qr
+	default:
+		// No sorted driver (e.g. an empty query); fall back.
+		return boundedPlan{}, false
+	}
+
+	return plan, true
 }
 
 // matchRange returns all matching block heights that match a given QueryRange

--- a/sei-tendermint/internal/state/indexer/block/kv/kv_test.go
+++ b/sei-tendermint/internal/state/indexer/block/kv/kv_test.go
@@ -229,6 +229,59 @@ func TestBlockIndexerBounded(t *testing.T) {
 			opts:    indexer.SearchOptions{Limit: 0, OrderDesc: true},
 			results: []int64{7, 6, 5, 4},
 		},
+		// Same dual-bounded range scanned ascending, capped mid-range.
+		"height range dual-bounded asc limit 3": {
+			q:       `block.height >= 4 AND block.height <= 7`,
+			opts:    indexer.SearchOptions{Limit: 3, OrderDesc: false},
+			results: []int64{4, 5, 6},
+		},
+		// Exclusive lower bound: block.height > 6 folds in the +1 adjustment via
+		// LowerBoundValue(), so the range is effectively >= 7.
+		"height range exclusive lower desc unbounded": {
+			q:       `block.height > 6`,
+			opts:    indexer.SearchOptions{Limit: 0, OrderDesc: true},
+			results: []int64{10, 9, 8, 7},
+		},
+		// Exclusive upper bound: block.height < 4 folds in the -1 adjustment via
+		// UpperBoundValue(), so the range is effectively <= 3.
+		"height range exclusive upper asc unbounded": {
+			q:       `block.height < 4`,
+			opts:    indexer.SearchOptions{Limit: 0, OrderDesc: false},
+			results: []int64{1, 2, 3},
+		},
+		// Dual-bounded range with both bounds exclusive: 3 < h < 8 => [4, 7].
+		"height range exclusive both desc unbounded": {
+			q:       `block.height > 3 AND block.height < 8`,
+			opts:    indexer.SearchOptions{Limit: 0, OrderDesc: true},
+			results: []int64{7, 6, 5, 4},
+		},
+		// Equality driver combined with an exclusive height range in the opposite
+		// scan direction.
+		"equality and exclusive height range asc limit 2": {
+			q:       `app.name = 'sei' AND block.height > 3`,
+			opts:    indexer.SearchOptions{Limit: 2, OrderDesc: false},
+			results: []int64{4, 5},
+		},
+		// A standalone block.height equality is intercepted by lookForHeight and
+		// returns that height alone when indexed.
+		"block.height equality": {
+			q:       `block.height = 6`,
+			opts:    indexer.SearchOptions{Limit: 3, OrderDesc: true},
+			results: []int64{6},
+		},
+		// block.height equality still routes through lookForHeight when combined
+		// with another (satisfied) equality; the indexed height is returned.
+		"block.height equality with matching equality": {
+			q:       `block.height = 6 AND app.name = 'sei'`,
+			opts:    indexer.SearchOptions{Limit: 3, OrderDesc: true},
+			results: []int64{6},
+		},
+		// A block.height equality on a height that was never indexed returns empty.
+		"block.height equality not indexed": {
+			q:       `block.height = 99`,
+			opts:    indexer.SearchOptions{Limit: 3, OrderDesc: true},
+			results: []int64{},
+		},
 		// Fallback path: CONTAINS cannot be point-probed, but the result set is
 		// still ordered and capped.
 		"contains fallback desc limit 3": {
@@ -259,5 +312,29 @@ func TestBlockIndexerBounded(t *testing.T) {
 		results, err := idx.Search(ctx, query.MustCompile(`app.name = 'sei'`), indexer.SearchOptions{Limit: 5, OrderDesc: true})
 		require.NoError(t, err)
 		require.Empty(t, results)
+	})
+
+	// Capping in the scan must not diverge from materialize-then-cap: for any
+	// query the bounded top-N equals the first N of the same query run
+	// unbounded. This covers both the fast path (equalities/height ranges) and
+	// the fallback (CONTAINS), guarding against future divergence between them.
+	t.Run("bounded cap matches unbounded prefix", func(t *testing.T) {
+		queries := []string{
+			`app.name = 'sei'`,                        // fast path: equality driver
+			`app.name = 'sei' AND app.kind = 'even'`,  // fast path: equality + probe
+			`block.height >= 3 AND block.height <= 9`, // fast path: height range driver
+			`app.name CONTAINS 'se'`,                  // fallback: materialize then bound
+		}
+		for _, q := range queries {
+			for _, desc := range []bool{true, false} {
+				full, err := idx.Search(t.Context(), query.MustCompile(q), indexer.SearchOptions{Limit: 0, OrderDesc: desc})
+				require.NoError(t, err)
+				for n := 1; n <= len(full); n++ {
+					capped, err := idx.Search(t.Context(), query.MustCompile(q), indexer.SearchOptions{Limit: n, OrderDesc: desc})
+					require.NoError(t, err)
+					require.Equalf(t, full[:n], capped, "query %q desc=%v limit=%d", q, desc, n)
+				}
+			}
+		}
 	})
 }

--- a/sei-tendermint/internal/state/indexer/block/kv/kv_test.go
+++ b/sei-tendermint/internal/state/indexer/block/kv/kv_test.go
@@ -1,6 +1,7 @@
 package kv_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -216,6 +217,18 @@ func TestBlockIndexerBounded(t *testing.T) {
 			opts:    indexer.SearchOptions{Limit: 3, OrderDesc: true},
 			results: []int64{10, 9, 8},
 		},
+		// Fast path: pure block.height range driver scanned ascending.
+		"height range asc limit 3": {
+			q:       `block.height >= 6`,
+			opts:    indexer.SearchOptions{Limit: 3, OrderDesc: false},
+			results: []int64{6, 7, 8},
+		},
+		// Fast path: a dual-bounded block.height range (lower AND upper bound).
+		"height range dual-bounded desc unbounded": {
+			q:       `block.height >= 4 AND block.height <= 7`,
+			opts:    indexer.SearchOptions{Limit: 0, OrderDesc: true},
+			results: []int64{7, 6, 5, 4},
+		},
 		// Fallback path: CONTAINS cannot be point-probed, but the result set is
 		// still ordered and capped.
 		"contains fallback desc limit 3": {
@@ -237,4 +250,14 @@ func TestBlockIndexerBounded(t *testing.T) {
 			require.Equal(t, tc.results, results)
 		})
 	}
+
+	// A cancelled context makes the bounded scan return the results gathered so
+	// far without an error, rather than failing the whole query.
+	t.Run("cancelled context returns partial results", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		results, err := idx.Search(ctx, query.MustCompile(`app.name = 'sei'`), indexer.SearchOptions{Limit: 5, OrderDesc: true})
+		require.NoError(t, err)
+		require.Empty(t, results)
+	})
 }

--- a/sei-tendermint/internal/state/indexer/block/kv/kv_test.go
+++ b/sei-tendermint/internal/state/indexer/block/kv/kv_test.go
@@ -9,9 +9,14 @@ import (
 
 	abci "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/pubsub/query"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/state/indexer"
 	blockidxkv "github.com/sei-protocol/sei-chain/sei-tendermint/internal/state/indexer/block/kv"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
 )
+
+// searchOpts is the zero-value (unbounded, ascending) options used by the
+// existing block-indexer tests.
+var searchOpts = indexer.SearchOptions{}
 
 func TestBlockIndexer(t *testing.T) {
 	store := dbm.NewPrefixDB(dbm.NewMemDB(), []byte("block_events"))
@@ -133,7 +138,101 @@ func TestBlockIndexer(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := t.Context()
 
-			results, err := indexer.Search(ctx, tc.q)
+			results, err := indexer.Search(ctx, tc.q, searchOpts)
+			require.NoError(t, err)
+			require.Equal(t, tc.results, results)
+		})
+	}
+}
+
+// TestBlockIndexerBounded exercises the bounded/ordered Search path:
+// the limit and order_by are pushed into the scan so a broad query returns the
+// correct top-N without materializing and sorting the full match set.
+func TestBlockIndexerBounded(t *testing.T) {
+	store := dbm.NewPrefixDB(dbm.NewMemDB(), []byte("block_events_bounded"))
+	idx := blockidxkv.New(store)
+
+	// Heights 1..10 all carry app.name=sei; even heights also carry
+	// app.kind=even.
+	for i := int64(1); i <= 10; i++ {
+		events := []abci.Event{{
+			Type: "app",
+			Attributes: []abci.EventAttribute{
+				{Key: []byte("name"), Value: []byte("sei"), Index: true},
+			},
+		}}
+		if i%2 == 0 {
+			events = append(events, abci.Event{
+				Type: "app",
+				Attributes: []abci.EventAttribute{
+					{Key: []byte("kind"), Value: []byte("even"), Index: true},
+				},
+			})
+		}
+		require.NoError(t, idx.Index(types.EventDataNewBlockHeader{
+			Header:              types.Header{Height: i},
+			ResultFinalizeBlock: abci.ResponseFinalizeBlock{Events: events},
+		}))
+	}
+
+	testCases := map[string]struct {
+		q       string
+		opts    indexer.SearchOptions
+		results []int64
+	}{
+		// Fast path: single equality driver, scanned in order_by order and
+		// capped at the scan rather than after a full sort.
+		"equality desc limit 3": {
+			q:       `app.name = 'sei'`,
+			opts:    indexer.SearchOptions{Limit: 3, OrderDesc: true},
+			results: []int64{10, 9, 8},
+		},
+		"equality asc limit 3": {
+			q:       `app.name = 'sei'`,
+			opts:    indexer.SearchOptions{Limit: 3, OrderDesc: false},
+			results: []int64{1, 2, 3},
+		},
+		// A disabled cap (Limit <= 0) returns the full set in order_by order.
+		"equality desc unbounded": {
+			q:       `app.name = 'sei'`,
+			opts:    indexer.SearchOptions{Limit: 0, OrderDesc: true},
+			results: []int64{10, 9, 8, 7, 6, 5, 4, 3, 2, 1},
+		},
+		// Fast path: two equalities — driver plus a point-probe.
+		"two equalities desc limit 2": {
+			q:       `app.name = 'sei' AND app.kind = 'even'`,
+			opts:    indexer.SearchOptions{Limit: 2, OrderDesc: true},
+			results: []int64{10, 8},
+		},
+		// Fast path: equality driver with a block.height range filter.
+		"equality and height range desc limit 2": {
+			q:       `app.name = 'sei' AND block.height >= 6`,
+			opts:    indexer.SearchOptions{Limit: 2, OrderDesc: true},
+			results: []int64{10, 9},
+		},
+		// Fast path: pure block.height range driver off the primary key.
+		"height range desc limit 3": {
+			q:       `block.height >= 6`,
+			opts:    indexer.SearchOptions{Limit: 3, OrderDesc: true},
+			results: []int64{10, 9, 8},
+		},
+		// Fallback path: CONTAINS cannot be point-probed, but the result set is
+		// still ordered and capped.
+		"contains fallback desc limit 3": {
+			q:       `app.name CONTAINS 'se'`,
+			opts:    indexer.SearchOptions{Limit: 3, OrderDesc: true},
+			results: []int64{10, 9, 8},
+		},
+		"contains fallback asc limit 2": {
+			q:       `app.name CONTAINS 'se'`,
+			opts:    indexer.SearchOptions{Limit: 2, OrderDesc: false},
+			results: []int64{1, 2},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			results, err := idx.Search(t.Context(), query.MustCompile(tc.q), tc.opts)
 			require.NoError(t, err)
 			require.Equal(t, tc.results, results)
 		})

--- a/sei-tendermint/internal/state/indexer/block/kv/util.go
+++ b/sei-tendermint/internal/state/indexer/block/kv/util.go
@@ -8,8 +8,57 @@ import (
 	"github.com/google/orderedcode"
 
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/pubsub/query/syntax"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/state/indexer"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
 )
+
+// maxBoundedPrealloc caps how much the bounded fast path preallocates for its
+// result slice, so a very large (or disabled) limit does not eagerly allocate.
+const maxBoundedPrealloc = 4096
+
+// boundedCap returns a sensible initial capacity for a result slice given a
+// limit. A non-positive limit means "unbounded", in which case we let the
+// slice grow on demand.
+func boundedCap(limit int) int {
+	if limit <= 0 {
+		return 0
+	}
+	if limit < maxBoundedPrealloc {
+		return limit
+	}
+	return maxBoundedPrealloc
+}
+
+// heightInRange reports whether height h falls within the (already
+// inclusivity-adjusted) bounds of a numeric block.height query range.
+func heightInRange(h int64, qr indexer.QueryRange) bool {
+	if lower := qr.LowerBoundValue(); lower != nil {
+		if lb, ok := lower.(int64); ok && h < lb {
+			return false
+		}
+	}
+	if upper := qr.UpperBoundValue(); upper != nil {
+		if ub, ok := upper.(int64); ok && h > ub {
+			return false
+		}
+	}
+	return true
+}
+
+// prefixUpperBound returns the exclusive end key for iterating over prefix,
+// i.e. the smallest key strictly greater than every key having the prefix.
+// It returns nil when prefix is empty or all bytes are 0xFF (no upper bound).
+func prefixUpperBound(prefix []byte) []byte {
+	end := make([]byte, len(prefix))
+	copy(end, prefix)
+	for i := len(end) - 1; i >= 0; i-- {
+		if end[i] != 0xFF {
+			end[i]++
+			return end[:i+1]
+		}
+	}
+	return nil
+}
 
 func intInSlice(a int, list []int) bool {
 	for _, b := range list {

--- a/sei-tendermint/internal/state/indexer/block/null/null.go
+++ b/sei-tendermint/internal/state/indexer/block/null/null.go
@@ -22,6 +22,6 @@ func (idx *BlockerIndexer) Index(types.EventDataNewBlockHeader) error {
 	return nil
 }
 
-func (idx *BlockerIndexer) Search(ctx context.Context, q *query.Query) ([]int64, error) {
+func (idx *BlockerIndexer) Search(ctx context.Context, q *query.Query, opts indexer.SearchOptions) ([]int64, error) {
 	return []int64{}, nil
 }

--- a/sei-tendermint/internal/state/indexer/eventsink.go
+++ b/sei-tendermint/internal/state/indexer/eventsink.go
@@ -33,12 +33,12 @@ type EventSink interface {
 	IndexTxEvents([]*abci.TxResultV2) error
 
 	// SearchBlockEvents provides the block search by given query conditions. This function only
-	// supported by the kvEventSink.
-	SearchBlockEvents(context.Context, *query.Query) ([]int64, error)
+	// supported by the kvEventSink. opts bounds and orders the result set; see SearchOptions.
+	SearchBlockEvents(context.Context, *query.Query, SearchOptions) ([]int64, error)
 
 	// SearchTxEvents provides the transaction search by given query conditions. This function only
-	// supported by the kvEventSink.
-	SearchTxEvents(context.Context, *query.Query) ([]*abci.TxResultV2, error)
+	// supported by the kvEventSink. opts bounds and orders the result set; see SearchOptions.
+	SearchTxEvents(context.Context, *query.Query, SearchOptions) ([]*abci.TxResultV2, error)
 
 	// GetTxByHash provides the transaction search by given transaction hash. This function only
 	// supported by the kvEventSink.

--- a/sei-tendermint/internal/state/indexer/indexer.go
+++ b/sei-tendermint/internal/state/indexer/indexer.go
@@ -9,6 +9,21 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
 )
 
+// SearchOptions bounds and orders the results of a Search. It lets the RPC
+// layer push its result cap and ordering down into the indexer so that broad
+// queries do not materialize and sort the entire match set before being
+// capped at the RPC layer.
+type SearchOptions struct {
+	// Limit caps the number of results returned. A value <= 0 means no limit (return the full match set)
+	Limit int
+
+	// OrderDesc selects which end of the height ordering the Limit retains so
+	// that the capped set matches what the RPC layer returns after sorting.
+	// When true the highest-ordered results (e.g. most-recent heights) are
+	// kept; when false the lowest-ordered results are kept.
+	OrderDesc bool
+}
+
 // TxIndexer interface defines methods to index and search transactions.
 type TxIndexer interface {
 	// Index analyzes, indexes and stores transactions. For indexing multiple
@@ -20,8 +35,9 @@ type TxIndexer interface {
 	// or stored.
 	Get(hash []byte) (*abci.TxResultV2, error)
 
-	// Search allows you to query for transactions.
-	Search(ctx context.Context, q *query.Query) ([]*abci.TxResultV2, error)
+	// Search allows you to query for transactions. opts bounds and orders the
+	// result set; see SearchOptions.
+	Search(ctx context.Context, q *query.Query, opts SearchOptions) ([]*abci.TxResultV2, error)
 }
 
 // BlockIndexer defines an interface contract for indexing block events.
@@ -34,8 +50,8 @@ type BlockIndexer interface {
 	Index(types.EventDataNewBlockHeader) error
 
 	// Search performs a query for block heights that match a given FinalizeBlock
-	// event search criteria.
-	Search(ctx context.Context, q *query.Query) ([]int64, error)
+	// event search criteria. opts bounds and orders the result set
+	Search(ctx context.Context, q *query.Query, opts SearchOptions) ([]int64, error)
 }
 
 // Batch groups together multiple Index operations to be performed at the same time.

--- a/sei-tendermint/internal/state/indexer/mocks/event_sink.go
+++ b/sei-tendermint/internal/state/indexer/mocks/event_sink.go
@@ -114,9 +114,9 @@ func (_m *EventSink) IndexTxEvents(_a0 []*types.TxResultV2) error {
 	return r0
 }
 
-// SearchBlockEvents provides a mock function with given fields: _a0, _a1
-func (_m *EventSink) SearchBlockEvents(_a0 context.Context, _a1 *query.Query) ([]int64, error) {
-	ret := _m.Called(_a0, _a1)
+// SearchBlockEvents provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EventSink) SearchBlockEvents(_a0 context.Context, _a1 *query.Query, _a2 indexer.SearchOptions) ([]int64, error) {
+	ret := _m.Called(_a0, _a1, _a2)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SearchBlockEvents")
@@ -124,19 +124,19 @@ func (_m *EventSink) SearchBlockEvents(_a0 context.Context, _a1 *query.Query) ([
 
 	var r0 []int64
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *query.Query) ([]int64, error)); ok {
-		return rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(context.Context, *query.Query, indexer.SearchOptions) ([]int64, error)); ok {
+		return rf(_a0, _a1, _a2)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *query.Query) []int64); ok {
-		r0 = rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(context.Context, *query.Query, indexer.SearchOptions) []int64); ok {
+		r0 = rf(_a0, _a1, _a2)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]int64)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *query.Query) error); ok {
-		r1 = rf(_a0, _a1)
+	if rf, ok := ret.Get(1).(func(context.Context, *query.Query, indexer.SearchOptions) error); ok {
+		r1 = rf(_a0, _a1, _a2)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -144,9 +144,9 @@ func (_m *EventSink) SearchBlockEvents(_a0 context.Context, _a1 *query.Query) ([
 	return r0, r1
 }
 
-// SearchTxEvents provides a mock function with given fields: _a0, _a1
-func (_m *EventSink) SearchTxEvents(_a0 context.Context, _a1 *query.Query) ([]*types.TxResultV2, error) {
-	ret := _m.Called(_a0, _a1)
+// SearchTxEvents provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EventSink) SearchTxEvents(_a0 context.Context, _a1 *query.Query, _a2 indexer.SearchOptions) ([]*types.TxResultV2, error) {
+	ret := _m.Called(_a0, _a1, _a2)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SearchTxEvents")
@@ -154,19 +154,19 @@ func (_m *EventSink) SearchTxEvents(_a0 context.Context, _a1 *query.Query) ([]*t
 
 	var r0 []*types.TxResultV2
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *query.Query) ([]*types.TxResultV2, error)); ok {
-		return rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(context.Context, *query.Query, indexer.SearchOptions) ([]*types.TxResultV2, error)); ok {
+		return rf(_a0, _a1, _a2)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *query.Query) []*types.TxResultV2); ok {
-		r0 = rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(context.Context, *query.Query, indexer.SearchOptions) []*types.TxResultV2); ok {
+		r0 = rf(_a0, _a1, _a2)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*types.TxResultV2)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *query.Query) error); ok {
-		r1 = rf(_a0, _a1)
+	if rf, ok := ret.Get(1).(func(context.Context, *query.Query, indexer.SearchOptions) error); ok {
+		r1 = rf(_a0, _a1, _a2)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/sei-tendermint/internal/state/indexer/sink/kv/kv.go
+++ b/sei-tendermint/internal/state/indexer/sink/kv/kv.go
@@ -43,12 +43,12 @@ func (kves *EventSink) IndexTxEvents(results []*abci.TxResultV2) error {
 	return kves.txi.Index(results)
 }
 
-func (kves *EventSink) SearchBlockEvents(ctx context.Context, q *query.Query) ([]int64, error) {
-	return kves.bi.Search(ctx, q)
+func (kves *EventSink) SearchBlockEvents(ctx context.Context, q *query.Query, opts indexer.SearchOptions) ([]int64, error) {
+	return kves.bi.Search(ctx, q, opts)
 }
 
-func (kves *EventSink) SearchTxEvents(ctx context.Context, q *query.Query) ([]*abci.TxResultV2, error) {
-	return kves.txi.Search(ctx, q)
+func (kves *EventSink) SearchTxEvents(ctx context.Context, q *query.Query, opts indexer.SearchOptions) ([]*abci.TxResultV2, error) {
+	return kves.txi.Search(ctx, q, opts)
 }
 
 func (kves *EventSink) GetTxByHash(hash []byte) (*abci.TxResultV2, error) {

--- a/sei-tendermint/internal/state/indexer/sink/kv/kv_test.go
+++ b/sei-tendermint/internal/state/indexer/sink/kv/kv_test.go
@@ -18,6 +18,10 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
 )
 
+// searchOpts is the zero-value (unbounded, ascending) options used by these
+// tests
+var searchOpts = indexer.SearchOptions{}
+
 func TestType(t *testing.T) {
 	kvSink := NewEventSink(dbm.NewMemDB())
 	assert.Equal(t, indexer.KV, kvSink.Type())
@@ -145,7 +149,7 @@ func TestBlockFuncs(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := t.Context()
 
-			results, err := indexer.SearchBlockEvents(ctx, tc.q)
+			results, err := indexer.SearchBlockEvents(ctx, tc.q, searchOpts)
 			require.NoError(t, err)
 			require.Equal(t, tc.results, results)
 		})
@@ -169,7 +173,7 @@ func TestTxSearchWithCancelation(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
-	results, err := indexer.SearchTxEvents(ctx, query.MustCompile(`account.number = 1`))
+	results, err := indexer.SearchTxEvents(ctx, query.MustCompile(`account.number = 1`), searchOpts)
 	assert.NoError(t, err)
 	assert.Empty(t, results)
 }
@@ -242,7 +246,7 @@ func TestTxSearchDeprecatedIndexing(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.q, func(t *testing.T) {
-			results, err := indexer.SearchTxEvents(ctx, query.MustCompile(tc.q))
+			results, err := indexer.SearchTxEvents(ctx, query.MustCompile(tc.q), searchOpts)
 			require.NoError(t, err)
 			for _, txr := range results {
 				for _, tr := range tc.results {
@@ -266,7 +270,7 @@ func TestTxSearchOneTxWithMultipleSameTagsButDifferentValues(t *testing.T) {
 
 	ctx := t.Context()
 
-	results, err := indexer.SearchTxEvents(ctx, query.MustCompile(`account.number >= 1`))
+	results, err := indexer.SearchTxEvents(ctx, query.MustCompile(`account.number >= 1`), searchOpts)
 	assert.NoError(t, err)
 
 	assert.Len(t, results, 1)
@@ -323,7 +327,7 @@ func TestTxSearchMultipleTxs(t *testing.T) {
 
 	ctx := t.Context()
 
-	results, err := indexer.SearchTxEvents(ctx, query.MustCompile(`account.number >= 1`))
+	results, err := indexer.SearchTxEvents(ctx, query.MustCompile(`account.number >= 1`), searchOpts)
 	assert.NoError(t, err)
 
 	require.Len(t, results, 3)

--- a/sei-tendermint/internal/state/indexer/sink/null/null.go
+++ b/sei-tendermint/internal/state/indexer/sink/null/null.go
@@ -30,11 +30,11 @@ func (nes *EventSink) IndexTxEvents(results []*abci.TxResultV2) error {
 	return nil
 }
 
-func (nes *EventSink) SearchBlockEvents(ctx context.Context, q *query.Query) ([]int64, error) {
+func (nes *EventSink) SearchBlockEvents(ctx context.Context, q *query.Query, opts indexer.SearchOptions) ([]int64, error) {
 	return nil, nil
 }
 
-func (nes *EventSink) SearchTxEvents(ctx context.Context, q *query.Query) ([]*abci.TxResultV2, error) {
+func (nes *EventSink) SearchTxEvents(ctx context.Context, q *query.Query, opts indexer.SearchOptions) ([]*abci.TxResultV2, error) {
 	return nil, nil
 }
 

--- a/sei-tendermint/internal/state/indexer/sink/null/null_test.go
+++ b/sei-tendermint/internal/state/indexer/sink/null/null_test.go
@@ -16,10 +16,10 @@ func TestNullEventSink(t *testing.T) {
 
 	assert.Nil(t, nullIndexer.IndexTxEvents(nil))
 	assert.Nil(t, nullIndexer.IndexBlockEvents(types.EventDataNewBlockHeader{}))
-	val1, err1 := nullIndexer.SearchBlockEvents(ctx, nil)
+	val1, err1 := nullIndexer.SearchBlockEvents(ctx, nil, indexer.SearchOptions{})
 	assert.Nil(t, val1)
 	assert.NoError(t, err1)
-	val2, err2 := nullIndexer.SearchTxEvents(ctx, nil)
+	val2, err2 := nullIndexer.SearchTxEvents(ctx, nil, indexer.SearchOptions{})
 	assert.Nil(t, val2)
 	assert.NoError(t, err2)
 	val3, err3 := nullIndexer.GetTxByHash(nil)

--- a/sei-tendermint/internal/state/indexer/sink/psql/psql.go
+++ b/sei-tendermint/internal/state/indexer/sink/psql/psql.go
@@ -234,12 +234,12 @@ INSERT INTO `+tableTxResults+` (block_id, index, created_at, tx_hash, tx_result)
 }
 
 // SearchBlockEvents is not implemented by this sink, and reports an error for all queries.
-func (es *EventSink) SearchBlockEvents(ctx context.Context, q *query.Query) ([]int64, error) {
+func (es *EventSink) SearchBlockEvents(ctx context.Context, q *query.Query, opts indexer.SearchOptions) ([]int64, error) {
 	return nil, errors.New("block search is not supported via the postgres event sink")
 }
 
 // SearchTxEvents is not implemented by this sink, and reports an error for all queries.
-func (es *EventSink) SearchTxEvents(ctx context.Context, q *query.Query) ([]*abci.TxResultV2, error) {
+func (es *EventSink) SearchTxEvents(ctx context.Context, q *query.Query, opts indexer.SearchOptions) ([]*abci.TxResultV2, error) {
 	return nil, errors.New("tx search is not supported via the postgres event sink")
 }
 

--- a/sei-tendermint/internal/state/indexer/sink/psql/psql_test.go
+++ b/sei-tendermint/internal/state/indexer/sink/psql/psql_test.go
@@ -28,6 +28,10 @@ import (
 // Verify that the type satisfies the EventSink interface.
 var _ indexer.EventSink = (*EventSink)(nil)
 
+// searchOpts is the zero-value options passed by these tests; the psql sink
+// ignores it and returns an unsupported error regardless.
+var searchOpts = indexer.SearchOptions{}
+
 var (
 	doPauseAtExit = flag.Bool("pause-at-exit", false,
 		"If true, pause the test until interrupted at shutdown, to allow debugging")
@@ -164,7 +168,7 @@ func TestIndexing(t *testing.T) {
 		verifyNotImplemented(t, "hasBlock", func() (bool, error) { return indexer.HasBlock(2) })
 
 		verifyNotImplemented(t, "block search", func() (bool, error) {
-			v, err := indexer.SearchBlockEvents(ctx, nil)
+			v, err := indexer.SearchBlockEvents(ctx, nil, searchOpts)
 			return v != nil, err
 		})
 
@@ -198,7 +202,7 @@ func TestIndexing(t *testing.T) {
 			return txr != nil, err
 		})
 		verifyNotImplemented(t, "tx search", func() (bool, error) {
-			txr, err := indexer.SearchTxEvents(ctx, nil)
+			txr, err := indexer.SearchTxEvents(ctx, nil, searchOpts)
 			return txr != nil, err
 		})
 

--- a/sei-tendermint/internal/state/indexer/tx/kv/kv.go
+++ b/sei-tendermint/internal/state/indexer/tx/kv/kv.go
@@ -139,7 +139,8 @@ func (txi *TxIndex) indexEvents(result *abci.TxResultV2, hash []byte, store dbm.
 //
 // Search will exit early and return any result fetched so far,
 // when a message is received on the context chan.
-func (txi *TxIndex) Search(ctx context.Context, q *query.Query) ([]*abci.TxResultV2, error) {
+// TODO(PLT-748): push opts.Limit/OrderDesc down into the scan path here
+func (txi *TxIndex) Search(ctx context.Context, q *query.Query, opts indexer.SearchOptions) ([]*abci.TxResultV2, error) {
 	select {
 	case <-ctx.Done():
 		return make([]*abci.TxResultV2, 0), nil

--- a/sei-tendermint/internal/state/indexer/tx/kv/kv_bench_test.go
+++ b/sei-tendermint/internal/state/indexer/tx/kv/kv_bench_test.go
@@ -62,7 +62,7 @@ func BenchmarkTxSearch(b *testing.B) {
 	ctx := b.Context()
 
 	for i := 0; i < b.N; i++ {
-		if _, err := indexer.Search(ctx, txQuery); err != nil {
+		if _, err := indexer.Search(ctx, txQuery, searchOpts); err != nil {
 			b.Errorf("failed to query for txs: %s", err)
 		}
 	}

--- a/sei-tendermint/internal/state/indexer/tx/kv/kv_test.go
+++ b/sei-tendermint/internal/state/indexer/tx/kv/kv_test.go
@@ -17,6 +17,10 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
 )
 
+// searchOpts is the zero-value (unbounded, ascending) options used by the tests
+// in this package
+var searchOpts = indexer.SearchOptions{}
+
 func TestTxIndex(t *testing.T) {
 	txIndexer := NewTxIndex(dbm.NewMemDB())
 
@@ -135,7 +139,7 @@ func TestTxSearch(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.q, func(t *testing.T) {
-			results, err := indexer.Search(ctx, query.MustCompile(tc.q))
+			results, err := indexer.Search(ctx, query.MustCompile(tc.q), searchOpts)
 			assert.NoError(t, err)
 
 			assert.Len(t, results, tc.resultsLength)
@@ -161,7 +165,7 @@ func TestTxSearchWithCancelation(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
-	results, err := indexer.Search(ctx, query.MustCompile(`account.number = 1`))
+	results, err := indexer.Search(ctx, query.MustCompile(`account.number = 1`), searchOpts)
 	assert.NoError(t, err)
 	assert.Empty(t, results)
 }
@@ -233,7 +237,7 @@ func TestTxSearchDeprecatedIndexing(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.q, func(t *testing.T) {
-			results, err := indexer.Search(ctx, query.MustCompile(tc.q))
+			results, err := indexer.Search(ctx, query.MustCompile(tc.q), searchOpts)
 			require.NoError(t, err)
 			for _, txr := range results {
 				for _, tr := range tc.results {
@@ -257,7 +261,7 @@ func TestTxSearchOneTxWithMultipleSameTagsButDifferentValues(t *testing.T) {
 
 	ctx := t.Context()
 
-	results, err := indexer.Search(ctx, query.MustCompile(`account.number >= 1`))
+	results, err := indexer.Search(ctx, query.MustCompile(`account.number >= 1`), searchOpts)
 	assert.NoError(t, err)
 
 	assert.Len(t, results, 1)
@@ -314,7 +318,7 @@ func TestTxSearchMultipleTxs(t *testing.T) {
 
 	ctx := t.Context()
 
-	results, err := indexer.Search(ctx, query.MustCompile(`account.number >= 1`))
+	results, err := indexer.Search(ctx, query.MustCompile(`account.number >= 1`), searchOpts)
 	assert.NoError(t, err)
 
 	require.Len(t, results, 3)

--- a/sei-tendermint/internal/state/indexer/tx/null/null.go
+++ b/sei-tendermint/internal/state/indexer/tx/null/null.go
@@ -29,6 +29,6 @@ func (txi *TxIndex) Index(results []*abci.TxResultV2) error {
 	return nil
 }
 
-func (txi *TxIndex) Search(ctx context.Context, q *query.Query) ([]*abci.TxResultV2, error) {
+func (txi *TxIndex) Search(ctx context.Context, q *query.Query, opts indexer.SearchOptions) ([]*abci.TxResultV2, error) {
 	return []*abci.TxResultV2{}, nil
 }


### PR DESCRIPTION
## Summary

`BlockSearch`/`TxSearch` previously fetched the **entire** match set from the KV
indexer, sorted it, and only then applied `MaxTxSearchResults` at the RPC layer.
For broad queries this materializes and sorts far more heights than the caller
will ever see. This PR pushes the result cap and ordering *down into the
indexer* so a broad block query is bounded at the scan path.

## What changed

- **New `indexer.SearchOptions{Limit, OrderDesc}`** threaded through the
  `TxIndexer` / `BlockIndexer` interfaces, the `EventSink` interface, the KV
  sink, and the null/mock implementations.
- **KV block indexer (`block/kv`) — bounded search:**
  - *Fast path* (`planBounded` / `searchBounded`): when every condition is an
    equality (point-probeable) or a `block.height` range (evaluable from the
    candidate height), drive a single height-ordered scan in `order_by` order,
    point-probe the remaining conditions per candidate, and stop at `Limit`.
    Memory is bounded by results kept, not by total match cardinality.
  - *Fallback path* (`intersect` + `collectBounded`): queries with
    `CONTAINS`/`MATCHES`/`EXISTS` or non-height ranges can't be point-probed, so
    the intersection is materialized as before, then ordered and capped.
- **RPC `BlockSearch`:** validates `order_by` up front, passes it and the cap
  into the indexer, and keeps the post-sort cap as a safety net for sinks that
  ignore the limit.
- **RPC `TxSearch`:** passes `SearchOptions` through now, but the tx scan path is
  not yet bounded — marked with `TODO(PLT-748)`; behavior is unchanged for tx.

## Tests

- `TestBlockIndexerBounded` covers the fast path (equality driver, multi-equality
  probe, equality + height range, pure height-range driver) and the fallback
  path (`CONTAINS`), across asc/desc and bounded/unbounded limits.
- Existing indexer/sink/rpc tests updated for the new `SearchOptions` argument.

## Follow-up

- Bound the KV **tx** scan path the same way (`TODO(PLT-748)` in `tx.go`).

PLT-748
