### PR TITLE
Accept legacy cosmos_only SC write mode

### DIFF
--- a/app/seidb.go
+++ b/app/seidb.go
@@ -16,6 +16,8 @@ import (
 )
 
 const (
+	legacySCWriteModeCosmosOnly = "cosmos_only"
+
 	// SC Store configs
 	FlagSCEnable                     = "state-commit.sc-enable"
 	FlagSCDirectory                  = "state-commit.sc-directory"
@@ -127,9 +129,9 @@ func parseSCConfigs(appOpts servertypes.AppOptions) config.StateCommitConfig {
 	// Always parse sc-write-mode (even when auto is on) so a typo'd value fails
 	// fast here exactly as it does in server/config.GetConfig.
 	if wm := cast.ToString(appOpts.Get(FlagSCWriteMode)); wm != "" {
-		parsedWM, err := sctypes.ParseWriteMode(wm)
+		parsedWM, err := parseSCWriteMode(wm)
 		if err != nil {
-			panic(fmt.Sprintf("invalid EVM SS write mode %q: %s", wm, err))
+			panic(fmt.Sprintf("invalid SC write mode %q: %s", wm, err))
 		}
 		scConfig.WriteMode = parsedWM
 	}
@@ -174,6 +176,13 @@ func parseSCConfigs(appOpts servertypes.AppOptions) config.StateCommitConfig {
 	scConfig.HashLogger.Version = version.Version
 
 	return scConfig
+}
+
+func parseSCWriteMode(wm string) (sctypes.WriteMode, error) {
+	if wm == legacySCWriteModeCosmosOnly {
+		return sctypes.MemiavlOnly, nil
+	}
+	return sctypes.ParseWriteMode(wm)
 }
 
 func parseSSConfigs(appOpts servertypes.AppOptions) config.StateStoreConfig {

--- a/app/seidb.go
+++ b/app/seidb.go
@@ -12,12 +12,9 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/version"
 	"github.com/sei-protocol/sei-chain/sei-db/config"
 	seidb "github.com/sei-protocol/sei-chain/sei-db/db_engine/types"
-	sctypes "github.com/sei-protocol/sei-chain/sei-db/state_db/sc/types"
 )
 
 const (
-	legacySCWriteModeCosmosOnly = "cosmos_only"
-
 	// SC Store configs
 	FlagSCEnable                     = "state-commit.sc-enable"
 	FlagSCDirectory                  = "state-commit.sc-directory"
@@ -129,7 +126,7 @@ func parseSCConfigs(appOpts servertypes.AppOptions) config.StateCommitConfig {
 	// Always parse sc-write-mode (even when auto is on) so a typo'd value fails
 	// fast here exactly as it does in server/config.GetConfig.
 	if wm := cast.ToString(appOpts.Get(FlagSCWriteMode)); wm != "" {
-		parsedWM, err := parseSCWriteMode(wm)
+		parsedWM, err := config.ParseSCWriteMode(wm)
 		if err != nil {
 			panic(fmt.Sprintf("invalid SC write mode %q: %s", wm, err))
 		}
@@ -176,13 +173,6 @@ func parseSCConfigs(appOpts servertypes.AppOptions) config.StateCommitConfig {
 	scConfig.HashLogger.Version = version.Version
 
 	return scConfig
-}
-
-func parseSCWriteMode(wm string) (sctypes.WriteMode, error) {
-	if wm == legacySCWriteModeCosmosOnly {
-		return sctypes.MemiavlOnly, nil
-	}
-	return sctypes.ParseWriteMode(wm)
 }
 
 func parseSSConfigs(appOpts servertypes.AppOptions) config.StateStoreConfig {

--- a/app/seidb_test.go
+++ b/app/seidb_test.go
@@ -115,6 +115,30 @@ func TestParseSCConfigs_FlatKVReadWriteMetrics(t *testing.T) {
 	assert.True(t, scConfig.FlatKVConfig.EnableReadWriteMetrics)
 }
 
+func TestParseSCConfigs_LegacyCosmosOnlyWriteMode(t *testing.T) {
+	scConfig := parseSCConfigs(mapAppOpts{
+		FlagSCEnable:    true,
+		FlagSCWriteMode: "cosmos_only",
+	})
+	assert.Equal(t, sctypes.Auto, scConfig.WriteMode)
+
+	scConfig = parseSCConfigs(mapAppOpts{
+		FlagSCEnable:              true,
+		FlagSCWriteMode:           "cosmos_only",
+		FlagSCWriteModeEnableAuto: false,
+	})
+	assert.Equal(t, sctypes.MemiavlOnly, scConfig.WriteMode)
+}
+
+func TestParseSCConfigs_InvalidWriteModePanicMentionsSC(t *testing.T) {
+	assert.PanicsWithValue(t, `invalid SC write mode "bogus": invalid write mode: bogus`, func() {
+		parseSCConfigs(mapAppOpts{
+			FlagSCEnable:    true,
+			FlagSCWriteMode: "bogus",
+		})
+	})
+}
+
 func TestParseSSConfigs_EVMFlags(t *testing.T) {
 	appOpts := mapAppOpts{
 		FlagSSEnable:            true,

--- a/sei-cosmos/server/config/config.go
+++ b/sei-cosmos/server/config/config.go
@@ -12,7 +12,6 @@ import (
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
 	"github.com/sei-protocol/sei-chain/sei-db/config"
 	"github.com/sei-protocol/sei-chain/sei-db/state_db/sc/memiavl"
-	sctypes "github.com/sei-protocol/sei-chain/sei-db/state_db/sc/types"
 	tmcfg "github.com/sei-protocol/sei-chain/sei-tendermint/config"
 	"github.com/spf13/viper"
 )
@@ -441,7 +440,7 @@ func GetConfig(v *viper.Viper) (Config, error) {
 	// default, matching the behavior of app/seidb.go.
 	scWriteMode := config.DefaultStateCommitConfig().WriteMode
 	if wm := v.GetString("state-commit.sc-write-mode"); wm != "" {
-		parsed, err := sctypes.ParseWriteMode(wm)
+		parsed, err := config.ParseSCWriteMode(wm)
 		if err != nil {
 			return Config{}, fmt.Errorf("invalid state-commit.sc-write-mode %q: %w", wm, err)
 		}

--- a/sei-cosmos/server/config/config_test.go
+++ b/sei-cosmos/server/config/config_test.go
@@ -499,6 +499,20 @@ func TestGetConfigLegacyMemiavlOnlyResolvesToAuto(t *testing.T) {
 		"absent sc-write-mode-enable-auto must default to true and override an explicit memiavl_only")
 }
 
+func TestGetConfigLegacyCosmosOnlyResolvesToAuto(t *testing.T) {
+	v := viper.New()
+
+	v.Set("minimum-gas-prices", DefaultMinGasPrices)
+	v.Set("telemetry.global-labels", []interface{}{})
+	v.Set("state-commit.sc-write-mode", "cosmos_only")
+
+	cfg, err := GetConfig(v)
+	require.NoError(t, err)
+	require.True(t, cfg.StateCommit.WriteModeEnableAuto)
+	require.Equal(t, sctypes.Auto, cfg.StateCommit.WriteMode,
+		"v6.4/v6.5 app.toml files with cosmos_only must parse before auto mode is applied")
+}
+
 // TestGetConfigPinnedModeRequiresAutoDisabled verifies that an explicit
 // sc-write-mode is only honored when sc-write-mode-enable-auto = false. With auto
 // enabled (the default), the explicit mode is ignored and the node runs in auto.

--- a/sei-db/config/sc_config.go
+++ b/sei-db/config/sc_config.go
@@ -12,6 +12,8 @@ const (
 	DefaultSCHistoricalProofMaxInFlight = 1
 	DefaultSCHistoricalProofRateLimit   = 1.0 // req/s, <=0 disables rate limit
 	DefaultSCHistoricalProofBurst       = 1
+
+	legacySCWriteModeCosmosOnly = "cosmos_only"
 )
 
 // StateCommitConfig defines configuration for the state commit (SC) layer.
@@ -104,6 +106,16 @@ func ApplyWriteModeAuto(enableAuto bool, mode types.WriteMode) types.WriteMode {
 		return types.Auto
 	}
 	return mode
+}
+
+// ParseSCWriteMode converts the configured state-commit write mode to the
+// current SC write-mode enum. v6.4/v6.5 app.toml files used "cosmos_only" for
+// the same memIAVL-only routing that v6.6 calls "memiavl_only".
+func ParseSCWriteMode(wm string) (types.WriteMode, error) {
+	if wm == legacySCWriteModeCosmosOnly {
+		return types.MemiavlOnly, nil
+	}
+	return types.ParseWriteMode(wm)
 }
 
 // Validate checks if the StateCommitConfig is valid

--- a/sei-db/config/sc_config_test.go
+++ b/sei-db/config/sc_config_test.go
@@ -39,3 +39,16 @@ func TestDefaultStateCommitConfigWriteMode(t *testing.T) {
 	require.Equal(t, types.MemiavlOnly, cfg.WriteMode)
 	require.True(t, cfg.WriteModeEnableAuto)
 }
+
+func TestParseSCWriteMode(t *testing.T) {
+	parsed, err := ParseSCWriteMode("cosmos_only")
+	require.NoError(t, err)
+	require.Equal(t, types.MemiavlOnly, parsed)
+
+	parsed, err = ParseSCWriteMode("migrate_evm")
+	require.NoError(t, err)
+	require.Equal(t, types.MigrateEVM, parsed)
+
+	_, err = ParseSCWriteMode("bogus")
+	require.Error(t, err)
+}


### PR DESCRIPTION
Nodes initialized with v6.4.x or v6.5.x write:

  sc-write-mode = "cosmos_only"

into app.toml. In v6.6 the state-commit write-mode enum was replaced with the migration-oriented modes (memiavl_only, migrate_evm, ..., flatkv_only), and app/seidb.go parses any non-empty sc-write-mode before auto-mode resolution so typos still fail fast. Because "cosmos_only" no longer parsed, those existing app.toml files panic on first v6.6 startup:

  panic: invalid EVM SS write mode "cosmos_only": invalid write mode: cosmos_only

Add a small parse-boundary compatibility shim that maps the legacy "cosmos_only" value to memiavl_only. With the v6.6 default sc-write-mode-enable-auto behavior, this still resolves to effective auto for upgraded nodes, while nodes that explicitly disable auto get the equivalent fixed memiavl_only mode.

Keep all other invalid values failing fast, and update the panic text to say "SC write mode" since the offending key is state-commit.sc-write-mode, not EVM SS config.

