### PR TITLE
precompile: convert json/pointerview/p256 to dynamic-gas precompiles

### DIFF
--- a/precompiles/json/json.go
+++ b/precompiles/json/json.go
@@ -34,16 +34,20 @@ const GasCostPerByte = 100 // TODO: parameterize
 var f embed.FS
 
 type PrecompileExecutor struct {
+	evmKeeper putils.EVMKeeper
+
 	ExtractAsBytesID          []byte
 	ExtractAsBytesListID      []byte
 	ExtractAsUint256ID        []byte
 	ExtractAsBytesFromArrayID []byte
 }
 
-func NewPrecompile(keepers putils.Keepers) (*pcommon.Precompile, error) {
+func NewPrecompile(keepers putils.Keepers) (*pcommon.DynamicGasPrecompile, error) {
 	newAbi := pcommon.MustGetABI(f, "abi.json")
 
-	p := &PrecompileExecutor{}
+	p := &PrecompileExecutor{
+		evmKeeper: keepers.EVMK(),
+	}
 
 	for name, m := range newAbi.Methods {
 		switch name {
@@ -58,37 +62,47 @@ func NewPrecompile(keepers putils.Keepers) (*pcommon.Precompile, error) {
 		}
 	}
 
-	return pcommon.NewPrecompile(newAbi, p, common.HexToAddress(JSONAddress), "json"), nil
+	return pcommon.NewDynamicGasPrecompile(newAbi, p, common.HexToAddress(JSONAddress), "json"), nil
 }
 
-// RequiredGas returns the required bare minimum gas to execute the precompile.
-func (p PrecompileExecutor) RequiredGas(input []byte, method *abi.Method) uint64 {
-	return uint64(GasCostPerByte * len(input)) //nolint:gosec
+func (p PrecompileExecutor) EVMKeeper() putils.EVMKeeper {
+	return p.evmKeeper
 }
 
-func (p PrecompileExecutor) Execute(ctx sdk.Context, method *abi.Method, caller common.Address, callingContract common.Address, args []interface{}, value *big.Int, readOnly bool, evm *vm.EVM, hooks *tracing.Hooks) (bz []byte, err error) {
+func (p PrecompileExecutor) Execute(ctx sdk.Context, method *abi.Method, caller common.Address, callingContract common.Address, args []interface{}, value *big.Int, readOnly bool, evm *vm.EVM, suppliedGas uint64, hooks *tracing.Hooks) (bz []byte, remainingGas uint64, err error) {
+	// The precompile is stateless (in-memory JSON parsing), so no gas would be
+	// charged via state access. Charge for the parse work up front, proportional
+	// to the payload being parsed (args[0]); this is the dominant cost of every
+	// method below.
+	if len(args) > 0 {
+		if payload, ok := args[0].([]byte); ok {
+			ctx.GasMeter().ConsumeGas(uint64(GasCostPerByte*len(payload)), "json parse") //nolint:gosec
+		}
+	}
+
 	switch method.Name {
 	case ExtractAsBytesMethod:
-		return p.extractAsBytes(ctx, method, args, value)
+		bz, err = p.extractAsBytes(ctx, method, args, value)
 	case ExtractAsBytesListMethod:
-		return p.extractAsBytesList(ctx, method, args, value)
+		bz, err = p.extractAsBytesList(ctx, method, args, value)
 	case ExtractAsUint256Method:
-		byteArr := make([]byte, 32)
-		uint_, err := p.ExtractAsUint256(ctx, method, args, value)
-		if err != nil {
-			return nil, err
+		var uint_ *big.Int
+		if uint_, err = p.ExtractAsUint256(ctx, method, args, value); err == nil {
+			if uint_.BitLen() > 256 {
+				err = errors.New("value does not fit in 32 bytes")
+			} else {
+				byteArr := make([]byte, 32)
+				uint_.FillBytes(byteArr)
+				bz = byteArr
+			}
 		}
-
-		if uint_.BitLen() > 256 {
-			return nil, errors.New("value does not fit in 32 bytes")
-		}
-
-		uint_.FillBytes(byteArr)
-		return byteArr, nil
 	case ExtractAsBytesFromArrayMethod:
-		return p.extractAsBytesFromArray(ctx, method, args, value)
+		bz, err = p.extractAsBytesFromArray(ctx, method, args, value)
 	}
-	return
+	if err != nil {
+		return nil, 0, err
+	}
+	return bz, pcommon.GetRemainingGas(ctx, p.evmKeeper), nil
 }
 
 func (p PrecompileExecutor) extractAsBytes(_ sdk.Context, method *abi.Method, args []interface{}, value *big.Int) ([]byte, error) {

--- a/precompiles/json/json_test.go
+++ b/precompiles/json/json_test.go
@@ -2,6 +2,7 @@ package json_test
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 	"strings"
 	"testing"
@@ -9,16 +10,17 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/sei-protocol/sei-chain/precompiles/json"
-	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
 	"github.com/stretchr/testify/require"
 )
 
 func TestExtractAsBytes(t *testing.T) {
-	stateDB := &state.DBImpl{}
-	stateDB.WithCtx(sdk.Context{})
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{})
+	stateDB := state.NewDBImpl(ctx, k, false)
 	evm := &vm.EVM{StateDB: stateDB}
-	p, err := json.NewPrecompile(nil)
+	p, err := json.NewPrecompile(testkeeper.EVMTestApp.GetPrecompileKeepers())
 	require.Nil(t, err)
 	method, err := p.MethodById(p.GetExecutor().(*json.PrecompileExecutor).ExtractAsBytesID)
 	require.Nil(t, err)
@@ -40,7 +42,7 @@ func TestExtractAsBytes(t *testing.T) {
 		args, err := method.Inputs.Pack(test.body, "key")
 		require.Nil(t, err)
 		input := append(p.GetExecutor().(*json.PrecompileExecutor).ExtractAsBytesID, args...)
-		res, err := p.Run(evm, common.Address{}, common.Address{}, input, nil, true, false, nil)
+		res, _, err := p.RunAndCalculateGas(evm, common.Address{}, common.Address{}, input, math.MaxUint64, nil, nil, true, false)
 		require.Nil(t, err)
 		output, err := method.Outputs.Unpack(res)
 		require.Nil(t, err)
@@ -50,10 +52,11 @@ func TestExtractAsBytes(t *testing.T) {
 }
 
 func TestExtractAsBytesList(t *testing.T) {
-	stateDB := &state.DBImpl{}
-	stateDB.WithCtx(sdk.Context{})
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{})
+	stateDB := state.NewDBImpl(ctx, k, false)
 	evm := &vm.EVM{StateDB: stateDB}
-	p, err := json.NewPrecompile(nil)
+	p, err := json.NewPrecompile(testkeeper.EVMTestApp.GetPrecompileKeepers())
 	require.Nil(t, err)
 	method, err := p.MethodById(p.GetExecutor().(*json.PrecompileExecutor).ExtractAsBytesListID)
 	require.Nil(t, err)
@@ -78,7 +81,7 @@ func TestExtractAsBytesList(t *testing.T) {
 		args, err := method.Inputs.Pack(test.body, "key")
 		require.Nil(t, err)
 		input := append(p.GetExecutor().(*json.PrecompileExecutor).ExtractAsBytesListID, args...)
-		res, err := p.Run(evm, common.Address{}, common.Address{}, input, nil, true, false, nil)
+		res, _, err := p.RunAndCalculateGas(evm, common.Address{}, common.Address{}, input, math.MaxUint64, nil, nil, true, false)
 		require.Nil(t, err)
 		output, err := method.Outputs.Unpack(res)
 		require.Nil(t, err)
@@ -88,10 +91,11 @@ func TestExtractAsBytesList(t *testing.T) {
 }
 
 func TestExtractAsUint256(t *testing.T) {
-	stateDB := &state.DBImpl{}
-	stateDB.WithCtx(sdk.Context{})
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{})
+	stateDB := state.NewDBImpl(ctx, k, false)
 	evm := &vm.EVM{StateDB: stateDB}
-	p, err := json.NewPrecompile(nil)
+	p, err := json.NewPrecompile(testkeeper.EVMTestApp.GetPrecompileKeepers())
 	require.Nil(t, err)
 	method, err := p.MethodById(p.GetExecutor().(*json.PrecompileExecutor).ExtractAsUint256ID)
 	require.Nil(t, err)
@@ -112,7 +116,7 @@ func TestExtractAsUint256(t *testing.T) {
 		args, err := method.Inputs.Pack(test.body, "key")
 		require.Nil(t, err)
 		input := append(p.GetExecutor().(*json.PrecompileExecutor).ExtractAsUint256ID, args...)
-		res, err := p.Run(evm, common.Address{}, common.Address{}, input, nil, true, false, nil)
+		res, _, err := p.RunAndCalculateGas(evm, common.Address{}, common.Address{}, input, math.MaxUint64, nil, nil, true, false)
 		require.Nil(t, err)
 		output, err := method.Outputs.Unpack(res)
 		require.Nil(t, err)
@@ -122,8 +126,9 @@ func TestExtractAsUint256(t *testing.T) {
 }
 
 func TestPrecompileExecutor_extractAsBytesFromArray(t *testing.T) {
-	stateDB := &state.DBImpl{}
-	stateDB.WithCtx(sdk.Context{})
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{})
+	stateDB := state.NewDBImpl(ctx, k, false)
 	evm := &vm.EVM{StateDB: stateDB}
 
 	type args struct {
@@ -266,14 +271,14 @@ func TestPrecompileExecutor_extractAsBytesFromArray(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := json.NewPrecompile(nil)
+			p, err := json.NewPrecompile(testkeeper.EVMTestApp.GetPrecompileKeepers())
 			require.Nil(t, err)
 			method, err := p.MethodById(p.GetExecutor().(*json.PrecompileExecutor).ExtractAsBytesFromArrayID)
 			require.Nil(t, err)
 			inputArgs, err := method.Inputs.Pack(tt.input.body, tt.input.indexArray)
 			require.Nil(t, err)
 			in := append(p.GetExecutor().(*json.PrecompileExecutor).ExtractAsBytesFromArrayID, inputArgs...)
-			res, err := p.Run(evm, common.Address{}, common.Address{}, in, tt.args.value, true, false, nil)
+			res, _, err := p.RunAndCalculateGas(evm, common.Address{}, common.Address{}, in, math.MaxUint64, tt.args.value, nil, true, false)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -297,10 +302,11 @@ func generateLargeArray(size int) []byte {
 }
 
 func TestExtractElementFromNestedArray(t *testing.T) {
-	stateDB := &state.DBImpl{}
-	stateDB.WithCtx(sdk.Context{})
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{})
+	stateDB := state.NewDBImpl(ctx, k, false)
 	evm := &vm.EVM{StateDB: stateDB}
-	p, err := json.NewPrecompile(nil)
+	p, err := json.NewPrecompile(testkeeper.EVMTestApp.GetPrecompileKeepers())
 	require.NoError(t, err)
 	methodExtractAsBytes, err := p.MethodById(p.GetExecutor().(*json.PrecompileExecutor).ExtractAsBytesID)
 	require.NoError(t, err)
@@ -314,7 +320,7 @@ func TestExtractElementFromNestedArray(t *testing.T) {
 	args, err := methodExtractAsBytes.Inputs.Pack(body, "data")
 	require.NoError(t, err)
 	input := append(p.GetExecutor().(*json.PrecompileExecutor).ExtractAsBytesID, args...)
-	res, err := p.Run(evm, common.Address{}, common.Address{}, input, nil, true, false, nil)
+	res, _, err := p.RunAndCalculateGas(evm, common.Address{}, common.Address{}, input, math.MaxUint64, nil, nil, true, false)
 	require.NoError(t, err)
 	data, err := methodExtractAsBytes.Outputs.Unpack(res)
 	require.NoError(t, err)
@@ -322,7 +328,7 @@ func TestExtractElementFromNestedArray(t *testing.T) {
 	args, err = methodExtractAsBytesList.Inputs.Pack(data[0].([]byte), "exchange_rates")
 	require.NoError(t, err)
 	input2 := append(p.GetExecutor().(*json.PrecompileExecutor).ExtractAsBytesListID, args...)
-	res, err = p.Run(evm, common.Address{}, common.Address{}, input2, nil, true, false, nil)
+	res, _, err = p.RunAndCalculateGas(evm, common.Address{}, common.Address{}, input2, math.MaxUint64, nil, nil, true, false)
 	require.NoError(t, err)
 	exchangeRates, err := methodExtractAsBytesList.Outputs.Unpack(res)
 	require.NoError(t, err)
@@ -333,7 +339,7 @@ func TestExtractElementFromNestedArray(t *testing.T) {
 	inputArgs, err := methodExtractAsBytesFromArray.Inputs.Pack(array, uint16(1))
 	require.NoError(t, err)
 	in := append(p.GetExecutor().(*json.PrecompileExecutor).ExtractAsBytesFromArrayID, inputArgs...)
-	res, err = p.Run(evm, common.Address{}, common.Address{}, in, nil, true, false, nil)
+	res, _, err = p.RunAndCalculateGas(evm, common.Address{}, common.Address{}, in, math.MaxUint64, nil, nil, true, false)
 	require.NoError(t, err)
 	output, err := methodExtractAsBytesFromArray.Outputs.Unpack(res)
 	require.NoError(t, err)

--- a/precompiles/p256/p256.go
+++ b/precompiles/p256/p256.go
@@ -72,6 +72,12 @@ func (p PrecompileExecutor) Execute(ctx sdk.Context, method *abi.Method, caller 
 
 	switch method.Name {
 	case VerifyMethod:
+		// Charge the fixed verification cost here, OUTSIDE verify's panic
+		// recovery, so an out-of-gas panic propagates (failing the tx) instead of
+		// being caught and downgraded to a reverted call. This matches the
+		// framework's executor out-of-gas semantics and the sibling
+		// json/pointerview precompiles, which charge their work gas unguarded.
+		ctx.GasMeter().ConsumeGas(P256VerifyGas, "p256Verify")
 		return p.verify(ctx, method, args)
 	}
 	return
@@ -94,9 +100,6 @@ func (p PrecompileExecutor) verify(ctx sdk.Context, method *abi.Method, args []i
 		return
 	}
 	input := args[0].([]byte)
-
-	// Charge the fixed verification cost before performing the crypto work.
-	ctx.GasMeter().ConsumeGas(P256VerifyGas, "p256Verify")
 
 	// Required input length is 160 bytes
 	const p256VerifyInputLength = 160

--- a/precompiles/p256/p256.go
+++ b/precompiles/p256/p256.go
@@ -22,7 +22,11 @@ const (
 
 const (
 	P256VerifyAddress = "0x0000000000000000000000000000000000001011"
-	GasCostPerByte    = 300
+	// P256VerifyGas is the fixed cost of a secp256r1 signature verification,
+	// matching RIP-7212's P256VERIFY precompile. The verification is a
+	// constant-work stateless operation, so it is priced as a flat charge
+	// against the call's gas meter rather than deriving from state access.
+	P256VerifyGas = 3450
 )
 
 // Embed abi json file to the executable binary. Needed when importing as dependency.
@@ -31,13 +35,17 @@ const (
 var f embed.FS
 
 type PrecompileExecutor struct {
+	evmKeeper utils.EVMKeeper
+
 	VerifyID []byte
 }
 
-func NewPrecompile(utils.Keepers) (*pcommon.Precompile, error) {
+func NewPrecompile(keepers utils.Keepers) (*pcommon.DynamicGasPrecompile, error) {
 	newAbi := pcommon.MustGetABI(f, "abi.json")
 
-	p := &PrecompileExecutor{}
+	p := &PrecompileExecutor{
+		evmKeeper: keepers.EVMK(),
+	}
 
 	for name, m := range newAbi.Methods {
 		switch name {
@@ -46,36 +54,36 @@ func NewPrecompile(utils.Keepers) (*pcommon.Precompile, error) {
 		}
 	}
 
-	return pcommon.NewPrecompile(newAbi, p, common.HexToAddress(P256VerifyAddress), "p256Verify"), nil
+	return pcommon.NewDynamicGasPrecompile(newAbi, p, common.HexToAddress(P256VerifyAddress), "p256Verify"), nil
 }
 
-// RequiredGas returns the required bare minimum gas to execute the precompile.
-func (p PrecompileExecutor) RequiredGas(input []byte, method *abi.Method) uint64 {
-	return uint64(GasCostPerByte * len(input)) //nolint:gosec
+func (p PrecompileExecutor) EVMKeeper() utils.EVMKeeper {
+	return p.evmKeeper
 }
 
-func (p PrecompileExecutor) Execute(ctx sdk.Context, method *abi.Method, caller common.Address, callingContract common.Address, args []interface{}, value *big.Int, readOnly bool, evm *vm.EVM, hooks *tracing.Hooks) (ret []byte, err error) {
+func (p PrecompileExecutor) Execute(ctx sdk.Context, method *abi.Method, caller common.Address, callingContract common.Address, args []interface{}, value *big.Int, readOnly bool, evm *vm.EVM, suppliedGas uint64, hooks *tracing.Hooks) (ret []byte, remainingGas uint64, err error) {
 	if err = pcommon.ValidateNonPayable(value); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	if ctx.EVMPrecompileCalledFromDelegateCall() {
-		return nil, errors.New("cannot delegatecall P256Verify")
+		return nil, 0, errors.New("cannot delegatecall P256Verify")
 	}
 
 	switch method.Name {
 	case VerifyMethod:
-		return p.verify(ctx, method, args, caller)
+		return p.verify(ctx, method, args)
 	}
 	return
 }
 
 // verify verifies the secp256r1 signature
 // Implements https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md
-func (p PrecompileExecutor) verify(ctx sdk.Context, method *abi.Method, args []interface{}, caller common.Address) (ret []byte, rerr error) {
+func (p PrecompileExecutor) verify(ctx sdk.Context, method *abi.Method, args []interface{}) (ret []byte, remainingGas uint64, rerr error) {
 	defer func() {
 		if err := recover(); err != nil {
 			ret = nil
+			remainingGas = 0
 			rerr = fmt.Errorf("%s", err)
 			return
 		}
@@ -86,6 +94,9 @@ func (p PrecompileExecutor) verify(ctx sdk.Context, method *abi.Method, args []i
 		return
 	}
 	input := args[0].([]byte)
+
+	// Charge the fixed verification cost before performing the crypto work.
+	ctx.GasMeter().ConsumeGas(P256VerifyGas, "p256Verify")
 
 	// Required input length is 160 bytes
 	const p256VerifyInputLength = 160
@@ -105,9 +116,10 @@ func (p PrecompileExecutor) verify(ctx sdk.Context, method *abi.Method, args []i
 	if Verify(hash, r, s, x, y) {
 		// Signature is valid
 		ret, rerr = method.Outputs.Pack(common.LeftPadBytes([]byte{1}, 32))
-		return
-	} else {
-		// Signature is invalid
+		remainingGas = pcommon.GetRemainingGas(ctx, p.evmKeeper)
 		return
 	}
+	// Signature is invalid
+	remainingGas = pcommon.GetRemainingGas(ctx, p.evmKeeper)
+	return
 }

--- a/precompiles/p256/p256_test.go
+++ b/precompiles/p256/p256_test.go
@@ -1,28 +1,47 @@
-package p256
+package p256_test
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"math"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
-	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	"github.com/sei-protocol/sei-chain/precompiles/p256"
+	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
 	"github.com/stretchr/testify/require"
 )
 
+// generateValidKeyAndSignature mirrors the helper in verifier_test.go; that one
+// lives in the white-box (package p256) test, which cannot import testkeeper
+// (import cycle), so the dynamic-path test below re-declares it here.
+func generateValidKeyAndSignature(t *testing.T) (hash []byte, r, s, x, y *big.Int) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	x = privateKey.PublicKey.X
+	y = privateKey.PublicKey.Y
+	hash = []byte("test message")
+	r, s, err = ecdsa.Sign(rand.Reader, privateKey, hash)
+	require.NoError(t, err)
+	return hash, r, s, x, y
+}
+
 func TestPrecompile_verify(t *testing.T) {
-	stateDB := &state.DBImpl{}
-	stateDB.WithCtx(sdk.Context{})
-	evm := &vm.EVM{StateDB: stateDB}
-	p, err := NewPrecompile(nil)
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{})
+	p, err := p256.NewPrecompile(testkeeper.EVMTestApp.GetPrecompileKeepers())
 	require.Nil(t, err)
-	method, err := p.MethodById(p.GetExecutor().(*PrecompileExecutor).VerifyID)
+	exec := p.GetExecutor().(*p256.PrecompileExecutor)
+	method, err := p.MethodById(exec.VerifyID)
 	require.Nil(t, err)
 	hash, r, s, x, y := generateValidKeyAndSignature(t)
 
 	tests := []struct {
-		name           string // Added name field for each test
+		name           string
 		hash           []byte
 		r, s, x, y     *big.Int
 		expectedOutput []byte
@@ -49,6 +68,8 @@ func TestPrecompile_verify(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			stateDB := state.NewDBImpl(ctx, k, false)
+			evm := &vm.EVM{StateDB: stateDB}
 			inputData := make([]byte, 0, 32*5)
 			inputData = append(inputData, common.LeftPadBytes(test.hash, 32)...)
 			inputData = append(inputData, common.LeftPadBytes(test.r.Bytes(), 32)...)
@@ -57,8 +78,8 @@ func TestPrecompile_verify(t *testing.T) {
 			inputData = append(inputData, common.LeftPadBytes(test.y.Bytes(), 32)...)
 			args, err := method.Inputs.Pack(inputData)
 			require.Nil(t, err)
-			input := append(p.GetExecutor().(*PrecompileExecutor).VerifyID, args...)
-			res, err := p.Run(evm, common.Address{}, common.Address{}, input, nil, true, false, nil)
+			input := append(exec.VerifyID, args...)
+			res, _, err := p.RunAndCalculateGas(evm, common.Address{}, common.Address{}, input, math.MaxUint64, nil, nil, true, false)
 			require.Nil(t, err)
 			if res != nil {
 				output, err := method.Outputs.Unpack(res)
@@ -67,7 +88,6 @@ func TestPrecompile_verify(t *testing.T) {
 			} else {
 				require.Equal(t, test.expectedOutput, res)
 			}
-
 		})
 	}
 }

--- a/precompiles/p256/p256_test.go
+++ b/precompiles/p256/p256_test.go
@@ -11,10 +11,44 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/sei-protocol/sei-chain/precompiles/p256"
+	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
 	"github.com/stretchr/testify/require"
 )
+
+// TestPrecompile_verifyOutOfGasPropagates guards the framework invariant that an
+// executor exhausting its gas mid-execution propagates the out-of-gas panic
+// (failing the tx) rather than having it caught and downgraded to a reverted
+// call. The fixed verify charge is levied outside verify's crypto recover, so a
+// call funded for the decode but not the verify cost must panic out, not revert.
+func TestPrecompile_verifyOutOfGasPropagates(t *testing.T) {
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{})
+	p, err := p256.NewPrecompile(testkeeper.EVMTestApp.GetPrecompileKeepers())
+	require.Nil(t, err)
+	exec := p.GetExecutor().(*p256.PrecompileExecutor)
+	method, err := p.MethodById(exec.VerifyID)
+	require.Nil(t, err)
+	hash, r, s, x, y := generateValidKeyAndSignature(t)
+	inputData := make([]byte, 0, 32*5)
+	inputData = append(inputData, common.LeftPadBytes(hash, 32)...)
+	inputData = append(inputData, common.LeftPadBytes(r.Bytes(), 32)...)
+	inputData = append(inputData, common.LeftPadBytes(s.Bytes(), 32)...)
+	inputData = append(inputData, common.LeftPadBytes(x.Bytes(), 32)...)
+	inputData = append(inputData, common.LeftPadBytes(y.Bytes(), 32)...)
+	packed, err := method.Inputs.Pack(inputData)
+	require.Nil(t, err)
+	input := append(exec.VerifyID, packed...)
+
+	stateDB := state.NewDBImpl(ctx, k, false)
+	evm := &vm.EVM{StateDB: stateDB}
+	// Enough gas to cover the calldata decode charge but not the fixed verify
+	// cost (P256VerifyGas = 3450), so the verify-cost out-of-gas must propagate.
+	require.PanicsWithValue(t, sdk.ErrorOutOfGas{Descriptor: "p256Verify"}, func() {
+		_, _, _ = p.RunAndCalculateGas(evm, common.Address{}, common.Address{}, input, 4000, nil, nil, true, false)
+	})
+}
 
 // generateValidKeyAndSignature mirrors the helper in verifier_test.go; that one
 // lives in the white-box (package p256) test, which cannot import testkeeper

--- a/precompiles/pointerview/pointerview.go
+++ b/precompiles/pointerview/pointerview.go
@@ -37,7 +37,7 @@ type PrecompileExecutor struct {
 	GetCW1155PointerID []byte
 }
 
-func NewPrecompile(keepers utils.Keepers) (*pcommon.Precompile, error) {
+func NewPrecompile(keepers utils.Keepers) (*pcommon.DynamicGasPrecompile, error) {
 	newAbi := pcommon.MustGetABI(f, "abi.json")
 
 	p := &PrecompileExecutor{
@@ -57,31 +57,36 @@ func NewPrecompile(keepers utils.Keepers) (*pcommon.Precompile, error) {
 		}
 	}
 
-	return pcommon.NewPrecompile(newAbi, p, common.HexToAddress(PointerViewAddress), "pointerview"), nil
+	return pcommon.NewDynamicGasPrecompile(newAbi, p, common.HexToAddress(PointerViewAddress), "pointerview"), nil
 }
 
-// RequiredGas returns the required bare minimum gas to execute the precompile.
-func (p PrecompileExecutor) RequiredGas([]byte, *abi.Method) uint64 {
-	return 2000
+func (p PrecompileExecutor) EVMKeeper() utils.EVMKeeper {
+	return p.evmKeeper
 }
 
-func (p PrecompileExecutor) Execute(ctx sdk.Context, method *abi.Method, caller common.Address, callingContract common.Address, args []interface{}, value *big.Int, readOnly bool, evm *vm.EVM, hooks *tracing.Hooks) (ret []byte, err error) {
-	if err := pcommon.ValidateNonPayable(value); err != nil {
-		return nil, err
+func (p PrecompileExecutor) Execute(ctx sdk.Context, method *abi.Method, caller common.Address, callingContract common.Address, args []interface{}, value *big.Int, readOnly bool, evm *vm.EVM, suppliedGas uint64, hooks *tracing.Hooks) (ret []byte, remainingGas uint64, err error) {
+	if err = pcommon.ValidateNonPayable(value); err != nil {
+		return nil, 0, err
 	}
+	// The pointer lookups below read state, so they self-meter against the call's
+	// gas meter (like the other dynamic precompiles); no flat work charge is
+	// needed. remainingGas reflects what those reads consumed.
 	switch method.Name {
 	case GetNativePointer:
-		return p.GetNative(ctx, method, args)
+		ret, err = p.GetNative(ctx, method, args)
 	case GetCW20Pointer:
-		return p.GetCW20(ctx, method, args)
+		ret, err = p.GetCW20(ctx, method, args)
 	case GetCW721Pointer:
-		return p.GetCW721(ctx, method, args)
+		ret, err = p.GetCW721(ctx, method, args)
 	case GetCW1155Pointer:
-		return p.GetCW1155(ctx, method, args)
+		ret, err = p.GetCW1155(ctx, method, args)
 	default:
 		err = fmt.Errorf("unknown method %s", method.Name)
 	}
-	return
+	if err != nil {
+		return nil, 0, err
+	}
+	return ret, pcommon.GetRemainingGas(ctx, p.evmKeeper), nil
 }
 
 func (p PrecompileExecutor) GetNative(ctx sdk.Context, method *abi.Method, args []interface{}) (ret []byte, err error) {


### PR DESCRIPTION
## Summary

Follow-up to #3737 (now merged): converts the three remaining **static-gas**
precompiles — `json`, `pointerview`, `p256` — to **dynamic-gas**, so every custom
precompile runs through one path (`RunAndCalculateGas`) and the up-front
calldata-decode gas accounting applies to them behind the gas meter (rather than
via the `RequiredGas` pre-gate).

Per precompile: the executor implements the dynamic
`Execute(… suppliedGas, hooks) (ret, remainingGas, err)` and `EVMKeeper()`;
`NewPrecompile` returns `*pcommon.DynamicGasPrecompile`; the internal methods are
unchanged — `Execute` wraps them and computes `remainingGas`.

## Gas model

These functions do little or no state access, so they charge for their work
explicitly (they would otherwise register ~no gas via the meter):

| precompile | state? | work charge |
|---|---|---|
| `p256` | stateless (crypto) | fixed `P256VerifyGas = 3450` (RIP-7212 P256VERIFY) |
| `json` | stateless (in-memory parse) | per-byte on the parsed payload (`GasCostPerByte`·len(args[0])) |
| `pointerview` | reads pointer registry | self-meters via its state reads (flat `2000` dropped) |

The framework decode charge is applied on top by `RunAndCalculateGas`. These are
deliberate re-prices and intentionally deviate from the old static costs.

## Release version bump — intentionally left out

This changes each precompile's effective cost (a consensus / app-hash change).
The current static behavior must be archived as a legacy snapshot before deploy,
or replay of current-version blocks would use the new gas. That archival is the
standard release step and is **not** in this PR by design:

```bash
echo "v6.7" >> app/tags   # or the real next tag
go generate ./...          # scripts/bump_version: archive current → legacy/, regenerate setup.go
```

Do not deploy on the current version until that lands.

## Tests

- `p256_test.go` moved to an external package (the white-box package can't import
  `testkeeper` — import cycle) and now exercises the dynamic path via
  `RunAndCalculateGas` with a real context; crypto-level `verifier_test.go` is
  unchanged.
- `json_test.go` reworked to a real context + `RunAndCalculateGas`.
- `pointerview_test.go` unchanged (it calls the internal methods directly).
- Rebased onto `main` (which now includes #3737 and the go-ethereum
  `v1.15.7-sei-18` bump). `go build ./...` clean; `precompiles/...` + the
  `evmrpc/tests` replay suite pass; golangci-lint (v2.8.0/go1.25.6) 0 issues.

CI note: broader integration/regression gas baselines that exercise these three
at the current version will shift once the version bump lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
