### PR TITLE
perf(params): validate ConsensusParams once per change set (CON-312)

### DIFF
--- a/sei-cosmos/x/params/types/proposal/proposal.go
+++ b/sei-cosmos/x/params/types/proposal/proposal.go
@@ -89,6 +89,7 @@ func ValidateChanges(changes []ParamChange) error {
 		return ErrEmptyChanges
 	}
 
+	hasBaseapp := false
 	for _, pc := range changes {
 		if len(pc.Subspace) == 0 {
 			return ErrEmptySubspace
@@ -99,14 +100,19 @@ func ValidateChanges(changes []ParamChange) error {
 		if len(pc.Value) == 0 {
 			return ErrEmptyValue
 		}
-		// We need to verify ConsensusParams since they are only validated once the proposal passes.
-		// If any of them are invalid at time of passing, this will cause a chain halt since validation is done during
-		// ApplyBlock: https://github.com/sei-protocol/sei-tendermint/blob/d426f1fe475eb0c406296770ff5e9f8869b3887e/internal/state/execution.go#L320
-		// Therefore, we validate when we get a param-change msg for ConsensusParams
 		if pc.Subspace == "baseapp" {
-			if err := verifyConsensusParamsUsingDefault(changes); err != nil {
-				return err
-			}
+			hasBaseapp = true
+		}
+	}
+
+	// Verify ConsensusParams once for the whole change set. Calling this inside
+	// the loop above is O(N^2) for N baseapp entries (each call re-scans and
+	// unmarshals all changes). ConsensusParams are otherwise only validated
+	// once the proposal passes; invalid values cause a chain halt in ApplyBlock:
+	// https://github.com/sei-protocol/sei-tendermint/blob/d426f1fe475eb0c406296770ff5e9f8869b3887e/internal/state/execution.go#L320
+	if hasBaseapp {
+		if err := verifyConsensusParamsUsingDefault(changes); err != nil {
+			return err
 		}
 	}
 

--- a/sei-cosmos/x/params/types/proposal/proposal_test.go
+++ b/sei-cosmos/x/params/types/proposal/proposal_test.go
@@ -2,9 +2,9 @@ package proposal
 
 import (
 	"fmt"
-	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
 	"testing"
 
+	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,4 +37,21 @@ func TestConsensusParameterChangeProposal(t *testing.T) {
 	pc1 = NewParamChange("baseapp", "BlockParams", fmt.Sprintf("{\"max_bytes\":\"%d\"}", types.MaxBlockSizeBytes+1))
 	pcp = NewParameterChangeProposal("test title", "test description", []ParamChange{pc1}, true)
 	require.Error(t, pcp.ValidateBasic())
+}
+
+func BenchmarkValidateChangesBaseapp(b *testing.B) {
+	value := fmt.Sprintf("{\"max_bytes\":\"%d\"}", types.MaxBlockSizeBytes)
+	for _, n := range []int{10, 100, 1000} {
+		changes := make([]ParamChange, n)
+		for i := 0; i < n; i++ {
+			changes[i] = NewParamChange("baseapp", "BlockParams", value)
+		}
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if err := ValidateChanges(changes); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- `ValidateChanges` now runs ConsensusParams verification once for the full change set instead of once per `baseapp` entry, which previously re-scanned and unmarshaled the whole list each time.
- Adds a `BenchmarkValidateChangesBaseapp` (`n=10/100/1000`) so cost scaling is easy to check locally.

## Notes
- For proposals that are invalid in more than one way (e.g. empty field and bad ConsensusParams), the returned error may differ because empty-field checks complete before ConsensusParams verification. Valid proposals are unchanged.
- Not app-hash-breaking: AppHash is the committed store root and does not include ValidateBasic error strings/codes.

## Test plan
- [ ] `go test ./sei-cosmos/x/params/types/proposal/ -count=1`
- [ ] `go test ./sei-cosmos/x/params/types/proposal/ -bench=BenchmarkValidateChangesBaseapp -benchmem -count=1`


Made with [Cursor](https://cursor.com)