### PR TITLE
Make telemetry metrics emission deterministic

### DIFF
--- a/sei-cosmos/telemetry/metrics_test.go
+++ b/sei-cosmos/telemetry/metrics_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
-	"time"
 
 	metrics "github.com/armon/go-metrics"
 	"github.com/prometheus/common/expfmt"
@@ -26,18 +25,23 @@ func TestMetrics_InMem(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, m)
 
-	emitMetrics()
+	emitMetrics(10)
 
 	gr, err := m.Gather(FormatText)
 	require.NoError(t, err)
 	require.Equal(t, gr.ContentType, "application/json")
 
-	jsonMetrics := make(map[string]interface{})
+	var jsonMetrics struct {
+		Counters []struct {
+			Name  string
+			Count int
+		}
+	}
 	require.NoError(t, json.Unmarshal(gr.Metrics, &jsonMetrics))
 
-	counters := jsonMetrics["Counters"].([]interface{})
-	require.Equal(t, counters[0].(map[string]interface{})["Count"].(float64), 10.0)
-	require.Equal(t, counters[0].(map[string]interface{})["Name"].(string), "test.dummy_counter")
+	require.Len(t, jsonMetrics.Counters, 1)
+	require.Equal(t, "test.dummy_counter", jsonMetrics.Counters[0].Name)
+	require.Equal(t, 10, jsonMetrics.Counters[0].Count)
 }
 
 func TestMetrics_Prom(t *testing.T) {
@@ -52,7 +56,7 @@ func TestMetrics_Prom(t *testing.T) {
 	require.NotNil(t, m)
 	require.True(t, m.prometheusEnabled)
 
-	emitMetrics()
+	emitMetrics(30)
 
 	gr, err := m.Gather(FormatPrometheus)
 	require.NoError(t, err)
@@ -61,16 +65,8 @@ func TestMetrics_Prom(t *testing.T) {
 	require.True(t, strings.Contains(string(gr.Metrics), "test_dummy_counter 30"))
 }
 
-func emitMetrics() {
-	ticker := time.NewTicker(time.Second)
-	timeout := time.After(30 * time.Second)
-
-	for {
-		select {
-		case <-ticker.C:
-			metrics.IncrCounter([]string{"dummy_counter"}, 1.0)
-		case <-timeout:
-			return
-		}
+func emitMetrics(count int) {
+	for range count {
+		metrics.IncrCounter([]string{"dummy_counter"}, 1.0)
 	}
 }


### PR DESCRIPTION
TestMetrics_InMem emitted metrics with a one-second ticker for thirty seconds and then asserted that the latest ten-second in-memory metrics bucket contained exactly ten samples. The in-memory sink buckets samples by wall-clock interval, and the ticker/timeout select can land on an interval boundary, leaving the finished bucket with only nine samples.

Emit the expected number of counter increments synchronously instead. This keeps the test focused on metrics gathering/encoding behavior, removes the 30 second delay, and avoids wall-clock bucket boundary flakiness.

Flaked on [main](https://github.com/sei-protocol/sei-chain/actions/runs/28951541498/job/85899289088).