### PR TITLE
feat(replay): historical_replay build tag for lenient tx decoder

### DIFF
--- a/app/params/proto_historical_replay.go
+++ b/app/params/proto_historical_replay.go
@@ -10,8 +10,9 @@ import (
 
 // This variant swaps the block-execution tx decoder to the lenient one that does
 // not reject non-canonical protobuf tx bodies, so a tagged build can replay
-// pre-v6.5 pacific-1 blocks. It is consensus-unsafe for live paths and must only
-// be reachable via the historical_replay build tag.
+// historical blocks whose tx bodies predate strict body-bloat rejection. It is
+// consensus-unsafe for live paths and must only be reachable via the
+// historical_replay build tag.
 
 // MakeEncodingConfig creates an EncodingConfig for an amino based test configuration.
 func MakeEncodingConfig() EncodingConfig {

--- a/app/params/proto_historical_replay.go
+++ b/app/params/proto_historical_replay.go
@@ -1,4 +1,4 @@
-//go:build !test_amino && !historical_replay
+//go:build !test_amino && historical_replay
 
 package params
 
@@ -8,12 +8,17 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/tx"
 )
 
+// This variant swaps the block-execution tx decoder to the lenient one that does
+// not reject non-canonical protobuf tx bodies, so a tagged build can replay
+// pre-v6.5 pacific-1 blocks. It is consensus-unsafe for live paths and must only
+// be reachable via the historical_replay build tag.
+
 // MakeEncodingConfig creates an EncodingConfig for an amino based test configuration.
 func MakeEncodingConfig() EncodingConfig {
 	amino := codec.NewLegacyAmino()
 	interfaceRegistry := types.NewInterfaceRegistry()
 	marshaler := codec.NewProtoCodec(interfaceRegistry)
-	txCfg := tx.NewTxConfig(marshaler, tx.DefaultSignModes)
+	txCfg := tx.NewTxConfigWithoutBodyBloatRejection(marshaler, tx.DefaultSignModes)
 
 	return EncodingConfig{
 		InterfaceRegistry: interfaceRegistry,
@@ -28,7 +33,7 @@ func MakeLegacyEncodingConfig() EncodingConfig {
 	amino := codec.NewLegacyAmino()
 	interfaceRegistry := types.NewLegacyInterfaceRegistry()
 	marshaler := codec.NewProtoCodec(interfaceRegistry)
-	txCfg := tx.NewTxConfig(marshaler, tx.DefaultSignModes)
+	txCfg := tx.NewTxConfigWithoutBodyBloatRejection(marshaler, tx.DefaultSignModes)
 
 	return EncodingConfig{
 		InterfaceRegistry: interfaceRegistry,

--- a/app/params/proto_historical_replay.go
+++ b/app/params/proto_historical_replay.go
@@ -14,7 +14,8 @@ import (
 // consensus-unsafe for live paths and must only be reachable via the
 // historical_replay build tag.
 
-// MakeEncodingConfig creates an EncodingConfig for an amino based test configuration.
+// MakeEncodingConfig creates an EncodingConfig whose TxConfig uses the lenient
+// (no body-bloat rejection) decoder, for historical-replay builds only.
 func MakeEncodingConfig() EncodingConfig {
 	amino := codec.NewLegacyAmino()
 	interfaceRegistry := types.NewInterfaceRegistry()
@@ -29,7 +30,8 @@ func MakeEncodingConfig() EncodingConfig {
 	}
 }
 
-// MakeLegacyEncodingConfig creates an EncodingConfig for an amino based test configuration.
+// MakeLegacyEncodingConfig creates a legacy EncodingConfig whose TxConfig uses the
+// lenient (no body-bloat rejection) decoder, for historical-replay builds only.
 func MakeLegacyEncodingConfig() EncodingConfig {
 	amino := codec.NewLegacyAmino()
 	interfaceRegistry := types.NewLegacyInterfaceRegistry()

--- a/sei-cosmos/x/auth/tx/config.go
+++ b/sei-cosmos/x/auth/tx/config.go
@@ -41,9 +41,10 @@ func NewTxConfigWithHandler(protoCodec codec.ProtoCodecMarshaler, handler signin
 	}
 }
 
-// NewTxConfigWithoutBodyBloatRejection returns a TxConfig whose decoder preserves
-// pre-v6.5 decode behavior (no body-bloat rejection). This is consensus-unsafe for
-// live paths and exists only for historical replay tooling gated behind a build tag.
+// NewTxConfigWithoutBodyBloatRejection returns a TxConfig whose decoder does not
+// reject non-canonical (body-bloat) protobuf tx bodies, so historical blocks whose
+// tx bodies predate that check can be decoded and executed. This is consensus-unsafe
+// for live paths and exists only for historical replay tooling gated behind a build tag.
 func NewTxConfigWithoutBodyBloatRejection(protoCodec codec.ProtoCodecMarshaler, enabledSignModes []signingtypes.SignMode) client.TxConfig {
 	return &config{
 		handler:     makeSignModeHandler(enabledSignModes),

--- a/sei-cosmos/x/auth/tx/config.go
+++ b/sei-cosmos/x/auth/tx/config.go
@@ -41,21 +41,6 @@ func NewTxConfigWithHandler(protoCodec codec.ProtoCodecMarshaler, handler signin
 	}
 }
 
-// NewTxConfigWithoutBodyBloatRejection returns a TxConfig whose decoder does not
-// reject non-canonical (body-bloat) protobuf tx bodies, so historical blocks whose
-// tx bodies predate that check can be decoded and executed. This is consensus-unsafe
-// for live paths and exists only for historical replay tooling gated behind a build tag.
-func NewTxConfigWithoutBodyBloatRejection(protoCodec codec.ProtoCodecMarshaler, enabledSignModes []signingtypes.SignMode) client.TxConfig {
-	return &config{
-		handler:     makeSignModeHandler(enabledSignModes),
-		decoder:     DefaultTxDecoderWithoutBodyBloatRejection(protoCodec),
-		encoder:     DefaultTxEncoder(),
-		jsonDecoder: DefaultJSONTxDecoder(protoCodec),
-		jsonEncoder: DefaultJSONTxEncoder(protoCodec),
-		protoCodec:  protoCodec,
-	}
-}
-
 func (g config) NewTxBuilder() client.TxBuilder {
 	return newBuilder()
 }

--- a/sei-cosmos/x/auth/tx/config.go
+++ b/sei-cosmos/x/auth/tx/config.go
@@ -41,6 +41,20 @@ func NewTxConfigWithHandler(protoCodec codec.ProtoCodecMarshaler, handler signin
 	}
 }
 
+// NewTxConfigWithoutBodyBloatRejection returns a TxConfig whose decoder preserves
+// pre-v6.5 decode behavior (no body-bloat rejection). This is consensus-unsafe for
+// live paths and exists only for historical replay tooling gated behind a build tag.
+func NewTxConfigWithoutBodyBloatRejection(protoCodec codec.ProtoCodecMarshaler, enabledSignModes []signingtypes.SignMode) client.TxConfig {
+	return &config{
+		handler:     makeSignModeHandler(enabledSignModes),
+		decoder:     DefaultTxDecoderWithoutBodyBloatRejection(protoCodec),
+		encoder:     DefaultTxEncoder(),
+		jsonDecoder: DefaultJSONTxDecoder(protoCodec),
+		jsonEncoder: DefaultJSONTxEncoder(protoCodec),
+		protoCodec:  protoCodec,
+	}
+}
+
 func (g config) NewTxBuilder() client.TxBuilder {
 	return newBuilder()
 }

--- a/sei-cosmos/x/auth/tx/config_historical_replay.go
+++ b/sei-cosmos/x/auth/tx/config_historical_replay.go
@@ -1,0 +1,27 @@
+//go:build historical_replay
+
+package tx
+
+import (
+	"github.com/sei-protocol/sei-chain/sei-cosmos/client"
+	"github.com/sei-protocol/sei-chain/sei-cosmos/codec"
+	signingtypes "github.com/sei-protocol/sei-chain/sei-cosmos/types/tx/signing"
+)
+
+// NewTxConfigWithoutBodyBloatRejection returns a TxConfig whose decoder does not
+// reject non-canonical (body-bloat) protobuf tx bodies, so historical blocks whose
+// tx bodies predate that check can be decoded and executed.
+//
+// It is consensus-unsafe for live paths, so it is compiled ONLY into
+// historical_replay-tagged builds — an untagged (production) binary cannot reach
+// it, keeping the lenient execution decoder off every mempool/CheckTx/DeliverTx path.
+func NewTxConfigWithoutBodyBloatRejection(protoCodec codec.ProtoCodecMarshaler, enabledSignModes []signingtypes.SignMode) client.TxConfig {
+	return &config{
+		handler:     makeSignModeHandler(enabledSignModes),
+		decoder:     DefaultTxDecoderWithoutBodyBloatRejection(protoCodec),
+		encoder:     DefaultTxEncoder(),
+		jsonDecoder: DefaultJSONTxDecoder(protoCodec),
+		jsonEncoder: DefaultJSONTxEncoder(protoCodec),
+		protoCodec:  protoCodec,
+	}
+}


### PR DESCRIPTION
## Problem

Replaying **pre-v6.5** pacific-1 history on a current build records historical transactions with **non-canonical protobuf bodies** as failed (`code 2`, `tx decode error: tx parse error`) instead of executing them. Empirically: at height `79,205,095` tx 6, a full-history `v6.5.1` archive executes the tx (`code 0`), while a replayer on a newer build rejects it. The tx isn't dropped (block tx-counts match), but it gets a failure result with no state mutation, so replayed state diverges from history and compounds downstream.

**Root cause:** the strict decoder is hardcoded — `NewTxConfigWithHandler` → `DefaultTxDecoder(protoCodec)` → `defaultTxDecoder(cdc, /*rejectBodyBloat=*/true)`. `rejectBloatedBody()` re-marshals the `TxBody` and rejects on any byte-length delta (a post-v6.5 ADR-027 strictness). Pre-v6.5 blocks were committed by a more lenient binary, so their bodies carry non-canonical protobuf padding the newer decoder rejects. There is no runtime/config/build-tag override today; every `app.New` funnels through `MakeEncodingConfig()`, which feeds both the BaseApp decoder and `app.txDecoder`. The lenient `DefaultTxDecoderWithoutBodyBloatRejection` already exists but is wired only into `evmrpc` trace.

## Change

A `historical_replay` build tag that swaps **only** the block-execution encoding config to the lenient decoder:

- `sei-cosmos/x/auth/tx/config.go` — new `NewTxConfigWithoutBodyBloatRejection(...)` wiring the existing `DefaultTxDecoderWithoutBodyBloatRejection` (no bool added to the strict constructor — strict stays the only accidentally-reachable default; `config.decoder` is unexported so a named constructor is required).
- `app/params/proto.go` (gated `!test_amino && !historical_replay`) + new `app/params/proto_historical_replay.go` (gated `!test_amino && historical_replay`) — a `//go:build` split of `MakeEncodingConfig` **and** `MakeLegacyEncodingConfig`. This single seam covers both the BaseApp decoder and `app.txDecoder`.

## Consensus safety

**Build tag, not a runtime flag — deliberately.** A runtime flag would leave one binary that could be misconfigured to accept non-canonical bodies on live CheckTx/DeliverTx (a lenient validator accepts txs its strict peers reject → fork risk). The lenient decoder is reachable **only** in a `historical_replay`-tagged artifact, intended purely for historical replay / analysis — never a validator or mempool-serving node. The default/untagged build is byte-for-byte unchanged.

## Verification

- Default and `-tags historical_replay` builds both compile (`app/params`, `sei-cosmos/x/auth/tx`, `app`); combination with `mock_chain_validation` also builds.
- Without the tag, nothing in the execution path references the lenient decoder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)