### PR TITLE
feat(cosmos): range-check Dec conversions and DecCoin validation (CON-369)

### DIFF
--- a/sei-cosmos/types/dec_coin.go
+++ b/sei-cosmos/types/dec_coin.go
@@ -135,13 +135,17 @@ func (coin DecCoin) String() string {
 	return fmt.Sprintf("%v%v", coin.Amount, coin.Denom)
 }
 
-// Validate returns an error if the DecCoin has a negative amount or if the denom is invalid.
+// Validate returns an error if the DecCoin has a negative amount, an
+// out-of-range amount, or if the denom is invalid.
 func (coin DecCoin) Validate() error {
 	if err := ValidateDenom(coin.Denom); err != nil {
 		return err
 	}
 	if coin.IsNegative() {
 		return fmt.Errorf("decimal coin %s amount cannot be negative", coin)
+	}
+	if !coin.Amount.IsInValidRange() {
+		return fmt.Errorf("decimal coin %s amount is out of range", coin)
 	}
 	return nil
 }
@@ -527,6 +531,9 @@ func (coins DecCoins) Validate() error {
 		if !coins[0].IsPositive() {
 			return fmt.Errorf("coin %s amount is not positive", coins[0])
 		}
+		if !coins[0].Amount.IsInValidRange() {
+			return fmt.Errorf("coin %s amount is out of range", coins[0])
+		}
 		return nil
 	default:
 		// check single coin case
@@ -550,6 +557,9 @@ func (coins DecCoins) Validate() error {
 			}
 			if !coin.IsPositive() {
 				return fmt.Errorf("coin %s amount is not positive", coin.Denom)
+			}
+			if !coin.Amount.IsInValidRange() {
+				return fmt.Errorf("coin %s amount is out of range", coin.Denom)
 			}
 
 			// we compare each coin against the last denom

--- a/sei-cosmos/types/dec_coin_test.go
+++ b/sei-cosmos/types/dec_coin_test.go
@@ -4,10 +4,22 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 )
+
+// TestNewDecCoinConversionRange covers the Coin -> DecCoin conversion boundary:
+// a max-magnitude Int coin cannot be scaled to a whole-coin Dec within range, so
+// every Coin -> DecCoin constructor must reject it before it can reach state.
+// This is the shared conversion used by the community-pool, fee-collector and
+// denom-normalization paths.
+func TestNewDecCoinConversionRange(t *testing.T) {
+	require.Panics(t, func() { sdk.NewDecCoin("stake", maxInt()) }, "NewDecCoin must reject max Int")
+	require.Panics(t, func() { sdk.NewDecCoinFromCoin(sdk.NewCoin("stake", maxInt())) }, "NewDecCoinFromCoin must reject max Int")
+	require.Panics(t, func() { sdk.NewDecCoinsFromCoins(sdk.NewCoin("stake", maxInt())) }, "NewDecCoinsFromCoins must reject max Int")
+}
 
 type decCoinTestSuite struct {
 	suite.Suite

--- a/sei-cosmos/types/decimal.go
+++ b/sei-cosmos/types/decimal.go
@@ -126,10 +126,16 @@ func NewDecFromInt(i Int) Dec {
 
 // NewDecFromIntWithPrec creates a new Dec from Int with decimal place at prec.
 // CONTRACT: prec <= Precision
+//
+// Scaling by 10^Precision can take a max-magnitude Int (bitLen 256) beyond
+// maxDecBitLen (315), so the result is range-checked to keep the conversion
+// within the canonical Dec range.
 func NewDecFromIntWithPrec(i Int, prec int64) Dec {
-	return Dec{
+	result := Dec{
 		new(big.Int).Mul(i.BigInt(), precisionMultiplier(prec)),
 	}
+	result.assertInValidRange()
+	return result
 }
 
 // create a decimal from an input decimal string.
@@ -706,6 +712,11 @@ func (d Dec) MarshalYAML() (interface{}, error) {
 func (d Dec) Marshal() ([]byte, error) {
 	if d.i == nil {
 		d.i = new(big.Int)
+	}
+	// Enforce the canonical range on encode so Marshal and Unmarshal accept the
+	// same set of values.
+	if !d.IsInValidRange() {
+		return nil, fmt.Errorf("decimal out of range; bitLen: got %d, max %d", d.i.BitLen(), maxDecBitLen)
 	}
 	return d.i.MarshalText()
 }

--- a/sei-cosmos/types/decimal_internal_test.go
+++ b/sei-cosmos/types/decimal_internal_test.go
@@ -21,12 +21,51 @@ func (s *decimalInternalTestSuite) TestPrecisionMultiplier() {
 	s.Require().Equal(0, res.Cmp(exp), "equality was incorrect, res %v, exp %v", res, exp)
 }
 
+// outOfRangeDec builds a Dec whose backing integer is one bit past maxDecBitLen,
+// bypassing the public constructors (which now reject such values).
+func outOfRangeDec() Dec {
+	return Dec{new(big.Int).Lsh(big.NewInt(1), maxDecBitLen+1)}
+}
+
+// Marshal and Unmarshal must accept the same set of values: an out-of-range
+// decimal is rejected by both ends of serialization.
+func (s *decimalInternalTestSuite) TestMarshalUnmarshalRangeParity() {
+	d := outOfRangeDec()
+	s.Require().False(d.IsInValidRange())
+
+	_, err := d.Marshal()
+	s.Require().Error(err, "Marshal must reject an out-of-range decimal")
+
+	// MarshalTo funnels non-zero values through Marshal.
+	_, err = (&d).MarshalTo(make([]byte, 200))
+	s.Require().Error(err, "MarshalTo must reject an out-of-range decimal")
+
+	// The same textual value must also be rejected by Unmarshal (the read side
+	// of the invariant).
+	text, err := d.i.MarshalText()
+	s.Require().NoError(err)
+	var back Dec
+	s.Require().Error((&back).Unmarshal(text), "Unmarshal must reject an out-of-range decimal")
+}
+
 func (s *decimalInternalTestSuite) TestZeroDeserializationJSON() {
 	d := Dec{new(big.Int)}
 	err := cdc.UnmarshalAsJSON([]byte(`"0"`), &d)
 	s.Require().Nil(err)
 	err = cdc.UnmarshalAsJSON([]byte(`"{}"`), &d)
 	s.Require().NotNil(err)
+}
+
+// DecCoin(s).Validate must flag an out-of-range amount, complementing the
+// constructor-level range checks.
+func (s *decimalInternalTestSuite) TestDecCoinValidateRange() {
+	coin := DecCoin{Denom: "stake", Amount: outOfRangeDec()}
+	s.Require().Error(coin.Validate(), "DecCoin.Validate must reject an out-of-range amount")
+	s.Require().Error(DecCoins{coin}.Validate(), "DecCoins.Validate must reject an out-of-range amount")
+
+	// A larger set (exercises the multi-coin branch) is rejected too.
+	ok := DecCoin{Denom: "aaa", Amount: NewDec(1)}
+	s.Require().Error(DecCoins{ok, coin}.Validate())
 }
 
 func (s *decimalInternalTestSuite) TestSerializationGocodecJSON() {

--- a/sei-cosmos/types/decimal_test.go
+++ b/sei-cosmos/types/decimal_test.go
@@ -718,3 +718,28 @@ func BenchmarkIsInValidRange(b *testing.B) {
 		})
 	}
 }
+
+// maxInt returns the maximum protocol-valid sdk.Int, 2^256 - 1.
+func maxInt() sdk.Int {
+	return sdk.NewIntFromBigInt(new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1)))
+}
+
+// TestIntToDecConversionRange checks the Int -> Dec boundary: an out-of-range
+// conversion is rejected, and an in-range value round-trips unchanged.
+func TestIntToDecConversionRange(t *testing.T) {
+	require.Panics(t, func() { sdk.NewDecFromInt(maxInt()) }, "NewDecFromInt must reject max Int")
+	require.Panics(t, func() { _ = maxInt().ToDec() }, "Int.ToDec must reject max Int")
+	require.Panics(t, func() { sdk.NewDecFromIntWithPrec(maxInt(), 0) }, "NewDecFromIntWithPrec must reject max Int")
+
+	// A whole-coin amount that stays within range converts and round-trips
+	// through Marshal/Unmarshal unchanged.
+	valid := sdk.NewIntFromBigInt(new(big.Int).Lsh(big.NewInt(1), 200))
+	d := valid.ToDec()
+	require.True(t, d.IsInValidRange())
+
+	bz, err := d.Marshal()
+	require.NoError(t, err)
+	var back sdk.Dec
+	require.NoError(t, (&back).Unmarshal(bz))
+	require.True(t, d.Equal(back))
+}

--- a/sei-cosmos/x/distribution/keeper/keeper_test.go
+++ b/sei-cosmos/x/distribution/keeper/keeper_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -172,4 +173,27 @@ func TestFundCommunityPool(t *testing.T) {
 
 	assert.Equal(t, initPool.CommunityPool.Add(sdk.NewDecCoinsFromCoins(amount...)...), app.DistrKeeper.GetFeePool(ctx).CommunityPool)
 	assert.Empty(t, app.BankKeeper.GetAllBalances(ctx, addr[0]))
+}
+
+// TestFundCommunityPoolRejectsOutOfRangeAmount verifies that funding the
+// community pool with an amount too large to convert to a whole-coin Dec is
+// rejected at the conversion boundary and leaves the stored fee pool
+// unchanged.
+func TestFundCommunityPoolRejectsOutOfRangeAmount(t *testing.T) {
+	app := seiapp.Setup(t, false, false, false)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+
+	addr := seiapp.AddTestAddrs(app, ctx, 1, sdk.ZeroInt())
+
+	maxAmt := sdk.NewIntFromBigInt(new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1)))
+	coins := sdk.NewCoins(sdk.NewCoin("bigcoin", maxAmt))
+	require.NoError(t, apptesting.FundAccount(app.BankKeeper, ctx, addr[0], coins))
+
+	require.Panics(t, func() {
+		_ = app.DistrKeeper.FundCommunityPool(ctx, coins, addr[0])
+	}, "funding the community pool with an out-of-range amount must be rejected")
+
+	// The stored fee pool must be unchanged after the rejected attempt.
+	require.NotPanics(t, func() { app.DistrKeeper.GetFeePool(ctx) })
+	require.True(t, app.DistrKeeper.GetFeePool(ctx).CommunityPool.IsZero())
 }


### PR DESCRIPTION
## Summary

- `NewDecFromIntWithPrec` range-checks the scaled result. A max-magnitude Int (bitLen 256) scaled by up to Precision can exceed maxDecBitLen (315); the assertion catches it at the conversion boundary.
- `Dec.Marshal` enforces the same invariant on encode so the encoder and decoder accept the same value set.
- `DecCoin.Validate` and `DecCoins.Validate` reject out-of-range amounts alongside the existing negative-amount check.

Tightens acceptance criteria at multiple boundaries — labeled `app-hash-breaking` because a historical block that ever produced an out-of-range Dec would replay differently on an upgraded node.

## Test plan

- [x] `gofmt -s` + `go vet` clean
- [x] New tests in `decimal_internal_test.go`, `decimal_test.go`, `dec_coin_test.go`, `x/distribution/keeper_test.go` cover the range-check and validate paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)