### PR TITLE
fix(app): honor mock_balances on the mempool balance-readiness path

### DIFF
--- a/app/abci.go
+++ b/app/abci.go
@@ -192,7 +192,10 @@ func (app *App) EvmBalance(evmAddr common.Address, seiAddrBz []byte) uint256.Int
 	if !seiAddr.Equals(sdk.AccAddress(evmAddr[:])) {
 		balance = new(big.Int).Add(balance, app.EvmKeeper.GetBalance(ctx, seiAddr))
 	}
-	return bigIntToUint256(balance)
+	// Under the mock_balances build tag, mirror the StateDB auto-top-off on this
+	// committed-balance read path so the mempool's readiness gate admits load-test
+	// txs from mock-funded accounts (no-op in production builds).
+	return bigIntToUint256(mockTopOffBalance(balance))
 }
 
 func bigIntToUint256(x *big.Int) uint256.Int {

--- a/app/mock_balances_evmbalance.go
+++ b/app/mock_balances_evmbalance.go
@@ -1,0 +1,26 @@
+//go:build mock_balances
+
+package app
+
+import (
+	"math/big"
+
+	"github.com/sei-protocol/sei-chain/x/evm/state"
+)
+
+// mockTopOffBalance mirrors the StateDB auto-top-off (state.DBImpl.ensureMinimumBalance)
+// on the mempool's committed-balance read path.
+//
+// The sei-tendermint mempool gates EVM-tx readiness on committed balance, which it
+// reads via App.EvmBalance -> EvmKeeper.GetBalance. mock_balances only inflates the
+// ephemeral StateDB (GetBalance/SubBalance), so without this a freshly-generated load
+// account reads as 0 on the gate path and its txs are never marked ready — the chain
+// produces empty blocks while eth_getBalance shows the account funded. Reporting at
+// least TopOffAmount here matches what StateDB will grant at execution time.
+// TESTING/BENCH ONLY (mock_balances is never built for mainnet).
+func mockTopOffBalance(balance *big.Int) *big.Int {
+	if balance.Cmp(state.TopOffAmount) < 0 {
+		return new(big.Int).Set(state.TopOffAmount)
+	}
+	return balance
+}

--- a/app/mock_balances_evmbalance_default.go
+++ b/app/mock_balances_evmbalance_default.go
@@ -1,0 +1,8 @@
+//go:build !mock_balances
+
+package app
+
+import "math/big"
+
+// mockTopOffBalance is a no-op in production builds.
+func mockTopOffBalance(balance *big.Int) *big.Int { return balance }


### PR DESCRIPTION
## Problem

Under the `mock_balances` build tag, EVM load tests (e.g. sei-load) accept transactions at the RPC but the chain produces **empty blocks** (`gasUsed=0x0`) — while `eth_getBalance` reports the sender accounts as fully funded. A single silent ~0-TPS result.

## Root cause

`mock_balances` only tops off the **ephemeral EVM StateDB**: `DBImpl.ensureMinimumBalance` / `ensureSufficientBalance` (`x/evm/state/mock_balances.go`), reached via `GetBalance` / `SubBalance` during execution and by `eth_getBalance`.

The sei-tendermint mempool gates EVM-tx readiness on **committed** balance, read through a different path:

- `internal/mempool/tx.go:368` → `s.app.EvmBalance(...)`
- `App.EvmBalance` (`app/abci.go`) → `EvmKeeper.GetBalance` — the committed store, never touched by the mock.

So a freshly generated load account reads as `0` on the gate path. The readiness loop at `tx.go:426` (`account.balance.Cmp(&requiredBalance) < 0`) is always true, the tx is never marked ready, and it's never included — a deadlock (no committed balance → never included → never gains committed balance).

## Fix

Mirror the StateDB top-off on the `EvmBalance` read path, gated behind the same `mock_balances` build tag:

- `app/mock_balances_evmbalance.go` (`//go:build mock_balances`) — `mockTopOffBalance` returns `max(balance, state.TopOffAmount)` (100 ETH), matching what StateDB grants at execution time.
- `app/mock_balances_evmbalance_default.go` (`//go:build !mock_balances`) — no-op passthrough.
- `app/abci.go` — `EvmBalance` returns `bigIntToUint256(mockTopOffBalance(balance))`.

Follows the existing `mock_balances_buildtag.go` / `_default.go` idiom. The gate compares each tx's `requiredBalance` against `account.balance` without decrementing, so a per-tx 100-ETH floor is sufficient for load traffic.

## Safety

- Behind the bench-only `mock_balances` tag; **production builds get the no-op passthrough and are unchanged**.
- No mainnet exposure — `mock_balances` is never built for mainnet (the StateDB path already hard-panics on `pacific-1`).

## Test plan

- [x] `go build ./app/` (default) compiles.
- [x] `go build -tags mock_balances ./app/` compiles.
- [ ] Build a `mock_balances` image from this branch, run sei-load against an ephemeral chain, confirm non-empty blocks / non-zero TPS from mock-funded accounts.

Made with [Cursor](https://cursor.com)