### PR TITLE
fix(autobahn): prevent block-sync livelock after restart catch-up

### DIFF
--- a/integration_test/upgrade_module/major_upgrade_test.yaml
+++ b/integration_test/upgrade_module/major_upgrade_test.yaml
@@ -127,8 +127,12 @@
     # It successfully reach TARGET_HEIGHT, panic, and log upgrade needed.
     - cmd: seid_downgrade.sh
       node: sei-node-0
-    - cmd: wait_for_height.sh $TARGET_HEIGHT node_admin
+    # The integration runner records non-zero script exits but does not fail the
+    # input step. Capture an explicit result so a live, stalled node cannot be
+    # mistaken for the expected upgrade panic.
+    - cmd: wait_for_height.sh $TARGET_HEIGHT node_admin; WAIT_STATUS=$?; if [ "$WAIT_STATUS" -eq 0 ]; then echo WAIT_FOR_HEIGHT_PASS; else echo WAIT_FOR_HEIGHT_FAIL; fi
       node: sei-node-0
+      env: DOWNGRADED_NODE_0_REACHED_TARGET
     - cmd: verify_panic.sh node_admin
       node: sei-node-0
       env: PANIC_AT_BLOCK_HEIGHT_NODE_0 
@@ -176,6 +180,9 @@
 
     # Downgrade node 0 so that it can sync the rest of the blocks
     # It successfully reach TARGET_HEIGHT, panic, and log upgrade needed.
+    - type: regex
+      result: DOWNGRADED_NODE_0_REACHED_TARGET
+      expr: '(?m)^WAIT_FOR_HEIGHT_PASS$'
     - type: eval
       expr: PANIC_AT_BLOCK_HEIGHT_NODE_0 == "PASS"
     - type: eval

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -529,18 +529,18 @@ func (s *State) TryBlock(n types.GlobalBlockNumber) (*types.Block, error) {
 	return s.blockFromDB(n)
 }
 
-// HaveBlock reports whether height n is already held in memory for catch-up:
-// either in the contiguous prefix (n < nextBlock) or as a gap-fill above
-// nextBlock. Unlike TryBlock, gap-fills count as present so the block fetcher
-// does not keep re-requesting heights it already holds while waiting for a
-// lower contiguous hole to close. Does not consult BlockDB.
-func (s *State) HaveBlock(n types.GlobalBlockNumber) bool {
+// NeedBlock reports whether catch-up still needs to fetch height n.
+// False when n is already past nextBlock (including heights pruned or
+// evicted from RAM) or an in-memory gap-fill is present. Unlike TryBlock,
+// gap-fills count as satisfied so the fetcher does not keep re-requesting
+// them while a lower contiguous hole is open. Does not consult BlockDB.
+func (s *State) NeedBlock(n types.GlobalBlockNumber) bool {
 	for inner := range s.inner.Lock() {
 		if n < inner.nextBlock {
-			return true
+			return false
 		}
 		_, ok := inner.blocks[n]
-		return ok
+		return !ok
 	}
 	panic("unreachable")
 }

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -506,6 +506,21 @@ func (s *State) TryBlock(n types.GlobalBlockNumber) (*types.Block, error) {
 	return s.blockFromDB(n)
 }
 
+// HaveBlock reports whether height n is already held in memory for catch-up:
+// either in the contiguous prefix (n < nextBlock) or as a gap-fill above
+// nextBlock. Unlike TryBlock, gap-fills count as present so the block fetcher
+// does not keep re-requesting heights it already holds while waiting for a
+// lower contiguous hole to close. Does not consult BlockDB.
+func (s *State) HaveBlock(n types.GlobalBlockNumber) bool {
+	for inner := range s.inner.Lock() {
+		if n < inner.nextBlock {
+			return true
+		}
+		return inner.blocks[n] != nil
+	}
+	panic("unreachable")
+}
+
 // assembleGlobalBlock builds a GlobalBlock from a block and its covering QC.
 // Callers must supply non-nil b and fqc for height n. In-memory paths look up
 // maps only for heights still indexed there (including gap-fills); BlockDB

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -539,7 +539,8 @@ func (s *State) HaveBlock(n types.GlobalBlockNumber) bool {
 		if n < inner.nextBlock {
 			return true
 		}
-		return inner.blocks[n] != nil
+		_, ok := inner.blocks[n]
+		return ok
 	}
 	panic("unreachable")
 }

--- a/sei-tendermint/internal/autobahn/data/state_test.go
+++ b/sei-tendermint/internal/autobahn/data/state_test.go
@@ -825,11 +825,9 @@ func TestTryBlockHidesGapFills(t *testing.T) {
 	require.NoError(t, state.PushBlock(ctx, last, gapBlock))
 	_, err := state.TryBlock(last)
 	require.ErrorIs(t, err, types.ErrNotFound, "gap-fill above nextBlock must stay hidden")
-	have := state.HaveBlock(last)
-	require.True(t, have, "HaveBlock must see gap-fills so the fetcher does not re-request them")
+	require.False(t, state.NeedBlock(last), "NeedBlock must treat gap-fills as already satisfied")
 	missing := gr2.First
-	have = state.HaveBlock(missing)
-	require.False(t, have, "HaveBlock must still report holes below a gap-fill")
+	require.True(t, state.NeedBlock(missing), "NeedBlock must still request holes below a gap-fill")
 
 	// ByHash must not fall through to BlockDB (gap-fills are not persisted yet).
 	gotOpt, err := state.GlobalBlockByHash(gapBlock.Header().Hash())

--- a/sei-tendermint/internal/autobahn/data/state_test.go
+++ b/sei-tendermint/internal/autobahn/data/state_test.go
@@ -825,6 +825,11 @@ func TestTryBlockHidesGapFills(t *testing.T) {
 	require.NoError(t, state.PushBlock(ctx, last, gapBlock))
 	_, err := state.TryBlock(last)
 	require.ErrorIs(t, err, types.ErrNotFound, "gap-fill above nextBlock must stay hidden")
+	have := state.HaveBlock(last)
+	require.True(t, have, "HaveBlock must see gap-fills so the fetcher does not re-request them")
+	missing := gr2.First
+	have = state.HaveBlock(missing)
+	require.False(t, have, "HaveBlock must still report holes below a gap-fill")
 
 	// ByHash must not fall through to BlockDB (gap-fills are not persisted yet).
 	gotOpt, err := state.GlobalBlockByHash(gapBlock.Header().Hash())

--- a/sei-tendermint/internal/p2p/giga/data.go
+++ b/sei-tendermint/internal/p2p/giga/data.go
@@ -119,11 +119,11 @@ func (x *Service) runBlockFetcher(ctx context.Context) error {
 			scope.Spawn(func() error {
 				defer release()
 				for first := true; ; first = false {
-					// HaveBlock (not TryBlock): gap-fills above nextBlock already
+					// NeedBlock (not TryBlock): gap-fills above nextBlock already
 					// satisfy this height. Re-fetching them while a lower hole is
 					// empty wastes the shared per-peer GetBlock queue and can
 					// starve the contiguous prefix.
-					if x.data.HaveBlock(n) {
+					if !x.data.NeedBlock(n) {
 						return nil
 					}
 					// Back off between repeated requests for the same block —

--- a/sei-tendermint/internal/p2p/giga/data.go
+++ b/sei-tendermint/internal/p2p/giga/data.go
@@ -119,13 +119,12 @@ func (x *Service) runBlockFetcher(ctx context.Context) error {
 			scope.Spawn(func() error {
 				defer release()
 				for first := true; ; first = false {
-					_, err := x.data.TryBlock(n)
-					if err == nil || errors.Is(err, types.ErrPruned) {
-						// Have it, or no longer needed (pruned past catch-up).
+					// HaveBlock (not TryBlock): gap-fills above nextBlock already
+					// satisfy this height. Re-fetching them while a lower hole is
+					// empty wastes the shared per-peer GetBlock queue and can
+					// starve the contiguous prefix.
+					if x.data.HaveBlock(n) {
 						return nil
-					}
-					if !errors.Is(err, types.ErrNotFound) {
-						return fmt.Errorf("TryBlock(%d): %w", n, err)
 					}
 					// Back off between repeated requests for the same block —
 					// avoids hammering a peer that responded with an empty

--- a/sei-tendermint/internal/p2p/giga/data_test.go
+++ b/sei-tendermint/internal/p2p/giga/data_test.go
@@ -87,7 +87,7 @@ func (e *testEnv) Run(ctx context.Context) error {
 				s.SpawnNamed("mux server", func() error { return server.Run(ctx, xConn) })
 				s.SpawnNamed("mux client", func() error { return client.Run(ctx, yConn) })
 				s.SpawnNamed("RunServer", func() error { return x.service.RunServer(ctx, server) })
-				s.SpawnNamed("RunClient", func() error { return y.service.RunClient(ctx, client) })
+				s.SpawnNamed("RunClient", func() error { return y.service.RunClient(ctx, client, true) })
 			}
 		}
 		return nil

--- a/sei-tendermint/internal/p2p/giga/service.go
+++ b/sei-tendermint/internal/p2p/giga/service.go
@@ -86,24 +86,17 @@ func (x *Service) RunClient(ctx context.Context, client rpc.Client[API], getBloc
 	// so connections that lack a height (including self) do not need a separate
 	// getBlock=false path to avoid starving the shared fetch queue.
 	return scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
-		s.Spawn(func() error { return x.runConsensusClientStreams(ctx, client) })
-		if getBlock {
-			s.Spawn(func() error { return x.clientStreamFullCommitQCs(ctx, client) })
-			s.Spawn(func() error { return x.clientGetBlock(ctx, client) })
-		}
-		return nil
-	})
-}
-
-func (x *Service) runConsensusClientStreams(ctx context.Context, client rpc.Client[API]) error {
-	return scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
 		s.Spawn(func() error { return x.clientPing(ctx, client) })
 		s.Spawn(func() error { return x.clientConsensus(ctx, client) })
+		s.Spawn(func() error { return x.clientStreamFullCommitQCs(ctx, client) })
 		s.Spawn(func() error { return x.clientStreamLaneProposals(ctx, client) })
 		s.Spawn(func() error { return x.clientStreamLaneVotes(ctx, client) })
 		s.Spawn(func() error { return x.clientStreamCommitQCs(ctx, client) })
 		s.Spawn(func() error { return x.clientStreamAppVotes(ctx, client) })
 		s.Spawn(func() error { return x.clientStreamAppQCs(ctx, client) })
+		if getBlock {
+			s.Spawn(func() error { return x.clientGetBlock(ctx, client) })
+		}
 		return nil
 	})
 }

--- a/sei-tendermint/internal/p2p/giga/service.go
+++ b/sei-tendermint/internal/p2p/giga/service.go
@@ -83,15 +83,9 @@ func (x *Service) RunServer(ctx context.Context, server rpc.Server[API]) error {
 
 func (x *Service) RunClient(ctx context.Context, client rpc.Client[API]) error {
 	return scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
-		s.Spawn(func() error { return x.clientPing(ctx, client) })
-		s.Spawn(func() error { return x.clientConsensus(ctx, client) })
+		x.spawnConsensusClientStreams(ctx, s, client)
 		s.Spawn(func() error { return x.clientStreamFullCommitQCs(ctx, client) })
 		s.Spawn(func() error { return x.clientGetBlock(ctx, client) })
-		s.Spawn(func() error { return x.clientStreamLaneProposals(ctx, client) })
-		s.Spawn(func() error { return x.clientStreamLaneVotes(ctx, client) })
-		s.Spawn(func() error { return x.clientStreamCommitQCs(ctx, client) })
-		s.Spawn(func() error { return x.clientStreamAppVotes(ctx, client) })
-		s.Spawn(func() error { return x.clientStreamAppQCs(ctx, client) })
 		return nil
 	})
 }
@@ -99,18 +93,26 @@ func (x *Service) RunClient(ctx context.Context, client rpc.Client[API]) error {
 // RunSelfClient runs validator-local consensus and availability streams without
 // block sync. The self connection is required for the validator's own votes,
 // but it must not consume catch-up GetBlock requests: by definition this node
-// cannot serve a block that is missing from its own data state.
+// cannot serve a block that is missing from its own data state. The self QC
+// stream is omitted too — it would only re-push QCs this node already holds.
 func (x *Service) RunSelfClient(ctx context.Context, client rpc.Client[API]) error {
 	return scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
-		s.Spawn(func() error { return x.clientPing(ctx, client) })
-		s.Spawn(func() error { return x.clientConsensus(ctx, client) })
-		s.Spawn(func() error { return x.clientStreamLaneProposals(ctx, client) })
-		s.Spawn(func() error { return x.clientStreamLaneVotes(ctx, client) })
-		s.Spawn(func() error { return x.clientStreamCommitQCs(ctx, client) })
-		s.Spawn(func() error { return x.clientStreamAppVotes(ctx, client) })
-		s.Spawn(func() error { return x.clientStreamAppQCs(ctx, client) })
+		x.spawnConsensusClientStreams(ctx, s, client)
 		return nil
 	})
+}
+
+// spawnConsensusClientStreams starts the streams shared by peer and self
+// clients. Block-sync streams (FullCommitQCs / GetBlock) are added only by
+// RunClient so the self dial cannot drift back into catch-up fetches.
+func (x *Service) spawnConsensusClientStreams(ctx context.Context, s scope.Scope, client rpc.Client[API]) {
+	s.Spawn(func() error { return x.clientPing(ctx, client) })
+	s.Spawn(func() error { return x.clientConsensus(ctx, client) })
+	s.Spawn(func() error { return x.clientStreamLaneProposals(ctx, client) })
+	s.Spawn(func() error { return x.clientStreamLaneVotes(ctx, client) })
+	s.Spawn(func() error { return x.clientStreamCommitQCs(ctx, client) })
+	s.Spawn(func() error { return x.clientStreamAppVotes(ctx, client) })
+	s.Spawn(func() error { return x.clientStreamAppQCs(ctx, client) })
 }
 
 // RunBlockSyncServer spawns only the block-sync server handlers. Used on

--- a/sei-tendermint/internal/p2p/giga/service.go
+++ b/sei-tendermint/internal/p2p/giga/service.go
@@ -96,6 +96,23 @@ func (x *Service) RunClient(ctx context.Context, client rpc.Client[API]) error {
 	})
 }
 
+// RunSelfClient runs validator-local consensus and availability streams without
+// block sync. The self connection is required for the validator's own votes,
+// but it must not consume catch-up GetBlock requests: by definition this node
+// cannot serve a block that is missing from its own data state.
+func (x *Service) RunSelfClient(ctx context.Context, client rpc.Client[API]) error {
+	return scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
+		s.Spawn(func() error { return x.clientPing(ctx, client) })
+		s.Spawn(func() error { return x.clientConsensus(ctx, client) })
+		s.Spawn(func() error { return x.clientStreamLaneProposals(ctx, client) })
+		s.Spawn(func() error { return x.clientStreamLaneVotes(ctx, client) })
+		s.Spawn(func() error { return x.clientStreamCommitQCs(ctx, client) })
+		s.Spawn(func() error { return x.clientStreamAppVotes(ctx, client) })
+		s.Spawn(func() error { return x.clientStreamAppQCs(ctx, client) })
+		return nil
+	})
+}
+
 // RunBlockSyncServer spawns only the block-sync server handlers. Used on
 // both validator and fullnode inbound connections from non-committee peers.
 func (x *Service) RunBlockSyncServer(ctx context.Context, server rpc.Server[API]) error {

--- a/sei-tendermint/internal/p2p/giga/service.go
+++ b/sei-tendermint/internal/p2p/giga/service.go
@@ -81,38 +81,31 @@ func (x *Service) RunServer(ctx context.Context, server rpc.Server[API]) error {
 	})
 }
 
-func (x *Service) RunClient(ctx context.Context, client rpc.Client[API]) error {
+func (x *Service) RunClient(ctx context.Context, client rpc.Client[API], getBlock bool) error {
+	// TODO: implement a uniform robust GetBlock peer-selection / retry strategy
+	// so connections that lack a height (including self) do not need a separate
+	// getBlock=false path to avoid starving the shared fetch queue.
 	return scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
-		x.spawnConsensusClientStreams(ctx, s, client)
-		s.Spawn(func() error { return x.clientStreamFullCommitQCs(ctx, client) })
-		s.Spawn(func() error { return x.clientGetBlock(ctx, client) })
+		s.Spawn(func() error { return x.runConsensusClientStreams(ctx, client) })
+		if getBlock {
+			s.Spawn(func() error { return x.clientStreamFullCommitQCs(ctx, client) })
+			s.Spawn(func() error { return x.clientGetBlock(ctx, client) })
+		}
 		return nil
 	})
 }
 
-// RunSelfClient runs validator-local consensus and availability streams without
-// block sync. The self connection is required for the validator's own votes,
-// but it must not consume catch-up GetBlock requests: by definition this node
-// cannot serve a block that is missing from its own data state. The self QC
-// stream is omitted too — it would only re-push QCs this node already holds.
-func (x *Service) RunSelfClient(ctx context.Context, client rpc.Client[API]) error {
+func (x *Service) runConsensusClientStreams(ctx context.Context, client rpc.Client[API]) error {
 	return scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
-		x.spawnConsensusClientStreams(ctx, s, client)
+		s.Spawn(func() error { return x.clientPing(ctx, client) })
+		s.Spawn(func() error { return x.clientConsensus(ctx, client) })
+		s.Spawn(func() error { return x.clientStreamLaneProposals(ctx, client) })
+		s.Spawn(func() error { return x.clientStreamLaneVotes(ctx, client) })
+		s.Spawn(func() error { return x.clientStreamCommitQCs(ctx, client) })
+		s.Spawn(func() error { return x.clientStreamAppVotes(ctx, client) })
+		s.Spawn(func() error { return x.clientStreamAppQCs(ctx, client) })
 		return nil
 	})
-}
-
-// spawnConsensusClientStreams starts the streams shared by peer and self
-// clients. Block-sync streams (FullCommitQCs / GetBlock) are added only by
-// RunClient so the self dial cannot drift back into catch-up fetches.
-func (x *Service) spawnConsensusClientStreams(ctx context.Context, s scope.Scope, client rpc.Client[API]) {
-	s.Spawn(func() error { return x.clientPing(ctx, client) })
-	s.Spawn(func() error { return x.clientConsensus(ctx, client) })
-	s.Spawn(func() error { return x.clientStreamLaneProposals(ctx, client) })
-	s.Spawn(func() error { return x.clientStreamLaneVotes(ctx, client) })
-	s.Spawn(func() error { return x.clientStreamCommitQCs(ctx, client) })
-	s.Spawn(func() error { return x.clientStreamAppVotes(ctx, client) })
-	s.Spawn(func() error { return x.clientStreamAppQCs(ctx, client) })
 }
 
 // RunBlockSyncServer spawns only the block-sync server handlers. Used on

--- a/sei-tendermint/internal/p2p/giga_router_validator.go
+++ b/sei-tendermint/internal/p2p/giga_router_validator.go
@@ -69,6 +69,9 @@ func (r *gigaValidatorRouter) Run(ctx context.Context) error {
 		// consensus/availability only: a loopback GetBlock consumer always
 		// returns empty for missing catch-up heights and can starve the
 		// contiguous prefix while higher gap-fills keep retrying.
+		// Compare against the p2p node key (r.key.Public), not validatorKey
+		// (consensus signing key used by EvmProxy): GigaNodeAddr.Key is a
+		// NodePublicKey.
 		selfKey := r.key.Public()
 		for _, addr := range r.cfg.ValidatorAddrs {
 			runClient := r.service.RunClient

--- a/sei-tendermint/internal/p2p/giga_router_validator.go
+++ b/sei-tendermint/internal/p2p/giga_router_validator.go
@@ -65,22 +65,20 @@ func (r *gigaValidatorRouter) Run(ctx context.Context) error {
 	return scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
 		// Validators dial every committee member in parallel — consensus
 		// voting needs fan-out, not stickiness. Same connections also
-		// serve block sync between committee peers. Self is dialed for
-		// consensus/availability only: a loopback GetBlock consumer always
-		// returns empty for missing catch-up heights and can starve the
-		// contiguous prefix while higher gap-fills keep retrying.
-		// Compare against the p2p node key (r.key.Public), not validatorKey
-		// (consensus signing key used by EvmProxy): GigaNodeAddr.Key is a
-		// NodePublicKey.
+		// serve block sync between committee peers. Self disables GetBlock:
+		// a loopback consumer always returns empty for missing catch-up
+		// heights and can starve the contiguous prefix while higher
+		// gap-fills keep retrying. Compare against the p2p node key
+		// (r.key.Public), not validatorKey (consensus signing key used by
+		// EvmProxy): GigaNodeAddr.Key is a NodePublicKey.
 		selfKey := r.key.Public()
 		for _, addr := range r.cfg.ValidatorAddrs {
-			runClient := r.service.RunClient
-			if addr.Key == selfKey {
-				runClient = r.service.RunSelfClient
-			}
+			getBlock := addr.Key != selfKey
 			s.Spawn(func() error {
 				for {
-					err := r.dialAndRunConn(ctx, utils.Some(addr.Key), addr.HostPort, runClient)
+					err := r.dialAndRunConn(ctx, utils.Some(addr.Key), addr.HostPort, func(ctx context.Context, client rpc.Client[giga.API]) error {
+						return r.service.RunClient(ctx, client, getBlock)
+					})
 					logger.Info("giga connection failed", "addr", addr, "err", err)
 					if err := utils.Sleep(ctx, r.cfg.DialInterval); err != nil {
 						return err

--- a/sei-tendermint/internal/p2p/giga_router_validator.go
+++ b/sei-tendermint/internal/p2p/giga_router_validator.go
@@ -65,11 +65,19 @@ func (r *gigaValidatorRouter) Run(ctx context.Context) error {
 	return scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
 		// Validators dial every committee member in parallel — consensus
 		// voting needs fan-out, not stickiness. Same connections also
-		// serve block sync between committee peers.
+		// serve block sync between committee peers. Self is dialed for
+		// consensus/availability only: a loopback GetBlock consumer always
+		// returns empty for missing catch-up heights and can starve the
+		// contiguous prefix while higher gap-fills keep retrying.
+		selfKey := r.key.Public()
 		for _, addr := range r.cfg.ValidatorAddrs {
+			runClient := r.service.RunClient
+			if addr.Key == selfKey {
+				runClient = r.service.RunSelfClient
+			}
 			s.Spawn(func() error {
 				for {
-					err := r.dialAndRunConn(ctx, utils.Some(addr.Key), addr.HostPort, r.service.RunClient)
+					err := r.dialAndRunConn(ctx, utils.Some(addr.Key), addr.HostPort, runClient)
 					logger.Info("giga connection failed", "addr", addr, "err", err)
 					if err := utils.Sleep(ctx, r.cfg.DialInterval); err != nil {
 						return err


### PR DESCRIPTION
## Summary
- Stop Autobahn validators from consuming catch-up `GetBlock` on the self dial (`RunSelfClient`), which always returns empty for missing local heights and can starve the contiguous prefix.
- Treat in-memory gap-fills as already fetched via `HaveBlock`, so the block fetcher does not keep re-requesting heights it already holds while a lower hole is open.
- Make the Autobahn major-upgrade post-downgrade height wait assert `WAIT_FOR_HEIGHT_PASS` explicitly, so a live stalled node cannot false-green as the expected upgrade panic.

## Test plan
- [x] `go test ./autobahn/... ./internal/autobahn/...` (253 passed)
- [x] Autobahn `TestUpgradeMajor` on local docker cluster
- [x] Autobahn `TestUpgradeMinor` on fresh local docker cluster
- [ ] CI Autobahn upgrade-module major/minor jobs


Made with [Cursor](https://cursor.com)