### PR TITLE
fix(giga): fix flaky TestAvailClientServer test

### DIFF
--- a/sei-tendermint/internal/p2p/giga/avail_test.go
+++ b/sei-tendermint/internal/p2p/giga/avail_test.go
@@ -2,9 +2,9 @@ package giga
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/sei-protocol/sei-chain/sei-tendermint/autobahn/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/avail"
@@ -58,13 +58,14 @@ func TestAvailClientServer(t *testing.T) {
 		a2 := nodes[2].consensus.Avail()
 		lane0 := activeKeys[0].Public()
 		corruptRng := rng.Split()
-		s.SpawnBg(func() error {
-			for a2.NextBlock(lane0) == 0 {
-				if err := utils.Sleep(ctx, time.Millisecond); err != nil {
-					return utils.IgnoreCancel(err)
-				}
+		// Spawn (not SpawnBg) so scope waits for at least one full corrupt PushBlock
+		// pass; bound is BlocksPerLane because corrupt is never Run, so its lane
+		// capacity never advances past the initial window.
+		s.Spawn(func() error {
+			if _, err := a2.Block(ctx, lane0, 0); err != nil && !errors.Is(err, types.ErrPruned) {
+				return utils.IgnoreCancel(err)
 			}
-			for range totalBlocks {
+			for range avail.BlocksPerLane {
 				n := corruptAvail.NextBlock(lane0)
 				if err := corruptAvail.WaitForLocalCapacity(ctx, n); err != nil {
 					return utils.IgnoreCancel(err)

--- a/sei-tendermint/internal/p2p/giga/avail_test.go
+++ b/sei-tendermint/internal/p2p/giga/avail_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/sei-protocol/sei-chain/sei-tendermint/autobahn/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/avail"
@@ -37,21 +38,49 @@ func TestAvailClientServer(t *testing.T) {
 	if err := scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
 		t.Log("Spawn network.")
 		s.SpawnBg(func() error { return env.Run(ctx) })
-		t.Log("Spawn a fake unconnected node0 to generate some conflicting blocks and push them to node2.")
-		fakeNode0, err := consensus.NewState(&consensus.Config{
-			Key:                keys[0],
-			ViewTimeout:        defaultViewTimeout,
-			PersistentStateDir: utils.Some(t.TempDir()),
-		}, nodes[0].data)
-		if err != nil {
-			return fmt.Errorf("consensus.NewState(): %w", err)
-		}
-		s.SpawnBgNamed("fakeNode0", func() error { return utils.IgnoreCancel(fakeNode0.Run(ctx)) })
-		for range min(avail.BlocksPerLane, 4) {
-			a := fakeNode0.Avail()
-			b := utils.OrPanic1(a.ProduceLocalBlock(a.NextBlock(a.PublicKey()), types.GenPayload(rng)))
-			utils.OrPanic(nodes[2].consensus.Avail().PushBlock(ctx, b))
-		}
+
+		// Equivocating peer: same key as node0, its own data/avail (not shared with
+		// nodes[0]). Not joined to env.Run's mesh (testEnv keys nodes by PublicKey, so
+		// a second node0 cannot be AddNode'd). Instead the test calls PushBlock on
+		// node2 directly — same admission API gossip would use, without a real peer
+		// connection. Do not Run a second consensus.State on nodes[0].data (that raced
+		// and hung under -race).
+		//
+		// Wait until node2 already has an honest tip before pushing: under parent-hash
+		// checks a corrupt genesis tip strands the lane (PushBlock drops forever).
+		// After an honest tip, corrupt PushBlocks are stale or parent-mismatch drops.
+		t.Log("Spawn task sending corrupted data of node 0 to node 2.")
+		corrupt := newTestNode(registry, &consensus.Config{
+			Key:         activeKeys[0],
+			ViewTimeout: defaultViewTimeout,
+		})
+		corruptAvail := corrupt.consensus.Avail()
+		a2 := nodes[2].consensus.Avail()
+		lane0 := activeKeys[0].Public()
+		corruptRng := rng.Split()
+		s.SpawnBg(func() error {
+			for a2.NextBlock(lane0) == 0 {
+				if err := utils.Sleep(ctx, time.Millisecond); err != nil {
+					return utils.IgnoreCancel(err)
+				}
+			}
+			for range totalBlocks {
+				n := corruptAvail.NextBlock(lane0)
+				if err := corruptAvail.WaitForLocalCapacity(ctx, n); err != nil {
+					return utils.IgnoreCancel(err)
+				}
+				b, err := corruptAvail.ProduceLocalBlock(n, types.GenPayload(corruptRng))
+				if err != nil {
+					return utils.IgnoreCancel(err)
+				}
+				// PushBlock may drop (stale / parent-hash mismatch); that is fine.
+				if err := a2.PushBlock(ctx, b); err != nil {
+					return utils.IgnoreCancel(err)
+				}
+			}
+			return nil
+		})
+
 		t.Logf("Run block production")
 		for _, node := range nodes {
 			rng := rng.Split()

--- a/sei-tendermint/internal/p2p/giga/avail_test.go
+++ b/sei-tendermint/internal/p2p/giga/avail_test.go
@@ -60,21 +60,19 @@ func TestAvailClientServer(t *testing.T) {
 		corruptRng := rng.Split()
 		s.SpawnBg(func() error {
 			if _, err := a2.Block(ctx, lane0, 0); err != nil && !errors.Is(err, types.ErrPruned) {
-				return utils.IgnoreCancel(err)
+				return utils.IgnoreCancel(fmt.Errorf("a2.Block(lane0, 0): %w", err))
 			}
-			// Corrupt is never Run, so lane capacity stays at the initial window.
+			// Corrupt is never Run, so lane capacity stays at the initial window —
+			// ProduceLocalBlock will fail loudly if this bound is raised past it.
 			for range avail.BlocksPerLane {
 				n := corruptAvail.NextBlock(lane0)
-				if err := corruptAvail.WaitForLocalCapacity(ctx, n); err != nil {
-					return utils.IgnoreCancel(err)
-				}
 				b, err := corruptAvail.ProduceLocalBlock(n, types.GenPayload(corruptRng))
 				if err != nil {
-					return utils.IgnoreCancel(err)
+					return utils.IgnoreCancel(fmt.Errorf("corrupt.ProduceLocalBlock(%d): %w", n, err))
 				}
 				// PushBlock may drop (stale / parent-hash mismatch); that is fine.
 				if err := a2.PushBlock(ctx, b); err != nil {
-					return utils.IgnoreCancel(err)
+					return utils.IgnoreCancel(fmt.Errorf("a2.PushBlock(%d): %w", n, err))
 				}
 			}
 			return nil

--- a/sei-tendermint/internal/p2p/giga/avail_test.go
+++ b/sei-tendermint/internal/p2p/giga/avail_test.go
@@ -58,13 +58,11 @@ func TestAvailClientServer(t *testing.T) {
 		a2 := nodes[2].consensus.Avail()
 		lane0 := activeKeys[0].Public()
 		corruptRng := rng.Split()
-		// Spawn (not SpawnBg) so scope waits for at least one full corrupt PushBlock
-		// pass; bound is BlocksPerLane because corrupt is never Run, so its lane
-		// capacity never advances past the initial window.
-		s.Spawn(func() error {
+		s.SpawnBg(func() error {
 			if _, err := a2.Block(ctx, lane0, 0); err != nil && !errors.Is(err, types.ErrPruned) {
 				return utils.IgnoreCancel(err)
 			}
+			// Corrupt is never Run, so lane capacity stays at the initial window.
 			for range avail.BlocksPerLane {
 				n := corruptAvail.NextBlock(lane0)
 				if err := corruptAvail.WaitForLocalCapacity(ctx, n); err != nil {


### PR DESCRIPTION
## Summary

- Fixes flaky `TestAvailClientServer` (`sei-tendermint/internal/p2p/giga`), which has been hanging Race Detection CI (including on unrelated PRs) with `parent hash mismatch` logs and a stuck `GlobalBlock` wait.
- Replaces the broken “fake node0” setup on **shared** `nodes[0].data` with a same-key equivocating peer that has its **own** store and feeds corrupt blocks into node2 via `PushBlock` (admission API), after an honest tip exists.

## History

**sei-v3** (`TestClientServer` in `stream/consensus/avail/server_test.go`) intentionally stressed the mesh by spawning a task that wrote **corrupt node0-lane blocks directly into node2’s avail** (`ProduceBlock` on node2’s state for lane 0) **concurrently** with honest production. There was no second node0, no shared data dual-`Run`, and no wait for an honest tip. That worked because sei-v3 `PushBlock` did **not** verify parent hashes—later honest blocks could still append at `next` even after a bad tip.

**sei-chain migration (#2791)** rewrote this into giga `TestAvailClientServer` as a “fake unconnected node0” that:
1. Built a second `consensus.State` on **shared** `nodes[0].data`
2. Called `fakeNode0.Run` while `env.Run` already ran `nodes[0].consensus.Run`
3. Seeded node2 from that fake producer **before** honest production

That mistranslated the sei-v3 inject and introduced a data race under `-race`.

**#2925** then added parent-hash verification in `PushBlock`/`PushHeader`: on mismatch it logs and returns `nil` (drop, no rewind). A divergent tip on node2 can no longer be extended by honest gossip, so `GlobalBlock` can wait forever. The test was already probed as flaky on clean main in Feb (`2fbb0c6e3`); under Race Detection the hang shows up as a ~30m package timeout.

## What we test now

1. **3-of-4 committee mesh** via `env.Run` (giga avail client/server) — same as before.
2. **Equivocating peer**: same key as node0, **own** `data`/avail (`newTestNode`), **not** joined to the mesh (`testEnv` keys nodes by `PublicKey`, so a second node0 cannot be `AddNode`’d). The test calls `PushBlock` on node2 directly—same admission path gossip would use, without a real peer connection. The peer is never `Run`, so inject is bounded to `avail.BlocksPerLane` (initial lane capacity); `ProduceLocalBlock` fails if that bound is raised.
3. **Honest production** on each active node’s own lane, concurrent with the corrupt sender (`SpawnBg`).
4. **Agreement**: all nodes see the same `GlobalBlock` sequence and accept `PushAppHash`.

No second `consensus.Run` on shared `nodes[0].data`.

## Why we wait for a non-empty honest tip

If the corrupt peer’s genesis block lands on node2 while lane 0 is still empty:

1. Corrupt block 0 becomes the tip
2. Honest block 0 is ignored as stale
3. Honest block 1 fails parent-hash check and is dropped
4. The lane never advances → `GlobalBlock` hangs

So the corrupt task blocks on `a2.Block(ctx, lane0, 0)` (tolerating `ErrPruned`) until node2 has an honest tip, then pushes its alternate chain. Those `PushBlock`s are then stale or parent-mismatch drops; the honest tip is preserved. This wait did **not** exist in sei-v3; it is required under today’s `PushBlock` semantics (#2925).

## Why main is flaky

On main, dual `Run` + shared data + early corrupt/fake seeding races under `-race`. When node2 adopts a fork that honest gossip cannot extend, parent-hash drops leave sequencing stuck until the test package times out. Without `-race` / low `-count` it often still passes by luck (historically known-flaky).

Verified locally:

```bash
GOWORK=off go test ./internal/p2p/giga/ -race -count=30 -timeout 300s -run '^TestAvailClientServer$'
```

(30/30 after this change.)

## Test plan

- [x] `GOWORK=off go test ./internal/p2p/giga/ -race -count=30 -timeout 300s -run '^TestAvailClientServer$'`
- [x] CI Race Detection on this PR