### PR TITLE
ci: retry docker registry push/pull in integration tests via shared helper

### DIFF
--- a/.github/scripts/docker-registry-retry.sh
+++ b/.github/scripts/docker-registry-retry.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Retry helpers for transient GHCR/docker registry errors (e.g. "unknown blob").
+
+_registry_retry() {
+  local op="$1"
+  local ref="$2"
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    if docker "$op" "$ref"; then
+      return 0
+    fi
+    echo "docker $op $ref failed (attempt $attempt), retrying in $((attempt * 5))s..."
+    sleep $((attempt * 5))
+  done
+  echo "docker $op $ref failed after 5 attempts"
+  return 1
+}
+
+push_with_retry() {
+  _registry_retry push "$1"
+}
+
+pull_with_retry() {
+  _registry_retry pull "$1"
+}

--- a/.github/scripts/docker-registry-retry.sh
+++ b/.github/scripts/docker-registry-retry.sh
@@ -9,8 +9,10 @@ _registry_retry() {
     if docker "$op" "$ref"; then
       return 0
     fi
-    echo "docker $op $ref failed (attempt $attempt), retrying in $((attempt * 5))s..."
-    sleep $((attempt * 5))
+    if [ "$attempt" -lt 5 ]; then
+      echo "docker $op $ref failed (attempt $attempt), retrying in $((attempt * 5))s..."
+      sleep $((attempt * 5))
+    fi
   done
   echo "docker $op $ref failed after 5 attempts"
   return 1

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -123,6 +123,13 @@ jobs:
           labels: sei-chain.ci-run-id=${{ github.run_id }}
           cache-from: type=registry,ref=${{ env.GHCR_RPCNODE }}:cache
           cache-to: ${{ github.event_name == 'push' && format('type=registry,ref={0}:cache,mode=max', env.GHCR_RPCNODE) || '' }}
+      # rpcnode is independent of the seid build, so push it now: push failures
+      # (retried below) surface before the expensive seid build rather than after.
+      - name: Push rpcnode image to GHCR for test jobs
+        run: |
+          source .github/scripts/docker-registry-retry.sh
+          docker tag sei-chain/rpcnode "${GHCR_RPCNODE}:${{ github.run_id }}"
+          push_with_retry "${GHCR_RPCNODE}:${{ github.run_id }}"
       - uses: actions/setup-go@v6
         with:
           go-version: '1.25.6'
@@ -130,13 +137,11 @@ jobs:
         env:
           DOCKER_PLATFORM: linux/amd64
         run: make build-seid-in-localnode-ci
-      # Registry pulls are content-addressed and retried per layer by the docker client
-      - name: Push images to GHCR for test jobs
+      - name: Push localnode image to GHCR for test jobs
         run: |
+          source .github/scripts/docker-registry-retry.sh
           docker tag sei-chain/localnode "${GHCR_LOCALNODE}:${{ github.run_id }}"
-          docker tag sei-chain/rpcnode "${GHCR_RPCNODE}:${{ github.run_id }}"
-          docker push "${GHCR_LOCALNODE}:${{ github.run_id }}"
-          docker push "${GHCR_RPCNODE}:${{ github.run_id }}"
+          push_with_retry "${GHCR_LOCALNODE}:${{ github.run_id }}"
       - name: Package CI artifacts
         run: tar -czf integration-build.tar.gz build/seid
       - name: Upload integration CI artifacts
@@ -209,15 +214,7 @@ jobs:
       - name: Load prebuilt seid and pull Docker images
         run: |
           tar -xzf integration-build.tar.gz
-          pull_with_retry() {
-            local ref="$1"
-            for attempt in 1 2 3 4 5; do
-              if docker pull "$ref"; then return 0; fi
-              echo "docker pull $ref failed (attempt $attempt), retrying in $((attempt*5))s..."
-              sleep $((attempt*5))
-            done
-            echo "docker pull $ref failed after 5 attempts"; return 1
-          }
+          source .github/scripts/docker-registry-retry.sh
           pull_with_retry "${GHCR_LOCALNODE}:${{ github.run_id }}"
           pull_with_retry "${GHCR_RPCNODE}:${{ github.run_id }}"
           docker tag "${GHCR_LOCALNODE}:${{ github.run_id }}" sei-chain/localnode
@@ -347,8 +344,9 @@ jobs:
       - name: Load prebuilt seid and pull Docker images
         run: |
           tar -xzf integration-build.tar.gz
-          docker pull "${GHCR_LOCALNODE}:${{ github.run_id }}"
-          docker pull "${GHCR_RPCNODE}:${{ github.run_id }}"
+          source .github/scripts/docker-registry-retry.sh
+          pull_with_retry "${GHCR_LOCALNODE}:${{ github.run_id }}"
+          pull_with_retry "${GHCR_RPCNODE}:${{ github.run_id }}"
           docker tag "${GHCR_LOCALNODE}:${{ github.run_id }}" sei-chain/localnode
           docker tag "${GHCR_RPCNODE}:${{ github.run_id }}" sei-chain/rpcnode
       - name: Run autobahn integration tests


### PR DESCRIPTION
## What

Harden the integration-test workflow against transient GHCR/registry flakes and de-duplicate the retry logic.

- Add a shared `.github/scripts/docker-registry-retry.sh` exposing `push_with_retry` / `pull_with_retry` (5 attempts, linear backoff). Sourced everywhere instead of inlining the retry loop.
- Wrap **pushes** in retry. Previously `docker push` was bare, so a transient `unknown blob`/5xx failed the whole `prepare-cluster` job and forced a full rebuild (including the expensive seid build).
- Split the single push step into an rpcnode push (before the seid build) and a localnode push (after). rpcnode is independent of the seid build, so pushing it first surfaces push failures before the expensive build rather than after.
- Add retry to the `autobahn-integration-tests` pulls, which were bare `docker pull` with no retry at all.

## Why

Registry pushes/pulls in CI intermittently hit transient GHCR errors. The retry loop already existed inline in one pull site but not the others, and pushes had no retry at all — so a single flake would fail the build job. This makes all three registry-touching jobs use the same retry path.

## Notes

- The reordering is safe: `build-seid-in-localnode-ci` writes the seid binary to a bind-mounted `build/` (shipped separately as `integration-build.tar.gz`) and does not modify the localnode or rpcnode images, so pushing rpcnode before the seid build publishes nothing stale.
