### PR TITLE
Add chain_id label to OTel metrics

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -519,7 +519,7 @@ func New(
 	bApp.SetInterfaceRegistry(interfaceRegistry)
 
 	// Bind OTEL metrics provider once at application construction
-	if err := utilmetrics.SetupOtelMetricsProvider(); err != nil {
+	if err := utilmetrics.SetupOtelMetricsProvider(bApp.ChainID); err != nil {
 		logger.Error(err.Error())
 	}
 

--- a/utils/metrics/metrics_util.go
+++ b/utils/metrics/metrics_util.go
@@ -13,19 +13,42 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/prometheus"
+	"go.opentelemetry.io/otel/sdk/resource"
 	sdk "go.opentelemetry.io/otel/sdk/metric"
 )
 
-func SetupOtelMetricsProvider() error {
+func SetupOtelMetricsProvider(chainID string) error {
+	if chainID == "" {
+		return fmt.Errorf("chainID must not be empty")
+	}
+
+	res, err := resource.Merge(
+		resource.Default(),
+		resource.NewWithAttributes(
+			"",
+			attribute.String("chain_id", chainID),
+		),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create OTel resource: %w", err)
+	}
+
 	metricsExporter, err := prometheus.New(
 		prometheus.WithNamespace("sei_chain"),
 		prometheus.WithTranslationStrategy(otlptranslator.UnderscoreEscapingWithSuffixes),
+		prometheus.WithResourceAsConstantLabels(
+			attribute.NewAllowKeysFilter("chain_id"),
+		),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create Prometheus exporter: %w", err)
 	}
-	otel.SetMeterProvider(sdk.NewMeterProvider(sdk.WithReader(metricsExporter)))
+	otel.SetMeterProvider(sdk.NewMeterProvider(
+		sdk.WithResource(res),
+		sdk.WithReader(metricsExporter),
+	))
 	return nil
 }
 

--- a/utils/metrics/metrics_util.go
+++ b/utils/metrics/metrics_util.go
@@ -15,8 +15,8 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/prometheus"
-	"go.opentelemetry.io/otel/sdk/resource"
 	sdk "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 func SetupOtelMetricsProvider(chainID string) error {

--- a/utils/metrics/metrics_util_test.go
+++ b/utils/metrics/metrics_util_test.go
@@ -1,0 +1,46 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+)
+
+func TestSetupOtelMetricsProviderRequiresChainID(t *testing.T) {
+	require.Error(t, SetupOtelMetricsProvider(""))
+}
+
+// TestSetupOtelMetricsProviderAttachesChainID verifies that chain_id is emitted
+// as a constant label on every OTel metric series scraped via Prometheus
+func TestSetupOtelMetricsProviderAttachesChainID(t *testing.T) {
+	const chainID = "test-chain-1"
+	require.NoError(t, SetupOtelMetricsProvider(chainID))
+
+	// Emit a measurement through the global provider the setup just installed.
+	counter, err := otel.Meter("meter_test").Int64Counter("meter_chain_id_probe")
+	require.NoError(t, err)
+	counter.Add(t.Context(), 1)
+
+	// Gathering triggers the exporter's pull-based collection.
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	var found bool
+	for _, mf := range families {
+		if !strings.Contains(mf.GetName(), "meter_chain_id_probe") {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "chain_id" {
+					require.Equal(t, chainID, l.GetValue())
+					found = true
+				}
+			}
+		}
+	}
+	require.True(t, found, "expected chain_id label on the emitted OTel metric")
+}


### PR DESCRIPTION
## Describe your changes

Attaches a `chain_id` label to every OTel metric series emitted by the chain.

Previously `SetupOtelMetricsProvider` created a meter provider with no resource
attributes, so metrics scraped via Prometheus carried no way to distinguish
which chain they came from — a problem when multiple chains scrape into the
same backend.

This PR:
- Adds a `chainID` parameter to `SetupOtelMetricsProvider` and wires
  `bApp.ChainID` in at application construction (`app/app.go`).
- Builds an OTel `resource` with a `chain_id` attribute and registers it on the
  meter provider.
- Uses `WithResourceAsConstantLabels` (scoped to an allow-list of just
  `chain_id`) so the attribute surfaces as a constant label on every scraped
  Prometheus series.
- Fails closed: returns an error when `chainID` is empty rather than emitting
  unlabeled metrics.

## Testing

Adds `utils/metrics/metrics_util_test.go`:
- `TestSetupOtelMetricsProviderRequiresChainID` — empty `chainID` returns an error.
- `TestSetupOtelMetricsProviderAttachesChainID` — emits a metric through the
  installed provider and asserts the scraped Prometheus series carries the
  expected `chain_id` label.

## Linear

PLT-783
