### PR TITLE
Close temporary rootmulti store in channel types setup

### DIFF
--- a/sei-ibc-go/modules/core/04-channel/types/msgs_test.go
+++ b/sei-ibc-go/modules/core/04-channel/types/msgs_test.go
@@ -75,6 +75,9 @@ func (suite *TypesTestSuite) SetupTest() {
 	scConfig.MemIAVLConfig.SnapshotMinTimeInterval = 0
 	ssConfig := seidbconfig.StateStoreConfig{}
 	store := storev2rootmulti.NewStore(suite.T().TempDir(), scConfig, ssConfig, nil)
+	defer func() {
+		suite.Require().NoError(store.Close())
+	}()
 	storeKey := storetypes.NewKVStoreKey("iavlStoreKey")
 
 	store.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, nil)


### PR DESCRIPTION
Close the rootmulti store created by TestTypesTestSuite once the proof fixture has been generated. The store starts asynchronous hash logger work during commit, and leaving it open can race with t.TempDir cleanup under the race-enabled CI job, causing flaky "directory not empty" cleanup failures in channel message validation tests.

Flaked [on main](https://github.com/sei-protocol/sei-chain/actions/runs/28517259993/job/84531996505).
