### PR TITLE
Tests: Precompile Tests Phase 2 (PLT-372)

### DIFF
--- a/integration_test/precompile_tests/README.md
+++ b/integration_test/precompile_tests/README.md
@@ -29,9 +29,12 @@ balances, associations, …) over RPC/REST. For every precompile, the spec file 
 
 - **Happy path & state parity.** The method works and its effect/answer matches
   the Cosmos-side truth.
-- **Error handling.** Bad input reverts (and out-of-gas failures trace as
-  `execution reverted`, never as a Go panic — a consensus-relevant guard
-  inherited from the legacy suite).
+- **Error handling.** Bad input reverts, and out-of-gas failures never leak a
+  Go panic — a consensus-relevant guard inherited from the legacy suite. (The
+  precise OOG shape differs per precompile: bank/addr executors convert the
+  gas-meter panic to `execution reverted`, while a starved staking call runs
+  out inside the cosmos store layer and surfaces a location-tagged
+  `out of gas` error instead.)
 - **Dispatch semantics.** Real `CALL` / `STATICCALL` / `DELEGATECALL` from
   deployed contract bytecode (via the `PrecompileCaller` fixture) behave
   correctly: view methods respond under STATICCALL, state-changing methods
@@ -42,18 +45,43 @@ balances, associations, …) over RPC/REST. For every precompile, the spec file 
 ABIs are loaded from the repo's own `precompiles/<name>/abi.json` (the files the
 chain binary embeds), so specs can never drift from the deployed interface.
 
-### Current coverage (phase 1)
+### Current coverage (phases 1–2, wasm-free)
 
 | Precompile | Spec |
 |---|---|
 | bank (0x…1001) | `precompiles/bank.spec.ts` |
+| json (0x…1003) | `precompiles/json.spec.ts` |
 | addr (0x…1004) | `precompiles/addr.spec.ts` |
+| staking (0x…1005) | `precompiles/staking.spec.ts` |
+| gov (0x…1006) | `precompiles/gov.spec.ts` |
+| distribution (0x…1007) | `precompiles/distribution.spec.ts` |
+| oracle (0x…1008) | `precompiles/oracle.spec.ts` (retirement assertion) |
+| pointerview (0x…100A) | `precompiles/pointerview.spec.ts` |
+| pointer (0x…100b) | `precompiles/pointer.spec.ts` (`addNativePointer`; CW methods are wasm-gated) |
+| p256 (0x…1011) | `precompiles/p256.spec.ts` |
 
-Planned next (wasm-free first): staking, gov, distribution, json, p256, oracle
-(retirement assertion), pointer (`addNativePointer`), pointerview. Wasm-gated
-flows (wasmd, pointer `addCW*`, solo CW claims) follow in a separate `wasm/`
-spec dir behind a live `isWasmEnabled()` check, since wasm deployments are
-blocked on production chains. The ibc precompile is out of scope.
+Planned next: wasm-gated flows (wasmd, pointer `addCW*`, solo CW claims) in a
+separate `wasm/` spec dir behind a live `isWasmEnabled()` check, since wasm
+deployments are blocked on production chains. The ibc precompile is out of
+scope.
+
+Hard-won facts encoded in these specs (read before writing a new one):
+
+- **Exact Go error strings never reach `eth_call`** — precompile errors are
+  rewritten to a bare `execution reverted` (the oracle retirement error is the
+  one exception, carrying real `Error(string)` data). To assert an exact
+  string, mine a failing tx with an explicit `gasLimit` and read it back via
+  the `eth_getVMError` RPC (`expectVmError` in `utils/precompileUtils.ts`).
+- **Mining a tx auto-associates its sender**, so "unassociated caller" errors
+  can only be exercised via `eth_call`/`staticCall`, never a real tx.
+- **Guard tables differ per precompile** — e.g. json and pointerview accept
+  DELEGATECALL, staking/gov/distribution/pointer reject it precompile-wide,
+  and `distribution.rewards` accepts value (no non-payable check). Don't
+  generalize dispatch tests; copy the per-method guards from the Go source.
+- **Staking `delegate`/`createValidator` and gov `deposit`/`submitProposal`
+  take whole-usei values**: `msg.value` must be a multiple of 10^12 wei or the
+  call reverts with a wei-remainder error. `bank.sendNative` is the exception —
+  it forwards wei-precision values (the usei/wei split is handled internally).
 
 ## Layout
 
@@ -133,6 +161,11 @@ npx mocha --require tsx precompiles/bank.spec.ts
 ```
 
 …but only after `npm run precompile:bootstrap` has produced `runtime/runtime.json`.
+**Re-run the bootstrap before re-running a state-mutating spec file** (staking,
+distribution, gov, …): the `claimPool` cursor resets per process, so a second
+run hands the same pool accounts — permanently mutated by the first run
+(delegations, validator creation) — to specs whose assertions assume fresh
+accounts.
 
 ## Configuration
 

--- a/integration_test/precompile_tests/_start/00_bootstrap.spec.ts
+++ b/integration_test/precompile_tests/_start/00_bootstrap.spec.ts
@@ -20,7 +20,7 @@ import { fundAdminOnSei, generateMnemonic, seiAddressFromMnemonic } from '../uti
 import { writeRuntimeState, RuntimeState } from '../utils/testUtils';
 import { ADDRESS } from '../utils/format';
 
-const POOL_SIZE = 32;
+const POOL_SIZE = 48;
 const POOL_FUND_WEI = ethers.parseEther('5');
 
 describe('precompile_tests bootstrap', function () {

--- a/integration_test/precompile_tests/precompiles/addr.spec.ts
+++ b/integration_test/precompile_tests/precompiles/addr.spec.ts
@@ -15,6 +15,7 @@ import {
     PRECOMPILE_ADDRESSES,
     precompileContract,
     precompileInterface,
+    callerContract,
     expectExecutionReverted,
     expectTraceRevertedNotPanicked,
 } from '../utils/precompileUtils';
@@ -51,15 +52,7 @@ describe('addr precompile (0x1004)', function () {
         runtime = readRuntimeState();
         admin = EvmAccount.fromMnemonic(runtime.funded.adminMnemonic, provider);
         addr = precompileContract('addr', admin.wallet);
-        caller = new ethers.Contract(
-            runtime.contracts.precompileCaller,
-            [
-                'function callTarget(address target, bytes data) payable returns (bytes)',
-                'function staticcallTarget(address target, bytes data) view returns (bytes)',
-                'function delegatecallTarget(address target, bytes data) returns (bytes)',
-            ],
-            admin.wallet,
-        );
+        caller = callerContract(runtime, admin.wallet);
     });
 
     describe('happy path & state parity', () => {

--- a/integration_test/precompile_tests/precompiles/bank.spec.ts
+++ b/integration_test/precompile_tests/precompiles/bank.spec.ts
@@ -16,6 +16,7 @@ import {
     PRECOMPILE_ADDRESSES,
     precompileContract,
     precompileInterface,
+    callerContract,
     expectExecutionReverted,
     expectTraceRevertedNotPanicked,
 } from '../utils/precompileUtils';
@@ -37,15 +38,7 @@ describe('bank precompile (0x1001)', function () {
         runtime = readRuntimeState();
         admin = EvmAccount.fromMnemonic(runtime.funded.adminMnemonic, provider);
         bank = precompileContract('bank', admin.wallet);
-        caller = new ethers.Contract(
-            runtime.contracts.precompileCaller,
-            [
-                'function callTarget(address target, bytes data) payable returns (bytes)',
-                'function staticcallTarget(address target, bytes data) view returns (bytes)',
-                'function delegatecallTarget(address target, bytes data) returns (bytes)',
-            ],
-            admin.wallet,
-        );
+        caller = callerContract(runtime, admin.wallet);
     });
 
     describe('happy path & state parity', () => {

--- a/integration_test/precompile_tests/precompiles/distribution.spec.ts
+++ b/integration_test/precompile_tests/precompiles/distribution.spec.ts
@@ -1,0 +1,227 @@
+/**
+ * distribution precompile (0x…1007) — end-to-end semantics against a live Sei chain.
+ *
+ * Fixture: a pool account delegates via the staking precompile, then rewards
+ * accrue per block. Reward amounts can never be asserted as exact equality
+ * across blocks — the withdrawal test instead pins the bank-balance delta to
+ * the amount decoded from the tx's own DelegationRewardsWithdrawn log.
+ *
+ * Guard quirk worth knowing: rewards() is the one phase-2 view WITHOUT a
+ * non-payable check (a value-bearing call would succeed and strand the funds),
+ * so this spec deliberately has no "view rejects value" test.
+ */
+import { ethers } from 'ethers';
+import { expect } from 'chai';
+import { seiRpc, waitUntil } from '../utils/chainUtils';
+import { EvmAccount, associateViaTx } from '../utils/evmUtils';
+import { bondedValidators, cosmosQuery, bankBalance } from '../utils/cosmosUtils';
+import {
+    PRECOMPILE_ADDRESSES,
+    precompileContract,
+    precompileInterface,
+    callerContract,
+    expectExecutionReverted,
+    expectVmError,
+} from '../utils/precompileUtils';
+import { readRuntimeState, claimPool, RuntimeState } from '../utils/testUtils';
+
+describe('distribution precompile (0x1007)', function () {
+    this.timeout(180 * 1000);
+
+    const provider = seiRpc();
+    const distrIface = precompileInterface('distribution');
+
+    let runtime: RuntimeState;
+    let admin: EvmAccount;
+    let distribution: ethers.Contract;
+    let staking: ethers.Contract;
+    let caller: ethers.Contract;
+    let validator: string;
+    let delegator: EvmAccount;
+    let withdrawTarget: EvmAccount;
+
+    before(async () => {
+        runtime = readRuntimeState();
+        admin = EvmAccount.fromMnemonic(runtime.funded.adminMnemonic, provider);
+        distribution = precompileContract('distribution', admin.wallet);
+        staking = precompileContract('staking', admin.wallet);
+        caller = callerContract(runtime, admin.wallet);
+        [validator] = await bondedValidators();
+
+        [delegator, withdrawTarget] = claimPool(runtime, provider, 2, 'distribution:fixture');
+        await associateViaTx(delegator);
+        await associateViaTx(withdrawTarget);
+
+        // Delegate so rewards start accruing; poll until they are visible.
+        const tx = await (staking.connect(delegator.wallet) as ethers.Contract).delegate(
+            validator,
+            { value: ethers.parseEther('1'), gasLimit: 1_000_000 },
+        );
+        expect((await tx.wait())!.status, 'fixture delegation must succeed').to.equal(1);
+
+        const qc = await cosmosQuery();
+        await waitUntil(
+            async () => {
+                const { rewards } = await qc.distribution.delegationRewards(
+                    delegator.seiAddress(),
+                    validator,
+                );
+                return rewards.some(c => BigInt(c.amount) > 0n) ? true : null;
+            },
+            { timeoutMs: 60_000, label: 'delegation rewards to accrue' },
+        );
+    });
+
+    describe('happy path & state parity', () => {
+        it('rewards query reports the accrued rewards for the delegation', async () => {
+            const result = await distribution.rewards(delegator.address);
+            expect(result.rewards.length, 'one delegation, one rewards entry').to.equal(1);
+            expect(result.rewards[0].validator_address).to.equal(validator);
+
+            const usei = result.rewards[0].coins.find((c: any) => c.denom === 'usei');
+            expect(usei, 'rewards carry a usei coin').to.not.equal(undefined);
+            // Amounts are sdk.Dec fixed-point integers scaled by 10^decimals (18).
+            expect(usei.decimals).to.equal(18n);
+            expect(usei.amount > 0n, 'accrued rewards are positive').to.equal(true);
+        });
+
+        it('setWithdrawAddress redirects future withdrawals, visible to the distribution module', async () => {
+            const tx = await (
+                distribution.connect(delegator.wallet) as ethers.Contract
+            ).setWithdrawAddress(withdrawTarget.address, { gasLimit: 500_000 });
+            expect((await tx.wait())!.status).to.equal(1);
+
+            const qc = await cosmosQuery();
+            const stored = await waitUntil(
+                async () =>
+                    (await qc.distribution.delegatorWithdrawAddress(delegator.seiAddress()))
+                        .withdrawAddress || null,
+                { timeoutMs: 15_000, label: 'withdraw address stored' },
+            );
+            expect(stored).to.equal(withdrawTarget.seiAddress());
+        });
+
+        it('withdrawDelegationRewards pays the withdraw address exactly the logged amount', async () => {
+            const targetBefore = await bankBalance(withdrawTarget.seiAddress());
+
+            const tx = await (
+                distribution.connect(delegator.wallet) as ethers.Contract
+            ).withdrawDelegationRewards(validator, { gasLimit: 2_000_000 });
+            const receipt = await tx.wait();
+            expect(receipt!.status, 'withdraw tx must succeed').to.equal(1);
+
+            const parsed = receipt!.logs
+                .map((l: ethers.Log) => {
+                    try {
+                        return distrIface.parseLog({ topics: [...l.topics], data: l.data });
+                    } catch {
+                        return null;
+                    }
+                })
+                .find((p: any) => p?.name === 'DelegationRewardsWithdrawn');
+            expect(parsed, 'DelegationRewardsWithdrawn log emitted').to.not.equal(undefined);
+            const withdrawnUsei: bigint = parsed!.args[2];
+            expect(withdrawnUsei > 0n, 'withdrawn amount is positive').to.equal(true);
+
+            // The delta lands at the withdraw address, not the delegator.
+            await waitUntil(
+                async () => {
+                    const b = await bankBalance(withdrawTarget.seiAddress());
+                    return b === targetBefore + withdrawnUsei ? b : null;
+                },
+                { timeoutMs: 30_000, label: 'withdraw address credited with logged amount' },
+            );
+        });
+
+        it('withdrawMultipleDelegationRewards succeeds for a list of validators', async () => {
+            const tx = await (
+                distribution.connect(delegator.wallet) as ethers.Contract
+            ).withdrawMultipleDelegationRewards([validator], { gasLimit: 2_000_000 });
+            expect((await tx.wait())!.status).to.equal(1);
+        });
+    });
+
+    describe('error handling', () => {
+        it('setWithdrawAddress rejects an unassociated withdraw address', async () => {
+            const [unassociated] = claimPool(runtime, provider, 1, 'distribution:unassoc-target');
+            await expectVmError(
+                (distribution.connect(delegator.wallet) as ethers.Contract).setWithdrawAddress(
+                    unassociated.address,
+                    { gasLimit: 500_000 },
+                ),
+                'unassociated address',
+            );
+        });
+
+        it('setWithdrawAddress rejects the zero address', async () => {
+            await expectExecutionReverted(
+                (distribution.connect(delegator.wallet) as ethers.Contract)
+                    .setWithdrawAddress.staticCall(ethers.ZeroAddress),
+                'distribution.setWithdrawAddress with the zero address',
+            );
+        });
+
+        it('withdrawDelegationRewards without a delegation reverts', async () => {
+            const [bystander] = claimPool(runtime, provider, 1, 'distribution:no-delegation');
+            await associateViaTx(bystander);
+            const tx = await (
+                distribution.connect(bystander.wallet) as ethers.Contract
+            ).withdrawDelegationRewards(validator, { gasLimit: 2_000_000 });
+            const receipt = await tx.wait().catch((e: any) => e.receipt);
+            expect(receipt.status, 'tx must fail').to.equal(0);
+        });
+
+        it('withdrawValidatorCommission from a non-validator fails', async () => {
+            await expectVmError(
+                (distribution.connect(delegator.wallet) as ethers.Contract)
+                    .withdrawValidatorCommission({ gasLimit: 500_000 }),
+                'no validator commission to withdraw',
+            );
+        });
+
+        it('rewards query rejects an unassociated delegator', async () => {
+            await expectExecutionReverted(
+                distribution.rewards(EvmAccount.random(provider).address),
+                'distribution.rewards for an unassociated address',
+            );
+        });
+    });
+
+    describe('dispatch semantics (via PrecompileCaller)', () => {
+        it('rewards responds through a real CALL and under STATICCALL', async () => {
+            const data = distrIface.encodeFunctionData('rewards', [delegator.address]);
+            // Rewards grow every block — pin both reads to the same height or
+            // the byte-equality below races block production.
+            const blockTag = await provider.getBlockNumber();
+            const [viaCall, viaStatic] = await Promise.all([
+                caller.callTarget.staticCall(PRECOMPILE_ADDRESSES.distribution, data, { blockTag }),
+                caller.staticcallTarget.staticCall(PRECOMPILE_ADDRESSES.distribution, data, {
+                    blockTag,
+                }),
+            ]);
+            const [decoded] = distrIface.decodeFunctionResult('rewards', viaCall as string);
+            expect(decoded.rewards[0].validator_address).to.equal(validator);
+            expect(viaStatic, 'CALL and STATICCALL return identical bytes').to.equal(viaCall);
+        });
+
+        it('write methods are rejected under STATICCALL (readOnly guard)', async () => {
+            const data = distrIface.encodeFunctionData('withdrawDelegationRewards', [validator]);
+            await expectVmError(
+                caller
+                    .getFunction('staticcallTarget')
+                    .send(PRECOMPILE_ADDRESSES.distribution, data, { gasLimit: 500_000 }),
+                'cannot call distr precompile from staticcall',
+            );
+        });
+
+        it('every method is rejected under DELEGATECALL — including the rewards view', async () => {
+            const data = distrIface.encodeFunctionData('rewards', [delegator.address]);
+            await expectVmError(
+                caller
+                    .getFunction('delegatecallTarget')
+                    .send(PRECOMPILE_ADDRESSES.distribution, data, { gasLimit: 500_000 }),
+                'cannot delegatecall distr',
+            );
+        });
+    });
+});

--- a/integration_test/precompile_tests/precompiles/gov.spec.ts
+++ b/integration_test/precompile_tests/precompiles/gov.spec.ts
@@ -1,0 +1,227 @@
+/**
+ * gov precompile (0x…1006) — end-to-end semantics against a live Sei chain.
+ *
+ * Devnet gov params: min_deposit 10 SEI, voting_period 30s, max_deposit_period
+ * 100s. The 30-second clock starts the moment min_deposit is reached (usually
+ * inside the submit tx itself), so every test that votes creates its OWN fresh
+ * proposal and votes immediately — never share a voting-period proposal across
+ * tests. EOA votes tally zero power, so every proposal is ultimately rejected
+ * at tally; that is what makes these submissions harmless to the devnet.
+ */
+import { ethers } from 'ethers';
+import { expect } from 'chai';
+import { seiRpc, waitUntil } from '../utils/chainUtils';
+import { EvmAccount } from '../utils/evmUtils';
+import { cosmosQuery } from '../utils/cosmosUtils';
+import {
+    PRECOMPILE_ADDRESSES,
+    precompileContract,
+    precompileInterface,
+    callerContract,
+    expectExecutionReverted,
+    expectVmError,
+} from '../utils/precompileUtils';
+import { readRuntimeState, claimPool, RuntimeState } from '../utils/testUtils';
+
+const MIN_DEPOSIT_WEI = ethers.parseEther('10'); // devnet min_deposit = 10 SEI
+const VOTING_PERIOD = 2; // PROPOSAL_STATUS_VOTING_PERIOD
+const DEPOSIT_PERIOD = 1; // PROPOSAL_STATUS_DEPOSIT_PERIOD
+
+const textProposal = (title: string): string =>
+    JSON.stringify({ title, description: 'precompile_tests e2e fixture', type: 'Text' });
+
+describe('gov precompile (0x1006)', function () {
+    this.timeout(180 * 1000);
+
+    const provider = seiRpc();
+    const govIface = precompileInterface('gov');
+
+    let runtime: RuntimeState;
+    let admin: EvmAccount;
+    let gov: ethers.Contract;
+    let caller: ethers.Contract;
+    let adminSeiAddress: string;
+
+    /**
+     * Submit a proposal from the admin and return its id. With value >=
+     * min_deposit the proposal enters VOTING_PERIOD inside this very tx. The id
+     * is predicted with a staticCall immediately before the send — race-free
+     * because the suite is serial and nothing else submits proposals.
+     */
+    async function submitProposal(json: string, valueWei: bigint): Promise<bigint> {
+        const id: bigint = await gov.submitProposal.staticCall(json, { value: valueWei });
+        const tx = await gov.submitProposal(json, { value: valueWei, gasLimit: 1_000_000 });
+        const receipt = await tx.wait();
+        expect(receipt!.status, 'submitProposal tx must succeed').to.equal(1);
+        return id;
+    }
+
+    before(() => {
+        runtime = readRuntimeState();
+        admin = EvmAccount.fromMnemonic(runtime.funded.adminMnemonic, provider);
+        adminSeiAddress = runtime.funded.adminSeiAddress;
+        gov = precompileContract('gov', admin.wallet);
+        caller = callerContract(runtime, admin.wallet);
+    });
+
+    describe('happy path & state parity', () => {
+        it('submitProposal with min_deposit enters voting period; vote is recorded by the gov module', async () => {
+            const id = await submitProposal(textProposal('e2e vote'), MIN_DEPOSIT_WEI);
+
+            const qc = await cosmosQuery();
+            await waitUntil(
+                async () => {
+                    const { proposal } = await qc.gov.proposal(id.toString());
+                    return proposal?.status === VOTING_PERIOD ? proposal : null;
+                },
+                { timeoutMs: 15_000, label: 'proposal in voting period' },
+            );
+
+            // Vote immediately — the 30s voting clock is already running.
+            const voteTx = await gov.vote(id, 1, { gasLimit: 500_000 });
+            expect((await voteTx.wait())!.status).to.equal(1);
+
+            const recorded = await waitUntil(
+                async () => (await qc.gov.vote(id.toString(), adminSeiAddress)).vote ?? null,
+                { timeoutMs: 15_000, label: 'vote recorded in gov module' },
+            );
+            expect(recorded.options.length).to.equal(1);
+            expect(recorded.options[0].option, 'VOTE_OPTION_YES').to.equal(1);
+        });
+
+        it('voteWeighted splits a vote across options with 18-decimal weights', async () => {
+            const id = await submitProposal(textProposal('e2e weighted vote'), MIN_DEPOSIT_WEI);
+
+            const voteTx = await gov.voteWeighted(
+                id,
+                [
+                    { option: 1, weight: '0.6' },
+                    { option: 3, weight: '0.4' },
+                ],
+                { gasLimit: 500_000 },
+            );
+            expect((await voteTx.wait())!.status).to.equal(1);
+
+            const qc = await cosmosQuery();
+            const recorded = await waitUntil(
+                async () => (await qc.gov.vote(id.toString(), adminSeiAddress)).vote ?? null,
+                { timeoutMs: 15_000, label: 'weighted vote recorded' },
+            );
+            expect(recorded.options.length).to.equal(2);
+            // Weights round-trip as 18-decimal fixed-point strings.
+            expect(recorded.options[0].weight).to.equal('600000000000000000');
+            expect(recorded.options[1].weight).to.equal('400000000000000000');
+        });
+
+        it('deposit tops up a deposit-period proposal into voting period', async () => {
+            const id = await submitProposal(textProposal('e2e deposit'), ethers.parseEther('2'));
+
+            // Poll: the gov query can race the EVM receipt on CI (cosmjs throws
+            // on a not-yet-visible proposal, so an unguarded read hard-fails).
+            const qc = await cosmosQuery();
+            const before = await waitUntil(
+                async () => (await qc.gov.proposal(id.toString())).proposal ?? null,
+                { timeoutMs: 15_000, label: 'proposal visible in deposit period' },
+            );
+            expect(before.status, 'starts in deposit period').to.equal(DEPOSIT_PERIOD);
+
+            const depositTx = await gov.deposit(id, {
+                value: ethers.parseEther('8'),
+                gasLimit: 500_000,
+            });
+            expect((await depositTx.wait())!.status).to.equal(1);
+
+            const after = await waitUntil(
+                async () => {
+                    const { proposal } = await qc.gov.proposal(id.toString());
+                    return proposal?.status === VOTING_PERIOD ? proposal : null;
+                },
+                { timeoutMs: 15_000, label: 'proposal activated by deposit' },
+            );
+            const total = after.totalDeposit.find(c => c.denom === 'usei');
+            expect(total?.amount, 'total deposit reaches min_deposit').to.equal('10000000');
+        });
+    });
+
+    describe('error handling', () => {
+        it('vote on an unknown proposal fails with the gov module error', async () => {
+            await expectVmError(
+                gov.vote(999_999n, 1, { gasLimit: 500_000 }),
+                'unknown proposal',
+            );
+        });
+
+        it('vote with an invalid option is rejected', async () => {
+            const id = await submitProposal(textProposal('e2e bad option'), MIN_DEPOSIT_WEI);
+            await expectVmError(
+                gov.vote(id, 0, { gasLimit: 500_000 }),
+                'invalid vote option',
+            );
+        });
+
+        it('vote from an unassociated caller reverts (via eth_call)', async () => {
+            // Mining a tx auto-associates its sender, so the association error
+            // can never surface from a real tx — only eth_call (which does not
+            // associate) reaches the precompile with an unassociated caller.
+            const [unassociated] = claimPool(runtime, provider, 1, 'gov:unassociated');
+            await expectExecutionReverted(
+                (gov.connect(unassociated.wallet) as ethers.Contract).vote.staticCall(1n, 1),
+                'gov.vote from an unassociated caller',
+            );
+        });
+
+        it('voteWeighted rejects more than 4 options', async () => {
+            const options = [1, 2, 3, 4, 1].map(option => ({ option, weight: '0.2' }));
+            await expectVmError(
+                gov.voteWeighted(1n, options, { gasLimit: 500_000 }),
+                'too many vote options provided',
+            );
+        });
+
+        it('voteWeighted rejects an unparseable weight', async () => {
+            await expectVmError(
+                gov.voteWeighted(1n, [{ option: 1, weight: 'not-a-decimal' }], {
+                    gasLimit: 500_000,
+                }),
+                'invalid weight format',
+            );
+        });
+
+        it('submitProposal rejects malformed JSON', async () => {
+            await expectExecutionReverted(
+                gov.submitProposal.staticCall('{not json', { value: 0n }),
+                'gov.submitProposal with malformed JSON',
+            );
+        });
+
+        it('deposit rejects a zero value', async () => {
+            const id = await submitProposal(textProposal('e2e zero deposit'), 0n);
+            await expectExecutionReverted(
+                gov.deposit.staticCall(id, { value: 0n }),
+                'gov.deposit with value 0',
+            );
+        });
+    });
+
+    describe('dispatch semantics (via PrecompileCaller)', () => {
+        it('all methods are rejected under STATICCALL (gov has no view methods)', async () => {
+            const data = govIface.encodeFunctionData('vote', [1n, 1]);
+            await expectVmError(
+                caller.getFunction('staticcallTarget').send(PRECOMPILE_ADDRESSES.gov, data, {
+                    gasLimit: 500_000,
+                }),
+                'cannot call gov precompile from staticcall',
+            );
+        });
+
+        it('all methods are rejected under DELEGATECALL', async () => {
+            const data = govIface.encodeFunctionData('vote', [1n, 1]);
+            await expectVmError(
+                caller.getFunction('delegatecallTarget').send(PRECOMPILE_ADDRESSES.gov, data, {
+                    gasLimit: 500_000,
+                }),
+                'cannot delegatecall gov',
+            );
+        });
+    });
+});

--- a/integration_test/precompile_tests/precompiles/json.spec.ts
+++ b/integration_test/precompile_tests/precompiles/json.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * json precompile (0x…1003) — end-to-end semantics against a live Sei chain.
+ *
+ * Pure functions of calldata (no chain state), so the parity oracle is
+ * client-side: expected outputs are computed in TS from the same JSON input.
+ * The interesting behaviors to pin are the quote-stripping asymmetry
+ * (extractAsBytes / extractAsBytesFromArray strip outer quotes from string
+ * values; extractAsBytesList keeps them) and the uint256 parsing rules.
+ *
+ * The 2^16 array-boundary cases need ~131KB inputs (~13.1M gas at 100 gas per
+ * arg byte) that exceed the 10M eth_call simulation cap — they stay covered by
+ * the Go unit tests (json_test.go) and are intentionally not repeated here.
+ */
+import { ethers } from 'ethers';
+import { expect } from 'chai';
+import { seiRpc, rawSei } from '../utils/chainUtils';
+import { EvmAccount } from '../utils/evmUtils';
+import {
+    PRECOMPILE_ADDRESSES,
+    precompileContract,
+    precompileInterface,
+    callerContract,
+    expectExecutionReverted,
+    expectVmError,
+} from '../utils/precompileUtils';
+import { readRuntimeState, RuntimeState } from '../utils/testUtils';
+
+const bytes = (s: string): Uint8Array => ethers.toUtf8Bytes(s);
+const text = (b: string): string => ethers.toUtf8String(b);
+
+describe('json precompile (0x1003)', function () {
+    this.timeout(120 * 1000);
+
+    const provider = seiRpc();
+    const jsonIface = precompileInterface('json');
+
+    let runtime: RuntimeState;
+    let admin: EvmAccount;
+    let json: ethers.Contract;
+    let caller: ethers.Contract;
+
+    before(() => {
+        runtime = readRuntimeState();
+        admin = EvmAccount.fromMnemonic(runtime.funded.adminMnemonic, provider);
+        json = precompileContract('json', admin.wallet);
+        caller = callerContract(runtime, admin.wallet);
+    });
+
+    describe('happy path (client-side parity)', () => {
+        it('extractAsBytes strips outer quotes from string values', async () => {
+            const ret: string = await json.extractAsBytes(bytes('{"key":"value"}'), 'key');
+            expect(text(ret)).to.equal('value');
+        });
+
+        it('extractAsBytes returns non-string values as raw JSON', async () => {
+            const ret: string = await json.extractAsBytes(
+                bytes('{"obj":{"a":1,"b":[2,3]}}'),
+                'obj',
+            );
+            expect(text(ret)).to.equal('{"a":1,"b":[2,3]}');
+        });
+
+        it('extractAsBytesList keeps quotes on string elements (asymmetry by design)', async () => {
+            const ret: string[] = await json.extractAsBytesList(
+                bytes('{"list":["1","2"]}'),
+                'list',
+            );
+            expect(ret.map(text)).to.deep.equal(['"1"', '"2"']);
+        });
+
+        it('extractAsBytesList returns an empty array for []', async () => {
+            const ret: string[] = await json.extractAsBytesList(bytes('{"list":[]}'), 'list');
+            expect(ret).to.deep.equal([]);
+        });
+
+        it('extractAsUint256 parses quoted and unquoted numbers identically', async () => {
+            const [quoted, unquoted] = await Promise.all([
+                json.extractAsUint256(bytes('{"n":"12345"}'), 'n'),
+                json.extractAsUint256(bytes('{"n":12345}'), 'n'),
+            ]);
+            expect(quoted).to.equal(12345n);
+            expect(unquoted).to.equal(12345n);
+        });
+
+        it('extractAsUint256 handles the uint256 maximum', async () => {
+            const max = 2n ** 256n - 1n;
+            const ret: bigint = await json.extractAsUint256(bytes(`{"n":"${max}"}`), 'n');
+            expect(ret).to.equal(max);
+        });
+
+        it('extractAsBytesFromArray indexes a top-level array, stripping string quotes', async () => {
+            const input = bytes('["x",7]');
+            const [el0, el1] = await Promise.all([
+                json.extractAsBytesFromArray(input, 0),
+                json.extractAsBytesFromArray(input, 1),
+            ]);
+            expect(text(el0)).to.equal('x');
+            expect(text(el1)).to.equal('7');
+        });
+    });
+
+    describe('error handling', () => {
+        it('missing key reverts', async () => {
+            await expectExecutionReverted(
+                json.extractAsBytes(bytes('{"a":1}'), 'missing'),
+                'json.extractAsBytes with a missing key',
+            );
+        });
+
+        it('invalid JSON reverts', async () => {
+            await expectExecutionReverted(
+                json.extractAsBytes(bytes('not json at all'), 'key'),
+                'json.extractAsBytes with invalid JSON',
+            );
+        });
+
+        it('out-of-bounds array index reverts', async () => {
+            await expectExecutionReverted(
+                json.extractAsBytesFromArray(bytes('[1]'), 5),
+                'json.extractAsBytesFromArray out of bounds',
+            );
+        });
+
+        it('extractAsUint256 rejects a number longer than 100 characters', async () => {
+            await expectExecutionReverted(
+                json.extractAsUint256(bytes(`{"n":"${'9'.repeat(101)}"}`), 'n'),
+                'json.extractAsUint256 with a >100 char number',
+            );
+        });
+
+        it('extractAsUint256 rejects a non-numeric value', async () => {
+            await expectExecutionReverted(
+                json.extractAsUint256(bytes('{"n":"abc"}'), 'n'),
+                'json.extractAsUint256 with a non-numeric value',
+            );
+        });
+
+        it('a mined failing tx carries the exact Go error in its VmError', async () => {
+            const data = jsonIface.encodeFunctionData('extractAsBytes', [
+                bytes('{"a":1}'),
+                'missing',
+            ]);
+            await expectVmError(
+                admin.wallet.sendTransaction({
+                    to: PRECOMPILE_ADDRESSES.json,
+                    data,
+                    gasLimit: 200_000,
+                }),
+                'input does not contain key',
+            );
+        });
+    });
+
+    describe('dispatch semantics (via PrecompileCaller)', () => {
+        const input = bytes('{"key":"value"}');
+
+        it('responds through a real CALL from contract bytecode', async () => {
+            const data = jsonIface.encodeFunctionData('extractAsBytes', [input, 'key']);
+            const ret: string = await caller.callTarget.staticCall(PRECOMPILE_ADDRESSES.json, data);
+            const [decoded] = jsonIface.decodeFunctionResult('extractAsBytes', ret);
+            expect(text(decoded)).to.equal('value');
+        });
+
+        it('responds under STATICCALL', async () => {
+            const data = jsonIface.encodeFunctionData('extractAsBytes', [input, 'key']);
+            const ret: string = await caller.staticcallTarget.staticCall(
+                PRECOMPILE_ADDRESSES.json,
+                data,
+            );
+            const [decoded] = jsonIface.decodeFunctionResult('extractAsBytes', ret);
+            expect(text(decoded)).to.equal('value');
+        });
+
+        it('responds under DELEGATECALL (json has no delegatecall guard)', async () => {
+            const data = jsonIface.encodeFunctionData('extractAsBytes', [input, 'key']);
+            const ret: string = await caller.delegatecallTarget.staticCall(
+                PRECOMPILE_ADDRESSES.json,
+                data,
+            );
+            const [decoded] = jsonIface.decodeFunctionResult('extractAsBytes', ret);
+            expect(text(decoded)).to.equal('value');
+        });
+
+        it('rejects value on every method (non-payable)', async () => {
+            const envelope = await rawSei('eth_call', [
+                {
+                    from: admin.address,
+                    to: PRECOMPILE_ADDRESSES.json,
+                    data: jsonIface.encodeFunctionData('extractAsBytes', [input, 'key']),
+                    value: '0x1',
+                },
+                'latest',
+            ]);
+            expect(envelope.error, 'value-bearing call must revert').to.not.equal(undefined);
+            expect(envelope.error!.message).to.match(/execution reverted|revert/i);
+        });
+    });
+});

--- a/integration_test/precompile_tests/precompiles/oracle.spec.ts
+++ b/integration_test/precompile_tests/precompiles/oracle.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * oracle precompile (0x…1008) — retirement assertion.
+ *
+ * The oracle precompile is retired: both methods unconditionally revert with
+ * "oracle precompile is retired; oracle data queries are disabled". Uniquely
+ * among Sei precompiles it returns REAL Error(string) revert data, so the
+ * reason is visible directly in eth_call errors — this spec pins that too.
+ *
+ * One ordering nuance: the non-payable check runs BEFORE the retirement
+ * revert, so a value-bearing call reverts WITHOUT the retirement reason.
+ */
+import { ethers } from 'ethers';
+import { expect } from 'chai';
+import { seiRpc, rawSei } from '../utils/chainUtils';
+import { EvmAccount } from '../utils/evmUtils';
+import {
+    PRECOMPILE_ADDRESSES,
+    PRECOMPILE_CALLER_ABI,
+    precompileInterface,
+    getVmError,
+} from '../utils/precompileUtils';
+import { readRuntimeState, RuntimeState } from '../utils/testUtils';
+
+const RETIRED = /oracle precompile is retired/;
+
+describe('oracle precompile (0x1008)', function () {
+    this.timeout(120 * 1000);
+
+    const provider = seiRpc();
+    const oracleIface = precompileInterface('oracle');
+
+    let runtime: RuntimeState;
+    let admin: EvmAccount;
+
+    const expectRetired = async (data: string, to: string = PRECOMPILE_ADDRESSES.oracle) => {
+        const envelope = await rawSei('eth_call', [{ to, data }, 'latest']);
+        expect(envelope.error, 'retired method must revert').to.not.equal(undefined);
+        expect(envelope.error!.message, 'retirement reason surfaces in eth_call').to.match(RETIRED);
+    };
+
+    before(() => {
+        runtime = readRuntimeState();
+        admin = EvmAccount.fromMnemonic(runtime.funded.adminMnemonic, provider);
+    });
+
+    describe('error handling (retirement)', () => {
+        it('getExchangeRates reverts with the retirement reason', async () => {
+            await expectRetired(oracleIface.encodeFunctionData('getExchangeRates', []));
+        });
+
+        it('getOracleTwaps reverts with the retirement reason', async () => {
+            await expectRetired(oracleIface.encodeFunctionData('getOracleTwaps', [3600n]));
+        });
+
+        it('a value-bearing call reverts on the non-payable check, without the retirement reason', async () => {
+            const envelope = await rawSei('eth_call', [
+                {
+                    from: admin.address,
+                    to: PRECOMPILE_ADDRESSES.oracle,
+                    data: oracleIface.encodeFunctionData('getExchangeRates', []),
+                    value: '0x1',
+                },
+                'latest',
+            ]);
+            expect(envelope.error, 'value-bearing call must revert').to.not.equal(undefined);
+            expect(envelope.error!.message).to.match(/execution reverted|revert/i);
+            expect(
+                envelope.error!.message,
+                'the non-payable check fires before the retirement revert',
+            ).to.not.match(RETIRED);
+        });
+
+        it('a mined tx fails with the retirement reason in its VmError', async () => {
+            const tx = await admin.wallet.sendTransaction({
+                to: PRECOMPILE_ADDRESSES.oracle,
+                data: oracleIface.encodeFunctionData('getExchangeRates', []),
+                gasLimit: 200_000,
+            });
+            const receipt = await tx.wait().catch((e: any) => e.receipt);
+            expect(receipt.status, 'tx must fail').to.equal(0);
+            expect(await getVmError(receipt.hash)).to.match(RETIRED);
+        });
+    });
+
+    describe('dispatch semantics (via PrecompileCaller)', () => {
+        it('the retirement reason bubbles through CALL, STATICCALL and DELEGATECALL', async () => {
+            const inner = oracleIface.encodeFunctionData('getExchangeRates', []);
+            const callerIface = new ethers.Interface(PRECOMPILE_CALLER_ABI as unknown as string[]);
+            for (const fn of ['callTarget', 'staticcallTarget', 'delegatecallTarget']) {
+                await expectRetired(
+                    callerIface.encodeFunctionData(fn, [PRECOMPILE_ADDRESSES.oracle, inner]),
+                    runtime.contracts.precompileCaller,
+                );
+            }
+        });
+    });
+});

--- a/integration_test/precompile_tests/precompiles/p256.spec.ts
+++ b/integration_test/precompile_tests/precompiles/p256.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * p256 precompile (0x…1011) — RIP-7212-style secp256r1 verification.
+ *
+ * The ABI wraps the raw RIP-7212 layout: verify(bytes) where the argument is
+ * exactly 160 bytes = hash(32) || r(32) || s(32) || x(32) || y(32). A VALID
+ * signature returns the 32-byte word 1; an INVALID signature returns EMPTY
+ * output from a SUCCESSFUL call (not a revert) — so assertions go through raw
+ * eth_call: ethers' decoder would throw BAD_DATA on the empty case.
+ *
+ * Test vectors are generated with node:crypto (P-256 keygen + ieee-p1363
+ * signatures); the precompile does no hashing itself — the first 32 bytes are
+ * the already-computed message digest.
+ */
+import { ethers } from 'ethers';
+import { expect } from 'chai';
+import { generateKeyPairSync, sign, createHash } from 'node:crypto';
+import { seiRpc, rawSei } from '../utils/chainUtils';
+import { EvmAccount } from '../utils/evmUtils';
+import {
+    PRECOMPILE_ADDRESSES,
+    precompileInterface,
+    callerContract,
+    expectVmError,
+} from '../utils/precompileUtils';
+import { readRuntimeState, RuntimeState } from '../utils/testUtils';
+
+const VALID_WORD = '0x' + '00'.repeat(31) + '01';
+
+/** A fresh valid 160-byte verify() input: sha256(msg) || r || s || x || y. */
+function validVector(): Buffer {
+    const { publicKey, privateKey } = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+    const message = Buffer.from('sei p256 precompile e2e');
+    const rs = sign('sha256', message, { key: privateKey, dsaEncoding: 'ieee-p1363' });
+    const hash = createHash('sha256').update(message).digest();
+    const jwk = publicKey.export({ format: 'jwk' });
+    return Buffer.concat([
+        hash,
+        rs,
+        Buffer.from(jwk.x!, 'base64url'),
+        Buffer.from(jwk.y!, 'base64url'),
+    ]);
+}
+
+describe('p256 precompile (0x1011)', function () {
+    this.timeout(120 * 1000);
+
+    const provider = seiRpc();
+    const p256Iface = precompileInterface('p256');
+
+    let runtime: RuntimeState;
+    let admin: EvmAccount;
+    let caller: ethers.Contract;
+
+    const rawVerify = async (input: Buffer): Promise<string> => {
+        const envelope = await rawSei<string>('eth_call', [
+            {
+                to: PRECOMPILE_ADDRESSES.p256,
+                data: p256Iface.encodeFunctionData('verify', [input]),
+            },
+            'latest',
+        ]);
+        if (envelope.error) {
+            throw new Error(`verify eth_call failed: ${envelope.error.message}`);
+        }
+        return envelope.result!;
+    };
+
+    before(() => {
+        runtime = readRuntimeState();
+        admin = EvmAccount.fromMnemonic(runtime.funded.adminMnemonic, provider);
+        caller = callerContract(runtime, admin.wallet);
+    });
+
+    describe('happy path', () => {
+        it('a valid signature verifies to the 32-byte word 1', async () => {
+            const result = await rawVerify(validVector());
+            const [decoded] = p256Iface.decodeFunctionResult('verify', result);
+            expect(decoded).to.equal(VALID_WORD);
+        });
+    });
+
+    describe('invalid signatures return empty output, not a revert', () => {
+        it('a tampered message hash yields empty output', async () => {
+            const input = validVector();
+            input[0] ^= 0xff;
+            expect(await rawVerify(input)).to.equal('0x');
+        });
+
+        it('a tampered s component yields empty output', async () => {
+            const input = validVector();
+            input[80] ^= 0xff; // middle of s (bytes 64..96)
+            expect(await rawVerify(input)).to.equal('0x');
+        });
+
+        it('a public key not on the curve yields empty output', async () => {
+            const input = validVector();
+            input[159] ^= 0x01; // nudge y off the curve
+            expect(await rawVerify(input)).to.equal('0x');
+        });
+    });
+
+    describe('error handling', () => {
+        it('input shorter than 160 bytes reverts', async () => {
+            const envelope = await rawSei<string>('eth_call', [
+                {
+                    to: PRECOMPILE_ADDRESSES.p256,
+                    data: p256Iface.encodeFunctionData('verify', [validVector().subarray(0, 159)]),
+                },
+                'latest',
+            ]);
+            expect(envelope.error, 'short input must revert').to.not.equal(undefined);
+            expect(envelope.error!.message).to.match(/execution reverted|revert/i);
+        });
+
+        it('a mined failing tx carries the exact Go error in its VmError', async () => {
+            const data = p256Iface.encodeFunctionData('verify', [validVector().subarray(0, 100)]);
+            await expectVmError(
+                admin.wallet.sendTransaction({
+                    to: PRECOMPILE_ADDRESSES.p256,
+                    data,
+                    gasLimit: 200_000,
+                }),
+                'invalid input length',
+            );
+        });
+
+        it('rejects value (non-payable)', async () => {
+            const envelope = await rawSei('eth_call', [
+                {
+                    from: admin.address,
+                    to: PRECOMPILE_ADDRESSES.p256,
+                    data: p256Iface.encodeFunctionData('verify', [validVector()]),
+                    value: '0x1',
+                },
+                'latest',
+            ]);
+            expect(envelope.error, 'value-bearing call must revert').to.not.equal(undefined);
+            expect(envelope.error!.message).to.match(/execution reverted|revert/i);
+        });
+    });
+
+    describe('dispatch semantics (via PrecompileCaller)', () => {
+        it('verifies under STATICCALL (no readOnly guard)', async () => {
+            const data = p256Iface.encodeFunctionData('verify', [validVector()]);
+            const ret: string = await caller.staticcallTarget.staticCall(
+                PRECOMPILE_ADDRESSES.p256,
+                data,
+            );
+            const [decoded] = p256Iface.decodeFunctionResult('verify', ret);
+            expect(decoded).to.equal(VALID_WORD);
+        });
+
+        it('is rejected under DELEGATECALL', async () => {
+            const data = p256Iface.encodeFunctionData('verify', [validVector()]);
+            await expectVmError(
+                caller.getFunction('delegatecallTarget').send(PRECOMPILE_ADDRESSES.p256, data, {
+                    gasLimit: 500_000,
+                }),
+                'cannot delegatecall P256Verify',
+            );
+        });
+    });
+});

--- a/integration_test/precompile_tests/precompiles/pointer.spec.ts
+++ b/integration_test/precompile_tests/precompiles/pointer.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * pointer precompile (0x…100b) — wasm-free subset (addNativePointer).
+ *
+ * Fixture: a tokenfactory denom created from the admin's cosmos key —
+ * x/tokenfactory sets bank denom metadata automatically on creation, which is
+ * exactly what addNativePointer requires. The CW-pointer methods (addCW20/721/
+ * 1155Pointer) need live CosmWasm contracts and belong to the future wasm-gated
+ * phase; only their cheap wasm-free negative paths are probed here.
+ *
+ * addNativePointer has upsert semantics: re-registering the same denom
+ * SUCCEEDS and keeps the pointer address stable — pinned below; do not add a
+ * "duplicate registration reverts" test.
+ */
+import { ethers } from 'ethers';
+import { expect } from 'chai';
+import { seiRpc, waitUntil } from '../utils/chainUtils';
+import { EvmAccount } from '../utils/evmUtils';
+import { createTokenfactoryDenom } from '../utils/cosmosUtils';
+import {
+    PRECOMPILE_ADDRESSES,
+    precompileContract,
+    precompileInterface,
+    callerContract,
+    expectExecutionReverted,
+    expectVmError,
+} from '../utils/precompileUtils';
+import { readRuntimeState, RuntimeState } from '../utils/testUtils';
+
+const ERC20_ABI = [
+    'function name() view returns (string)',
+    'function symbol() view returns (string)',
+    'function decimals() view returns (uint8)',
+];
+
+describe('pointer precompile (0x100b)', function () {
+    this.timeout(180 * 1000);
+
+    const provider = seiRpc();
+    const pointerIface = precompileInterface('pointer');
+
+    let runtime: RuntimeState;
+    let admin: EvmAccount;
+    let pointer: ethers.Contract;
+    let pointerview: ethers.Contract;
+    let caller: ethers.Contract;
+    let denom: string;
+
+    before(async () => {
+        runtime = readRuntimeState();
+        admin = EvmAccount.fromMnemonic(runtime.funded.adminMnemonic, provider);
+        pointer = precompileContract('pointer', admin.wallet);
+        pointerview = precompileContract('pointerview', provider);
+        caller = callerContract(runtime, admin.wallet);
+        // Unique subdenom so reruns against a long-lived devnet never collide.
+        denom = await createTokenfactoryDenom(
+            runtime.funded.adminMnemonic,
+            `ptr${Date.now().toString(36)}`,
+        );
+    });
+
+    describe('happy path & state parity', () => {
+        let pointerAddress: string;
+
+        it('addNativePointer deploys an ERC20 pointer for a metadata-backed denom', async () => {
+            // eth_call runs readOnly=false at top level, so staticCall predicts
+            // the pointer address without persisting anything.
+            pointerAddress = await pointer.addNativePointer.staticCall(denom);
+            expect(pointerAddress).to.match(/^0x[0-9a-fA-F]{40}$/);
+
+            const tx = await pointer.addNativePointer(denom, { gasLimit: 5_000_000 });
+            const receipt = await tx.wait();
+            expect(receipt!.status, 'addNativePointer tx must succeed').to.equal(1);
+
+            const registered = await waitUntil(
+                async () => {
+                    const [addr, , exists] = await pointerview.getNativePointer(denom);
+                    return exists ? addr : null;
+                },
+                { timeoutMs: 15_000, label: 'native pointer registered' },
+            );
+            expect(registered.toLowerCase()).to.equal(pointerAddress.toLowerCase());
+        });
+
+        it('the deployed pointer is a live ERC20 whose metadata mirrors the denom', async () => {
+            const erc20 = new ethers.Contract(pointerAddress, ERC20_ABI, provider);
+            // Tokenfactory metadata: name/symbol are the FULL factory/… denom
+            // string and the single denom unit has exponent 0.
+            expect(await erc20.name()).to.equal(denom);
+            expect(await erc20.symbol()).to.equal(denom);
+            expect(await erc20.decimals()).to.equal(0n);
+        });
+
+        it('re-registering the same denom upserts and keeps the address stable', async () => {
+            const again: string = await pointer.addNativePointer.staticCall(denom);
+            expect(again.toLowerCase()).to.equal(pointerAddress.toLowerCase());
+
+            const tx = await pointer.addNativePointer(denom, { gasLimit: 5_000_000 });
+            expect((await tx.wait())!.status, 'upsert must succeed').to.equal(1);
+
+            const [addr, , exists] = await pointerview.getNativePointer(denom);
+            expect(exists).to.equal(true);
+            expect(addr.toLowerCase()).to.equal(pointerAddress.toLowerCase());
+        });
+    });
+
+    describe('error handling', () => {
+        it('addNativePointer rejects a denom without bank metadata (usei)', async () => {
+            await expectVmError(
+                pointer.addNativePointer('usei', { gasLimit: 5_000_000 }),
+                'does not have metadata stored',
+            );
+        });
+
+        it('addCW20Pointer rejects a malformed bech32 contract address', async () => {
+            await expectExecutionReverted(
+                pointer.addCW20Pointer.staticCall('not-a-contract'),
+                'pointer.addCW20Pointer with a malformed address',
+            );
+        });
+
+        it('addCW20Pointer rejects a valid sei address that is not a contract', async () => {
+            await expectExecutionReverted(
+                pointer.addCW20Pointer.staticCall(runtime.funded.adminSeiAddress),
+                'pointer.addCW20Pointer with a non-contract address',
+            );
+        });
+
+        it('rejects value despite the payable ABI declaration', async () => {
+            // The ABI marks add* methods payable but the Go handler rejects any
+            // value — the mismatch itself is the behavior under test.
+            await expectExecutionReverted(
+                pointer.addNativePointer.staticCall(denom, { value: 10n ** 12n }),
+                'pointer.addNativePointer with value',
+            );
+        });
+    });
+
+    describe('dispatch semantics (via PrecompileCaller)', () => {
+        it('is rejected under STATICCALL (readOnly guard)', async () => {
+            const data = pointerIface.encodeFunctionData('addNativePointer', [denom]);
+            await expectVmError(
+                caller.getFunction('staticcallTarget').send(PRECOMPILE_ADDRESSES.pointer, data, {
+                    gasLimit: 1_000_000,
+                }),
+                'cannot call pointer precompile from staticcall',
+            );
+        });
+
+        it('is rejected under DELEGATECALL', async () => {
+            const data = pointerIface.encodeFunctionData('addNativePointer', [denom]);
+            await expectVmError(
+                caller.getFunction('delegatecallTarget').send(PRECOMPILE_ADDRESSES.pointer, data, {
+                    gasLimit: 1_000_000,
+                }),
+                'cannot delegatecall pointer',
+            );
+        });
+    });
+});

--- a/integration_test/precompile_tests/precompiles/pointerview.spec.ts
+++ b/integration_test/precompile_tests/precompiles/pointerview.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * pointerview precompile (0x…100A) — pointer registry lookups.
+ *
+ * Lookups NEVER revert: unregistered (or garbage) keys return the tuple
+ * (0x0, 0, false). This spec registers its own native pointer (for `uatom`,
+ * which ships devnet genesis metadata; registration is an upsert, so it is
+ * safe and address-stable regardless of what other specs did) — spec files
+ * must not depend on each other's execution order.
+ */
+import { ethers } from 'ethers';
+import { expect } from 'chai';
+import { seiRpc, rawSei, waitUntil } from '../utils/chainUtils';
+import { EvmAccount } from '../utils/evmUtils';
+import {
+    PRECOMPILE_ADDRESSES,
+    precompileContract,
+    precompileInterface,
+    callerContract,
+} from '../utils/precompileUtils';
+import { readRuntimeState, RuntimeState } from '../utils/testUtils';
+import { ZERO_ADDRESS } from '../utils/constants';
+
+describe('pointerview precompile (0x100A)', function () {
+    this.timeout(120 * 1000);
+
+    const provider = seiRpc();
+    const viewIface = precompileInterface('pointerview');
+
+    let runtime: RuntimeState;
+    let admin: EvmAccount;
+    let pointerview: ethers.Contract;
+    let caller: ethers.Contract;
+    let uatomPointer: string;
+
+    before(async () => {
+        runtime = readRuntimeState();
+        admin = EvmAccount.fromMnemonic(runtime.funded.adminMnemonic, provider);
+        pointerview = precompileContract('pointerview', provider);
+        caller = callerContract(runtime, admin.wallet);
+
+        // Own fixture: register (upsert) the native pointer for uatom.
+        const pointer = precompileContract('pointer', admin.wallet);
+        uatomPointer = await pointer.addNativePointer.staticCall('uatom');
+        const tx = await pointer.addNativePointer('uatom', { gasLimit: 5_000_000 });
+        expect((await tx.wait())!.status, 'uatom pointer registration must succeed').to.equal(1);
+        await waitUntil(
+            async () => {
+                const [, , exists] = await pointerview.getNativePointer('uatom');
+                return exists ? true : null;
+            },
+            { timeoutMs: 15_000, label: 'uatom pointer visible' },
+        );
+    });
+
+    describe('happy path & state parity', () => {
+        it('getNativePointer returns the registered pointer with a positive version', async () => {
+            const [addr, version, exists] = await pointerview.getNativePointer('uatom');
+            expect(exists).to.equal(true);
+            expect(addr.toLowerCase()).to.equal(uatomPointer.toLowerCase());
+            expect(version > 0n, 'registered pointer carries a version').to.equal(true);
+        });
+
+        it('unregistered lookups return (0x0, 0, false) without reverting', async () => {
+            const cases: Array<[string, string]> = [
+                ['getNativePointer', 'factory/sei1nonexistent/nope'],
+                ['getCW20Pointer', 'sei1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq'],
+                ['getCW721Pointer', 'complete garbage — not even bech32'],
+                ['getCW1155Pointer', ''],
+            ];
+            for (const [method, key] of cases) {
+                const [addr, version, exists] = await pointerview[method](key);
+                expect(exists, `${method}(${JSON.stringify(key)}) exists flag`).to.equal(false);
+                expect(addr, `${method} address`).to.equal(ZERO_ADDRESS);
+                expect(version, `${method} version`).to.equal(0n);
+            }
+        });
+    });
+
+    describe('error handling', () => {
+        it('rejects value (non-payable)', async () => {
+            const envelope = await rawSei('eth_call', [
+                {
+                    from: admin.address,
+                    to: PRECOMPILE_ADDRESSES.pointerview,
+                    data: viewIface.encodeFunctionData('getNativePointer', ['uatom']),
+                    value: '0x1',
+                },
+                'latest',
+            ]);
+            expect(envelope.error, 'value-bearing call must revert').to.not.equal(undefined);
+            expect(envelope.error!.message).to.match(/execution reverted|revert/i);
+        });
+    });
+
+    describe('dispatch semantics (via PrecompileCaller)', () => {
+        it('responds through a real CALL, under STATICCALL and under DELEGATECALL', async () => {
+            // pointerview has neither a readOnly nor a delegatecall guard —
+            // all three dispatch paths return the same tuple (unlike staking
+            // and distribution, whose views reject DELEGATECALL).
+            const data = viewIface.encodeFunctionData('getNativePointer', ['uatom']);
+            const [viaCall, viaStatic, viaDelegate] = await Promise.all([
+                caller.callTarget.staticCall(PRECOMPILE_ADDRESSES.pointerview, data),
+                caller.staticcallTarget.staticCall(PRECOMPILE_ADDRESSES.pointerview, data),
+                caller.delegatecallTarget.staticCall(PRECOMPILE_ADDRESSES.pointerview, data),
+            ]);
+            expect(viaStatic).to.equal(viaCall);
+            expect(viaDelegate).to.equal(viaCall);
+            const [addr, , exists] = viewIface.decodeFunctionResult('getNativePointer', viaCall);
+            expect(exists).to.equal(true);
+            expect(addr.toLowerCase()).to.equal(uatomPointer.toLowerCase());
+        });
+    });
+});

--- a/integration_test/precompile_tests/precompiles/staking.spec.ts
+++ b/integration_test/precompile_tests/precompiles/staking.spec.ts
@@ -1,0 +1,433 @@
+/**
+ * staking precompile (0x…1005) — end-to-end semantics against a live Sei chain.
+ *
+ * Boundary note: rpc_tests already asserts how staking-precompile txs surface
+ * through eth_* endpoints (validators() decode via eth_call, Delegate logs via
+ * eth_getLogs, estimateGas). This spec owns the Cosmos-side state effects of
+ * delegate/undelegate/redelegate/createValidator/editValidator, query-method
+ * parity vs the staking module, error handling, and dispatch guards.
+ *
+ * Exact Go error strings only surface via eth_getVMError on mined failing txs
+ * (eth_call rewrites precompile errors to a bare "execution reverted"), so the
+ * error-handling section mines deliberate failures with explicit gas limits.
+ */
+import { ethers } from 'ethers';
+import { expect } from 'chai';
+import { generateKeyPairSync } from 'node:crypto';
+import { fromBech32, toBech32 } from '@cosmjs/encoding';
+import { seiRpc, waitUntil } from '../utils/chainUtils';
+import { EvmAccount, associateViaTx } from '../utils/evmUtils';
+import { bondedValidators, cosmosQuery, bankBalance } from '../utils/cosmosUtils';
+import {
+    PRECOMPILE_ADDRESSES,
+    precompileContract,
+    precompileInterface,
+    callerContract,
+    expectExecutionReverted,
+    expectVmError,
+    getVmError,
+    traceTransaction,
+} from '../utils/precompileUtils';
+import { readRuntimeState, claimPool, RuntimeState } from '../utils/testUtils';
+import { WEI_PER_USEI } from '../utils/constants';
+
+const DELEGATE_WEI = ethers.parseEther('1'); // == 1_000_000 usei exactly
+const DELEGATE_USEI = DELEGATE_WEI / WEI_PER_USEI;
+
+describe('staking precompile (0x1005)', function () {
+    this.timeout(180 * 1000);
+
+    const provider = seiRpc();
+    const stakingIface = precompileInterface('staking');
+
+    let runtime: RuntimeState;
+    let admin: EvmAccount;
+    let staking: ethers.Contract;
+    let caller: ethers.Contract;
+    let validators: string[];
+    let delegator: EvmAccount;
+
+    before(async () => {
+        runtime = readRuntimeState();
+        admin = EvmAccount.fromMnemonic(runtime.funded.adminMnemonic, provider);
+        staking = precompileContract('staking', admin.wallet);
+        caller = callerContract(runtime, admin.wallet);
+        validators = await bondedValidators();
+        expect(validators.length, 'devnet must have >=2 bonded validators').to.be.greaterThan(1);
+        [delegator] = claimPool(runtime, provider, 1, 'staking:delegator');
+        await associateViaTx(delegator);
+    });
+
+    describe('happy path & state parity', () => {
+        it('delegate stakes msg.value and the staking module sees the delegation', async () => {
+            const tx = await (staking.connect(delegator.wallet) as ethers.Contract).delegate(
+                validators[0],
+                { value: DELEGATE_WEI, gasLimit: 1_000_000 },
+            );
+            const receipt = await tx.wait();
+            expect(receipt!.status, 'delegate tx must succeed').to.equal(1);
+
+            // Legacy scar tissue: the delegation query can race right after the
+            // delegate tx on CI — poll instead of asserting immediately.
+            const qc = await cosmosQuery();
+            const cosmosDelegation = await waitUntil(
+                async () => {
+                    const d = await qc.staking.delegation(delegator.seiAddress(), validators[0]);
+                    return d.delegationResponse?.balance ?? null;
+                },
+                { timeoutMs: 30_000, label: 'cosmos delegation after delegate' },
+            );
+            expect(cosmosDelegation.amount, 'staking module records the usei amount').to.equal(
+                DELEGATE_USEI.toString(),
+            );
+            expect(cosmosDelegation.denom).to.equal('usei');
+        });
+
+        it('delegate emits the Delegate event (amount in wei) plus a rewards-withdrawn log', async () => {
+            const tx = await (staking.connect(delegator.wallet) as ethers.Contract).delegate(
+                validators[0],
+                { value: DELEGATE_WEI, gasLimit: 1_000_000 },
+            );
+            const receipt = await tx.wait();
+
+            const parsed = receipt!.logs.map((l: ethers.Log) => {
+                try {
+                    return stakingIface.parseLog({ topics: [...l.topics], data: l.data });
+                } catch {
+                    return null;
+                }
+            });
+            const delegateEvent = parsed.find((p: any) => p?.name === 'Delegate');
+            expect(delegateEvent, 'Delegate event must be emitted').to.not.equal(undefined);
+            expect(delegateEvent!.args[0]).to.equal(delegator.address);
+            expect(delegateEvent!.args[1]).to.equal(validators[0]);
+            // The Delegate event reports the raw wei msg.value, not usei.
+            expect(delegateEvent!.args[2]).to.equal(DELEGATE_WEI);
+
+            const rewardsEvent = parsed.find((p: any) => p?.name === 'DelegationRewardsWithdrawn');
+            expect(
+                rewardsEvent,
+                'delegate implicitly withdraws rewards and logs it',
+            ).to.not.equal(undefined);
+        });
+
+        it('delegation query matches the staking module exactly', async () => {
+            const [viaPrecompile, qc] = await Promise.all([
+                staking.delegation(delegator.address, validators[0]),
+                cosmosQuery(),
+            ]);
+            const viaCosmos = await qc.staking.delegation(delegator.seiAddress(), validators[0]);
+
+            expect(viaPrecompile.balance.amount).to.equal(
+                BigInt(viaCosmos.delegationResponse!.balance!.amount),
+            );
+            expect(viaPrecompile.balance.denom).to.equal('usei');
+            expect(viaPrecompile.delegation.delegator_address).to.equal(delegator.seiAddress());
+            expect(viaPrecompile.delegation.validator_address).to.equal(validators[0]);
+        });
+
+        it('undelegate creates an unbonding entry and funds return after unbonding_time', async () => {
+            const half = DELEGATE_USEI; // one of the two 1-SEI delegations above
+
+            // Legacy scar tissue: undelegate gas fluctuates block-to-block on CI
+            // (staking queue writes) — give it a generous explicit limit up front.
+            const tx = await (staking.connect(delegator.wallet) as ethers.Contract).undelegate(
+                validators[0],
+                half,
+                { gasLimit: 2_000_000 },
+            );
+            const receipt = await tx.wait();
+            expect(receipt!.status, 'undelegate tx must succeed').to.equal(1);
+
+            // Baseline AFTER the undelegate (its gas and implicit reward
+            // withdrawal already applied) but before the 10s maturity.
+            const balanceBeforeMaturity = await bankBalance(delegator.seiAddress());
+
+            // The devnet's unbonding_time is 10s — poll for the entry before it
+            // matures (the RPC node can lag the block that included the tx).
+            // NB: the component is named `entries`, which collides with
+            // Array.prototype.entries on ethers' Result — use getValue().
+            const entries = await waitUntil(
+                async () => {
+                    const ubd = await staking.unbondingDelegation(
+                        delegator.address,
+                        validators[0],
+                    );
+                    const list = ubd.getValue('entries') as ethers.Result;
+                    return list.length > 0 ? list : null;
+                },
+                { timeoutMs: 8_000, intervalMs: 200, label: 'unbonding entry before maturity' },
+            );
+            expect(BigInt(entries[0].balance), 'unbonding entry carries the amount').to.equal(half);
+
+            // After ~10s the staking EndBlocker credits the delegator's bank balance.
+            await waitUntil(
+                async () => {
+                    const b = await bankBalance(delegator.seiAddress());
+                    return b >= balanceBeforeMaturity + half ? b : null;
+                },
+                { timeoutMs: 45_000, label: 'unbonded funds returned to bank balance' },
+            );
+        });
+
+        it('redelegate moves stake to a second validator', async () => {
+            const moved = DELEGATE_USEI / 2n;
+            const tx = await (staking.connect(delegator.wallet) as ethers.Contract).redelegate(
+                validators[0],
+                validators[1],
+                moved,
+                { gasLimit: 2_000_000 },
+            );
+            const receipt = await tx.wait();
+            expect(receipt!.status, 'redelegate tx must succeed').to.equal(1);
+
+            const qc = await cosmosQuery();
+            const dst = await waitUntil(
+                async () => {
+                    const d = await qc.staking.delegation(delegator.seiAddress(), validators[1]);
+                    return d.delegationResponse?.balance ?? null;
+                },
+                { timeoutMs: 30_000, label: 'destination delegation after redelegate' },
+            );
+            expect(BigInt(dst.amount)).to.equal(moved);
+        });
+
+        it('pool and params queries match the staking module', async () => {
+            const qc = await cosmosQuery();
+            const [poolP, paramsP, poolC, paramsC] = await Promise.all([
+                staking.pool(),
+                staking.params(),
+                qc.staking.pool(),
+                qc.staking.params(),
+            ]);
+            expect(BigInt(poolP.bondedTokens)).to.equal(BigInt(poolC.pool!.bondedTokens));
+            expect(paramsP.bondDenom).to.equal(paramsC.params!.bondDenom);
+            expect(Number(paramsP.maxValidators)).to.equal(paramsC.params!.maxValidators);
+        });
+
+        it('createValidator registers a new validator and editValidator updates its moniker', async () => {
+            const [operator] = claimPool(runtime, provider, 1, 'staking:validator-creator');
+            await associateViaTx(operator);
+
+            // The operator address is the caller's own sei address under the
+            // seivaloper prefix — derive it instead of searching by moniker
+            // (monikers collide across suite re-runs on a long-lived devnet).
+            const valoper = toBech32('seivaloper', fromBech32(operator.seiAddress()).data);
+            // Unique moniker per run for the same reason.
+            const moniker = `e2e-val-${Date.now().toString(36)}`;
+
+            // Bare-hex ed25519 consensus pubkey (32 bytes, no 0x).
+            const { publicKey } = generateKeyPairSync('ed25519');
+            const pubKeyHex = (publicKey.export({ format: 'der', type: 'spki' }) as Buffer)
+                .subarray(-32)
+                .toString('hex');
+
+            const createTx = await (staking.connect(operator.wallet) as ethers.Contract).createValidator(
+                pubKeyHex,
+                moniker,
+                '0.05', // devnet min_commission_rate
+                '0.20',
+                '0.01',
+                1n,
+                { value: ethers.parseEther('1'), gasLimit: 2_000_000 },
+            );
+            const createReceipt = await createTx.wait();
+            expect(createReceipt!.status, 'createValidator tx must succeed').to.equal(1);
+
+            // validator() packs the whole Description as one string field.
+            const created = await waitUntil(
+                async () => {
+                    const v = await staking.validator(valoper);
+                    return v.description.includes(moniker) ? v : null;
+                },
+                { timeoutMs: 30_000, label: 'new validator visible via the precompile' },
+            );
+            expect(created.operatorAddress).to.equal(valoper);
+
+            const qc = await cosmosQuery();
+            const viaCosmos = await qc.staking.validator(valoper);
+            expect(viaCosmos.validator?.description?.moniker, 'staking module parity').to.equal(
+                moniker,
+            );
+
+            // Commission cannot change within 24h of creation: pass '' (untouched)
+            // and minSelfDelegation 0 (untouched) — only the moniker updates.
+            const editTx = await (staking.connect(operator.wallet) as ethers.Contract).editValidator(
+                `${moniker}-edited`,
+                '',
+                0n,
+                { gasLimit: 1_000_000 },
+            );
+            const editReceipt = await editTx.wait();
+            expect(editReceipt!.status, 'editValidator tx must succeed').to.equal(1);
+
+            await waitUntil(
+                async () => {
+                    const v = await staking.validator(valoper);
+                    return v.description.includes(`${moniker}-edited`) ? v : null;
+                },
+                { timeoutMs: 30_000, label: 'edited moniker visible' },
+            );
+
+            // The operator address is derived from the caller, so a second
+            // createValidator from the same account must fail.
+            await expectVmError(
+                (staking.connect(operator.wallet) as ethers.Contract).createValidator(
+                    pubKeyHex,
+                    `${moniker}-2`,
+                    '0.05',
+                    '0.20',
+                    '0.01',
+                    1n,
+                    { value: ethers.parseEther('1'), gasLimit: 2_000_000 },
+                ),
+                'validator already exist',
+            );
+        });
+    });
+
+    describe('error handling', () => {
+        it('delegate from an unassociated caller reverts (via eth_call)', async () => {
+            // Mining a tx auto-associates its sender, so the association error
+            // can never surface from a real tx — only eth_call (which does not
+            // associate) reaches the precompile with an unassociated caller.
+            const [unassociated] = claimPool(runtime, provider, 1, 'staking:unassociated');
+            await expectExecutionReverted(
+                (staking.connect(unassociated.wallet) as ethers.Contract).delegate.staticCall(
+                    validators[0],
+                    { value: DELEGATE_WEI },
+                ),
+                'staking.delegate from an unassociated caller',
+            );
+        });
+
+        it('delegate rejects a zero value', async () => {
+            await expectExecutionReverted(
+                (staking.connect(delegator.wallet) as ethers.Contract).delegate.staticCall(
+                    validators[0],
+                    { value: 0n },
+                ),
+                'staking.delegate with value 0',
+            );
+        });
+
+        it('delegate rejects a value with a non-zero wei remainder', async () => {
+            await expectVmError(
+                (staking.connect(delegator.wallet) as ethers.Contract).delegate(validators[0], {
+                    value: DELEGATE_WEI + 1n,
+                    gasLimit: 1_000_000,
+                }),
+                'non-zero wei remainder',
+            );
+        });
+
+        it('undelegate without a delegation fails with the staking module error', async () => {
+            const [bystander] = claimPool(runtime, provider, 1, 'staking:no-delegation');
+            await associateViaTx(bystander);
+            await expectVmError(
+                (staking.connect(bystander.wallet) as ethers.Contract).undelegate(
+                    validators[0],
+                    1n,
+                    { gasLimit: 2_000_000 },
+                ),
+                'no delegation for (address, validator) tuple',
+            );
+        });
+
+        it('redelegate to the same validator is rejected', async () => {
+            await expectVmError(
+                (staking.connect(delegator.wallet) as ethers.Contract).redelegate(
+                    validators[1],
+                    validators[1],
+                    1n,
+                    { gasLimit: 2_000_000 },
+                ),
+                'cannot redelegate to the same validator',
+            );
+        });
+
+        it('delegation query for an unknown validator reverts', async () => {
+            // A checksummed-but-never-seen operator address (random 20 bytes).
+            const unknownValoper = toBech32('seivaloper', ethers.randomBytes(20));
+            await expectExecutionReverted(
+                staking.delegation(delegator.address, unknownValoper),
+                'staking.delegation with an unknown validator',
+            );
+        });
+
+        it('delegation query for a malformed bech32 reverts', async () => {
+            await expectExecutionReverted(
+                staking.delegation(delegator.address, 'seivaloper1not-a-real-address'),
+                'staking.delegation with a malformed bech32',
+            );
+        });
+
+        it('out-of-gas fails cleanly, never as a panic (legacy guard)', async () => {
+            // Unlike bank/addr (whose executors convert the gas-meter panic to
+            // "execution reverted"), a starved delegate runs out inside the
+            // cosmos store layer and surfaces as a location-tagged out-of-gas
+            // error. The load-bearing property is the same: no Go panic leaks.
+            const tx = await (staking.connect(delegator.wallet) as ethers.Contract).delegate(
+                validators[0],
+                { value: DELEGATE_WEI, gasLimit: 60_000 },
+            );
+            const receipt = await tx.wait().catch((e: any) => e.receipt);
+            expect(receipt.status, 'tx must fail').to.equal(0);
+
+            const vmError = await getVmError(receipt.hash);
+            expect(vmError).to.include('out of gas');
+            expect(vmError, 'no panic may leak into the VM error').to.not.include('panic');
+
+            const trace = await traceTransaction(receipt.hash);
+            expect(trace.error ?? '', 'trace carries a non-panic error').to.not.equal('');
+            expect(trace.error, 'no panic may leak into traces').to.not.include('panic');
+        });
+    });
+
+    describe('dispatch semantics (via PrecompileCaller)', () => {
+        it('query methods respond through a real CALL from contract bytecode', async () => {
+            const data = stakingIface.encodeFunctionData('delegation', [
+                delegator.address,
+                validators[1],
+            ]);
+            const ret: string = await caller.callTarget.staticCall(
+                PRECOMPILE_ADDRESSES.staking,
+                data,
+            );
+            const [decoded] = stakingIface.decodeFunctionResult('delegation', ret);
+            expect(decoded.delegation.validator_address).to.equal(validators[1]);
+        });
+
+        it('query methods are callable via STATICCALL', async () => {
+            const data = stakingIface.encodeFunctionData('params', []);
+            const ret: string = await caller.staticcallTarget.staticCall(
+                PRECOMPILE_ADDRESSES.staking,
+                data,
+            );
+            const [decoded] = stakingIface.decodeFunctionResult('params', ret);
+            expect(decoded.bondDenom).to.equal('usei');
+        });
+
+        it('write methods are rejected under STATICCALL (readOnly guard)', async () => {
+            const data = stakingIface.encodeFunctionData('undelegate', [validators[0], 1n]);
+            await expectVmError(
+                caller.getFunction('staticcallTarget').send(PRECOMPILE_ADDRESSES.staking, data, {
+                    gasLimit: 1_000_000,
+                }),
+                'cannot call staking precompile from staticcall',
+            );
+        });
+
+        it('every method is rejected under DELEGATECALL (staking-wide guard)', async () => {
+            // The delegatecall guard sits above method dispatch, so even a view
+            // method like params() rejects — unlike json/pointerview.
+            const data = stakingIface.encodeFunctionData('params', []);
+            await expectVmError(
+                caller.getFunction('delegatecallTarget').send(PRECOMPILE_ADDRESSES.staking, data, {
+                    gasLimit: 1_000_000,
+                }),
+                'cannot delegatecall staking',
+            );
+        });
+    });
+});

--- a/integration_test/precompile_tests/utils/cosmosUtils.ts
+++ b/integration_test/precompile_tests/utils/cosmosUtils.ts
@@ -3,9 +3,16 @@ import { ethers } from 'ethers';
 import {
     QueryClient,
     setupBankExtension,
+    setupStakingExtension,
+    setupGovExtension,
+    setupDistributionExtension,
     BankExtension,
+    StakingExtension,
+    GovExtension,
+    DistributionExtension,
     SigningStargateClient,
     defaultRegistryTypes,
+    assertIsDeliverTxSuccess,
 } from '@cosmjs/stargate';
 import { Tendermint34Client } from '@cosmjs/tendermint-rpc';
 import { DirectSecp256k1HdWallet, Registry } from '@cosmjs/proto-signing';
@@ -29,16 +36,42 @@ function seiWalletFromMnemonic(mnemonic: string): Promise<DirectSecp256k1HdWalle
     });
 }
 
-let clientPromise: Promise<QueryClient & BankExtension> | undefined;
+export type CosmosQueryClient = QueryClient &
+    BankExtension &
+    StakingExtension &
+    GovExtension &
+    DistributionExtension;
 
-async function bankClient(): Promise<QueryClient & BankExtension> {
+let clientPromise: Promise<CosmosQueryClient> | undefined;
+
+/**
+ * The suite's Cosmos-side parity oracle: one shared query client over the
+ * chain's own modules (bank, staking, gov, distribution). Precompile-reported
+ * values and EVM-side effects are asserted against these reads.
+ */
+export async function cosmosQuery(): Promise<CosmosQueryClient> {
     if (!clientPromise) {
         clientPromise = (async () => {
             const tm = await Tendermint34Client.connect(Endpoints.sei.cosmosRpc);
-            return QueryClient.withExtensions(tm, setupBankExtension);
+            return QueryClient.withExtensions(
+                tm,
+                setupBankExtension,
+                setupStakingExtension,
+                setupGovExtension,
+                setupDistributionExtension,
+            );
         })();
     }
     return clientPromise;
+}
+
+const bankClient = cosmosQuery;
+
+/** Operator addresses (seivaloper1…) of the currently bonded validators. */
+export async function bondedValidators(): Promise<string[]> {
+    const qc = await cosmosQuery();
+    const { validators } = await qc.staking.validators('BOND_STATUS_BONDED');
+    return validators.map(v => v.operatorAddress);
 }
 
 /** A fresh random BIP39 mnemonic (coin type 118) — used to mint an ephemeral admin. */
@@ -83,6 +116,47 @@ export async function bankSupplyOf(denom = 'usei'): Promise<bigint> {
     const qc = await bankClient();
     const coin = await qc.bank.supplyOf(denom);
     return BigInt(coin.amount);
+}
+
+/**
+ * Create a tokenfactory denom from `mnemonic` and wait until its bank metadata
+ * is visible. x/tokenfactory sets denom metadata automatically on creation
+ * (name/symbol = the full `factory/<creator>/<subdenom>` string, exponent 0),
+ * which is exactly the precondition the pointer precompile's addNativePointer
+ * checks. Returns the full denom.
+ */
+export async function createTokenfactoryDenom(
+    mnemonic: string,
+    subdenom: string,
+): Promise<string> {
+    const wallet = await seiWalletFromMnemonic(mnemonic);
+    const [account] = await wallet.getAccounts();
+    const registry = new Registry([...seiProtoRegistry, ...defaultRegistryTypes]);
+    const client = await SigningStargateClient.connectWithSigner(Endpoints.sei.cosmosRpc, wallet, {
+        registry,
+    });
+    try {
+        const msg = {
+            typeUrl: `/${Encoder.tokenfactory.MsgCreateDenom.$type}`,
+            value: Encoder.tokenfactory.MsgCreateDenom.fromPartial({
+                sender: account.address,
+                subdenom,
+            }),
+        };
+        const fee = { amount: coins(40000, 'usei'), gas: '400000' };
+        const res = await client.signAndBroadcast(account.address, [msg], fee, 'create denom');
+        assertIsDeliverTxSuccess(res);
+    } finally {
+        client.disconnect();
+    }
+
+    const denom = `factory/${account.address}/${subdenom}`;
+    const qc = await cosmosQuery();
+    await waitUntil(async () => (await qc.bank.denomMetadata(denom)) ?? null, {
+        timeoutMs: 30_000,
+        label: `bank metadata for ${denom}`,
+    });
+    return denom;
 }
 
 /** True when a local `sei-node-0` docker container is running. */

--- a/integration_test/precompile_tests/utils/precompileUtils.ts
+++ b/integration_test/precompile_tests/utils/precompileUtils.ts
@@ -2,7 +2,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { ethers } from 'ethers';
 import { expect } from 'chai';
-import { rawSei } from './chainUtils';
+import { rawSei, waitUntil } from './chainUtils';
+import type { RuntimeState } from './testUtils';
 
 /**
  * Canonical addresses of Sei's custom precompiles, mirroring the constants in
@@ -22,6 +23,7 @@ export const PRECOMPILE_ADDRESSES = {
     pointerview: '0x000000000000000000000000000000000000100A',
     pointer: '0x000000000000000000000000000000000000100b',
     solo: '0x000000000000000000000000000000000000100C',
+    p256: '0x0000000000000000000000000000000000001011',
 } as const;
 
 export type PrecompileName = keyof typeof PRECOMPILE_ADDRESSES;
@@ -78,6 +80,61 @@ export async function expectExecutionReverted(
         return message;
     }
     throw new Error(`${label}: expected the call to revert but it succeeded`);
+}
+
+/** ABI of the PrecompileCaller fixture (contracts/PrecompileCaller.sol). */
+export const PRECOMPILE_CALLER_ABI = [
+    'function callTarget(address target, bytes data) payable returns (bytes)',
+    'function staticcallTarget(address target, bytes data) view returns (bytes)',
+    'function delegatecallTarget(address target, bytes data) returns (bytes)',
+] as const;
+
+/** The deployed PrecompileCaller fixture, bound to `runner`. */
+export function callerContract(
+    runtime: RuntimeState,
+    runner: ethers.ContractRunner,
+): ethers.Contract {
+    return new ethers.Contract(
+        runtime.contracts.precompileCaller,
+        PRECOMPILE_CALLER_ABI as unknown as string[],
+        runner,
+    );
+}
+
+/**
+ * The precompile's Go error for a mined, failed tx via Sei's eth_getVMError
+ * (format "execution reverted|<go error>"). This is the ONLY channel that
+ * carries exact precompile error strings: eth_call rewrites every executor
+ * error to a bare "execution reverted" with no reason data (except the oracle
+ * retirement error, which ships real revert data). Polls briefly — the
+ * persisted receipt can lag tx.wait() by a beat on the 4-node devnet.
+ */
+export async function getVmError(txHash: string): Promise<string> {
+    return waitUntil(
+        async () => {
+            const env = await rawSei<string>('eth_getVMError', [txHash]);
+            return env.result && env.result.length > 0 ? env.result : null;
+        },
+        { timeoutMs: 15_000, label: `eth_getVMError(${txHash})` },
+    );
+}
+
+/**
+ * Assert an already-broadcast tx (send with an explicit gasLimit — estimateGas
+ * on a failing call throws client-side) mines with status 0 and that its
+ * VmError carries `substring` — the exact Go error from the precompile.
+ */
+export async function expectVmError(
+    txPromise: Promise<ethers.TransactionResponse>,
+    substring: string,
+): Promise<void> {
+    const tx = await txPromise;
+    const receipt = await tx.wait().catch((e: any) => e.receipt);
+    expect(receipt, 'the failing tx must still be mined').to.not.equal(undefined);
+    expect(receipt.status, 'tx must fail').to.equal(0);
+    const vmError = await getVmError(receipt.hash);
+    expect(vmError).to.include('execution reverted');
+    expect(vmError, 'precompile error must surface in VmError').to.include(substring);
 }
 
 interface CallTrace {


### PR DESCRIPTION
## Describe your changes and provide context

Phase 2 of the precompile test refactor ([PLT-372](https://linear.app/seilabs/issue/PLT-372/refactor-precompile-tests)), building on the Phase 1 framework merged in #3777. Adds end-to-end specs for the remaining **wasm-free** precompiles, bringing coverage to 10 of 13:

| Precompile | New spec | Highlights |
|---|---|---|
| staking (0x…1005) | `staking.spec.ts` | delegate/undelegate/redelegate with Cosmos-side parity, createValidator/editValidator via bech32-derived valoper, unbonding maturity (10s devnet), whole-usei value guard, OOG-never-panics invariant |
| gov (0x…1006) | `gov.spec.ts` | submitProposal (JSON payload) with staticCall id prediction, vote/voteWeighted/deposit verified against the gov module |
| distribution (0x…1007) | `distribution.spec.ts` | rewards accrual fixture, setWithdrawAddress, withdrawal delta pinned to the tx's own `DelegationRewardsWithdrawn` log amount |
| json (0x…1003) | `json.spec.ts` | extraction methods incl. the quote-stripping asymmetry; accepts STATICCALL and DELEGATECALL |
| oracle (0x…1008) | `oracle.spec.ts` | retirement assertion — the one precompile returning real `Error(string)` revert data |
| pointer (0x…100b) | `pointer.spec.ts` | `addNativePointer` with a fresh tokenfactory denom, upsert semantics, metadata-missing error (CW methods are wasm-gated → Phase 3) |
| pointerview (0x…100A) | `pointerview.spec.ts` | registered/unregistered lookups incl. `(0x0, 0, false)` zero-tuples |
| p256 (0x…1011) | `p256.spec.ts` | RFC-style verify with node:crypto P-256 vectors; invalid signature returns empty bytes (success), not a revert |

Framework additions:
- `utils/cosmosUtils.ts`: typed query client with staking/gov/distribution extensions, `bondedValidators()`, tokenfactory denom creation.
- `utils/precompileUtils.ts`: shared `callerContract` helper (PrecompileCaller fixture), `getVmError`/`expectVmError` for asserting exact Go error strings via the `eth_getVMError` RPC (they never reach `eth_call`).
- Phase 1 bank/addr specs refactored onto the shared caller helper; bootstrap pool grown 32 → 48 accounts.
- README: coverage table + "hard-won facts" (auto-association, per-precompile guard tables, whole-usei payable rule, OOG shapes).

Out of scope, per PLT-372 planning: wasm-gated flows (wasmd, pointer `addCW*`, solo) land in Phase 3 behind a live wasm check; the ibc precompile is permanently out of scope.

## Testing performed to validate your changes

- Full suite run from scratch, CI-style: fresh 4-node docker cluster (`GIGA_STORAGE=true`), `scripts/run-ci.sh` (npm ci → compile → wait for block production → bootstrap → run): **bootstrap 7 + 119 specs passing, 0 failing**.
- Suite is rerun-stable: previously validated twice consecutively against an already-mutated chain (no fresh-genesis assumptions).
- `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)