### PR TITLE
fix(ante): address association parity across EVM ante paths

### DIFF
--- a/app/ante/evm_checktx.go
+++ b/app/ante/evm_checktx.go
@@ -57,6 +57,12 @@ func EvmCheckTxAnte(
 	if err := AssociateAddress(ctx, ek, evmAddr, seiAddr, seiPubkey); err != nil {
 		return ctx, err
 	}
+	// Mirror the deliver-tx path and pre-associate EIP-7702 authorization authorities so the
+	// mempool's check state matches how the transaction will execute. CheckTx runs on a
+	// throwaway cache (its writes are never committed) and never applies authorizations, so
+	// this cannot itself cause the direct-cast halt; it is here purely for mempool consistency
+	// with EvmDeliverTxAnte.
+	AssociateAuthorizationAuthorities(ctx, ek, etx)
 	if _, err := EvmCheckAndChargeFees(ctx, evmAddr, ek, upgradeKeeper, txData, etx, msg, version, false); err != nil {
 		return ctx, err
 	}
@@ -240,6 +246,41 @@ func AssociateAddress(ctx sdk.Context, ek *evmkeeper.Keeper, evmAddr common.Addr
 		}
 	}
 	return nil
+}
+
+// AssociateAuthorizationAuthorities pre-associates every EIP-7702 SetCode authorization
+// authority in the transaction with its true (pubkey-derived) Sei address before EVM
+// execution installs delegation code for it. Authorities are distinct accounts from the tx
+// sender, so the sender association performed by the caller does not cover them. Without
+// this, SetCode creates a mutable direct-cast EVM->Sei mapping that a later associatePubKey
+// call can remap, orphaning any staking/distribution state created under the direct-cast
+// identity (which can then halt the chain via the distribution validator-removal hook).
+//
+// This is the legacyabci counterpart of x/evm/ante's EVMPreprocessDecorator so both ante
+// paths associate authorities identically. It is best-effort: only authorities whose
+// authorization the EVM will actually apply are pre-associated — helpers.AuthorityToPreAssociate
+// enforces the same chain-id/nonce/account-code checks go-ethereum uses, which also prevents
+// replaying a publicly-visible authorization a user signed for another chain to force-associate
+// them. Each association runs in its own cache context and is only committed on success, so an
+// already-associated, skipped, or failing authority affects only itself and never rejects the
+// transaction (matching go-ethereum, which would still accept it). Non-SetCode transactions
+// carry no authorizations and are a no-op.
+func AssociateAuthorizationAuthorities(ctx sdk.Context, ek *evmkeeper.Keeper, etx *ethtypes.Transaction) {
+	auths := etx.SetCodeAuthorizations()
+	if len(auths) == 0 {
+		return
+	}
+	associateHelper := helpers.NewAssociationHelper(ek, ek.BankKeeper(), ek.AccountKeeper())
+	for _, auth := range auths {
+		evmAddr, seiAddr, pubkey, ok := helpers.AuthorityToPreAssociate(ctx, ek, auth)
+		if !ok {
+			continue
+		}
+		cacheCtx, write := ctx.CacheContext()
+		if err := associateHelper.AssociateAddresses(cacheCtx, seiAddr, evmAddr, pubkey, false); err == nil {
+			write()
+		}
+	}
 }
 
 func EvmCheckAndChargeFees(ctx sdk.Context, sender common.Address, ek *evmkeeper.Keeper, upgradeKeeper *upgradekeeper.Keeper, txData ethtx.TxData, etx *ethtypes.Transaction, msg *evmtypes.MsgEVMTransaction, version derived.SignerVersion, statelessChecks bool) (*state.DBImpl, error) {

--- a/app/ante/evm_delivertx.go
+++ b/app/ante/evm_delivertx.go
@@ -39,6 +39,13 @@ func EvmDeliverTxAnte(
 	if err != nil {
 		return ctx, err
 	}
+	// EIP-7702 authorization authorities are distinct accounts from the tx sender, so the
+	// sender association above does not cover them. Pre-associate each authority the EVM will
+	// apply to its true (pubkey-derived) Sei address before execution installs delegation code,
+	// otherwise SetCode creates a mutable direct-cast mapping that a later associatePubKey can
+	// remap, orphaning staking/distribution state (which can halt the chain via the distribution
+	// validator-removal hook).
+	AssociateAuthorizationAuthorities(ctx, ek, etx)
 	ctx = DecorateNonceCallback(ctx, ek, evmAddr, etx.Nonce())
 	if err := EvmDeliverChargeFees(ctx, ek, upgradeKeeper, txData, etx, msg, version, evmAddr); err != nil {
 		return ctx, err

--- a/app/setcode_authority_test.go
+++ b/app/setcode_authority_test.go
@@ -9,6 +9,7 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/holiman/uint256"
+	"github.com/sei-protocol/sei-chain/app/ante"
 	tmproto "github.com/sei-protocol/sei-chain/sei-tendermint/proto/tendermint/types"
 	"github.com/sei-protocol/sei-chain/utils/helpers"
 	"github.com/stretchr/testify/require"
@@ -93,4 +94,82 @@ func TestSetCodeTxRequiresAuthorityAssociation(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.False(t, a.setCodeTxRequiresAuthorityAssociation(ctx, legacyTx))
+}
+
+// TestAssociateAuthorizationAuthorities verifies the legacyabci ante path (EvmDeliverTxAnte /
+// EvmCheckTxAnte) pre-associates an EIP-7702 authorization authority with its true
+// (pubkey-derived) Sei address before EVM execution, and skips authorities the EVM would not
+// apply — mirroring the EVMPreprocessDecorator root-cause fix so both ante paths behave
+// identically.
+func TestAssociateAuthorizationAuthorities(t *testing.T) {
+	a := Setup(t, false, false, false)
+	ctx := a.NewContext(false, tmproto.Header{Height: 1, ChainID: "sei-test", Time: time.Now()})
+	chainID := a.EvmKeeper.ChainID(ctx)
+
+	victimKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	victimEVM := crypto.PubkeyToAddress(victimKey.PublicKey)
+	_, victimTrueSei, _, err := helpers.GetAddressesFromPubkeyBytes(crypto.FromECDSAPub(&victimKey.PublicKey))
+	require.NoError(t, err)
+
+	// Precondition: the authority is not yet associated.
+	_, associated := a.EvmKeeper.GetEVMAddress(ctx, victimTrueSei)
+	require.False(t, associated)
+
+	auth, err := ethtypes.SignSetCode(victimKey, ethtypes.SetCodeAuthorization{
+		ChainID: *uint256.MustFromBig(chainID),
+		Address: common.HexToAddress("0x000000000000000000000000000000000000c0de"),
+		Nonce:   0,
+	})
+	require.NoError(t, err)
+
+	sponsorKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	to := common.HexToAddress("0x00000000000000000000000000000000000000aa")
+	setCodeTx, err := ethtypes.SignNewTx(sponsorKey, ethtypes.NewPragueSigner(chainID), &ethtypes.SetCodeTx{
+		ChainID:   uint256.MustFromBig(chainID),
+		Nonce:     0,
+		GasTipCap: uint256.NewInt(1),
+		GasFeeCap: uint256.NewInt(1),
+		Gas:       100000,
+		To:        to,
+		Value:     uint256.NewInt(0),
+		AuthList:  []ethtypes.SetCodeAuthorization{auth},
+	})
+	require.NoError(t, err)
+
+	// A matching-chain authority is associated to its true (pubkey-derived) Sei address, so a
+	// subsequent SetCode cannot create a mutable direct-cast mapping for it.
+	ante.AssociateAuthorizationAuthorities(ctx, &a.EvmKeeper, setCodeTx)
+	gotEVM, associated := a.EvmKeeper.GetEVMAddress(ctx, victimTrueSei)
+	require.True(t, associated)
+	require.Equal(t, victimEVM, gotEVM)
+
+	// An authority signed for a FOREIGN chain must NOT be associated: the EVM skips the
+	// wrong-chain authorization, so no direct-cast mapping is ever created for it and a
+	// public cross-chain authorization cannot be replayed to force-associate the victim.
+	foreignVictimKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	_, foreignVictimTrueSei, _, err := helpers.GetAddressesFromPubkeyBytes(crypto.FromECDSAPub(&foreignVictimKey.PublicKey))
+	require.NoError(t, err)
+	foreignAuth, err := ethtypes.SignSetCode(foreignVictimKey, ethtypes.SetCodeAuthorization{
+		ChainID: *uint256.MustFromBig(new(big.Int).Add(chainID, big.NewInt(1))),
+		Address: common.HexToAddress("0x000000000000000000000000000000000000c0de"),
+		Nonce:   0,
+	})
+	require.NoError(t, err)
+	foreignTx, err := ethtypes.SignNewTx(sponsorKey, ethtypes.NewPragueSigner(chainID), &ethtypes.SetCodeTx{
+		ChainID:   uint256.MustFromBig(chainID),
+		Nonce:     1,
+		GasTipCap: uint256.NewInt(1),
+		GasFeeCap: uint256.NewInt(1),
+		Gas:       100000,
+		To:        to,
+		Value:     uint256.NewInt(0),
+		AuthList:  []ethtypes.SetCodeAuthorization{foreignAuth},
+	})
+	require.NoError(t, err)
+	ante.AssociateAuthorizationAuthorities(ctx, &a.EvmKeeper, foreignTx)
+	_, associated = a.EvmKeeper.GetEVMAddress(ctx, foreignVictimTrueSei)
+	require.False(t, associated)
 }


### PR DESCRIPTION
## Summary

Follow-up to #3716, aligning EVM address-association handling between the two ante paths:

- The `EVMPreprocessDecorator` path already pre-associates EIP-7702 `SetCode` authorization authorities (not just the tx sender) before execution.
- The legacyabci path (`EvmDeliverTxAnte` / `EvmCheckTxAnte`) previously associated only the sender.

This adds `ante.AssociateAuthorizationAuthorities`, invoked from `EvmDeliverTxAnte` (after sender association, before fee-charging / execution) and mirrored in `EvmCheckTxAnte`. It reuses the existing `helpers.AuthorityToPreAssociate` validation, so both paths associate an identical set of addresses.

## Notes

- **State-machine-breaking**: the two ante paths must behave identically, so this should be released together with #3716 in the same coordinated upgrade.
- `EvmCheckTxAnte` runs on a throwaway cache and does not apply authorizations — its call is purely for mempool-state consistency with the deliver path.

## Testing

- `GOWORK=off go test ./app/ -run 'TestAssociateAuthorizationAuthorities|TestSetCodeTxRequiresAuthorityAssociation'` — pass
- `GOWORK=off go test -race ./app/ante/...` — pass
- Added `TestAssociateAuthorizationAuthorities` (matching-chain authority associated; foreign-chain authority skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
