### PR TITLE
fix(receipt): correct log heap struct overhead in eth_getLogs budget (PLT-862)

### DIFF
--- a/sei-db/ledger_db/receipt/log_budget.go
+++ b/sei-db/ledger_db/receipt/log_budget.go
@@ -16,8 +16,14 @@ const (
 	// Per-log heap overhead beyond Address/Data/Topics payload bytes: the slice
 	// slot pointer, struct fields, and topics slice header. This bounds peak
 	// heap for OOM prevention, not JSON-RPC wire size.
+	//
+	// logHeapStructOverhead covers everything in ethtypes.Log besides Address
+	// and the Topics slice header (both counted separately below): Data's own
+	// slice header (24) plus BlockNumber/TxHash/TxIndex/BlockHash/Index/Removed
+	// and struct padding (100) = 124 on amd64/arm64, where unsafe.Sizeof(Log{})
+	// is 168.
 	logHeapPointerOverhead = int64(8)
-	logHeapStructOverhead  = int64(64)
+	logHeapStructOverhead  = int64(124)
 	logTopicsSliceHeader   = int64(24)
 )
 


### PR DESCRIPTION
## Summary

Correct `logHeapStructOverhead` from 64 to 124 bytes so `EstimateLogHeapBytes` matches the actual `ethtypes.Log` heap footprint on amd64/arm64.

The prior constant undercounted per-log struct overhead by ~60 bytes. That let `eth_getLogs` queries accumulate more heap than the intended byte budget before `LogBudget` tripped, weakening the OOM guard on wide log scans.

## Context

`LogBudget` caps how much heap a single `eth_getLogs` result may materialize (default 64 MiB). `EstimateLogHeapBytes` counts address/data/topics payload bytes separately; `logHeapStructOverhead` covers the rest of `ethtypes.Log`:

- `Data` slice header (24 bytes)
- `BlockNumber`, `TxHash`, `TxIndex`, `BlockHash`, `Index`, `Removed`, and struct padding (100 bytes)

`unsafe.Sizeof(ethtypes.Log{})` is 168 on amd64/arm64; with address (20) and topics slice header (24) counted elsewhere, the remaining struct overhead is 124.

## Test plan

- [x] `go test ./sei-db/ledger_db/receipt/...`