### PR TITLE
fix(evmrpc): resolve earliest/block 0 to genesis, not tip, when state store disabled

### DIFF
--- a/evmrpc/watermark_manager.go
+++ b/evmrpc/watermark_manager.go
@@ -61,7 +61,10 @@ func (m *WatermarkManager) Watermarks(ctx context.Context) (int64, int64, int64,
 	)
 
 	// State store heights (historical state DB) may lag behind block pruning.
-	stateEarliest := latest // no historical storage => just the current state.
+	// With SS disabled the versioned commit store still serves history back to
+	// the earliest retained block, so the earliest queryable state height is
+	// blockEarliest, not the tip (SEI-10383).
+	stateEarliest := blockEarliest
 	if m.stateStore != nil {
 		latest = min(latest, m.stateStore.GetLatestVersion())
 		stateEarliest = m.stateStore.GetEarliestVersion()

--- a/evmrpc/watermark_manager_test.go
+++ b/evmrpc/watermark_manager_test.go
@@ -55,8 +55,41 @@ func TestWatermarksIncludesCtxProviderHeight(t *testing.T) {
 	blockEarliest, stateEarliest, latest, err := wm.Watermarks(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, int64(5), blockEarliest)
-	require.Equal(t, int64(12), stateEarliest)
+	// SS disabled: earliest queryable state height is the earliest block, not the tip (SEI-10383).
+	require.Equal(t, int64(5), stateEarliest)
 	require.Equal(t, int64(12), latest)
+}
+
+// TestResolveEarliestServesGenesisWhenStateStoreDisabled is the regression test
+// for SEI-10383: on a state-store-disabled node the `earliest` tag (and block 0,
+// which is the same rpc.BlockNumber) must resolve to the earliest available
+// block, not the chain tip. Before the fix stateEarliest defaulted to `latest`,
+// so eth_getCode / eth_getTransactionCount at `earliest` read current state
+// instead of historical.
+func TestResolveEarliestServesGenesisWhenStateStoreDisabled(t *testing.T) {
+	tmClient := &fakeTMClient{
+		status: &coretypes.ResultStatus{SyncInfo: coretypes.SyncInfo{LatestBlockHeight: 10, EarliestBlockHeight: 1}},
+	}
+	// nil stateStore = SS disabled; history is still served by the versioned commit store.
+	wm := newTestWatermarkManager(tmClient, 10, nil, 10)
+
+	blockEarliest, stateEarliest, latest, err := wm.Watermarks(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), blockEarliest)
+	require.Equal(t, int64(1), stateEarliest, "SS-disabled earliest state height must be the earliest block, not the tip")
+	require.Equal(t, int64(10), latest)
+
+	// `earliest` resolves through the same path eth_getCode/eth_getTransactionCount use.
+	earliest := rpc.EarliestBlockNumber
+	h, err := wm.ResolveHeight(context.Background(), rpc.BlockNumberOrHash{BlockNumber: &earliest})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), h, "earliest must resolve to the earliest block so historical reads see historical state")
+
+	// Numeric block 0 is the same rpc.BlockNumber as the earliest tag and must resolve identically.
+	zero := rpc.BlockNumber(0)
+	h0, err := wm.ResolveHeight(context.Background(), rpc.BlockNumberOrHash{BlockNumber: &zero})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), h0)
 }
 
 func TestWatermarksPropagatesHeightSourceError(t *testing.T) {


### PR DESCRIPTION
## What

On a state-store-disabled RPC node, `eth_getCode` / `eth_getTransactionCount` at the `earliest` tag (and block `0`) return **latest** state instead of historical:
- `eth_getCode(contract, 'earliest'|0)` returns the deployed bytecode; expected `0x` (contract absent at genesis).
- `eth_getTransactionCount(addr, 'earliest')` returns the current nonce; expected `0`.

Root cause: in `evmrpc/watermark_manager.go`, `Watermarks()` defaulted `stateEarliest := latest` and only overrode it when `m.stateStore != nil`. With SS disabled, `stateEarliest` stayed at the tip, and `ResolveHeight`'s `case rpc.EarliestBlockNumber: return stateEarliest` (block 0 and `earliest` are the same `rpc.BlockNumber`) resolved historical reads to the chain head. Regressed in #3739; the earliest branch itself is unchanged across that commit, so the defect is entirely the default.

## Fix

Default `stateEarliest` to `blockEarliest`. The versioned commit store still serves history back to the earliest retained block when SS is disabled, so the earliest queryable state height is the earliest block, not the tip. This restores the pre-#3739 behavior.

## Test

Adds `TestResolveEarliestServesGenesisWhenStateStoreDisabled`, which drives the same `ResolveHeight('earliest')` path the RPC handlers use and asserts it resolves to the earliest block (not the tip) with `stateStore == nil`. Verified it fails on the pre-fix default (`stateEarliest = latest` → resolves to 10) and passes with the fix (→ 1). Also corrects `TestWatermarksIncludesCtxProviderHeight`, whose `stateEarliest` assertion had encoded the regressed value.

## Open question (does not block this fix)

For a full-history node `blockEarliest` (genesis) is correct. On a node that prunes its state-commit versions, the earliest *servable* state height is the SC prune floor, which can be above `blockEarliest`. The precise semantic — advertise genesis vs the SC prune floor for an SS-disabled node — is worth settling for indexers/agents that query by `earliest`; this PR restores the prior correct-for-full-history behavior in the meantime. Tracked in SEI-10383.

## Blast radius

State-store-disabled RPC nodes only. Nodes with SS enabled (the evm-ss-split default) compute `stateEarliest` from `GetEarliestVersion()` and are unaffected. The exposed configuration is the autobahn/evm-only node (the config #3739 was written to support) and the nightly release-test node (memiavl-only state commitment, SS at image default), where the nightly harness surfaced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)