### PR TITLE
fix(ss/composite): gate EVM kind parsing on the evm module in convertFlatKVNodes

### DIFF
--- a/sei-db/state_db/ss/composite/store.go
+++ b/sei-db/state_db/ss/composite/store.go
@@ -339,6 +339,11 @@ func convertFlatKVNodes(node types.SnapshotNode) ([]types.SnapshotNode, error) {
 	if err != nil {
 		return nil, fmt.Errorf("convertFlatKVNodes failed: %w", err)
 	}
+	if moduleName == "" {
+		// Same guard as classifyAndPrefix and routePhysicalKey: an empty
+		// module would produce a StoreKey the SS importer silently drops.
+		return nil, fmt.Errorf("flatkv: empty module name in physical key %q", node.Key)
+	}
 
 	// Only keys under the EVM module carry EVM kind prefixes. Legacy module
 	// keys are opaque bytes: a staking/bank/... key can coincidentally start

--- a/sei-db/state_db/ss/composite/store.go
+++ b/sei-db/state_db/ss/composite/store.go
@@ -344,6 +344,14 @@ func convertFlatKVNodes(node types.SnapshotNode) ([]types.SnapshotNode, error) {
 		// module would produce a StoreKey the SS importer silently drops.
 		return nil, fmt.Errorf("flatkv: empty module name in physical key %q", node.Key)
 	}
+	if len(innerKey) == 0 {
+		// A bare "module/" key cannot be produced by a healthy writer (the
+		// SDK rejects empty keys before they reach a changeset), so seeing
+		// one during import signals corruption. Reject it explicitly: the
+		// misc path would emit an empty-key node that the SS importer
+		// silently skips, hiding the problem.
+		return nil, fmt.Errorf("flatkv: empty inner key in physical key %q", node.Key)
+	}
 
 	// Only keys under the EVM module carry EVM kind prefixes. Legacy module
 	// keys are opaque bytes: a staking/bank/... key can coincidentally start

--- a/sei-db/state_db/ss/composite/store.go
+++ b/sei-db/state_db/ss/composite/store.go
@@ -344,19 +344,13 @@ func convertFlatKVNodes(node types.SnapshotNode) ([]types.SnapshotNode, error) {
 	// keys are opaque bytes: a staking/bank/... key can coincidentally start
 	// with an EVM prefix byte and satisfy its length check, and would then be
 	// deserialized as the wrong vtype (observed on production-scale data).
-	// This mirrors the write side (classifyAndPrefix) and the read routing
+	// Default them to the misc kind — their values are always MiscData. This
+	// mirrors the write side (classifyAndPrefix) and the read routing
 	// (routePhysicalKey), which both gate EVM parsing on the module name.
-	if moduleName != evm.EVMStoreKey {
-		ld, err := vtype.DeserializeMiscData(node.Value)
-		if err != nil {
-			return nil, fmt.Errorf("failed to DeserializeMiscData for module %s: %w", moduleName, err)
-		}
-		return []types.SnapshotNode{
-			{StoreKey: moduleName, Key: innerKey, Value: ld.GetValue()},
-		}, nil
+	kind, strippedKey := keys.EVMKeyMisc, innerKey
+	if moduleName == evm.EVMStoreKey {
+		kind, strippedKey = keys.ParseEVMKey(innerKey)
 	}
-
-	kind, strippedKey := keys.ParseEVMKey(innerKey)
 
 	switch kind {
 	case keys.EVMKeyNonce:

--- a/sei-db/state_db/ss/composite/store.go
+++ b/sei-db/state_db/ss/composite/store.go
@@ -340,6 +340,22 @@ func convertFlatKVNodes(node types.SnapshotNode) ([]types.SnapshotNode, error) {
 		return nil, fmt.Errorf("convertFlatKVNodes failed: %w", err)
 	}
 
+	// Only keys under the EVM module carry EVM kind prefixes. Legacy module
+	// keys are opaque bytes: a staking/bank/... key can coincidentally start
+	// with an EVM prefix byte and satisfy its length check, and would then be
+	// deserialized as the wrong vtype (observed on production-scale data).
+	// This mirrors the write side (classifyAndPrefix) and the read routing
+	// (routePhysicalKey), which both gate EVM parsing on the module name.
+	if moduleName != evm.EVMStoreKey {
+		ld, err := vtype.DeserializeMiscData(node.Value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to DeserializeMiscData for module %s: %w", moduleName, err)
+		}
+		return []types.SnapshotNode{
+			{StoreKey: moduleName, Key: innerKey, Value: ld.GetValue()},
+		}, nil
+	}
+
 	kind, strippedKey := keys.ParseEVMKey(innerKey)
 
 	switch kind {

--- a/sei-db/state_db/ss/composite/store_test.go
+++ b/sei-db/state_db/ss/composite/store_test.go
@@ -1229,19 +1229,35 @@ func TestImport_LegacyKeyMimickingEVMShapeStaysLegacy(t *testing.T) {
 	payload := []byte("legacy-value-that-is-not-32-bytes-long-at-all-....")
 	mimicVal := vtype.NewMiscData().SetValue(payload).Serialize()
 
-	store, cleanup := setupImportTestStore(t, true)
-	defer cleanup()
+	// The misroute's failure shape differs per mode: with EVMSplit a
+	// misclassified node would land in the EVM store; without it, in the
+	// cosmos store under "evm". Pin both.
+	for _, mode := range []bool{true, false} {
+		t.Run(fmt.Sprintf("EVMSplit=%v", mode), func(t *testing.T) {
+			store, cleanup := setupImportTestStore(t, mode)
+			defer cleanup()
 
-	ch := make(chan types.SnapshotNode, 10)
-	go feedNodes(ch, []types.SnapshotNode{
-		{StoreKey: commonevm.FlatKVStoreKey, Key: mimicPhysKey, Value: mimicVal},
-	})
+			ch := make(chan types.SnapshotNode, 10)
+			go feedNodes(ch, []types.SnapshotNode{
+				{StoreKey: commonevm.FlatKVStoreKey, Key: mimicPhysKey, Value: mimicVal},
+			})
 
-	require.NoError(t, store.Import(1, ch))
+			require.NoError(t, store.Import(1, ch))
 
-	got, err := store.cosmosStore.Get("staking", 1, mimicInnerKey)
-	require.NoError(t, err)
-	require.Equal(t, payload, got, "legacy key mimicking EVM storage shape must round-trip as MiscData under its module")
+			got, err := store.cosmosStore.Get("staking", 1, mimicInnerKey)
+			require.NoError(t, err)
+			require.Equal(t, payload, got, "legacy key mimicking EVM storage shape must round-trip as MiscData under its module")
+
+			misrouted, err := store.cosmosStore.Get(evm.EVMStoreKey, 1, mimicInnerKey)
+			require.NoError(t, err)
+			require.Nil(t, misrouted, "mimic key must not land under the evm module in the cosmos store")
+			if store.evmStore != nil {
+				misrouted, err = store.evmStore.Get(evm.EVMStoreKey, 1, mimicInnerKey)
+				require.NoError(t, err)
+				require.Nil(t, misrouted, "mimic key must not land in the EVM store")
+			}
+		})
+	}
 }
 
 func TestImport_NonEvmModulesUnaffected(t *testing.T) {

--- a/sei-db/state_db/ss/composite/store_test.go
+++ b/sei-db/state_db/ss/composite/store_test.go
@@ -1,6 +1,7 @@
 package composite
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -1226,37 +1227,51 @@ func TestImport_LegacyKeyMimickingEVMShapeStaysLegacy(t *testing.T) {
 	// conversion would fail (or worse, silently corrupt).
 	mimicInnerKey := commonevm.BuildEVMKey(commonevm.EVMKeyStorage, append(addr, slot...))
 	mimicPhysKey := ktype.ModulePhysicalKey("staking", mimicInnerKey)
-	payload := []byte("legacy-value-that-is-not-32-bytes-long-at-all-....")
-	mimicVal := vtype.NewMiscData().SetValue(payload).Serialize()
 
-	// The misroute's failure shape differs per mode: with EVMSplit a
+	// Two pre-fix failure shapes, selected by payload length:
+	// - 50 bytes: serialized MiscData (9-byte header) is 59 bytes, so a
+	//   misclassified DeserializeStorageData errors out — the crash variant.
+	// - 32 bytes: serialized MiscData is exactly storageDataLength (41), so a
+	//   misclassified deserialization *succeeds* and the row is silently
+	//   written under StoreKey "evm" instead of its module — the corruption
+	//   variant, which no failing import would ever surface.
+	payloads := map[string][]byte{
+		"crash-shape":      []byte("legacy-value-that-is-not-32-bytes-long-at-all-...."),
+		"corruption-shape": bytes.Repeat([]byte{0x5A}, 32),
+	}
+
+	// The misroute's landing spot also differs per mode: with EVMSplit a
 	// misclassified node would land in the EVM store; without it, in the
 	// cosmos store under "evm". Pin both.
 	for _, mode := range []bool{true, false} {
-		t.Run(fmt.Sprintf("EVMSplit=%v", mode), func(t *testing.T) {
-			store, cleanup := setupImportTestStore(t, mode)
-			defer cleanup()
+		for name, payload := range payloads {
+			t.Run(fmt.Sprintf("EVMSplit=%v/%s", mode, name), func(t *testing.T) {
+				mimicVal := vtype.NewMiscData().SetValue(payload).Serialize()
 
-			ch := make(chan types.SnapshotNode, 10)
-			go feedNodes(ch, []types.SnapshotNode{
-				{StoreKey: commonevm.FlatKVStoreKey, Key: mimicPhysKey, Value: mimicVal},
-			})
+				store, cleanup := setupImportTestStore(t, mode)
+				defer cleanup()
 
-			require.NoError(t, store.Import(1, ch))
+				ch := make(chan types.SnapshotNode, 10)
+				go feedNodes(ch, []types.SnapshotNode{
+					{StoreKey: commonevm.FlatKVStoreKey, Key: mimicPhysKey, Value: mimicVal},
+				})
 
-			got, err := store.cosmosStore.Get("staking", 1, mimicInnerKey)
-			require.NoError(t, err)
-			require.Equal(t, payload, got, "legacy key mimicking EVM storage shape must round-trip as MiscData under its module")
+				require.NoError(t, store.Import(1, ch))
 
-			misrouted, err := store.cosmosStore.Get(evm.EVMStoreKey, 1, mimicInnerKey)
-			require.NoError(t, err)
-			require.Nil(t, misrouted, "mimic key must not land under the evm module in the cosmos store")
-			if store.evmStore != nil {
-				misrouted, err = store.evmStore.Get(evm.EVMStoreKey, 1, mimicInnerKey)
+				got, err := store.cosmosStore.Get("staking", 1, mimicInnerKey)
 				require.NoError(t, err)
-				require.Nil(t, misrouted, "mimic key must not land in the EVM store")
-			}
-		})
+				require.Equal(t, payload, got, "legacy key mimicking EVM storage shape must round-trip as MiscData under its module")
+
+				misrouted, err := store.cosmosStore.Get(evm.EVMStoreKey, 1, mimicInnerKey)
+				require.NoError(t, err)
+				require.Nil(t, misrouted, "mimic key must not land under the evm module in the cosmos store")
+				if store.evmStore != nil {
+					misrouted, err = store.evmStore.Get(evm.EVMStoreKey, 1, mimicInnerKey)
+					require.NoError(t, err)
+					require.Nil(t, misrouted, "mimic key must not land in the EVM store")
+				}
+			})
+		}
 	}
 }
 

--- a/sei-db/state_db/ss/composite/store_test.go
+++ b/sei-db/state_db/ss/composite/store_test.go
@@ -1208,6 +1208,42 @@ func TestImport_FlatKVLegacyKeysPreserveModule(t *testing.T) {
 	}
 }
 
+// TestImport_LegacyKeyMimickingEVMShapeStaysLegacy is a regression test for a
+// production-scale import failure: a non-EVM module key that coincidentally
+// starts with an EVM prefix byte and matches that kind's length check must
+// still be treated as legacy MiscData, not deserialized as an EVM vtype.
+// EVM kind parsing is only valid under the "evm" module, mirroring the write
+// side (classifyAndPrefix) and read routing (routePhysicalKey).
+func TestImport_LegacyKeyMimickingEVMShapeStaysLegacy(t *testing.T) {
+	addr := make([]byte, 20)
+	addr[0] = 0x11
+	slot := make([]byte, 32)
+	slot[31] = 0x22
+
+	// Inner key with the exact shape of an EVM storage key (prefix + addr +
+	// slot), but under a legacy module. The value is MiscData whose payload
+	// length differs from the fixed StorageData length, so a misclassified
+	// conversion would fail (or worse, silently corrupt).
+	mimicInnerKey := commonevm.BuildEVMKey(commonevm.EVMKeyStorage, append(addr, slot...))
+	mimicPhysKey := ktype.ModulePhysicalKey("staking", mimicInnerKey)
+	payload := []byte("legacy-value-that-is-not-32-bytes-long-at-all-....")
+	mimicVal := vtype.NewMiscData().SetValue(payload).Serialize()
+
+	store, cleanup := setupImportTestStore(t, true)
+	defer cleanup()
+
+	ch := make(chan types.SnapshotNode, 10)
+	go feedNodes(ch, []types.SnapshotNode{
+		{StoreKey: commonevm.FlatKVStoreKey, Key: mimicPhysKey, Value: mimicVal},
+	})
+
+	require.NoError(t, store.Import(1, ch))
+
+	got, err := store.cosmosStore.Get("staking", 1, mimicInnerKey)
+	require.NoError(t, err)
+	require.Equal(t, payload, got, "legacy key mimicking EVM storage shape must round-trip as MiscData under its module")
+}
+
 func TestImport_NonEvmModulesUnaffected(t *testing.T) {
 	store, cleanup := setupImportTestStore(t, true)
 	defer cleanup()

--- a/sei-db/state_db/ss/composite/store_test.go
+++ b/sei-db/state_db/ss/composite/store_test.go
@@ -1275,6 +1275,27 @@ func TestImport_LegacyKeyMimickingEVMShapeStaysLegacy(t *testing.T) {
 	}
 }
 
+// TestImport_FlatKVEmptyModuleKeyRejected pins the empty-module guard shared
+// with classifyAndPrefix and routePhysicalKey: a physical key of the form
+// "/<key>" must fail the import instead of producing a StoreKey "" node that
+// the SS importer would silently drop.
+func TestImport_FlatKVEmptyModuleKeyRejected(t *testing.T) {
+	store, cleanup := setupImportTestStore(t, false)
+	defer cleanup()
+
+	ch := make(chan types.SnapshotNode, 10)
+	go feedNodes(ch, []types.SnapshotNode{
+		{
+			StoreKey: commonevm.FlatKVStoreKey,
+			Key:      []byte("/orphan"),
+			Value:    vtype.NewMiscData().SetValue([]byte("x")).Serialize(),
+		},
+	})
+
+	err := store.Import(1, ch)
+	require.ErrorContains(t, err, "empty module name")
+}
+
 func TestImport_NonEvmModulesUnaffected(t *testing.T) {
 	store, cleanup := setupImportTestStore(t, true)
 	defer cleanup()

--- a/sei-db/state_db/ss/composite/store_test.go
+++ b/sei-db/state_db/ss/composite/store_test.go
@@ -1296,6 +1296,27 @@ func TestImport_FlatKVEmptyModuleKeyRejected(t *testing.T) {
 	require.ErrorContains(t, err, "empty module name")
 }
 
+// TestImport_FlatKVEmptyInnerKeyRejected pins the degenerate "module/" shape:
+// such a key cannot be produced by a healthy writer, and letting it take the
+// misc path would end in the SS importer silently skipping the empty-key
+// node. The import must fail loudly instead.
+func TestImport_FlatKVEmptyInnerKeyRejected(t *testing.T) {
+	store, cleanup := setupImportTestStore(t, false)
+	defer cleanup()
+
+	ch := make(chan types.SnapshotNode, 10)
+	go feedNodes(ch, []types.SnapshotNode{
+		{
+			StoreKey: commonevm.FlatKVStoreKey,
+			Key:      []byte("staking/"),
+			Value:    vtype.NewMiscData().SetValue([]byte("x")).Serialize(),
+		},
+	})
+
+	err := store.Import(1, ch)
+	require.ErrorContains(t, err, "empty inner key")
+}
+
 func TestImport_NonEvmModulesUnaffected(t *testing.T) {
 	store, cleanup := setupImportTestStore(t, true)
 	defer cleanup()


### PR DESCRIPTION
## Problem

`convertFlatKVNodes` (state sync SS import) ran `ParseEVMKey` on every
module's keys. Legacy module keys are opaque bytes: one that happens to start
with an EVM prefix byte and match that kind's length check gets deserialized
as the wrong vtype. Hit on production-scale data (~1B keys):

    DeserializeStorageData: data length at version 0 should be 41, got 58

If the lengths happen to match instead, the value is silently written under
the wrong store key — corruption, not a crash. Small fixtures can't hit this;
at 10^9 keys the collision is near-certain.

## Fix

Parse EVM kinds only under the `evm` module; everything else takes the
MiscData path. Mirrors the existing gates in `classifyAndPrefix` (write) and
`routePhysicalKey` (read).

## Testing

- Regression test matrix: both `EVMSplit` modes × both pre-fix failure
  shapes — a 50-byte payload (length mismatch, import errors) and a 32-byte
  payload (MiscData serializes to exactly 41 bytes, pre-fix the row silently
  lands under the `evm` store key instead of its module). Negative assertions
  pin that nothing lands in either wrong location. Verified the corruption
  case fails on the pre-fix code.
- 1.0B-entry production-scale import that previously failed now completes;
  historical queries byte-identical to a reference node.