### PR TITLE
fix(mock_balances): mempool readiness gate must see the mock top-off (empty-blocks regression)

### DIFF
--- a/app/abci.go
+++ b/app/abci.go
@@ -192,7 +192,7 @@ func (app *App) EvmBalance(evmAddr common.Address, seiAddrBz []byte) uint256.Int
 	if !seiAddr.Equals(sdk.AccAddress(evmAddr[:])) {
 		balance = new(big.Int).Add(balance, app.EvmKeeper.GetBalance(ctx, seiAddr))
 	}
-	return bigIntToUint256(balance)
+	return bigIntToUint256(mempoolBalanceFloor(balance))
 }
 
 func bigIntToUint256(x *big.Int) uint256.Int {

--- a/app/mock_balances_buildtag.go
+++ b/app/mock_balances_buildtag.go
@@ -2,5 +2,25 @@
 
 package app
 
+import (
+	"math/big"
+
+	"github.com/sei-protocol/sei-chain/x/evm/state"
+)
+
 // MockBalancesEnabled indicates whether mock_balances build tag is set.
 const MockBalancesEnabled = true
+
+// mempoolBalanceFloor lifts the balance the mempool readiness gate sees to at
+// least the mock top-off amount. The CheckTx top-off writes to a discarded
+// cache, so the check-state balance behind EvmBalance never reflects it —
+// without this floor a mock-funded sender never satisfies requiredBalance,
+// its txs are never promoted to ready, and ready-only gossip/reaping means
+// they can never reach a block. Execution is unaffected: the real top-off
+// runs in the delivery path, where writes persist.
+func mempoolBalanceFloor(balance *big.Int) *big.Int {
+	if balance.Cmp(state.TopOffAmount) < 0 {
+		return new(big.Int).Set(state.TopOffAmount)
+	}
+	return balance
+}

--- a/app/mock_balances_buildtag_default.go
+++ b/app/mock_balances_buildtag_default.go
@@ -2,5 +2,13 @@
 
 package app
 
+import "math/big"
+
 // MockBalancesEnabled indicates whether mock_balances build tag is set.
 const MockBalancesEnabled = false
+
+// mempoolBalanceFloor is the identity in production builds: the mempool
+// readiness gate sees the real check-state balance.
+func mempoolBalanceFloor(balance *big.Int) *big.Int {
+	return balance
+}

--- a/app/mock_balances_buildtag_test.go
+++ b/app/mock_balances_buildtag_test.go
@@ -1,0 +1,22 @@
+//go:build mock_balances
+
+package app
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/sei-protocol/sei-chain/x/evm/state"
+)
+
+func TestMempoolBalanceFloor(t *testing.T) {
+	below := big.NewInt(0)
+	if got := mempoolBalanceFloor(below); got.Cmp(state.TopOffAmount) != 0 {
+		t.Errorf("floor(0) = %s; want TopOffAmount %s", got, state.TopOffAmount)
+	}
+
+	above := new(big.Int).Add(state.TopOffAmount, big.NewInt(1))
+	if got := mempoolBalanceFloor(above); got.Cmp(above) != 0 {
+		t.Errorf("floor(above) = %s; want unchanged %s", got, above)
+	}
+}


### PR DESCRIPTION
## Problem

Since the TxMempool rewrite (CON-305, #3476, 2026-05-26), ready-promotion gates on the sender's **check-state balance** (`App.EvmBalance`, `app/abci.go`) vs the tx's `requiredBalance` (`internal/mempool/tx.go` ~426), and **gossip + block-reaping consume only ready txs**. The `mock_balances` top-off runs inside CheckTx on a cache branch that is discarded (`app/legacyabci/check_tx.go` — `anteCtx, _ := contextCacher(ctx)`, no `Write()`), so the balance the gate reads never reflects it.

Result on every multi-node `mock_balances` chain since the rewrite: `eth_sendRawTransaction` returns hashes (CheckTx passes via the ephemeral top-off), the tx is inserted **pending** and never promoted, never gossiped, never proposed — **zero transactions reach blocks** while load tools report healthy submission TPS. Before CON-305 there was no balance readiness gate, so mock txs gossiped and the delivery-path top-off (which does persist) funded them — i.e., this worked for ~2.5 years and regressed silently in late May.

Reproduced end-to-end on a harbor dev chain (4 validators + 1 RPC follower, `mock-nightly-20260706-068afb8`): seiload accepted 60k+ txs at ~1000 TPS; every block in the window had `num_txs=0` / `gasUsed=0x0`; a single traced tx sat in the follower's mempool and TTL-evicted while all four validators' `tendermint_mempool_cache_size` stayed 0 lifetime (nothing ever gossiped). The nightly harness did not catch this because `TestBenchmark` asserts Job-completion + liveness only (separate issue being filed).

## Fix

Floor the balance `EvmBalance` reports with `state.TopOffAmount`, via the existing `mock_balances` build-tag pair in package `app` (`mempoolBalanceFloor`). `EvmBalance`'s only consumer is the mempool readiness gate (`sei-tendermint/internal/mempool/tx.go:368` via the proxy), so consensus/execution semantics are untouched. Production (`!mock_balances`) builds get the identity function — zero behavior change.

## Verification
- `go build ./app/` and `go build -tags mock_balances ./app/` both clean
- `go test -tags mock_balances ./app/ -run TestMempoolBalanceFloor` passes
- Post-merge plan: respin the harbor repro chain on the fixed image and re-run the seiload profile — expect nonzero `num_txs`/`gasUsed` and receipts (will report on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)