### PR TITLE
Tolerate failed Codex review executions

### DIFF
--- a/.github/workflows/pr-to-slack-codex.yml
+++ b/.github/workflows/pr-to-slack-codex.yml
@@ -139,6 +139,7 @@ jobs:
                 < prompt.txt \
                 > codex.log 2>&1; then
               echo "Codex review failed; publishing fallback review." >&2
+              cat codex.log >&2
             fi
           fi
 

--- a/.github/workflows/pr-to-slack-codex.yml
+++ b/.github/workflows/pr-to-slack-codex.yml
@@ -93,12 +93,14 @@ jobs:
             echo "---- prompt size ----"; wc -c prompt.txt >&2
 
             # Run Codex with a scrubbed env: only OPENAI_API_KEY, PATH, HOME
-            env -i OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" PATH="$PATH" HOME="$HOME" \
-            codex --model gpt-5-codex --ask-for-approval never exec \
-              --sandbox read-only \
-              --output-last-message review.md \
-              < prompt.txt \
-              > codex.log 2>&1
+            if ! env -i OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" PATH="$PATH" HOME="$HOME" \
+              codex --model gpt-5-codex --ask-for-approval never exec \
+                --sandbox read-only \
+                --output-last-message review.md \
+                < prompt.txt \
+                > codex.log 2>&1; then
+              echo "Codex review failed; publishing fallback review." >&2
+            fi
 
           else
             echo "Large diff – switching to fallback that lets Codex fetch the .diff URL"
@@ -130,12 +132,14 @@ jobs:
             echo "---- fallback prompt size ----"; wc -c prompt.txt >&2
 
             # Network-enabled only for this large-diff case; still scrub env
-            env -i OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" PATH="$PATH" HOME="$HOME" \
-            codex --model gpt-5-codex --ask-for-approval never exec \
-              --sandbox danger-full-access \
-              --output-last-message review.md \
-              < prompt.txt \
-              > codex.log 2>&1
+            if ! env -i OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" PATH="$PATH" HOME="$HOME" \
+              codex --model gpt-5-codex --ask-for-approval never exec \
+                --sandbox danger-full-access \
+                --output-last-message review.md \
+                < prompt.txt \
+                > codex.log 2>&1; then
+              echo "Codex review failed; publishing fallback review." >&2
+            fi
           fi
 
           # Defensive: ensure later steps don't explode


### PR DESCRIPTION
Codex failures previously terminated the shell before the existing fallback review could be generated and posted to Slack. Handle failed invocations as non-blocking so the workflow publishes its fallback review instead.
