### PR TITLE
fix(seidb):  offline memiavl-to-FlatKV import tool - prevent memiavl writes during FlatKV import

### DIFF
--- a/sei-db/state_db/bench/wrappers/db_implementations.go
+++ b/sei-db/state_db/bench/wrappers/db_implementations.go
@@ -150,7 +150,11 @@ func NewDBImpl(ctx context.Context, dbType DBType, dataDir string, dbConfig any)
 	case MemIAVL:
 		return newMemIAVLCommitStore(dataDir)
 	case FlatKV:
-		return newFlatKVCommitStore(ctx, dataDir, dbConfig.(*flatkvConfig.Config))
+		flatKVConfig, ok := dbConfig.(*flatkvConfig.Config)
+		if dbConfig != nil && !ok {
+			return nil, fmt.Errorf("invalid FlatKV config type %T", dbConfig)
+		}
+		return newFlatKVCommitStore(ctx, dataDir, flatKVConfig)
 	case CompositeDual:
 		return newCompositeCommitStore(ctx, dataDir, sctypes.TestOnlyDualWrite)
 	case CompositeSplit:

--- a/sei-db/state_db/bench/wrappers/wrappers_test.go
+++ b/sei-db/state_db/bench/wrappers/wrappers_test.go
@@ -191,3 +191,16 @@ func TestNoOpWrapperTracksVersionWithoutReadsOrWrites(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(9), version)
 }
+
+func TestNewDBImplFlatKVUsesDefaultConfigWhenNil(t *testing.T) {
+	wrapper, err := NewDBImpl(t.Context(), FlatKV, t.TempDir(), nil)
+	require.NoError(t, err)
+	require.NoError(t, wrapper.Close())
+}
+
+func TestNewDBImplFlatKVRejectsInvalidConfigType(t *testing.T) {
+	wrapper, err := NewDBImpl(t.Context(), FlatKV, t.TempDir(), "invalid")
+	require.Error(t, err)
+	require.Nil(t, wrapper)
+	require.ErrorContains(t, err, "invalid FlatKV config type string")
+}

--- a/sei-db/tools/cmd/seidb/operations/import_flatkv_from_memiavl.go
+++ b/sei-db/tools/cmd/seidb/operations/import_flatkv_from_memiavl.go
@@ -33,15 +33,30 @@ const translatorBatchSize = 2048
 
 // ImportFlatKVFromMemiavlCmd imports selected memiavl modules into FlatKV.
 //
-// Initial production scope is intentionally narrow: only the evm module is
+// This is an offline test-seeding and pre-migration recovery utility. Typical
+// uses are constructing FlatKV fixtures from an existing memiavl-only data
+// directory, testing memiavl-to-FlatKV encoding, or rebuilding FlatKV from a
+// pre-migration memiavl backup without replaying from genesis. It is not the
+// production MigrationManager path and does not perform state sync or write
+// migration metadata.
+//
+// The supported scope is intentionally narrow: only the evm module is
 // accepted. Non-EVM modules remain in memiavl and are not copied into FlatKV.
 // Importing resets FlatKV and replaces it with the selected memiavl data; the
-// CLI refuses to run over existing FlatKV data unless --force is supplied.
+// CLI refuses to run over existing FlatKV data unless --force is supplied. The
+// source node must be stopped; the command holds memiavl's writer lock for the
+// full import and fails if a live node already owns it.
 func ImportFlatKVFromMemiavlCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "import-flatkv-from-memiavl",
 		Short: "Import selected memiavl modules into FlatKV",
 		Long: strings.TrimSpace(`Import selected memiavl modules into FlatKV.
+
+This is an offline test-seeding and pre-migration recovery tool, not the
+production migration or state-sync path. Use it to construct FlatKV test data
+from a memiavl-only store or to rebuild FlatKV from a pre-migration backup.
+It does not write migration metadata. Stop seid before running it; the import
+fails if the memiavl database is locked by a running node.
 
 WARNING: this restore-style import resets the FlatKV directory before loading
 the imported rows. If FlatKV already has committed data, the command refuses to
@@ -152,6 +167,24 @@ func emitPairs(importer sctypes.Importer, pairs []flatkv.PhysicalKVPair, height 
 
 func importMemiavlModulesToFlatKV(ctx context.Context, homeDir string, modules []string, height int64, force bool) (err error) {
 	cosmosDir := utils.GetCosmosSCStorePath(homeDir)
+	if height > math.MaxUint32 {
+		return fmt.Errorf("height %d out of range", height)
+	}
+
+	// Exclude a live memiavl writer for the entire check-and-import sequence.
+	// Without this lock, the node could commit after memiavlLatest is checked
+	// but before FlatKV is finalized, leaving the stores at different heights
+	// and causing reconciliation to roll memiavl back on the next startup.
+	memLock, err := memiavl.LockFile(filepath.Join(cosmosDir, memiavl.LockFileName))
+	if err != nil {
+		return fmt.Errorf("failed to lock memiavl database for FlatKV import (is seid still running?): %w", err)
+	}
+	defer func() {
+		if unlockErr := memLock.Unlock(); unlockErr != nil && err == nil {
+			err = fmt.Errorf("failed to unlock memiavl database after FlatKV import: %w", unlockErr)
+		}
+	}()
+
 	memiavlLatest, err := memiavl.GetLatestVersion(cosmosDir)
 	if err != nil {
 		return fmt.Errorf("failed to resolve latest memiavl version from %s: %w", cosmosDir, err)
@@ -161,9 +194,6 @@ func importMemiavlModulesToFlatKV(ctx context.Context, homeDir string, modules [
 	}
 	if height <= 0 {
 		return fmt.Errorf("height must be positive after resolution, got %d", height)
-	}
-	if height > math.MaxUint32 {
-		return fmt.Errorf("height %d out of range", height)
 	}
 	// Refuse mismatched heights. If we wrote FlatKV at H < memiavlLatest,
 	// the next GIGA_STORAGE startup would call

--- a/sei-db/tools/cmd/seidb/operations/import_flatkv_from_memiavl_test.go
+++ b/sei-db/tools/cmd/seidb/operations/import_flatkv_from_memiavl_test.go
@@ -82,6 +82,37 @@ func TestImportMemiavlModulesToFlatKVEncodesEVMValues(t *testing.T) {
 	require.Equal(t, legacyValue, gotLegacy)
 }
 
+func TestImportMemiavlModulesToFlatKVRefusesLiveWriter(t *testing.T) {
+	homeDir := t.TempDir()
+	addr := addrN(0x42)
+
+	memStore := newTestMemiavlStore(t, homeDir)
+	require.NoError(t, memStore.ApplyChangeSets([]*proto.NamedChangeSet{{
+		Name: keys.EVMStoreKey,
+		Changeset: proto.ChangeSet{Pairs: []*proto.KVPair{
+			noncePair(addr, 7),
+		}},
+	}}))
+	_, err := memStore.Commit()
+	require.NoError(t, err)
+
+	err = importMemiavlModulesToFlatKV(
+		context.Background(), homeDir, []string{keys.EVMStoreKey}, 0, false,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to lock memiavl database for FlatKV import")
+
+	// Lock contention must be detected before FlatKV is opened or modified.
+	flatStore := newTestFlatKVStoreAtHome(t, homeDir)
+	require.Equal(t, int64(0), flatStore.Version())
+	require.NoError(t, flatStore.Close())
+
+	require.NoError(t, memStore.Close())
+	require.NoError(t, importMemiavlModulesToFlatKV(
+		context.Background(), homeDir, []string{keys.EVMStoreKey}, 0, false,
+	))
+}
+
 func TestImportMemiavlModulesToFlatKVRefusesExistingFlatKVWithoutForce(t *testing.T) {
 	homeDir := t.TempDir()
 	oldAddr := addrN(0x11)


### PR DESCRIPTION
## Summary

Prevent the offline memiavl-to-FlatKV import from racing a live memiavl writer. The import now holds memiavl's exclusive file lock from before the source-height check through FlatKV finalization, so a running node is rejected before FlatKV is opened or modified. CLI documentation now identifies the command as an offline test-seeding and pre-migration recovery tool rather than the production migration or state-sync path.

- `sei-db/tools/cmd/seidb/operations/import_flatkv_from_memiavl.go`: holds the memiavl writer lock across the complete check-and-import sequence and documents the command's intended scope and shutdown requirement.
- `sei-db/state_db/bench/wrappers/db_implementations.go`: allows FlatKV benchmarks to use the default configuration when none is supplied and returns a descriptive error for invalid configuration types instead of panicking.

## Test plan

- `import_flatkv_from_memiavl_test.go`: verifies that a live memiavl writer blocks import before FlatKV is modified and that import succeeds after the writer releases its lock.
- `wrappers_test.go`: verifies nil FlatKV configuration uses defaults and invalid configuration types are rejected.
- Run `go test ./sei-db/tools/cmd/seidb/operations`.
- Run `go test ./sei-db/state_db/bench/wrappers`.
