### PR TITLE
Fix PebbleDB iterator for stackoverflow

### DIFF
--- a/sei-db/db_engine/pebbledb/mvcc/iterator_ascending.go
+++ b/sei-db/db_engine/pebbledb/mvcc/iterator_ascending.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"sync"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -15,10 +16,9 @@ import (
 )
 
 // This file contains the ascending-version MVCC iterator used for legacy DBs
-// that were written by the pre-descending build. It is a verbatim port of the
-// iterator implementation from main and is intentionally kept isolated from
-// the descending fast-path iterator to avoid subtle interactions between the
-// two encoding schemes.
+// that were written by the pre-descending build. It mirrors the traversal
+// structure of the descending fast-path iterator but is kept isolated from it to
+// avoid subtle interactions between the two encoding schemes.
 //
 // Archive nodes that cannot migrate will continue to use this path.
 
@@ -74,27 +74,15 @@ func newAscendingIterator(src *pebble.Iterator, prefix, mvccStart, mvccEnd []byt
 	}
 
 	if valid {
-		currKey, currKeyVersion, ok := SplitMVCCKey(itr.source.Key())
+		currKey, _, ok := SplitMVCCKey(itr.source.Key())
 		if !ok {
 			// XXX: This should not happen as that would indicate we have a malformed MVCC key.
 			panic(fmt.Sprintf("invalid PebbleDB MVCC key: %s", itr.source.Key()))
 		}
-
-		curKeyVersionDecoded, err := decodeUint64Ascending(currKeyVersion)
-		if err != nil {
-			itr.valid = false
-			return itr
-		}
-
-		// We need to check whether initial key iterator visits has a version <= requested version
-		// If larger version, call next to find another key which does
-		if curKeyVersionDecoded > itr.version {
-			itr.Next()
+		if reverse {
+			itr.positionAtOrBeforeKey(currKey)
 		} else {
-			// If version is less, seek to the largest version of that key <= requested iterator version
-			// It is guaranteed this won't move the iterator to a key that is invalid since
-			// curKeyVersionDecoded <= requested iterator version, so there exists at least one version of currKey SeekLT may move to
-			itr.valid = itr.source.SeekLT(MVCCEncodeAscending(currKey, itr.version+1))
+			itr.positionAtOrAfterKey(currKey)
 		}
 	}
 
@@ -109,6 +97,104 @@ func newAscendingIterator(src *pebble.Iterator, prefix, mvccStart, mvccEnd []byt
 	}
 
 	return itr
+}
+
+// visibleVersionUpperBound returns the exclusive seek bound that isolates the
+// versions of key which are visible at itr.version. Ascending encoding sorts a
+// key's versions oldest-first, so this bound sits immediately past the newest
+// visible one.
+func (itr *ascendingIterator) visibleVersionUpperBound(key []byte) []byte {
+	version := itr.version
+	if version < math.MaxInt64 {
+		version++
+	}
+	return MVCCEncodeAscending(key, version)
+}
+
+// seekVisibleVersionForKey positions the cursor on the newest version of
+// targetKey that is visible at itr.version, reporting whether such a version
+// exists. When it does not, the seek lands on an earlier logical key, so callers
+// must not assume the cursor still refers to targetKey.
+func (itr *ascendingIterator) seekVisibleVersionForKey(targetKey []byte) bool {
+	if !itr.source.SeekLT(itr.visibleVersionUpperBound(targetKey)) {
+		return false
+	}
+	foundKey, _, ok := SplitMVCCKey(itr.source.Key())
+	if !ok {
+		return false
+	}
+	return bytes.Equal(foundKey, targetKey)
+}
+
+// nextLogicalKey returns the first logical key ordered after every version of
+// currKey. It seeks from an explicit bound rather than stepping the cursor, so
+// it does not care where the cursor was left by a previous failed seek.
+func (itr *ascendingIterator) nextLogicalKey(currKey []byte) ([]byte, bool) {
+	seekKey := MVCCEncodeAscending(currKey, math.MaxInt64)
+	for valid := itr.source.SeekGE(seekKey); valid; valid = itr.source.Next() {
+		nextKey, _, ok := SplitMVCCKey(itr.source.Key())
+		if !ok || !bytes.HasPrefix(nextKey, itr.prefix) {
+			return nil, false
+		}
+		// A key stored at exactly math.MaxInt64 lands on currKey itself; step over
+		// any such residual versions.
+		if !bytes.Equal(nextKey, currKey) {
+			return nextKey, true
+		}
+	}
+	return nil, false
+}
+
+// prevLogicalKey returns the logical key ordered immediately before every
+// version of currKey.
+func (itr *ascendingIterator) prevLogicalKey(currKey []byte) ([]byte, bool) {
+	if !itr.source.SeekLT(MVCCEncodeAscending(currKey, 0)) {
+		return nil, false
+	}
+	prevKey, _, ok := SplitMVCCKey(itr.source.Key())
+	if !ok || !bytes.HasPrefix(prevKey, itr.prefix) {
+		return nil, false
+	}
+	return prevKey, true
+}
+
+// positionAtOrAfterKey walks forward from startKey to the first logical key that
+// is visible at itr.version and not tombstoned. The walk is iterative, so stack
+// usage stays constant no matter how many keys must be skipped.
+func (itr *ascendingIterator) positionAtOrAfterKey(startKey []byte) {
+	currentKey := startKey
+	for {
+		itr.valid = itr.seekVisibleVersionForKey(currentKey)
+		if itr.valid && !itr.cursorTombstoned() {
+			return
+		}
+		nextKey, ok := itr.nextLogicalKey(currentKey)
+		if !ok {
+			itr.valid = false
+			return
+		}
+		currentKey = nextKey
+	}
+}
+
+// positionAtOrBeforeKey walks backward from startKey to the first logical key
+// that is visible at itr.version and not tombstoned. A key whose newest version
+// is above itr.version may still have an older visible version, so the whole key
+// must not be skipped on that basis alone.
+func (itr *ascendingIterator) positionAtOrBeforeKey(startKey []byte) {
+	currentKey := startKey
+	for {
+		itr.valid = itr.seekVisibleVersionForKey(currentKey)
+		if itr.valid && !itr.cursorTombstoned() {
+			return
+		}
+		prevKey, ok := itr.prevLogicalKey(currentKey)
+		if !ok {
+			itr.valid = false
+			return
+		}
+		currentKey = prevKey
+	}
 }
 
 // Domain returns the domain of the iterator. The caller must not modify the
@@ -157,80 +243,12 @@ func (itr *ascendingIterator) nextForward() {
 		panic(fmt.Sprintf("invalid PebbleDB MVCC key: %s", itr.source.Key()))
 	}
 
-	next := itr.source.NextPrefix()
-
-	// First move the iterator to the next prefix, which may not correspond to the
-	// desired version for that key, e.g. if the key was written at a later version,
-	// so we seek back to the latest desired version, s.t. the version is <= itr.version.
-	if next {
-		nextKey, _, ok := SplitMVCCKey(itr.source.Key())
-		if !ok {
-			// XXX: This should not happen as that would indicate we have a malformed
-			// MVCC key.
-			itr.valid = false
-			return
-		}
-		if !bytes.HasPrefix(nextKey, itr.prefix) {
-			// the next key must have itr.prefix as the prefix
-			itr.valid = false
-			return
-		}
-
-		// Move the iterator to the closest version to the desired version, so we
-		// append the current iterator key to the prefix and seek to that key.
-		itr.valid = itr.source.SeekLT(MVCCEncodeAscending(nextKey, itr.version+1))
-
-		tmpKey, tmpKeyVersion, ok := SplitMVCCKey(itr.source.Key())
-		if !ok {
-			// XXX: This should not happen as that would indicate we have a malformed
-			// MVCC key.
-			itr.valid = false
-			return
-		}
-
-		// There exists cases where the SeekLT() call moved us back to the same key
-		// we started at, so we must move to next key, i.e. two keys forward.
-		if bytes.Equal(tmpKey, currKey) {
-			if itr.source.NextPrefix() {
-				itr.nextForward()
-
-				_, tmpKeyVersion, ok = SplitMVCCKey(itr.source.Key())
-				if !ok {
-					// XXX: This should not happen as that would indicate we have a malformed
-					// MVCC key.
-					itr.valid = false
-					return
-				}
-
-			} else {
-				itr.valid = false
-				return
-			}
-		}
-
-		// We need to verify that every Next call either moves the iterator to a key whose version
-		// is less than or equal to requested iterator version, or exhausts the iterator
-		tmpKeyVersionDecoded, err := decodeUint64Ascending(tmpKeyVersion)
-		if err != nil {
-			itr.valid = false
-			return
-		}
-
-		// If iterator is at a entry whose version is higher than requested version, call nextForward again
-		if tmpKeyVersionDecoded > itr.version {
-			itr.nextForward()
-		}
-
-		// The cursor might now be pointing at a key/value pair that is tombstoned.
-		// If so, we must move the cursor.
-		if itr.valid && itr.cursorTombstoned() {
-			itr.nextForward()
-		}
-
+	nextKey, ok := itr.nextLogicalKey(currKey)
+	if !ok {
+		itr.valid = false
 		return
 	}
-
-	itr.valid = false
+	itr.positionAtOrAfterKey(nextKey)
 }
 
 func (itr *ascendingIterator) nextReverse() {
@@ -246,60 +264,12 @@ func (itr *ascendingIterator) nextReverse() {
 		panic(fmt.Sprintf("invalid PebbleDB MVCC key: %s", itr.source.Key()))
 	}
 
-	next := itr.source.SeekLT(MVCCEncodeAscending(currKey, 0))
-
-	// First move the iterator to the next prefix, which may not correspond to the
-	// desired version for that key, e.g. if the key was written at a later version,
-	// so we seek back to the latest desired version, s.t. the version is <= itr.version.
-	if next {
-		nextKey, _, ok := SplitMVCCKey(itr.source.Key())
-		if !ok {
-			// XXX: This should not happen as that would indicate we have a malformed
-			// MVCC key.
-			itr.valid = false
-			return
-		}
-		if !bytes.HasPrefix(nextKey, itr.prefix) {
-			// the next key must have itr.prefix as the prefix
-			itr.valid = false
-			return
-		}
-
-		// Move the iterator to the closest version to the desired version, so we
-		// append the current iterator key to the prefix and seek to that key.
-		itr.valid = itr.source.SeekLT(MVCCEncodeAscending(nextKey, itr.version+1))
-
-		_, tmpKeyVersion, ok := SplitMVCCKey(itr.source.Key())
-		if !ok {
-			// XXX: This should not happen as that would indicate we have a malformed
-			// MVCC key.
-			itr.valid = false
-			return
-		}
-
-		// We need to verify that every Next call either moves the iterator to a key whose version
-		// is less than or equal to requested iterator version, or exhausts the iterator
-		tmpKeyVersionDecoded, err := decodeUint64Ascending(tmpKeyVersion)
-		if err != nil {
-			itr.valid = false
-			return
-		}
-
-		// If iterator is at a entry whose version is higher than requested version, call nextReverse again
-		if tmpKeyVersionDecoded > itr.version {
-			itr.nextReverse()
-		}
-
-		// The cursor might now be pointing at a key/value pair that is tombstoned.
-		// If so, we must move the cursor.
-		if itr.valid && itr.cursorTombstoned() {
-			itr.nextReverse()
-		}
-
+	prevKey, ok := itr.prevLogicalKey(currKey)
+	if !ok {
+		itr.valid = false
 		return
 	}
-
-	itr.valid = false
+	itr.positionAtOrBeforeKey(prevKey)
 }
 
 func (itr *ascendingIterator) Next() {

--- a/sei-db/db_engine/pebbledb/mvcc/iterator_ascending_test.go
+++ b/sei-db/db_engine/pebbledb/mvcc/iterator_ascending_test.go
@@ -1,0 +1,135 @@
+package mvcc
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime/debug"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sei-protocol/sei-chain/sei-db/config"
+	"github.com/sei-protocol/sei-chain/sei-db/proto"
+)
+
+const ascTestStore = "store1"
+
+// newAscendingTestDB seeds a directory the way the legacy ascending-version
+// build would have left it -- ascending-encoded data plus a latest-version
+// marker, but no descending sentinel -- so OpenDB selects the ascending path.
+func newAscendingTestDB(t *testing.T) *Database {
+	t.Helper()
+
+	dir := t.TempDir()
+	raw, err := pebble.Open(dir, &pebble.Options{Comparer: MVCCComparer})
+	require.NoError(t, err)
+	// Seeded under a different store so it never shows up in the iterations below.
+	require.NoError(t, raw.Set(
+		MVCCEncodeAscending(prependStoreKey("seedstore", []byte("seed")), 1),
+		MVCCEncodeAscending([]byte("seed"), 0),
+		pebble.Sync,
+	))
+	var ts [VersionSize]byte
+	ts[0] = 1
+	require.NoError(t, raw.Set([]byte(latestVersionKey), ts[:], pebble.Sync))
+	require.NoError(t, raw.Close())
+
+	cfg := config.DefaultStateStoreConfig()
+	cfg.Backend = "pebbledb"
+	store, err := OpenDB(dir, cfg)
+	require.NoError(t, err)
+	db := store.(*Database)
+	t.Cleanup(func() { _ = db.Close() })
+	require.False(t, db.descending, "test DB must operate in ascending mode")
+	return db
+}
+
+// A logical key that is visible at the target version but was also written at a
+// later version must still be returned by a reverse iteration at that version.
+// The previous implementation seeked past the whole key whenever the version it
+// landed on was newer than the target.
+func TestAscendingReverseIteratorDoesNotSkipShadowedKey(t *testing.T) {
+	db := newAscendingTestDB(t)
+
+	applyVersion(t, db, ascTestStore, 5, []byte("keyA"), []byte("A@5"))
+	applyVersion(t, db, ascTestStore, 30, []byte("keyB"), []byte("B@30"))
+	applyVersion(t, db, ascTestStore, 100, []byte("keyA"), []byte("A@100"))
+	applyVersion(t, db, ascTestStore, 200, []byte("keyB"), []byte("B@200"))
+
+	itr, err := db.ReverseIterator(ascTestStore, 50, nil, nil)
+	require.NoError(t, err)
+	defer func() { _ = itr.Close() }()
+
+	var got []string
+	for ; itr.Valid(); itr.Next() {
+		got = append(got, fmt.Sprintf("%s=%s", itr.Key(), itr.Value()))
+	}
+	require.NoError(t, itr.Error())
+	require.Equal(t, []string{"keyB=B@30", "keyA=A@5"}, got)
+}
+
+// Reverse iteration at an old version must not consume stack proportional to the
+// number of keys it has to skip. The child process runs with a small max stack
+// so that a per-skipped-key stack frame fails fast instead of needing millions
+// of keys to exhaust the default limit.
+func TestAscendingReverseIteratorDeepSkipDoesNotOverflowStack(t *testing.T) {
+	if os.Getenv("MVCC_ASC_DEEP_SKIP_CHILD") == "1" {
+		debug.SetMaxStack(16 << 20)
+		runAscendingDeepReverseSkip(t)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestAscendingReverseIteratorDeepSkipDoesNotOverflowStack", "-test.v")
+	cmd.Env = append(os.Environ(), "MVCC_ASC_DEEP_SKIP_CHILD=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("child process failed: %v\nstack overflow present: %v\n%s",
+			err, strings.Contains(string(out), "stack overflow"), lastLines(string(out), 40))
+	}
+}
+
+func runAscendingDeepReverseSkip(t *testing.T) {
+	db := newAscendingTestDB(t)
+
+	// One key visible at version 10, then many keys that sort after it and only
+	// exist at much later versions, all of which a reverse scan at 10 must skip.
+	applyVersion(t, db, ascTestStore, 10, []byte("aaa"), []byte("visible"))
+
+	const newKeys = 150_000
+	const batch = 1000
+	for i := 0; i < newKeys; i += batch {
+		pairs := make([]*proto.KVPair, 0, batch)
+		for j := 0; j < batch; j++ {
+			pairs = append(pairs, &proto.KVPair{
+				Key:   []byte(fmt.Sprintf("zzz%08d", i+j)),
+				Value: []byte("new"),
+			})
+		}
+		require.NoError(t, db.ApplyChangesetSync(int64(1000+i/batch), []*proto.NamedChangeSet{{
+			Name:      ascTestStore,
+			Changeset: proto.ChangeSet{Pairs: pairs},
+		}}))
+	}
+
+	itr, err := db.ReverseIterator(ascTestStore, 10, nil, nil)
+	require.NoError(t, err)
+	defer func() { _ = itr.Close() }()
+
+	var got []string
+	for ; itr.Valid(); itr.Next() {
+		got = append(got, fmt.Sprintf("%s=%s", itr.Key(), itr.Value()))
+	}
+	require.NoError(t, itr.Error())
+	require.Equal(t, []string{"aaa=visible"}, got)
+}
+
+func lastLines(s string, n int) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
+}


### PR DESCRIPTION
### The situation on release/v6.6
The branch had restructured the PebbleDB MVCC layer since v6.5.1. Instead of one iterator, there are now two, matching a split in the on-disk encoding: iterator.go for descending-encoded DBs (newest version of a key sorts first) and iterator_ascending.go for legacy DBs written by the older ascending build. Which one a DB uses is decided at open time by a descendingMVCCMarkerKey sentinel — fresh DBs get the marker and use the descending path, while unmarked legacy DBs fall back to ascending. The same split exists on the DB side as db.go / db_ascending.go.

That split is what made the picture different from v6.5.1:

The descending path was already fixed. Commit 85674224e (#3513), "Iterator utilities and simplfications" had independently replaced the recursion with the same iterative structure fix, including the bytes.Equal(foundKey, targetKey) correctness check. Nothing semantic was missing, so this file needed no change.

The ascending path was not fixed. It had been created as a straight copy of the old implementation — its own header comment described it as "a verbatim port of the iterator implementation from main" — so it carried both original defects forward untouched. This is the path archive nodes take when their PebbleDB predates the descending marker and they haven't migrated, which is exactly the population most likely to serve deep historical queries and therefore most exposed to the original crash.

### What's fixed in this PR
Two bugs, both in iterator_ascending.go:

The stack overflow — the same defect as the original incident. nextForward and nextReverse called themselves recursively at five separate sites, adding one stack frame per skipped key. A reverse scan at an old version over a range where many keys only exist at newer versions consumed stack proportional to the number of keys skipped, which is what blew the 512 MB limit in production. Both methods are now a single seek followed by an iterative positionAtOrAfterKey/positionAtOrBeforeKey loop, so stack usage is constant regardless of how many keys get skipped.

A silent correctness bug in reverse iteration. When the seek landed on a version newer than the requested one, the old code recursed and moved to the previous logical key, discarding the current key entirely — even when that key had an older version that was visible at the requested height. Historical reverse-range queries were quietly returning incomplete results. The new seekVisibleVersionForKey verifies with bytes.Equal that the seek actually landed on the key being asked about, so a key is only skipped when it genuinely has no visible version.

The rewrite mirrors the descending file so the two stay reviewable side by side, with the seek arithmetic adapted for ascending order. Two places where we deliberately did not copy descending: nextLogicalKey seeks from an explicit key@math.MaxInt64 bound rather than calling NextPrefix(), because after a failed seek the cursor sits on an earlier key and stepping from there could walk back onto the key just rejected and loop forever; and visibleVersionUpperBound guards the version+1 increment, which the old code did unguarded at three sites and would have overflowed at math.MaxInt64. 

I checked both sentinels against MVCCKeyCompare to confirm they order correctly under both the MVCC comparer and the default one.