### PR TITLE
(Autobahn) load Block DB at the app tip on restart (CON-272)

### DIFF
--- a/sei-tendermint/internal/autobahn/avail/state_test.go
+++ b/sei-tendermint/internal/autobahn/avail/state_test.go
@@ -36,7 +36,7 @@ func makeAppVotes(keys []types.SecretKey, proposal *types.AppProposal) []*types.
 	return votes
 }
 
-func TestSubscribeAppVotesStartsAtDataFloor(t *testing.T) {
+func TestSubscribeAppVotesJumpsToDataFloor(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
 	qc, blocks := data.TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
@@ -54,12 +54,20 @@ func TestSubscribeAppVotesStartsAtDataFloor(t *testing.T) {
 	first := gr.First + types.GlobalBlockNumber(gr.Len()/2)
 	ds, err := data.NewState(&data.Config{
 		Registry:          registry,
-		LastExecutedBlock: first,
+		LastExecutedBlock: utils.Some(first),
 	}, db)
 	require.NoError(t, err)
+	appHash := types.GenAppHash(rng)
+	require.NoError(t, ds.PushAppHash(t.Context(), first, appHash))
 
-	recv := (&State{data: ds}).SubscribeAppVotes()
-	require.Equal(t, first, recv.next)
+	state, err := NewState(keys[0], ds, utils.None[string]())
+	require.NoError(t, err)
+	recv := state.SubscribeAppVotes()
+	require.Equal(t, types.GlobalBlockNumber(0), recv.next)
+
+	vote, err := recv.Recv(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, first, vote.Msg().Proposal().GlobalNumber())
 }
 
 func makeLaneVotes(keys []types.SecretKey, h *types.BlockHeader) []*types.Signed[*types.LaneVote] {

--- a/sei-tendermint/internal/autobahn/avail/state_test.go
+++ b/sei-tendermint/internal/autobahn/avail/state_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sei-protocol/sei-chain/sei-db/ledger_db/block/memblock"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/autobahn/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/consensus/persist"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/data"
@@ -33,6 +34,32 @@ func makeAppVotes(keys []types.SecretKey, proposal *types.AppProposal) []*types.
 		votes = append(votes, types.Sign(k, vote))
 	}
 	return votes
+}
+
+func TestSubscribeAppVotesStartsAtDataFloor(t *testing.T) {
+	rng := utils.TestRng()
+	registry, keys := epoch.GenRegistry(rng, 3)
+	qc, blocks := data.TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+	gr := qc.QC().GlobalRange()
+	require.Greater(t, gr.Len(), uint64(2))
+
+	db := memblock.NewBlockDB()
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	require.NoError(t, db.WriteQC(qc))
+	for i, n := 0, gr.First; n < gr.Next; i, n = i+1, n+1 {
+		require.NoError(t, db.WriteBlock(n, blocks[i]))
+	}
+	require.NoError(t, db.Flush())
+
+	first := gr.First + types.GlobalBlockNumber(gr.Len()/2)
+	ds, err := data.NewState(&data.Config{
+		Registry:          registry,
+		LastExecutedBlock: first,
+	}, db)
+	require.NoError(t, err)
+
+	recv := (&State{data: ds}).SubscribeAppVotes()
+	require.Equal(t, first, recv.next)
 }
 
 func makeLaneVotes(keys []types.SecretKey, h *types.BlockHeader) []*types.Signed[*types.LaneVote] {

--- a/sei-tendermint/internal/autobahn/avail/subscriptions.go
+++ b/sei-tendermint/internal/autobahn/avail/subscriptions.go
@@ -76,7 +76,7 @@ type AppVotesRecv struct {
 }
 
 func (s *State) SubscribeAppVotes() *AppVotesRecv {
-	return &AppVotesRecv{s, s.data.FirstAppProposal()}
+	return &AppVotesRecv{s, 0}
 }
 
 func (r *AppVotesRecv) Recv(ctx context.Context) (*types.Signed[*types.AppVote], error) {
@@ -89,7 +89,7 @@ func (r *AppVotesRecv) Recv(ctx context.Context) (*types.Signed[*types.AppVote],
 		p, err := r.state.data.AppProposal(ctx, r.next)
 		if err != nil {
 			if errors.Is(err, types.ErrPruned) {
-				r.next = r.next + 1
+				r.next = max(r.next+1, r.state.data.FirstAppProposal())
 				continue
 			}
 			return nil, err

--- a/sei-tendermint/internal/autobahn/avail/subscriptions.go
+++ b/sei-tendermint/internal/autobahn/avail/subscriptions.go
@@ -76,7 +76,7 @@ type AppVotesRecv struct {
 }
 
 func (s *State) SubscribeAppVotes() *AppVotesRecv {
-	return &AppVotesRecv{s, 0}
+	return &AppVotesRecv{s, s.data.FirstAppProposal()}
 }
 
 func (r *AppVotesRecv) Recv(ctx context.Context) (*types.Signed[*types.AppVote], error) {

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -18,15 +18,15 @@ const blocksCacheSize = 4000
 type Config struct {
 	// Registry is the authoritative source of committee and stake information.
 	Registry *epoch.Registry
-	// LastExecutedBlock is the app's committed global height. Recovery starts
-	// its BlockDB scan here because runExecute replays this block's AppHash. The
-	// scan start is capped at BlockDB's last stored block because app.Commit
-	// currently precedes the BlockDB durability wait; a crash between them can
-	// legitimately leave the app one block ahead. A larger gap is inconsistent
-	// because PushAppHash waits for each block's durability before execution
-	// proceeds. If BlockDB has no blocks, only the first committed block can be
-	// missing legitimately.
-	LastExecutedBlock types.GlobalBlockNumber
+	// LastExecutedBlock is the app's committed global height, None when the app
+	// has not committed any block yet. Recovery starts its BlockDB scan here
+	// because runExecute replays this block's AppHash. The scan start is capped
+	// at BlockDB's last stored block because app.Commit currently precedes the
+	// BlockDB durability wait; a crash between them can legitimately leave the
+	// app one block ahead. A larger gap is inconsistent because PushAppHash
+	// waits for each block's durability before execution proceeds. If BlockDB
+	// has no blocks, only the first committed block can be missing legitimately.
+	LastExecutedBlock utils.Option[types.GlobalBlockNumber]
 }
 
 // StateAPI is the interface of the State for consuming global blocks
@@ -202,7 +202,7 @@ func NewState(cfg *Config, blockDB types.BlockDB) (*State, error) {
 		inner:   utils.NewWatch(newInner(cfg.Registry.FirstBlock())),
 		blockDB: blockDB,
 	}
-	if err := s.loadFromBlockDB(blockDB, cfg.LastExecutedBlock); err != nil {
+	if err := s.loadFromBlockDB(blockDB); err != nil {
 		return nil, fmt.Errorf("loadFromBlockDB: %w", err)
 	}
 	return s, nil
@@ -213,11 +213,12 @@ func NewState(cfg *Config, blockDB types.BlockDB) (*State, error) {
 // only to satisfy the Watch API.
 //
 // Recovery starts at the app tip capped at BlockDB's last stored block. An empty
-// block store starts at zero. BlockDB.Iterator then clamps that start up to its
-// retained floor; cursors skipTo the first number the scan yields. That number
-// may sit inside its covering QC's range rather than on that range's first
-// number. Taking the floor from the position rather than from the QC is what
-// keeps blocks dense over [first, nextBlock) as inner requires.
+// block store, or an app that has not committed a block, starts at the registry's
+// first block and replays whatever BlockDB retains. BlockDB.Iterator then clamps
+// that start up to its retained floor; cursors skipTo the first number the scan
+// yields. That number may sit inside its covering QC's range rather than on that
+// range's first number. Taking the floor from the position rather than from the
+// QC is what keeps blocks dense over [first, nextBlock) as inner requires.
 //
 // A single iterator scan restores both record kinds: each yielded number carries
 // its covering QC (inserted the first time the scan sees that QC) and its block
@@ -227,27 +228,35 @@ func NewState(cfg *Config, blockDB types.BlockDB) (*State, error) {
 // violation from Next, and an in-memory one cannot reach one (see
 // types.BlockDBIterator). A first QC that predates committee genesis is the one
 // inconsistency checked here.
-func (s *State) loadFromBlockDB(blockDB types.BlockDB, lastExecutedBlock types.GlobalBlockNumber) error {
+func (s *State) loadFromBlockDB(blockDB types.BlockDB) error {
 	for in := range s.inner.Lock() {
 		err := func() error {
-			recoveryStart := lastExecutedBlock
+			firstBlock := s.cfg.Registry.FirstBlock()
 			dbNextBlock := blockDB.Status().NextBlock
-			if dbNextBlock == 0 {
-				firstBlock := s.cfg.Registry.FirstBlock()
-				if lastExecutedBlock != 0 && lastExecutedBlock != firstBlock {
+			recoveryStart := firstBlock
+			if lastExecutedBlock, executed := s.cfg.LastExecutedBlock.Get(); executed {
+				switch {
+				case dbNextBlock == 0:
+					// No blocks stored: only the first committed block can be missing,
+					// because PushAppHash waits for durability of every later one.
+					if lastExecutedBlock != firstBlock {
+						return fmt.Errorf(
+							"BlockDB has no blocks for app tip %d; restore matching BlockDB data or state-sync the node: %w",
+							lastExecutedBlock, types.ErrNotFound,
+						)
+					}
+				case lastExecutedBlock > dbNextBlock:
 					return fmt.Errorf(
-						"BlockDB has no blocks for app tip %d; restore matching BlockDB data or state-sync the node: %w",
-						lastExecutedBlock, types.ErrNotFound,
+						"BlockDB next block %d is behind app tip %d by more than the recoverable crash window; restore matching BlockDB data or state-sync the node: %w",
+						dbNextBlock, lastExecutedBlock, types.ErrNotFound,
 					)
+				case lastExecutedBlock == dbNextBlock:
+					// The app.Commit-before-durability crash window: the app tip itself
+					// never reached BlockDB, so resume from the last stored block.
+					recoveryStart = dbNextBlock - 1
+				default:
+					recoveryStart = lastExecutedBlock
 				}
-				recoveryStart = 0
-			} else if recoveryStart > dbNextBlock {
-				return fmt.Errorf(
-					"BlockDB next block %d is behind app tip %d by more than the recoverable crash window; restore matching BlockDB data or state-sync the node: %w",
-					dbNextBlock, lastExecutedBlock, types.ErrNotFound,
-				)
-			} else if recoveryStart == dbNextBlock {
-				recoveryStart = dbNextBlock - 1
 			}
 			it, err := blockDB.Iterator(recoveryStart)
 			if err != nil {

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -18,14 +18,7 @@ const blocksCacheSize = 4000
 type Config struct {
 	// Registry is the authoritative source of committee and stake information.
 	Registry *epoch.Registry
-	// LastExecutedBlock is the app's committed global height, None when the app
-	// has not committed any block yet. Recovery starts its BlockDB scan here
-	// because runExecute replays this block's AppHash. The scan start is capped
-	// at BlockDB's last stored block because app.Commit currently precedes the
-	// BlockDB durability wait; a crash between them can legitimately leave the
-	// app one block ahead. A larger gap is inconsistent because PushAppHash
-	// waits for each block's durability before execution proceeds. If BlockDB
-	// has no blocks, only the first committed block can be missing legitimately.
+	// LastExecutedBlock is the app's committed global height if any.
 	LastExecutedBlock utils.Option[types.GlobalBlockNumber]
 }
 
@@ -212,22 +205,20 @@ func NewState(cfg *Config, blockDB types.BlockDB) (*State, error) {
 // Called from NewState before any goroutines are spawned; the lock is acquired
 // only to satisfy the Watch API.
 //
-// Recovery starts at the app tip capped at BlockDB's last stored block. An empty
-// block store, or an app that has not committed a block, starts at the registry's
-// first block and replays whatever BlockDB retains. BlockDB.Iterator then clamps
-// that start up to its retained floor; cursors skipTo the first number the scan
-// yields. That number may sit inside its covering QC's range rather than on that
-// range's first number. Taking the floor from the position rather than from the
-// QC is what keeps blocks dense over [first, nextBlock) as inner requires.
+// Recovery starts at the app tip so runExecute can replay its AppHash. If the
+// app tip equals BlockDB's next block, recovery starts at the last stored block:
+// app.Commit may finish before BlockDB is durable. A larger gap violates the
+// PushAppHash durability invariant. An empty BlockDB allows only no app tip or
+// the first committed block.
 //
-// A single iterator scan restores both record kinds: each yielded number carries
-// its covering QC (inserted the first time the scan sees that QC) and its block
-// when one survives — HasBlock is false only in the trailing positions, where a
-// QC outlived (or preceded) its blocks. Density and QC-coverage consistency hold
-// below this loop, so it does not re-check them: a durable BlockDB reports a
-// violation from Next, and an in-memory one cannot reach one (see
-// types.BlockDBIterator). A first QC that predates committee genesis is the one
-// inconsistency checked here.
+// Without an app tip, recovery starts at the registry's first block.
+// BlockDB.Iterator clamps the start to its retained floor. skipTo uses the first
+// returned position, even inside a QC, to keep blocks dense over
+// [first, nextBlock).
+//
+// Each iterator position has its covering QC and an optional block. Missing
+// blocks are allowed only at the tail. BlockDB enforces other consistency; this
+// method only rejects a first QC before committee genesis.
 func (s *State) loadFromBlockDB(blockDB types.BlockDB) error {
 	for in := range s.inner.Lock() {
 		err := func() error {

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -226,27 +226,16 @@ func (s *State) loadFromBlockDB(blockDB types.BlockDB) error {
 			dbNextBlock := blockDB.Status().NextBlock
 			recoveryStart := firstBlock
 			if lastExecutedBlock, executed := s.cfg.LastExecutedBlock.Get(); executed {
-				switch {
-				case dbNextBlock == 0:
-					// No blocks stored: only the first committed block can be missing,
-					// because PushAppHash waits for durability of every later one.
-					if lastExecutedBlock != firstBlock {
-						return fmt.Errorf(
-							"BlockDB has no blocks for app tip %d; restore matching BlockDB data or state-sync the node: %w",
-							lastExecutedBlock, types.ErrNotFound,
-						)
-					}
-				case lastExecutedBlock > dbNextBlock:
+				if lastExecutedBlock > max(dbNextBlock, firstBlock) {
 					return fmt.Errorf(
 						"BlockDB next block %d is behind app tip %d by more than the recoverable crash window; restore matching BlockDB data or state-sync the node: %w",
 						dbNextBlock, lastExecutedBlock, types.ErrNotFound,
 					)
-				case lastExecutedBlock == dbNextBlock:
-					// The app.Commit-before-durability crash window: the app tip itself
-					// never reached BlockDB, so resume from the last stored block.
+				}
+				recoveryStart = lastExecutedBlock
+				if dbNextBlock != 0 && lastExecutedBlock == dbNextBlock {
+					// app.Commit completed before the app tip became durable.
 					recoveryStart = dbNextBlock - 1
-				default:
-					recoveryStart = lastExecutedBlock
 				}
 			}
 			it, err := blockDB.Iterator(recoveryStart)

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -18,6 +18,15 @@ const blocksCacheSize = 4000
 type Config struct {
 	// Registry is the authoritative source of committee and stake information.
 	Registry *epoch.Registry
+	// LastExecutedBlock is the app's committed global height. Recovery starts
+	// its BlockDB scan here because runExecute replays this block's AppHash. The
+	// scan start is capped at BlockDB's last stored block because app.Commit
+	// currently precedes the BlockDB durability wait; a crash between them can
+	// legitimately leave the app one block ahead. A larger gap is inconsistent
+	// because PushAppHash waits for each block's durability before execution
+	// proceeds. If BlockDB has no blocks, only the first committed block can be
+	// missing legitimately.
+	LastExecutedBlock types.GlobalBlockNumber
 }
 
 // StateAPI is the interface of the State for consuming global blocks
@@ -184,7 +193,8 @@ type State struct {
 // Use memblock.NewBlockDB() for an in-memory store (testing / no persistent dir).
 // The caller owns blockDB and must close it after State.Run returns (nodeImpl
 // owns this in production); State never closes it.
-// Recovery from a non-zero CommitQC tip is handled by loadFromBlockDB (skipTo).
+// Recovery starts at cfg.LastExecutedBlock and handles a non-zero CommitQC tip
+// via loadFromBlockDB (skipTo).
 func NewState(cfg *Config, blockDB types.BlockDB) (*State, error) {
 	s := &State{
 		cfg:     cfg,
@@ -192,7 +202,7 @@ func NewState(cfg *Config, blockDB types.BlockDB) (*State, error) {
 		inner:   utils.NewWatch(newInner(cfg.Registry.FirstBlock())),
 		blockDB: blockDB,
 	}
-	if err := s.loadFromBlockDB(blockDB); err != nil {
+	if err := s.loadFromBlockDB(blockDB, cfg.LastExecutedBlock); err != nil {
 		return nil, fmt.Errorf("loadFromBlockDB: %w", err)
 	}
 	return s, nil
@@ -202,13 +212,12 @@ func NewState(cfg *Config, blockDB types.BlockDB) (*State, error) {
 // Called from NewState before any goroutines are spawned; the lock is acquired
 // only to satisfy the Watch API.
 //
-// The recovery floor is derived from BlockDB: an empty store keeps
-// registry.FirstBlock(); otherwise cursors skipTo the first number the scan
-// yields. BlockDB.Iterator opens on a block that exists, so that number is the
-// start of the retained block history — which may sit inside its covering QC's
-// range rather than on that range's first number, since the first block is free
-// to start there. Taking the floor from the position rather than from the QC is
-// what keeps blocks dense over [first, nextBlock) as inner requires.
+// Recovery starts at the app tip capped at BlockDB's last stored block. An empty
+// block store starts at zero. BlockDB.Iterator then clamps that start up to its
+// retained floor; cursors skipTo the first number the scan yields. That number
+// may sit inside its covering QC's range rather than on that range's first
+// number. Taking the floor from the position rather than from the QC is what
+// keeps blocks dense over [first, nextBlock) as inner requires.
 //
 // A single iterator scan restores both record kinds: each yielded number carries
 // its covering QC (inserted the first time the scan sees that QC) and its block
@@ -218,14 +227,29 @@ func NewState(cfg *Config, blockDB types.BlockDB) (*State, error) {
 // violation from Next, and an in-memory one cannot reach one (see
 // types.BlockDBIterator). A first QC that predates committee genesis is the one
 // inconsistency checked here.
-//
-// TODO: Cap how much of BlockDB we replay into RAM (similar to PushQC's
-// blocksCacheSize gate). Deferred to a follow-up PR — today we load the full
-// retained store.
-func (s *State) loadFromBlockDB(blockDB types.BlockDB) error {
+func (s *State) loadFromBlockDB(blockDB types.BlockDB, lastExecutedBlock types.GlobalBlockNumber) error {
 	for in := range s.inner.Lock() {
 		err := func() error {
-			it, err := blockDB.Iterator(0)
+			recoveryStart := lastExecutedBlock
+			dbNextBlock := blockDB.Status().NextBlock
+			if dbNextBlock == 0 {
+				firstBlock := s.cfg.Registry.FirstBlock()
+				if lastExecutedBlock != 0 && lastExecutedBlock != firstBlock {
+					return fmt.Errorf(
+						"BlockDB has no blocks for app tip %d; restore matching BlockDB data or state-sync the node: %w",
+						lastExecutedBlock, types.ErrNotFound,
+					)
+				}
+				recoveryStart = 0
+			} else if recoveryStart > dbNextBlock {
+				return fmt.Errorf(
+					"BlockDB next block %d is behind app tip %d by more than the recoverable crash window; restore matching BlockDB data or state-sync the node: %w",
+					dbNextBlock, lastExecutedBlock, types.ErrNotFound,
+				)
+			} else if recoveryStart == dbNextBlock {
+				recoveryStart = dbNextBlock - 1
+			}
+			it, err := blockDB.Iterator(recoveryStart)
 			if err != nil {
 				return fmt.Errorf("open block db iterator: %w", err)
 			}
@@ -237,7 +261,7 @@ func (s *State) loadFromBlockDB(blockDB types.BlockDB) error {
 					return fmt.Errorf("advance block db iterator: %w", err)
 				}
 				if !ok {
-					return nil
+					break
 				}
 				n, qc := pos.Number, pos.QC
 				gr := qc.QC().GlobalRange()
@@ -285,6 +309,7 @@ func (s *State) loadFromBlockDB(blockDB types.BlockDB) error {
 					return fmt.Errorf("insert block %d from BlockDB: %w", n, err)
 				}
 			}
+			return nil
 		}()
 		if err != nil {
 			return err
@@ -302,6 +327,15 @@ func (s *State) loadFromBlockDB(blockDB types.BlockDB) error {
 
 // Registry returns the epoch registry.
 func (s *State) Registry() *epoch.Registry { return s.cfg.Registry }
+
+// FirstAppProposal is the first global number for which AppProposal may become
+// available. Requests below it return ErrPruned.
+func (s *State) FirstAppProposal() types.GlobalBlockNumber {
+	for inner := range s.inner.Lock() {
+		return inner.first
+	}
+	panic("unreachable")
+}
 
 // insertBlocksByHash matches byHash against stored (already verified) QC
 // headers over gr ∩ [nextBlock, nextQC) and inserts hits. Advances nextBlock
@@ -616,9 +650,6 @@ func (s *State) PushAppHash(ctx context.Context, n types.GlobalBlockNumber, hash
 			inner.qcs[n].QC().Proposal().EpochIndex(),
 		)
 		t := time.Now()
-		// TODO(gprusak): this will be problematic on restart,
-		// nextAppProposal should be initiated wrt current application height,
-		// so that we don't iterate over all blocks in storage on startup.
 		for inner.nextAppProposal <= n {
 			b := inner.blocks[inner.nextAppProposal]
 			latency := t.Sub(b.Payload().CreatedAt()).Seconds()

--- a/sei-tendermint/internal/autobahn/data/state_recovery_test.go
+++ b/sei-tendermint/internal/autobahn/data/state_recovery_test.go
@@ -14,6 +14,16 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/scope"
 )
 
+type recoveryStartBlockDB struct {
+	types.BlockDB
+	start types.GlobalBlockNumber
+}
+
+func (db *recoveryStartBlockDB) Iterator(n types.GlobalBlockNumber) (types.BlockDBIterator, error) {
+	db.start = n
+	return db.BlockDB.Iterator(n)
+}
+
 // TestRecoveryEmpty verifies that NewState is a no-op on a fresh BlockDB.
 func TestRecoveryEmpty(t *testing.T) {
 	rng := utils.TestRng()
@@ -96,6 +106,140 @@ func TestRecoveryNormal(t *testing.T) {
 	db3 := newTestBlockDB(t, dir)
 	state3 := newTestState(t, &Config{Registry: registry}, db3)
 	require.Equal(t, gr2.Next, state3.NextBlock())
+}
+
+func TestRecoveryStartsAtLastExecutedBlock(t *testing.T) {
+	rng := utils.TestRng()
+	registry, keys := epoch.GenRegistry(rng, 3)
+	qc1, blocks1 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+	qc2, blocks2 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.Some(qc1.QC()))
+	gr2 := qc2.QC().GlobalRange()
+	require.Greater(t, gr2.Len(), 2)
+
+	db := &recoveryStartBlockDB{BlockDB: newTestBlockDB(t, t.TempDir())}
+	writeToBlockDB(t, db,
+		[]*types.FullCommitQC{qc1, qc2},
+		[][]*types.Block{blocks1, blocks2})
+
+	offset := gr2.Len() / 2
+	lastExecuted := gr2.First + types.GlobalBlockNumber(offset)
+	state := newTestState(t, &Config{
+		Registry:          registry,
+		LastExecutedBlock: lastExecuted,
+	}, db)
+
+	require.Equal(t, lastExecuted, db.start)
+	require.Equal(t, lastExecuted, state.FirstAppProposal())
+	require.Equal(t, gr2.Next, state.NextBlock())
+	got, err := state.TryBlock(lastExecuted)
+	require.NoError(t, err)
+	require.Equal(t, blocks2[offset].Header().Hash(), got.Header().Hash())
+
+	appHash := types.GenAppHash(rng)
+	require.NoError(t, state.PushAppHash(t.Context(), lastExecuted, appHash))
+	proposal, err := state.AppProposal(t.Context(), lastExecuted)
+	require.NoError(t, err)
+	require.Equal(t, appHash, proposal.AppHash())
+}
+
+func TestRecoveryCapsAppTipAtLastBlockInBlockDB(t *testing.T) {
+	rng := utils.TestRng()
+	registry, keys := epoch.GenRegistry(rng, 3)
+	qc1, blocks1 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+	qc2, blocks2 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.Some(qc1.QC()))
+	gr1 := qc1.QC().GlobalRange()
+	gr2 := qc2.QC().GlobalRange()
+
+	dir := t.TempDir()
+	db1 := newTestBlockDB(t, dir)
+	writeToBlockDB(t, db1, []*types.FullCommitQC{qc1}, [][]*types.Block{blocks1})
+	require.NoError(t, db1.Close())
+
+	db := &recoveryStartBlockDB{BlockDB: newTestBlockDB(t, dir)}
+
+	state, err := NewState(&Config{
+		Registry:          registry,
+		LastExecutedBlock: gr2.First,
+	}, db)
+	require.NoError(t, err)
+	require.Equal(t, gr1.Next-1, db.start)
+	require.Equal(t, gr2.First, state.NextBlock())
+
+	require.NoError(t, state.PushQC(t.Context(), qc2, blocks2))
+	got, err := state.GlobalBlock(t.Context(), gr2.First)
+	require.NoError(t, err)
+	require.Equal(t, blocks2[0].Header().Hash(), got.Header.Hash())
+
+	require.NoError(t, pushAppHashesRunning(t.Context(), state, rng, gr2.First, gr2.First+1))
+}
+
+func TestRecoveryRejectsAppTipBeyondCrashWindow(t *testing.T) {
+	rng := utils.TestRng()
+	registry, keys := epoch.GenRegistry(rng, 3)
+	qc, blocks := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+
+	db := newTestBlockDB(t, t.TempDir())
+	writeToBlockDB(t, db, []*types.FullCommitQC{qc}, [][]*types.Block{blocks})
+	dbNextBlock := db.Status().NextBlock
+	lastExecuted := dbNextBlock + 1
+
+	_, err := NewState(&Config{
+		Registry:          registry,
+		LastExecutedBlock: lastExecuted,
+	}, db)
+	require.ErrorIs(t, err, types.ErrNotFound)
+}
+
+func TestRecoveryStartsAtZeroWhenBlockDBMissingFirstCommittedBlock(t *testing.T) {
+	rng := utils.TestRng()
+	registry, keys := epoch.GenRegistry(rng, 3)
+	qc, _ := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+	gr := qc.QC().GlobalRange()
+
+	db := &recoveryStartBlockDB{BlockDB: newTestBlockDB(t, t.TempDir())}
+	require.NoError(t, db.WriteQC(qc))
+	require.NoError(t, db.Flush())
+
+	state, err := NewState(&Config{
+		Registry:          registry,
+		LastExecutedBlock: gr.First,
+	}, db)
+	require.NoError(t, err)
+	require.Equal(t, types.GlobalBlockNumber(0), db.start)
+	require.Equal(t, gr.First, state.NextBlock())
+}
+
+func TestRecoveryRejectsEmptyBlockDBAfterFirstCommittedBlock(t *testing.T) {
+	rng := utils.TestRng()
+	registry, _ := epoch.GenRegistry(rng, 3)
+	lastExecuted := registry.FirstBlock() + 1
+
+	_, err := NewState(&Config{
+		Registry:          registry,
+		LastExecutedBlock: lastExecuted,
+	}, newTestBlockDB(t, t.TempDir()))
+	require.ErrorIs(t, err, types.ErrNotFound)
+}
+
+func TestRecoveryLeavesAppTipBelowPruneFloorUnreadable(t *testing.T) {
+	rng := utils.TestRng()
+	registry, keys := epoch.GenRegistry(rng, 3)
+	qc1, blocks1 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+	qc2, blocks2 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.Some(qc1.QC()))
+
+	db := newTestBlockDB(t, t.TempDir())
+	writeToBlockDB(t, db,
+		[]*types.FullCommitQC{qc1, qc2},
+		[][]*types.Block{blocks1, blocks2})
+	require.NoError(t, db.PruneBefore(qc2.QC().GlobalRange().First))
+
+	state, err := NewState(&Config{
+		Registry:          registry,
+		LastExecutedBlock: qc1.QC().GlobalRange().First,
+	}, db)
+	require.NoError(t, err)
+	_, err = state.GlobalBlock(t.Context(), qc1.QC().GlobalRange().First)
+	require.ErrorIs(t, err, types.ErrPruned)
 }
 
 // TestPruningDiscards verifies that PruneBefore advances BlockDB's watermark so

--- a/sei-tendermint/internal/autobahn/data/state_recovery_test.go
+++ b/sei-tendermint/internal/autobahn/data/state_recovery_test.go
@@ -125,7 +125,7 @@ func TestRecoveryStartsAtLastExecutedBlock(t *testing.T) {
 	lastExecuted := gr2.First + types.GlobalBlockNumber(offset)
 	state := newTestState(t, &Config{
 		Registry:          registry,
-		LastExecutedBlock: lastExecuted,
+		LastExecutedBlock: utils.Some(lastExecuted),
 	}, db)
 
 	require.Equal(t, lastExecuted, db.start)
@@ -159,7 +159,7 @@ func TestRecoveryCapsAppTipAtLastBlockInBlockDB(t *testing.T) {
 
 	state, err := NewState(&Config{
 		Registry:          registry,
-		LastExecutedBlock: gr2.First,
+		LastExecutedBlock: utils.Some(gr2.First),
 	}, db)
 	require.NoError(t, err)
 	require.Equal(t, gr1.Next-1, db.start)
@@ -185,12 +185,12 @@ func TestRecoveryRejectsAppTipBeyondCrashWindow(t *testing.T) {
 
 	_, err := NewState(&Config{
 		Registry:          registry,
-		LastExecutedBlock: lastExecuted,
+		LastExecutedBlock: utils.Some(lastExecuted),
 	}, db)
 	require.ErrorIs(t, err, types.ErrNotFound)
 }
 
-func TestRecoveryStartsAtZeroWhenBlockDBMissingFirstCommittedBlock(t *testing.T) {
+func TestRecoveryStartsAtRegistryFloorWhenBlockDBMissingFirstCommittedBlock(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
 	qc, _ := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
@@ -202,10 +202,10 @@ func TestRecoveryStartsAtZeroWhenBlockDBMissingFirstCommittedBlock(t *testing.T)
 
 	state, err := NewState(&Config{
 		Registry:          registry,
-		LastExecutedBlock: gr.First,
+		LastExecutedBlock: utils.Some(gr.First),
 	}, db)
 	require.NoError(t, err)
-	require.Equal(t, types.GlobalBlockNumber(0), db.start)
+	require.Equal(t, registry.FirstBlock(), db.start)
 	require.Equal(t, gr.First, state.NextBlock())
 }
 
@@ -216,7 +216,7 @@ func TestRecoveryRejectsEmptyBlockDBAfterFirstCommittedBlock(t *testing.T) {
 
 	_, err := NewState(&Config{
 		Registry:          registry,
-		LastExecutedBlock: lastExecuted,
+		LastExecutedBlock: utils.Some(lastExecuted),
 	}, newTestBlockDB(t, t.TempDir()))
 	require.ErrorIs(t, err, types.ErrNotFound)
 }
@@ -235,7 +235,7 @@ func TestRecoveryLeavesAppTipBelowPruneFloorUnreadable(t *testing.T) {
 
 	state, err := NewState(&Config{
 		Registry:          registry,
-		LastExecutedBlock: qc1.QC().GlobalRange().First,
+		LastExecutedBlock: utils.Some(qc1.QC().GlobalRange().First),
 	}, db)
 	require.NoError(t, err)
 	_, err = state.GlobalBlock(t.Context(), qc1.QC().GlobalRange().First)

--- a/sei-tendermint/internal/p2p/giga_router_common.go
+++ b/sei-tendermint/internal/p2p/giga_router_common.go
@@ -67,9 +67,13 @@ func BuildDataState(cfg *GigaRouterCommonConfig, blockDB atypes.BlockDB) (*data.
 		return nil, fmt.Errorf("GigaRouterCommonConfig.MaxInboundFullnodePeers = %v, want 0..%v", cfg.MaxInboundFullnodePeers, maxInboundFullnodePeers)
 	}
 	lastExecutedHeight := cfg.App.Info().LastBlockHeight
-	lastExecutedBlock, ok := utils.SafeCast[atypes.GlobalBlockNumber](lastExecutedHeight)
-	if !ok {
-		return nil, fmt.Errorf("invalid App.Info().LastBlockHeight = %v", lastExecutedHeight)
+	lastExecutedBlock := utils.None[atypes.GlobalBlockNumber]()
+	if lastExecutedHeight != 0 {
+		n, ok := utils.SafeCast[atypes.GlobalBlockNumber](lastExecutedHeight)
+		if !ok {
+			return nil, fmt.Errorf("invalid App.Info().LastBlockHeight = %v", lastExecutedHeight)
+		}
+		lastExecutedBlock = utils.Some(n)
 	}
 	firstBlock := atypes.GlobalBlockNumber(cfg.GenDoc.InitialHeight) // nolint:gosec // verified to be positive.
 	genesisWeights := map[atypes.PublicKey]uint64{}

--- a/sei-tendermint/internal/p2p/giga_router_common.go
+++ b/sei-tendermint/internal/p2p/giga_router_common.go
@@ -66,6 +66,11 @@ func BuildDataState(cfg *GigaRouterCommonConfig, blockDB atypes.BlockDB) (*data.
 	if cfg.MaxInboundFullnodePeers < 0 || cfg.MaxInboundFullnodePeers > maxInboundFullnodePeers {
 		return nil, fmt.Errorf("GigaRouterCommonConfig.MaxInboundFullnodePeers = %v, want 0..%v", cfg.MaxInboundFullnodePeers, maxInboundFullnodePeers)
 	}
+	lastExecutedHeight := cfg.App.Info().LastBlockHeight
+	lastExecutedBlock, ok := utils.SafeCast[atypes.GlobalBlockNumber](lastExecutedHeight)
+	if !ok {
+		return nil, fmt.Errorf("invalid App.Info().LastBlockHeight = %v", lastExecutedHeight)
+	}
 	firstBlock := atypes.GlobalBlockNumber(cfg.GenDoc.InitialHeight) // nolint:gosec // verified to be positive.
 	genesisWeights := map[atypes.PublicKey]uint64{}
 	for k := range cfg.ValidatorAddrs {
@@ -79,7 +84,10 @@ func BuildDataState(cfg *GigaRouterCommonConfig, blockDB atypes.BlockDB) (*data.
 	if err != nil {
 		return nil, fmt.Errorf("epoch.NewRegistry(): %w", err)
 	}
-	ds, err := data.NewState(&data.Config{Registry: registry}, blockDB)
+	ds, err := data.NewState(&data.Config{
+		Registry:          registry,
+		LastExecutedBlock: lastExecutedBlock,
+	}, blockDB)
 	if err != nil {
 		return nil, fmt.Errorf("data.NewState: %w", err)
 	}
@@ -355,8 +363,16 @@ func (r *gigaRouterCommon) runExecute(ctx context.Context) error {
 			return fmt.Errorf("invalid GenDoc.InitialHeight = %v", r.cfg.GenDoc.InitialHeight)
 		}
 	} else {
+		// BuildDataState caps recovery at BlockDB's durable block tip, so a crash
+		// after app.Commit but before the BlockDB flush resumes by syncing the
+		// missing suffix. If retention instead passed the app tip, GlobalBlock
+		// returns ErrPruned here. A readable tip restores the last header and
+		// replays AppHash.
 		b, err := r.data.GlobalBlock(ctx, last)
 		if err != nil {
+			if errors.Is(err, atypes.ErrPruned) {
+				return fmt.Errorf("app tip %d is unavailable in BlockDB; restore matching BlockDB data or state-sync the node: %w", last, err)
+			}
 			return fmt.Errorf("r.data.GlobalBlock(): %w", err)
 		}
 		app.InitLastHeader((&types.Header{

--- a/sei-tendermint/internal/p2p/giga_router_common_test.go
+++ b/sei-tendermint/internal/p2p/giga_router_common_test.go
@@ -3,11 +3,30 @@ package p2p
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/sei-protocol/sei-chain/sei-db/ledger_db/block/memblock"
 	"github.com/sei-protocol/sei-chain/sei-db/state_db/sc/hashvault"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
 	atypes "github.com/sei-protocol/sei-chain/sei-tendermint/autobahn/types"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/data"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/epoch"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/proxy"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/require"
+	tmtypes "github.com/sei-protocol/sei-chain/sei-tendermint/types"
 )
+
+type fixedHeightApp struct {
+	types.BaseApplication
+	height int64
+}
+
+func (a *fixedHeightApp) LastBlockHeight() int64 { return a.height }
+
+func (a *fixedHeightApp) Info() *types.ResponseInfo {
+	return &types.ResponseInfo{LastBlockHeight: a.height}
+}
 
 // newSeededVault returns a durable Pebble vault rooted in a temp dir with hash committed at height.
 func newSeededVault(t *testing.T, height atypes.GlobalBlockNumber, hash []byte) hashvault.HashVault {
@@ -55,4 +74,48 @@ func TestCommitHashToVault(t *testing.T) {
 		err := commitAppHashToVault(ctx, vault, height, h2)
 		require.Error(t, err)
 	})
+}
+
+func TestBuildDataStateStartsRecoveryAtAppTip(t *testing.T) {
+	rng := utils.TestRng()
+	key := atypes.GenSecretKey(rng)
+	keys := []atypes.SecretKey{key}
+	validatorAddrs := map[atypes.PublicKey]GigaNodeAddr{key.Public(): {}}
+
+	genDoc := &tmtypes.GenesisDoc{
+		ChainID:         "restart-tip-test",
+		InitialHeight:   1,
+		GenesisTime:     time.Now(),
+		ConsensusParams: tmtypes.DefaultConsensusParams(),
+	}
+	require.NoError(t, genDoc.ValidateAndComplete())
+
+	committee, err := atypes.NewCommittee(map[atypes.PublicKey]uint64{key.Public(): 1})
+	require.NoError(t, err)
+	registry, err := epoch.NewRegistry(committee, atypes.GlobalBlockNumber(genDoc.InitialHeight), genDoc.GenesisTime)
+	require.NoError(t, err)
+	qc, blocks := data.TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*atypes.CommitQC]())
+	gr := qc.QC().GlobalRange()
+	require.Greater(t, gr.Len(), 2)
+	last := gr.First + atypes.GlobalBlockNumber(gr.Len()/2)
+
+	db := memblock.NewBlockDB()
+	require.NoError(t, db.WriteQC(qc))
+	for i, n := 0, gr.First; n < gr.Next; i, n = i+1, n+1 {
+		require.NoError(t, db.WriteBlock(n, blocks[i]))
+	}
+	require.NoError(t, db.Flush())
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	state, err := BuildDataState(&GigaRouterCommonConfig{
+		DialInterval:   time.Second,
+		ValidatorAddrs: validatorAddrs,
+		GenDoc:         genDoc,
+		App:            proxy.New(&fixedHeightApp{height: int64(last)}),
+	}, db)
+	require.NoError(t, err)
+	require.Equal(t, last, state.FirstAppProposal())
+	got, err := state.TryBlock(last)
+	require.NoError(t, err)
+	require.Equal(t, blocks[gr.Len()/2].Header().Hash(), got.Header().Hash())
 }


### PR DESCRIPTION
## Summary
- pass the app's last committed global height into Autobahn data recovery
- start BlockDB replay at that height while retaining the app-tip AppHash replay
- document hard failure when the app tip has already been pruned and cover recovery wiring

## Test plan
- [x] `GOWORK=off go test -race -count=1 ./internal/autobahn/data/ ./internal/p2p/`
- [x] verify edited files have no IDE lint errors

Made with [Cursor](https://cursor.com)