### PR TITLE
fix(seidb): give FlatKV and memIAVL latency histograms explicit buckets

### DIFF
--- a/sei-db/common/metrics/buckets.go
+++ b/sei-db/common/metrics/buckets.go
@@ -13,6 +13,17 @@ var LatencyBuckets = []float64{
 	0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, // 100ms–5min
 }
 
+// LongLatencyBuckets covers 100ms to 12 hours for whole-lifecycle operations
+// — store open/restart, snapshot rewrite/write/prune, import, WAL catchup —
+// whose durations run to minutes or hours and overflow LatencyBuckets. On a
+// pacific-1-sized store a memIAVL snapshot rewrite takes 1–7 hours.
+var LongLatencyBuckets = []float64{
+	0.1, 0.5, 1, 5, 15, 30, // 100ms–30s
+	60, 120, 300, 600, 1200, 1800, // 1min–30min
+	2700, 3600, 5400, 7200, 10800, 14400, // 45min–4h
+	21600, 28800, 43200, // 6h–12h
+}
+
 // ByteSizeBuckets covers 256B to 1GB for data size histograms.
 var ByteSizeBuckets = []float64{
 	256, unit.KB, 4 * unit.KB, 16 * unit.KB, 64 * unit.KB, 256 * unit.KB,

--- a/sei-db/common/metrics/buckets.go
+++ b/sei-db/common/metrics/buckets.go
@@ -13,11 +13,14 @@ var LatencyBuckets = []float64{
 	0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, // 100ms–5min
 }
 
-// LongLatencyBuckets covers 100ms to 12 hours for whole-lifecycle operations
+// LongLatencyBuckets covers 10ms to 12 hours for whole-lifecycle operations
 // — store open/restart, snapshot rewrite/write/prune, import, WAL catchup —
 // whose durations run to minutes or hours and overflow LatencyBuckets. On a
-// pacific-1-sized store a memIAVL snapshot rewrite takes 1–7 hours.
+// pacific-1-sized store a memIAVL snapshot rewrite takes 1–7 hours. The
+// sub-100ms boundaries matter because some of these operations are usually
+// cheap: pruning is a directory removal, and WAL catchup is often tens of ms.
 var LongLatencyBuckets = []float64{
+	0.01, 0.025, 0.05, // 10ms–50ms
 	0.1, 0.5, 1, 5, 15, 30, // 100ms–30s
 	60, 120, 300, 600, 1200, 1800, // 1min–30min
 	2700, 3600, 5400, 7200, 10800, 14400, // 45min–4h

--- a/sei-db/state_db/sc/flatkv/metrics.go
+++ b/sei-db/state_db/sc/flatkv/metrics.go
@@ -40,7 +40,7 @@ var (
 			"flatkv_open_latency",
 			metric.WithDescription("Time taken to open the FlatKV store"),
 			metric.WithUnit("s"),
-			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LongLatencyBuckets...),
 		)),
 		ApplyChangesetsLatency: must(flatkvMeter.Float64Histogram(
 			"flatkv_apply_changesets_latency",
@@ -85,7 +85,7 @@ var (
 			"flatkv_catchup_latency",
 			metric.WithDescription("Time taken to replay FlatKV WAL entries"),
 			metric.WithUnit("s"),
-			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LongLatencyBuckets...),
 		)),
 		CatchupReplayNumBlocks: must(flatkvMeter.Int64Counter(
 			"flatkv_catchup_replay_num_blocks",
@@ -96,13 +96,13 @@ var (
 			"flatkv_snapshot_write_latency",
 			metric.WithDescription("Time taken to write a FlatKV snapshot"),
 			metric.WithUnit("s"),
-			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LongLatencyBuckets...),
 		)),
 		SnapshotPruneLatency: must(flatkvMeter.Float64Histogram(
 			"flatkv_snapshot_prune_latency",
 			metric.WithDescription("Time taken to prune FlatKV snapshots"),
 			metric.WithUnit("s"),
-			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LongLatencyBuckets...),
 		)),
 		SnapshotPruneAttempts: must(flatkvMeter.Int64Counter(
 			"flatkv_snapshot_prune_attempts",
@@ -118,13 +118,13 @@ var (
 			"flatkv_rollback_latency",
 			metric.WithDescription("Time taken to rollback FlatKV state"),
 			metric.WithUnit("s"),
-			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LongLatencyBuckets...),
 		)),
 		ImportLatency: must(flatkvMeter.Float64Histogram(
 			"flatkv_import_latency",
 			metric.WithDescription("Time taken to import FlatKV snapshot data"),
 			metric.WithUnit("s"),
-			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LongLatencyBuckets...),
 		)),
 		ImportKVPairs: must(flatkvMeter.Int64Counter(
 			"flatkv_import_kv_pairs",

--- a/sei-db/state_db/sc/flatkv/metrics.go
+++ b/sei-db/state_db/sc/flatkv/metrics.go
@@ -8,6 +8,8 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+
+	commonmetrics "github.com/sei-protocol/sei-chain/sei-db/common/metrics"
 )
 
 var (
@@ -38,26 +40,31 @@ var (
 			"flatkv_open_latency",
 			metric.WithDescription("Time taken to open the FlatKV store"),
 			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
 		)),
 		ApplyChangesetsLatency: must(flatkvMeter.Float64Histogram(
 			"flatkv_apply_changesets_latency",
 			metric.WithDescription("Time taken to apply changesets to FlatKV"),
 			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
 		)),
 		CommitLatency: must(flatkvMeter.Float64Histogram(
 			"flatkv_commit_latency",
 			metric.WithDescription("Time taken to commit FlatKV changes"),
 			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
 		)),
 		CommitBatchLatency: must(flatkvMeter.Float64Histogram(
 			"flatkv_commit_batch_latency",
 			metric.WithDescription("Time taken to commit a FlatKV data DB batch"),
 			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
 		)),
 		BatchReadOldValuesLatency: must(flatkvMeter.Float64Histogram(
 			"flatkv_batch_read_old_values_latency",
 			metric.WithDescription("Time taken to batch read old FlatKV values"),
 			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
 		)),
 		NumKVPairs: must(flatkvMeter.Int64Counter(
 			"flatkv_num_kv_pairs",
@@ -78,6 +85,7 @@ var (
 			"flatkv_catchup_latency",
 			metric.WithDescription("Time taken to replay FlatKV WAL entries"),
 			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
 		)),
 		CatchupReplayNumBlocks: must(flatkvMeter.Int64Counter(
 			"flatkv_catchup_replay_num_blocks",
@@ -88,11 +96,13 @@ var (
 			"flatkv_snapshot_write_latency",
 			metric.WithDescription("Time taken to write a FlatKV snapshot"),
 			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
 		)),
 		SnapshotPruneLatency: must(flatkvMeter.Float64Histogram(
 			"flatkv_snapshot_prune_latency",
 			metric.WithDescription("Time taken to prune FlatKV snapshots"),
 			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
 		)),
 		SnapshotPruneAttempts: must(flatkvMeter.Int64Counter(
 			"flatkv_snapshot_prune_attempts",
@@ -108,11 +118,13 @@ var (
 			"flatkv_rollback_latency",
 			metric.WithDescription("Time taken to rollback FlatKV state"),
 			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
 		)),
 		ImportLatency: must(flatkvMeter.Float64Histogram(
 			"flatkv_import_latency",
 			metric.WithDescription("Time taken to import FlatKV snapshot data"),
 			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
 		)),
 		ImportKVPairs: must(flatkvMeter.Int64Counter(
 			"flatkv_import_kv_pairs",
@@ -123,11 +135,13 @@ var (
 			"flatkv_import_worker_flush_latency",
 			metric.WithDescription("Time taken to flush a FlatKV import worker batch"),
 			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
 		)),
 		FlushLatency: must(flatkvMeter.Float64Histogram(
 			"flatkv_flush_latency",
 			metric.WithDescription("Time taken to flush a FlatKV data DB"),
 			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
 		)),
 	}
 )

--- a/sei-db/state_db/sc/memiavl/metrics.go
+++ b/sei-db/state_db/sc/memiavl/metrics.go
@@ -30,13 +30,13 @@ var (
 			"memiavl_restart_latency",
 			metric.WithDescription("Time taken to restart the memiavl database"),
 			metric.WithUnit("s"),
-			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LongLatencyBuckets...),
 		)),
 		SnapshotRewriteLatency: must(meter.Float64Histogram(
 			"memiavl_snapshot_rewrite_latency",
 			metric.WithDescription("Time taken to write to the new memiavl snapshot"),
 			metric.WithUnit("s"),
-			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LongLatencyBuckets...),
 		)),
 		NumSnapshotRewriteAttempts: must(meter.Int64Counter(
 			"memiavl_num_snapshot_rewrite_attempts",
@@ -46,7 +46,7 @@ var (
 			"memiavl_snapshot_prune_latency",
 			metric.WithDescription("Time taken to prune memiavl snapshot"),
 			metric.WithUnit("s"),
-			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LongLatencyBuckets...),
 		)),
 		NumSnapshotPruneAttempts: must(meter.Int64Counter(
 			"memiavl_num_snapshot_prune_attempts",
@@ -57,13 +57,13 @@ var (
 			"memiavl_snapshot_catchup_after_rewrite_latency",
 			metric.WithDescription("Time taken to catchup and replay after snapshot rewrite"),
 			metric.WithUnit("s"),
-			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LongLatencyBuckets...),
 		)),
 		CatchupBeforeReloadLatency: must(meter.Float64Histogram(
 			"memiavl_snapshot_catchup_before_reload_latency",
 			metric.WithDescription("Time taken to catchup and replay before switch to new snapshot"),
 			metric.WithUnit("s"),
-			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LongLatencyBuckets...),
 		)),
 		CatchupReplayNumBlocks: must(meter.Int64Counter(
 			"memiavl_snapshot_catchup_replay_num_blocks",

--- a/sei-db/state_db/sc/memiavl/metrics.go
+++ b/sei-db/state_db/sc/memiavl/metrics.go
@@ -3,6 +3,8 @@ package memiavl
 import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
+
+	commonmetrics "github.com/sei-protocol/sei-chain/sei-db/common/metrics"
 )
 
 var (
@@ -28,11 +30,13 @@ var (
 			"memiavl_restart_latency",
 			metric.WithDescription("Time taken to restart the memiavl database"),
 			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
 		)),
 		SnapshotRewriteLatency: must(meter.Float64Histogram(
 			"memiavl_snapshot_rewrite_latency",
 			metric.WithDescription("Time taken to write to the new memiavl snapshot"),
 			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
 		)),
 		NumSnapshotRewriteAttempts: must(meter.Int64Counter(
 			"memiavl_num_snapshot_rewrite_attempts",
@@ -42,6 +46,7 @@ var (
 			"memiavl_snapshot_prune_latency",
 			metric.WithDescription("Time taken to prune memiavl snapshot"),
 			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
 		)),
 		NumSnapshotPruneAttempts: must(meter.Int64Counter(
 			"memiavl_num_snapshot_prune_attempts",
@@ -52,11 +57,13 @@ var (
 			"memiavl_snapshot_catchup_after_rewrite_latency",
 			metric.WithDescription("Time taken to catchup and replay after snapshot rewrite"),
 			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
 		)),
 		CatchupBeforeReloadLatency: must(meter.Float64Histogram(
 			"memiavl_snapshot_catchup_before_reload_latency",
 			metric.WithDescription("Time taken to catchup and replay before switch to new snapshot"),
 			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
 		)),
 		CatchupReplayNumBlocks: must(meter.Int64Counter(
 			"memiavl_snapshot_catchup_replay_num_blocks",
@@ -71,11 +78,13 @@ var (
 			"memiavl_commit_latency",
 			metric.WithDescription("Time taken to commit"),
 			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
 		)),
 		ApplyChangesetLatency: must(meter.Float64Histogram(
 			"memiavl_apply_changeset_latency",
 			metric.WithDescription("Time taken to apply changesets"),
 			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(commonmetrics.LatencyBuckets...),
 		)),
 		NumOfKVPairs: must(meter.Int64Counter(
 			"memiavl_num_of_kv_pairs",


### PR DESCRIPTION
## Describe your changes and provide context

The FlatKV (`seidb_flatkv`) and memIAVL (`seidb_memiavl`) meters record durations in seconds via `metric.WithUnit("s")` but never declared bucket boundaries, so they inherited the OTel Go SDK defaults:

```
{0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000}
```

Those are sized for **milliseconds**. Applied to seconds-valued observations, every per-block commit falls into the single `le="5"` bucket, so `histogram_quantile` can only interpolate linearly between 0 and 5s — it reports multi-second p99s for sub-millisecond commits. `_sum` and `_count` remain accurate, which is why the FlatKV EVM migration dashboard (sei-protocol/platform#1442) had to compute mean latency (`rate(_sum)/rate(_count)`) for these series and pin its only usable slow-op threshold at `le="5"`.

These histograms span two very different operation classes, so this PR uses two bucket sets rather than one.

### Per-block operations → existing `LatencyBuckets` (10µs–5min)

`flatkv_commit_latency`, `flatkv_apply_changesets_latency`, `flatkv_commit_batch_latency`, `flatkv_batch_read_old_values_latency`, `flatkv_flush_latency`, `flatkv_import_worker_flush_latency`, `memiavl_commit_latency`, `memiavl_apply_changeset_latency`.

This is the shared set (`sei-db/common/metrics/buckets.go`) that the migration, phase-timer, pebbledb, seiwal, littdb and dbcache meters already use. FlatKV and memIAVL were the two remaining `sei-db` state-commit meters without it.

### Whole-lifecycle operations → new `LongLatencyBuckets` (10ms–12h)

`flatkv_open_latency`, `flatkv_catchup_latency`, `flatkv_snapshot_write_latency`, `flatkv_snapshot_prune_latency`, `flatkv_rollback_latency`, `flatkv_import_latency`, `memiavl_restart_latency`, `memiavl_snapshot_rewrite_latency`, `memiavl_snapshot_prune_latency`, `memiavl_snapshot_catchup_after_rewrite_latency`, `memiavl_snapshot_catchup_before_reload_latency`.

`LatencyBuckets` tops out at 300s, which these operations blow past. Measured on a pacific-1-sized store:

| operation | observed | vs 300s ceiling |
|---|---|---|
| memIAVL snapshot rewrite | 3957s–25456s (66min–7.1h), n=23 | 13–85x over |
| memIAVL cold `OpenDB` | ~349s (215s tree load + 133s replay) | over |
| memIAVL catchup after rewrite | up to 1209s | over |
| FlatKV WAL catchup | 33ms–35s | under, but unbounded on a large gap |

Without the wider set those observations would all land in `+Inf` and `histogram_quantile` would report a value pinned at 300s — for these specific metrics that is *worse* than the OTel defaults this PR replaces, since the defaults happen to extend to 10000.

### Compatibility

No metric is renamed and no collection logic changes, so existing panels and alerts keep working. `le="5"` is a member of both sets, so the dashboard's slow-op ratio panels continue to resolve; they can be retuned to a finer threshold once the fleet is on this build.

Note for the rollout: while old and new binaries coexist, the same metric name carries two different `le` sets, so `sum by (le)` cross-node aggregation is only valid on boundaries present in both. The current dashboard is unaffected because it runs no `histogram_quantile` on these series and pins `le="5"`. The follow-up switch to p95/p99 should wait until the whole fleet is on this build.

Cardinality: 24 series per per-block histogram (up from 16) and 25 per lifecycle histogram, per attribute set. Confined to nodes with a Prometheus exporter configured.

Not included: `sei-db/db_engine/pebbledb/mvcc/metrics.go` still has 8 seconds-valued histograms with no bucket option (its sibling `pebble_metrics.go` does use `LatencyBuckets`). After this PR that file is the only remaining instance in the tree. Left out to keep this change scoped to the state-commit meters the migration dashboard reads.

## Testing performed to validate your change

- `go test -race -count=1 ./sei-db/state_db/sc/flatkv/... ./sei-db/state_db/sc/memiavl/...` — all pass.
- `go build ./sei-db/...`, `go vet` on all three packages, `gofmt -s -l` and `goimports -l` clean.
- These instruments are constructed in a package-level `var` block at init, *before* `utils/metrics` installs the real `MeterProvider`, so the bucket option has to survive the global-provider delegation. Verified with a throwaway test that installs a `ManualReader` after init and replays the measured durations above:

```
memiavl_commit_latency            max_bound=300    +Inf=0 [(0.001, 0.0025]x1]
memiavl_restart_latency           max_bound=43200  +Inf=0 [(300, 600]x1]
memiavl_snapshot_rewrite_latency  max_bound=43200  +Inf=0 [(3600, 5400]x1 (21600, 28800]x1]
```

Every observation lands in a finite bucket at usable resolution, with no `+Inf` overflow. The scaffold was not committed.
