### PR TITLE
fix(seidb-bench): tolerate nil FlatKV config in bench wrapper factory

### DIFF
--- a/sei-db/state_db/bench/wrappers/db_implementations.go
+++ b/sei-db/state_db/bench/wrappers/db_implementations.go
@@ -150,7 +150,11 @@ func NewDBImpl(ctx context.Context, dbType DBType, dataDir string, dbConfig any)
 	case MemIAVL:
 		return newMemIAVLCommitStore(dataDir)
 	case FlatKV:
-		return newFlatKVCommitStore(ctx, dataDir, dbConfig.(*flatkvConfig.Config))
+		flatKVConfig, ok := dbConfig.(*flatkvConfig.Config)
+		if dbConfig != nil && !ok {
+			return nil, fmt.Errorf("invalid FlatKV config type %T", dbConfig)
+		}
+		return newFlatKVCommitStore(ctx, dataDir, flatKVConfig)
 	case CompositeDual:
 		return newCompositeCommitStore(ctx, dataDir, sctypes.TestOnlyDualWrite)
 	case CompositeSplit:

--- a/sei-db/state_db/bench/wrappers/wrappers_test.go
+++ b/sei-db/state_db/bench/wrappers/wrappers_test.go
@@ -191,3 +191,16 @@ func TestNoOpWrapperTracksVersionWithoutReadsOrWrites(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(9), version)
 }
+
+func TestNewDBImplFlatKVUsesDefaultConfigWhenNil(t *testing.T) {
+	wrapper, err := NewDBImpl(t.Context(), FlatKV, t.TempDir(), nil)
+	require.NoError(t, err)
+	require.NoError(t, wrapper.Close())
+}
+
+func TestNewDBImplFlatKVRejectsInvalidConfigType(t *testing.T) {
+	wrapper, err := NewDBImpl(t.Context(), FlatKV, t.TempDir(), "invalid")
+	require.Error(t, err)
+	require.Nil(t, wrapper)
+	require.ErrorContains(t, err, "invalid FlatKV config type string")
+}


### PR DESCRIPTION
## Summary
- `runBenchmark` passes a nil `dbConfig` into `wrappers.NewDBImpl`; the FlatKV branch did an unchecked `*flatkvConfig.Config` type assertion, so every FlatKV bench scenario (e.g. `BenchmarkFlatKVWriteWithDifferentBlockSize`) panicked at startup with `interface conversion: interface {} is nil, not *config.Config` — before ever reaching `newFlatKVCommitStore`'s existing nil-to-default handling.
- Replace the assertion with a comma-ok check: nil falls through to the default config; a non-nil wrong type returns an error instead of panicking.
- Add regression tests for both the nil-config and wrong-type paths.

## Test plan
- [x] `go test ./sei-db/state_db/bench/wrappers`
- [x] `go test ./sei-db/state_db/bench -run '^$' -bench '^BenchmarkFlatKVWriteWithDifferentBlockSize$/^100_keys_per_block$' -benchtime=1x` now runs to completion
- [x] `gofmt -s` / `goimports` clean

Made with [Cursor](https://cursor.com)