### PR TITLE
fix(memiavl): make state-sync import idempotent across restore re-offers

### DIFF
--- a/sei-db/state_db/sc/memiavl/import.go
+++ b/sei-db/state_db/sc/memiavl/import.go
@@ -2,10 +2,13 @@ package memiavl
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"math"
 	"os"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/sei-protocol/sei-chain/sei-db/proto"
@@ -48,13 +51,20 @@ func NewMultiTreeImporter(dir string, height uint64) (*MultiTreeImporter, error)
 		return nil, fmt.Errorf("fail to lock db: %w", err)
 	}
 
-	return &MultiTreeImporter{
+	mti := &MultiTreeImporter{
 		dir:         dir,
 		height:      int64(height),
 		snapshotDir: snapshotName(int64(height)),
 		fileLock:    fileLock,
 		ctx:         context.Background(), // Default to background context for backward compatibility
-	}, nil
+	}
+	// State-sync can re-offer the same snapshot, so a prior pass may have left a
+	// temp dir at this height; clear it so it can't poison this import.
+	if err := os.RemoveAll(mti.tmpDir()); err != nil {
+		_ = fileLock.Unlock()
+		return nil, fmt.Errorf("fail to clear stale import tmp dir: %w", err)
+	}
+	return mti, nil
 }
 
 func (mti *MultiTreeImporter) tmpDir() string {
@@ -87,7 +97,15 @@ func (mti *MultiTreeImporter) AddNode(node *types.SnapshotNode) {
 	mti.importer.Add(node)
 }
 
-func (mti *MultiTreeImporter) Close() error {
+func (mti *MultiTreeImporter) Close() (err error) {
+	// Release the import flock on every return path; a leaked lock fails a
+	// same-process restore re-offer with ErrLocked.
+	defer func() {
+		if unlockErr := mti.fileLock.Unlock(); unlockErr != nil && err == nil {
+			err = unlockErr
+		}
+	}()
+
 	if mti.importer != nil {
 		if err := mti.importer.Close(); err != nil {
 			return err
@@ -100,14 +118,34 @@ func (mti *MultiTreeImporter) Close() error {
 		return err
 	}
 
-	if err := os.Rename(tmpDir, filepath.Join(mti.dir, mti.snapshotDir)); err != nil {
-		return err
+	// A re-offered restore may have already produced snapshot-<h>; adopt it and
+	// drop our temp instead of failing. The ErrExist/ENOTEMPTY arm covers
+	// rename-into-existing-dir across kernels (EEXIST darwin, ENOTEMPTY linux).
+	finalDir := filepath.Join(mti.dir, mti.snapshotDir)
+	if info, statErr := os.Stat(finalDir); statErr == nil {
+		// Only a directory is a valid prior snapshot; a non-directory at this path
+		// is corruption/external interference and must not be adopted.
+		if !info.IsDir() {
+			return fmt.Errorf("snapshot path %q exists but is not a directory", finalDir)
+		}
+		if rmErr := os.RemoveAll(tmpDir); rmErr != nil {
+			return rmErr
+		}
+	} else if err := os.Rename(tmpDir, finalDir); err != nil {
+		if !errors.Is(err, fs.ErrExist) && !errors.Is(err, syscall.ENOTEMPTY) {
+			return err
+		}
+		// finalDir appeared between the stat and the rename; only a directory is a
+		// valid prior snapshot, so don't adopt a non-directory.
+		if info, statErr := os.Stat(finalDir); statErr != nil || !info.IsDir() {
+			return fmt.Errorf("snapshot path %q exists but is not a directory: %w", finalDir, err)
+		}
+		if rmErr := os.RemoveAll(tmpDir); rmErr != nil {
+			return rmErr
+		}
 	}
 
-	if err := updateCurrentSymlink(mti.dir, mti.snapshotDir); err != nil {
-		return err
-	}
-	return mti.fileLock.Unlock()
+	return updateCurrentSymlink(mti.dir, mti.snapshotDir)
 }
 
 // TreeImporter import a single memiavl tree from state-sync snapshot

--- a/sei-db/state_db/sc/memiavl/snapshot_test.go
+++ b/sei-db/state_db/sc/memiavl/snapshot_test.go
@@ -12,6 +12,63 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-db/state_db/sc/types"
 )
 
+// TestMultiTreeImporterIdempotentRename reproduces the state-sync restore
+// crashloop seen on migrate_evm syncers: a prior aborted restore attempt leaves
+// a snapshot-<H> directory behind, and the next attempt's Close() does
+// os.Rename(tmp, snapshot-<H>) which fails "file exists" (ENOTEMPTY) on Linux.
+// The importer must be idempotent across retries.
+func TestMultiTreeImporterIdempotentRename(t *testing.T) {
+	dir := t.TempDir()
+	db, err := OpenDB(0, Options{
+		Config:          Config{AsyncCommitBuffer: -1},
+		Dir:             dir,
+		CreateIfMissing: true,
+		InitialStores:   []string{"test"},
+	})
+	require.NoError(t, err)
+	for _, changes := range ChangeSets {
+		require.NoError(t, db.ApplyChangeSets([]*proto.NamedChangeSet{{Name: "test", Changeset: changes}}))
+		_, err := db.Commit()
+		require.NoError(t, err)
+	}
+	require.NoError(t, db.RewriteSnapshot(context.Background()))
+	version := db.Version()
+
+	restoreDir := t.TempDir()
+
+	importOnce := func() error {
+		exporter, err := NewMultiTreeExporter(db.dir, uint32(version), true)
+		require.NoError(t, err)
+		importer, err := NewMultiTreeImporter(restoreDir, uint64(version))
+		require.NoError(t, err)
+		for {
+			item, err := exporter.Next()
+			if errors.Is(err, errorutils.ErrorExportDone) {
+				break
+			}
+			require.NoError(t, err)
+			require.NoError(t, importer.Add(item))
+		}
+		require.NoError(t, exporter.Close())
+		return importer.Close()
+	}
+
+	// First import: creates restoreDir/snapshot-<H>.
+	require.NoError(t, importOnce())
+	// Second import at the same version simulates a state-sync retry after a
+	// prior attempt already created snapshot-<H>. Before the fix this fails
+	// os.Rename "file exists" and the syncer crashloops; after the fix the
+	// importer removes the stale target and the rename succeeds.
+	require.NoError(t, importOnce(),
+		"import must be idempotent across a retry that left snapshot-<H> behind")
+
+	// Restored store opens and reaches the imported version.
+	db2, err := OpenDB(0, Options{Dir: restoreDir})
+	require.NoError(t, err)
+	require.Equal(t, version, db2.Version(), "restored store must be at the imported version")
+	require.NoError(t, db2.Close())
+}
+
 func TestSnapshotEncodingRoundTrip(t *testing.T) {
 	// setup test tree
 	tree := New(0)


### PR DESCRIPTION
## Summary
- Ports the memIAVL state-sync restore idempotency fix from `main` (#3663) onto the `v6.5.0-flatkv-clean` branch, which predates it (the deployed flatkv image at commit `25541070` lacks it).
- `MultiTreeImporter.Close()` finalized a restore with `os.Rename(tmp, snapshot-<H>)`, which fails with `ENOTEMPTY` ("file exists") when a prior aborted restore attempt already produced `snapshot-<H>`. On migrate_evm state-sync syncers this turned a single failure into a **permanent crashloop** — every retry re-collided at the rename, so the node imported all ~700M pairs but could never finish state sync (observed on `pacific1-flatkv-p2p-2`, 60+ restarts, exact error `rename .../memiavl/snapshot-<H>-tmp .../memiavl/snapshot-<H>: file exists`).
- The importer now: clears any stale `<snapshot>-tmp` working dir on start; on close, adopts an existing `snapshot-<H>` directory (dropping its own temp) instead of failing the rename; and releases the import flock on every return path. This matches `main`'s canonical fix so a future rebase is conflict-free.

## Root cause / investigation
Reproduced and root-caused independently before finding it was already fixed on `main` (#3663). Full write-up: `sto558-artifacts/statesync-snapshot-findings-20260709.md`. The non-idempotent restore also explains a one-off post-restore app-hash divergence seen earlier (a retry reused stale partial state); a clean import per attempt removes that class of contamination.

## Test plan
- `go test ./sei-db/state_db/sc/memiavl -run TestMultiTreeImporterIdempotentRename` — re-imports the same version twice (state-sync re-offer); both succeed, restored store opens at the imported version. Fails with "file exists" without the fix.
- Composite integration (`TestComposite_MigrateEVM_StateSyncRestorePreservesCommitInfo`, on the flatkv branch) double-imports and still matches the source commit info; confirmed to fail with the exact `file exists` error when the fix is reverted.
- End-to-end: a build with this fix (`mock_block_validation-ssfix-20260710`) deployed to `pacific1-flatkv-p2p-2` for a clean state-sync run (verification in progress).

Made with [Cursor](https://cursor.com)