### PR TITLE
perf(evm): cache BLOCKHASH via 32-byte hash ring (CON-372)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -364,6 +364,9 @@ type gigaBlockCache struct {
 }
 
 func newGigaBlockCache(ctx sdk.Context, keeper *gigaevmkeeper.Keeper) (*gigaBlockCache, error) {
+	if !ctx.IsTracing() {
+		keeper.PruneBlockHashCache(ctx)
+	}
 	chainID := keeper.ChainID(ctx)
 	gp := keeper.GetGasPool()
 	blockCtx, err := keeper.GetVMBlockContext(ctx, gp)

--- a/app/app.go
+++ b/app/app.go
@@ -364,9 +364,6 @@ type gigaBlockCache struct {
 }
 
 func newGigaBlockCache(ctx sdk.Context, keeper *gigaevmkeeper.Keeper) (*gigaBlockCache, error) {
-	if !ctx.IsTracing() {
-		keeper.PruneBlockHashCache(ctx)
-	}
 	chainID := keeper.ChainID(ctx)
 	gp := keeper.GetGasPool()
 	blockCtx, err := keeper.GetVMBlockContext(ctx, gp)

--- a/giga/deps/xevm/keeper/block_hash.go
+++ b/giga/deps/xevm/keeper/block_hash.go
@@ -1,0 +1,38 @@
+package keeper
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/sei-protocol/sei-chain/giga/deps/xevm/types"
+	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+)
+
+// MaxBlockHashHistory is the number of recent block hashes retained for BLOCKHASH
+// (Yellow Paper / EVM: only the previous 256 blocks are available).
+const MaxBlockHashHistory = 256
+
+func (k *Keeper) GetBlockHash(ctx sdk.Context, height int64) (common.Hash, bool) {
+	store := ctx.KVStore(k.GetStoreKey())
+	bz := store.Get(types.BlockHashKey(height))
+	if len(bz) == 0 {
+		return common.Hash{}, false
+	}
+	return common.BytesToHash(bz), true
+}
+
+func (k *Keeper) SetBlockHash(ctx sdk.Context, height int64, hash common.Hash) {
+	store := ctx.KVStore(k.GetStoreKey())
+	store.Set(types.BlockHashKey(height), hash.Bytes())
+}
+
+func (k *Keeper) DeleteBlockHash(ctx sdk.Context, height int64) {
+	store := ctx.KVStore(k.GetStoreKey())
+	store.Delete(types.BlockHashKey(height))
+}
+
+// PruneBlockHashCache drops the in-memory entry that fell out of MaxBlockHashHistory.
+// The KV ring is maintained by EvmKeeper.TrackBlockHash (shared store).
+func (k *Keeper) PruneBlockHashCache(ctx sdk.Context) {
+	if prune := ctx.BlockHeight() - 1 - MaxBlockHashHistory; prune >= 0 {
+		k.blockHashCache.Delete(uint64(prune)) //nolint:gosec
+	}
+}

--- a/giga/deps/xevm/keeper/block_hash.go
+++ b/giga/deps/xevm/keeper/block_hash.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"github.com/ethereum/go-ethereum/common"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/sei-protocol/sei-chain/giga/deps/xevm/types"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 )
@@ -10,6 +11,19 @@ import (
 // (Yellow Paper / EVM: only the previous 256 blocks are available).
 const MaxBlockHashHistory = 256
 
+// blockHashCacheSize bounds the process-local BLOCKHASH cache (tip window plus headroom).
+const blockHashCacheSize = MaxBlockHashHistory * 2
+
+func newBlockHashCache() *lru.Cache[uint64, common.Hash] {
+	c, err := lru.New[uint64, common.Hash](blockHashCacheSize)
+	if err != nil {
+		panic(err)
+	}
+	return c
+}
+
+// Block-hash ring accessors use ctx.KVStore (not GetKVStore / GigaKVStore) so
+// they read the same store EvmKeeper.TrackBlockHash writes on BeginBlock.
 func (k *Keeper) GetBlockHash(ctx sdk.Context, height int64) (common.Hash, bool) {
 	store := ctx.KVStore(k.GetStoreKey())
 	bz := store.Get(types.BlockHashKey(height))
@@ -29,10 +43,14 @@ func (k *Keeper) DeleteBlockHash(ctx sdk.Context, height int64) {
 	store.Delete(types.BlockHashKey(height))
 }
 
-// PruneBlockHashCache drops the in-memory entry that fell out of MaxBlockHashHistory.
-// The KV ring is maintained by EvmKeeper.TrackBlockHash (shared store).
-func (k *Keeper) PruneBlockHashCache(ctx sdk.Context) {
-	if prune := ctx.BlockHeight() - 1 - MaxBlockHashHistory; prune >= 0 {
-		k.blockHashCache.Delete(uint64(prune)) //nolint:gosec
+// cacheBlockHash stores a BLOCKHASH result for DeliverTx execution only.
+// CheckTx/recheck and RPC/trace contexts may read the cache but do not insert.
+func (k *Keeper) cacheBlockHash(ctx sdk.Context, height uint64, hash common.Hash) {
+	if hash == (common.Hash{}) {
+		return
 	}
+	if ctx.IsCheckTx() || ctx.IsReCheckTx() || ctx.IsTracing() {
+		return
+	}
+	k.blockHashCache.Add(height, hash)
 }

--- a/giga/deps/xevm/keeper/block_hash_test.go
+++ b/giga/deps/xevm/keeper/block_hash_test.go
@@ -8,17 +8,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPruneBlockHashCache(t *testing.T) {
+func TestBlockHashCacheDeliverOnly(t *testing.T) {
 	testApp, ctx := keeper.MockApp(t)
 	k := &testApp.GigaEvmKeeper
 
-	stale := common.HexToHash("0x0101010101010101010101010101010101010101010101010101010101010101")
-	k.SetBlockHash(ctx, 0, stale)
-	require.Equal(t, stale, k.GetHashFn(ctx)(0))
-	k.DeleteBlockHash(ctx, 0)
-	require.Equal(t, stale, k.GetHashFn(ctx)(0))
+	hash := common.HexToHash("0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20")
+	k.SetBlockHash(ctx, 7, hash)
 
-	ctx = ctx.WithBlockHeight(257)
-	k.PruneBlockHashCache(ctx)
-	require.Equal(t, common.Hash{}, k.GetHashFn(ctx)(0))
+	traceCtx := ctx.WithTraceMode(true)
+	require.Equal(t, hash, k.GetHashFn(traceCtx)(7))
+	k.DeleteBlockHash(ctx, 7)
+	require.Equal(t, common.Hash{}, k.GetHashFn(traceCtx)(7))
+
+	k.SetBlockHash(ctx, 7, hash)
+	require.Equal(t, hash, k.GetHashFn(ctx)(7))
+	k.DeleteBlockHash(ctx, 7)
+	require.Equal(t, hash, k.GetHashFn(ctx)(7))
 }

--- a/giga/deps/xevm/keeper/block_hash_test.go
+++ b/giga/deps/xevm/keeper/block_hash_test.go
@@ -1,0 +1,24 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/sei-protocol/sei-chain/giga/deps/testutil/keeper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPruneBlockHashCache(t *testing.T) {
+	testApp, ctx := keeper.MockApp(t)
+	k := &testApp.GigaEvmKeeper
+
+	stale := common.HexToHash("0x0101010101010101010101010101010101010101010101010101010101010101")
+	k.SetBlockHash(ctx, 0, stale)
+	require.Equal(t, stale, k.GetHashFn(ctx)(0))
+	k.DeleteBlockHash(ctx, 0)
+	require.Equal(t, stale, k.GetHashFn(ctx)(0))
+
+	ctx = ctx.WithBlockHeight(257)
+	k.PruneBlockHashCache(ctx)
+	require.Equal(t, common.Hash{}, k.GetHashFn(ctx)(0))
+}

--- a/giga/deps/xevm/keeper/keeper.go
+++ b/giga/deps/xevm/keeper/keeper.go
@@ -66,7 +66,7 @@ type Keeper struct {
 	hashToNonce                  map[tmtypes.TxHash]*AddressNoncePair
 
 	// blockHashCache caches BLOCKHASH results; pruned in PruneBlockHashCache.
-	blockHashCache sync.Map
+	blockHashCache *sync.Map
 
 	// used for both ETH replay and block tests. Not used in chain critical path.
 	Trie        ethstate.Trie
@@ -145,6 +145,7 @@ func NewKeeper(
 		pendingTxs:                   make(map[string][]*PendingTx),
 		nonceMx:                      &sync.RWMutex{},
 		cachedFeeCollectorAddressMtx: &sync.RWMutex{},
+		blockHashCache:               &sync.Map{},
 		hashToNonce:                  make(map[tmtypes.TxHash]*AddressNoncePair),
 		receiptStore:                 receiptStateStore,
 	}

--- a/giga/deps/xevm/keeper/keeper.go
+++ b/giga/deps/xevm/keeper/keeper.go
@@ -65,6 +65,9 @@ type Keeper struct {
 	pendingTxs                   map[string][]*PendingTx
 	hashToNonce                  map[tmtypes.TxHash]*AddressNoncePair
 
+	// blockHashCache caches BLOCKHASH results; pruned in PruneBlockHashCache.
+	blockHashCache sync.Map
+
 	// used for both ETH replay and block tests. Not used in chain critical path.
 	Trie        ethstate.Trie
 	DB          ethstate.Database
@@ -320,6 +323,14 @@ func (k *Keeper) GetHashFn(ctx sdk.Context) vm.GetHashFunc {
 }
 
 func (k *Keeper) getHistoricalHash(ctx sdk.Context, h int64) common.Hash {
+	height := uint64(h) //nolint:gosec
+	if cached, ok := k.blockHashCache.Load(height); ok {
+		return cached.(common.Hash)
+	}
+	if hash, found := k.GetBlockHash(ctx, h); found {
+		k.blockHashCache.Store(height, hash)
+		return hash
+	}
 	histInfo, found := k.stakingKeeper.GetHistoricalInfo(ctx, h)
 	if !found {
 		// too old, already pruned
@@ -327,7 +338,11 @@ func (k *Keeper) getHistoricalHash(ctx sdk.Context, h int64) common.Hash {
 	}
 	header, _ := tmtypes.HeaderFromProto(&histInfo.Header)
 
-	return common.BytesToHash(header.Hash())
+	hash := common.BytesToHash(header.Hash())
+	if hash != (common.Hash{}) {
+		k.blockHashCache.Store(height, hash)
+	}
+	return hash
 }
 
 // CalculateNextNonce calculates the next nonce for an address

--- a/giga/deps/xevm/keeper/keeper.go
+++ b/giga/deps/xevm/keeper/keeper.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/params"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/holiman/uint256"
 	bankkeeper "github.com/sei-protocol/sei-chain/giga/deps/xbank/keeper"
 	"github.com/sei-protocol/sei-chain/giga/deps/xevm/state"
@@ -65,8 +66,9 @@ type Keeper struct {
 	pendingTxs                   map[string][]*PendingTx
 	hashToNonce                  map[tmtypes.TxHash]*AddressNoncePair
 
-	// blockHashCache caches BLOCKHASH results; pruned in PruneBlockHashCache.
-	blockHashCache *sync.Map
+	// blockHashCache is a bounded process-local cache of BLOCKHASH results for
+	// DeliverTx. RPC/trace and CheckTx may read it but do not insert.
+	blockHashCache *lru.Cache[uint64, common.Hash]
 
 	// used for both ETH replay and block tests. Not used in chain critical path.
 	Trie        ethstate.Trie
@@ -145,7 +147,7 @@ func NewKeeper(
 		pendingTxs:                   make(map[string][]*PendingTx),
 		nonceMx:                      &sync.RWMutex{},
 		cachedFeeCollectorAddressMtx: &sync.RWMutex{},
-		blockHashCache:               &sync.Map{},
+		blockHashCache:               newBlockHashCache(),
 		hashToNonce:                  make(map[tmtypes.TxHash]*AddressNoncePair),
 		receiptStore:                 receiptStateStore,
 	}
@@ -325,11 +327,12 @@ func (k *Keeper) GetHashFn(ctx sdk.Context) vm.GetHashFunc {
 
 func (k *Keeper) getHistoricalHash(ctx sdk.Context, h int64) common.Hash {
 	height := uint64(h) //nolint:gosec
-	if cached, ok := k.blockHashCache.Load(height); ok {
-		return cached.(common.Hash)
+	// Peek keeps LRU order driven by DeliverTx inserts only.
+	if cached, ok := k.blockHashCache.Peek(height); ok {
+		return cached
 	}
 	if hash, found := k.GetBlockHash(ctx, h); found {
-		k.blockHashCache.Store(height, hash)
+		k.cacheBlockHash(ctx, height, hash)
 		return hash
 	}
 	histInfo, found := k.stakingKeeper.GetHistoricalInfo(ctx, h)
@@ -340,9 +343,7 @@ func (k *Keeper) getHistoricalHash(ctx sdk.Context, h int64) common.Hash {
 	header, _ := tmtypes.HeaderFromProto(&histInfo.Header)
 
 	hash := common.BytesToHash(header.Hash())
-	if hash != (common.Hash{}) {
-		k.blockHashCache.Store(height, hash)
-	}
+	k.cacheBlockHash(ctx, height, hash)
 	return hash
 }
 

--- a/giga/deps/xevm/keeper/keeper_test.go
+++ b/giga/deps/xevm/keeper/keeper_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"math"
@@ -20,9 +21,12 @@ import (
 	"github.com/sei-protocol/sei-chain/giga/deps/xevm/types/ethtx"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	authtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/types"
+	stakingtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/staking/types"
 	abci "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/crypto/tmhash"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/rand"
 	tmtypes "github.com/sei-protocol/sei-chain/sei-tendermint/types"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/version"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,12 +65,38 @@ func TestGetVMBlockContext(t *testing.T) {
 }
 
 func TestGetHashFn(t *testing.T) {
-	k, ctx := keeper.MockEVMKeeper(t)
+	testApp, ctx := keeper.MockApp(t)
+	ctx = ctx.WithBlockHeight(8)
+	k := &testApp.GigaEvmKeeper
+
+	// HistoricalInfo path (ValidatorsHash required for a non-empty header hash).
+	histHeight := int64(6)
+	tmHeader := tmtypes.Header{
+		Version:        version.Consensus{Block: version.BlockProtocol},
+		Height:         histHeight,
+		ChainID:        "test-chain",
+		ValidatorsHash: bytes.Repeat([]byte{0x01}, tmhash.Size),
+	}
+	fallbackHash := common.BytesToHash(tmHeader.Hash())
+	require.NotEqual(t, common.Hash{}, fallbackHash)
+	hi := stakingtypes.NewHistoricalInfo(*tmHeader.ToProto(), stakingtypes.Validators{}, sdk.DefaultPowerReduction)
+	testApp.StakingKeeper.SetHistoricalInfo(ctx, histHeight, &hi)
+
+	kvHeight := int64(7)
+	kvHash := common.HexToHash("0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20")
+	k.SetBlockHash(ctx, kvHeight, kvHash)
+
 	f := k.GetHashFn(ctx)
 	require.Equal(t, common.Hash{}, f(math.MaxInt64+1))
 	require.Equal(t, common.BytesToHash(ctx.HeaderHash()), f(uint64(ctx.BlockHeight())))
 	require.Equal(t, common.Hash{}, f(uint64(ctx.BlockHeight())+1))
-	require.Equal(t, common.Hash{}, f(uint64(ctx.BlockHeight())-1))
+
+	require.Equal(t, kvHash, f(uint64(kvHeight)))
+	require.Equal(t, fallbackHash, f(uint64(histHeight)))
+	_, found := k.GetBlockHash(ctx, histHeight)
+	require.False(t, found)
+	require.Equal(t, fallbackHash, k.GetHashFn(ctx)(uint64(histHeight)))
+	require.Equal(t, common.Hash{}, f(uint64(ctx.BlockHeight())-3))
 }
 
 func TestKeeper_CalculateNextNonce(t *testing.T) {

--- a/giga/deps/xevm/keeper/keeper_test.go
+++ b/giga/deps/xevm/keeper/keeper_test.go
@@ -95,6 +95,8 @@ func TestGetHashFn(t *testing.T) {
 	require.Equal(t, fallbackHash, f(uint64(histHeight)))
 	_, found := k.GetBlockHash(ctx, histHeight)
 	require.False(t, found)
+	// Remove HistoricalInfo so a second lookup can only succeed via the mem-cache.
+	testApp.StakingKeeper.DeleteHistoricalInfo(ctx, histHeight)
 	require.Equal(t, fallbackHash, k.GetHashFn(ctx)(uint64(histHeight)))
 	require.Equal(t, common.Hash{}, f(uint64(ctx.BlockHeight())-3))
 }

--- a/giga/deps/xevm/types/keys.go
+++ b/giga/deps/xevm/types/keys.go
@@ -62,6 +62,7 @@ var (
 	NextBaseFeePerGasPrefix         = []byte{0x1c}
 	EvmOnlyBlockBloomPrefix         = []byte{0x1d}
 	ZeroStorageCleanupCheckpointKey = []byte{0x1e}
+	BlockHashPrefix                 = []byte{0x20}
 )
 
 var (
@@ -107,6 +108,12 @@ func BlockBloomKey(height int64) []byte {
 	bz := make([]byte, 8)
 	binary.BigEndian.PutUint64(bz, uint64(height)) //nolint:gosec
 	return append(BlockBloomPrefix, bz...)
+}
+
+func BlockHashKey(height int64) []byte {
+	bz := make([]byte, 8)
+	binary.BigEndian.PutUint64(bz, uint64(height)) //nolint:gosec
+	return append(BlockHashPrefix, bz...)
 }
 
 func TxHashesKey(height int64) []byte {

--- a/x/evm/keeper/abci.go
+++ b/x/evm/keeper/abci.go
@@ -29,6 +29,7 @@ func (k *Keeper) BeginBlock(ctx sdk.Context) {
 	if !ctx.IsTracing() {
 		k.SetMsgs([]*types.MsgEVMTransaction{})
 		k.SetTxResults([]*abci.ExecTxResult{})
+		k.TrackBlockHash(ctx)
 	}
 	// mock beacon root if replaying
 	if k.EthReplayConfig.Enabled {

--- a/x/evm/keeper/block_hash.go
+++ b/x/evm/keeper/block_hash.go
@@ -1,0 +1,47 @@
+package keeper
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	"github.com/sei-protocol/sei-chain/x/evm/types"
+)
+
+// MaxBlockHashHistory is the number of recent block hashes retained for BLOCKHASH
+// (Yellow Paper / EVM: only the previous 256 blocks are available).
+const MaxBlockHashHistory = 256
+
+func (k *Keeper) GetBlockHash(ctx sdk.Context, height int64) (common.Hash, bool) {
+	store := ctx.KVStore(k.GetStoreKey())
+	bz := store.Get(types.BlockHashKey(height))
+	if len(bz) == 0 {
+		return common.Hash{}, false
+	}
+	return common.BytesToHash(bz), true
+}
+
+func (k *Keeper) SetBlockHash(ctx sdk.Context, height int64, hash common.Hash) {
+	store := ctx.KVStore(k.GetStoreKey())
+	store.Set(types.BlockHashKey(height), hash.Bytes())
+}
+
+func (k *Keeper) DeleteBlockHash(ctx sdk.Context, height int64) {
+	store := ctx.KVStore(k.GetStoreKey())
+	store.Delete(types.BlockHashKey(height))
+}
+
+// TrackBlockHash stores LastBlockId.Hash for height-1 and prunes the height
+// that fell out of MaxBlockHashHistory from KV and the in-memory cache.
+func (k *Keeper) TrackBlockHash(ctx sdk.Context) {
+	height := ctx.BlockHeight()
+	if height <= 0 {
+		return
+	}
+	parent := common.BytesToHash(ctx.BlockHeader().LastBlockId.Hash)
+	if parent != (common.Hash{}) {
+		k.SetBlockHash(ctx, height-1, parent)
+	}
+	if prune := height - 1 - MaxBlockHashHistory; prune >= 0 {
+		k.DeleteBlockHash(ctx, prune)
+		k.blockHashCache.Delete(uint64(prune)) //nolint:gosec
+	}
+}

--- a/x/evm/keeper/block_hash.go
+++ b/x/evm/keeper/block_hash.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"github.com/ethereum/go-ethereum/common"
+	lru "github.com/hashicorp/golang-lru/v2"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
@@ -9,6 +10,17 @@ import (
 // MaxBlockHashHistory is the number of recent block hashes retained for BLOCKHASH
 // (Yellow Paper / EVM: only the previous 256 blocks are available).
 const MaxBlockHashHistory = 256
+
+// blockHashCacheSize bounds the process-local BLOCKHASH cache (tip window plus headroom).
+const blockHashCacheSize = MaxBlockHashHistory * 2
+
+func newBlockHashCache() *lru.Cache[uint64, common.Hash] {
+	c, err := lru.New[uint64, common.Hash](blockHashCacheSize)
+	if err != nil {
+		panic(err)
+	}
+	return c
+}
 
 func (k *Keeper) GetBlockHash(ctx sdk.Context, height int64) (common.Hash, bool) {
 	store := ctx.KVStore(k.GetStoreKey())
@@ -30,7 +42,7 @@ func (k *Keeper) DeleteBlockHash(ctx sdk.Context, height int64) {
 }
 
 // TrackBlockHash stores LastBlockId.Hash for height-1 and prunes the height
-// that fell out of MaxBlockHashHistory from KV and the in-memory cache.
+// that fell out of MaxBlockHashHistory from the KV ring.
 func (k *Keeper) TrackBlockHash(ctx sdk.Context) {
 	height := ctx.BlockHeight()
 	if height <= 0 {
@@ -42,6 +54,17 @@ func (k *Keeper) TrackBlockHash(ctx sdk.Context) {
 	}
 	if prune := height - 1 - MaxBlockHashHistory; prune >= 0 {
 		k.DeleteBlockHash(ctx, prune)
-		k.blockHashCache.Delete(uint64(prune)) //nolint:gosec
 	}
+}
+
+// cacheBlockHash stores a BLOCKHASH result for DeliverTx execution only.
+// CheckTx/recheck and RPC/trace contexts may read the cache but do not insert.
+func (k *Keeper) cacheBlockHash(ctx sdk.Context, height uint64, hash common.Hash) {
+	if hash == (common.Hash{}) {
+		return
+	}
+	if ctx.IsCheckTx() || ctx.IsReCheckTx() || ctx.IsTracing() {
+		return
+	}
+	k.blockHashCache.Add(height, hash)
 }

--- a/x/evm/keeper/block_hash_test.go
+++ b/x/evm/keeper/block_hash_test.go
@@ -1,0 +1,44 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/sei-protocol/sei-chain/app"
+	tmproto "github.com/sei-protocol/sei-chain/sei-tendermint/proto/tendermint/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrackBlockHash(t *testing.T) {
+	testApp := app.Setup(t, false, false, false)
+	k := &testApp.EvmKeeper
+
+	parentHash := common.HexToHash("0xaabbccddeeff00112233445566778899aabbccddeeff00112233445566778899")
+	header := testApp.GetContextForDeliverTx([]byte{}).BlockHeader()
+	header.Height = 10
+	header.LastBlockId = tmproto.BlockID{Hash: parentHash.Bytes()}
+	ctx := testApp.GetContextForDeliverTx([]byte{}).WithBlockHeader(header)
+
+	k.TrackBlockHash(ctx)
+	got, found := k.GetBlockHash(ctx, 9)
+	require.True(t, found)
+	require.Equal(t, parentHash, got)
+
+	// At height 257, prune height 0 out of the window.
+	stale := common.HexToHash("0x0101010101010101010101010101010101010101010101010101010101010101")
+	k.SetBlockHash(ctx, 0, stale)
+	require.Equal(t, stale, k.GetHashFn(ctx)(0))
+
+	nextParent := common.HexToHash("0x0202020202020202020202020202020202020202020202020202020202020202")
+	header.Height = 257
+	header.LastBlockId = tmproto.BlockID{Hash: nextParent.Bytes()}
+	ctx = ctx.WithBlockHeader(header)
+	k.TrackBlockHash(ctx)
+
+	_, found = k.GetBlockHash(ctx, 0)
+	require.False(t, found)
+	parent, found := k.GetBlockHash(ctx, 256)
+	require.True(t, found)
+	require.Equal(t, nextParent, parent)
+	require.Equal(t, common.Hash{}, k.GetHashFn(ctx)(0))
+}

--- a/x/evm/keeper/block_hash_test.go
+++ b/x/evm/keeper/block_hash_test.go
@@ -35,6 +35,8 @@ func TestTrackBlockHash(t *testing.T) {
 
 	_, found = k.GetBlockHash(ctx, 0)
 	require.False(t, found)
+	_, found = k.GetBlockHash(ctx, 9)
+	require.True(t, found)
 	parent, found := k.GetBlockHash(ctx, 256)
 	require.True(t, found)
 	require.Equal(t, nextParent, parent)

--- a/x/evm/keeper/block_hash_test.go
+++ b/x/evm/keeper/block_hash_test.go
@@ -1,11 +1,15 @@
 package keeper_test
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/sei-protocol/sei-chain/app"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/crypto/tmhash"
 	tmproto "github.com/sei-protocol/sei-chain/sei-tendermint/proto/tendermint/types"
+	tmtypes "github.com/sei-protocol/sei-chain/sei-tendermint/types"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/version"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,6 +44,57 @@ func TestTrackBlockHash(t *testing.T) {
 	parent, found := k.GetBlockHash(ctx, 256)
 	require.True(t, found)
 	require.Equal(t, nextParent, parent)
+}
+
+// TestBlockHashRingMatchesHistoricalInfo checks that the ring value written from
+// LastBlockId.Hash matches the hash derived from staking HistoricalInfo for the
+// same height (the pre-ring BLOCKHASH source).
+func TestBlockHashRingMatchesHistoricalInfo(t *testing.T) {
+	testApp := app.Setup(t, false, false, false)
+	k := &testApp.EvmKeeper
+
+	const height int64 = 10
+	tmHeader := tmtypes.Header{
+		Version:            version.Consensus{Block: version.BlockProtocol},
+		Height:             height,
+		ChainID:            "test-chain",
+		ValidatorsHash:     bytes.Repeat([]byte{0x01}, tmhash.Size),
+		NextValidatorsHash: bytes.Repeat([]byte{0x02}, tmhash.Size),
+		ConsensusHash:      bytes.Repeat([]byte{0x03}, tmhash.Size),
+		AppHash:            bytes.Repeat([]byte{0x04}, tmhash.Size),
+		DataHash:           bytes.Repeat([]byte{0x05}, tmhash.Size),
+		EvidenceHash:       bytes.Repeat([]byte{0x06}, tmhash.Size),
+		LastResultsHash:    bytes.Repeat([]byte{0x07}, tmhash.Size),
+		LastCommitHash:     bytes.Repeat([]byte{0x08}, tmhash.Size),
+		ProposerAddress:    bytes.Repeat([]byte{0x09}, 20),
+	}
+	wantHash := common.BytesToHash(tmHeader.Hash())
+	require.NotEqual(t, common.Hash{}, wantHash)
+
+	// BeginBlock at height: staking persists HistoricalInfo from the block header.
+	ctx := testApp.GetContextForDeliverTx([]byte{}).
+		WithBlockHeader(*tmHeader.ToProto()).
+		WithBlockHeight(height)
+	testApp.StakingKeeper.TrackHistoricalInfo(ctx)
+
+	// BeginBlock at height+1: EVM ring records LastBlockId.Hash for the parent.
+	next := testApp.GetContextForDeliverTx([]byte{}).BlockHeader()
+	next.Height = height + 1
+	next.LastBlockId = tmproto.BlockID{Hash: tmHeader.Hash()}
+	ctx = ctx.WithBlockHeader(next).WithBlockHeight(height + 1)
+	k.TrackBlockHash(ctx)
+
+	ring, found := k.GetBlockHash(ctx, height)
+	require.True(t, found)
+	require.Equal(t, wantHash, ring)
+
+	hi, found := testApp.StakingKeeper.GetHistoricalInfo(ctx, height)
+	require.True(t, found)
+	histHeader, err := tmtypes.HeaderFromProto(&hi.Header)
+	require.NoError(t, err)
+	histHash := common.BytesToHash(histHeader.Hash())
+	require.Equal(t, wantHash, histHash)
+	require.Equal(t, histHash, ring)
 }
 
 func TestBlockHashCacheDeliverOnly(t *testing.T) {

--- a/x/evm/keeper/block_hash_test.go
+++ b/x/evm/keeper/block_hash_test.go
@@ -24,10 +24,8 @@ func TestTrackBlockHash(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, parentHash, got)
 
-	// At height 257, prune height 0 out of the window.
 	stale := common.HexToHash("0x0101010101010101010101010101010101010101010101010101010101010101")
 	k.SetBlockHash(ctx, 0, stale)
-	require.Equal(t, stale, k.GetHashFn(ctx)(0))
 
 	nextParent := common.HexToHash("0x0202020202020202020202020202020202020202020202020202020202020202")
 	header.Height = 257
@@ -40,5 +38,25 @@ func TestTrackBlockHash(t *testing.T) {
 	parent, found := k.GetBlockHash(ctx, 256)
 	require.True(t, found)
 	require.Equal(t, nextParent, parent)
-	require.Equal(t, common.Hash{}, k.GetHashFn(ctx)(0))
+}
+
+func TestBlockHashCacheDeliverOnly(t *testing.T) {
+	testApp := app.Setup(t, false, false, false)
+	k := &testApp.EvmKeeper
+	ctx := testApp.GetContextForDeliverTx([]byte{}).WithBlockHeight(8)
+
+	hash := common.HexToHash("0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20")
+	k.SetBlockHash(ctx, 7, hash)
+
+	// RPC/trace may read store but must not insert into the process cache.
+	traceCtx := ctx.WithTraceMode(true)
+	require.Equal(t, hash, k.GetHashFn(traceCtx)(7))
+	k.DeleteBlockHash(ctx, 7)
+	require.Equal(t, common.Hash{}, k.GetHashFn(traceCtx)(7))
+
+	// DeliverTx populates the cache.
+	k.SetBlockHash(ctx, 7, hash)
+	require.Equal(t, hash, k.GetHashFn(ctx)(7))
+	k.DeleteBlockHash(ctx, 7)
+	require.Equal(t, hash, k.GetHashFn(ctx)(7))
 }

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -67,6 +67,9 @@ type Keeper struct {
 	cachedFeeCollectorAddressMtx *sync.RWMutex
 	cachedFeeCollectorAddress    *common.Address
 
+	// blockHashCache caches BLOCKHASH results; pruned in TrackBlockHash.
+	blockHashCache sync.Map
+
 	QueryConfig *querier.Config
 
 	// only used during ETH replay. Not used in chain critical path.
@@ -327,6 +330,14 @@ func (k *Keeper) GetHashFn(ctx sdk.Context) vm.GetHashFunc {
 }
 
 func (k *Keeper) getHistoricalHash(ctx sdk.Context, h int64) common.Hash {
+	height := uint64(h) //nolint:gosec
+	if cached, ok := k.blockHashCache.Load(height); ok {
+		return cached.(common.Hash)
+	}
+	if hash, found := k.GetBlockHash(ctx, h); found {
+		k.blockHashCache.Store(height, hash)
+		return hash
+	}
 	histInfo, found := k.stakingKeeper.GetHistoricalInfo(ctx, h)
 	if !found {
 		// too old, already pruned
@@ -334,7 +345,11 @@ func (k *Keeper) getHistoricalHash(ctx sdk.Context, h int64) common.Hash {
 	}
 	header, _ := tmtypes.HeaderFromProto(&histInfo.Header)
 
-	return common.BytesToHash(header.Hash())
+	hash := common.BytesToHash(header.Hash())
+	if hash != (common.Hash{}) {
+		k.blockHashCache.Store(height, hash)
+	}
+	return hash
 }
 
 func (k *Keeper) SetTxResults(txResults []*abci.ExecTxResult) {

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/tests"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/holiman/uint256"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store/prefix"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
@@ -67,8 +68,9 @@ type Keeper struct {
 	cachedFeeCollectorAddressMtx *sync.RWMutex
 	cachedFeeCollectorAddress    *common.Address
 
-	// blockHashCache caches BLOCKHASH results; pruned in TrackBlockHash.
-	blockHashCache *sync.Map
+	// blockHashCache is a bounded process-local cache of BLOCKHASH results for
+	// DeliverTx. RPC/trace and CheckTx may read it but do not insert.
+	blockHashCache *lru.Cache[uint64, common.Hash]
 
 	QueryConfig *querier.Config
 
@@ -147,7 +149,7 @@ func NewKeeper(
 		wasmViewKeeper:               wasmViewKeeper,
 		upgradeKeeper:                upgradeKeeper,
 		cachedFeeCollectorAddressMtx: &sync.RWMutex{},
-		blockHashCache:               &sync.Map{},
+		blockHashCache:               newBlockHashCache(),
 		receiptStore:                 receiptStore,
 	}
 	return k
@@ -332,11 +334,12 @@ func (k *Keeper) GetHashFn(ctx sdk.Context) vm.GetHashFunc {
 
 func (k *Keeper) getHistoricalHash(ctx sdk.Context, h int64) common.Hash {
 	height := uint64(h) //nolint:gosec
-	if cached, ok := k.blockHashCache.Load(height); ok {
-		return cached.(common.Hash)
+	// Peek keeps LRU order driven by DeliverTx inserts only.
+	if cached, ok := k.blockHashCache.Peek(height); ok {
+		return cached
 	}
 	if hash, found := k.GetBlockHash(ctx, h); found {
-		k.blockHashCache.Store(height, hash)
+		k.cacheBlockHash(ctx, height, hash)
 		return hash
 	}
 	histInfo, found := k.stakingKeeper.GetHistoricalInfo(ctx, h)
@@ -347,9 +350,7 @@ func (k *Keeper) getHistoricalHash(ctx sdk.Context, h int64) common.Hash {
 	header, _ := tmtypes.HeaderFromProto(&histInfo.Header)
 
 	hash := common.BytesToHash(header.Hash())
-	if hash != (common.Hash{}) {
-		k.blockHashCache.Store(height, hash)
-	}
+	k.cacheBlockHash(ctx, height, hash)
 	return hash
 }
 

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -68,7 +68,7 @@ type Keeper struct {
 	cachedFeeCollectorAddress    *common.Address
 
 	// blockHashCache caches BLOCKHASH results; pruned in TrackBlockHash.
-	blockHashCache sync.Map
+	blockHashCache *sync.Map
 
 	QueryConfig *querier.Config
 
@@ -147,6 +147,7 @@ func NewKeeper(
 		wasmViewKeeper:               wasmViewKeeper,
 		upgradeKeeper:                upgradeKeeper,
 		cachedFeeCollectorAddressMtx: &sync.RWMutex{},
+		blockHashCache:               &sync.Map{},
 		receiptStore:                 receiptStore,
 	}
 	return k

--- a/x/evm/keeper/keeper_test.go
+++ b/x/evm/keeper/keeper_test.go
@@ -97,6 +97,8 @@ func TestGetHashFn(t *testing.T) {
 	require.Equal(t, fallbackHash, f(uint64(histHeight)))
 	_, found := k.GetBlockHash(ctx, histHeight)
 	require.False(t, found)
+	// Remove HistoricalInfo so a second lookup can only succeed via the mem-cache.
+	testApp.StakingKeeper.DeleteHistoricalInfo(ctx, histHeight)
 	require.Equal(t, fallbackHash, k.GetHashFn(ctx)(uint64(histHeight)))
 	require.Equal(t, common.Hash{}, f(uint64(ctx.BlockHeight())-3))
 }

--- a/x/evm/keeper/keeper_test.go
+++ b/x/evm/keeper/keeper_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"fmt"
@@ -17,7 +18,11 @@ import (
 	"github.com/sei-protocol/sei-chain/app"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	authtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/types"
+	stakingtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/staking/types"
 	abci "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/crypto/tmhash"
+	tmtypes "github.com/sei-protocol/sei-chain/sei-tendermint/types"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/version"
 	"github.com/sei-protocol/sei-chain/testutil/keeper"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/utils"
@@ -62,12 +67,38 @@ func TestGetVMBlockContext(t *testing.T) {
 }
 
 func TestGetHashFn(t *testing.T) {
-	k, ctx := keeper.MockEVMKeeper(t)
+	testApp := app.Setup(t, false, false, false)
+	ctx := testApp.GetContextForDeliverTx([]byte{}).WithBlockHeight(8)
+	k := &testApp.EvmKeeper
+
+	// HistoricalInfo path (ValidatorsHash required for a non-empty header hash).
+	histHeight := int64(6)
+	tmHeader := tmtypes.Header{
+		Version:        version.Consensus{Block: version.BlockProtocol},
+		Height:         histHeight,
+		ChainID:        "test-chain",
+		ValidatorsHash: bytes.Repeat([]byte{0x01}, tmhash.Size),
+	}
+	fallbackHash := common.BytesToHash(tmHeader.Hash())
+	require.NotEqual(t, common.Hash{}, fallbackHash)
+	hi := stakingtypes.NewHistoricalInfo(*tmHeader.ToProto(), stakingtypes.Validators{}, sdk.DefaultPowerReduction)
+	testApp.StakingKeeper.SetHistoricalInfo(ctx, histHeight, &hi)
+
+	kvHeight := int64(7)
+	kvHash := common.HexToHash("0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20")
+	k.SetBlockHash(ctx, kvHeight, kvHash)
+
 	f := k.GetHashFn(ctx)
 	require.Equal(t, common.Hash{}, f(math.MaxInt64+1))
 	require.Equal(t, common.BytesToHash(ctx.HeaderHash()), f(uint64(ctx.BlockHeight())))
 	require.Equal(t, common.Hash{}, f(uint64(ctx.BlockHeight())+1))
-	require.Equal(t, common.Hash{}, f(uint64(ctx.BlockHeight())-1))
+
+	require.Equal(t, kvHash, f(uint64(kvHeight)))
+	require.Equal(t, fallbackHash, f(uint64(histHeight)))
+	_, found := k.GetBlockHash(ctx, histHeight)
+	require.False(t, found)
+	require.Equal(t, fallbackHash, k.GetHashFn(ctx)(uint64(histHeight)))
+	require.Equal(t, common.Hash{}, f(uint64(ctx.BlockHeight())-3))
 }
 
 func TestDeferredInfo(t *testing.T) {

--- a/x/evm/types/keys.go
+++ b/x/evm/types/keys.go
@@ -63,6 +63,7 @@ var (
 	EvmOnlyBlockBloomPrefix         = []byte{0x1d}
 	ZeroStorageCleanupCheckpointKey = []byte{0x1e}
 	NonceBumpPrefix                 = []byte{0x1f} // transient
+	BlockHashPrefix                 = []byte{0x20}
 )
 
 var (
@@ -108,6 +109,12 @@ func BlockBloomKey(height int64) []byte {
 	bz := make([]byte, 8)
 	binary.BigEndian.PutUint64(bz, uint64(height)) //nolint:gosec
 	return append(BlockBloomPrefix, bz...)
+}
+
+func BlockHashKey(height int64) []byte {
+	bz := make([]byte, 8)
+	binary.BigEndian.PutUint64(bz, uint64(height)) //nolint:gosec
+	return append(BlockHashPrefix, bz...)
 }
 
 func TxHashesKey(height int64) []byte {


### PR DESCRIPTION
## Summary
- Persist the last 256 parent block hashes (`LastBlockId.Hash`) in the EVM store on BeginBlock, with a sliding prune of the oldest entry
- Serve `BLOCKHASH` from that ring (plus a process-local mem cache), falling back to staking `HistoricalInfo` when a height is not yet in the ring
- Mirror the helpers in `giga/deps/xevm` (shared store; giga only prunes its mem cache)


Made with [Cursor](https://cursor.com)