### PR TITLE
Align multisig SignatureData with bitarray invariants (CON-371)

### DIFF
--- a/sei-cosmos/crypto/keys/multisig/multisig.go
+++ b/sei-cosmos/crypto/keys/multisig/multisig.go
@@ -48,6 +48,9 @@ func (m *LegacyAminoPubKey) Bytes() []byte {
 // the power of the owner of that key - in that case the signer will still need to append
 // multiple same signatures in the right order.
 func (m *LegacyAminoPubKey) VerifyMultisignature(getSignBytes multisigtypes.GetSignBytesFunc, sig *signing.MultiSignatureData) error {
+	if err := multisigtypes.ValidateSignatureDataStructure(sig); err != nil {
+		return err
+	}
 	bitarray := sig.BitArray
 	sigs := sig.Signatures
 	size := bitarray.Count()
@@ -56,11 +59,7 @@ func (m *LegacyAminoPubKey) VerifyMultisignature(getSignBytes multisigtypes.GetS
 	if len(pubKeys) != size {
 		return fmt.Errorf("bit array size is incorrect, expecting: %d", len(pubKeys))
 	}
-	// Signatures must match true bits exactly.
-	nTrue := bitarray.NumTrueBitsBefore(size)
-	if len(sigs) != nTrue {
-		return fmt.Errorf("signature size is incorrect %d", len(sigs))
-	}
+	nTrue := len(sigs)
 	// ensure at least k signatures are set
 	if nTrue < int(m.Threshold) {
 		return fmt.Errorf("not enough signatures set, have %d, expected %d", nTrue, int(m.Threshold))

--- a/sei-cosmos/crypto/keys/multisig/multisig.go
+++ b/sei-cosmos/crypto/keys/multisig/multisig.go
@@ -59,10 +59,10 @@ func (m *LegacyAminoPubKey) VerifyMultisignature(getSignBytes multisigtypes.GetS
 	if len(pubKeys) != size {
 		return fmt.Errorf("bit array size is incorrect, expecting: %d", len(pubKeys))
 	}
-	nTrue := len(sigs)
+	nSigs := len(sigs)
 	// ensure at least k signatures are set
-	if nTrue < int(m.Threshold) {
-		return fmt.Errorf("not enough signatures set, have %d, expected %d", nTrue, int(m.Threshold))
+	if nSigs < int(m.Threshold) {
+		return fmt.Errorf("not enough signatures set, have %d, expected %d", nSigs, int(m.Threshold))
 	}
 	// index in the list of signatures which we are concerned with.
 	sigIndex := 0

--- a/sei-cosmos/crypto/keys/multisig/multisig.go
+++ b/sei-cosmos/crypto/keys/multisig/multisig.go
@@ -75,8 +75,7 @@ func (m *LegacyAminoPubKey) verifyMultisignature(getSignBytes multisigtypes.GetS
 	sigIndex := 0
 	for i := 0; i < size; i++ {
 		if bitarray.GetIndex(i) {
-			// Unreachable if ValidateSignatureDataStructure succeeded (len(sigs) ==
-			// NumTrueBits); kept as defense-in-depth.
+			// Redundant with ValidateSignatureDataStructure (len(sigs) == NumTrueBits).
 			if sigIndex >= len(sigs) {
 				return fmt.Errorf("signature size is incorrect %d", len(sigs))
 			}

--- a/sei-cosmos/crypto/keys/multisig/multisig.go
+++ b/sei-cosmos/crypto/keys/multisig/multisig.go
@@ -47,10 +47,17 @@ func (m *LegacyAminoPubKey) Bytes() []byte {
 // LegacyAminoPubKey. It's OK to have multiple same keys in the multisig - it will increase
 // the power of the owner of that key - in that case the signer will still need to append
 // multiple same signatures in the right order.
+//
+// Structure is validated once for the whole tree; nested LegacyAminoPubKey recursion skips
+// re-validation.
 func (m *LegacyAminoPubKey) VerifyMultisignature(getSignBytes multisigtypes.GetSignBytesFunc, sig *signing.MultiSignatureData) error {
 	if err := multisigtypes.ValidateSignatureDataStructure(sig); err != nil {
 		return err
 	}
+	return m.verifyMultisignature(getSignBytes, sig)
+}
+
+func (m *LegacyAminoPubKey) verifyMultisignature(getSignBytes multisigtypes.GetSignBytesFunc, sig *signing.MultiSignatureData) error {
 	bitarray := sig.BitArray
 	sigs := sig.Signatures
 	size := bitarray.Count()
@@ -88,7 +95,12 @@ func (m *LegacyAminoPubKey) VerifyMultisignature(getSignBytes multisigtypes.GetS
 				if !ok {
 					return fmt.Errorf("unable to parse pubkey of index %d", i)
 				}
-				if err := nestedMultisigPk.VerifyMultisignature(getSignBytes, si); err != nil {
+				// Prefer same-type recursion without re-validating structure.
+				if nested, ok := nestedMultisigPk.(*LegacyAminoPubKey); ok {
+					if err := nested.verifyMultisignature(getSignBytes, si); err != nil {
+						return err
+					}
+				} else if err := nestedMultisigPk.VerifyMultisignature(getSignBytes, si); err != nil {
 					return err
 				}
 			default:

--- a/sei-cosmos/crypto/keys/multisig/multisig.go
+++ b/sei-cosmos/crypto/keys/multisig/multisig.go
@@ -56,18 +56,22 @@ func (m *LegacyAminoPubKey) VerifyMultisignature(getSignBytes multisigtypes.GetS
 	if len(pubKeys) != size {
 		return fmt.Errorf("bit array size is incorrect, expecting: %d", len(pubKeys))
 	}
-	// ensure size of signature list
-	if len(sigs) < int(m.Threshold) || len(sigs) > size {
+	// Signatures must match true bits exactly.
+	nTrue := bitarray.NumTrueBitsBefore(size)
+	if len(sigs) != nTrue {
 		return fmt.Errorf("signature size is incorrect %d", len(sigs))
 	}
 	// ensure at least k signatures are set
-	if bitarray.NumTrueBitsBefore(size) < int(m.Threshold) {
-		return fmt.Errorf("not enough signatures set, have %d, expected %d", bitarray.NumTrueBitsBefore(size), int(m.Threshold))
+	if nTrue < int(m.Threshold) {
+		return fmt.Errorf("not enough signatures set, have %d, expected %d", nTrue, int(m.Threshold))
 	}
 	// index in the list of signatures which we are concerned with.
 	sigIndex := 0
 	for i := 0; i < size; i++ {
 		if bitarray.GetIndex(i) {
+			if sigIndex >= len(sigs) {
+				return fmt.Errorf("signature size is incorrect %d", len(sigs))
+			}
 			si := sig.Signatures[sigIndex]
 			switch si := si.(type) {
 			case *signing.SingleSignatureData:

--- a/sei-cosmos/crypto/keys/multisig/multisig.go
+++ b/sei-cosmos/crypto/keys/multisig/multisig.go
@@ -68,6 +68,8 @@ func (m *LegacyAminoPubKey) VerifyMultisignature(getSignBytes multisigtypes.GetS
 	sigIndex := 0
 	for i := 0; i < size; i++ {
 		if bitarray.GetIndex(i) {
+			// Unreachable if ValidateSignatureDataStructure succeeded (len(sigs) ==
+			// NumTrueBits); kept as defense-in-depth.
 			if sigIndex >= len(sigs) {
 				return fmt.Errorf("signature size is incorrect %d", len(sigs))
 			}

--- a/sei-cosmos/crypto/keys/multisig/multisig_test.go
+++ b/sei-cosmos/crypto/keys/multisig/multisig_test.go
@@ -212,6 +212,30 @@ func TestVerifyMultisignature(t *testing.T) {
 				multisig.AddSignatureFromPubKey(sig, sigs[1], pubKeys[1], pubKeys)
 			},
 			false,
+		}, {
+			"trailing signatures past true bits",
+			func(require *require.Assertions) {
+				pubKeys, sigs := generatePubKeysAndSignatures(3, msg)
+				pk = kmultisig.NewLegacyAminoPubKey(2, pubKeys)
+				sig = multisig.NewMultisig(len(pubKeys))
+				require.NoError(multisig.AddSignatureFromPubKey(sig, sigs[0], pubKeys[0], pubKeys))
+				require.NoError(multisig.AddSignatureFromPubKey(sig, sigs[1], pubKeys[1], pubKeys))
+				// More Signatures than true bits.
+				sig.Signatures = append(sig.Signatures, sigs[2])
+			},
+			false,
+		}, {
+			"more true bits than signatures",
+			func(require *require.Assertions) {
+				pubKeys, sigs := generatePubKeysAndSignatures(3, msg)
+				pk = kmultisig.NewLegacyAminoPubKey(2, pubKeys)
+				sig = multisig.NewMultisig(len(pubKeys))
+				require.NoError(multisig.AddSignatureFromPubKey(sig, sigs[0], pubKeys[0], pubKeys))
+				require.NoError(multisig.AddSignatureFromPubKey(sig, sigs[1], pubKeys[1], pubKeys))
+				// Extra set bit without a corresponding signature entry.
+				sig.BitArray.SetIndex(2, true)
+			},
+			false,
 		},
 	}
 

--- a/sei-cosmos/crypto/keys/multisig/multisig_test.go
+++ b/sei-cosmos/crypto/keys/multisig/multisig_test.go
@@ -236,6 +236,17 @@ func TestVerifyMultisignature(t *testing.T) {
 				sig.BitArray.SetIndex(2, true)
 			},
 			false,
+		}, {
+			// Regression: NumTrueBitsBefore(Count()) used to panic when Count()%8==0.
+			"size multiple of 8 passes",
+			func(require *require.Assertions) {
+				pubKeys, sigs := generatePubKeysAndSignatures(8, msg)
+				pk = kmultisig.NewLegacyAminoPubKey(2, pubKeys)
+				sig = multisig.NewMultisig(len(pubKeys))
+				require.NoError(multisig.AddSignatureFromPubKey(sig, sigs[0], pubKeys[0], pubKeys))
+				require.NoError(multisig.AddSignatureFromPubKey(sig, sigs[7], pubKeys[7], pubKeys))
+			},
+			true,
 		},
 	}
 

--- a/sei-cosmos/crypto/keys/multisig/multisig_test.go
+++ b/sei-cosmos/crypto/keys/multisig/multisig_test.go
@@ -237,7 +237,7 @@ func TestVerifyMultisignature(t *testing.T) {
 			},
 			false,
 		}, {
-			// Regression: NumTrueBitsBefore(Count()) used to panic when Count()%8==0.
+			// Size multiple of 8: NumTrueBitsBefore(Count()) must succeed.
 			"size multiple of 8 passes",
 			func(require *require.Assertions) {
 				pubKeys, sigs := generatePubKeysAndSignatures(8, msg)

--- a/sei-cosmos/crypto/types/compact_bit_array.go
+++ b/sei-cosmos/crypto/types/compact_bit_array.go
@@ -16,6 +16,10 @@ import (
 // space after amino encoding.
 // This is not thread safe, and is not intended for concurrent usage.
 
+// MaxExtraBitsStored is the largest valid CompactBitArray.ExtraBitsStored.
+// Honest construction sets ExtraBitsStored = bits % 8, so it is always in [0, 7].
+const MaxExtraBitsStored = 7
+
 // NewCompactBitArray returns a new compact bit array.
 // It returns nil if the number of bits is zero, or if there is any overflow
 // in the arithmetic to encounter for the number of its elements: (bits+7)/8,
@@ -33,7 +37,7 @@ func NewCompactBitArray(bits int) *CompactBitArray {
 		return nil
 	}
 	return &CompactBitArray{
-		ExtraBitsStored: uint32(bits % 8), //nolint:gosec // bits is validated positive above, bits%8 is always 0-7
+		ExtraBitsStored: uint32(bits % 8), //nolint:gosec // bits is validated positive above, bits%8 is always 0..MaxExtraBitsStored
 		Elems:           make([]byte, nElems),
 	}
 }
@@ -80,6 +84,23 @@ func (bA *CompactBitArray) SetIndex(i int, v bool) bool {
 	}
 
 	return true
+}
+
+// ValidateBasic checks that ExtraBitsStored is consistent with Elems.
+// ExtraBitsStored is attacker-controlled on protobuf decode; values above
+// MaxExtraBitsStored make Count() exceed the bits backed by Elems (and can go
+// negative when Elems is empty).
+func (bA *CompactBitArray) ValidateBasic() error {
+	if bA == nil {
+		return fmt.Errorf("compact bit array is nil")
+	}
+	if bA.ExtraBitsStored > MaxExtraBitsStored {
+		return fmt.Errorf("compact bit array extra bits stored is incorrect %d", bA.ExtraBitsStored)
+	}
+	if bA.ExtraBitsStored != 0 && len(bA.Elems) == 0 {
+		return fmt.Errorf("compact bit array elems is empty")
+	}
+	return nil
 }
 
 // NumTrueBitsBefore returns the number of bits set to true before the

--- a/sei-cosmos/crypto/types/compact_bit_array.go
+++ b/sei-cosmos/crypto/types/compact_bit_array.go
@@ -87,9 +87,8 @@ func (bA *CompactBitArray) SetIndex(i int, v bool) bool {
 }
 
 // ValidateBasic checks that ExtraBitsStored is consistent with Elems.
-// ExtraBitsStored is attacker-controlled on protobuf decode; values above
-// MaxExtraBitsStored make Count() exceed the bits backed by Elems (and can go
-// negative when Elems is empty).
+// Values above MaxExtraBitsStored make Count() exceed the bits backed by Elems
+// (and Count can go negative when Elems is empty).
 func (bA *CompactBitArray) ValidateBasic() error {
 	if bA == nil {
 		return fmt.Errorf("compact bit array is nil")

--- a/sei-cosmos/crypto/types/compact_bit_array.go
+++ b/sei-cosmos/crypto/types/compact_bit_array.go
@@ -86,19 +86,26 @@ func (bA *CompactBitArray) SetIndex(i int, v bool) bool {
 // given index. e.g. if bA = _XX__XX, NumOfTrueBitsBefore(4) = 2, since
 // there are two bits set to true before index 4.
 func (bA *CompactBitArray) NumTrueBitsBefore(index int) int {
-	onesCount := 0
+	if bA == nil || index <= 0 || len(bA.Elems) == 0 {
+		return 0
+	}
 	max := bA.Count()
 	if index > max {
 		index = max
 	}
-	// below we iterate over the bytes then over bits (in low endian) and count bits set to 1
-	for elem := 0; ; elem++ {
-		if elem*8+7 >= index {
-			onesCount += bits.OnesCount8(bA.Elems[elem] >> (7 - (index % 8) + 1))
-			return onesCount
-		}
+
+	onesCount := 0
+	fullBytes := index / 8
+	for elem := 0; elem < fullBytes; elem++ {
 		onesCount += bits.OnesCount8(bA.Elems[elem])
 	}
+	remaining := index % 8
+	if remaining == 0 {
+		return onesCount
+	}
+	// Bits are stored MSB-first within each byte (see GetIndex/SetIndex).
+	onesCount += bits.OnesCount8(bA.Elems[fullBytes] >> (8 - remaining))
+	return onesCount
 }
 
 // Copy returns a copy of the provided bit array.

--- a/sei-cosmos/crypto/types/compact_bit_array_test.go
+++ b/sei-cosmos/crypto/types/compact_bit_array_test.go
@@ -224,6 +224,24 @@ func TestCompactBitArrayNumOfTrueBitsBefore(t *testing.T) {
 	}
 }
 
+func TestNumTrueBitsBeforeAtCountMultiplesOf8(t *testing.T) {
+	require.Equal(t, 0, (*CompactBitArray)(nil).NumTrueBitsBefore(0))
+	require.Equal(t, 0, (&CompactBitArray{}).NumTrueBitsBefore(0))
+
+	for _, size := range []int{8, 16, 24} {
+		ba := NewCompactBitArray(size)
+		require.NotNil(t, ba)
+		require.Equal(t, size, ba.Count())
+		require.Equal(t, 0, ba.NumTrueBitsBefore(size))
+
+		ba.SetIndex(0, true)
+		ba.SetIndex(size-1, true)
+		require.Equal(t, 2, ba.NumTrueBitsBefore(size))
+		require.Equal(t, 1, ba.NumTrueBitsBefore(1))
+		require.Equal(t, 1, ba.NumTrueBitsBefore(size-1))
+	}
+}
+
 func TestCompactBitArrayGetSetIndex(t *testing.T) {
 	r := rand.New(rand.NewSource(100))
 	numTests := 10

--- a/sei-cosmos/crypto/types/compact_bit_array_test.go
+++ b/sei-cosmos/crypto/types/compact_bit_array_test.go
@@ -242,6 +242,15 @@ func TestNumTrueBitsBeforeAtCountMultiplesOf8(t *testing.T) {
 	}
 }
 
+func TestCompactBitArrayValidateBasic(t *testing.T) {
+	require.Error(t, (*CompactBitArray)(nil).ValidateBasic())
+	require.NoError(t, NewCompactBitArray(3).ValidateBasic())
+	require.NoError(t, NewCompactBitArray(8).ValidateBasic())
+	require.NoError(t, (&CompactBitArray{}).ValidateBasic())
+	require.Error(t, (&CompactBitArray{ExtraBitsStored: MaxExtraBitsStored + 1, Elems: []byte{0xFF}}).ValidateBasic())
+	require.Error(t, (&CompactBitArray{ExtraBitsStored: 5}).ValidateBasic())
+}
+
 func TestCompactBitArrayGetSetIndex(t *testing.T) {
 	r := rand.New(rand.NewSource(100))
 	numTests := 10

--- a/sei-cosmos/crypto/types/multisig/multisignature.go
+++ b/sei-cosmos/crypto/types/multisig/multisignature.go
@@ -43,7 +43,7 @@ func validateMultiSignatureDataStructure(sig *signing.MultiSignatureData) error 
 	}
 	nTrue := sig.BitArray.NumTrueBitsBefore(size)
 	if len(sig.Signatures) != nTrue {
-		return fmt.Errorf("signature size is incorrect %d", len(sig.Signatures))
+		return fmt.Errorf("signature size is incorrect: have %d, expected %d", len(sig.Signatures), nTrue)
 	}
 	for i, child := range sig.Signatures {
 		if err := ValidateSignatureDataStructure(child); err != nil {

--- a/sei-cosmos/crypto/types/multisig/multisignature.go
+++ b/sei-cosmos/crypto/types/multisig/multisignature.go
@@ -33,6 +33,9 @@ func validateMultiSignatureDataStructure(sig *signing.MultiSignatureData) error 
 		return fmt.Errorf("bit array is required")
 	}
 	size := sig.BitArray.Count()
+	if size == 0 {
+		return fmt.Errorf("bit array size is incorrect %d", size)
+	}
 	nTrue := sig.BitArray.NumTrueBitsBefore(size)
 	if len(sig.Signatures) != nTrue {
 		return fmt.Errorf("signature size is incorrect %d", len(sig.Signatures))

--- a/sei-cosmos/crypto/types/multisig/multisignature.go
+++ b/sei-cosmos/crypto/types/multisig/multisignature.go
@@ -8,6 +8,46 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/types/tx/signing"
 )
 
+// ValidateSignatureDataStructure checks SignatureData tree shape only (no crypto).
+// For MultiSignatureData, len(Signatures) must equal the number of true bits in
+// BitArray at every nesting level (the same invariant AddSignature maintains).
+func ValidateSignatureDataStructure(data signing.SignatureData) error {
+	if data == nil {
+		return fmt.Errorf("signature data is required")
+	}
+	switch data := data.(type) {
+	case *signing.SingleSignatureData:
+		return nil
+	case *signing.MultiSignatureData:
+		return validateMultiSignatureDataStructure(data)
+	default:
+		return fmt.Errorf("unexpected signature data type %T", data)
+	}
+}
+
+func validateMultiSignatureDataStructure(sig *signing.MultiSignatureData) error {
+	if sig == nil {
+		return fmt.Errorf("multi signature data is required")
+	}
+	if sig.BitArray == nil {
+		return fmt.Errorf("bit array is required")
+	}
+	size := sig.BitArray.Count()
+	nTrue := sig.BitArray.NumTrueBitsBefore(size)
+	if len(sig.Signatures) != nTrue {
+		return fmt.Errorf("signature size is incorrect %d", len(sig.Signatures))
+	}
+	for i, child := range sig.Signatures {
+		if child == nil {
+			return fmt.Errorf("signature data at index %d is nil", i)
+		}
+		if err := ValidateSignatureDataStructure(child); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // AminoMultisignature is used to represent amino multi-signatures for StdTx's.
 // It is assumed that all signatures were made with SIGN_MODE_LEGACY_AMINO_JSON.
 // Sigs is a list of signatures, sorted by corresponding index.

--- a/sei-cosmos/crypto/types/multisig/multisignature.go
+++ b/sei-cosmos/crypto/types/multisig/multisignature.go
@@ -12,11 +12,13 @@ import (
 // For MultiSignatureData, len(Signatures) must equal the number of true bits in
 // BitArray at every nesting level (the same invariant AddSignature maintains).
 func ValidateSignatureDataStructure(data signing.SignatureData) error {
-	if data == nil {
-		return fmt.Errorf("signature data is required")
-	}
 	switch data := data.(type) {
+	case nil:
+		return fmt.Errorf("signature data is required")
 	case *signing.SingleSignatureData:
+		if data == nil {
+			return fmt.Errorf("single signature data is required")
+		}
 		return nil
 	case *signing.MultiSignatureData:
 		return validateMultiSignatureDataStructure(data)
@@ -32,6 +34,9 @@ func validateMultiSignatureDataStructure(sig *signing.MultiSignatureData) error 
 	if sig.BitArray == nil {
 		return fmt.Errorf("bit array is required")
 	}
+	if err := sig.BitArray.ValidateBasic(); err != nil {
+		return err
+	}
 	size := sig.BitArray.Count()
 	if size == 0 {
 		return fmt.Errorf("bit array size is incorrect %d", size)
@@ -41,11 +46,8 @@ func validateMultiSignatureDataStructure(sig *signing.MultiSignatureData) error 
 		return fmt.Errorf("signature size is incorrect %d", len(sig.Signatures))
 	}
 	for i, child := range sig.Signatures {
-		if child == nil {
-			return fmt.Errorf("signature data at index %d is nil", i)
-		}
 		if err := ValidateSignatureDataStructure(child); err != nil {
-			return err
+			return fmt.Errorf("signature data at index %d: %w", i, err)
 		}
 	}
 	return nil

--- a/sei-cosmos/crypto/types/multisig/multisignature_test.go
+++ b/sei-cosmos/crypto/types/multisig/multisignature_test.go
@@ -58,6 +58,20 @@ func TestValidateSignatureDataStructure(t *testing.T) {
 			Signatures: []signing.SignatureData{single},
 		}))
 	})
+
+	t.Run("empty bit array", func(t *testing.T) {
+		require.Error(t, multisig.ValidateSignatureDataStructure(&signing.MultiSignatureData{
+			BitArray:   &cryptotypes.CompactBitArray{},
+			Signatures: nil,
+		}))
+	})
+
+	t.Run("size multiple of 8", func(t *testing.T) {
+		msig := multisig.NewMultisig(8)
+		multisig.AddSignature(msig, single, 0)
+		multisig.AddSignature(msig, single, 7)
+		require.NoError(t, multisig.ValidateSignatureDataStructure(msig))
+	})
 }
 
 func TestValidateSignatureDataStructure_MoreTrueBitsThanSigs(t *testing.T) {

--- a/sei-cosmos/crypto/types/multisig/multisignature_test.go
+++ b/sei-cosmos/crypto/types/multisig/multisignature_test.go
@@ -1,0 +1,71 @@
+package multisig_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sei-protocol/sei-chain/sei-cosmos/crypto/keys/secp256k1"
+	cryptotypes "github.com/sei-protocol/sei-chain/sei-cosmos/crypto/types"
+	"github.com/sei-protocol/sei-chain/sei-cosmos/crypto/types/multisig"
+	"github.com/sei-protocol/sei-chain/sei-cosmos/types/tx/signing"
+)
+
+func TestValidateSignatureDataStructure(t *testing.T) {
+	msg := []byte("validate")
+	priv := secp256k1.GenPrivKey()
+	sigBytes, err := priv.Sign(msg)
+	require.NoError(t, err)
+	single := &signing.SingleSignatureData{Signature: sigBytes}
+
+	t.Run("single ok", func(t *testing.T) {
+		require.NoError(t, multisig.ValidateSignatureDataStructure(single))
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		require.Error(t, multisig.ValidateSignatureDataStructure(nil))
+	})
+
+	t.Run("honest multisig", func(t *testing.T) {
+		msig := multisig.NewMultisig(3)
+		multisig.AddSignature(msig, single, 0)
+		multisig.AddSignature(msig, single, 1)
+		require.NoError(t, multisig.ValidateSignatureDataStructure(msig))
+	})
+
+	t.Run("trailing signature", func(t *testing.T) {
+		msig := multisig.NewMultisig(3)
+		multisig.AddSignature(msig, single, 0)
+		multisig.AddSignature(msig, single, 1)
+		msig.Signatures = append(msig.Signatures, single)
+		require.Error(t, multisig.ValidateSignatureDataStructure(msig))
+	})
+
+	t.Run("nested trailing signature", func(t *testing.T) {
+		inner := multisig.NewMultisig(2)
+		multisig.AddSignature(inner, single, 0)
+		inner.Signatures = append(inner.Signatures, single)
+
+		outer := multisig.NewMultisig(2)
+		multisig.AddSignature(outer, single, 0)
+		multisig.AddSignature(outer, inner, 1)
+		require.Error(t, multisig.ValidateSignatureDataStructure(outer))
+	})
+
+	t.Run("nil bit array", func(t *testing.T) {
+		require.Error(t, multisig.ValidateSignatureDataStructure(&signing.MultiSignatureData{
+			BitArray:   nil,
+			Signatures: []signing.SignatureData{single},
+		}))
+	})
+}
+
+func TestValidateSignatureDataStructure_MoreTrueBitsThanSigs(t *testing.T) {
+	ba := cryptotypes.NewCompactBitArray(3)
+	ba.SetIndex(0, true)
+	ba.SetIndex(1, true)
+	require.Error(t, multisig.ValidateSignatureDataStructure(&signing.MultiSignatureData{
+		BitArray:   ba,
+		Signatures: []signing.SignatureData{&signing.SingleSignatureData{Signature: []byte{1}}},
+	}))
+}

--- a/sei-cosmos/crypto/types/multisig/multisignature_test.go
+++ b/sei-cosmos/crypto/types/multisig/multisignature_test.go
@@ -26,6 +26,26 @@ func TestValidateSignatureDataStructure(t *testing.T) {
 		require.Error(t, multisig.ValidateSignatureDataStructure(nil))
 	})
 
+	t.Run("typed nil single", func(t *testing.T) {
+		var typedNil *signing.SingleSignatureData
+		require.Error(t, multisig.ValidateSignatureDataStructure(typedNil))
+	})
+
+	t.Run("typed nil multi", func(t *testing.T) {
+		var typedNil *signing.MultiSignatureData
+		require.Error(t, multisig.ValidateSignatureDataStructure(typedNil))
+	})
+
+	t.Run("typed nil child", func(t *testing.T) {
+		var typedNil *signing.SingleSignatureData
+		ba := cryptotypes.NewCompactBitArray(1)
+		ba.SetIndex(0, true)
+		require.Error(t, multisig.ValidateSignatureDataStructure(&signing.MultiSignatureData{
+			BitArray:   ba,
+			Signatures: []signing.SignatureData{typedNil},
+		}))
+	})
+
 	t.Run("honest multisig", func(t *testing.T) {
 		msig := multisig.NewMultisig(3)
 		multisig.AddSignature(msig, single, 0)
@@ -71,6 +91,26 @@ func TestValidateSignatureDataStructure(t *testing.T) {
 		multisig.AddSignature(msig, single, 0)
 		multisig.AddSignature(msig, single, 7)
 		require.NoError(t, multisig.ValidateSignatureDataStructure(msig))
+	})
+
+	t.Run("extra bits stored too large", func(t *testing.T) {
+		require.Error(t, multisig.ValidateSignatureDataStructure(&signing.MultiSignatureData{
+			BitArray: &cryptotypes.CompactBitArray{
+				ExtraBitsStored: cryptotypes.MaxExtraBitsStored + 1,
+				Elems:           []byte{0xFF},
+			},
+			Signatures: []signing.SignatureData{single},
+		}))
+	})
+
+	t.Run("extra bits without elems", func(t *testing.T) {
+		require.Error(t, multisig.ValidateSignatureDataStructure(&signing.MultiSignatureData{
+			BitArray: &cryptotypes.CompactBitArray{
+				ExtraBitsStored: 5,
+				Elems:           nil,
+			},
+			Signatures: nil,
+		}))
 	})
 }
 

--- a/sei-cosmos/x/auth/ante/sigverify.go
+++ b/sei-cosmos/x/auth/ante/sigverify.go
@@ -428,14 +428,14 @@ func ConsumeMultisignatureVerificationGas(
 	params types.Params, accSeq uint64,
 ) error {
 	if err := multisig.ValidateSignatureDataStructure(sig); err != nil {
-		return err
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidType, err.Error())
 	}
 
 	size := sig.BitArray.Count()
 	pubKeys := pubkey.GetPubKeys()
 	// This runs before VerifyMultisignature; require bit-array size to match the key set.
 	if len(pubKeys) != size {
-		return fmt.Errorf("bit array size is incorrect, expecting: %d", len(pubKeys))
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidType, "bit array size is incorrect, expecting: %d", len(pubKeys))
 	}
 
 	sigIndex := 0
@@ -443,8 +443,10 @@ func ConsumeMultisignatureVerificationGas(
 		if !sig.BitArray.GetIndex(i) {
 			continue
 		}
+		// Unreachable if ValidateSignatureDataStructure succeeded (len(sigs) ==
+		// NumTrueBits); kept as defense-in-depth.
 		if sigIndex >= len(sig.Signatures) {
-			return fmt.Errorf("signature size is incorrect %d", len(sig.Signatures))
+			return sdkerrors.Wrapf(sdkerrors.ErrInvalidType, "signature size is incorrect %d", len(sig.Signatures))
 		}
 		sigV2 := signing.SignatureV2{
 			PubKey:   pubKeys[i],
@@ -493,7 +495,7 @@ func CountSubKeys(pub cryptotypes.PubKey) int {
 // Nested MultiSignatureData nodes contribute leaves only; they do not emit their own aggregates.
 func SignatureDataToBz(data signing.SignatureData) ([][]byte, error) {
 	if err := multisig.ValidateSignatureDataStructure(data); err != nil {
-		return nil, err
+		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidType, err.Error())
 	}
 
 	switch data := data.(type) {

--- a/sei-cosmos/x/auth/ante/sigverify.go
+++ b/sei-cosmos/x/auth/ante/sigverify.go
@@ -422,7 +422,8 @@ func DefaultSigVerificationGasConsumer(
 	}
 }
 
-// ConsumeMultisignatureVerificationGas consumes gas from a GasMeter for verifying a multisig pubkey signature
+// ConsumeMultisignatureVerificationGas consumes gas from a GasMeter for verifying a multisig pubkey signature.
+// Structure is validated once for the whole tree here; nested multisig recursion skips re-validation.
 func ConsumeMultisignatureVerificationGas(
 	meter sdk.GasMeter, sig *signing.MultiSignatureData, pubkey multisig.PubKey,
 	params types.Params, accSeq uint64,
@@ -430,7 +431,15 @@ func ConsumeMultisignatureVerificationGas(
 	if err := multisig.ValidateSignatureDataStructure(sig); err != nil {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidType, err.Error())
 	}
+	return consumeMultisignatureVerificationGas(meter, sig, pubkey, params, accSeq)
+}
 
+// consumeMultisignatureVerificationGas walks true bits and charges gas. Assumes sig already
+// passed ValidateSignatureDataStructure (including nested children).
+func consumeMultisignatureVerificationGas(
+	meter sdk.GasMeter, sig *signing.MultiSignatureData, pubkey multisig.PubKey,
+	params types.Params, accSeq uint64,
+) error {
 	size := sig.BitArray.Count()
 	pubKeys := pubkey.GetPubKeys()
 	// This runs before VerifyMultisignature; require bit-array size to match the key set.
@@ -447,6 +456,18 @@ func ConsumeMultisignatureVerificationGas(
 		// NumTrueBits); kept as defense-in-depth.
 		if sigIndex >= len(sig.Signatures) {
 			return sdkerrors.Wrapf(sdkerrors.ErrInvalidType, "signature size is incorrect %d", len(sig.Signatures))
+		}
+		// Nested multisig: recurse without re-running ValidateSignatureDataStructure.
+		if nestedPk, ok := pubKeys[i].(multisig.PubKey); ok {
+			nestedSig, ok := sig.Signatures[sigIndex].(*signing.MultiSignatureData)
+			if !ok {
+				return fmt.Errorf("expected %T, got, %T", &signing.MultiSignatureData{}, sig.Signatures[sigIndex])
+			}
+			if err := consumeMultisignatureVerificationGas(meter, nestedSig, nestedPk, params, accSeq); err != nil {
+				return err
+			}
+			sigIndex++
+			continue
 		}
 		sigV2 := signing.SignatureV2{
 			PubKey:   pubKeys[i],

--- a/sei-cosmos/x/auth/ante/sigverify.go
+++ b/sei-cosmos/x/auth/ante/sigverify.go
@@ -461,7 +461,7 @@ func consumeMultisignatureVerificationGas(
 		if nestedPk, ok := pubKeys[i].(multisig.PubKey); ok {
 			nestedSig, ok := sig.Signatures[sigIndex].(*signing.MultiSignatureData)
 			if !ok {
-				return fmt.Errorf("expected %T, got, %T", &signing.MultiSignatureData{}, sig.Signatures[sigIndex])
+				return sdkerrors.Wrapf(sdkerrors.ErrInvalidType, "expected %T, got %T", &signing.MultiSignatureData{}, sig.Signatures[sigIndex])
 			}
 			if err := consumeMultisignatureVerificationGas(meter, nestedSig, nestedPk, params, accSeq); err != nil {
 				return err

--- a/sei-cosmos/x/auth/ante/sigverify.go
+++ b/sei-cosmos/x/auth/ante/sigverify.go
@@ -452,8 +452,7 @@ func consumeMultisignatureVerificationGas(
 		if !sig.BitArray.GetIndex(i) {
 			continue
 		}
-		// Unreachable if ValidateSignatureDataStructure succeeded (len(sigs) ==
-		// NumTrueBits); kept as defense-in-depth.
+		// Redundant with ValidateSignatureDataStructure (len(sigs) == NumTrueBits).
 		if sigIndex >= len(sig.Signatures) {
 			return sdkerrors.Wrapf(sdkerrors.ErrInvalidType, "signature size is incorrect %d", len(sig.Signatures))
 		}

--- a/sei-cosmos/x/auth/ante/sigverify.go
+++ b/sei-cosmos/x/auth/ante/sigverify.go
@@ -427,16 +427,27 @@ func ConsumeMultisignatureVerificationGas(
 	meter sdk.GasMeter, sig *signing.MultiSignatureData, pubkey multisig.PubKey,
 	params types.Params, accSeq uint64,
 ) error {
+	if err := multisig.ValidateSignatureDataStructure(sig); err != nil {
+		return err
+	}
 
 	size := sig.BitArray.Count()
-	sigIndex := 0
+	pubKeys := pubkey.GetPubKeys()
+	// This runs before VerifyMultisignature; require bit-array size to match the key set.
+	if len(pubKeys) != size {
+		return fmt.Errorf("bit array size is incorrect, expecting: %d", len(pubKeys))
+	}
 
+	sigIndex := 0
 	for i := 0; i < size; i++ {
 		if !sig.BitArray.GetIndex(i) {
 			continue
 		}
+		if sigIndex >= len(sig.Signatures) {
+			return fmt.Errorf("signature size is incorrect %d", len(sig.Signatures))
+		}
 		sigV2 := signing.SignatureV2{
-			PubKey:   pubkey.GetPubKeys()[i],
+			PubKey:   pubKeys[i],
 			Data:     sig.Signatures[sigIndex],
 			Sequence: accSeq,
 		}
@@ -475,40 +486,78 @@ func CountSubKeys(pub cryptotypes.PubKey) int {
 	return numKeys
 }
 
-// SignatureDataToBz converts a SignatureData into raw bytes signature.
+// SignatureDataToBz converts a SignatureData into raw bytes for tx.signature events.
 // For SingleSignatureData, it returns the signature raw bytes.
-// For MultiSignatureData, it returns an array of all individual signatures,
-// as well as the aggregated signature.
+// For MultiSignatureData, it returns all leaf signature bytes plus one wire-compatible
+// root aggregate (same encoding as Tx.signatures / SignatureDataToModeInfoAndSig).
+// Nested MultiSignatureData nodes contribute leaves only; they do not emit their own aggregates.
 func SignatureDataToBz(data signing.SignatureData) ([][]byte, error) {
-	if data == nil {
-		return nil, fmt.Errorf("got empty SignatureData")
+	if err := multisig.ValidateSignatureDataStructure(data); err != nil {
+		return nil, err
 	}
 
 	switch data := data.(type) {
 	case *signing.SingleSignatureData:
 		return [][]byte{data.Signature}, nil
 	case *signing.MultiSignatureData:
-		sigs := [][]byte{}
-		var err error
-
-		for _, d := range data.Signatures {
-			nestedSigs, err := SignatureDataToBz(d)
-			if err != nil {
-				return nil, err
-			}
-			sigs = append(sigs, nestedSigs...)
-		}
-
-		multisig := cryptotypes.MultiSignature{
-			Signatures: sigs,
-		}
-		aggregatedSig, err := multisig.Marshal()
+		leaves, err := collectMultisigSignatureLeaves(data)
 		if err != nil {
 			return nil, err
 		}
-		sigs = append(sigs, aggregatedSig)
+		agg, err := wireCompatibleMultisigAggregate(data)
+		if err != nil {
+			return nil, err
+		}
+		return append(leaves, agg), nil
+	default:
+		return nil, sdkerrors.ErrInvalidType.Wrapf("unexpected signature data type %T", data)
+	}
+}
 
-		return sigs, nil
+// collectMultisigSignatureLeaves returns SingleSignatureData.Signature bytes under multi,
+// recursively; nested multis do not contribute aggregates.
+func collectMultisigSignatureLeaves(multi *signing.MultiSignatureData) ([][]byte, error) {
+	var leaves [][]byte
+	for _, child := range multi.Signatures {
+		switch child := child.(type) {
+		case *signing.SingleSignatureData:
+			leaves = append(leaves, child.Signature)
+		case *signing.MultiSignatureData:
+			chunk, err := collectMultisigSignatureLeaves(child)
+			if err != nil {
+				return nil, err
+			}
+			leaves = append(leaves, chunk...)
+		default:
+			return nil, sdkerrors.ErrInvalidType.Wrapf("unexpected signature data type %T", child)
+		}
+	}
+	return leaves, nil
+}
+
+// wireCompatibleMultisigAggregate marshals direct child signature bytes the same way
+// SignatureDataToModeInfoAndSig encodes MultiSignatureData onto Tx.signatures.
+func wireCompatibleMultisigAggregate(data *signing.MultiSignatureData) ([]byte, error) {
+	childRaw := make([][]byte, len(data.Signatures))
+	for i, child := range data.Signatures {
+		raw, err := signatureDataWireBytes(child)
+		if err != nil {
+			return nil, err
+		}
+		childRaw[i] = raw
+	}
+	agg := cryptotypes.MultiSignature{Signatures: childRaw}
+	return agg.Marshal()
+}
+
+// signatureDataWireBytes returns the raw signature bytes stored on the wire for one
+// SignatureData node (single leaf bytes, or nested MultiSignature marshal).
+func signatureDataWireBytes(data signing.SignatureData) ([]byte, error) {
+	switch data := data.(type) {
+	case *signing.SingleSignatureData:
+		return data.Signature, nil
+	case *signing.MultiSignatureData:
+		return wireCompatibleMultisigAggregate(data)
 	default:
 		return nil, sdkerrors.ErrInvalidType.Wrapf("unexpected signature data type %T", data)
 	}

--- a/sei-cosmos/x/auth/ante/sigverify_signaturedata_test.go
+++ b/sei-cosmos/x/auth/ante/sigverify_signaturedata_test.go
@@ -136,3 +136,28 @@ func TestConsumeMultisignatureVerificationGas_TrailingSignatures(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, sdkerrors.ErrInvalidType.Is(err))
 }
+
+func TestConsumeMultisignatureVerificationGas_NestedExactGas(t *testing.T) {
+	params := types.DefaultParams()
+	secpCost := params.GetSigVerifyCostSecp256k1()
+
+	alice := secp256k1.GenPrivKey()
+	bob := secp256k1.GenPrivKey()
+	carol := secp256k1.GenPrivKey()
+
+	innerPk := kmultisig.NewLegacyAminoPubKey(2, []cryptotypes.PubKey{bob.PubKey(), carol.PubKey()})
+	outerPk := kmultisig.NewLegacyAminoPubKey(2, []cryptotypes.PubKey{alice.PubKey(), innerPk})
+
+	// outer: alice + nested(bob, carol) — three secp256k1 leaf verifications.
+	innerSig := multisig.NewMultisig(2)
+	multisig.AddSignature(innerSig, &signing.SingleSignatureData{Signature: []byte{1}}, 0)
+	multisig.AddSignature(innerSig, &signing.SingleSignatureData{Signature: []byte{2}}, 1)
+
+	outerSig := multisig.NewMultisig(2)
+	multisig.AddSignature(outerSig, &signing.SingleSignatureData{Signature: []byte{3}}, 0)
+	multisig.AddSignature(outerSig, innerSig, 1)
+
+	meter := sdk.NewInfiniteGasMeter(1, 1)
+	require.NoError(t, ante.ConsumeMultisignatureVerificationGas(meter, outerSig, outerPk, params, 0))
+	require.Equal(t, 3*secpCost, meter.GasConsumed())
+}

--- a/sei-cosmos/x/auth/ante/sigverify_signaturedata_test.go
+++ b/sei-cosmos/x/auth/ante/sigverify_signaturedata_test.go
@@ -11,6 +11,7 @@ import (
 	cryptotypes "github.com/sei-protocol/sei-chain/sei-cosmos/crypto/types"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/crypto/types/multisig"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/types/tx/signing"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/ante"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/tx"
@@ -94,6 +95,7 @@ func TestSignatureDataToBz_RejectsTrailingSignatures(t *testing.T) {
 
 	_, err = ante.SignatureDataToBz(msig)
 	require.Error(t, err)
+	require.True(t, sdkerrors.ErrInvalidType.Is(err))
 }
 
 func TestConsumeMultisignatureVerificationGas_BitArrayExceedsKeySet(t *testing.T) {
@@ -112,6 +114,7 @@ func TestConsumeMultisignatureVerificationGas_BitArrayExceedsKeySet(t *testing.T
 	meter := sdk.NewInfiniteGasMeter(1, 1)
 	err := ante.ConsumeMultisignatureVerificationGas(meter, sig, pubkey, params, 0)
 	require.Error(t, err)
+	require.True(t, sdkerrors.ErrInvalidType.Is(err))
 }
 
 func TestConsumeMultisignatureVerificationGas_TrailingSignatures(t *testing.T) {
@@ -131,4 +134,5 @@ func TestConsumeMultisignatureVerificationGas_TrailingSignatures(t *testing.T) {
 	meter := sdk.NewInfiniteGasMeter(1, 1)
 	err := ante.ConsumeMultisignatureVerificationGas(meter, sig, pubkey, params, 0)
 	require.Error(t, err)
+	require.True(t, sdkerrors.ErrInvalidType.Is(err))
 }

--- a/sei-cosmos/x/auth/ante/sigverify_signaturedata_test.go
+++ b/sei-cosmos/x/auth/ante/sigverify_signaturedata_test.go
@@ -1,0 +1,134 @@
+package ante_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	kmultisig "github.com/sei-protocol/sei-chain/sei-cosmos/crypto/keys/multisig"
+	"github.com/sei-protocol/sei-chain/sei-cosmos/crypto/keys/secp256k1"
+	cryptotypes "github.com/sei-protocol/sei-chain/sei-cosmos/crypto/types"
+	"github.com/sei-protocol/sei-chain/sei-cosmos/crypto/types/multisig"
+	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	"github.com/sei-protocol/sei-chain/sei-cosmos/types/tx/signing"
+	"github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/ante"
+	"github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/tx"
+	"github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/types"
+)
+
+func TestSignatureDataToBz_FlatMultisigMatchesWireAggregate(t *testing.T) {
+	msg := []byte("flat-msig")
+	privs := []*secp256k1.PrivKey{secp256k1.GenPrivKey(), secp256k1.GenPrivKey(), secp256k1.GenPrivKey()}
+	msig := multisig.NewMultisig(3)
+	var leafSigs [][]byte
+	for i := 0; i < 2; i++ {
+		sigBz, err := privs[i].Sign(msg)
+		require.NoError(t, err)
+		leafSigs = append(leafSigs, sigBz)
+		multisig.AddSignature(msig, &signing.SingleSignatureData{Signature: sigBz}, i)
+	}
+
+	got, err := ante.SignatureDataToBz(msig)
+	require.NoError(t, err)
+	require.Len(t, got, 3) // two leaves + root aggregate
+	require.Equal(t, leafSigs[0], got[0])
+	require.Equal(t, leafSigs[1], got[1])
+
+	_, wireSig := tx.SignatureDataToModeInfoAndSig(msig)
+	require.Equal(t, wireSig, got[2], "root aggregate must match Tx.signatures encoding")
+}
+
+func TestSignatureDataToBz_NestedLeavesPlusRootWireOnly(t *testing.T) {
+	msg := []byte("nested-msig")
+	alice := secp256k1.GenPrivKey()
+	bob := secp256k1.GenPrivKey()
+	carol := secp256k1.GenPrivKey()
+
+	sigAlice, err := alice.Sign(msg)
+	require.NoError(t, err)
+	sigBob, err := bob.Sign(msg)
+	require.NoError(t, err)
+	sigCarol, err := carol.Sign(msg)
+	require.NoError(t, err)
+
+	inner := multisig.NewMultisig(2)
+	multisig.AddSignature(inner, &signing.SingleSignatureData{Signature: sigBob}, 0)
+
+	outer := multisig.NewMultisig(2)
+	multisig.AddSignature(outer, &signing.SingleSignatureData{Signature: sigAlice}, 0)
+	multisig.AddSignature(outer, inner, 1)
+
+	got, err := ante.SignatureDataToBz(outer)
+	require.NoError(t, err)
+	// leaves + one root wire aggregate; no separate inner aggregate event
+	require.Len(t, got, 3)
+	require.Equal(t, sigAlice, got[0])
+	require.Equal(t, sigBob, got[1])
+
+	_, wireOuter := tx.SignatureDataToModeInfoAndSig(outer)
+	require.Equal(t, wireOuter, got[2])
+
+	_, wireInner := tx.SignatureDataToModeInfoAndSig(inner)
+	for _, bz := range got {
+		require.False(t, bytes.Equal(bz, wireInner), "inner-only aggregate must not be emitted as its own event")
+	}
+	for _, bz := range got {
+		require.False(t, bytes.Equal(bz, sigCarol))
+	}
+}
+
+func TestSignatureDataToBz_RejectsTrailingSignatures(t *testing.T) {
+	msg := []byte("trailing")
+	priv := secp256k1.GenPrivKey()
+	sigBz, err := priv.Sign(msg)
+	require.NoError(t, err)
+	single := &signing.SingleSignatureData{Signature: sigBz}
+
+	msig := multisig.NewMultisig(3)
+	multisig.AddSignature(msig, single, 0)
+	multisig.AddSignature(msig, single, 1)
+	msig.Signatures = append(msig.Signatures, &signing.SingleSignatureData{
+		Signature: bytes.Repeat([]byte{0xab}, 1024),
+	})
+
+	_, err = ante.SignatureDataToBz(msig)
+	require.Error(t, err)
+}
+
+func TestConsumeMultisignatureVerificationGas_BitArrayExceedsKeySet(t *testing.T) {
+	params := types.DefaultParams()
+	pkSet := []cryptotypes.PubKey{secp256k1.GenPrivKey().PubKey(), secp256k1.GenPrivKey().PubKey()}
+	pubkey := kmultisig.NewLegacyAminoPubKey(2, pkSet)
+
+	sig := multisig.NewMultisig(4)
+	sig.BitArray.SetIndex(0, true)
+	sig.BitArray.SetIndex(1, true)
+	sig.Signatures = []signing.SignatureData{
+		&signing.SingleSignatureData{Signature: []byte{1}},
+		&signing.SingleSignatureData{Signature: []byte{2}},
+	}
+
+	meter := sdk.NewInfiniteGasMeter(1, 1)
+	err := ante.ConsumeMultisignatureVerificationGas(meter, sig, pubkey, params, 0)
+	require.Error(t, err)
+}
+
+func TestConsumeMultisignatureVerificationGas_TrailingSignatures(t *testing.T) {
+	params := types.DefaultParams()
+	pkSet := []cryptotypes.PubKey{
+		secp256k1.GenPrivKey().PubKey(),
+		secp256k1.GenPrivKey().PubKey(),
+		secp256k1.GenPrivKey().PubKey(),
+	}
+	pubkey := kmultisig.NewLegacyAminoPubKey(2, pkSet)
+
+	sig := multisig.NewMultisig(3)
+	multisig.AddSignature(sig, &signing.SingleSignatureData{Signature: []byte{1}}, 0)
+	multisig.AddSignature(sig, &signing.SingleSignatureData{Signature: []byte{2}}, 1)
+	sig.Signatures = append(sig.Signatures, &signing.SingleSignatureData{Signature: []byte{3}})
+
+	meter := sdk.NewInfiniteGasMeter(1, 1)
+	err := ante.ConsumeMultisignatureVerificationGas(meter, sig, pubkey, params, 0)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- Enforce `len(Signatures) == NumTrueBits` for `MultiSignatureData` at every nesting level (`ValidateSignatureDataStructure`), shared by verify and multisig gas accounting.
- Validate `CompactBitArray` shape via `ValidateBasic` (`ExtraBitsStored` in range; elems present when required) before bit counting.
- Emit `tx.signature` events as leaf signature bytes plus one root aggregate matching `Tx.signatures` / `SignatureDataToModeInfoAndSig` encoding.
- Map structure validation failures at ante boundaries to `sdkerrors.ErrInvalidType`.
- Add unit coverage for structure checks, verify edge cases, event encoding, and gas accounting.

## Compatibility: `tx.signature` events
- **Flat multisig:** event set unchanged (leaves + wire-compatible root aggregate).
- **Nested multisig:** event set changes — no per-level inner aggregates; root aggregate uses direct children only. Clients/indexers that key on nested `tx.signature` values should use the updated encoding.
