### PR TITLE
feat(seidb-bench): op-type sweep for insert/update/delete storage cost

### DIFF
--- a/sei-db/state_db/bench/opsweep.go
+++ b/sei-db/state_db/bench/opsweep.go
@@ -1,0 +1,179 @@
+package bench
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"sort"
+)
+
+// This file builds controlled write sets that isolate a single write
+// operation (insert / update / delete) so the replay benchmark can measure
+// the per-op storage cost asymmetry — the empirical input to the
+// insert-vs-update-vs-delete pricing question (Jeremy's new-key premium, the
+// delete-refund idea). v1 scope is the EVM storage key family; the generator
+// takes a key family so account/code can be added without shape changes.
+
+// OpKind is the write operation whose cost a generated write set isolates.
+type OpKind string
+
+const (
+	// OpInsert writes keys that do not already exist (fresh slots).
+	OpInsert OpKind = "insert"
+	// OpUpdate overwrites keys that already exist (a warm-up block seeds them).
+	OpUpdate OpKind = "update"
+	// OpDelete deletes keys that already exist (a warm-up block seeds them).
+	OpDelete OpKind = "delete"
+)
+
+// OpSweepSpec describes one controlled scenario.
+type OpSweepSpec struct {
+	Op OpKind
+	// KeyKind is the write-set entry kind (WriteKindStorage/Code/... ). v1 uses
+	// storage; the generator only supports fixed-shape families here.
+	KeyKind string
+	// ValueBytes is the value width for non-delete writes. For storage/codehash
+	// it must be 32; for nonce, 8. Ignored for deletes.
+	ValueBytes int
+	// KeysPerBlock is the number of writes committed together in each block.
+	KeysPerBlock int
+	// TimedBlocks is the number of measured blocks (samples in the distribution).
+	TimedBlocks int
+}
+
+// keyIndexStride keeps generated addresses/slots from colliding across blocks
+// and scenarios: each write gets a globally unique index.
+type keyCursor struct{ next uint64 }
+
+func (c *keyCursor) take() uint64 {
+	i := c.next
+	c.next++
+	return i
+}
+
+// GenerateOpWriteSet builds a write set that isolates spec.Op, plus the number
+// of leading warm-up (untimed) blocks the caller must pass to
+// ReplayWriteSetSampled.
+//
+//   - insert: TimedBlocks blocks of fresh keys, no warm-up (warmup=0).
+//   - update: one warm-up block writing every key the timed blocks will
+//     overwrite, then TimedBlocks blocks overwriting those same keys.
+//   - delete: one warm-up block writing every key, then TimedBlocks blocks
+//     deleting them.
+//
+// For update/delete the warm-up block is a single block containing all
+// TimedBlocks*KeysPerBlock keys; each timed block then re-touches its own
+// KeysPerBlock-sized slice of them, so a timed block operates entirely on
+// pre-existing keys.
+func GenerateOpWriteSet(spec OpSweepSpec) (*WriteSet, int, error) {
+	if spec.KeysPerBlock <= 0 || spec.TimedBlocks <= 0 {
+		return nil, 0, fmt.Errorf("keys-per-block and timed-blocks must be positive")
+	}
+	if spec.KeyKind != WriteKindStorage {
+		return nil, 0, fmt.Errorf("op sweep v1 supports only %q keys, got %q", WriteKindStorage, spec.KeyKind)
+	}
+	if want := valueLenForKind(spec.KeyKind); want > 0 && spec.ValueBytes != want {
+		return nil, 0, fmt.Errorf("%s value must be %d bytes, got %d", spec.KeyKind, want, spec.ValueBytes)
+	}
+
+	total := spec.KeysPerBlock * spec.TimedBlocks
+	cursor := &keyCursor{}
+
+	// Pre-generate the (address, slot) pairs the timed blocks will touch so
+	// update/delete can seed exactly those keys in the warm-up block.
+	type slotKey struct{ addr, slot string }
+	touched := make([]slotKey, total)
+	for i := range touched {
+		idx := cursor.take()
+		touched[i] = slotKey{addr: deterministicAddr(idx), slot: deterministicSlot(idx)}
+	}
+
+	value := hex.EncodeToString(make([]byte, spec.ValueBytes))
+
+	mkWrite := func(k slotKey, del bool) WriteSetEntry {
+		e := WriteSetEntry{Kind: WriteKindStorage, Address: k.addr, Slot: k.slot, Delete: del}
+		if !del {
+			e.Value = value
+		}
+		return e
+	}
+
+	var blocks []WriteSetBlock
+	warmup := 0
+
+	if spec.Op == OpUpdate || spec.Op == OpDelete {
+		// One warm-up block seeds every key the timed blocks operate on.
+		seed := make([]WriteSetEntry, total)
+		for i, k := range touched {
+			seed[i] = mkWrite(k, false)
+		}
+		blocks = append(blocks, WriteSetBlock{Writes: seed})
+		warmup = 1
+	}
+
+	for b := 0; b < spec.TimedBlocks; b++ {
+		writes := make([]WriteSetEntry, spec.KeysPerBlock)
+		for j := 0; j < spec.KeysPerBlock; j++ {
+			k := touched[b*spec.KeysPerBlock+j]
+			switch spec.Op {
+			case OpInsert, OpUpdate:
+				writes[j] = mkWrite(k, false)
+			case OpDelete:
+				writes[j] = mkWrite(k, true)
+			default:
+				return nil, 0, fmt.Errorf("unknown op %q", spec.Op)
+			}
+		}
+		blocks = append(blocks, WriteSetBlock{Writes: writes})
+	}
+
+	ws := &WriteSet{Module: "evm", Blocks: blocks}
+	if err := ws.Validate(); err != nil {
+		return nil, 0, fmt.Errorf("generated write set invalid: %w", err)
+	}
+	return ws, warmup, nil
+}
+
+// deterministicAddr derives a stable 20-byte EVM address hex from an index.
+func deterministicAddr(idx uint64) string {
+	var in [9]byte
+	binary.LittleEndian.PutUint64(in[1:], idx)
+	sum := sha256.Sum256(in[:])
+	return hex.EncodeToString(sum[:20])
+}
+
+// deterministicSlot derives a stable 32-byte slot hex from an index.
+func deterministicSlot(idx uint64) string {
+	var in [9]byte
+	in[0] = 1
+	binary.LittleEndian.PutUint64(in[1:], idx)
+	sum := sha256.Sum256(in[:])
+	return hex.EncodeToString(sum[:])
+}
+
+// percentile returns the q-quantile (0..1) of samples using nearest-rank on a
+// sorted copy. Returns 0 for an empty input.
+func percentile(samples []float64, q float64) float64 {
+	if len(samples) == 0 {
+		return 0
+	}
+	sorted := make([]float64, len(samples))
+	copy(sorted, samples)
+	sort.Float64s(sorted)
+	if q <= 0 {
+		return sorted[0]
+	}
+	if q >= 1 {
+		return sorted[len(sorted)-1]
+	}
+	rank := int(math.Ceil(q*float64(len(sorted)))) - 1
+	if rank < 0 {
+		rank = 0
+	}
+	if rank >= len(sorted) {
+		rank = len(sorted) - 1
+	}
+	return sorted[rank]
+}

--- a/sei-db/state_db/bench/opsweep_test.go
+++ b/sei-db/state_db/bench/opsweep_test.go
@@ -1,0 +1,185 @@
+package bench
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sei-protocol/sei-chain/sei-db/state_db/bench/wrappers"
+)
+
+func TestGenerateOpWriteSetShapes(t *testing.T) {
+	const kpb, blocks = 4, 3
+
+	t.Run("insert has no warmup", func(t *testing.T) {
+		ws, warmup, err := GenerateOpWriteSet(OpSweepSpec{
+			Op: OpInsert, KeyKind: WriteKindStorage, ValueBytes: 32,
+			KeysPerBlock: kpb, TimedBlocks: blocks,
+		})
+		require.NoError(t, err)
+		require.Equal(t, 0, warmup)
+		require.Len(t, ws.Blocks, blocks)
+		for _, blk := range ws.Blocks {
+			require.Len(t, blk.Writes, kpb)
+			for _, w := range blk.Writes {
+				require.False(t, w.Delete)
+			}
+		}
+	})
+
+	t.Run("update seeds then overwrites the same keys", func(t *testing.T) {
+		ws, warmup, err := GenerateOpWriteSet(OpSweepSpec{
+			Op: OpUpdate, KeyKind: WriteKindStorage, ValueBytes: 32,
+			KeysPerBlock: kpb, TimedBlocks: blocks,
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, warmup)
+		require.Len(t, ws.Blocks, blocks+1)
+		require.Len(t, ws.Blocks[0].Writes, kpb*blocks, "warm-up seeds every timed key")
+
+		// Every timed-block key must appear in the warm-up block (overwrite,
+		// not insert).
+		seeded := map[string]bool{}
+		for _, w := range ws.Blocks[0].Writes {
+			seeded[w.Address+"/"+w.Slot] = true
+			require.False(t, w.Delete)
+		}
+		for _, blk := range ws.Blocks[1:] {
+			for _, w := range blk.Writes {
+				require.True(t, seeded[w.Address+"/"+w.Slot], "timed key must be pre-seeded")
+				require.False(t, w.Delete)
+			}
+		}
+	})
+
+	t.Run("delete seeds then deletes", func(t *testing.T) {
+		ws, warmup, err := GenerateOpWriteSet(OpSweepSpec{
+			Op: OpDelete, KeyKind: WriteKindStorage, ValueBytes: 32,
+			KeysPerBlock: kpb, TimedBlocks: blocks,
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, warmup)
+		for _, blk := range ws.Blocks[1:] {
+			for _, w := range blk.Writes {
+				require.True(t, w.Delete)
+			}
+		}
+	})
+}
+
+func TestReplayWriteSetSampledSkipsWarmup(t *testing.T) {
+	ws, warmup, err := GenerateOpWriteSet(OpSweepSpec{
+		Op: OpUpdate, KeyKind: WriteKindStorage, ValueBytes: 32,
+		KeysPerBlock: 8, TimedBlocks: 5,
+	})
+	require.NoError(t, err)
+
+	for _, backend := range []wrappers.DBType{wrappers.MemIAVL, wrappers.FlatKV} {
+		t.Run(string(backend), func(t *testing.T) {
+			wrapper, err := OpenReplayWrapper(t.Context(), backend, t.TempDir())
+			require.NoError(t, err)
+			defer func() { require.NoError(t, wrapper.Close()) }()
+
+			samples, err := ReplayWriteSetSampled(wrapper, ws, warmup)
+			require.NoError(t, err)
+			require.Len(t, samples.ApplyNs, 5, "one sample per timed block, warm-up excluded")
+			require.Len(t, samples.CommitNs, 5)
+			require.Equal(t, 8, samples.KeysPerBlock)
+			for _, ns := range samples.CommitNs {
+				require.Positive(t, ns)
+			}
+		})
+	}
+}
+
+func TestPercentile(t *testing.T) {
+	s := []float64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100}
+	require.InDelta(t, 50, percentile(s, 0.5), 10)
+	require.Equal(t, 100.0, percentile(s, 0.99))
+	require.Equal(t, 10.0, percentile(s, 0.0))
+	require.Zero(t, percentile(nil, 0.5))
+}
+
+// TestOpTypeSweep runs the full insert/update/delete grid on both backends and
+// writes a CSV of per-key apply/commit percentiles. It is skipped unless
+// OP_SWEEP_CSV names an output path, so it never runs in CI. Tune the grid with
+// OP_SWEEP_KEYS_PER_BLOCK and OP_SWEEP_BLOCKS.
+//
+// This variant runs on an empty temp DB, so it measures the relative op
+// asymmetry only. For mainnet-sized absolute cost, run it against a copy of a
+// real data directory on the cluster (a follow-up wires OpenReplayWrapper to
+// the real memiavl/flatkv paths); the empty-DB numbers understate memiavl cost
+// because the tree is shallow.
+func TestOpTypeSweep(t *testing.T) {
+	csvPath := os.Getenv("OP_SWEEP_CSV")
+	if csvPath == "" {
+		t.Skip("set OP_SWEEP_CSV=/path/out.csv to run the op-type sweep")
+	}
+	keysPerBlock := envInt("OP_SWEEP_KEYS_PER_BLOCK", 100)
+	blocks := envInt("OP_SWEEP_BLOCKS", 50)
+
+	f, err := os.Create(csvPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, f.Close()) }()
+	w := csv.NewWriter(f)
+	defer w.Flush()
+	require.NoError(t, w.Write([]string{
+		"backend", "op", "key_kind", "value_bytes", "keys_per_block", "timed_blocks",
+		"apply_p50_ns_per_key", "apply_p99_ns_per_key",
+		"commit_p50_ns_per_key", "commit_p99_ns_per_key",
+	}))
+
+	backends := []wrappers.DBType{wrappers.MemIAVL, wrappers.FlatKV}
+	ops := []OpKind{OpInsert, OpUpdate, OpDelete}
+	for _, backend := range backends {
+		for _, op := range ops {
+			spec := OpSweepSpec{
+				Op: op, KeyKind: WriteKindStorage, ValueBytes: 32,
+				KeysPerBlock: keysPerBlock, TimedBlocks: blocks,
+			}
+			ws, warmup, err := GenerateOpWriteSet(spec)
+			require.NoError(t, err)
+
+			wrapper, err := OpenReplayWrapper(t.Context(), backend, t.TempDir())
+			require.NoError(t, err)
+			samples, err := ReplayWriteSetSampled(wrapper, ws, warmup)
+			require.NoError(t, wrapper.Close())
+			require.NoError(t, err)
+
+			kpb := float64(samples.KeysPerBlock)
+			row := []string{
+				string(backend), string(op), spec.KeyKind, strconv.Itoa(spec.ValueBytes),
+				strconv.Itoa(keysPerBlock), strconv.Itoa(blocks),
+				perKey(percentile(samples.ApplyNs, 0.5), kpb),
+				perKey(percentile(samples.ApplyNs, 0.99), kpb),
+				perKey(percentile(samples.CommitNs, 0.5), kpb),
+				perKey(percentile(samples.CommitNs, 0.99), kpb),
+			}
+			require.NoError(t, w.Write(row))
+			fmt.Printf("[OpSweep] %s %s: commit p50=%.0f ns/key p99=%.0f ns/key\n",
+				backend, op,
+				percentile(samples.CommitNs, 0.5)/kpb, percentile(samples.CommitNs, 0.99)/kpb)
+		}
+	}
+	fmt.Printf("[OpSweep] wrote %s\n", csvPath)
+}
+
+func perKey(blockNs, keysPerBlock float64) string {
+	if keysPerBlock == 0 {
+		return "0"
+	}
+	return strconv.FormatFloat(blockNs/keysPerBlock, 'f', 2, 64)
+}
+
+func envInt(name string, def int) int {
+	if v := os.Getenv(name); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}

--- a/sei-db/state_db/bench/opsweep_test.go
+++ b/sei-db/state_db/bench/opsweep_test.go
@@ -144,7 +144,24 @@ func TestOpTypeSweep(t *testing.T) {
 			ws, warmup, err := GenerateOpWriteSet(spec)
 			require.NoError(t, err)
 
-			wrapper, err := OpenReplayWrapper(t.Context(), backend, t.TempDir())
+			// Real-dir opening: memiavl wants the node HOME (it resolves the
+			// SC path internally), FlatKV wants the flatkv directory itself.
+			// Point these at a COPY of a real data dir for mainnet-sized
+			// absolute cost; unset falls back to an empty temp DB (relative
+			// asymmetry only).
+			dir := t.TempDir()
+			switch backend {
+			case wrappers.MemIAVL:
+				if h := os.Getenv("OP_SWEEP_MEMIAVL_HOME"); h != "" {
+					dir = h
+				}
+			case wrappers.FlatKV:
+				if d := os.Getenv("OP_SWEEP_FLATKV_DIR"); d != "" {
+					dir = d
+				}
+			}
+
+			wrapper, err := OpenReplayWrapper(t.Context(), backend, dir)
 			require.NoError(t, err)
 			samples, err := ReplayWriteSetSampled(wrapper, ws, warmup)
 			require.NoError(t, wrapper.Close())

--- a/sei-db/state_db/bench/writeset.go
+++ b/sei-db/state_db/bench/writeset.go
@@ -278,3 +278,65 @@ func ReplayWriteSet(wrapper wrappers.DBWrapper, ws *WriteSet) (ReplayResult, err
 	}
 	return result, nil
 }
+
+// ReplaySamples holds per-block apply/commit latencies from a sampled replay,
+// so callers can compute distributions (p50/p95/p99) rather than a single mean.
+// Warm-up blocks are applied and committed to build state but are not sampled.
+type ReplaySamples struct {
+	// KeysPerBlock is the number of writes in each sampled block. Percentile
+	// helpers divide the per-block latency by this to get per-key figures.
+	KeysPerBlock int
+	// ApplyNs and CommitNs hold one sample per timed (non-warmup) block.
+	ApplyNs  []float64
+	CommitNs []float64
+}
+
+// ReplayWriteSetSampled replays the write set one block per version, applying
+// and committing every block but recording apply/commit latency only for
+// blocks at index >= warmupBlocks. Warm-up blocks let insert/update/delete
+// scenarios establish the pre-state (e.g. write keys before overwriting or
+// deleting them) without polluting the measured samples. Replay starts at
+// wrapper.Version()+1, so it composes with an existing (snapshot- or
+// real-dir-backed) base version.
+func ReplayWriteSetSampled(wrapper wrappers.DBWrapper, ws *WriteSet, warmupBlocks int) (ReplaySamples, error) {
+	samples := ReplaySamples{}
+	timed := len(ws.Blocks) - warmupBlocks
+	if timed > 0 {
+		samples.ApplyNs = make([]float64, 0, timed)
+		samples.CommitNs = make([]float64, 0, timed)
+	}
+	baseVersion := wrapper.Version()
+	for i := range ws.Blocks {
+		changesets, err := ws.BlockChangesets(i)
+		if err != nil {
+			return samples, err
+		}
+		entry := &proto.ChangelogEntry{
+			Version:    baseVersion + int64(i) + 1,
+			Changesets: changesets,
+		}
+
+		applyStart := time.Now()
+		if err := wrapper.ApplyChangeSets(entry); err != nil {
+			return samples, fmt.Errorf("apply block %d: %w", i, err)
+		}
+		applyNs := float64(time.Since(applyStart).Nanoseconds())
+
+		commitStart := time.Now()
+		if _, err := wrapper.Commit(); err != nil {
+			return samples, fmt.Errorf("commit block %d: %w", i, err)
+		}
+		commitNs := float64(time.Since(commitStart).Nanoseconds())
+
+		if i >= warmupBlocks {
+			// Timed blocks are uniform in the sweep generator, so record the
+			// per-block key count once from the first sampled block.
+			if len(samples.ApplyNs) == 0 {
+				samples.KeysPerBlock = len(ws.Blocks[i].Writes)
+			}
+			samples.ApplyNs = append(samples.ApplyNs, applyNs)
+			samples.CommitNs = append(samples.CommitNs, commitNs)
+		}
+	}
+	return samples, nil
+}


### PR DESCRIPTION
## Summary
Measurement substrate for the insert-vs-update-vs-delete storage-cost question raised in the gas-repricing discussion (Jeremy's new-key premium, the delete-refund idea). Builds on the write-set replay adapter (#3772).

- **`ReplayWriteSetSampled`** — applies+commits every block but times only blocks past a warm-up prefix, capturing one apply/commit sample per timed block so callers get p50/p95/p99 instead of a single mean.
- **`GenerateOpWriteSet`** — builds `insert`/`update`/`delete` scenarios over deterministic EVM storage keys. `update`/`delete` seed the exact keys in a warm-up (untimed) block so a timed block operates entirely on pre-existing keys; `insert` writes fresh keys.
- **`TestOpTypeSweep`** — env-gated (`OP_SWEEP_CSV`), skipped in CI; runs the grid on memiavl and FlatKV and writes a CSV of per-key apply/commit percentiles. Grid tunable via `OP_SWEEP_KEYS_PER_BLOCK` / `OP_SWEEP_BLOCKS`.

## Scope / caveats
- Empty-DB runs measure the **relative** op asymmetry only. **Absolute** (gas-calibration) numbers require running against a copy of a mainnet-sized data directory — a cluster-side follow-up (wiring the opener to the real memiavl/flatkv paths).
- memiavl uses the synchronous-WAL replay config (from #3772's `OpenReplayWrapper`) so commit timings are comparable to FlatKV.

## Test plan
- [x] `go test ./sei-db/state_db/bench -run 'TestGenerateOpWriteSetShapes|TestReplayWriteSetSampledSkipsWarmup|TestPercentile'`
- [x] end-to-end sweep: `OP_SWEEP_CSV=/tmp/opsweep.csv OP_SWEEP_KEYS_PER_BLOCK=50 OP_SWEEP_BLOCKS=10 go test ... -run TestOpTypeSweep` produces a valid CSV on both backends
- [x] `gofmt -s` / `goimports` clean

Made with [Cursor](https://cursor.com)