### PR TITLE
(CI) Remove redundant Docker Hub login from integration-tests matrix job

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -335,6 +335,14 @@ jobs:
           go-version: '1.25.6'
       - name: Install jq
         run: sudo apt-get install -y jq
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        if: env.DOCKERHUB_USERNAME != ''
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -192,15 +192,6 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.25.6'
-      - name: Login to Docker Hub
-        # See: https://github.com/docker/login-action/releases/tag/v4.2.0
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
-        if: env.DOCKERHUB_USERNAME != ''
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GitHub Container Registry
         # See: https://github.com/docker/login-action/releases/tag/v4.2.0
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
@@ -344,14 +335,6 @@ jobs:
           go-version: '1.25.6'
       - name: Install jq
         run: sudo apt-get install -y jq
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        if: env.DOCKERHUB_USERNAME != ''
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -515,6 +515,7 @@ docker-cluster-start-giga-mixed: docker-cluster-stop build-docker-node
 # CI variant: reuse the prebuilt image loaded from GHCR instead of rebuilding.
 docker-cluster-start-giga-mixed-ci: docker-cluster-stop ensure-integration-ci-images
 	@rm -rf $(PROJECT_HOME)/build/generated
+	@test -f $(PROJECT_HOME)/build/seid || (echo "build/seid missing; download integration-build.tar.gz from prepare-cluster" && exit 1)
 	@mkdir -p $(shell go env GOMODCACHE)
 	@mkdir -p $(shell go env GOCACHE)
 	@cd docker && \
@@ -523,8 +524,7 @@ docker-cluster-start-giga-mixed-ci: docker-cluster-stop ensure-integration-ci-im
 		else \
 			DETACH_FLAG=""; \
 		fi; \
-		DOCKER_PLATFORM=$(DOCKER_PLATFORM) USERID=$(shell id -u) GROUPID=$(shell id -g) GOCACHE=$(shell go env GOCACHE) NUM_ACCOUNTS=10 INVARIANT_CHECK_INTERVAL=${INVARIANT_CHECK_INTERVAL} UPGRADE_VERSION_LIST=${UPGRADE_VERSION_LIST} MOCK_BALANCES=${MOCK_BALANCES} GIGA_EXECUTOR=${GIGA_EXECUTOR} GIGA_OCC=${GIGA_OCC} RECEIPT_BACKEND=${RECEIPT_BACKEND} AUTOBAHN=${AUTOBAHN} GIGA_STORAGE=${GIGA_STORAGE} \
-		SKIP_BUILD=true docker compose -f docker-compose.yml -f docker-compose.giga-mixed.yml up $$DETACH_FLAG
+		$(CLUSTER_ENV_VARS) SKIP_BUILD=true docker compose -f docker-compose.yml -f docker-compose.giga-mixed.yml up $$DETACH_FLAG
 .PHONY: docker-cluster-start-giga-mixed-ci
 
 # Run the giga mixed-mode integration test.

--- a/Makefile
+++ b/Makefile
@@ -512,6 +512,21 @@ docker-cluster-start-giga-mixed: docker-cluster-stop build-docker-node
 		docker compose -f docker-compose.yml -f docker-compose.giga-mixed.yml up $$DETACH_FLAG
 .PHONY: docker-cluster-start-giga-mixed
 
+# CI variant: reuse the prebuilt image loaded from GHCR instead of rebuilding.
+docker-cluster-start-giga-mixed-ci: docker-cluster-stop ensure-integration-ci-images
+	@rm -rf $(PROJECT_HOME)/build/generated
+	@mkdir -p $(shell go env GOMODCACHE)
+	@mkdir -p $(shell go env GOCACHE)
+	@cd docker && \
+		if [ "$${DOCKER_DETACH:-}" = "true" ]; then \
+			DETACH_FLAG="-d"; \
+		else \
+			DETACH_FLAG=""; \
+		fi; \
+		DOCKER_PLATFORM=$(DOCKER_PLATFORM) USERID=$(shell id -u) GROUPID=$(shell id -g) GOCACHE=$(shell go env GOCACHE) NUM_ACCOUNTS=10 INVARIANT_CHECK_INTERVAL=${INVARIANT_CHECK_INTERVAL} UPGRADE_VERSION_LIST=${UPGRADE_VERSION_LIST} MOCK_BALANCES=${MOCK_BALANCES} GIGA_EXECUTOR=${GIGA_EXECUTOR} GIGA_OCC=${GIGA_OCC} RECEIPT_BACKEND=${RECEIPT_BACKEND} AUTOBAHN=${AUTOBAHN} GIGA_STORAGE=${GIGA_STORAGE} \
+		SKIP_BUILD=true docker compose -f docker-compose.yml -f docker-compose.giga-mixed.yml up $$DETACH_FLAG
+.PHONY: docker-cluster-start-giga-mixed-ci
+
 # Run the giga mixed-mode integration test.
 # Starts a cluster where only node 0 runs giga (concurrent, OCC), nodes 1-3 run standard V2.
 # Then runs hardhat tests. If giga produces different results, node 0 will halt.

--- a/integration_test/evm_module/scripts/evm_giga_mixed_tests.sh
+++ b/integration_test/evm_module/scripts/evm_giga_mixed_tests.sh
@@ -22,10 +22,10 @@ echo "=== Node 0: GIGA_EXECUTOR=true GIGA_OCC=true, Nodes 1-3: standard V2 ==="
 echo "Stopping default cluster..."
 make docker-cluster-stop || true
 
-# Start mixed-mode cluster (node 0 = giga, nodes 1-3 = V2)
-# build-docker-node is a no-op since the image was already built
+# Start mixed-mode cluster (node 0 = giga, nodes 1-3 = V2), reusing the
+# image already loaded from GHCR by the workflow.
 echo "Starting mixed-mode cluster..."
-DOCKER_DETACH=true make docker-cluster-start-giga-mixed
+DOCKER_DETACH=true make docker-cluster-start-giga-mixed-ci
 
 # Wait for all 4 nodes to be ready
 echo "Waiting for mixed cluster to be ready..."


### PR DESCRIPTION
## Summary

Remove the Docker Hub login step from the `integration-tests` matrix job, which only pulls prebuilt images from GHCR and (for nearly all entries) uses `docker-cluster-start-ci` (no `docker build`, no `docker.io` pulls).

Docker Hub login is unchanged on `prepare-cluster` (builds images) and `autobahn-integration-tests` (`TestMain` runs `docker-cluster-start`, which rebuilds from `docker.io` base layers).

This avoids spurious merge-queue failures when `registry-1.docker.io` is unreachable during login on matrix jobs that never use Docker Hub. See [#3804](https://github.com/sei-protocol/sei-chain/pull/3804), where merge queue failed on `Integration Test (EVM Precompiles)` with `context deadline exceeded` before any test ran.

## The one exception: EVM GIGA Mixed (Determinism)

Review caught that one matrix entry, `EVM GIGA Mixed (Determinism)`, didn't fit the "no `docker build`" premise: `evm_giga_mixed_tests.sh` called `make docker-cluster-start-giga-mixed`, which (unlike the other entries' `docker-cluster-start-ci`) unconditionally depended on `build-docker-node` and rebuilt `localnode` from `docker.io` base layers (`golang:1.25.6-bookworm`, `ubuntu:24.04`).

Fixed by adding `docker-cluster-start-giga-mixed-ci` to the Makefile — same cluster, but depends on `ensure-integration-ci-images` + `SKIP_BUILD=true` instead of `build-docker-node`, reusing the image already pulled from GHCR (same pattern as `docker-cluster-start-ci`). The original `docker-cluster-start-giga-mixed` is untouched and still used by the local-dev target `giga-mixed-integration-test`, which needs a fresh build. This keeps the login removal safe without a `matrix.test.name == '...'` conditional that would go stale as the matrix changes.

## Changes

- **`.github/workflows/integration-test.yml`**: remove Docker Hub login from `integration-tests`; GHCR login and image pull unchanged. `prepare-cluster` and `autobahn-integration-tests` unchanged.
- **`Makefile`**: add `docker-cluster-start-giga-mixed-ci` (CI-only, reuses GHCR image instead of rebuilding).
- **`integration_test/evm_module/scripts/evm_giga_mixed_tests.sh`**: use `docker-cluster-start-giga-mixed-ci` instead of `docker-cluster-start-giga-mixed`.

## Test plan

- [ ] Integration test workflow passes on this PR (including merge queue)
- [ ] `prepare-cluster` still authenticates to Docker Hub and builds/pushes images to GHCR
- [ ] Matrix jobs still pull `localnode` / `rpcnode` from GHCR and run tests successfully
- [ ] `EVM GIGA Mixed (Determinism)` entry passes using the GHCR image (no Docker Hub pulls)
- [ ] `autobahn-integration-tests` still passes with Docker Hub login retained
