### PR TITLE
Use DBImpl for giga mock balance validation

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -2061,13 +2061,17 @@ func (app *App) executeEVMTxWithGigaExecutor(ctx sdk.Context, msg *evmtypes.MsgE
 		}, nil
 	}
 
-	_, isAssociated := app.GigaEvmKeeper.GetEVMAddress(ctx, seiAddr)
-
-	// Run validation checks (fee/nonce/balance - stateless checks done earlier)
-	validation := app.validateGigaEVMTx(ctx, ethTx, sender, seiAddr, isAssociated)
-
 	// Prepare context for EVM transaction (set infinite gas meter like original flow)
 	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeterWithMultiplier(ctx))
+
+	_, isAssociated := app.GigaEvmKeeper.GetEVMAddress(ctx, seiAddr)
+
+	// Create state DB before validation so balance checks use DBImpl hooks.
+	stateDB := gigaevmstate.NewDBImpl(ctx, &app.GigaEvmKeeper, false)
+	defer stateDB.Cleanup()
+
+	// Run validation checks (fee/nonce/balance - stateless checks done earlier)
+	validation := app.validateGigaEVMTx(ctx, stateDB, ethTx, sender, seiAddr, isAssociated)
 
 	if validation.err != nil {
 		// v2 rejects fee/nonce/balance failures in its ante chain, whose
@@ -2091,10 +2095,6 @@ func (app *App) executeEVMTxWithGigaExecutor(ctx sdk.Context, msg *evmtypes.MsgE
 	if app.setCodeTxRequiresAuthorityAssociation(ctx, ethTx) {
 		return nil, gigaprecompiles.ErrBalanceMigrationRequired
 	}
-
-	// Create state DB for this transaction (only for valid transactions)
-	stateDB := gigaevmstate.NewDBImpl(ctx, &app.GigaEvmKeeper, false)
-	defer stateDB.Cleanup()
 
 	// Pre-charge gas fee (like V2's ante handler), then execute with feeAlreadyCharged=true.
 	// V2 charges fees in the ante handler, then runs the EVM with feeAlreadyCharged=true
@@ -3085,6 +3085,7 @@ type gigaValidationResult struct {
 //  7. Balance check
 func (app *App) validateGigaEVMTx(
 	ctx sdk.Context,
+	stateDB *gigaevmstate.DBImpl,
 	ethTx *ethtypes.Transaction,
 	sender common.Address,
 	seiAddr sdk.AccAddress,
@@ -3235,13 +3236,18 @@ func (app *App) validateGigaEVMTx(
 	balanceCheck := new(big.Int).Mul(new(big.Int).SetUint64(ethTx.Gas()), ethTx.GasFeeCap())
 	balanceCheck.Add(balanceCheck, ethTx.Value())
 
-	senderBalance := app.GigaEvmKeeper.GetBalance(ctx, seiAddr)
+	// Route validation balance handling through DBImpl so mock_balances can top
+	// up the sender via ensureSufficientBalance before the manual precheck.
+	stateDB.EnsureSufficientBalance(sender, balanceCheck)
+	senderBalance := stateDB.GetBalance(sender).ToBig()
 
-	// Include cast address balance for unassociated addresses (matches V2 PreprocessDecorator)
+	// Include the derived Sei address balance for unassociated addresses (matches V2 PreprocessDecorator).
 	if !isAssociated {
-		castAddr := sdk.AccAddress(sender[:])
-		castBalance := app.GigaEvmKeeper.GetBalance(ctx, castAddr)
-		senderBalance = new(big.Int).Add(senderBalance, castBalance)
+		seiEVMAddr := common.BytesToAddress(seiAddr)
+		if seiEVMAddr != sender {
+			seiBalance := stateDB.GetBalance(seiEVMAddr).ToBig()
+			senderBalance = new(big.Int).Add(senderBalance, seiBalance)
+		}
 	}
 
 	if senderBalance.Cmp(balanceCheck) < 0 {

--- a/app/app.go
+++ b/app/app.go
@@ -3236,9 +3236,8 @@ func (app *App) validateGigaEVMTx(
 	balanceCheck := new(big.Int).Mul(new(big.Int).SetUint64(ethTx.Gas()), ethTx.GasFeeCap())
 	balanceCheck.Add(balanceCheck, ethTx.Value())
 
-	// Route validation balance handling through DBImpl so mock_balances can top
-	// up the sender via ensureSufficientBalance before the manual precheck.
-	stateDB.EnsureSufficientBalance(sender, balanceCheck)
+	// Route validation balance reads through DBImpl so mock_balances follows
+	// the same ensureMinimumBalance behavior as V2's StateTransition.BuyGas.
 	senderBalance := stateDB.GetBalance(sender).ToBig()
 
 	// Include the derived Sei address balance for unassociated addresses (matches V2 PreprocessDecorator).

--- a/giga/deps/xevm/state/balance.go
+++ b/giga/deps/xevm/state/balance.go
@@ -12,13 +12,6 @@ import (
 
 var ZeroInt = uint256.NewInt(0)
 
-func (s *DBImpl) EnsureSufficientBalance(evmAddr common.Address, amt *big.Int) {
-	if amt == nil || amt.Sign() <= 0 {
-		return
-	}
-	s.ensureSufficientBalance(evmAddr, amt)
-}
-
 func (s *DBImpl) SubBalance(evmAddr common.Address, amtUint256 *uint256.Int, reason tracing.BalanceChangeReason) uint256.Int {
 	amt := amtUint256.ToBig()
 	if amt.Sign() == 0 {

--- a/giga/deps/xevm/state/balance.go
+++ b/giga/deps/xevm/state/balance.go
@@ -12,6 +12,13 @@ import (
 
 var ZeroInt = uint256.NewInt(0)
 
+func (s *DBImpl) EnsureSufficientBalance(evmAddr common.Address, amt *big.Int) {
+	if amt == nil || amt.Sign() <= 0 {
+		return
+	}
+	s.ensureSufficientBalance(evmAddr, amt)
+}
+
 func (s *DBImpl) SubBalance(evmAddr common.Address, amtUint256 *uint256.Int, reason tracing.BalanceChangeReason) uint256.Int {
 	amt := amtUint256.ToBig()
 	if amt.Sign() == 0 {

--- a/giga/tests/giga_mock_balances_test.go
+++ b/giga/tests/giga_mock_balances_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	gigaevmstate "github.com/sei-protocol/sei-chain/giga/deps/xevm/state"
 	"github.com/sei-protocol/sei-chain/occ_tests/utils"
 	"github.com/stretchr/testify/require"
 )
@@ -22,7 +21,7 @@ func TestGigaMockBalancesValidationUsesDBImpl(t *testing.T) {
 	gigaCtx.TestApp.GigaEvmKeeper.SetAddressMapping(gigaCtx.Ctx, signer.AccountAddress, signer.EvmAddress)
 
 	to := recipient.EvmAddress
-	value := new(big.Int).Mul(gigaevmstate.TopOffAmount, big.NewInt(2))
+	value := big.NewInt(1_000_000_000_000_000_000)
 	fee := big.NewInt(100000000000)
 	tx := createCustomEVMTx(t, gigaCtx, signer, &to, value, 21000, fee, fee, 0)
 

--- a/giga/tests/giga_mock_balances_test.go
+++ b/giga/tests/giga_mock_balances_test.go
@@ -1,0 +1,33 @@
+//go:build mock_balances
+
+package giga_test
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	gigaevmstate "github.com/sei-protocol/sei-chain/giga/deps/xevm/state"
+	"github.com/sei-protocol/sei-chain/occ_tests/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGigaMockBalancesValidationUsesDBImpl(t *testing.T) {
+	blockTime := time.Now()
+	accts := utils.NewTestAccounts(3)
+	signer := utils.NewSigner()
+	recipient := utils.NewSigner()
+
+	gigaCtx := NewGigaTestContext(t, accts, blockTime, 1, ModeGigaSequential)
+	gigaCtx.TestApp.GigaEvmKeeper.SetAddressMapping(gigaCtx.Ctx, signer.AccountAddress, signer.EvmAddress)
+
+	to := recipient.EvmAddress
+	value := new(big.Int).Mul(gigaevmstate.TopOffAmount, big.NewInt(2))
+	fee := big.NewInt(100000000000)
+	tx := createCustomEVMTx(t, gigaCtx, signer, &to, value, 21000, fee, fee, 0)
+
+	_, results, err := RunBlock(t, gigaCtx, [][]byte{tx})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, uint32(0), results[0].Code, results[0].Log)
+}


### PR DESCRIPTION
## Summary

Routes giga executor balance validation reads through the giga EVM `DBImpl` so `mock_balances` builds follow the same `ensureMinimumBalance` behavior as V2's `StateTransition.BuyGas`.

## Root Cause

`validateGigaEVMTx` was checking balances with `GigaEvmKeeper.GetBalance`, bypassing `DBImpl`. In V2, `BuyGas` reads through `DBImpl.GetBalance`, so mock-balance builds can apply the 100 SEI minimum top-off before the affordability comparison. Giga's manual validation precheck missed that StateDB boundary.

## Changes

- Create the giga `DBImpl` before validation and pass it into `validateGigaEVMTx`.
- Use DB-backed `GetBalance` during validation, including the unassociated-address balance case.
- Add a `mock_balances` regression test covering an unfunded giga transfer within the minimum top-off amount.

## Validation

- `go test ./giga/deps/xevm/state -run TestSubBalance -count=1`
- `go test ./giga/tests -run TestGigaValidation_InsufficientBalance -count=1`
- `go test -tags mock_balances ./giga/tests -run TestGigaMockBalancesValidationUsesDBImpl -count=1`