### PR TITLE
Enable seidroid xreview on sei-chain

### DIFF
--- a/.github/workflows/seidroid-xreview.yml
+++ b/.github/workflows/seidroid-xreview.yml
@@ -1,10 +1,8 @@
 name: seidroid xreview
-# Comment `seidroid xreview` (or `... --dry-run`) on a PR to run the on-demand,
-# sandbox-backed agentic review. Thin caller: the logic is the reusable workflow in
-# sei-protocol/uci; bump both refs below (to the next release's commit SHA) to adopt a
-# new xreview release. Runs dry-run until the SEIDROID_XREVIEW_DRY_RUN repo variable is
-# set to 'false' (read as `vars.SEIDROID_XREVIEW_DRY_RUN` by the reusable workflow, which
-# resolves it against this repo — there is no `with:` input for it here).
+# Comment `seidroid xreview` on a PR to run the on-demand, sandbox-backed agentic review.
+# Thin caller: the logic is the reusable workflow in sei-protocol/uci; bump both refs below
+# (to the next release's commit SHA) to adopt a new xreview release. The verdict is posted to
+# the PR as one sticky comment when a review produces one.
 on:
   issue_comment:
     types: [created]
@@ -22,10 +20,10 @@ jobs:
       && github.event.comment.user.type != 'Bot'
       && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
       && contains(github.event.comment.body, 'seidroid xreview') }}
-    # Pinned to the immutable commit for uci v0.0.14 — a mutable tag would let anyone
+    # Pinned to the immutable commit for uci v0.0.15 — a mutable tag would let anyone
     # able to move it run code in this repo's Actions context with the passed secret.
     # Matches how ai-review/ai-assist pin uci (a full commit SHA).
-    uses: sei-protocol/uci/.github/workflows/seidroid-xreview.yml@a63adbcea9100121491ec25c758a36baf6a5cf9c  # uci v0.0.14
+    uses: sei-protocol/uci/.github/workflows/seidroid-xreview.yml@65901242783550521f25a19199a6b10e54550b97  # uci v0.0.15
     permissions:
       pull-requests: write   # upsert the one sticky verdict comment
       contents: read         # read PR metadata
@@ -37,4 +35,4 @@ jobs:
     secrets:
       OMNIGENT_M2M_CLIENT_SECRET: ${{ secrets.OMNIGENT_M2M_CLIENT_SECRET }}
     with:
-      uci-ref: a63adbcea9100121491ec25c758a36baf6a5cf9c   # uci v0.0.14 (same commit as `uses:`)
+      uci-ref: 65901242783550521f25a19199a6b10e54550b97   # uci v0.0.15 (same commit as `uses:`)

--- a/.github/workflows/seidroid-xreview.yml
+++ b/.github/workflows/seidroid-xreview.yml
@@ -3,7 +3,8 @@ name: seidroid xreview
 # sandbox-backed agentic review. Thin caller: the logic is the reusable workflow in
 # sei-protocol/uci; bump both refs below (to the next release's commit SHA) to adopt a
 # new xreview release. Runs dry-run until the SEIDROID_XREVIEW_DRY_RUN repo variable is
-# set to 'false'.
+# set to 'false' (read as `vars.SEIDROID_XREVIEW_DRY_RUN` by the reusable workflow, which
+# resolves it against this repo — there is no `with:` input for it here).
 on:
   issue_comment:
     types: [created]
@@ -21,9 +22,9 @@ jobs:
       && github.event.comment.user.type != 'Bot'
       && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
       && contains(github.event.comment.body, 'seidroid xreview') }}
-    # Pinned to the immutable commit for uci v0.0.14 — a mutable tag plus
-    # `secrets: inherit` would let anyone able to move the tag reach this repo's
-    # secrets. Matches how ai-review/ai-assist pin uci (a full commit SHA).
+    # Pinned to the immutable commit for uci v0.0.14 — a mutable tag would let anyone
+    # able to move it run code in this repo's Actions context with the passed secret.
+    # Matches how ai-review/ai-assist pin uci (a full commit SHA).
     uses: sei-protocol/uci/.github/workflows/seidroid-xreview.yml@a63adbcea9100121491ec25c758a36baf6a5cf9c  # uci v0.0.14
     permissions:
       pull-requests: write   # upsert the one sticky verdict comment
@@ -31,6 +32,9 @@ jobs:
       # id-token: write intentionally omitted — xreview mints its omnigent bearer via the
       # client-credentials grant (no OIDC exchange), unlike ai-review/ai-assist which use
       # Anthropic workload-identity federation.
-    secrets: inherit
+    # Pass ONLY the one secret xreview needs — not `secrets: inherit`, which would hand the
+    # cross-repo reusable workflow every secret on this repo (release, ECR/GHCR, Slack, …).
+    secrets:
+      OMNIGENT_M2M_CLIENT_SECRET: ${{ secrets.OMNIGENT_M2M_CLIENT_SECRET }}
     with:
       uci-ref: a63adbcea9100121491ec25c758a36baf6a5cf9c   # uci v0.0.14 (same commit as `uses:`)

--- a/.github/workflows/seidroid-xreview.yml
+++ b/.github/workflows/seidroid-xreview.yml
@@ -1,0 +1,36 @@
+name: seidroid xreview
+# Comment `seidroid xreview` (or `... --dry-run`) on a PR to run the on-demand,
+# sandbox-backed agentic review. Thin caller: the logic is the reusable workflow in
+# sei-protocol/uci; bump both refs below (to the next release's commit SHA) to adopt a
+# new xreview release. Runs dry-run until the SEIDROID_XREVIEW_DRY_RUN repo variable is
+# set to 'false'.
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  xreview:
+    # Pre-filter that MIRRORS the reusable workflow's trust gate locally (PR comment, a
+    # human, a trusted author, and the command mentioned) so an unrelated, bot-echoed, or
+    # untrusted comment never dispatches the workflow — defense in depth that does not rely
+    # on the cross-repo guard alone. The reusable workflow's guard remains the authoritative
+    # exact-command + author check; overlapping runs on one PR are handled by its job-level
+    # concurrency group.
+    if: >-
+      ${{ github.event.issue.pull_request
+      && github.event.comment.user.type != 'Bot'
+      && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      && contains(github.event.comment.body, 'seidroid xreview') }}
+    # Pinned to the immutable commit for uci v0.0.14 — a mutable tag plus
+    # `secrets: inherit` would let anyone able to move the tag reach this repo's
+    # secrets. Matches how ai-review/ai-assist pin uci (a full commit SHA).
+    uses: sei-protocol/uci/.github/workflows/seidroid-xreview.yml@a63adbcea9100121491ec25c758a36baf6a5cf9c  # uci v0.0.14
+    permissions:
+      pull-requests: write   # upsert the one sticky verdict comment
+      contents: read         # read PR metadata
+      # id-token: write intentionally omitted — xreview mints its omnigent bearer via the
+      # client-credentials grant (no OIDC exchange), unlike ai-review/ai-assist which use
+      # Anthropic workload-identity federation.
+    secrets: inherit
+    with:
+      uci-ref: a63adbcea9100121491ec25c758a36baf6a5cf9c   # uci v0.0.14 (same commit as `uses:`)


### PR DESCRIPTION
Enables **seidroid xreview** on sei-chain — the on-demand, sandbox-backed agentic review, a third seidroid capability alongside the `ai-review` / `ai-assist` this repo already runs.

Comment **`seidroid xreview`** on a PR and the `sei-droid` agent reviews it inside a managed omnigent Kubernetes sandbox (real `git`/`gh` toolchain, so it can build, test, and inspect the tree) and posts a structured verdict as one sticky comment.

## What this adds

One file, `.github/workflows/seidroid-xreview.yml` — a thin caller that `uses:` the uci reusable workflow, so the review logic lives in `sei-protocol/uci` and updates are a ref bump here:
- Pinned to the **uci v0.0.15 commit SHA** (`6590124`) on both `uses:` and `uci-ref` — a fixed ref, never a moving tag.
- Passes **only** `OMNIGENT_M2M_CLIENT_SECRET` (not `secrets: inherit`), so the cross-repo reusable workflow never receives this repo's release/ECR/GHCR/Slack secrets.
- A local `if:` gate mirrors the reusable workflow's trust check (PR comment, non-bot, `OWNER`/`MEMBER`/`COLLABORATOR`, command mentioned) so an unrelated or untrusted comment never dispatches it.

## Posting behavior

The verdict is **always posted** as a single sticky comment when a run produces one (a no-verdict run posts nothing). uci v0.0.15 removed the earlier dry-run mode: a review that posts nothing isn't useful, and dry-run was never a security boundary — the only real risk (a prompt injection driving the sandbox agent's vended `pull_requests: write` token) is independent of whether the driver posts.

## Safety

- **Trusted commenters only** — the guard admits `OWNER`/`MEMBER`/`COLLABORATOR`; an untrusted PR author cannot trigger it.
- Runs on the in-cluster `uci-default` runner; one session per trigger, torn down on exit; verdict is a single sticky upsert.
- **Operative constraint:** keep xreview on first-party / trusted content until a server-side shell gate is verified for the `sei-droid` agent. sei-chain PRs are first-party, so this is within scope.

sei-chain already has the seidroid app installed, `uci-default` runner-group access, and a rotator token scoped to it, and the `OMNIGENT_M2M_CLIENT_SECRET` secret is set — so xreview is live on merge.