### PR TITLE
fix(distribution): align withdraw-address checks with bank send restrictions

### DIFF
--- a/sei-cosmos/x/distribution/keeper/keeper.go
+++ b/sei-cosmos/x/distribution/keeper/keeper.go
@@ -55,7 +55,12 @@ func NewKeeper(
 
 // SetWithdrawAddr sets a new address that will receive the rewards upon withdrawal
 func (k Keeper) SetWithdrawAddr(ctx sdk.Context, delegatorAddr sdk.AccAddress, withdrawAddr sdk.AccAddress) error {
-	if k.blockedAddrs[withdrawAddr.String()] {
+	// Reject any address the bank keeper would block from receiving funds, not just
+	// the module-account blocklist: BlockedAddr also covers dynamically-derived
+	// addresses such as the EVM coinbase addresses. Rejecting them here prevents a
+	// delegator from parking an unpayable withdraw address that would later make the
+	// force-withdraw in AfterValidatorRemoved panic during EndBlock.
+	if k.blockedAddrs[withdrawAddr.String()] || k.bankKeeper.BlockedAddr(withdrawAddr) {
 		return sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "%s is not allowed to receive external funds", withdrawAddr)
 	}
 
@@ -79,7 +84,15 @@ func (k Keeper) SetWithdrawAddr(ctx sdk.Context, delegatorAddr sdk.AccAddress, w
 }
 
 func (k Keeper) canReceiveWithdrawAddr(ctx sdk.Context, withdrawAddr sdk.AccAddress) bool {
-	return !k.blockedAddrs[withdrawAddr.String()] && k.bankKeeper.CanSendTo(ctx, withdrawAddr)
+	// BlockedAddr mirrors the gate SendCoinsFromModuleToAccount actually enforces:
+	// beyond the module-account blocklist it also rejects dynamically-derived
+	// addresses such as the EVM coinbase addresses (an "evm_coinbase"-prefixed
+	// address), which CanSendTo does not catch. Consulting it here keeps this
+	// predicate in lockstep with the send, so AfterValidatorRemoved never concludes
+	// an address is receivable and then panics on the resulting bank error.
+	return !k.blockedAddrs[withdrawAddr.String()] &&
+		!k.bankKeeper.BlockedAddr(withdrawAddr) &&
+		k.bankKeeper.CanSendTo(ctx, withdrawAddr)
 }
 
 // withdraw rewards from a delegation

--- a/sei-cosmos/x/distribution/keeper/keeper_test.go
+++ b/sei-cosmos/x/distribution/keeper/keeper_test.go
@@ -12,8 +12,17 @@ import (
 	seiapp "github.com/sei-protocol/sei-chain/app"
 	"github.com/sei-protocol/sei-chain/app/apptesting"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	bankkeeper "github.com/sei-protocol/sei-chain/sei-cosmos/x/bank/keeper"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/x/distribution/types"
 )
+
+// coinbaseWithdrawAddr builds an address carrying the reserved "evm_coinbase"
+// prefix that BaseSendKeeper.BlockedAddr rejects. Such an address is not
+// EVM-associated, so CanSendTo still allows it — exactly the gap that let an
+// unpayable withdraw address slip past the distribution checks.
+func coinbaseWithdrawAddr() sdk.AccAddress {
+	return sdk.AccAddress(append(append([]byte{}, bankkeeper.CoinbaseAddressPrefix...), make([]byte, 8)...))
+}
 
 func TestSetWithdrawAddr(t *testing.T) {
 	app := seiapp.Setup(t, false, false, false)
@@ -136,6 +145,75 @@ func TestAfterValidatorRemovedRoutesToCommunityPoolForUnreceivableValidator(t *t
 	require.Equal(t, communityBefore.Add(sdk.NewDec(10)), communityAfter)
 	require.True(t, app.BankKeeper.GetBalance(ctx, castAddr, "usei").IsZero())
 	require.Equal(t, moduleBalanceBefore, app.BankKeeper.GetBalance(ctx, distrAcc.GetAddress(), "usei"))
+}
+
+// TestSetWithdrawAddrRejectsCoinbaseAddress verifies that a withdraw address
+// carrying the reserved "evm_coinbase" prefix is rejected at set time. Such an
+// address passes CanSendTo (it is not EVM-associated) but is blocked by
+// BlockedAddr, so SendCoinsFromModuleToAccount would fail on it. Rejecting it up
+// front prevents a delegator from parking an unpayable withdraw address that would
+// later panic the force-withdraw in AfterValidatorRemoved during EndBlock.
+func TestSetWithdrawAddrRejectsCoinbaseAddress(t *testing.T) {
+	app := seiapp.Setup(t, false, false, false)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+
+	params := app.DistrKeeper.GetParams(ctx)
+	params.WithdrawAddrEnabled = true
+	app.DistrKeeper.SetParams(ctx, params)
+
+	addr := seiapp.AddTestAddrs(app, ctx, 1, sdk.NewInt(1000000000))
+	coinbaseAddr := coinbaseWithdrawAddr()
+
+	// CanSendTo alone would let this address through; BlockedAddr is what catches it.
+	require.True(t, app.BankKeeper.CanSendTo(ctx, coinbaseAddr))
+	require.True(t, app.BankKeeper.BlockedAddr(coinbaseAddr))
+
+	require.Error(t, app.DistrKeeper.SetWithdrawAddr(ctx, addr[0], coinbaseAddr))
+}
+
+// TestAfterValidatorRemovedFallsBackForCoinbaseWithdrawAddr covers a withdraw
+// address with the reserved "evm_coinbase" prefix already parked in the store —
+// e.g. set before SetWithdrawAddr rejected such addresses. The address passes
+// CanSendTo but BlockedAddr rejects it, so SendCoinsFromModuleToAccount would fail.
+// AfterValidatorRemoved runs during EndBlock, so it must not panic: the withdraw
+// resolves back to the receivable operator address instead of attempting — and
+// panicking on — the send.
+func TestAfterValidatorRemovedFallsBackForCoinbaseWithdrawAddr(t *testing.T) {
+	app := seiapp.Setup(t, false, false, false)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+
+	params := app.DistrKeeper.GetParams(ctx)
+	params.WithdrawAddrEnabled = true
+	app.DistrKeeper.SetParams(ctx, params)
+
+	addr := seiapp.AddTestAddrs(app, ctx, 1, sdk.NewInt(1000000000))
+	valAddr := seiapp.ConvertAddrsToValAddrs(addr[:1])[0]
+	valAccAddr := sdk.AccAddress(valAddr)
+
+	// Park a coinbase-prefixed withdraw address via the low-level setter, bypassing
+	// the SetWithdrawAddr guard to mimic pre-existing state.
+	coinbaseAddr := coinbaseWithdrawAddr()
+	app.DistrKeeper.SetDelegatorWithdrawAddr(ctx, valAccAddr, coinbaseAddr)
+
+	// The stored address cannot receive, so the withdraw resolves back to the operator.
+	require.Equal(t, valAccAddr.String(), app.DistrKeeper.GetDelegatorWithdrawAddr(ctx, valAccAddr).String())
+
+	commission := sdk.DecCoins{sdk.NewDecCoin("usei", sdk.NewInt(10))}
+	coins := sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(10)))
+	distrAcc := app.DistrKeeper.GetDistributionAccount(ctx)
+	require.NoError(t, apptesting.FundModuleAccount(app.BankKeeper, ctx, distrAcc.GetName(), coins))
+	app.AccountKeeper.SetModuleAccount(ctx, distrAcc)
+
+	app.DistrKeeper.SetValidatorOutstandingRewards(ctx, valAddr, types.ValidatorOutstandingRewards{Rewards: commission})
+	app.DistrKeeper.SetValidatorAccumulatedCommission(ctx, valAddr, types.ValidatorAccumulatedCommission{Commission: commission})
+
+	balanceBefore := app.BankKeeper.GetBalance(ctx, valAccAddr, "usei")
+	require.NotPanics(t, func() {
+		app.DistrKeeper.Hooks().AfterValidatorRemoved(ctx, sdk.ConsAddress{}, valAddr)
+	})
+	balanceAfter := app.BankKeeper.GetBalance(ctx, valAccAddr, "usei")
+	require.Equal(t, balanceBefore.Amount.Add(sdk.NewInt(10)), balanceAfter.Amount)
+	require.True(t, app.BankKeeper.GetBalance(ctx, coinbaseAddr, "usei").IsZero())
 }
 
 func TestWithdrawValidatorCommission(t *testing.T) {

--- a/sei-cosmos/x/distribution/types/expected_keepers.go
+++ b/sei-cosmos/x/distribution/types/expected_keepers.go
@@ -28,6 +28,7 @@ type BankKeeper interface {
 	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
 	CanSendTo(ctx sdk.Context, recipient sdk.AccAddress) bool
+	BlockedAddr(addr sdk.AccAddress) bool
 }
 
 // StakingKeeper expected staking keeper (noalias)


### PR DESCRIPTION
## Summary

The distribution module decides whether a delegator's withdraw address may receive funds using its local blocked-address set together with `CanSendTo`. Those conditions do not fully match the restrictions the bank keeper enforces when it actually transfers from a module account, so an address accepted by the distribution checks can still be refused by the bank layer at send time.

This change consults the bank keeper's `BlockedAddr` in both places that gate a withdraw address, keeping the receivability decision in lockstep with the actual transfer:

- `SetWithdrawAddr` — rejects such an address up front, consistent with the bank's transfer restrictions.
- `canReceiveWithdrawAddr` — the internal receivability check used by `GetDelegatorWithdrawAddr`, so every reward/commission payout path resolves to an address the bank will accept.

Behavior is otherwise unchanged: when a withdraw address is not receivable, the payout falls back to the delegator, and any residual commission is routed to the community pool as before.

## Testing

- `go test ./sei-cosmos/x/distribution/...` — pass
- Added regression tests for both entry points (the `SetWithdrawAddr` rejection and the `AfterValidatorRemoved` fallback), each verified to fail without the change.
- `gofmt` / `goimports` / `go vet` clean; `go build ./app/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
