### PR TITLE
Bump version in prep to release v6.6-rc3

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v6.6.0-rc2"
+  "version": "v6.6.0-rc3"
 }


### PR DESCRIPTION
Bumps `version.json` `v6.6.0-rc2` → `v6.6.0-rc3`. On merge to `release/v6.6`, the UCI release-publish workflow cuts the **`v6.6.0-rc3`** tag + GitHub release (auto-generated notes) and GoReleaser builds the `seid` binaries.

rc3 is cut from `release/v6.6` HEAD, which includes **[#3743](https://github.com/sei-protocol/sei-chain/pull/3743)** — `feat(cosmos): range-check Dec conversions and DecCoin validation (CON-369)`, the app-hash-breaking immunefi fix motivating this rc.

Mirrors Masih's rc2 bump (#3732): `version.json` only, authored directly on the release branch, labeled `release` (required for UCI to cut the tag on a non-default branch).

**Ordering:** merge the changelog backport #3746 first, then this — matching the rc1/rc2 sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)