### PR TITLE
Harden account key validation

### DIFF
--- a/app/ante/cosmos_checktx.go
+++ b/app/ante/cosmos_checktx.go
@@ -10,6 +10,8 @@ import (
 	"github.com/sei-protocol/sei-chain/app/antedecorators"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/client"
 	codectypes "github.com/sei-protocol/sei-chain/sei-cosmos/codec/types"
+	kmultisig "github.com/sei-protocol/sei-chain/sei-cosmos/crypto/keys/multisig"
+	cryptotypes "github.com/sei-protocol/sei-chain/sei-cosmos/crypto/types"
 	storetypes "github.com/sei-protocol/sei-chain/sei-cosmos/store/types"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
@@ -215,6 +217,9 @@ func CosmosStatelessChecks(tx sdk.Tx, height int64, consensusParams *tmproto.Con
 		if pk == nil {
 			continue
 		}
+		if err := validatePubKey(pk); err != nil {
+			return oracleVote, err
+		}
 		if !bytes.Equal(pk.Address(), signers[i]) {
 			return oracleVote, sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey,
 				"pubKey does not match signer address %s with signer index: %d", signers[i], i)
@@ -237,6 +242,56 @@ func CosmosStatelessChecks(tx sdk.Tx, height int64, consensusParams *tmproto.Con
 		}
 	}
 	return oracleVote, nil
+}
+
+func validatePubKey(pubKey cryptotypes.PubKey) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey, "invalid public key: %v", r)
+		}
+	}()
+
+	return validatePubKeyNoPanic(pubKey)
+}
+
+func validatePubKeyNoPanic(pubKey cryptotypes.PubKey) error {
+	switch pk := pubKey.(type) {
+	case nil:
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "missing public key")
+	case *kmultisig.LegacyAminoPubKey:
+		return validateMultisigPubKey(pk)
+	default:
+		if len(pubKey.Address()) == 0 {
+			return sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey, "invalid public key type: %T", pubKey)
+		}
+		return nil
+	}
+}
+
+func validateMultisigPubKey(pubKey *kmultisig.LegacyAminoPubKey) error {
+	if pubKey == nil {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "missing multisig public key")
+	}
+
+	pubKeys := pubKey.GetPubKeys()
+	threshold := pubKey.GetThreshold()
+	if threshold == 0 {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "multisig threshold must be positive")
+	}
+	if threshold > uint(len(pubKeys)) {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey, "multisig threshold %d exceeds public key count %d", threshold, len(pubKeys))
+	}
+
+	for i, pk := range pubKeys {
+		if err := validatePubKey(pk); err != nil {
+			return sdkerrors.Wrapf(err, "invalid multisig public key at index %d", i)
+		}
+	}
+
+	if len(pubKey.Address()) == 0 {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "invalid multisig public key")
+	}
+	return nil
 }
 
 func SetGasMeter(ctx sdk.Context, gasLimit uint64, paramsKeeper paramskeeper.Keeper) sdk.Context {
@@ -363,6 +418,9 @@ func CheckPubKeys(ctx sdk.Context, tx sdk.Tx, accountKeeper authkeeper.AccountKe
 		if pk == nil || acc.GetPubKey() != nil {
 			signerAcounts[i] = acc
 			continue
+		}
+		if err := validatePubKey(pk); err != nil {
+			return nil, err
 		}
 		err = acc.SetPubKey(pk)
 		if err != nil {

--- a/app/ante/cosmos_checktx.go
+++ b/app/ante/cosmos_checktx.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/client"
 	codectypes "github.com/sei-protocol/sei-chain/sei-cosmos/codec/types"
 	kmultisig "github.com/sei-protocol/sei-chain/sei-cosmos/crypto/keys/multisig"
+	"github.com/sei-protocol/sei-chain/sei-cosmos/crypto/keys/secp256k1"
 	cryptotypes "github.com/sei-protocol/sei-chain/sei-cosmos/crypto/types"
 	storetypes "github.com/sei-protocol/sei-chain/sei-cosmos/store/types"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
@@ -251,47 +252,51 @@ func validatePubKey(pubKey cryptotypes.PubKey) (err error) {
 		}
 	}()
 
-	return validatePubKeyNoPanic(pubKey)
-}
-
-func validatePubKeyNoPanic(pubKey cryptotypes.PubKey) error {
 	switch pk := pubKey.(type) {
 	case nil:
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "missing public key")
 	case *kmultisig.LegacyAminoPubKey:
-		return validateMultisigPubKey(pk)
+		if pk == nil {
+			return sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "missing multisig public key")
+		}
+
+		pubKeys := pk.GetPubKeys()
+		threshold := pk.GetThreshold()
+		if threshold == 0 {
+			return sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "multisig threshold must be positive")
+		}
+		if threshold > uint(len(pubKeys)) {
+			return sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey, "multisig threshold %d exceeds public key count %d", threshold, len(pubKeys))
+		}
+
+		for i, child := range pubKeys {
+			if err := validatePubKey(child); err != nil {
+				return sdkerrors.Wrapf(err, "invalid multisig public key at index %d", i)
+			}
+		}
+
+		if len(pk.Address()) == 0 {
+			return sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "invalid multisig public key")
+		}
+		return nil
+	case *secp256k1.PubKey:
+		if pk == nil {
+			return sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "missing secp256k1 public key")
+		}
+		if len(pk.Key) != secp256k1.PubKeySize {
+			return sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey, "invalid secp256k1 public key size %d", len(pk.Key))
+		}
+		if _, err := btcec.ParsePubKey(pk.Key); err != nil {
+			return sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "invalid secp256k1 public key")
+		}
+		return nil
 	default:
 		if len(pubKey.Address()) == 0 {
 			return sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey, "invalid public key type: %T", pubKey)
 		}
+
 		return nil
 	}
-}
-
-func validateMultisigPubKey(pubKey *kmultisig.LegacyAminoPubKey) error {
-	if pubKey == nil {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "missing multisig public key")
-	}
-
-	pubKeys := pubKey.GetPubKeys()
-	threshold := pubKey.GetThreshold()
-	if threshold == 0 {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "multisig threshold must be positive")
-	}
-	if threshold > uint(len(pubKeys)) {
-		return sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey, "multisig threshold %d exceeds public key count %d", threshold, len(pubKeys))
-	}
-
-	for i, pk := range pubKeys {
-		if err := validatePubKey(pk); err != nil {
-			return sdkerrors.Wrapf(err, "invalid multisig public key at index %d", i)
-		}
-	}
-
-	if len(pubKey.Address()) == 0 {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "invalid multisig public key")
-	}
-	return nil
 }
 
 func SetGasMeter(ctx sdk.Context, gasLimit uint64, paramsKeeper paramskeeper.Keeper) sdk.Context {

--- a/app/ante/cosmos_checktx.go
+++ b/app/ante/cosmos_checktx.go
@@ -37,7 +37,10 @@ import (
 	oracletypes "github.com/sei-protocol/sei-chain/x/oracle/types"
 )
 
-const maxNestedMsgs = 5
+const (
+	maxNestedMsgs    = 5
+	maxNestedPubKeys = 5
+)
 
 var (
 	_ GasTx = (*legacytx.StdTx)(nil) // assert StdTx implements GasTx
@@ -218,7 +221,7 @@ func CosmosStatelessChecks(tx sdk.Tx, height int64, consensusParams *tmproto.Con
 		if pk == nil {
 			continue
 		}
-		if err := validatePubKey(pk, &remainingSigCount); err != nil {
+		if err := validatePubKey(pk, &remainingSigCount, 0); err != nil {
 			return oracleVote, err
 		}
 	}
@@ -253,7 +256,7 @@ func CosmosStatelessChecks(tx sdk.Tx, height int64, consensusParams *tmproto.Con
 	return oracleVote, nil
 }
 
-func validatePubKey(pubKey cryptotypes.PubKey, remainingSigCount *uint64) (err error) {
+func validatePubKey(pubKey cryptotypes.PubKey, remainingSigCount *uint64, depth int) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey, "invalid public key: %v", r)
@@ -266,6 +269,9 @@ func validatePubKey(pubKey cryptotypes.PubKey, remainingSigCount *uint64) (err e
 	case *kmultisig.LegacyAminoPubKey:
 		if pk == nil {
 			return sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "missing multisig public key")
+		}
+		if depth >= maxNestedPubKeys {
+			return sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey, "multisig public key nesting exceeds limit %d", maxNestedPubKeys)
 		}
 
 		pubKeyCount := len(pk.PubKeys)
@@ -288,14 +294,11 @@ func validatePubKey(pubKey cryptotypes.PubKey, remainingSigCount *uint64) (err e
 			if !ok {
 				return sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey, "invalid multisig public key at index %d", i)
 			}
-			if err := validatePubKey(child, remainingSigCount); err != nil {
+			if err := validatePubKey(child, remainingSigCount, depth+1); err != nil {
 				return sdkerrors.Wrapf(err, "invalid multisig public key at index %d", i)
 			}
 		}
 
-		if len(pk.Address()) == 0 {
-			return sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "invalid multisig public key")
-		}
 		return nil
 	case *secp256k1.PubKey:
 		if pk == nil {
@@ -457,7 +460,7 @@ func CheckPubKeys(ctx sdk.Context, tx sdk.Tx, accountKeeper authkeeper.AccountKe
 		// Normal CheckTx/DeliverTx callers already validate provided pubkeys in
 		// CosmosStatelessChecks. Revalidate here as a defensive guard because the
 		// next step persists this pubkey to account state.
-		if err := validatePubKey(pk, nil); err != nil {
+		if err := validatePubKey(pk, nil, 0); err != nil {
 			return nil, err
 		}
 		err = acc.SetPubKey(pk)

--- a/app/ante/cosmos_checktx.go
+++ b/app/ante/cosmos_checktx.go
@@ -211,15 +211,22 @@ func CosmosStatelessChecks(tx sdk.Tx, height int64, consensusParams *tmproto.Con
 	if err != nil {
 		return oracleVote, err
 	}
-	signers := sigTx.GetSigners()
-
-	for i, pk := range pubkeys {
+	// Validate all provided public keys before deriving addresses from them below.
+	for _, pk := range pubkeys {
 		// PublicKey was omitted from slice since it has already been set in context
 		if pk == nil {
 			continue
 		}
 		if err := validatePubKey(pk); err != nil {
 			return oracleVote, err
+		}
+	}
+
+	signers := sigTx.GetSigners()
+	for i, pk := range pubkeys {
+		// PublicKey was omitted from slice since it has already been set in context
+		if pk == nil {
+			continue
 		}
 		if !bytes.Equal(pk.Address(), signers[i]) {
 			return oracleVote, sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey,

--- a/app/ante/cosmos_checktx.go
+++ b/app/ante/cosmos_checktx.go
@@ -77,7 +77,10 @@ func CosmosCheckTxAnte(
 	feegrantKeeper *feegrantkeeper.Keeper,
 	ibcKeeper *ibckeeper.Keeper,
 ) (returnCtx sdk.Context, returnErr error) {
-	authParams := accountKeeper.GetParams(ctx)
+	// Auth params are needed for stateless checks before SetGasMeter installs the
+	// tx meter. Read them on a throwaway meter so this early lookup does not
+	// charge the incoming caller/block meter.
+	authParams := accountKeeper.GetParams(ctx.WithGasMeter(storetypes.NewNoConsumptionInfiniteGasMeter()))
 
 	oracleVote, err := CosmosStatelessChecks(tx, ctx.BlockHeight(), ctx.ConsensusParams(), authParams)
 	if err != nil {
@@ -215,12 +218,15 @@ func CosmosStatelessChecks(tx sdk.Tx, height int64, consensusParams *tmproto.Con
 		return oracleVote, err
 	}
 	// Validate all provided public keys before deriving addresses from them below.
-	remainingSigCount := authParams.TxSigLimit
+	// Keep the recursive work budget local to each pubkey: this bounds a single
+	// multisig tree without changing CheckPubKeys' aggregate TxSigLimit behavior
+	// for pubkeys that are persisted to account state.
 	for _, pk := range pubkeys {
 		// PublicKey was omitted from slice since it has already been set in context
 		if pk == nil {
 			continue
 		}
+		remainingSigCount := authParams.TxSigLimit
 		if err := validatePubKey(pk, &remainingSigCount, 0); err != nil {
 			return oracleVote, err
 		}

--- a/app/ante/cosmos_checktx.go
+++ b/app/ante/cosmos_checktx.go
@@ -431,6 +431,9 @@ func CheckPubKeys(ctx sdk.Context, tx sdk.Tx, accountKeeper authkeeper.AccountKe
 			signerAcounts[i] = acc
 			continue
 		}
+		// Normal CheckTx/DeliverTx callers already validate provided pubkeys in
+		// CosmosStatelessChecks. Revalidate here as a defensive guard because the
+		// next step persists this pubkey to account state.
 		if err := validatePubKey(pk); err != nil {
 			return nil, err
 		}

--- a/app/ante/cosmos_checktx.go
+++ b/app/ante/cosmos_checktx.go
@@ -74,7 +74,9 @@ func CosmosCheckTxAnte(
 	feegrantKeeper *feegrantkeeper.Keeper,
 	ibcKeeper *ibckeeper.Keeper,
 ) (returnCtx sdk.Context, returnErr error) {
-	oracleVote, err := CosmosStatelessChecks(tx, ctx.BlockHeight(), ctx.ConsensusParams())
+	authParams := accountKeeper.GetParams(ctx)
+
+	oracleVote, err := CosmosStatelessChecks(tx, ctx.BlockHeight(), ctx.ConsensusParams(), authParams)
 	if err != nil {
 		return SetGasMeter(ctx, 0, pk), err
 	}
@@ -92,8 +94,6 @@ func CosmosCheckTxAnte(
 	if !isGasless {
 		ctx = SetGasMeter(ctx, tx.(GasTx).GetGas(), pk)
 	}
-
-	authParams := accountKeeper.GetParams(ctx)
 
 	if err := CheckMemoLength(tx, authParams); err != nil {
 		return ctx, err
@@ -136,7 +136,7 @@ func HandleOutofGas(recoveredErr any, gasLimit uint64, gasConsumed uint64) error
 	}
 }
 
-func CosmosStatelessChecks(tx sdk.Tx, height int64, consensusParams *tmproto.ConsensusParams) (
+func CosmosStatelessChecks(tx sdk.Tx, height int64, consensusParams *tmproto.ConsensusParams, authParams authtypes.Params) (
 	isOracleVote bool, err error,
 ) {
 	gasTx, ok := tx.(GasTx)
@@ -212,12 +212,13 @@ func CosmosStatelessChecks(tx sdk.Tx, height int64, consensusParams *tmproto.Con
 		return oracleVote, err
 	}
 	// Validate all provided public keys before deriving addresses from them below.
+	remainingSigCount := authParams.TxSigLimit
 	for _, pk := range pubkeys {
 		// PublicKey was omitted from slice since it has already been set in context
 		if pk == nil {
 			continue
 		}
-		if err := validatePubKey(pk); err != nil {
+		if err := validatePubKey(pk, &remainingSigCount); err != nil {
 			return oracleVote, err
 		}
 	}
@@ -252,7 +253,7 @@ func CosmosStatelessChecks(tx sdk.Tx, height int64, consensusParams *tmproto.Con
 	return oracleVote, nil
 }
 
-func validatePubKey(pubKey cryptotypes.PubKey) (err error) {
+func validatePubKey(pubKey cryptotypes.PubKey, remainingSigCount *uint64) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey, "invalid public key: %v", r)
@@ -267,17 +268,27 @@ func validatePubKey(pubKey cryptotypes.PubKey) (err error) {
 			return sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "missing multisig public key")
 		}
 
-		pubKeys := pk.GetPubKeys()
+		pubKeyCount := len(pk.PubKeys)
 		threshold := pk.GetThreshold()
 		if threshold == 0 {
 			return sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "multisig threshold must be positive")
 		}
-		if threshold > uint(len(pubKeys)) {
-			return sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey, "multisig threshold %d exceeds public key count %d", threshold, len(pubKeys))
+		if threshold > uint(pubKeyCount) {
+			return sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey, "multisig threshold %d exceeds public key count %d", threshold, pubKeyCount)
+		}
+		if remainingSigCount != nil && *remainingSigCount < uint64(pubKeyCount) { //nolint:gosec // pubKeyCount is bounded by tx size and compared to tx sig limit.
+			return sdkerrors.Wrapf(sdkerrors.ErrTooManySignatures, "signatures exceed limit %d", *remainingSigCount)
 		}
 
-		for i, child := range pubKeys {
-			if err := validatePubKey(child); err != nil {
+		for i, packedKey := range pk.PubKeys {
+			if packedKey == nil {
+				return sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey, "missing multisig public key at index %d", i)
+			}
+			child, ok := packedKey.GetCachedValue().(cryptotypes.PubKey)
+			if !ok {
+				return sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey, "invalid multisig public key at index %d", i)
+			}
+			if err := validatePubKey(child, remainingSigCount); err != nil {
 				return sdkerrors.Wrapf(err, "invalid multisig public key at index %d", i)
 			}
 		}
@@ -290,6 +301,12 @@ func validatePubKey(pubKey cryptotypes.PubKey) (err error) {
 		if pk == nil {
 			return sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "missing secp256k1 public key")
 		}
+		if remainingSigCount != nil {
+			if *remainingSigCount == 0 {
+				return sdkerrors.Wrap(sdkerrors.ErrTooManySignatures, "signatures exceed limit")
+			}
+			*remainingSigCount--
+		}
 		if len(pk.Key) != secp256k1.PubKeySize {
 			return sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey, "invalid secp256k1 public key size %d", len(pk.Key))
 		}
@@ -298,6 +315,12 @@ func validatePubKey(pubKey cryptotypes.PubKey) (err error) {
 		}
 		return nil
 	default:
+		if remainingSigCount != nil {
+			if *remainingSigCount == 0 {
+				return sdkerrors.Wrap(sdkerrors.ErrTooManySignatures, "signatures exceed limit")
+			}
+			*remainingSigCount--
+		}
 		if len(pubKey.Address()) == 0 {
 			return sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey, "invalid public key type: %T", pubKey)
 		}
@@ -434,7 +457,7 @@ func CheckPubKeys(ctx sdk.Context, tx sdk.Tx, accountKeeper authkeeper.AccountKe
 		// Normal CheckTx/DeliverTx callers already validate provided pubkeys in
 		// CosmosStatelessChecks. Revalidate here as a defensive guard because the
 		// next step persists this pubkey to account state.
-		if err := validatePubKey(pk); err != nil {
+		if err := validatePubKey(pk, nil); err != nil {
 			return nil, err
 		}
 		err = acc.SetPubKey(pk)

--- a/app/ante/cosmos_delivertx.go
+++ b/app/ante/cosmos_delivertx.go
@@ -24,7 +24,10 @@ func CosmosDeliverTxAnte(
 	bankKeeper bankkeeper.Keeper,
 	feegrantKeeper *feegrantkeeper.Keeper,
 ) (returnCtx sdk.Context, returnErr error) {
-	authParams := accountKeeper.GetParams(ctx)
+	// Auth params are needed for stateless checks before SetGasMeter installs the
+	// tx meter. Read them on a throwaway meter so this early lookup does not
+	// charge the incoming caller/block meter.
+	authParams := accountKeeper.GetParams(ctx.WithGasMeter(storetypes.NewNoConsumptionInfiniteGasMeter()))
 
 	if _, err := CosmosStatelessChecks(tx, ctx.BlockHeight(), ctx.ConsensusParams(), authParams); err != nil {
 		return SetGasMeter(ctx, 0, pk), err

--- a/app/ante/cosmos_delivertx.go
+++ b/app/ante/cosmos_delivertx.go
@@ -24,7 +24,9 @@ func CosmosDeliverTxAnte(
 	bankKeeper bankkeeper.Keeper,
 	feegrantKeeper *feegrantkeeper.Keeper,
 ) (returnCtx sdk.Context, returnErr error) {
-	if _, err := CosmosStatelessChecks(tx, ctx.BlockHeight(), ctx.ConsensusParams()); err != nil {
+	authParams := accountKeeper.GetParams(ctx)
+
+	if _, err := CosmosStatelessChecks(tx, ctx.BlockHeight(), ctx.ConsensusParams(), authParams); err != nil {
 		return SetGasMeter(ctx, 0, pk), err
 	}
 
@@ -41,8 +43,6 @@ func CosmosDeliverTxAnte(
 	if !isGasless {
 		ctx = SetGasMeter(ctx, tx.(GasTx).GetGas(), pk)
 	}
-
-	authParams := accountKeeper.GetParams(ctx)
 
 	if err := CheckMemoLength(tx, authParams); err != nil {
 		return ctx, err

--- a/app/cosmos_checktx_test.go
+++ b/app/cosmos_checktx_test.go
@@ -1,12 +1,17 @@
 package app_test
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
 	"github.com/sei-protocol/sei-chain/app"
 	anteante "github.com/sei-protocol/sei-chain/app/ante"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/client/tx"
+	kmultisig "github.com/sei-protocol/sei-chain/sei-cosmos/crypto/keys/multisig"
+	"github.com/sei-protocol/sei-chain/sei-cosmos/crypto/keys/secp256k1"
+	cryptotypes "github.com/sei-protocol/sei-chain/sei-cosmos/crypto/types"
+	"github.com/sei-protocol/sei-chain/sei-cosmos/crypto/types/multisig"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/testutil/testdata"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/types/tx/signing"
@@ -191,4 +196,78 @@ func TestCheckSignaturesSkipsEventsOnCheckTx(t *testing.T) {
 	events, err = anteante.CheckSignatures(recheckCtx, txConfig, signedTx, signerAccounts, authParams)
 	require.NoError(t, err)
 	require.Empty(t, events, "expected no signature events in ReCheckTx context")
+}
+
+func TestCosmosStatelessChecksRejectsInvalidNestedMultisigKey(t *testing.T) {
+	testApp := app.Setup(t, false, false, false)
+	ctx := testApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "sei-test", Time: time.Now().UTC()})
+	signedTx, _ := buildNestedMultisigTx(t, ctx)
+
+	_, err := anteante.CosmosStatelessChecks(signedTx, ctx.BlockHeight(), ctx.ConsensusParams())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid multisig public key")
+}
+
+func TestCheckPubKeysRejectsInvalidNestedMultisigKey(t *testing.T) {
+	testApp := app.Setup(t, false, false, false)
+	ctx := testApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "sei-test", Time: time.Now().UTC()})
+	signedTx, addr := buildNestedMultisigTx(t, ctx)
+
+	acc := testApp.AccountKeeper.NewAccountWithAddress(ctx, addr)
+	require.NoError(t, acc.SetAccountNumber(0))
+	testApp.AccountKeeper.SetAccount(ctx, acc)
+
+	_, err := anteante.CheckPubKeys(ctx, signedTx, testApp.AccountKeeper, authtypes.DefaultParams())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid multisig public key")
+
+	storedAcc := testApp.AccountKeeper.GetAccount(ctx, addr)
+	require.NotNil(t, storedAcc)
+	require.Nil(t, storedAcc.GetPubKey())
+}
+
+func buildNestedMultisigTx(t *testing.T, ctx sdk.Context) (sdk.Tx, sdk.AccAddress) {
+	t.Helper()
+
+	txConfig := app.MakeEncodingConfig().TxConfig
+	txBuilder := txConfig.NewTxBuilder()
+
+	priv, pubKey, _ := testdata.KeyTestPubAddr()
+	malformedPubKey := &secp256k1.PubKey{Key: bytes.Repeat([]byte{1}, secp256k1.PubKeySize+1)}
+	pubKeys := []cryptotypes.PubKey{pubKey, malformedPubKey}
+	multisigPubKey := kmultisig.NewLegacyAminoPubKey(1, pubKeys)
+	addr := sdk.AccAddress(multisigPubKey.Address())
+
+	require.NoError(t, txBuilder.SetMsgs(testdata.NewTestMsg(addr)))
+	txBuilder.SetFeeAmount(testdata.NewTestFeeAmount())
+	txBuilder.SetGasLimit(testdata.NewTestGasLimit())
+	require.NoError(t, txBuilder.SetSignatures(signing.SignatureV2{
+		PubKey:   multisigPubKey,
+		Data:     multisig.NewMultisig(len(pubKeys)),
+		Sequence: 0,
+	}))
+
+	singleSig, err := tx.SignWithPrivKey(
+		txConfig.SignModeHandler().DefaultMode(),
+		authsigning.SignerData{
+			ChainID:       ctx.ChainID(),
+			AccountNumber: 0,
+			Sequence:      0,
+		},
+		txBuilder,
+		priv,
+		txConfig,
+		0,
+	)
+	require.NoError(t, err)
+
+	multisigSig := multisig.NewMultisig(len(pubKeys))
+	require.NoError(t, multisig.AddSignatureV2(multisigSig, singleSig, pubKeys))
+	require.NoError(t, txBuilder.SetSignatures(signing.SignatureV2{
+		PubKey:   multisigPubKey,
+		Data:     multisigSig,
+		Sequence: 0,
+	}))
+
+	return txBuilder.GetTx(), addr
 }

--- a/app/cosmos_checktx_test.go
+++ b/app/cosmos_checktx_test.go
@@ -199,41 +199,72 @@ func TestCheckSignaturesSkipsEventsOnCheckTx(t *testing.T) {
 }
 
 func TestCosmosStatelessChecksRejectsInvalidNestedMultisigKey(t *testing.T) {
-	testApp := app.Setup(t, false, false, false)
-	ctx := testApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "sei-test", Time: time.Now().UTC()})
-	signedTx, _ := buildNestedMultisigTx(t, ctx)
+	for _, tc := range []struct {
+		name           string
+		malformedChild cryptotypes.PubKey
+	}{
+		{
+			name:           "wrong length secp256k1 child",
+			malformedChild: &secp256k1.PubKey{Key: bytes.Repeat([]byte{1}, secp256k1.PubKeySize+1)},
+		},
+		{
+			name:           "correct length invalid secp256k1 child",
+			malformedChild: &secp256k1.PubKey{Key: append([]byte{0x02}, bytes.Repeat([]byte{0xff}, secp256k1.PubKeySize-1)...)},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testApp := app.Setup(t, false, false, false)
+			ctx := testApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "sei-test", Time: time.Now().UTC()})
+			signedTx, _ := buildNestedMultisigTx(t, ctx, tc.malformedChild)
 
-	_, err := anteante.CosmosStatelessChecks(signedTx, ctx.BlockHeight(), ctx.ConsensusParams())
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid multisig public key")
+			_, err := anteante.CosmosStatelessChecks(signedTx, ctx.BlockHeight(), ctx.ConsensusParams())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid secp256k1 public key")
+		})
+	}
 }
 
 func TestCheckPubKeysRejectsInvalidNestedMultisigKey(t *testing.T) {
-	testApp := app.Setup(t, false, false, false)
-	ctx := testApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "sei-test", Time: time.Now().UTC()})
-	signedTx, addr := buildNestedMultisigTx(t, ctx)
+	for _, tc := range []struct {
+		name           string
+		malformedChild cryptotypes.PubKey
+	}{
+		{
+			name:           "wrong length secp256k1 child",
+			malformedChild: &secp256k1.PubKey{Key: bytes.Repeat([]byte{1}, secp256k1.PubKeySize+1)},
+		},
+		{
+			name:           "correct length invalid secp256k1 child",
+			malformedChild: &secp256k1.PubKey{Key: append([]byte{0x02}, bytes.Repeat([]byte{0xff}, secp256k1.PubKeySize-1)...)},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testApp := app.Setup(t, false, false, false)
+			ctx := testApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "sei-test", Time: time.Now().UTC()})
+			signedTx, addr := buildNestedMultisigTx(t, ctx, tc.malformedChild)
 
-	acc := testApp.AccountKeeper.NewAccountWithAddress(ctx, addr)
-	require.NoError(t, acc.SetAccountNumber(0))
-	testApp.AccountKeeper.SetAccount(ctx, acc)
+			acc := testApp.AccountKeeper.NewAccountWithAddress(ctx, addr)
+			require.NoError(t, acc.SetAccountNumber(0))
+			testApp.AccountKeeper.SetAccount(ctx, acc)
 
-	_, err := anteante.CheckPubKeys(ctx, signedTx, testApp.AccountKeeper, authtypes.DefaultParams())
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid multisig public key")
+			_, err := anteante.CheckPubKeys(ctx, signedTx, testApp.AccountKeeper, authtypes.DefaultParams())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid secp256k1 public key")
 
-	storedAcc := testApp.AccountKeeper.GetAccount(ctx, addr)
-	require.NotNil(t, storedAcc)
-	require.Nil(t, storedAcc.GetPubKey())
+			storedAcc := testApp.AccountKeeper.GetAccount(ctx, addr)
+			require.NotNil(t, storedAcc)
+			require.Nil(t, storedAcc.GetPubKey())
+		})
+	}
 }
 
-func buildNestedMultisigTx(t *testing.T, ctx sdk.Context) (sdk.Tx, sdk.AccAddress) {
+func buildNestedMultisigTx(t *testing.T, ctx sdk.Context, malformedPubKey cryptotypes.PubKey) (sdk.Tx, sdk.AccAddress) {
 	t.Helper()
 
 	txConfig := app.MakeEncodingConfig().TxConfig
 	txBuilder := txConfig.NewTxBuilder()
 
 	priv, pubKey, _ := testdata.KeyTestPubAddr()
-	malformedPubKey := &secp256k1.PubKey{Key: bytes.Repeat([]byte{1}, secp256k1.PubKeySize+1)}
 	pubKeys := []cryptotypes.PubKey{pubKey, malformedPubKey}
 	multisigPubKey := kmultisig.NewLegacyAminoPubKey(1, pubKeys)
 	addr := sdk.AccAddress(multisigPubKey.Address())

--- a/app/cosmos_checktx_test.go
+++ b/app/cosmos_checktx_test.go
@@ -241,6 +241,43 @@ func TestCosmosStatelessChecksRejectsOversizedMultisigBeforePubKeyValidation(t *
 	require.NotContains(t, err.Error(), "invalid secp256k1 public key")
 }
 
+func TestCosmosStatelessChecksDoesNotAggregateTxSigLimitAcrossProvidedPubKeys(t *testing.T) {
+	testApp := app.Setup(t, false, false, false)
+	ctx := testApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "sei-test", Time: time.Now().UTC()})
+	txConfig := app.MakeEncodingConfig().TxConfig
+	txBuilder := txConfig.NewTxBuilder()
+
+	multisigPubKeys := make([]cryptotypes.PubKey, authtypes.DefaultTxSigLimit)
+	for i := range multisigPubKeys {
+		_, pubKey, _ := testdata.KeyTestPubAddr()
+		multisigPubKeys[i] = pubKey
+	}
+	multisigPubKey := kmultisig.NewLegacyAminoPubKey(1, multisigPubKeys)
+	multisigAddr := sdk.AccAddress(multisigPubKey.Address())
+	_, singlePubKey, singleAddr := testdata.KeyTestPubAddr()
+
+	require.NoError(t, txBuilder.SetMsgs(testdata.NewTestMsg(multisigAddr, singleAddr)))
+	txBuilder.SetFeeAmount(testdata.NewTestFeeAmount())
+	txBuilder.SetGasLimit(testdata.NewTestGasLimit())
+	require.NoError(t, txBuilder.SetSignatures(
+		signing.SignatureV2{
+			PubKey:   multisigPubKey,
+			Data:     multisig.NewMultisig(len(multisigPubKeys)),
+			Sequence: 0,
+		},
+		signing.SignatureV2{
+			PubKey: singlePubKey,
+			Data: &signing.SingleSignatureData{
+				SignMode: txConfig.SignModeHandler().DefaultMode(),
+			},
+			Sequence: 0,
+		},
+	))
+
+	_, err := anteante.CosmosStatelessChecks(txBuilder.GetTx(), ctx.BlockHeight(), ctx.ConsensusParams(), authtypes.DefaultParams())
+	require.NoError(t, err)
+}
+
 func TestCosmosStatelessChecksRejectsDeepNestedMultisig(t *testing.T) {
 	testApp := app.Setup(t, false, false, false)
 	ctx := testApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "sei-test", Time: time.Now().UTC()})

--- a/app/cosmos_checktx_test.go
+++ b/app/cosmos_checktx_test.go
@@ -241,6 +241,22 @@ func TestCosmosStatelessChecksRejectsOversizedMultisigBeforePubKeyValidation(t *
 	require.NotContains(t, err.Error(), "invalid secp256k1 public key")
 }
 
+func TestCosmosStatelessChecksRejectsDeepNestedMultisig(t *testing.T) {
+	testApp := app.Setup(t, false, false, false)
+	ctx := testApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "sei-test", Time: time.Now().UTC()})
+
+	_, leafPubKey, _ := testdata.KeyTestPubAddr()
+	nestedPubKey := leafPubKey
+	for i := 0; i < 5; i++ {
+		nestedPubKey = kmultisig.NewLegacyAminoPubKey(1, []cryptotypes.PubKey{nestedPubKey})
+	}
+	signedTx, _ := buildNestedMultisigTx(t, ctx, nestedPubKey)
+
+	_, err := anteante.CosmosStatelessChecks(signedTx, ctx.BlockHeight(), ctx.ConsensusParams(), authtypes.DefaultParams())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "multisig public key nesting exceeds limit")
+}
+
 func TestCheckPubKeysRejectsInvalidNestedMultisigKey(t *testing.T) {
 	for _, tc := range []struct {
 		name           string

--- a/app/cosmos_checktx_test.go
+++ b/app/cosmos_checktx_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/crypto/types/multisig"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/testutil/testdata"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/types/tx/signing"
 	authsigning "github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/signing"
 	authtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/types"
@@ -217,11 +218,27 @@ func TestCosmosStatelessChecksRejectsInvalidNestedMultisigKey(t *testing.T) {
 			ctx := testApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "sei-test", Time: time.Now().UTC()})
 			signedTx, _ := buildNestedMultisigTx(t, ctx, tc.malformedChild)
 
-			_, err := anteante.CosmosStatelessChecks(signedTx, ctx.BlockHeight(), ctx.ConsensusParams())
+			_, err := anteante.CosmosStatelessChecks(signedTx, ctx.BlockHeight(), ctx.ConsensusParams(), authtypes.DefaultParams())
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "invalid secp256k1 public key")
 		})
 	}
+}
+
+func TestCosmosStatelessChecksRejectsOversizedMultisigBeforePubKeyValidation(t *testing.T) {
+	testApp := app.Setup(t, false, false, false)
+	ctx := testApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "sei-test", Time: time.Now().UTC()})
+
+	malformedChildren := make([]cryptotypes.PubKey, authtypes.DefaultTxSigLimit)
+	for i := range malformedChildren {
+		malformedChildren[i] = &secp256k1.PubKey{Key: append([]byte{0x02}, bytes.Repeat([]byte{0xff}, secp256k1.PubKeySize-1)...)}
+	}
+	signedTx, _ := buildNestedMultisigTx(t, ctx, malformedChildren...)
+
+	_, err := anteante.CosmosStatelessChecks(signedTx, ctx.BlockHeight(), ctx.ConsensusParams(), authtypes.DefaultParams())
+	require.Error(t, err)
+	require.ErrorIs(t, err, sdkerrors.ErrTooManySignatures)
+	require.NotContains(t, err.Error(), "invalid secp256k1 public key")
 }
 
 func TestCheckPubKeysRejectsInvalidNestedMultisigKey(t *testing.T) {
@@ -258,14 +275,14 @@ func TestCheckPubKeysRejectsInvalidNestedMultisigKey(t *testing.T) {
 	}
 }
 
-func buildNestedMultisigTx(t *testing.T, ctx sdk.Context, malformedPubKey cryptotypes.PubKey) (sdk.Tx, sdk.AccAddress) {
+func buildNestedMultisigTx(t *testing.T, ctx sdk.Context, malformedPubKeys ...cryptotypes.PubKey) (sdk.Tx, sdk.AccAddress) {
 	t.Helper()
 
 	txConfig := app.MakeEncodingConfig().TxConfig
 	txBuilder := txConfig.NewTxBuilder()
 
 	priv, pubKey, _ := testdata.KeyTestPubAddr()
-	pubKeys := []cryptotypes.PubKey{pubKey, malformedPubKey}
+	pubKeys := append([]cryptotypes.PubKey{pubKey}, malformedPubKeys...)
 	multisigPubKey := kmultisig.NewLegacyAminoPubKey(1, pubKeys)
 	addr := sdk.AccAddress(multisigPubKey.Address())
 

--- a/sei-cosmos/x/auth/ante/sigverify.go
+++ b/sei-cosmos/x/auth/ante/sigverify.go
@@ -198,6 +198,11 @@ func (sgcd SigGasConsumeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simula
 // Verify all signatures for a tx and return an error if any are invalid. Note,
 // the SigVerificationDecorator will not check signatures on ReCheck.
 //
+// NOTE: Deprecated for normal Sei App transaction handling. The active CheckTx
+// and DeliverTx ante logic lives under app/ante/; update that path for App tx
+// validation changes. This decorator remains wired for BaseApp-driven flows and
+// should not be treated as the primary App ante implementation.
+//
 // CONTRACT: Pubkeys are set in context for all signers before this decorator runs
 // CONTRACT: Tx must implement SigVerifiableTx interface
 type SigVerificationDecorator struct {


### PR DESCRIPTION
## Summary
- Add defensive validation for account key metadata before active ante handling persists it.
- Keep invalid account key metadata from being written into account state.
- Add regression coverage for invalid account key metadata in the active app ante path.

## Validation
- `go test ./app -run 'Test(CosmosStatelessChecksRejectsInvalidNestedMultisigKey|CheckPubKeysRejectsInvalidNestedMultisigKey)' -count=1`
- `go test ./app/ante -count=1`
- `gofmt -s -l .`
- `goimports -l app/ante/cosmos_checktx.go app/cosmos_checktx_test.go`

Note: `goimports -l .` reports existing generated files and nested local worktree files unrelated to this branch.