### PR TITLE
Make boot-smoke gate deterministic (first boot RAYON_NUM_THREADS=1)

### DIFF
--- a/scripts/boot-smoke.sh
+++ b/scripts/boot-smoke.sh
@@ -3,14 +3,17 @@
 # assert every boot gets through the genesis wasm store (the first wasmer JIT compile)
 # and completes the ABCI handshake.
 #
-# Why repeated boots: the class of defect this guards against crashes probabilistically
-# at first wasm use (the gcc>=12 unwind b-tree bug killed ~70% of boots, so any single
-# boot check can pass on luck). N clean boots make a lucky pass vanishingly unlikely.
+# The first boot pins RAYON_NUM_THREADS=1. Serializing wasmer's compile makes the
+# gcc>=12 unwind b-tree crash DETERMINISTIC on an affected binary (empirically 100% vs
+# ~70% with default threading), so the gate rejects a broken binary in a single boot
+# rather than relying on probability. A healthy binary boots clean regardless of thread
+# count. The remaining boots use default threading for broader timing coverage.
 #
 # Why "handshake completed" is the success marker: a lone node cannot leave blocksync on
 # this codebase (blocksync's IsCaughtUp requires more than one peer), so block production
 # is not observable single-node. The handshake only completes after the genesis wasm
-# StoreCode calls succeed, which is exactly the code path that crashes.
+# StoreCode calls succeed (Sei stores its built-in pointer contracts at InitChain), which
+# is exactly the code path that crashes.
 #
 # Linux-only (runs the linux/amd64 binary natively; uses GNU timeout).
 #
@@ -31,20 +34,24 @@ for i in $(seq 1 "$BOOTS"); do
   "$BIN" gentx val 10000000000000usei --chain-id "$CHAIN_ID" --keyring-backend test --home "$H" >/dev/null 2>&1
   "$BIN" collect-gentxs --home "$H" >/dev/null 2>&1
 
+  # First boot: force the deterministic single-threaded repro. Others: default threading.
+  RAYON=""
+  [ "$i" -eq 1 ] && RAYON="RAYON_NUM_THREADS=1"
+
   LOG="$H/start.log"
-  timeout -k 5 25 "$BIN" start --home "$H" >"$LOG" 2>&1 || true
+  env $RAYON timeout -k 5 25 "$BIN" start --home "$H" >"$LOG" 2>&1 || true
 
   if grep -qE "SIGSEGV|SIGILL|SIGBUS|panic:" "$LOG"; then
-    echo "boot-smoke: boot $i/$BOOTS CRASHED:" >&2
+    echo "boot-smoke: boot $i/$BOOTS CRASHED${RAYON:+ (RAYON_NUM_THREADS=1)}:" >&2
     tail -25 "$LOG" >&2
     exit 1
   fi
   if ! grep -q "Completed ABCI Handshake" "$LOG"; then
-    echo "boot-smoke: boot $i/$BOOTS did not reach the ABCI handshake:" >&2
+    echo "boot-smoke: boot $i/$BOOTS did not reach the ABCI handshake${RAYON:+ (RAYON_NUM_THREADS=1)}:" >&2
     tail -25 "$LOG" >&2
     exit 1
   fi
-  echo "boot-smoke: boot $i/$BOOTS ok"
+  echo "boot-smoke: boot $i/$BOOTS ok${RAYON:+ (RAYON_NUM_THREADS=1, deterministic)}"
   rm -rf "$H"
 done
 echo "boot-smoke: all $BOOTS boots clean"

--- a/scripts/boot-smoke.sh
+++ b/scripts/boot-smoke.sh
@@ -24,6 +24,16 @@ BIN=${1:?usage: boot-smoke.sh <path-to-seid> [boots]}
 BOOTS=${2:-8}
 CHAIN_ID=boot-smoke-1
 
+# Linux-only: this gate runs the linux/amd64 binary natively and uses GNU timeout.
+# Skip cleanly on other hosts so local `goreleaser release --snapshot` on macOS still
+# works (build-static.sh cross-builds in Docker there, but the ELF can't run on the
+# host). The real release path and the CI static-build job both run on Linux and always
+# execute the gate.
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "boot-smoke: host is $(uname -s), not Linux; skipping (cannot run the linux/amd64 binary natively here)"
+  exit 0
+fi
+
 for i in $(seq 1 "$BOOTS"); do
   H=$(mktemp -d)
   "$BIN" init smoke --chain-id "$CHAIN_ID" --home "$H" >/dev/null 2>&1


### PR DESCRIPTION
Follow-up to #3749. The boot-smoke gate catches a crash-at-first-wasm-use binary, but only probabilistically (~70% per boot), so N boots could in principle pass a fully broken build. This pins the **first** boot to `RAYON_NUM_THREADS=1`: serializing wasmer's compile makes the gcc≥12 unwind b-tree crash reproduce **100%** of the time on an affected binary, so a single boot rejects it deterministically. Healthy binaries boot clean regardless of thread count; the remaining boots keep default threading for broader timing coverage.

Prompted by a Cursor Bugbot comment on the release/v6.6 backport (#3802) questioning whether the gate exercises the failing path. It does — verified by running the gate against the preserved broken rc2 binary — but the probabilistic nature was a fair concern, which this closes.

Same change is in the backport #3802 so main and release/v6.6 stay in sync.

Docs-only/CI-only change to a test script; no runtime code touched.