### PR TITLE
ci(PLT-825): run all Autobahn integration tests on every PR

### DIFF
--- a/.github/workflows/integration-test-matrix.json
+++ b/.github/workflows/integration-test-matrix.json
@@ -16,7 +16,6 @@
   },
   {
     "name": "Autobahn Mint & Staking & Bank Module",
-    "merge_only": true,
     "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
     "scripts": [
       "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run \"TestMintModule|TestStakingModule|TestAutobahnBankModule\""
@@ -30,7 +29,6 @@
   },
   {
     "name": "Autobahn Gov & Oracle & Authz Module",
-    "merge_only": true,
     "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true",
     "scripts": [
       "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run \"TestGovModule|TestOracleModule|TestAuthzModule\""
@@ -63,7 +61,6 @@
   },
   {
     "name": "Autobahn Upgrade Module (Major)",
-    "merge_only": true,
     "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true UPGRADE_VERSION_LIST=v1.0.0,v1.0.1,v1.0.2",
     "scripts": [
       "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestUpgradeMajor"
@@ -78,7 +75,6 @@
   },
   {
     "name": "Autobahn Upgrade Module (Minor)",
-    "merge_only": true,
     "env": "AUTOBAHN=true GIGA_EXECUTOR=true GIGA_STORAGE=true GIGA_OCC=true UPGRADE_VERSION_LIST=v1.0.0,v1.0.1,v1.0.2",
     "scripts": [
       "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run TestUpgradeMinor"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -27,12 +27,9 @@ defaults:
 
 jobs:
   # Generate the integration-test matrix from integration-test-matrix.json.
-  # On pull_request we drop entries tagged `merge_only: true` (Autobahn Gov/Mint/
-  # Upgrade GIGA-mode variants) to cut per-PR ubuntu-large fan-out; on push and merge
-  # queue the full matrix runs. The matrix is built here, in a job output,
-  # because the `matrix` context is NOT available to a job-level `if:` — a
-  # per-combination `if` on the test job would fail workflow validation
-  # (startup failure), so the filtering must happen before the matrix expands.
+  # Runs the full matrix on every event (pull_request, push, merge_group) — all
+  # Autobahn coverage runs on every PR. The matrix is built here, in a job
+  # output, because the `matrix` context is NOT available to a job-level `if:`.
   set-matrix:
     name: Resolve integration test matrix
     runs-on: ubuntu-latest
@@ -44,19 +41,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Build matrix
         id: build
-        env:
-          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
           matrix_file=.github/workflows/integration-test-matrix.json
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            # Defer merge_only Autobahn Gov/Mint/Upgrade entries to merge queue / push.
-            tests=$(jq -c '[.[] | select(.merge_only != true)]' "$matrix_file")
-          else
-            tests=$(jq -c '.' "$matrix_file")
-          fi
+          tests=$(jq -c '.' "$matrix_file")
           echo "tests=$tests" >> "$GITHUB_OUTPUT"
-          echo "Selected $(echo "$tests" | jq 'length') of $(jq 'length' "$matrix_file") matrix entries for event '$EVENT_NAME'."
+          echo "Selected $(echo "$tests" | jq 'length') matrix entries."
 
   # Build localnode/rpcnode images and seid once; matrix jobs pull the images
   # from GHCR (tagged with the run id) and download seid as a small artifact.
@@ -162,10 +152,6 @@ jobs:
 
   integration-tests:
     name: Integration Test (${{ matrix.test.name }})
-    # The merge_only Autobahn Gov/Mint/Upgrade variants are filtered out of the
-    # matrix on pull_request by the set-matrix job above; a smoke of Autobahn
-    # coverage still runs on PRs via the dedicated autobahn-integration-tests
-    # job below. On push and merge queue the full matrix runs.
     needs: [ set-matrix, prepare-cluster ]
     runs-on: ubuntu-large
     timeout-minutes: 30
@@ -183,7 +169,7 @@ jobs:
       # other jobs should run even if one integration test fails
       fail-fast: false
       # Matrix is resolved by the set-matrix job from
-      # integration-test-matrix.json (merge_only entries filtered on PRs).
+      # integration-test-matrix.json.
       matrix:
         test: ${{ fromJSON(needs.set-matrix.outputs.tests) }}
     steps:


### PR DESCRIPTION
## What

Reverts the Autobahn Gov/Mint/Upgrade PR-matrix deferral introduced in #3639 (PLT-761):

- Removes the `merge_only: true` tags from `integration-test-matrix.json` on the four Autobahn Gov & Oracle & Authz, Mint & Staking & Bank, Upgrade (Major), and Upgrade (Minor) entries.
- Simplifies the `set-matrix` job in `integration-test.yml` to always resolve the full matrix, instead of filtering `merge_only` entries out on `pull_request`.
- Updates the related comments accordingly.

The `concurrency`/`cancel-in-progress` change from #3639 (which cancels superseded PR runs) is untouched — it's kept, since it's an unambiguous win.

## Why

The matrix deferral was meant to reduce `ubuntu-large` runner contention, but measurement showed it didn't cut wall-clock for PR authors (matrix jobs run in parallel, so trimming 4 of ~32 entries doesn't shorten the run) — it only reduced total runner-minutes consumed. Meanwhile, deferring this coverage to merge-queue/push only caused real developer confusion: PRs looked green locally while Gov/Mint/Upgrade Autobahn failures only surfaced at merge-queue time, which is more disruptive and more expensive to fix than catching them on the PR itself.

See PLT-825 for the follow-up analysis and decision.

## Effect

- **PRs:** all Autobahn matrix entries (including Gov/Mint/Upgrade) run on every PR again, matching pre-#3639 coverage.
- **Merge queue / push:** unchanged — full matrix always ran here.
- Superseded PR runs still get cancelled via the concurrency block, so this doesn't reintroduce the wasted-runner-minutes problem #3639 fixed.

Fixes PLT-825.