### PR TITLE
Revert "Fix seid rollback after deprecating cosmos pruning strategy"

### DIFF
--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -247,6 +247,11 @@ func newApp(
 		skipUpgradeHeights[int64(h)] = true
 	}
 
+	pruningOpts, err := server.GetPruningOptionsFromFlags(appOpts)
+	if err != nil {
+		panic(err)
+	}
+
 	snapshotDirectory := cast.ToString(appOpts.Get(server.FlagStateSyncSnapshotDir))
 	if snapshotDirectory == "" {
 		snapshotDirectory = filepath.Join(cast.ToString(appOpts.Get(flags.FlagHome)), "data", "snapshots")
@@ -287,6 +292,7 @@ func newApp(
 			),
 		},
 		app.EmptyAppOptions,
+		baseapp.SetPruning(pruningOpts),
 		baseapp.SetMinGasPrices(cast.ToString(appOpts.Get(server.FlagMinGasPrices))),
 		baseapp.SetMinRetainBlocks(cast.ToUint64(appOpts.Get(server.FlagMinRetainBlocks))),
 		baseapp.SetHaltHeight(cast.ToUint64(appOpts.Get(server.FlagHaltHeight))),


### PR DESCRIPTION
This reverts commit 49f9022d87cca26b0fa30ab2ff5291704f1042f0.

Pushed by accident to main without a PR.