### PR TITLE
v6.5.1 Stackoverflow patch

### DIFF
--- a/sei-db/db_engine/pebbledb/mvcc/iterator.go
+++ b/sei-db/db_engine/pebbledb/mvcc/iterator.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"sync"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -21,10 +22,7 @@ var _ types.DBIterator = (*iterator)(nil)
 // in the provided domain for a given version. If a key has been written at the
 // provided version, that key/value pair will be iterated over. Otherwise, the
 // latest version for that key/value pair will be iterated over s.t. it's less
-// than the provided version. Note:
-//
-// - The start key must not be empty.
-// - Currently, reverse iteration is NOT supported.
+// than the provided version. The start key must not be empty.
 type iterator struct {
 	source             *pebble.Iterator
 	prefix, start, end []byte
@@ -72,41 +70,149 @@ func newPebbleDBIterator(src *pebble.Iterator, prefix, mvccStart, mvccEnd []byte
 	}
 
 	if valid {
-		currKey, currKeyVersion, ok := SplitMVCCKey(itr.source.Key())
+		currKey, _, ok := SplitMVCCKey(itr.source.Key())
 		if !ok {
 			// XXX: This should not happen as that would indicate we have a malformed MVCC key.
 			panic(fmt.Sprintf("invalid PebbleDB MVCC key: %s", itr.source.Key()))
 		}
 
-		curKeyVersionDecoded, err := decodeUint64Ascending(currKeyVersion)
-		if err != nil {
-			itr.valid = false
-			return itr
-		}
-
-		// We need to check whether initial key iterator visits has a version <= requested version
-		// If larger version, call next to find another key which does
-		if curKeyVersionDecoded > itr.version {
-			itr.Next()
-		} else {
-			// If version is less, seek to the largest version of that key <= requested iterator version
-			// It is guaranteed this won't move the iterator to a key that is invalid since
-			// curKeyVersionDecoded <= requested iterator version, so there exists at least one version of currKey SeekLT may move to
-			itr.valid = itr.source.SeekLT(MVCCEncode(currKey, itr.version+1))
-		}
-	}
-
-	// Make sure we skip to the next key if the current one is tombstone
-	// Only check if iterator is still valid after the seek/next operations above
-	if itr.valid && valTombstoned(itr.source.Value()) {
+		// Last()/First() land on an arbitrary version of currKey, so walk to the
+		// first logical key at or beyond it that is visible at itr.version. Note
+		// that currKey itself may still be visible even when the version we
+		// landed on is newer than itr.version, so the whole key must not be
+		// skipped on that basis alone.
 		if reverse {
-			itr.nextReverse()
+			itr.positionAtOrBeforeKey(currKey)
 		} else {
-			itr.nextForward()
+			itr.positionAtOrAfterKey(currKey)
 		}
 	}
 
 	return itr
+}
+
+// visibleVersionUpperBound returns the exclusive seek bound that isolates the
+// versions of key which are visible at itr.version.
+func (itr *iterator) visibleVersionUpperBound(key []byte) []byte {
+	version := itr.version
+	if version < math.MaxInt64 {
+		version++
+	}
+	return MVCCEncode(key, version)
+}
+
+// seekVisibleVersionForKey positions the cursor on the newest version of
+// targetKey that is visible at itr.version, reporting whether such a version
+// exists. When it does not, the cursor is left on an earlier logical key and
+// the caller must not treat the current position as a result.
+func (itr *iterator) seekVisibleVersionForKey(targetKey []byte) bool {
+	if !itr.source.SeekLT(itr.visibleVersionUpperBound(targetKey)) {
+		return false
+	}
+
+	foundKey, foundVersion, ok := SplitMVCCKey(itr.source.Key())
+	if !ok {
+		return false
+	}
+	// Every version of targetKey sorts at or above the seek bound when none of
+	// them are visible, which lands the cursor on a preceding logical key.
+	if !bytes.Equal(foundKey, targetKey) {
+		return false
+	}
+
+	foundVersionDecoded, err := decodeUint64Ascending(foundVersion)
+	if err != nil {
+		return false
+	}
+	return foundVersionDecoded <= itr.version
+}
+
+// nextLogicalKey returns the smallest logical key greater than currKey that is
+// still within the iterator's prefix, independent of which version the cursor
+// currently sits on.
+func (itr *iterator) nextLogicalKey(currKey []byte) ([]byte, bool) {
+	// MVCCEncode(currKey, 0) carries an empty version, which sorts below every
+	// version of currKey, so this lands on currKey's oldest version if it has
+	// any and on the following logical key otherwise.
+	if !itr.source.SeekGE(MVCCEncode(currKey, 0)) {
+		return nil, false
+	}
+
+	nextKey, _, ok := SplitMVCCKey(itr.source.Key())
+	if !ok {
+		return nil, false
+	}
+	if bytes.Equal(nextKey, currKey) {
+		if !itr.source.NextPrefix() {
+			return nil, false
+		}
+		nextKey, _, ok = SplitMVCCKey(itr.source.Key())
+		if !ok {
+			return nil, false
+		}
+	}
+	if !bytes.HasPrefix(nextKey, itr.prefix) {
+		return nil, false
+	}
+	return nextKey, true
+}
+
+// prevLogicalKey returns the largest logical key smaller than currKey that is
+// still within the iterator's prefix, independent of which version the cursor
+// currently sits on.
+func (itr *iterator) prevLogicalKey(currKey []byte) ([]byte, bool) {
+	if !itr.source.SeekLT(MVCCEncode(currKey, 0)) {
+		return nil, false
+	}
+
+	prevKey, _, ok := SplitMVCCKey(itr.source.Key())
+	if !ok || !bytes.HasPrefix(prevKey, itr.prefix) {
+		return nil, false
+	}
+	return prevKey, true
+}
+
+// positionAtOrAfterKey advances to the first logical key at or after startKey
+// that has a non-tombstoned version visible at itr.version.
+//
+// The walk is iterative on purpose: a historical iteration has to step over
+// every logical key written after itr.version, and on an archive node that can
+// be millions of keys. Recursing once per skipped key overflows the goroutine
+// stack and takes the whole process down with it.
+func (itr *iterator) positionAtOrAfterKey(startKey []byte) {
+	currentKey := startKey
+	for {
+		if itr.seekVisibleVersionForKey(currentKey) && !itr.cursorTombstoned() {
+			itr.valid = true
+			return
+		}
+
+		nextKey, ok := itr.nextLogicalKey(currentKey)
+		if !ok {
+			itr.valid = false
+			return
+		}
+		currentKey = nextKey
+	}
+}
+
+// positionAtOrBeforeKey is the reverse-iteration counterpart of
+// positionAtOrAfterKey.
+func (itr *iterator) positionAtOrBeforeKey(startKey []byte) {
+	currentKey := startKey
+	for {
+		if itr.seekVisibleVersionForKey(currentKey) && !itr.cursorTombstoned() {
+			itr.valid = true
+			return
+		}
+
+		prevKey, ok := itr.prevLogicalKey(currentKey)
+		if !ok {
+			itr.valid = false
+			return
+		}
+		currentKey = prevKey
+	}
 }
 
 // Domain returns the domain of the iterator. The caller must not modify the
@@ -155,80 +261,12 @@ func (itr *iterator) nextForward() {
 		panic(fmt.Sprintf("invalid PebbleDB MVCC key: %s", itr.source.Key()))
 	}
 
-	next := itr.source.NextPrefix()
-
-	// First move the iterator to the next prefix, which may not correspond to the
-	// desired version for that key, e.g. if the key was written at a later version,
-	// so we seek back to the latest desired version, s.t. the version is <= itr.version.
-	if next {
-		nextKey, _, ok := SplitMVCCKey(itr.source.Key())
-		if !ok {
-			// XXX: This should not happen as that would indicate we have a malformed
-			// MVCC key.
-			itr.valid = false
-			return
-		}
-		if !bytes.HasPrefix(nextKey, itr.prefix) {
-			// the next key must have itr.prefix as the prefix
-			itr.valid = false
-			return
-		}
-
-		// Move the iterator to the closest version to the desired version, so we
-		// append the current iterator key to the prefix and seek to that key.
-		itr.valid = itr.source.SeekLT(MVCCEncode(nextKey, itr.version+1))
-
-		tmpKey, tmpKeyVersion, ok := SplitMVCCKey(itr.source.Key())
-		if !ok {
-			// XXX: This should not happen as that would indicate we have a malformed
-			// MVCC key.
-			itr.valid = false
-			return
-		}
-
-		// There exists cases where the SeekLT() call moved us back to the same key
-		// we started at, so we must move to next key, i.e. two keys forward.
-		if bytes.Equal(tmpKey, currKey) {
-			if itr.source.NextPrefix() {
-				itr.nextForward()
-
-				_, tmpKeyVersion, ok = SplitMVCCKey(itr.source.Key())
-				if !ok {
-					// XXX: This should not happen as that would indicate we have a malformed
-					// MVCC key.
-					itr.valid = false
-					return
-				}
-
-			} else {
-				itr.valid = false
-				return
-			}
-		}
-
-		// We need to verify that every Next call either moves the iterator to a key whose version
-		// is less than or equal to requested iterator version, or exhausts the iterator
-		tmpKeyVersionDecoded, err := decodeUint64Ascending(tmpKeyVersion)
-		if err != nil {
-			itr.valid = false
-			return
-		}
-
-		// If iterator is at a entry whose version is higher than requested version, call nextForward again
-		if tmpKeyVersionDecoded > itr.version {
-			itr.nextForward()
-		}
-
-		// The cursor might now be pointing at a key/value pair that is tombstoned.
-		// If so, we must move the cursor.
-		if itr.valid && itr.cursorTombstoned() {
-			itr.nextForward()
-		}
-
+	nextKey, ok := itr.nextLogicalKey(currKey)
+	if !ok {
+		itr.valid = false
 		return
 	}
-
-	itr.valid = false
+	itr.positionAtOrAfterKey(nextKey)
 }
 
 func (itr *iterator) nextReverse() {
@@ -244,60 +282,12 @@ func (itr *iterator) nextReverse() {
 		panic(fmt.Sprintf("invalid PebbleDB MVCC key: %s", itr.source.Key()))
 	}
 
-	next := itr.source.SeekLT(MVCCEncode(currKey, 0))
-
-	// First move the iterator to the next prefix, which may not correspond to the
-	// desired version for that key, e.g. if the key was written at a later version,
-	// so we seek back to the latest desired version, s.t. the version is <= itr.version.
-	if next {
-		nextKey, _, ok := SplitMVCCKey(itr.source.Key())
-		if !ok {
-			// XXX: This should not happen as that would indicate we have a malformed
-			// MVCC key.
-			itr.valid = false
-			return
-		}
-		if !bytes.HasPrefix(nextKey, itr.prefix) {
-			// the next key must have itr.prefix as the prefix
-			itr.valid = false
-			return
-		}
-
-		// Move the iterator to the closest version to the desired version, so we
-		// append the current iterator key to the prefix and seek to that key.
-		itr.valid = itr.source.SeekLT(MVCCEncode(nextKey, itr.version+1))
-
-		_, tmpKeyVersion, ok := SplitMVCCKey(itr.source.Key())
-		if !ok {
-			// XXX: This should not happen as that would indicate we have a malformed
-			// MVCC key.
-			itr.valid = false
-			return
-		}
-
-		// We need to verify that every Next call either moves the iterator to a key whose version
-		// is less than or equal to requested iterator version, or exhausts the iterator
-		tmpKeyVersionDecoded, err := decodeUint64Ascending(tmpKeyVersion)
-		if err != nil {
-			itr.valid = false
-			return
-		}
-
-		// If iterator is at a entry whose version is higher than requested version, call nextReverse again
-		if tmpKeyVersionDecoded > itr.version {
-			itr.nextReverse()
-		}
-
-		// The cursor might now be pointing at a key/value pair that is tombstoned.
-		// If so, we must move the cursor.
-		if itr.valid && itr.cursorTombstoned() {
-			itr.nextReverse()
-		}
-
+	prevKey, ok := itr.prevLogicalKey(currKey)
+	if !ok {
+		itr.valid = false
 		return
 	}
-
-	itr.valid = false
+	itr.positionAtOrBeforeKey(prevKey)
 }
 
 func (itr *iterator) Next() {

--- a/sei-db/db_engine/pebbledb/mvcc/iterator_test.go
+++ b/sei-db/db_engine/pebbledb/mvcc/iterator_test.go
@@ -1,0 +1,110 @@
+package mvcc
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime/debug"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sei-protocol/sei-chain/sei-db/config"
+	sstest "github.com/sei-protocol/sei-chain/sei-db/db_engine/test"
+	"github.com/sei-protocol/sei-chain/sei-db/db_engine/types"
+)
+
+const iterTestStoreKey = "store1"
+
+func newIterTestDB(t *testing.T) types.StateStore {
+	t.Helper()
+	cfg := config.DefaultStateStoreConfig()
+	cfg.Backend = "pebbledb"
+	db, err := OpenDB(t.TempDir(), cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// A logical key that is visible at the target version but was also written at a
+// later version must still be returned by a reverse iteration at that version.
+func TestReverseIteratorDoesNotSkipShadowedKey(t *testing.T) {
+	db := newIterTestDB(t)
+
+	require.NoError(t, sstest.DBApplyChangeset(db, 5, iterTestStoreKey, [][]byte{[]byte("keyA")}, [][]byte{[]byte("A@5")}))
+	require.NoError(t, sstest.DBApplyChangeset(db, 30, iterTestStoreKey, [][]byte{[]byte("keyB")}, [][]byte{[]byte("B@30")}))
+	require.NoError(t, sstest.DBApplyChangeset(db, 100, iterTestStoreKey, [][]byte{[]byte("keyA")}, [][]byte{[]byte("A@100")}))
+	require.NoError(t, sstest.DBApplyChangeset(db, 200, iterTestStoreKey, [][]byte{[]byte("keyB")}, [][]byte{[]byte("B@200")}))
+
+	itr, err := db.ReverseIterator(iterTestStoreKey, 50, nil, nil)
+	require.NoError(t, err)
+	defer func() { _ = itr.Close() }()
+
+	var got []string
+	for ; itr.Valid(); itr.Next() {
+		got = append(got, fmt.Sprintf("%s=%s", itr.Key(), itr.Value()))
+	}
+	require.NoError(t, itr.Error())
+	require.Equal(t, []string{"keyB=B@30", "keyA=A@5"}, got)
+}
+
+// Reverse iteration at an old version must not consume stack proportional to the
+// number of keys it has to skip. The child process runs with a small max stack so
+// that a per-skipped-key stack frame fails fast instead of needing ~3M keys.
+func TestReverseIteratorDeepSkipDoesNotOverflowStack(t *testing.T) {
+	if os.Getenv("MVCC_DEEP_SKIP_CHILD") == "1" {
+		debug.SetMaxStack(16 << 20)
+		runDeepReverseSkip(t)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestReverseIteratorDeepSkipDoesNotOverflowStack", "-test.v")
+	cmd.Env = append(os.Environ(), "MVCC_DEEP_SKIP_CHILD=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("child process failed: %v\nstack overflow present: %v\n%s",
+			err, strings.Contains(string(out), "stack overflow"), lastLines(string(out), 40))
+	}
+}
+
+func runDeepReverseSkip(t *testing.T) {
+	db := newIterTestDB(t)
+
+	// One key visible at version 10, then many keys that sort after it and only
+	// exist at a much later version.
+	require.NoError(t, sstest.DBApplyChangeset(db, 10, iterTestStoreKey, [][]byte{[]byte("aaa")}, [][]byte{[]byte("visible")}))
+
+	const newKeys = 150_000
+	const batch = 1000
+	keys := make([][]byte, 0, batch)
+	vals := make([][]byte, 0, batch)
+	for i := 0; i < newKeys; i += batch {
+		keys = keys[:0]
+		vals = vals[:0]
+		for j := 0; j < batch; j++ {
+			keys = append(keys, []byte(fmt.Sprintf("zzz%08d", i+j)))
+			vals = append(vals, []byte("new"))
+		}
+		require.NoError(t, sstest.DBApplyChangeset(db, int64(1000+i/batch), iterTestStoreKey, keys, vals))
+	}
+
+	itr, err := db.ReverseIterator(iterTestStoreKey, 10, nil, nil)
+	require.NoError(t, err)
+	defer func() { _ = itr.Close() }()
+
+	var got []string
+	for ; itr.Valid(); itr.Next() {
+		got = append(got, fmt.Sprintf("%s=%s", itr.Key(), itr.Value()))
+	}
+	require.NoError(t, itr.Error())
+	require.Equal(t, []string{"aaa=visible"}, got)
+}
+
+func lastLines(s string, n int) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
+}


### PR DESCRIPTION
### **Root cause**
nextReverse implements "skip backwards until you find a key visible at the target version" as self-recursion. Go has no tail-call optimization, so recursion depth grows one frame per skipped key, and the depth is bounded only by how many keys are in the scanned range.

The MVCC layout is what makes that depth enormous. Keys are stored as userKey || 0x00 || version sorted ascending by (userKey, version), so all versions of all keys are interleaved in one keyspace. To iterate backwards at version V, the iterator must physically walk over every key created after V. There is no index that lets it skip them in bulk.

The trigger was this request chain, reading up the stack:

debug_traceBlockByNumber(0x73d8857) → tracers.API.traceBlock → evmrpc.Backend.BlockByNumber → BaseApp.DeliverTx → wasm ExecuteContract → cgo into the wasm VM → cQueryExternal155 callback → QuerySmart → a contract smart-query that does a descending range scan.

0x73d8857 is block 121,473,111, while the node was at 222,485,912 — a block roughly 101 million heights (about two years) old, confirmed by the interleaved x/epoch/keeper logs showing current=2024-06-18T13:11:43. CacheMultiStoreWithVersion serves all historical queries from the SS PebbleDB store, so that scan ran against a two-year-old version. The contract's map had grown by ~1.77M keys since then, and because those keys sort after the old ones (monotonic IDs), they formed one contiguous run that a single logical step had to skip — 1.77M frames in one go.

### A second bug in the same code
While reproducing this I found the reverse iterator also silently returns wrong results. After SeekLT(nextKey@version+1) the code checks only the version it landed on, never whether it landed on the key it asked for. When a key has no visible version, the seek overshoots onto the previous key, and the recursion then skips that previous key entirely — even if it does have an older visible version.

Added a test against unmodified v6.5.1: keys keyA@5, keyB@30, keyA@100, keyB@200, reverse-iterating at version 50. It should yield keyB=B@30, keyA=A@5:

expected: []string{"keyB=B@30", "keyA=A@5"}
actual  : []string{"keyA=A@5"}
keyB vanishes because it also has a version 200. This directly violates the rule in evmrpc/AGENTS.md that "RPC responses for historical heights should never change" — historical debug_trace* and archive queries have been quietly dropping keys. It is confined to queries, though: CacheMultiStoreWithVersion is documented as "used to createQueryContext, abci_query or grpc query service", while consensus block execution reads from SC/memiavl, so consensus determinism was never at risk from this.