### PR TITLE
fix(logging): demote per-mint bank log to Debug (mock_balances top-off spam)

### DIFF
--- a/giga/deps/xbank/keeper/keeper.go
+++ b/giga/deps/xbank/keeper/keeper.go
@@ -494,7 +494,7 @@ func (k BaseKeeper) createCoins(ctx sdk.Context, moduleName string, amounts sdk.
 		k.SetSupply(ctx, supply)
 	}
 
-	logger.Info("minted coins from module account", "amount", amounts, "from", moduleName)
+	logger.Debug("minted coins from module account", "amount", amounts, "from", moduleName)
 
 	// emit mint event
 	ctx.EventManager().EmitEvent(

--- a/giga/deps/xevm/state/mock_balances.go
+++ b/giga/deps/xevm/state/mock_balances.go
@@ -59,13 +59,11 @@ func (s *DBImpl) topOffAccount(seiAddr sdk.AccAddress, amt *big.Int) {
 		s.k.AccountKeeper().SetAccount(s.ctx, s.k.AccountKeeper().NewAccountWithAddress(s.ctx, seiAddr))
 	}
 
-	// Mint and send (use NopLogger to suppress log spam)
 	usei, wei := SplitUseiWeiAmount(amt)
 	coinsAmt := sdk.NewCoins(sdk.NewCoin(s.k.GetBaseDenom(s.ctx), usei.Add(sdk.OneInt())))
-	ctx := s.ctx
-	if err := s.k.BankKeeper().MintCoins(ctx, types.ModuleName, coinsAmt); err != nil {
+	if err := s.k.BankKeeper().MintCoins(s.ctx, types.ModuleName, coinsAmt); err != nil {
 		return
 	}
 	moduleAddr := s.k.AccountKeeper().GetModuleAddress(types.ModuleName)
-	_ = s.k.BankKeeper().SendCoinsAndWei(ctx, moduleAddr, seiAddr, usei, wei)
+	_ = s.k.BankKeeper().SendCoinsAndWei(s.ctx, moduleAddr, seiAddr, usei, wei)
 }

--- a/sei-cosmos/x/bank/keeper/keeper.go
+++ b/sei-cosmos/x/bank/keeper/keeper.go
@@ -586,7 +586,7 @@ func (k BaseKeeper) createCoins(ctx sdk.Context, moduleName string, amounts sdk.
 		k.SetSupply(ctx, supply)
 	}
 
-	logger.Info("minted coins from module account", "amount", amounts, "from", moduleName)
+	logger.Debug("minted coins from module account", "amount", amounts, "from", moduleName)
 
 	// emit mint event
 	ctx.EventManager().EmitEvent(

--- a/x/evm/state/mock_balances.go
+++ b/x/evm/state/mock_balances.go
@@ -59,13 +59,11 @@ func (s *DBImpl) topOffAccount(seiAddr sdk.AccAddress, amt *big.Int) {
 		s.k.AccountKeeper().SetAccount(s.ctx, s.k.AccountKeeper().NewAccountWithAddress(s.ctx, seiAddr))
 	}
 
-	// Mint and send (use NopLogger to suppress log spam)
 	usei, wei := SplitUseiWeiAmount(amt)
 	coinsAmt := sdk.NewCoins(sdk.NewCoin(s.k.GetBaseDenom(s.ctx), usei.Add(sdk.OneInt())))
-	ctx := s.ctx
-	if err := s.k.BankKeeper().MintCoins(ctx, types.ModuleName, coinsAmt); err != nil {
+	if err := s.k.BankKeeper().MintCoins(s.ctx, types.ModuleName, coinsAmt); err != nil {
 		return
 	}
 	moduleAddr := s.k.AccountKeeper().GetModuleAddress(types.ModuleName)
-	_ = s.k.BankKeeper().SendCoinsAndWei(ctx, moduleAddr, seiAddr, usei, wei)
+	_ = s.k.BankKeeper().SendCoinsAndWei(s.ctx, moduleAddr, seiAddr, usei, wei)
 }


### PR DESCRIPTION
## Problem

On `mock_balances` builds, every account top-off emits an Info log — `minted coins from module account` — once per funded sender. On a seiload chain funding thousands of fresh accounts, this floods node logs with lines that carry no signal (the amount is always the fixed 100 ETH top-off).

This wasn't always the case: `topOffAccount` used to suppress the bank keeper's mint log by swapping a `NopLogger` onto the context. The package-level `slog` migration (#3050) removed ctx-scoped loggers, and with them the suppression — silently re-enabling the spam. The stale `(use NopLogger to suppress log spam)` comment in `mock_balances.go` still pointed at the old mechanism.

## Change

- Demote the bank keepers' per-mint `minted coins from module account` log from Info to Debug, in both copies (`sei-cosmos/x/bank/keeper`, `giga/deps/xbank/keeper`). Per-mint logging is a Debug-level concern; upstream cosmos-sdk made the same move.
- Drop the stale NopLogger comment and the now-dead `ctx := s.ctx` alias in both `mock_balances.go` top-off paths.

Production visibility is unaffected: block minting already logs `Minted coins` at Info from `x/mint/keeper/hooks.go`, so the bank-level line was duplicative there; the event emission (`NewCoinMintEvent`) is unchanged.

## Verification

- `go build ./giga/deps/xbank/... ./sei-cosmos/x/bank/...` passes
- `go build -tags mock_balances ./x/evm/state/... ./giga/deps/xevm/state/... ./app/...` passes
- `go test -tags mock_balances ./app/ -run TestMempoolBalanceFloor` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)