### PR TITLE
fix(docker): giga-mixed cluster silently ran all-giga; write explicit executor config + role guard

### DIFF
--- a/.github/workflows/integration-test-matrix.json
+++ b/.github/workflows/integration-test-matrix.json
@@ -236,7 +236,7 @@
   },
   {
     "name": "Autobahn RPC .io/.iox (spec fixtures)",
-    "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true",
+    "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_OCC=false GIGA_STORAGE=true",
     "scripts": [
       "./integration_test/evm_module/scripts/evm_rpc_tests.sh"
     ]

--- a/app/app.go
+++ b/app/app.go
@@ -823,6 +823,7 @@ func New(
 		} else {
 			logger.Debug("failed to load evmone VM", "error", err)
 		}
+		// evm_giga_mixed_tests.sh matches these ENABLED/DISABLED strings to guard node roles; keep them in sync.
 		if gigaExecutorConfig.OCCEnabled {
 			logger.Info("benchmark: Giga Executor with OCC is ENABLED - using new EVM execution path with parallel execution")
 		} else {

--- a/docker/localnode/scripts/step4_config_override.sh
+++ b/docker/localnode/scripts/step4_config_override.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env sh
 
 NODE_ID=${ID:-0}
-GIGA_EXECUTOR=${GIGA_EXECUTOR:-false}
-GIGA_OCC=${GIGA_OCC:-false}
+# Defaults mirror the app's DefaultConfig (giga+OCC on): unset runs what an
+# unconfigured seid would; only an explicit false selects V2.
+GIGA_EXECUTOR=${GIGA_EXECUTOR:-true}
+GIGA_OCC=${GIGA_OCC:-true}
 AUTOBAHN=${AUTOBAHN:-false}
 GIGA_STORAGE=${GIGA_STORAGE:-false}
 # GIGA_FLATKV_ONLY=true boots the cluster directly in the terminal v3

--- a/docker/localnode/scripts/step4_config_override.sh
+++ b/docker/localnode/scripts/step4_config_override.sh
@@ -105,28 +105,34 @@ if [ "$GIGA_STORAGE" = "true" ] && [ "$GIGA_MIGRATE_FROM_MEMIAVL" != "true" ] &&
   sed -i 's/^evm-ss-split[[:space:]]*=.*/evm-ss-split = true/' ~/.sei/config/app.toml
 fi
 
-# Enable Giga Executor if requested
+# Write the [giga_executor] section explicitly for every node. The Go config
+# default is Enabled=true and ReadConfig only overrides keys that are present,
+# so a node that never writes the section silently runs giga regardless of its
+# intended role. Emitting enabled/occ_enabled unconditionally keeps each node's
+# executor mode self-describing in app.toml and immune to that default flip.
 if [ "$GIGA_EXECUTOR" = "true" ]; then
+  GIGA_ENABLED_VALUE=true
   echo "Enabling Giga Executor for node $NODE_ID..."
-  if grep -q "\[giga_executor\]" ~/.sei/config/app.toml; then
-    # If the section exists, update enabled to true
-    sed -i 's/enabled = false/enabled = true/' ~/.sei/config/app.toml
-  else
-    # If section doesn't exist, append it
-    echo "" >> ~/.sei/config/app.toml
-    echo "[giga_executor]" >> ~/.sei/config/app.toml
-    echo "enabled = true" >> ~/.sei/config/app.toml
-    echo "occ_enabled = false" >> ~/.sei/config/app.toml
-  fi
+else
+  GIGA_ENABLED_VALUE=false
+  echo "Configuring node $NODE_ID with the V2 executor (Giga disabled)..."
+fi
+if [ "$GIGA_OCC" = "true" ]; then
+  GIGA_OCC_VALUE=true
+else
+  GIGA_OCC_VALUE=false
+fi
 
-  # Set OCC based on GIGA_OCC flag
-  if [ "$GIGA_OCC" = "true" ]; then
-    echo "Enabling OCC for Giga Executor on node $NODE_ID..."
-    sed -i 's/occ_enabled = false/occ_enabled = true/' ~/.sei/config/app.toml
-  else
-    echo "Disabling OCC for Giga Executor (sequential mode) on node $NODE_ID..."
-    sed -i 's/occ_enabled = true/occ_enabled = false/' ~/.sei/config/app.toml
-  fi
+if grep -q "\[giga_executor\]" ~/.sei/config/app.toml; then
+  # Section already present: rewrite its keys in place. The range address scopes
+  # the substitutions to the giga block so an identically-named key in another
+  # section (e.g. [telemetry] enabled) is never rewritten.
+  sed -i "/^\[giga_executor\]/,/^\[/{s/^enabled = .*/enabled = $GIGA_ENABLED_VALUE/;s/^occ_enabled = .*/occ_enabled = $GIGA_OCC_VALUE/;}" ~/.sei/config/app.toml
+else
+  echo "" >> ~/.sei/config/app.toml
+  echo "[giga_executor]" >> ~/.sei/config/app.toml
+  echo "enabled = $GIGA_ENABLED_VALUE" >> ~/.sei/config/app.toml
+  echo "occ_enabled = $GIGA_OCC_VALUE" >> ~/.sei/config/app.toml
 fi
 
 # Override receipt store backend if requested

--- a/integration_test/evm_module/rpc_io_test/RPC_IO_README.md
+++ b/integration_test/evm_module/rpc_io_test/RPC_IO_README.md
@@ -41,7 +41,7 @@ GIGA_EXECUTOR=true GIGA_OCC=true DOCKER_DETACH=true make docker-cluster-start
 ./integration_test/evm_module/scripts/evm_rpc_tests.sh
 ```
 
-Without `GIGA_EXECUTOR` and `GIGA_OCC`, the cluster uses the legacy (V2) executor. The Makefile passes these through to `docker compose`; the node image uses them in `docker/localnode/scripts/step4_config_override.sh`.
+Leaving `GIGA_EXECUTOR` unset runs giga (the app's `DefaultConfig` is `Enabled: true`); set `GIGA_EXECUTOR=false` for the legacy (V2) executor. The Makefile passes these through to `docker compose`; the node image uses them in `docker/localnode/scripts/step4_config_override.sh`.
 
 1. Run the suite against the **legacy** endpoint and record the final report:
    ```bash

--- a/integration_test/evm_module/scripts/evm_giga_mixed_tests.sh
+++ b/integration_test/evm_module/scripts/evm_giga_mixed_tests.sh
@@ -57,22 +57,24 @@ sleep 10
 # this checks the effective runtime mode rather than what the config intended.
 assert_giga_mode() {
     node_id="$1"
-    expected="$2" # "enabled" or "disabled"
+    expected="$2" # "occ", "sequential", or "disabled"
     log="build/generated/logs/seid-${node_id}.log"
 
-    # Poll: a slow boot must not read as a missing signal.
+    # Poll: a slow boot must not read as a missing signal. Match the LAST
+    # "Giga Executor" line so a restart under a different config can't leave an
+    # earlier, stale signal to read ambiguously. OCC must be tested before the
+    # bare ENABLED pattern — "with OCC is ENABLED" also contains "is ENABLED".
     deadline=60
     waited=0
     actual=""
     while [ "$waited" -lt "$deadline" ]; do
         if [ -f "$log" ]; then
-            if grep -q "Giga Executor is DISABLED" "$log"; then
-                actual="disabled"
-                break
-            elif grep -q "Giga Executor.*is ENABLED" "$log"; then
-                actual="enabled"
-                break
-            fi
+            signal=$(grep "Giga Executor" "$log" | tail -1)
+            case "$signal" in
+                *"with OCC is ENABLED"*) actual="occ"; break ;;
+                *"is ENABLED"*)          actual="sequential"; break ;;
+                *"is DISABLED"*)         actual="disabled"; break ;;
+            esac
         fi
         sleep 2
         waited=$((waited + 2))
@@ -93,9 +95,9 @@ assert_giga_mode() {
     return 0
 }
 
-echo "=== Verifying mixed-mode roles (node 0 giga, nodes 1-3 V2) ==="
+echo "=== Verifying mixed-mode roles (node 0 giga+OCC, nodes 1-3 V2) ==="
 GUARD_FAILED=0
-assert_giga_mode 0 enabled || GUARD_FAILED=1
+assert_giga_mode 0 occ || GUARD_FAILED=1
 assert_giga_mode 1 disabled || GUARD_FAILED=1
 assert_giga_mode 2 disabled || GUARD_FAILED=1
 assert_giga_mode 3 disabled || GUARD_FAILED=1

--- a/integration_test/evm_module/scripts/evm_giga_mixed_tests.sh
+++ b/integration_test/evm_module/scripts/evm_giga_mixed_tests.sh
@@ -49,6 +49,53 @@ fi
 echo "Waiting 10s for nodes to stabilize..."
 sleep 10
 
+# Assert each node's EFFECTIVE giga executor mode before running the test. The
+# mixed cluster only exercises giga-vs-V2 determinism if node 0 actually runs
+# giga and nodes 1-3 actually run V2; a config default silently flipping a V2
+# node to giga makes "mixed" homogeneous and the divergence check never fires.
+# Read the startup signal each seid logs after reading its config (app.go), so
+# this checks the effective runtime mode rather than what the config intended.
+assert_giga_mode() {
+    node_id="$1"
+    expected="$2" # "enabled" or "disabled"
+    log="build/generated/logs/seid-${node_id}.log"
+
+    if [ ! -f "$log" ]; then
+        echo "GUARD FAILURE: node ${node_id} log ${log} not found; cannot verify giga executor mode"
+        return 1
+    fi
+
+    if grep -q "Giga Executor is DISABLED" "$log"; then
+        actual="disabled"
+    elif grep -q "Giga Executor.*is ENABLED" "$log"; then
+        actual="enabled"
+    else
+        echo "GUARD FAILURE: node ${node_id} logged no giga executor startup signal; expected ${expected}"
+        return 1
+    fi
+
+    if [ "$actual" != "$expected" ]; then
+        echo "GUARD FAILURE: node ${node_id} giga executor mode mismatch: expected ${expected}, got ${actual}"
+        echo "  A homogeneous cluster makes the mixed-determinism test vacuous; refusing to run."
+        return 1
+    fi
+
+    echo "  node ${node_id}: giga executor ${actual} (expected ${expected}) OK"
+    return 0
+}
+
+echo "=== Verifying mixed-mode roles (node 0 giga, nodes 1-3 V2) ==="
+GUARD_FAILED=0
+assert_giga_mode 0 enabled || GUARD_FAILED=1
+assert_giga_mode 1 disabled || GUARD_FAILED=1
+assert_giga_mode 2 disabled || GUARD_FAILED=1
+assert_giga_mode 3 disabled || GUARD_FAILED=1
+if [ "$GUARD_FAILED" -ne 0 ]; then
+    echo "ERROR: giga mixed-mode role guard failed; aborting before tests."
+    make docker-cluster-stop || true
+    exit 1
+fi
+
 # Run the same giga EVM tests — they hit node 0 (giga) via seilocal RPC
 echo "=== Running GIGA EVM Tests against mixed cluster ==="
 ./integration_test/evm_module/scripts/evm_giga_tests.sh

--- a/integration_test/evm_module/scripts/evm_giga_mixed_tests.sh
+++ b/integration_test/evm_module/scripts/evm_giga_mixed_tests.sh
@@ -60,17 +60,26 @@ assert_giga_mode() {
     expected="$2" # "enabled" or "disabled"
     log="build/generated/logs/seid-${node_id}.log"
 
-    if [ ! -f "$log" ]; then
-        echo "GUARD FAILURE: node ${node_id} log ${log} not found; cannot verify giga executor mode"
-        return 1
-    fi
+    # Poll: a slow boot must not read as a missing signal.
+    deadline=60
+    waited=0
+    actual=""
+    while [ "$waited" -lt "$deadline" ]; do
+        if [ -f "$log" ]; then
+            if grep -q "Giga Executor is DISABLED" "$log"; then
+                actual="disabled"
+                break
+            elif grep -q "Giga Executor.*is ENABLED" "$log"; then
+                actual="enabled"
+                break
+            fi
+        fi
+        sleep 2
+        waited=$((waited + 2))
+    done
 
-    if grep -q "Giga Executor is DISABLED" "$log"; then
-        actual="disabled"
-    elif grep -q "Giga Executor.*is ENABLED" "$log"; then
-        actual="enabled"
-    else
-        echo "GUARD FAILURE: node ${node_id} logged no giga executor startup signal; expected ${expected}"
+    if [ -z "$actual" ]; then
+        echo "GUARD FAILURE: node ${node_id} logged no giga executor startup signal within ${deadline}s (log: ${log}); expected ${expected}"
         return 1
     fi
 


### PR DESCRIPTION
## The bug

The "EVM GIGA Mixed (Determinism)" job has never actually run a mixed cluster. Three facts combine:

1. `docker-compose.giga-mixed.yml` sets `GIGA_EXECUTOR=false` for nodes 1-3 (the intended V2 nodes).
2. `step4_config_override.sh` only wrote the `[giga_executor]` section when `GIGA_EXECUTOR=true` — the `false` nodes got no section at all.
3. `giga/executor/config.DefaultConfig` is `Enabled: true`, and `ReadConfig` only overrides when the key is present.

So the three "V2" nodes silently ran giga. The cluster was homogeneous all-giga, and the determinism test has been comparing giga against itself.

## The fix

- **`step4_config_override.sh`**: write `[giga_executor]` with an explicit `enabled` / `occ_enabled` for **every** node, so section-absent can never silently select an executor. The env defaults are aligned with the app's `DefaultConfig` (`GIGA_EXECUTOR=${GIGA_EXECUTOR:-true}`, same for OCC): an unset env keeps the executor an unconfigured seid would run, so **every other matrix leg keeps its current effective engine** — only an explicit `GIGA_EXECUTOR=false` (the giga-mixed compose's V2 nodes) selects V2. The in-place update is range-scoped to the giga block so it cannot touch `[telemetry] enabled`.
- **`evm_giga_mixed_tests.sh`**: a pre-test role guard that asserts each node's *effective* runtime mode — the `Giga Executor ... ENABLED/DISABLED` startup line each node logs after reading its config — matches its compose role (node 0 giga, nodes 1-3 V2). It polls up to 60s for the signal (a slow boot is not a failure), and on mismatch or a missing signal it stops the cluster and exits 1 naming the node, instead of running a vacuous test. Checking the runtime signal (not app.toml) also catches any future default flip.

## Blast radius

`step4` runs for every matrix leg, so the always-write change was checked against all of them at executor AND OCC granularity. Legs with `GIGA_EXECUTOR=true` (GIGA/Autobahn) and legs with it unset (everything else) keep their current effective engine — unset resolves to the app default (giga+OCC on), which is what section-absent legs were already running. One leg needed an explicit pin: Autobahn RPC .io/.iox set `GIGA_EXECUTOR=true` without `GIGA_OCC`, and the old shell default (`false`) made it the matrix's only sequential-giga leg — it now carries `GIGA_OCC=false` explicitly, preserving that coverage rather than leaving it to a shell default. Net: every leg keeps its pre-PR effective mode; the only behavior change is the giga-mixed job's V2 nodes, which now genuinely run V2.

## Heads-up for reviewers

Once merged, this job runs genuinely mixed for the first time. If giga and V2 are not byte-for-byte consistent on this workload, node 0 will halt on a real consensus mismatch that the homogeneous config was masking — i.e. the job may start failing for a legitimate reason. (An in-process mixed giga/V2 run passed direct state-root equality on a send/deploy workload, so consistency is plausible — but this suite's load differs.)

Verified by hand-trace on synthetic configs (GNU/BSD/BusyBox sed) and synthetic startup logs: explicit-false nodes get `enabled = false`; the guard passes correct roles and fails a silently-flipped node, a signal-absent node, and a missing log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
