### PR TITLE
Bump version in prep to release v6.6-rc4

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v6.6.0-rc3"
+  "version": "v6.6.0-rc4"
 }


### PR DESCRIPTION
Bumps `version.json` to `v6.6.0-rc4` to cut the next release candidate.

**Contents since rc3:** the CON-368 fix (#3757) — route old-giga EVM validation failures to the v2 fallback so the ABCI gas tuple (and LastResultsHash) matches v2. That fix is `app-hash-breaking` relative to rc3, so rc4 must be rolled to arctic-1 as a coordinated same-height cutover of the giga cohort, **not** the staged mixed-version roll in the release runbook. (This bump PR's own diff is one line and non-app-hash-breaking.)

On merge, `uci-release-check` validates the bump and creates the draft GitHub Release; the push builds the ECR image tagged by the merge-commit SHA. Prerelease publish stays admin-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)