### PR TITLE
fix stale blockDB godocs

### DIFF
--- a/sei-tendermint/autobahn/types/block_db.go
+++ b/sei-tendermint/autobahn/types/block_db.go
@@ -140,10 +140,6 @@ type BlockDB interface {
 	// watermark guarantees nothing below n is removed before n is
 	// reached, but does NOT bound when eligible data is actually
 	// reclaimed — pruned entries may remain readable for a while.
-	//
-	// Callers must ensure no in-flight reader is holding a pointer
-	// returned from a Read* call for a record being pruned. Pruning a
-	// record still being processed is undefined.
 	PruneBefore(n GlobalBlockNumber) error
 
 	// Flush blocks until every Write that has returned before Flush is


### PR DESCRIPTION
## Describe your changes and provide context

`BlockDB.PruneBefore()` godoc made claims about thread safety that were simply untrue. There is no reason why it's unsafe to hold a byte slice returned by any of the read methods after that block is pruned. LittDB does not reuse buffers, and neither does the BlockDB wrapper around LittDB.

