### PR TITLE
fix(consensus): guard /consensus_state RPC against empty-validator-set divide-by-zero

### DIFF
--- a/sei-tendermint/internal/consensus/state_empty_valset_test.go
+++ b/sei-tendermint/internal/consensus/state_empty_valset_test.go
@@ -1,0 +1,76 @@
+package consensus
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/sei-protocol/sei-chain/sei-tendermint/abci/example/kvstore"
+	abci "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/proxy"
+	sm "github.com/sei-protocol/sei-chain/sei-tendermint/internal/state"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/store"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/test/factory"
+
+	dbm "github.com/tendermint/tm-db"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newStateFromEmptyGenesisValidators builds a consensus State whose genesis
+// carries no validators — the shape a gentx-launched chain has before its set
+// is installed — and drives the reactor's OnStart -> updateStateFromStore path,
+// leaving the round state holding an empty validator set.
+func newStateFromEmptyGenesisValidators(t *testing.T) *State {
+	t.Helper()
+	ctx := t.Context()
+
+	cfg := configSetup(t)
+	genDoc := factory.GenesisDoc(cfg, time.Now(), nil, factory.ConsensusParams())
+	state, err := sm.MakeGenesisState(genDoc)
+	require.NoError(t, err)
+	require.Equal(t, 0, state.Validators.Size(), "genesis validator set must be empty")
+	require.Zero(t, state.LastBlockHeight)
+
+	thisConfig, err := ResetConfig(t.TempDir(), "plt794")
+	require.NoError(t, err)
+
+	app := kvstore.NewApplication()
+	t.Cleanup(func() { _ = app.Close() })
+	_, err = app.InitChain(ctx, &abci.RequestInitChain{})
+	require.NoError(t, err)
+
+	pv := loadPrivValidator(thisConfig)
+	blockStore := store.NewBlockStore(dbm.NewMemDB())
+	proxyApp := proxy.New(app)
+
+	return newStateWithConfigAndBlockStore(t, thisConfig, state, pv, proxyApp, blockStore).State
+}
+
+// TestConsensusStateRPCEmptyValidatorSet guards the /consensus_state RPC path
+// (GetRoundStateSimpleJSON -> RoundStateSimple -> leader resolution) against an
+// empty validator set: with zero total voting power, leader election divides by
+// zero and takes the process down. The RPC must serialize an empty proposer
+// instead.
+func TestConsensusStateRPCEmptyValidatorSet(t *testing.T) {
+	cs := newStateFromEmptyGenesisValidators(t)
+	require.Equal(t, 0, cs.roundState.Validators().Size())
+
+	var bz []byte
+	require.NotPanics(t, func() {
+		var err error
+		bz, err = cs.GetRoundStateSimpleJSON()
+		require.NoError(t, err)
+	}, "the /consensus_state RPC path must not divide by zero on an empty validator set")
+
+	// The serialized round state carries an empty proposer rather than crashing.
+	var simple struct {
+		Proposer struct {
+			Address []byte `json:"address"`
+			Index   int32  `json:"index"`
+		} `json:"proposer"`
+	}
+	require.NoError(t, json.Unmarshal(bz, &simple))
+	require.Empty(t, simple.Proposer.Address)
+	require.Zero(t, simple.Proposer.Index)
+}

--- a/sei-tendermint/internal/consensus/types/round_state.go
+++ b/sei-tendermint/internal/consensus/types/round_state.go
@@ -419,6 +419,9 @@ var leaderElectionSeed = [32]byte(utils.OrPanic1(hex.DecodeString(
 // Validators are assigned subintervals of [0,TotalVotingPower) of length
 // equal to their voting poser.
 // Validator i is the leader of (height,round) <=> pos(height,round)%TotalVotingPower \in validator_interval[i]
+//
+// Leader must not be called with an empty validator set: it divides by the
+// set's total voting power.
 func (rs *RoundState) Leader() crypto.PubKey {
 	// sha256 does not support seed natively, so we add it by hand.
 	d := slices.Clone(leaderElectionSeed[:])
@@ -455,12 +458,6 @@ func (rs *RoundState) RoundStateSimple() RoundStateSimple {
 		panic(err)
 	}
 
-	addr := rs.Leader().Address()
-	idx, _, ok := rs.Validators.GetByAddress(addr)
-	if !ok {
-		panic(fmt.Errorf("validator %v not in committee", addr))
-	}
-
 	return RoundStateSimple{
 		HeightRoundStep:   fmt.Sprintf("%d/%d/%d", rs.Height, rs.Round, rs.Step),
 		StartTime:         rs.StartTime,
@@ -468,28 +465,34 @@ func (rs *RoundState) RoundStateSimple() RoundStateSimple {
 		LockedBlockHash:   rs.LockedBlock.Hash(),
 		ValidBlockHash:    rs.ValidBlock.Hash(),
 		Votes:             votesJSON,
-		Proposer: types.ValidatorInfo{
-			Address: addr,
-			Index:   idx,
-		},
+		Proposer:          rs.leaderInfo(),
 	}
 }
 
-// NewRoundEvent returns the RoundState with proposer information as an event.
-func (rs *RoundState) NewRoundEvent() types.EventDataNewRound {
+// leaderInfo resolves the current leader into a ValidatorInfo for event/RPC
+// serialization, guarding the emptiness precondition that Leader itself cannot:
+// an empty validator set has no leader and yields a zero ValidatorInfo. This is
+// the reachable surface — /consensus_state (RoundStateSimple) can be scraped
+// while the validator set is still empty.
+func (rs *RoundState) leaderInfo() types.ValidatorInfo {
+	if rs.Validators.IsNilOrEmpty() {
+		return types.ValidatorInfo{}
+	}
 	addr := rs.Leader().Address()
 	idx, _, ok := rs.Validators.GetByAddress(addr)
 	if !ok {
 		panic(fmt.Errorf("validator %v not in committee", addr))
 	}
+	return types.ValidatorInfo{Address: addr, Index: idx}
+}
+
+// NewRoundEvent returns the RoundState with proposer information as an event.
+func (rs *RoundState) NewRoundEvent() types.EventDataNewRound {
 	return types.EventDataNewRound{
-		Height: rs.Height,
-		Round:  rs.Round,
-		Step:   rs.Step.String(),
-		Proposer: types.ValidatorInfo{
-			Address: addr,
-			Index:   idx,
-		},
+		Height:   rs.Height,
+		Round:    rs.Round,
+		Step:     rs.Step.String(),
+		Proposer: rs.leaderInfo(),
 	}
 }
 

--- a/sei-tendermint/internal/consensus/types/round_state_test.go
+++ b/sei-tendermint/internal/consensus/types/round_state_test.go
@@ -59,6 +59,25 @@ func TestRoundStateLeaderChangeDetector(t *testing.T) {
 	}
 }
 
+// TestRoundStateEmptyValidatorSet checks that the event/RPC serializers yield
+// an empty proposer on an empty validator set rather than dividing by the set's
+// zero total voting power in leader election.
+func TestRoundStateEmptyValidatorSet(t *testing.T) {
+	rs := RoundState{
+		Validators: tmtypes.NewValidatorSet(nil),
+	}
+	rs.Height, rs.Round = 1, 0
+	require.Zero(t, rs.Validators.TotalVotingPower())
+
+	// The event/RPC serializers must yield an empty proposer rather than
+	// dividing by zero in leader election.
+	require.NotPanics(t, func() {
+		ev := rs.NewRoundEvent()
+		require.Zero(t, ev.Proposer.Index)
+		require.Empty(t, ev.Proposer.Address)
+	}, "NewRoundEvent must not divide by zero on an empty validator set")
+}
+
 func TestRoundStateLeaderDistribution(t *testing.T) {
 	const samples = 100000
 


### PR DESCRIPTION
## Summary

Guards an unauthenticated RPC divide-by-zero: `/consensus_state` → `GetRoundStateSimpleJSON` → `RoundStateSimple` → `Leader()` computes `x.Mod(x, big.NewInt(TotalVotingPower()))`, and on a chain whose genesis carries no CometBFT validators (a collect-gentxs / ceremony-assembled genesis) `TotalVotingPower()==0` in the window after state sync completes but before `SwitchToConsensus` installs the real validator set. A scrape of `/consensus_state` in that window panics the process with `division by zero`.

Fix: route the two proposer-deref serializers (`RoundStateSimple`, the reachable RPC path; `NewRoundEvent`, the gated event path) through a new `RoundState.leaderInfo()` that returns a zero `ValidatorInfo` when the validator set is nil/empty, before any `Leader()` call. `Leader()` stays a pure protocol primitive with a documented precondition; the gated consensus-stepping derefs are unchanged.

## Relationship to #3724

#3724 fixed the *load-path* boot crash (empty-valset genesis state load). This closes the residual *RPC* surface it left — the consensus-stepping `Leader()` derefs are gated behind `readySignal`/`SwitchToConsensus` (which install a populated set first) and are not reachable with an empty set, and giga mode constructs no `consensus.State` at all. The RPC serializer is the one genuinely reachable path.

## Approach & considered alternative

Guard at the serialization boundary (`leaderInfo`), per sei-tendermint's boundary principle (nil-check at the boundary, keep internal primitives pure). A considered alternative — a fail-fast `panic` inside `Leader()` on an empty set — was declined: it would push a defensive check into an internal primitive against that principle. The precondition is instead documented and enforced by tests.

## Tests

- `TestConsensusStateRPCEmptyValidatorSet` — drives the real serializer entrypoint (`GetRoundStateSimpleJSON`) on an empty-genesis consensus state; asserts no panic + empty proposer.
- `TestRoundStateEmptyValidatorSet` — the gated `NewRoundEvent` path.

Both verified fail-on-main (`division by zero`) / pass-on-fix. `go test ./internal/consensus/... -race`, `go vet`, `gofmt`, build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
