### PR TITLE
fix(seidb): omit migration boundary from EVM logical digest

### DIFF
--- a/sei-db/tools/cmd/seidb/operations/evm_logical_digest.go
+++ b/sei-db/tools/cmd/seidb/operations/evm_logical_digest.go
@@ -30,6 +30,12 @@ import (
 // compared apples-to-apples against memiavl-only output.
 var migrationVersionPhysKey = []byte(migration.MigrationStore + "/" + migration.MigrationVersionKey)
 
+// migrationBoundaryPhysKey is the FlatKV physical key of the in-progress
+// migration cursor. Like migrationVersionPhysKey, it is a FlatKV-only
+// MigrationStore row that a memiavl-only node never owns; unlike the version
+// marker, it exists only while migration is in flight.
+var migrationBoundaryPhysKey = []byte(migration.MigrationStore + "/" + migration.MigrationBoundaryKey)
+
 // EvmLogicalDigestCmd computes a backend-independent digest of the EVM logical
 // state (account / code / storage canonical buckets) so a memIAVL node and a
 // FlatKV node can be compared at the same chain height.
@@ -56,8 +62,8 @@ var migrationVersionPhysKey = []byte(migration.MigrationStore + "/" + migration.
 // are flushed out of order at Finalize.
 //
 // The primary comparison is account+code+storage. The legacy bucket is printed
-// separately, plus a marker-adjusted comparison line, because FlatKV can contain
-// a FlatKV-only migration-version row that a memiavl-only truth node never owns.
+// separately, plus marker-adjusted comparison lines, because FlatKV can contain
+// FlatKV-only MigrationStore rows that a memiavl-only truth node never owns.
 //
 // Usage:
 //
@@ -167,6 +173,13 @@ type evmDigest struct {
 	// should match memiavl-only output exactly.
 	migrationVersionFound bool
 	migrationVersionHash  [sha256.Size]byte
+
+	// migrationBoundaryFound/Hash capture the FlatKV-only
+	// "migration/migration-boundary" cursor, present only while migration is in
+	// flight. It is folded into the legacy bucket like any other row but must be
+	// XORed back out for cross-phase logical comparisons.
+	migrationBoundaryFound bool
+	migrationBoundaryHash  [sha256.Size]byte
 }
 
 type digestPrintContext struct {
@@ -211,6 +224,10 @@ func (d *evmDigest) addLogical(bucket string, physKey, logical, rawVal []byte) {
 			d.migrationVersionFound = true
 			d.migrationVersionHash = sum
 		}
+		if bytes.Equal(physKey, migrationBoundaryPhysKey) {
+			d.migrationBoundaryFound = true
+			d.migrationBoundaryHash = sum
+		}
 	}
 }
 
@@ -251,19 +268,39 @@ func normalizeEVMFlatKVPair(physKey, val []byte) (string, []byte, error) {
 	}
 }
 
+// legacyForCompare returns the legacy accumulator with FlatKV-only migration
+// marker rows omitted. That keeps memiavl_only, migrate_evm, and evm_migrated
+// comparable when their logical EVM state is identical.
+func (d *evmDigest) legacyForCompare() (acc [sha256.Size]byte, count uint64) {
+	acc = d.legacy.acc
+	count = d.legacy.count
+	if d.migrationVersionFound {
+		for i := 0; i < sha256.Size; i++ {
+			acc[i] ^= d.migrationVersionHash[i]
+		}
+		count--
+	}
+	if d.migrationBoundaryFound {
+		for i := 0; i < sha256.Size; i++ {
+			acc[i] ^= d.migrationBoundaryHash[i]
+		}
+		count--
+	}
+	return acc, count
+}
+
 func (d *evmDigest) print(ctx digestPrintContext) {
 	fmt.Println("EVM logical digest report")
 	printDigestContext(ctx)
 	fmt.Println()
 
-	legacyForCompare := d.legacy.acc
-	legacyCountForCompare := d.legacy.count
+	legacyForCompare, legacyCountForCompare := d.legacyForCompare()
 	if d.migrationVersionFound {
-		for i := 0; i < sha256.Size; i++ {
-			legacyForCompare[i] ^= d.migrationVersionHash[i]
-		}
-		legacyCountForCompare--
 		fmt.Println("flatkv_marker_adjustment: omitted migration/migration-version from legacy bucket in final result")
+		fmt.Println()
+	}
+	if d.migrationBoundaryFound {
+		fmt.Println("flatkv_marker_adjustment: omitted migration/migration-boundary from legacy bucket in final result")
 		fmt.Println()
 	}
 
@@ -386,7 +423,7 @@ func digestFlatKV(dbDir string, height int64, findTarget []byte) error {
 }
 
 func shouldIncludeFlatKVEVMLogicalDigestKey(physKey []byte) bool {
-	if bytes.Equal(physKey, migrationVersionPhysKey) {
+	if bytes.Equal(physKey, migrationVersionPhysKey) || bytes.Equal(physKey, migrationBoundaryPhysKey) {
 		return true
 	}
 	moduleName, _, err := ktype.StripModulePrefix(physKey)

--- a/sei-db/tools/cmd/seidb/operations/evm_logical_digest_test.go
+++ b/sei-db/tools/cmd/seidb/operations/evm_logical_digest_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-db/proto"
 	"github.com/sei-protocol/sei-chain/sei-db/state_db/sc/flatkv"
 	"github.com/sei-protocol/sei-chain/sei-db/state_db/sc/flatkv/ktype"
+	"github.com/sei-protocol/sei-chain/sei-db/state_db/sc/flatkv/vtype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -95,9 +96,41 @@ func TestShouldIncludeFlatKVEVMLogicalDigestKey(t *testing.T) {
 	require.True(t, shouldIncludeFlatKVEVMLogicalDigestKey(ktype.EVMPhysicalKey(keys.EVMKeyStorage, storageKeyBytes)))
 	require.True(t, shouldIncludeFlatKVEVMLogicalDigestKey(ktype.ModulePhysicalKey(keys.EVMStoreKey, []byte{0xFF, 0xAA})))
 	require.True(t, shouldIncludeFlatKVEVMLogicalDigestKey(migrationVersionPhysKey))
+	require.True(t, shouldIncludeFlatKVEVMLogicalDigestKey(migrationBoundaryPhysKey))
 
 	require.False(t, shouldIncludeFlatKVEVMLogicalDigestKey(ktype.ModulePhysicalKey("bank", []byte("balance"))))
 	require.False(t, shouldIncludeFlatKVEVMLogicalDigestKey([]byte("malformed-key-without-module-prefix")))
+}
+
+func TestLegacyForCompareOmitsMigrationMarkerRows(t *testing.T) {
+	legacyKey := append([]byte{0x09}, bytesOfLen(keys.AddressLen, 0x33)...)
+	legacyVal := vtype.NewLegacyData().SetBlockHeight(10).SetValue([]byte{0xDE, 0xAD}).Serialize()
+	versionVal := vtype.NewLegacyData().SetBlockHeight(20).SetValue([]byte{0x01}).Serialize()
+	boundaryVal := vtype.NewLegacyData().SetBlockHeight(30).SetValue([]byte{0x02, 0x03}).Serialize()
+
+	clean := evmDigest{}
+	require.NoError(t, clean.consume(legacyKey, legacyVal))
+
+	completed := evmDigest{}
+	require.NoError(t, completed.consume(legacyKey, legacyVal))
+	require.NoError(t, completed.consume(migrationVersionPhysKey, versionVal))
+	require.True(t, completed.migrationVersionFound)
+
+	inProgress := evmDigest{}
+	require.NoError(t, inProgress.consume(legacyKey, legacyVal))
+	require.NoError(t, inProgress.consume(migrationBoundaryPhysKey, boundaryVal))
+	require.True(t, inProgress.migrationBoundaryFound)
+
+	require.NotEqual(t, clean.legacy, completed.legacy)
+	require.NotEqual(t, clean.legacy, inProgress.legacy)
+
+	cleanAcc, cleanCount := clean.legacyForCompare()
+	compAcc, compCount := completed.legacyForCompare()
+	progAcc, progCount := inProgress.legacyForCompare()
+	require.Equal(t, cleanAcc, compAcc, "evm_migrated marker must be omitted for comparison")
+	require.Equal(t, cleanCount, compCount)
+	require.Equal(t, cleanAcc, progAcc, "migrate_evm boundary must be omitted for comparison")
+	require.Equal(t, cleanCount, progCount)
 }
 
 func coreEVMRawPairs() []*proto.KVPair {


### PR DESCRIPTION
## Summary
- Treat the in-flight `migration/migration-boundary` cursor like the completed `migration/migration-version` marker for EVM logical digest comparisons.
- Include the boundary row in FlatKV scans so it can be detected, then XOR it out of the final legacy bucket comparison.
- Add coverage showing `memiavl_only`, `migrate_evm`, and `evm_migrated` marker layouts compare to the same logical legacy digest.

## Test plan
- `go test ./sei-db/tools/cmd/seidb/operations -run 'TestLegacyForCompareOmitsMigrationMarkerRows|TestShouldIncludeFlatKVEVMLogicalDigestKey|TestSemanticMemiavlDigestMatchesTranslatorForCoreEVMKeys|TestCompositeAccountMergeCombinesFlatKVAndMemiavlFragments'`
- `go test ./sei-db/tools/cmd/seidb/operations`


Made with [Cursor](https://cursor.com)