### PR TITLE
fix(evidence): remove unused GetAllEvidence call in AllEvidence query

### DIFF
--- a/sei-cosmos/x/evidence/keeper/grpc_query.go
+++ b/sei-cosmos/x/evidence/keeper/grpc_query.go
@@ -55,8 +55,6 @@ func (k Keeper) AllEvidence(c context.Context, req *types.QueryAllEvidenceReques
 	}
 	ctx := sdk.UnwrapSDKContext(c)
 
-	k.GetAllEvidence(ctx)
-
 	var evidence []*codectypes.Any
 	store := ctx.KVStore(k.storeKey)
 	evidenceStore := prefix.NewStore(store, types.KeyPrefixEvidence)


### PR DESCRIPTION
## Summary
- Removes the dead `k.GetAllEvidence(ctx)` call in `AllEvidence` (`sei-cosmos/x/evidence/keeper/grpc_query.go`) — its result was discarded and the response is already built via `query.Paginate` over the evidence store directly after.
- `GetAllEvidence` fully iterates and unmarshals every evidence record, so this was unbounded, unnecessary work on every `AllEvidence` gRPC query.

Fixes [PLT-821](https://linear.app/seilabs/issue/PLT-821/remove-unused-getallevidence-call-in-evidence-grpc-querygo-allevidence).

## Test plan
- [x] `go build ./x/evidence/...` passes
- [x] `gofmt -s` / `goimports` clean on the changed file