### PR TITLE
Upgrade to lates UCI AI review for skip label support

### DIFF
--- a/.github/workflows/ai-assist.yml
+++ b/.github/workflows/ai-assist.yml
@@ -8,8 +8,8 @@ on:
     types: [ submitted ]
 jobs:
   assistant:
-    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.12
-    uses: sei-protocol/uci/.github/workflows/ai-assistant.yml@258d2c3216d54872b33ac07430d23c847fc239ca
+    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.13
+    uses: sei-protocol/uci/.github/workflows/ai-assistant.yml@29a9c73301b2218e1940cf3f9a2c3d34c86fbd9a
     permissions:
       contents: read
       pull-requests: write
@@ -17,6 +17,6 @@ jobs:
       id-token: write
     secrets: inherit
     with:
-      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.12
-      uci-ref: 258d2c3216d54872b33ac07430d23c847fc239ca
+      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.13
+      uci-ref: 29a9c73301b2218e1940cf3f9a2c3d34c86fbd9a
       allowed-team: 'sei-protocol/sei-core'

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -4,8 +4,8 @@ on:
     types: [ opened, ready_for_review, synchronize, reopened ]
 jobs:
   ai-review:
-    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.12
-    uses: sei-protocol/uci/.github/workflows/ai-review.yml@258d2c3216d54872b33ac07430d23c847fc239ca
+    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.13
+    uses: sei-protocol/uci/.github/workflows/ai-review.yml@29a9c73301b2218e1940cf3f9a2c3d34c86fbd9a
     permissions:
       contents: read
       pull-requests: write
@@ -13,6 +13,6 @@ jobs:
       id-token: write
     secrets: inherit
     with:
-      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.12
-      uci-ref: 258d2c3216d54872b33ac07430d23c847fc239ca
+      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.13
+      uci-ref: 29a9c73301b2218e1940cf3f9a2c3d34c86fbd9a
       enable-cursor: false # Disabled for now since there is a dedicated Bugbot flow built into Cursor currently enabled on repo.


### PR DESCRIPTION
Upgrade to latest to add the ability to skip AI review by label.
