### PR TITLE
Bump sei-protocol/go-ethereum to v1.15.7-sei-18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -278,7 +278,7 @@ replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
 	github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.23.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.15.7-sei-17
+	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.15.7-sei-18
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/keybase/go-keychain v0.0.0-20190712205309-48d3d31d256d

--- a/go.sum
+++ b/go.sum
@@ -1801,8 +1801,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/segmentio/kafka-go v0.4.50 h1:mcyC3tT5WeyWzrFbd6O374t+hmcu1NKt2Pu1L3QaXmc=
 github.com/segmentio/kafka-go v0.4.50/go.mod h1:Y1gn60kzLEEaW28YshXyk2+VCUKbJ3Qr6DrnT3i4+9E=
-github.com/sei-protocol/go-ethereum v1.15.7-sei-17 h1:jUDHZqcKAiLi8nR0isZPZn8nDZBUJSIaV2csWV/JQ+4=
-github.com/sei-protocol/go-ethereum v1.15.7-sei-17/go.mod h1:+S9k+jFzlyVTNcYGvqFhzN/SFhI6vA+aOY4T5tLSPL0=
+github.com/sei-protocol/go-ethereum v1.15.7-sei-18 h1:de8M2eVCTF/UXgLZ7DyGMmQH3pUxonvtIzK9fBqenNc=
+github.com/sei-protocol/go-ethereum v1.15.7-sei-18/go.mod h1:+S9k+jFzlyVTNcYGvqFhzN/SFhI6vA+aOY4T5tLSPL0=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-load v0.0.0-20251007135253-78fbdc141082 h1:f2sY8OcN60UL1/6POx+HDMZ4w04FTZtSScnrFSnGZHg=


### PR DESCRIPTION
## Summary
- Bumps the `github.com/ethereum/go-ethereum` replace directive to [`sei-protocol/go-ethereum` v1.15.7-sei-18](https://github.com/sei-protocol/go-ethereum/releases/tag/v1.15.7-sei-18)
- Updates `go.sum` accordingly via `go mod tidy`

### What's new in v1.15.7-sei-18
- **rpc: WebSocket concurrent request-byte admission control** (sei-protocol/go-ethereum#81, PLT-776) — adds a weighted concurrent byte budget for persistent JSON-RPC connections (WebSocket/IPC/stdio), closing the gap where only HTTP had pre-decode request-size admission (`requestSizeLimiter`). A single connection could previously pile up many large in-flight `eth_call`/`eth_estimateGas` simulations over WS with no budget; reads now block (bounded by an admission timeout) instead of buffering unbounded in-flight work. Adds `Server.SetWSConcurrentRequestBytes` / `Client.SetWSConcurrentRequestBytes`, floored to the existing per-frame `SetReadLimits`.
- **rpc: WebSocket admission rejection hook + configurable timeout** (sei-protocol/go-ethereum#82) — adds an `admissionEventHook func(reason string)` callback fired when WS admission times out (pre-decode or post-decode), so callers can emit metrics/logs on rejection. Also makes the previously-hardcoded 30s admission wait configurable via `Server.SetWSAdmissionTimeout` / `WithWSAdmissionTimeout`.

Note: this PR only bumps the dependency. Wiring sei-chain's `MaxRequestBodyBytes`/`MaxConcurrentRequestBytes` config into the new `SetReadLimits`/`SetWSConcurrentRequestBytes` APIs is tracked as a follow-up.

Resolves [PLT-832](https://linear.app/seilabs/issue/PLT-832/bump-sei-protocolgo-ethereum-to-v1157-sei-18)

## Test plan
- [x] `go mod tidy`
- [x] `go build ./...`