### PR TITLE
Update v6.6 changelog in prep to cut rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 # Changelog
 ## v6.6
 sei-chain
+* [#3743](https://github.com/sei-protocol/sei-chain/pull/3743) Backport `release/v6.6`: feat(cosmos): range-check Dec conversions and DecCoin validation (CON-369)
+* [#3732](https://github.com/sei-protocol/sei-chain/pull/3732) Bump version in prep to release v6.6-rc2
+* [#3731](https://github.com/sei-protocol/sei-chain/pull/3731) Backport `release/v6.6`: Update v6.6 changelog in prep to cut RC2
 * [#3717](https://github.com/sei-protocol/sei-chain/pull/3717) Backport `release/v6.6`: Accept legacy cosmos_only SC write mode
 * [#3697](https://github.com/sei-protocol/sei-chain/pull/3697) Backport `release/v6.6`: Fix rpc hash race condition
 * [#3694](https://github.com/sei-protocol/sei-chain/pull/3694) Backport `release/v6.6`: Add GoReleaser release pipeline for static seid binaries (#3425)


### PR DESCRIPTION
Adds the `release/v6.6` entries merged since the rc2 changelog (#3730), in prep to cut **v6.6.0-rc3**:

- **[#3743](https://github.com/sei-protocol/sei-chain/pull/3743)** — `feat(cosmos): range-check Dec conversions and DecCoin validation (CON-369)` (the immunefi/app-hash-breaking fix that motivates rc3)
- **[#3732](https://github.com/sei-protocol/sei-chain/pull/3732)** — rc2 version bump
- **[#3731](https://github.com/sei-protocol/sei-chain/pull/3731)** — rc2 changelog backport

The two process commits mirror how the rc2 changelog (#3730) captured the rc1 cut's process commits (#3688 version bump, #3686 changelog). Authored on `main`; the `backport release/v6.6` label will trigger the backport to the release branch, after which the `version.json` rc3 bump can cut the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)