### PR TITLE
fix(composite): reset sticky commit-info latches on rollback across migration boundaries

### DIFF
--- a/sei-db/state_db/sc/composite/store.go
+++ b/sei-db/state_db/sc/composite/store.go
@@ -1147,6 +1147,21 @@ func (cs *CompositeCommitStore) Rollback(targetVersion int64) error {
 		}
 	}
 
+	// Clear the sticky lattice-append latch so the next commit-info call
+	// re-derives it from the rolled-back migration boundary. A store opened
+	// after the migrate_evm activation latches it true; rolling back to a
+	// pre-activation height (memiavl-only AppHash, no evm_lattice) must not
+	// keep appending the lattice, or the in-process commit info diverges from
+	// the canonical AppHash. Scope: only this latch is reset; the symmetric
+	// memiavlHashExcluded (bank-completion) and currentWriteMode are not
+	// re-derived here — out of scope while only migrate_evm is in flight, and
+	// self-healed by the next `seid start`.
+	cs.latticeAppendLatched.Store(false)
+
+	// Rollback is offline (no commit cycle in flight); clear the per-block
+	// migration-advance gate defensively.
+	cs.migrationAdvancedThisCommit = false
+
 	return nil
 }
 

--- a/sei-db/state_db/sc/composite/store.go
+++ b/sei-db/state_db/sc/composite/store.go
@@ -1147,16 +1147,28 @@ func (cs *CompositeCommitStore) Rollback(targetVersion int64) error {
 		}
 	}
 
-	// Clear the sticky lattice-append latch so the next commit-info call
-	// re-derives it from the rolled-back migration boundary. A store opened
-	// after the migrate_evm activation latches it true; rolling back to a
-	// pre-activation height (memiavl-only AppHash, no evm_lattice) must not
-	// keep appending the lattice, or the in-process commit info diverges from
-	// the canonical AppHash. Scope: only this latch is reset; the symmetric
-	// memiavlHashExcluded (bank-completion) and currentWriteMode are not
-	// re-derived here — out of scope while only migrate_evm is in flight, and
-	// self-healed by the next `seid start`.
+	// Clear both sticky commit-info latches so the next LastCommitInfo /
+	// WorkingCommitInfo re-derives from the rolled-back migration metadata.
+	// Rollback can move the boundary backwards across a seam that either
+	// flag latched on:
+	//   - latticeAppendLatched: set after the migrate_evm activation; a
+	//     rollback to a pre-activation height (memiavl-only AppHash, no
+	//     evm_lattice) must stop appending the lattice.
+	//   - memiavlHashExcluded: set after the bank migration completes
+	//     (version 3); a rollback below completion must re-include memiavl's
+	//     per-store infos, which the AppHash still carries at that height.
+	// Without these resets the in-process post-rollback commit info (the hash
+	// `seid rollback` prints and rootmulti caches in rs.lastCommitInfo)
+	// diverges from the canonical AppHash for the target height. The gates
+	// re-latch correctly on the next call against the rolled-back metadata.
+	//
+	// Note: currentWriteMode is not re-derived here. It only matters when a
+	// rollback crosses a seam whose latest-derived mode differs from the
+	// target's (e.g. a rollback all the way across a completed migration);
+	// that in-process view self-heals on the next `seid start`, which
+	// re-derives the mode from the rolled-back metadata.
 	cs.latticeAppendLatched.Store(false)
+	cs.memiavlHashExcluded.Store(false)
 
 	// Rollback is offline (no commit cycle in flight); clear the per-block
 	// migration-advance gate defensively.

--- a/sei-db/state_db/sc/composite/store_migration_test.go
+++ b/sei-db/state_db/sc/composite/store_migration_test.go
@@ -1,6 +1,7 @@
 package composite
 
 import (
+	"encoding/hex"
 	"sort"
 	"testing"
 
@@ -887,4 +888,282 @@ func TestComposite_MigrateEVM_PostCompletionFlipToEVMMigrated(t *testing.T) {
 	t.Cleanup(func() { _ = iter.Close() })
 	require.False(t, iter.Valid(),
 		"post-flip memiavl evm tree must remain empty (EVM writes route to flatkv)")
+}
+
+// cloneCommitInfo deep-copies a *proto.CommitInfo so a captured snapshot
+// survives later commits / reopens that mutate the live store.
+func cloneCommitInfo(ci *proto.CommitInfo) *proto.CommitInfo {
+	if ci == nil {
+		return nil
+	}
+	out := &proto.CommitInfo{
+		Version:    ci.Version,
+		StoreInfos: make([]proto.StoreInfo, len(ci.StoreInfos)),
+	}
+	for i, si := range ci.StoreInfos {
+		out.StoreInfos[i] = proto.StoreInfo{
+			Name: si.Name,
+			CommitId: proto.CommitID{
+				Version: si.CommitId.Version,
+				Hash:    append([]byte(nil), si.CommitId.Hash...),
+			},
+		}
+	}
+	return out
+}
+
+// requireCommitInfoEqual asserts two commit infos carry the same version
+// and the same per-store hashes. It compares name->hex maps so a failure
+// names exactly which store (e.g. evm_lattice vs a memiavl module)
+// diverged and by how much, rather than dumping opaque byte slices.
+func requireCommitInfoEqual(t *testing.T, want, got *proto.CommitInfo, msg string) {
+	t.Helper()
+	require.NotNilf(t, want, "%s: no canonical commit info captured", msg)
+	require.NotNilf(t, got, "%s: got nil commit info", msg)
+	require.Equalf(t, want.Version, got.Version, "%s: version", msg)
+
+	hashByName := func(ci *proto.CommitInfo) map[string]string {
+		m := make(map[string]string, len(ci.StoreInfos))
+		for _, si := range ci.StoreInfos {
+			m[si.Name] = hex.EncodeToString(si.CommitId.Hash)
+		}
+		return m
+	}
+	require.Equalf(t, hashByName(want), hashByName(got), "%s: per-store hashes", msg)
+}
+
+// rollbackSnapSettings selects the snapshot cadence applied to both
+// backends in the rollback reproduction test. Zero disables periodic
+// snapshots (everything replays from the genesis snapshot); a small
+// positive interval forces snapshots mid-run so rollback must seek a
+// snapshot below the target and discard snapshots above it.
+type rollbackSnapSettings struct {
+	memiavlInterval uint32
+	flatkvInterval  uint32
+}
+
+// openCompositeForRollback opens a composite store with deterministic,
+// synchronous commit settings and the requested snapshot cadence. Used
+// by the rollback reproduction test so the same forward/rollback driver
+// runs with and without snapshot boundaries straddling the target.
+func openCompositeForRollback(
+	t *testing.T, dir string, mode types.WriteMode, batch int, snap rollbackSnapSettings,
+) *CompositeCommitStore {
+	t.Helper()
+	cfg := config.DefaultStateCommitConfig()
+	cfg.WriteMode = mode
+	cfg.MemIAVLConfig.AsyncCommitBuffer = 0
+	cfg.MemIAVLConfig.SnapshotInterval = snap.memiavlInterval
+	// Disable the time throttle so snapshots fire on the block interval
+	// alone, and keep several so the rollback target sits below the
+	// newest snapshot but above an older retained one.
+	cfg.MemIAVLConfig.SnapshotMinTimeInterval = 0
+	cfg.MemIAVLConfig.SnapshotKeepRecent = 5
+	cfg.FlatKVConfig.SnapshotInterval = snap.flatkvInterval
+	cfg.FlatKVConfig.SnapshotKeepRecent = 5
+
+	cs, err := NewCompositeCommitStore(t.Context(), dir, cfg)
+	require.NoError(t, err)
+	require.NoError(t, cs.SetMigrationBatchSize(batch))
+	require.NoError(t, cs.Initialize([]string{keys.BankStoreKey, keys.EVMStoreKey}))
+	_, err = cs.LoadVersion(0, false)
+	require.NoError(t, err)
+	return cs
+}
+
+// TestComposite_MigrateEVM_RollbackAcrossActivationBoundary reproduces
+// the rollback failure at the memiavl-only -> migrate_evm activation
+// boundary. Blocks before the migration boundary commits are memiavl-only
+// AppHash blocks (no evm_lattice); once the boundary opens, later AppHashes
+// include the lattice. CompositeCommitStore.latticeAppendLatched latches to
+// true the first time it observes the open boundary. A node opened at a
+// post-activation height (latch=true) that is rolled back before activation
+// must invalidate that latch, or LastCommitInfo wrongly appends the stale
+// lattice and produces a non-canonical AppHash.
+func TestComposite_MigrateEVM_RollbackAcrossActivationBoundary(t *testing.T) {
+	dir := t.TempDir()
+	workload := newMigrationWorkload(0x5701)
+
+	const phase1Blocks = 8
+	const batch = 4
+
+	// Phase 1: MemiavlOnly bootstrap.
+	cs := openCompositeForRollback(t, dir, types.MemiavlOnly, batch, rollbackSnapSettings{})
+	for i := 0; i < phase1Blocks; i++ {
+		require.NoError(t, cs.ApplyChangeSets(workload.generateBlock(30, 0, 0, 5, 0)))
+		_, err := cs.Commit()
+		require.NoError(t, err)
+	}
+	// Capture the canonical pre-activation commit info. It must not carry
+	// the lattice because all consensus state still lives in memiavl.
+	target := int64(phase1Blocks)
+	canonicalTarget := cloneCommitInfo(cs.LastCommitInfo())
+	require.False(t, hasLattice(canonicalTarget),
+		"sanity: canonical pre-activation commit info must not contain evm_lattice")
+	require.NoError(t, cs.Close())
+
+	// Phase 2: MigrateEVM. Capture the canonical commit info at each
+	// version. Versions after activation must include the lattice.
+	cs = openCompositeForRollback(t, dir, types.MigrateEVM, batch, rollbackSnapSettings{})
+	canonical := map[int64]*proto.CommitInfo{}
+	const phase2Blocks = 10
+	for i := 0; i < phase2Blocks; i++ {
+		require.NoError(t, cs.ApplyChangeSets(workload.generateBlock(8, 4, 1, 2, 1)))
+		v, err := cs.Commit()
+		require.NoError(t, err)
+		canonical[v] = cloneCommitInfo(cs.LastCommitInfo())
+	}
+	finalVer := cs.Version()
+	require.NoError(t, cs.Close())
+
+	require.Contains(t, canonical, finalVer)
+	require.True(t, hasLattice(canonical[finalVer]),
+		"sanity: canonical post-activation commit info must contain evm_lattice")
+
+	// Reopen fresh at the latest (post-H_start) height, then roll back
+	// across the boundary exactly as `seid rollback` would.
+	//
+	// The CLI reads the latest commit info before rolling back (it
+	// prints "Initial App state height=.. hash=.."), and
+	// rootmulti.loadVersion itself calls scStore.LastCommitInfo()
+	// during load. Either path observes the open migration boundary at
+	// the post-activation height and latches latticeAppendLatched=true.
+	// We reproduce that read here so the rollback runs with the flag
+	// already latched, as it is in production.
+	cs = openCompositeForRollback(t, dir, types.MigrateEVM, batch, rollbackSnapSettings{})
+	preRollback := cs.LastCommitInfo()
+	require.True(t, hasLattice(preRollback),
+		"sanity: latest commit info is post-activation and must carry the lattice (this latches the flag)")
+
+	require.NoError(t, cs.Rollback(target))
+	require.Equal(t, target, cs.Version())
+
+	// In-process post-rollback view: the AppHash the `seid rollback` CLI
+	// prints and the value rootmulti caches in rs.lastCommitInfo. Before
+	// the latch reset in Rollback this wrongly included the evm_lattice
+	// for a pre-activation height.
+	require.False(t, hasLattice(cs.LastCommitInfo()),
+		"post-rollback commit info for a pre-activation height must not carry evm_lattice")
+	requireCommitInfoEqual(t, canonicalTarget, cs.LastCommitInfo(),
+		"post-rollback LastCommitInfo across the activation boundary (same process)")
+	require.NoError(t, cs.Close())
+
+	// Post-restart view: the AppHash `seid start` hands to Tendermint.
+	cs = openCompositeForRollback(t, dir, types.MigrateEVM, batch, rollbackSnapSettings{})
+	defer func() { _ = cs.Close() }()
+	require.Equal(t, target, cs.Version())
+	requireCommitInfoEqual(t, canonicalTarget, cs.LastCommitInfo(),
+		"post-restart LastCommitInfo across the activation boundary (fresh process)")
+}
+
+// hasLattice reports whether a commit info carries the synthetic
+// evm_lattice store info contributed by the flatkv backend.
+func hasLattice(ci *proto.CommitInfo) bool {
+	if ci == nil {
+		return false
+	}
+	for _, si := range ci.StoreInfos {
+		if si.Name == "evm_lattice" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestComposite_MigrateEVM_RollbackRestoresCanonicalCommitInfo pins the
+// invariant that `seid rollback` violated on the mid-migration hstart-2
+// node: rolling a migrate_evm composite store back to version T must
+// reproduce the exact commit info (and therefore AppHash) the chain
+// committed at T during forward progress. If the post-rollback
+// LastCommitInfo diverges, Tendermint's handshake at restart fails with
+// "Did you reset Tendermint without resetting your application's data?"
+// because the app's AppHash no longer matches the value Tendermint
+// recorded for that height.
+//
+// The test captures the canonical commit info at every committed version
+// during forward migration, then reopens fresh (mirroring the CLI
+// constructing the app and loading latest), rolls back into the middle
+// of the run, and asserts the commit info matches — both immediately
+// after Rollback (the hash the CLI prints) and after a subsequent reopen
+// (the hash `seid start` hands to Tendermint).
+//
+// The snapshots_across_boundary subtest reproduces the production
+// conditions most likely to break rollback: both backends took periodic
+// snapshots, so the rollback target lands between an older retained
+// snapshot and newer snapshots that must be discarded and replayed past.
+func TestComposite_MigrateEVM_RollbackRestoresCanonicalCommitInfo(t *testing.T) {
+	cases := []struct {
+		name string
+		snap rollbackSnapSettings
+	}{
+		{name: "no_periodic_snapshots", snap: rollbackSnapSettings{}},
+		{name: "snapshots_across_boundary", snap: rollbackSnapSettings{memiavlInterval: 2, flatkvInterval: 2}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			workload := newMigrationWorkload(0x5701)
+
+			const phase1Blocks = 8
+			const phase2Blocks = 16
+			const batch = 4
+
+			// Phase 1: MemiavlOnly bootstrap so there is pre-migration
+			// state living on memiavl when the boundary opens.
+			cs := openCompositeForRollback(t, dir, types.MemiavlOnly, batch, tc.snap)
+			for i := 0; i < phase1Blocks; i++ {
+				require.NoError(t, cs.ApplyChangeSets(workload.generateBlock(30, 0, 0, 5, 0)))
+				_, err := cs.Commit()
+				require.NoError(t, err)
+			}
+			require.NoError(t, cs.Close())
+
+			// Phase 2: MigrateEVM. Record the canonical commit info at
+			// each committed version. A small batch relative to the live
+			// EVM key count keeps the migration in progress across the
+			// whole run, so every captured version carries the
+			// evm_lattice store info.
+			cs = openCompositeForRollback(t, dir, types.MigrateEVM, batch, tc.snap)
+			canonical := map[int64]*proto.CommitInfo{}
+			for i := 0; i < phase2Blocks; i++ {
+				require.NoError(t, cs.ApplyChangeSets(workload.generateBlock(8, 4, 1, 2, 1)))
+				v, err := cs.Commit()
+				require.NoError(t, err)
+				canonical[v] = cloneCommitInfo(cs.LastCommitInfo())
+			}
+
+			done, err := migration.IsAtVersion(flatKVReaderFor(cs), uint64(migration.Version1_MigrateEVM))
+			require.NoError(t, err)
+			require.False(t, done,
+				"migration must still be in progress for this test to exercise the migrate_evm rollback path")
+
+			finalVer := cs.Version()
+			require.NoError(t, cs.Close())
+
+			target := finalVer - 5
+			require.Contains(t, canonical, target, "target must be a captured version")
+
+			// Reopen fresh, mirroring `seid rollback` building the app
+			// via appCreator and LoadVersion(0), then perform the
+			// rollback exactly as rootmulti.RollbackToVersion does.
+			cs = openCompositeForRollback(t, dir, types.MigrateEVM, batch, tc.snap)
+			require.NoError(t, cs.Rollback(target))
+			require.Equal(t, target, cs.Version())
+
+			requireCommitInfoEqual(t, canonical[target], cs.LastCommitInfo(),
+				"post-rollback LastCommitInfo (the AppHash the CLI prints)")
+			require.NoError(t, cs.Close())
+
+			// Reopen once more, mirroring `seid start` after the
+			// rollback. The AppHash Tendermint validates during the
+			// handshake is derived from this freshly-loaded
+			// LastCommitInfo.
+			cs = openCompositeForRollback(t, dir, types.MigrateEVM, batch, tc.snap)
+			defer func() { _ = cs.Close() }()
+			require.Equal(t, target, cs.Version())
+			requireCommitInfoEqual(t, canonical[target], cs.LastCommitInfo(),
+				"post-restart LastCommitInfo (the AppHash `seid start` hands to Tendermint)")
+		})
+	}
 }

--- a/sei-db/state_db/sc/composite/store_migration_test.go
+++ b/sei-db/state_db/sc/composite/store_migration_test.go
@@ -1167,3 +1167,72 @@ func TestComposite_MigrateEVM_RollbackRestoresCanonicalCommitInfo(t *testing.T) 
 		})
 	}
 }
+
+// TestComposite_MigrateBank_RollbackAcrossCompletionBoundary is the
+// memiavl-side mirror of TestComposite_MigrateEVM_RollbackAcrossActivationBoundary.
+// Once the bank migration completes (version 3) a store with memiavl still
+// open latches memiavlHashExcluded=true and drops memiavl's per-store infos
+// from the commit info (the flatkv_only shape). Rolling back below the
+// completion boundary must re-include memiavl, or the in-process
+// post-rollback AppHash diverges from the canonical value the chain
+// committed at that height (which still carries the memiavl stores).
+func TestComposite_MigrateBank_RollbackAcrossCompletionBoundary(t *testing.T) {
+	dir := t.TempDir()
+	workload := newMigrationWorkload(0xB0A7)
+	const batch = 8
+
+	cs := openAutoStore(t, dir, batch)
+
+	// Bootstrap bank+evm state under MemiavlOnly (bank-heavy so migrate_bank
+	// later spans several blocks), then walk the ladder to migrate_bank.
+	for i := 0; i < 12; i++ {
+		require.NoError(t, cs.ApplyChangeSets(workload.generateBlock(6, 0, 0, 40, 0)))
+		_, err := cs.Commit()
+		require.NoError(t, err)
+	}
+	require.NoError(t, cs.SetWriteMode(types.MigrateEVM))
+	runUntilAtMigrationVersion(t, cs, workload, migration.Version1_MigrateEVM, 400)
+	require.NoError(t, cs.SetWriteMode(types.EVMMigrated))
+	runBlocks(t, cs, workload, 2)
+	require.NoError(t, cs.SetWriteMode(types.MigrateAllButBank))
+	runUntilAtMigrationVersion(t, cs, workload, migration.Version2_MigrateAllButBank, 400)
+	require.NoError(t, cs.SetWriteMode(types.AllMigratedButBank))
+	runBlocks(t, cs, workload, 2)
+
+	require.NoError(t, cs.SetWriteMode(types.MigrateBank))
+	require.Equal(t, types.MigrateBank, cs.currentWriteMode)
+
+	// One migrate_bank block that does not complete the migration: memiavl
+	// is still part of the AppHash here. Capture it as the rollback target.
+	require.NoError(t, cs.ApplyChangeSets(workload.generateBlock(0, 2, 1, 0, 2)))
+	_, err := cs.Commit()
+	require.NoError(t, err)
+	target := cs.Version()
+	canonicalTarget := cloneCommitInfo(cs.LastCommitInfo())
+	require.Greater(t, len(canonicalTarget.StoreInfos), 1,
+		"sanity: migrate_bank in-progress commit info must still include memiavl stores")
+
+	// Drive to bank completion while staying in currentWriteMode
+	// MigrateBank (do NOT flip to FlatKVOnly), so the rollback exercises the
+	// latch reset rather than a mode change. Reaching version 3 latches
+	// memiavlHashExcluded=true and drops memiavl from the commit info.
+	runUntilAtMigrationVersion(t, cs, workload, migration.Version3_FlatKVOnly, 800)
+	require.Equal(t, []string{"evm_lattice"}, storeInfoNames(cs),
+		"once bank migration completes, memiavl infos are excluded (latches memiavlHashExcluded)")
+
+	// Roll back across the completion boundary. Without resetting
+	// memiavlHashExcluded the post-rollback commit info would keep the
+	// flatkv_only shape and drop memiavl.
+	require.NoError(t, cs.Rollback(target))
+	require.Equal(t, target, cs.Version())
+	requireCommitInfoEqual(t, canonicalTarget, cs.LastCommitInfo(),
+		"post-rollback commit info across the bank-completion boundary must re-include memiavl")
+	require.NoError(t, cs.Close())
+
+	// Fresh restart re-derives from the rolled-back metadata and must agree.
+	cs = openAutoStore(t, dir, batch)
+	defer func() { _ = cs.Close() }()
+	require.Equal(t, target, cs.Version())
+	requireCommitInfoEqual(t, canonicalTarget, cs.LastCommitInfo(),
+		"post-restart commit info across the bank-completion boundary must re-include memiavl")
+}


### PR DESCRIPTION
## Summary
- Reset the composite store's two sticky commit-info latches (`latticeAppendLatched` and `memiavlHashExcluded`) after rollback, so post-rollback commit info is re-derived from the rolled-back migration metadata instead of a stale pre-rollback decision.
- Prevents a non-canonical in-process AppHash when `seid rollback` crosses a migration seam: the migrate_evm activation boundary (lattice side) or the bank-migration completion boundary (memiavl side).
- Regression coverage: rollback from a post-migrate_evm-activation height to a pre-activation height, canonical commit-info checks during migrate_evm rollback, and rollback across the bank-completion boundary (memiavl re-included).

## Known limitation
`currentWriteMode` is not re-derived in `Rollback`. Under `types.Auto` after a derived `FlatKVOnly` transition, an in-process rollback across a completed migration can re-latch via the fast path; this only affects the in-process/CLI-printed AppHash and self-heals on the next `seid start`. Fixed-mode configs (incl. fixed `MigrateBank`) are fully covered. Tracked as a follow-up.

## Test plan
- `go test ./sei-db/state_db/sc/composite -run 'TestComposite_MigrateEVM_Rollback(AcrossActivationBoundary|RestoresCanonicalCommitInfo)|TestComposite_MigrateBank_RollbackAcrossCompletionBoundary'`
- `go test ./sei-db/state_db/sc/composite/...`