### PR TITLE
Close merkle suite store during teardown

### DIFF
--- a/sei-ibc-go/modules/core/23-commitment/types/commitment_test.go
+++ b/sei-ibc-go/modules/core/23-commitment/types/commitment_test.go
@@ -36,6 +36,10 @@ func (suite *MerkleTestSuite) SetupTest() {
 	suite.iavlStore = suite.store.GetCommitKVStore(suite.storeKey)
 }
 
+func (suite *MerkleTestSuite) TearDownTest() {
+	suite.Require().NoError(suite.store.Close())
+}
+
 func TestMerkleTestSuite(t *testing.T) {
 	suite.Run(t, new(MerkleTestSuite))
 }


### PR DESCRIPTION
The MerkleTestSuite creates a rootmulti store in a test TempDir but never closes it. The store owns a hash-logger background goroutine, which may still create files in data/hash.log while t.TempDir cleanup is removing that directory.

This intermittently fails TestConvertProofs with: `TempDir RemoveAll cleanup: .../data/hash.log: directory not empty`

Close the store in TearDownTest so its state-commit store and hash logger shut down before the per-test temporary directory is removed.

Flaked on [main](https://github.com/sei-protocol/sei-chain/actions/runs/29916089590/job/88910158834)
