### PR TITLE
Backport `release/v6.6`: Add GoReleaser release pipeline for static seid binaries (#3425)

### DIFF
--- a/.github/workflows/cross-arch-build.yml
+++ b/.github/workflows/cross-arch-build.yml
@@ -54,6 +54,50 @@ jobs:
 
       - name: Verify build binary
         run: ./build/seid version --long
+  linux-amd64-static:
+    name: "Linux AMD64 (static)"
+    runs-on: ubuntu-latest
+    # The static seid is a release artefact, so only build it for release work,
+    # not on every PR: PRs into release/**, pushes to release/**, or merge-queue
+    # entries targeting release/**.
+    if: >-
+      startsWith(github.base_ref, 'release/') ||
+      startsWith(github.ref, 'refs/heads/release/') ||
+      startsWith(github.event.merge_group.base_ref, 'refs/heads/release/')
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      # Build inside Alpine (musl-native): Ubuntu's musl-gcc can't fully static-link
+      # on 24.04 (glibc libgcc -> _dl_find_object, absent in musl), and zig cc rejects
+      # the -z muldefs flag needed to link the libwasmvm v152/v155 archives. Alpine's
+      # gcc is GNU ld + musl, so it links cleanly. Same script the goreleaser release
+      # build runs (scripts/build-static.sh); goreleaser then packages it via the tool shim.
+      - name: Build statically (Alpine / musl)
+        run: bash scripts/build-static.sh
+
+      - name: Assert binary is statically linked
+        run: |
+          info=$(file ./build/seid)
+          echo "$info"
+          echo "$info" | grep -q "statically linked" \
+            || { echo "ERROR: seid is not statically linked"; exit 1; }
+
+      - name: Assert no dynamic dependencies
+        run: |
+          # On a true static binary, ldd reports "not a dynamic executable".
+          ldd ./build/seid 2>&1 | grep -qE "not a dynamic|statically linked" \
+            || { echo "ERROR: seid has dynamic dependencies:"; ldd ./build/seid; exit 1; }
+
+      - name: Smoke test
+        run: ./build/seid version --long
+
+      - name: Upload artifact for inspection
+        uses: actions/upload-artifact@v5
+        with:
+          name: seid-linux-amd64-static
+          path: ./build/seid
+          retention-days: 14
   macos-arm64:
     name: "macOS ARM64"
     runs-on: macos-latest

--- a/.github/workflows/cross-arch-build.yml
+++ b/.github/workflows/cross-arch-build.yml
@@ -66,7 +66,8 @@ jobs:
       startsWith(github.event.merge_group.base_ref, 'refs/heads/release/')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       # Build inside Alpine (musl-native): Ubuntu's musl-gcc can't fully static-link
       # on 24.04 (glibc libgcc -> _dl_find_object, absent in musl), and zig cc rejects

--- a/.github/workflows/goreleaser-release.yml
+++ b/.github/workflows/goreleaser-release.yml
@@ -1,0 +1,24 @@
+name: GoReleaser (manual)
+run-name: GoReleaser / manual ${{ inputs.tag }}
+
+# Automatic releases attach binaries via the chained job in uci-release-publish.yml
+# (publish -> goreleaser). This is a manual escape hatch: (re)build + attach artifacts to
+# an existing tag — e.g. backfill a release cut before this tooling, or re-run after a
+# failure. The static build lives in .goreleaser.yaml's before: hook (scripts/build-static.sh).
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to (re)build and attach artifacts to (e.g. v6.1.13)."
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    uses: sei-protocol/uci/.github/workflows/goreleaser-release.yml@v0.0.11
+    with:
+      ref: ${{ inputs.tag }}
+      go-version: '1.25.6'
+      submodules: 'false'

--- a/.github/workflows/uci-release-publish.yml
+++ b/.github/workflows/uci-release-publish.yml
@@ -14,6 +14,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  releaser:
+  publish:
     name: Release
-    uses: sei-protocol/uci/.github/workflows/release-publish.yml@v0.0.9
+    uses: sei-protocol/uci/.github/workflows/release-publish.yml@v0.0.11
+
+  goreleaser:
+    name: GoReleaser
+    needs: publish
+    if: needs.publish.outputs.release_created == 'true'
+    uses: sei-protocol/uci/.github/workflows/goreleaser-release.yml@v0.0.11
+    with:
+      ref: ${{ needs.publish.outputs.version }}
+      go-version: '1.25.6'
+      # Repo submodules are Solidity test libs (forge-std/openzeppelin/solmate); the
+      # seid binary build doesn't use them, so skip the fetch.
+      submodules: 'false'

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ release/
 .cursor/
 .DS_Store
 build/
+dist/
 cache/
 ./evm_stress
 *.iml

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,83 @@
+version: 2
+
+project_name: sei-chain
+
+before:
+  hooks:
+    - go mod download
+    # build-static.sh self-verifies (libwasmvm archives present + output is static).
+    - bash scripts/build-static.sh
+
+builds:
+  # The static seid is built in Alpine (musl-native) by the `before:` hook above
+  # (scripts/build-static.sh); neither Ubuntu's musl-gcc nor zig cc can produce this
+  # static link on the runner. GoReleaser does NOT recompile: the `tool` shim hands it
+  # that prebuilt static binary (OSS-friendly equivalent of the Pro `prebuilt` builder;
+  # see scripts/goreleaser-shim.sh), so the released binary is byte-identical to the
+  # static muslc `make build` (LINK_STATICALLY/muslc, ledger off). ledger is omitted from
+  # the static build (needs static HID/USB; not relevant for a server seid); make/source
+  # builds keep it (Makefile LEDGER_ENABLED defaults to true).
+  - id: seid
+    builder: go
+    tool: ./scripts/goreleaser-shim.sh
+    main: ./cmd/seid
+    binary: seid
+    goos:
+      - linux
+    goarch:
+      - amd64
+
+archives:
+  - id: seid
+    formats: [tar.gz]
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+    files:
+      - LICENSE*
+      - README.md
+      - CHANGELOG*
+
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha256
+
+snapshot:
+  version_template: '{{ incpatch .Version }}-snapshot-{{ .ShortCommit }}'
+
+changelog:
+  use: github
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - 'merge conflict'
+      - Merge pull request
+      - Merge remote-tracking branch
+      - Merge branch
+
+release:
+  github:
+    owner: sei-protocol
+    name: sei-chain
+  draft: false
+  prerelease: auto
+  mode: append
+  name_template: '{{ .Tag }}'
+  header: |
+    # Sei {{ .Tag }}
+
+    Pre-built **statically-linked** `seid` binary attached below for `linux/amd64`.
+
+    Verify your download:
+
+    ```
+    sha256sum -c checksums.txt --ignore-missing
+    ```
+
+    For Docker images, see `ghcr.io/sei-protocol/sei`.
+  footer: |
+    **Full Changelog**: https://github.com/sei-protocol/sei-chain/compare/{{ .PreviousTag }}...{{ .Tag }}

--- a/scripts/build-static.sh
+++ b/scripts/build-static.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Build the statically-linked linux/amd64 `seid` in Alpine (musl-native).
+# Single source of truth for the static build: used by the goreleaser `before:` hook,
+# the cross-arch CI guard, and local runs (`goreleaser release --snapshot`). It also
+# self-verifies (required libwasmvm archives present, and the output is actually static)
+# so every entry point fails fast rather than producing or shipping a broken binary.
+#
+# Ubuntu's musl-gcc can't fully static-link on 24.04 (glibc libgcc needs _dl_find_object,
+# absent in musl) and zig cc rejects the -z muldefs flag needed for the libwasmvm
+# v152/v155 archives; Alpine's GNU ld + musl links cleanly. --platform linux/amd64 is a
+# no-op on amd64 CI and forces the right arch on Apple Silicon for local runs.
+set -euo pipefail
+
+# Fail fast if the required static libwasmvm archives are missing.
+bash "$(dirname "$0")/check-libwasmvm-static.sh"
+
+docker run --rm --platform linux/amd64 -v "$PWD":/src -w /src golang:1.25.6-alpine sh -c '
+  apk add --no-cache build-base git &&
+  git config --global --add safe.directory /src &&
+  LINK_STATICALLY=true BUILD_TAGS=muslc LEDGER_ENABLED=false make build'
+
+# Assert the output really is statically linked, so a regression fails here rather than
+# shipping a dynamically-linked binary advertised as static.
+info="$(file build/seid)"
+echo "$info"
+case "$info" in
+  *"statically linked"*) ;;
+  *) echo "build-static: ERROR: build/seid is not statically linked" >&2; exit 1 ;;
+esac

--- a/scripts/check-libwasmvm-static.sh
+++ b/scripts/check-libwasmvm-static.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Verifies that the static libwasmvm artefacts required for a static `seid`
+# build are present. The .a files are produced by `make release-build-alpine`
+# in sei-wasmvm and are checked into sei-wasmvm/internal/api/.
+#
+# Used by .goreleaser.yaml as a `before:` hook so a release tag fails fast
+# when the artefacts are missing rather than producing a broken binary.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+# A muslc static seid links the base libwasmvm (sei-wasmvm) plus the versioned
+# CosmWasm VMs v152 + v155 (sei-wasmd); every archive must be present or the
+# static link fails late instead of fast.
+required=(
+  "$repo_root/sei-wasmvm/internal/api/libwasmvm_muslc.a"
+  "$repo_root/sei-wasmvm/internal/api/libwasmvm_muslc.aarch64.a"
+  "$repo_root/sei-wasmd/x/wasm/artifacts/v152/api/libwasmvm152_muslc.a"
+  "$repo_root/sei-wasmd/x/wasm/artifacts/v152/api/libwasmvm152_muslc.aarch64.a"
+  "$repo_root/sei-wasmd/x/wasm/artifacts/v155/api/libwasmvm155_muslc.a"
+  "$repo_root/sei-wasmd/x/wasm/artifacts/v155/api/libwasmvm155_muslc.aarch64.a"
+)
+
+missing=0
+for f in "${required[@]}"; do
+  if [[ ! -f "$f" ]]; then
+    echo "::error::missing static libwasmvm artefact: $f"
+    missing=1
+  fi
+done
+
+if [[ $missing -eq 1 ]]; then
+  echo "::error::regenerate the missing muslc archive(s) from their module (sei-wasmvm: 'make release-build-alpine'; sei-wasmd: x/wasm/artifacts)"
+  exit 1
+fi
+
+echo "All required static libwasmvm artefacts present:"
+ls -la "${required[@]}"

--- a/scripts/goreleaser-shim.sh
+++ b/scripts/goreleaser-shim.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# GoReleaser build-tool shim: an OSS-friendly stand-in for the Pro-only `prebuilt` builder.
+#
+# GoReleaser invokes this wherever it would invoke `go`. Every subcommand is passed
+# straight through to the real `go` EXCEPT `build`, which we intercept: instead of
+# recompiling, we hand back the already-built static `seid` (produced in Alpine by the
+# goreleaser `before:` hook, scripts/build-static.sh). This keeps the Makefile the single
+# source of truth for the build and makes the released binary byte-identical to the static
+# muslc `make build` (LINK_STATICALLY/muslc, ledger off), i.e. exactly what GoReleaser
+# Pro's `prebuilt` builder would do, but on the OSS distribution. Wired via `builds[].tool`
+# in .goreleaser.yaml.
+#
+# The prebuilt binary path can be overridden with $PREBUILT_SEID (defaults to build/seid).
+set -euo pipefail
+
+PREBUILT="${PREBUILT_SEID:-build/seid}"
+
+if [ "${1:-}" = "build" ]; then
+  # The prebuilt binary is linux/amd64 only. If goreleaser ever requests another arch
+  # (e.g. once arm64 lands, PLT-757), fail loudly rather than mislabel the amd64 binary.
+  if [ -n "${GOARCH:-}" ] && [ "$GOARCH" != "amd64" ]; then
+    echo "goreleaser-shim: only linux/amd64 is prebuilt; refusing to package for GOARCH=$GOARCH." >&2
+    exit 1
+  fi
+
+  # Extract the output path GoReleaser asked us to write the binary to. Handle both
+  # `-o <path>` (what goreleaser emits) and `-o=<path>`, so the shim is robust either way.
+  out=""
+  prev=""
+  for a in "$@"; do
+    case "$a" in -o=*) out="${a#-o=}" ;; esac
+    [ "$prev" = "-o" ] && out="$a"
+    prev="$a"
+  done
+  : "${out:?goreleaser-shim: no -o output path found in build args}"
+
+  if [ ! -x "$PREBUILT" ]; then
+    echo "goreleaser-shim: prebuilt binary '$PREBUILT' is missing or not executable." >&2
+    echo "                 Run scripts/build-static.sh (the goreleaser before: hook) first." >&2
+    exit 1
+  fi
+
+  mkdir -p "$(dirname "$out")"
+  cp "$PREBUILT" "$out"
+  echo "goreleaser-shim: packaged prebuilt $PREBUILT into $out" >&2
+  exit 0
+fi
+
+exec go "$@"


### PR DESCRIPTION
Manual backport of #3425 to `release/v6.6`.

## Why this was done manually
The `/backport` bot cannot open this one. #3425 modifies files under `.github/workflows/`, and GitHub refuses to let the backport GitHub App push commits that touch workflow files without the `workflows` permission (which the app token does not hold):

```
! [remote rejected] refusing to allow a GitHub App to create or update
workflow `.github/workflows/cross-arch-build.yml` without `workflows` permission
```

The cherry-pick itself is clean; only the bot's push was rejected. Cherry-picked and pushed manually instead. Any future backport that touches workflow files will hit the same wall.

## What this brings to `release/v6.6`
The GoReleaser pipeline that builds and attaches a pre-built statically-linked `seid` binary (linux/amd64) to GitHub releases:

* `.goreleaser.yaml` plus `scripts/goreleaser-shim.sh`, `scripts/build-static.sh`, `scripts/check-libwasmvm-static.sh`
* Chained `uci-release-publish.yml` (publish, then goreleaser) pinned to uci `@v0.0.11`
* `goreleaser-release.yml` manual dispatch escape hatch (rebuild and attach to an existing tag)
* `cross-arch-build.yml` static build guard, and `dist/` added to `.gitignore`

## Backport fidelity
Cherry-picked from squash commit `b8f05ce`. Seven of the eight files are byte identical to `main`. `cross-arch-build.yml` differs from `main` in exactly one respect: it keeps this branch's SHA-pinned `actions/checkout` (v7.0.0) rather than main's `@v5`, which is the correct behavior for the release branch. The static build guard itself is identical to main.

## Next step for the RC
Once this merges, `release/v6.6` has the pipeline. Note the existing `v6.6.0-rc1` tag predates it, so its tree contains no `.goreleaser.yaml` or scripts and the manual GoReleaser dispatch cannot backfill it (the dispatch checks out the tag it is given). The path for the RC binary is to cut `v6.6.0-rc2` from `release/v6.6` after this merges; the binary then builds and attaches automatically. The manual dispatch remains the escape hatch for re-running any tag cut after this landed.

Backport of #3425.
