### PR TITLE
Extend tx decoder canonical-size check to AuthInfo (CON-343)

### DIFF
--- a/app/params/proto_historical_replay.go
+++ b/app/params/proto_historical_replay.go
@@ -9,13 +9,13 @@ import (
 )
 
 // This variant swaps the block-execution tx decoder to the lenient one that does
-// not reject non-canonical protobuf tx bodies, so a tagged build can replay
-// historical blocks whose tx bodies predate strict body-bloat rejection. It is
-// consensus-unsafe for live paths and must only be reachable via the
+// not reject non-canonical protobuf TxBody or AuthInfo encodings, so a tagged
+// build can replay historical blocks whose txs predate strict bloat rejection.
+// It is consensus-unsafe for live paths and must only be reachable via the
 // historical_replay build tag.
 
 // MakeEncodingConfig creates an EncodingConfig whose TxConfig uses the lenient
-// (no body-bloat rejection) decoder, for historical-replay builds only.
+// (no body/auth-info bloat rejection) decoder, for historical-replay builds only.
 func MakeEncodingConfig() EncodingConfig {
 	amino := codec.NewLegacyAmino()
 	interfaceRegistry := types.NewInterfaceRegistry()
@@ -31,7 +31,7 @@ func MakeEncodingConfig() EncodingConfig {
 }
 
 // MakeLegacyEncodingConfig creates a legacy EncodingConfig whose TxConfig uses the
-// lenient (no body-bloat rejection) decoder, for historical-replay builds only.
+// lenient (no body/auth-info bloat rejection) decoder, for historical-replay builds only.
 func MakeLegacyEncodingConfig() EncodingConfig {
 	amino := codec.NewLegacyAmino()
 	interfaceRegistry := types.NewLegacyInterfaceRegistry()

--- a/app/params/proto_historical_replay.go
+++ b/app/params/proto_historical_replay.go
@@ -8,14 +8,14 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/tx"
 )
 
-// This variant swaps the block-execution tx decoder to the lenient one that does
-// not reject non-canonical protobuf TxBody or AuthInfo encodings, so a tagged
-// build can replay historical blocks whose txs predate strict bloat rejection.
+// This variant swaps the block-execution tx decoder to the fully lenient one
+// that does not reject non-canonical protobuf TxBody or AuthInfo encodings, so
+// a tagged build can replay historical blocks whose txs predate those checks.
 // It is consensus-unsafe for live paths and must only be reachable via the
 // historical_replay build tag.
 
 // MakeEncodingConfig creates an EncodingConfig whose TxConfig uses the lenient
-// (no body/auth-info bloat rejection) decoder, for historical-replay builds only.
+// (no TxBody/AuthInfo canonical-size checks) decoder, for historical-replay builds only.
 func MakeEncodingConfig() EncodingConfig {
 	amino := codec.NewLegacyAmino()
 	interfaceRegistry := types.NewInterfaceRegistry()
@@ -31,7 +31,7 @@ func MakeEncodingConfig() EncodingConfig {
 }
 
 // MakeLegacyEncodingConfig creates a legacy EncodingConfig whose TxConfig uses the
-// lenient (no body/auth-info bloat rejection) decoder, for historical-replay builds only.
+// lenient (no TxBody/AuthInfo canonical-size checks) decoder, for historical-replay builds only.
 func MakeLegacyEncodingConfig() EncodingConfig {
 	amino := codec.NewLegacyAmino()
 	interfaceRegistry := types.NewLegacyInterfaceRegistry()

--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -307,9 +307,9 @@ func (b *Backend) isV65ActiveAtHeight(height int64) bool {
 	return b.keeper.UpgradeKeeper().IsUpgradeActiveAtHeight(ctx, "v6.5", height)
 }
 
-func (b *Backend) isV68ActiveAtHeight(height int64) bool {
+func (b *Backend) isV67ActiveAtHeight(height int64) bool {
 	ctx := b.ctxProvider(LatestCtxHeight).WithGasMeter(sdk.NewInfiniteGasMeter(1, 1))
-	return b.keeper.UpgradeKeeper().IsUpgradeActiveAtHeight(ctx, "v6.8", height)
+	return b.keeper.UpgradeKeeper().IsUpgradeActiveAtHeight(ctx, "v6.7", height)
 }
 
 func (b *Backend) SetTraceContextProvider(provider TraceContextProvider) {
@@ -390,7 +390,7 @@ func (b *Backend) GetTransaction(ctx context.Context, txHash common.Hash) (found
 	tx = getEthTxForTxBz(tmTx, traceCompatTxDecoder(
 		b.txConfigProvider(block.Block.Height),
 		b.isV65ActiveAtHeight(block.Block.Height),
-		b.isV68ActiveAtHeight(block.Block.Height),
+		b.isV67ActiveAtHeight(block.Block.Height),
 	))
 	// Use BlockID.Hash rather than Header.Hash(): under CometBFT they
 	// are equal, but under Autobahn the Block.Header returned by /block
@@ -436,7 +436,7 @@ func (b Backend) BlockByNumber(ctx context.Context, bn rpc.BlockNumber) (*ethtyp
 	sdkCtx := b.ctxProvider(LatestCtxHeight)
 	var txs []*ethtypes.Transaction
 	var metadata []tracersutils.TraceBlockMetadata
-	traceTxConfigProvider := traceCompatTxConfigProvider(b.txConfigProvider, b.isV65ActiveAtHeight, b.isV68ActiveAtHeight)
+	traceTxConfigProvider := traceCompatTxConfigProvider(b.txConfigProvider, b.isV65ActiveAtHeight, b.isV67ActiveAtHeight)
 	msgs := filterTransactions(b.keeper, b.ctxProvider, traceTxConfigProvider, tmBlock, false, false, b.cacheCreationMutex, b.globalBlockCache)
 	idxToMsgs := make(map[int]sdk.Msg, len(msgs))
 	for _, msg := range msgs {
@@ -446,7 +446,7 @@ func (b Backend) BlockByNumber(ctx context.Context, bn rpc.BlockNumber) (*ethtyp
 		decoded, err := traceCompatTxDecoder(
 			b.txConfigProvider(tmBlock.Block.Height),
 			b.isV65ActiveAtHeight(tmBlock.Block.Height),
-			b.isV68ActiveAtHeight(tmBlock.Block.Height),
+			b.isV67ActiveAtHeight(tmBlock.Block.Height),
 		)(tmBlock.Block.Txs[i])
 		if err != nil {
 			return nil, nil, err
@@ -596,7 +596,7 @@ func (b *Backend) StateAtTransaction(ctx context.Context, block *ethtypes.Block,
 	sdkTx, err := traceCompatTxDecoder(
 		b.txConfigProvider(block.Number().Int64()),
 		b.isV65ActiveAtHeight(block.Number().Int64()),
-		b.isV68ActiveAtHeight(block.Number().Int64()),
+		b.isV67ActiveAtHeight(block.Number().Int64()),
 	)(tx)
 	if err != nil {
 		panic(err)
@@ -655,7 +655,7 @@ func (b *Backend) replayTransactionTillIndex(ctx context.Context, block *ethtype
 		sdkTx, err := traceCompatTxDecoder(
 			b.txConfigProvider(block.Number().Int64()),
 			b.isV65ActiveAtHeight(block.Number().Int64()),
-			b.isV68ActiveAtHeight(block.Number().Int64()),
+			b.isV67ActiveAtHeight(block.Number().Int64()),
 		)(tx)
 		if err != nil {
 			panic(err)

--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -307,6 +307,11 @@ func (b *Backend) isV65ActiveAtHeight(height int64) bool {
 	return b.keeper.UpgradeKeeper().IsUpgradeActiveAtHeight(ctx, "v6.5", height)
 }
 
+func (b *Backend) isV68ActiveAtHeight(height int64) bool {
+	ctx := b.ctxProvider(LatestCtxHeight).WithGasMeter(sdk.NewInfiniteGasMeter(1, 1))
+	return b.keeper.UpgradeKeeper().IsUpgradeActiveAtHeight(ctx, "v6.8", height)
+}
+
 func (b *Backend) SetTraceContextProvider(provider TraceContextProvider) {
 	if provider != nil {
 		b.traceCtxProvider = provider
@@ -382,7 +387,11 @@ func (b *Backend) GetTransaction(ctx context.Context, txHash common.Hash) (found
 	}
 	txIndex := hexutil.Uint(receipt.TransactionIndex)
 	tmTx := block.Block.Txs[txIndex]
-	tx = getEthTxForTxBz(tmTx, traceCompatTxDecoder(b.txConfigProvider(block.Block.Height), b.isV65ActiveAtHeight(block.Block.Height)))
+	tx = getEthTxForTxBz(tmTx, traceCompatTxDecoder(
+		b.txConfigProvider(block.Block.Height),
+		b.isV65ActiveAtHeight(block.Block.Height),
+		b.isV68ActiveAtHeight(block.Block.Height),
+	))
 	// Use BlockID.Hash rather than Header.Hash(): under CometBFT they
 	// are equal, but under Autobahn the Block.Header returned by /block
 	// is sparse (the GigaRouter's translateGlobalBlock only populates
@@ -427,14 +436,18 @@ func (b Backend) BlockByNumber(ctx context.Context, bn rpc.BlockNumber) (*ethtyp
 	sdkCtx := b.ctxProvider(LatestCtxHeight)
 	var txs []*ethtypes.Transaction
 	var metadata []tracersutils.TraceBlockMetadata
-	traceTxConfigProvider := traceCompatTxConfigProvider(b.txConfigProvider, b.isV65ActiveAtHeight)
+	traceTxConfigProvider := traceCompatTxConfigProvider(b.txConfigProvider, b.isV65ActiveAtHeight, b.isV68ActiveAtHeight)
 	msgs := filterTransactions(b.keeper, b.ctxProvider, traceTxConfigProvider, tmBlock, false, false, b.cacheCreationMutex, b.globalBlockCache)
 	idxToMsgs := make(map[int]sdk.Msg, len(msgs))
 	for _, msg := range msgs {
 		idxToMsgs[msg.index] = msg.msg
 	}
 	for i := range tmBlock.Block.Txs {
-		decoded, err := traceCompatTxDecoder(b.txConfigProvider(tmBlock.Block.Height), b.isV65ActiveAtHeight(tmBlock.Block.Height))(tmBlock.Block.Txs[i])
+		decoded, err := traceCompatTxDecoder(
+			b.txConfigProvider(tmBlock.Block.Height),
+			b.isV65ActiveAtHeight(tmBlock.Block.Height),
+			b.isV68ActiveAtHeight(tmBlock.Block.Height),
+		)(tmBlock.Block.Txs[i])
 		if err != nil {
 			return nil, nil, err
 		}
@@ -580,7 +593,11 @@ func (b *Backend) StateAtTransaction(ctx context.Context, block *ethtypes.Block,
 		return nil, vm.BlockContext{}, nil, emptyRelease, errors.New("transaction not found")
 	}
 	tx := txs[txIndex]
-	sdkTx, err := traceCompatTxDecoder(b.txConfigProvider(block.Number().Int64()), b.isV65ActiveAtHeight(block.Number().Int64()))(tx)
+	sdkTx, err := traceCompatTxDecoder(
+		b.txConfigProvider(block.Number().Int64()),
+		b.isV65ActiveAtHeight(block.Number().Int64()),
+		b.isV68ActiveAtHeight(block.Number().Int64()),
+	)(tx)
 	if err != nil {
 		panic(err)
 	}
@@ -635,7 +652,11 @@ func (b *Backend) replayTransactionTillIndex(ctx context.Context, block *ethtype
 		if err := ctx.Err(); err != nil {
 			return nil, nil, emptyRelease, err
 		}
-		sdkTx, err := traceCompatTxDecoder(b.txConfigProvider(block.Number().Int64()), b.isV65ActiveAtHeight(block.Number().Int64()))(tx)
+		sdkTx, err := traceCompatTxDecoder(
+			b.txConfigProvider(block.Number().Int64()),
+			b.isV65ActiveAtHeight(block.Number().Int64()),
+			b.isV68ActiveAtHeight(block.Number().Int64()),
+		)(tx)
 		if err != nil {
 			panic(err)
 		}

--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -442,12 +442,14 @@ func (b Backend) BlockByNumber(ctx context.Context, bn rpc.BlockNumber) (*ethtyp
 	for _, msg := range msgs {
 		idxToMsgs[msg.index] = msg.msg
 	}
+	height := tmBlock.Block.Height
+	decoder := traceCompatTxDecoder(
+		b.txConfigProvider(height),
+		b.isV65ActiveAtHeight(height),
+		b.isV67ActiveAtHeight(height),
+	)
 	for i := range tmBlock.Block.Txs {
-		decoded, err := traceCompatTxDecoder(
-			b.txConfigProvider(tmBlock.Block.Height),
-			b.isV65ActiveAtHeight(tmBlock.Block.Height),
-			b.isV67ActiveAtHeight(tmBlock.Block.Height),
-		)(tmBlock.Block.Txs[i])
+		decoded, err := decoder(tmBlock.Block.Txs[i])
 		if err != nil {
 			return nil, nil, err
 		}
@@ -645,6 +647,12 @@ func (b *Backend) replayTransactionTillIndex(ctx context.Context, block *ethtype
 		success = true
 		return state.NewDBImpl(sdkCtx.WithIsEVM(true), b.keeper, true), tmBlock.Block.Txs, release, nil
 	}
+	height := block.Number().Int64()
+	decoder := traceCompatTxDecoder(
+		b.txConfigProvider(height),
+		b.isV65ActiveAtHeight(height),
+		b.isV67ActiveAtHeight(height),
+	)
 	for idx, tx := range tmBlock.Block.Txs {
 		if idx > txIndex {
 			break
@@ -652,11 +660,7 @@ func (b *Backend) replayTransactionTillIndex(ctx context.Context, block *ethtype
 		if err := ctx.Err(); err != nil {
 			return nil, nil, emptyRelease, err
 		}
-		sdkTx, err := traceCompatTxDecoder(
-			b.txConfigProvider(block.Number().Int64()),
-			b.isV65ActiveAtHeight(block.Number().Int64()),
-			b.isV67ActiveAtHeight(block.Number().Int64()),
-		)(tx)
+		sdkTx, err := decoder(tx)
 		if err != nil {
 			panic(err)
 		}

--- a/evmrpc/simulate_test.go
+++ b/evmrpc/simulate_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/sei-protocol/sei-chain/x/evm/types/ethtx"
 	"github.com/stretchr/testify/require"
 	dbm "github.com/tendermint/tm-db"
+	"google.golang.org/protobuf/encoding/protowire"
 )
 
 func primeReceiptStore(t *testing.T, store receipt.ReceiptStore, latest int64) {
@@ -1114,7 +1115,7 @@ func TestTraceBlockByNumberUsesCompatDecoderForHistoricalCosmosTx(t *testing.T) 
 
 			_, err = TxConfig.TxDecoder()(bloatedTxBz)
 			require.Error(t, err)
-			require.Contains(t, err.Error(), "exceeds canonical size")
+			require.Contains(t, err.Error(), "does not match canonical size")
 
 			makeBlock := func(height int64) *coretypes.ResultBlock {
 				return &coretypes.ResultBlock{
@@ -1154,9 +1155,101 @@ func TestTraceBlockByNumberUsesCompatDecoderForHistoricalCosmosTx(t *testing.T) 
 			)
 			_, _, err = strictBackend.BlockByNumber(context.Background(), rpc.BlockNumber(v65Height))
 			require.Error(t, err)
-			require.Contains(t, err.Error(), "exceeds canonical size")
+			require.Contains(t, err.Error(), "does not match canonical size")
 		})
 	}
+}
+
+func TestTraceBlockByNumberUsesCompatDecoderForHistoricalAuthInfo(t *testing.T) {
+	const (
+		preV68Height = int64(150)
+		v65Height    = int64(100)
+		v68Height    = int64(200)
+	)
+
+	testApp := app.Setup(t, false, false, false)
+	ctx := testApp.GetContextForDeliverTx([]byte{}).WithBlockHeight(v65Height).WithClosestUpgradeName("v6.5")
+	testApp.UpgradeKeeper.SetDone(ctx, "v6.5")
+	ctx = ctx.WithBlockHeight(v68Height).WithClosestUpgradeName("v6.8")
+	testApp.UpgradeKeeper.SetDone(ctx, "v6.8")
+	primeReceiptStore(t, testApp.EvmKeeper.ReceiptStore(), v68Height)
+	ctxProvider := func(height int64) sdk.Context {
+		if height == evmrpc.LatestCtxHeight {
+			return ctx
+		}
+		return ctx.WithBlockHeight(height)
+	}
+
+	_, fromAddr := testkeeper.MockAddressPair()
+	_, toAddr := testkeeper.MockAddressPair()
+	txBuilder := TxConfig.NewTxBuilder()
+	require.NoError(t, txBuilder.SetMsgs(banktypes.NewMsgSend(
+		sdk.AccAddress(fromAddr.Bytes()),
+		sdk.AccAddress(toAddr.Bytes()),
+		sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(1))),
+	)))
+	txBuilder.SetGasLimit(127)
+	txBz, err := Encoder(txBuilder.GetTx())
+	require.NoError(t, err)
+
+	var raw txtypes.TxRaw
+	require.NoError(t, raw.Unmarshal(txBz))
+	fee := &txtypes.Fee{GasLimit: 127}
+	feeBz, err := fee.Marshal()
+	require.NoError(t, err)
+	extra := protowire.AppendTag(nil, 2, protowire.BytesType)
+	extra = protowire.AppendBytes(extra, feeBz)
+	raw.AuthInfoBytes = append(raw.AuthInfoBytes, extra...)
+	bloatedTxBz, err := raw.Marshal()
+	require.NoError(t, err)
+
+	_, err = TxConfig.TxDecoder()(bloatedTxBz)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not match canonical size")
+	require.Contains(t, err.Error(), "auth info")
+
+	makeBlock := func(height int64) *coretypes.ResultBlock {
+		return &coretypes.ResultBlock{
+			BlockID: tmtypes.BlockID{Hash: bytes.HexBytes(mustHexToBytes("0000000000000000000000000000000000000000000000000000000000000042"))},
+			Block: &tmtypes.Block{
+				Header: mockBlockHeader(height),
+				Data:   tmtypes.Data{Txs: []tmtypes.Tx{bloatedTxBz}},
+				LastCommit: &tmtypes.Commit{
+					Height: height,
+				},
+			},
+		}
+	}
+
+	// v6.5-to-v6.8 window: AuthInfo checks are skipped for tracing.
+	compatTmClient := &fixedBlockClient{block: makeBlock(preV68Height)}
+	compatWatermarks := evmrpc.NewWatermarkManager(compatTmClient, ctxProvider, nil, testApp.EvmKeeper.ReceiptStore())
+	compatBackend := evmrpc.NewBackend(
+		ctxProvider, &testApp.EvmKeeper, legacyabci.BeginBlockKeepers{},
+		func(int64) client.TxConfig { return TxConfig }, compatTmClient, &SConfig,
+		testApp.BaseApp, testApp.TracerAnteHandler,
+		evmrpc.NewBlockCache(3000), &sync.Mutex{}, compatWatermarks,
+	)
+	ethBlock, metadata, err := compatBackend.BlockByNumber(context.Background(), rpc.BlockNumber(preV68Height))
+	require.NoError(t, err)
+	require.Len(t, ethBlock.Transactions(), 0)
+	require.Len(t, metadata, 1)
+	require.False(t, metadata[0].ShouldIncludeInTraceResult)
+	require.NotNil(t, metadata[0].TraceRunnable)
+
+	// v6.8+: AuthInfo checks are enforced for tracing.
+	strictTmClient := &fixedBlockClient{block: makeBlock(v68Height)}
+	strictWatermarks := evmrpc.NewWatermarkManager(strictTmClient, ctxProvider, nil, testApp.EvmKeeper.ReceiptStore())
+	strictBackend := evmrpc.NewBackend(
+		ctxProvider, &testApp.EvmKeeper, legacyabci.BeginBlockKeepers{},
+		func(int64) client.TxConfig { return TxConfig }, strictTmClient, &SConfig,
+		testApp.BaseApp, testApp.TracerAnteHandler,
+		evmrpc.NewBlockCache(3000), &sync.Mutex{}, strictWatermarks,
+	)
+	_, _, err = strictBackend.BlockByNumber(context.Background(), rpc.BlockNumber(v68Height))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not match canonical size")
+	require.Contains(t, err.Error(), "auth info")
 }
 
 // TestBlockByNumberNonTracedTxPassesTxBytes verifies that when BlockByNumber

--- a/evmrpc/simulate_test.go
+++ b/evmrpc/simulate_test.go
@@ -1162,17 +1162,17 @@ func TestTraceBlockByNumberUsesCompatDecoderForHistoricalCosmosTx(t *testing.T) 
 
 func TestTraceBlockByNumberUsesCompatDecoderForHistoricalAuthInfo(t *testing.T) {
 	const (
-		preV68Height = int64(150)
+		preV67Height = int64(150)
 		v65Height    = int64(100)
-		v68Height    = int64(200)
+		v67Height    = int64(200)
 	)
 
 	testApp := app.Setup(t, false, false, false)
 	ctx := testApp.GetContextForDeliverTx([]byte{}).WithBlockHeight(v65Height).WithClosestUpgradeName("v6.5")
 	testApp.UpgradeKeeper.SetDone(ctx, "v6.5")
-	ctx = ctx.WithBlockHeight(v68Height).WithClosestUpgradeName("v6.8")
-	testApp.UpgradeKeeper.SetDone(ctx, "v6.8")
-	primeReceiptStore(t, testApp.EvmKeeper.ReceiptStore(), v68Height)
+	ctx = ctx.WithBlockHeight(v67Height).WithClosestUpgradeName("v6.7")
+	testApp.UpgradeKeeper.SetDone(ctx, "v6.7")
+	primeReceiptStore(t, testApp.EvmKeeper.ReceiptStore(), v67Height)
 	ctxProvider := func(height int64) sdk.Context {
 		if height == evmrpc.LatestCtxHeight {
 			return ctx
@@ -1221,8 +1221,8 @@ func TestTraceBlockByNumberUsesCompatDecoderForHistoricalAuthInfo(t *testing.T) 
 		}
 	}
 
-	// v6.5-to-v6.8 window: AuthInfo checks are skipped for tracing.
-	compatTmClient := &fixedBlockClient{block: makeBlock(preV68Height)}
+	// v6.5-to-v6.7 window: AuthInfo checks are skipped for tracing.
+	compatTmClient := &fixedBlockClient{block: makeBlock(preV67Height)}
 	compatWatermarks := evmrpc.NewWatermarkManager(compatTmClient, ctxProvider, nil, testApp.EvmKeeper.ReceiptStore())
 	compatBackend := evmrpc.NewBackend(
 		ctxProvider, &testApp.EvmKeeper, legacyabci.BeginBlockKeepers{},
@@ -1230,15 +1230,15 @@ func TestTraceBlockByNumberUsesCompatDecoderForHistoricalAuthInfo(t *testing.T) 
 		testApp.BaseApp, testApp.TracerAnteHandler,
 		evmrpc.NewBlockCache(3000), &sync.Mutex{}, compatWatermarks,
 	)
-	ethBlock, metadata, err := compatBackend.BlockByNumber(context.Background(), rpc.BlockNumber(preV68Height))
+	ethBlock, metadata, err := compatBackend.BlockByNumber(context.Background(), rpc.BlockNumber(preV67Height))
 	require.NoError(t, err)
 	require.Len(t, ethBlock.Transactions(), 0)
 	require.Len(t, metadata, 1)
 	require.False(t, metadata[0].ShouldIncludeInTraceResult)
 	require.NotNil(t, metadata[0].TraceRunnable)
 
-	// v6.8+: AuthInfo checks are enforced for tracing.
-	strictTmClient := &fixedBlockClient{block: makeBlock(v68Height)}
+	// v6.7+: AuthInfo checks are enforced for tracing.
+	strictTmClient := &fixedBlockClient{block: makeBlock(v67Height)}
 	strictWatermarks := evmrpc.NewWatermarkManager(strictTmClient, ctxProvider, nil, testApp.EvmKeeper.ReceiptStore())
 	strictBackend := evmrpc.NewBackend(
 		ctxProvider, &testApp.EvmKeeper, legacyabci.BeginBlockKeepers{},
@@ -1246,7 +1246,7 @@ func TestTraceBlockByNumberUsesCompatDecoderForHistoricalAuthInfo(t *testing.T) 
 		testApp.BaseApp, testApp.TracerAnteHandler,
 		evmrpc.NewBlockCache(3000), &sync.Mutex{}, strictWatermarks,
 	)
-	_, _, err = strictBackend.BlockByNumber(context.Background(), rpc.BlockNumber(v68Height))
+	_, _, err = strictBackend.BlockByNumber(context.Background(), rpc.BlockNumber(v67Height))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "does not match canonical size")
 	require.Contains(t, err.Error(), "auth info")

--- a/evmrpc/trace_tx_decoder.go
+++ b/evmrpc/trace_tx_decoder.go
@@ -20,26 +20,44 @@ type protoCodecProvider interface {
 	ProtoCodec() codec.ProtoCodecMarshaler
 }
 
-func traceCompatTxConfig(txConfig client.TxConfig, v65ActiveAtHeight bool) client.TxConfig {
-	if v65ActiveAtHeight {
+// traceCompatTxConfig selects a historical-compatible decoder for debug_trace*:
+//   - pre-v6.5: skip TxBody and AuthInfo canonical-size checks
+//   - v6.5 to v6.8: enforce TxBody checks, skip AuthInfo checks
+//   - v6.8+: use the live (fully strict) decoder
+func traceCompatTxConfig(txConfig client.TxConfig, v65ActiveAtHeight, v68ActiveAtHeight bool) client.TxConfig {
+	if v68ActiveAtHeight {
 		return txConfig
 	}
 	provider, ok := txConfig.(protoCodecProvider)
 	if !ok {
 		return txConfig
 	}
+	var decoder sdk.TxDecoder
+	if v65ActiveAtHeight {
+		decoder = authtx.DefaultTxDecoderWithoutAuthInfoBloatRejection(provider.ProtoCodec())
+	} else {
+		decoder = authtx.DefaultTxDecoderWithoutBodyBloatRejection(provider.ProtoCodec())
+	}
 	return traceTxConfig{
 		TxConfig: txConfig,
-		decoder:  authtx.DefaultTxDecoderWithoutBodyBloatRejection(provider.ProtoCodec()),
+		decoder:  decoder,
 	}
 }
 
-func traceCompatTxConfigProvider(txConfigProvider func(int64) client.TxConfig, isV65ActiveAtHeight func(int64) bool) func(int64) client.TxConfig {
+func traceCompatTxConfigProvider(
+	txConfigProvider func(int64) client.TxConfig,
+	isV65ActiveAtHeight func(int64) bool,
+	isV68ActiveAtHeight func(int64) bool,
+) func(int64) client.TxConfig {
 	return func(height int64) client.TxConfig {
-		return traceCompatTxConfig(txConfigProvider(height), isV65ActiveAtHeight(height))
+		return traceCompatTxConfig(
+			txConfigProvider(height),
+			isV65ActiveAtHeight(height),
+			isV68ActiveAtHeight(height),
+		)
 	}
 }
 
-func traceCompatTxDecoder(txConfig client.TxConfig, v65ActiveAtHeight bool) sdk.TxDecoder {
-	return traceCompatTxConfig(txConfig, v65ActiveAtHeight).TxDecoder()
+func traceCompatTxDecoder(txConfig client.TxConfig, v65ActiveAtHeight, v68ActiveAtHeight bool) sdk.TxDecoder {
+	return traceCompatTxConfig(txConfig, v65ActiveAtHeight, v68ActiveAtHeight).TxDecoder()
 }

--- a/evmrpc/trace_tx_decoder.go
+++ b/evmrpc/trace_tx_decoder.go
@@ -22,10 +22,10 @@ type protoCodecProvider interface {
 
 // traceCompatTxConfig selects a historical-compatible decoder for debug_trace*:
 //   - pre-v6.5: skip TxBody and AuthInfo canonical-size checks
-//   - v6.5 to v6.8: enforce TxBody checks, skip AuthInfo checks
-//   - v6.8+: use the live (fully strict) decoder
-func traceCompatTxConfig(txConfig client.TxConfig, v65ActiveAtHeight, v68ActiveAtHeight bool) client.TxConfig {
-	if v68ActiveAtHeight {
+//   - v6.5 to v6.7: enforce TxBody checks, skip AuthInfo checks
+//   - v6.7+: use the live (fully strict) decoder
+func traceCompatTxConfig(txConfig client.TxConfig, v65ActiveAtHeight, v67ActiveAtHeight bool) client.TxConfig {
+	if v67ActiveAtHeight {
 		return txConfig
 	}
 	provider, ok := txConfig.(protoCodecProvider)
@@ -47,17 +47,17 @@ func traceCompatTxConfig(txConfig client.TxConfig, v65ActiveAtHeight, v68ActiveA
 func traceCompatTxConfigProvider(
 	txConfigProvider func(int64) client.TxConfig,
 	isV65ActiveAtHeight func(int64) bool,
-	isV68ActiveAtHeight func(int64) bool,
+	isV67ActiveAtHeight func(int64) bool,
 ) func(int64) client.TxConfig {
 	return func(height int64) client.TxConfig {
 		return traceCompatTxConfig(
 			txConfigProvider(height),
 			isV65ActiveAtHeight(height),
-			isV68ActiveAtHeight(height),
+			isV67ActiveAtHeight(height),
 		)
 	}
 }
 
-func traceCompatTxDecoder(txConfig client.TxConfig, v65ActiveAtHeight, v68ActiveAtHeight bool) sdk.TxDecoder {
-	return traceCompatTxConfig(txConfig, v65ActiveAtHeight, v68ActiveAtHeight).TxDecoder()
+func traceCompatTxDecoder(txConfig client.TxConfig, v65ActiveAtHeight, v67ActiveAtHeight bool) sdk.TxDecoder {
+	return traceCompatTxConfig(txConfig, v65ActiveAtHeight, v67ActiveAtHeight).TxDecoder()
 }

--- a/sei-cosmos/x/auth/tx/config_historical_replay.go
+++ b/sei-cosmos/x/auth/tx/config_historical_replay.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewTxConfigWithoutBodyBloatRejection returns a TxConfig whose decoder does not
-// reject non-canonical (bloat) protobuf TxBody or AuthInfo encodings, so historical
+// reject non-canonical protobuf TxBody or AuthInfo encodings, so historical
 // blocks whose txs predate those checks can be decoded and executed.
 //
 // It is consensus-unsafe for live paths, so it is compiled ONLY into

--- a/sei-cosmos/x/auth/tx/config_historical_replay.go
+++ b/sei-cosmos/x/auth/tx/config_historical_replay.go
@@ -9,8 +9,8 @@ import (
 )
 
 // NewTxConfigWithoutBodyBloatRejection returns a TxConfig whose decoder does not
-// reject non-canonical (body-bloat) protobuf tx bodies, so historical blocks whose
-// tx bodies predate that check can be decoded and executed.
+// reject non-canonical (bloat) protobuf TxBody or AuthInfo encodings, so historical
+// blocks whose txs predate those checks can be decoded and executed.
 //
 // It is consensus-unsafe for live paths, so it is compiled ONLY into
 // historical_replay-tagged builds — an untagged (production) binary cannot reach

--- a/sei-cosmos/x/auth/tx/decoder.go
+++ b/sei-cosmos/x/auth/tx/decoder.go
@@ -28,7 +28,7 @@ func DefaultTxDecoderWithoutBodyBloatRejection(cdc codec.ProtoCodecMarshaler) sd
 
 // DefaultTxDecoderWithoutAuthInfoBloatRejection returns a protobuf TxDecoder that
 // rejects non-canonical TxBody encodings (v6.5+) but not non-canonical AuthInfo
-// encodings. Used for historical tooling that replays the v6.5-to-v6.8 window.
+// encodings. Used for historical tooling that replays the v6.5-to-v6.7 window.
 // Do not use this for mempool, CheckTx, or DeliverTx paths.
 func DefaultTxDecoderWithoutAuthInfoBloatRejection(cdc codec.ProtoCodecMarshaler) sdk.TxDecoder {
 	return defaultTxDecoder(cdc, true, false)

--- a/sei-cosmos/x/auth/tx/decoder.go
+++ b/sei-cosmos/x/auth/tx/decoder.go
@@ -19,13 +19,14 @@ func DefaultTxDecoder(cdc codec.ProtoCodecMarshaler) sdk.TxDecoder {
 }
 
 // DefaultTxDecoderWithoutBodyBloatRejection returns a protobuf TxDecoder that
-// preserves pre-v6.5 decode behavior for historical tooling. Do not use this for
+// preserves pre-v6.5 decode behavior for historical tooling: it does not reject
+// non-canonical TxBody or AuthInfo wire encodings. Do not use this for
 // mempool, CheckTx, or DeliverTx paths.
 func DefaultTxDecoderWithoutBodyBloatRejection(cdc codec.ProtoCodecMarshaler) sdk.TxDecoder {
 	return defaultTxDecoder(cdc, false)
 }
 
-func defaultTxDecoder(cdc codec.ProtoCodecMarshaler, rejectBodyBloat bool) sdk.TxDecoder {
+func defaultTxDecoder(cdc codec.ProtoCodecMarshaler, rejectBloat bool) sdk.TxDecoder {
 	return func(txBytes []byte) (sdk.Tx, error) {
 		// Make sure txBytes follow ADR-027.
 		err := rejectNonADR027TxRaw(txBytes)
@@ -59,8 +60,8 @@ func defaultTxDecoder(cdc codec.ProtoCodecMarshaler, rejectBodyBloat bool) sdk.T
 			return nil, sdkerrors.Wrap(sdkerrors.ErrTxDecode, err.Error())
 		}
 
-		if rejectBodyBloat {
-			if err := rejectBloatedBody(raw.BodyBytes, &body); err != nil {
+		if rejectBloat {
+			if err := rejectBloatedProto(raw.BodyBytes, &body, "tx body"); err != nil {
 				return nil, sdkerrors.Wrap(sdkerrors.ErrTxDecode, err.Error())
 			}
 		}
@@ -76,6 +77,12 @@ func defaultTxDecoder(cdc codec.ProtoCodecMarshaler, rejectBodyBloat bool) sdk.T
 		err = cdc.Unmarshal(raw.AuthInfoBytes, &authInfo)
 		if err != nil {
 			return nil, sdkerrors.Wrap(sdkerrors.ErrTxDecode, err.Error())
+		}
+
+		if rejectBloat {
+			if err := rejectBloatedProto(raw.AuthInfoBytes, &authInfo, "tx auth info"); err != nil {
+				return nil, sdkerrors.Wrap(sdkerrors.ErrTxDecode, err.Error())
+			}
 		}
 
 		theTx := &tx.Tx{
@@ -159,17 +166,17 @@ func rejectNonADR027TxRaw(txBytes []byte) error {
 	return nil
 }
 
-// rejectBloatedBody rejects tx bodies where the raw wire encoding is larger
+// rejectBloatedProto rejects messages where the raw wire encoding is larger
 // than the canonical re-marshal of the decoded struct. This catches protobuf-level
-// bloat (e.g. padded sdk.Int fields, oversized Any.Value) that UnpackAny would
-// otherwise silently canonicalize away before validation runs.
-func rejectBloatedBody(rawBodyBytes []byte, body *tx.TxBody) error {
-	canonicalBytes, err := proto.Marshal(body)
+// bloat (e.g. padded sdk.Int fields, oversized Any.Value, non-canonical encodings)
+// that Unmarshal would otherwise silently canonicalize away before validation runs.
+func rejectBloatedProto(rawBytes []byte, msg proto.Message, name string) error {
+	canonicalBytes, err := proto.Marshal(msg)
 	if err != nil {
-		return fmt.Errorf("failed to re-marshal tx body: %w", err)
+		return fmt.Errorf("failed to re-marshal %s: %w", name, err)
 	}
-	if len(rawBodyBytes) != len(canonicalBytes) {
-		return fmt.Errorf("tx body wire size (%d) exceeds canonical size (%d)", len(rawBodyBytes), len(canonicalBytes))
+	if len(rawBytes) != len(canonicalBytes) {
+		return fmt.Errorf("%s wire size (%d) exceeds canonical size (%d)", name, len(rawBytes), len(canonicalBytes))
 	}
 	return nil
 }

--- a/sei-cosmos/x/auth/tx/decoder.go
+++ b/sei-cosmos/x/auth/tx/decoder.go
@@ -20,15 +20,17 @@ func DefaultTxDecoder(cdc codec.ProtoCodecMarshaler) sdk.TxDecoder {
 
 // DefaultTxDecoderWithoutBodyBloatRejection returns a protobuf TxDecoder that
 // preserves pre-v6.5 decode behavior for historical tooling: it does not reject
-// non-canonical TxBody or AuthInfo wire encodings. Do not use this for
-// mempool, CheckTx, or DeliverTx paths.
+// non-canonical TxBody, AuthInfo, or TxRaw envelope encodings, and does not
+// reject duplicate singular TxRaw fields. Do not use this for mempool, CheckTx,
+// or DeliverTx paths.
 func DefaultTxDecoderWithoutBodyBloatRejection(cdc codec.ProtoCodecMarshaler) sdk.TxDecoder {
 	return defaultTxDecoder(cdc, false, false)
 }
 
 // DefaultTxDecoderWithoutAuthInfoBloatRejection returns a protobuf TxDecoder that
 // rejects non-canonical TxBody encodings (v6.5+) but not non-canonical AuthInfo
-// encodings. Used for historical tooling that replays the v6.5-to-v6.7 window.
+// or TxRaw envelope encodings, and does not reject duplicate singular TxRaw
+// fields. Used for historical tooling that replays the v6.5-to-v6.7 window.
 // Do not use this for mempool, CheckTx, or DeliverTx paths.
 func DefaultTxDecoderWithoutAuthInfoBloatRejection(cdc codec.ProtoCodecMarshaler) sdk.TxDecoder {
 	return defaultTxDecoder(cdc, true, false)
@@ -36,8 +38,11 @@ func DefaultTxDecoderWithoutAuthInfoBloatRejection(cdc codec.ProtoCodecMarshaler
 
 func defaultTxDecoder(cdc codec.ProtoCodecMarshaler, rejectBodyBloat, rejectAuthInfoBloat bool) sdk.TxDecoder {
 	return func(txBytes []byte) (sdk.Tx, error) {
-		// Make sure txBytes follow ADR-027.
-		err := rejectNonADR027TxRaw(txBytes)
+		// Make sure txBytes follow ADR-027. Singular-field uniqueness for
+		// body_bytes/auth_info_bytes is only enforced once AuthInfo bloat
+		// rejection is on (v6.7+), so historical tooling can still decode
+		// last-wins duplicates that predate this check.
+		err := rejectNonADR027TxRaw(txBytes, rejectAuthInfoBloat)
 		if err != nil {
 			return nil, sdkerrors.Wrap(sdkerrors.ErrTxDecode, err.Error())
 		}
@@ -56,8 +61,8 @@ func defaultTxDecoder(cdc codec.ProtoCodecMarshaler, rejectBodyBloat, rejectAuth
 		}
 
 		// Reject non-canonical TxRaw envelopes (e.g. explicit default encodings).
-		// Duplicate singular fields are also rejected earlier by rejectNonADR027TxRaw.
-		if rejectBodyBloat || rejectAuthInfoBloat {
+		// New in v6.7 — keep off the v6.5-to-v6.7 body-strict/AuthInfo-lenient path.
+		if rejectAuthInfoBloat {
 			if err := rejectBloatedProto(txBytes, &raw, "tx raw"); err != nil {
 				return nil, sdkerrors.Wrap(sdkerrors.ErrTxDecode, err.Error())
 			}
@@ -135,13 +140,18 @@ func DefaultJSONTxDecoder(cdc codec.ProtoCodecMarshaler) sdk.TxDecoder {
 // a generic ADR-027 checker, it only applies decoding TxRaw. Specifically, it
 // only checks that:
 //   - field numbers are in ascending order (1, 2, and potentially multiple 3s),
-//   - singular fields 1 (body_bytes) and 2 (auth_info_bytes) appear at most once
-//     (field 3 / signatures is repeated and may appear multiple times),
+//   - when rejectDuplicateSingularFields is set, singular fields 1 (body_bytes)
+//     and 2 (auth_info_bytes) appear at most once (field 3 / signatures is
+//     repeated and may appear multiple times),
 //   - and varints are as short as possible.
+//
+// rejectDuplicateSingularFields should be true for live (v6.7+) decoding and
+// false for historical tooling, which must still accept last-wins duplicates
+// that were valid before that check existed.
 //
 // All other ADR-027 edge cases (e.g. default values) are not applicable with
 // TxRaw.
-func rejectNonADR027TxRaw(txBytes []byte) error {
+func rejectNonADR027TxRaw(txBytes []byte, rejectDuplicateSingularFields bool) error {
 	// Make sure all fields are ordered in ascending order with this variable.
 	prevTagNum := protowire.Number(0)
 
@@ -159,7 +169,7 @@ func rejectNonADR027TxRaw(txBytes []byte) error {
 			return fmt.Errorf("txRaw must follow ADR-027, got tagNum %d after tagNum %d", tagNum, prevTagNum)
 		}
 		// body_bytes and auth_info_bytes are singular; only signatures may repeat.
-		if tagNum == prevTagNum && tagNum != 3 {
+		if rejectDuplicateSingularFields && tagNum == prevTagNum && tagNum != 3 {
 			return fmt.Errorf("txRaw must follow ADR-027, field %d appears more than once", tagNum)
 		}
 		prevTagNum = tagNum
@@ -189,10 +199,11 @@ func rejectNonADR027TxRaw(txBytes []byte) error {
 	return nil
 }
 
-// rejectBloatedProto rejects messages where the raw wire encoding is larger
-// than the canonical re-marshal of the decoded struct. This catches protobuf-level
-// bloat (e.g. padded sdk.Int fields, oversized Any.Value, non-canonical encodings)
-// that Unmarshal would otherwise silently canonicalize away before validation runs.
+// rejectBloatedProto rejects messages whose raw wire encoding does not match
+// the size of the canonical re-marshal of the decoded struct. This catches
+// protobuf-level bloat (e.g. padded sdk.Int fields, oversized Any.Value,
+// non-canonical encodings) that Unmarshal would otherwise silently canonicalize
+// away before validation runs.
 func rejectBloatedProto(rawBytes []byte, msg proto.Message, name string) error {
 	canonicalBytes, err := proto.Marshal(msg)
 	if err != nil {

--- a/sei-cosmos/x/auth/tx/decoder.go
+++ b/sei-cosmos/x/auth/tx/decoder.go
@@ -55,6 +55,14 @@ func defaultTxDecoder(cdc codec.ProtoCodecMarshaler, rejectBodyBloat, rejectAuth
 			return nil, err
 		}
 
+		// Reject non-canonical TxRaw envelopes (e.g. explicit default encodings).
+		// Duplicate singular fields are also rejected earlier by rejectNonADR027TxRaw.
+		if rejectBodyBloat || rejectAuthInfoBloat {
+			if err := rejectBloatedProto(txBytes, &raw, "tx raw"); err != nil {
+				return nil, sdkerrors.Wrap(sdkerrors.ErrTxDecode, err.Error())
+			}
+		}
+
 		var body tx.TxBody
 
 		// allow non-critical unknown fields in TxBody
@@ -126,8 +134,11 @@ func DefaultJSONTxDecoder(cdc codec.ProtoCodecMarshaler) sdk.TxDecoder {
 // rejectNonADR027TxRaw rejects txBytes that do not follow ADR-027. This is NOT
 // a generic ADR-027 checker, it only applies decoding TxRaw. Specifically, it
 // only checks that:
-// - field numbers are in ascending order (1, 2, and potentially multiple 3s),
-// - and varints are as short as possible.
+//   - field numbers are in ascending order (1, 2, and potentially multiple 3s),
+//   - singular fields 1 (body_bytes) and 2 (auth_info_bytes) appear at most once
+//     (field 3 / signatures is repeated and may appear multiple times),
+//   - and varints are as short as possible.
+//
 // All other ADR-027 edge cases (e.g. default values) are not applicable with
 // TxRaw.
 func rejectNonADR027TxRaw(txBytes []byte) error {
@@ -146,6 +157,10 @@ func rejectNonADR027TxRaw(txBytes []byte) error {
 		// Make sure fields are ordered in ascending order.
 		if tagNum < prevTagNum {
 			return fmt.Errorf("txRaw must follow ADR-027, got tagNum %d after tagNum %d", tagNum, prevTagNum)
+		}
+		// body_bytes and auth_info_bytes are singular; only signatures may repeat.
+		if tagNum == prevTagNum && tagNum != 3 {
+			return fmt.Errorf("txRaw must follow ADR-027, field %d appears more than once", tagNum)
 		}
 		prevTagNum = tagNum
 

--- a/sei-cosmos/x/auth/tx/decoder.go
+++ b/sei-cosmos/x/auth/tx/decoder.go
@@ -15,7 +15,7 @@ import (
 
 // DefaultTxDecoder returns a default protobuf TxDecoder using the provided Marshaler.
 func DefaultTxDecoder(cdc codec.ProtoCodecMarshaler) sdk.TxDecoder {
-	return defaultTxDecoder(cdc, true)
+	return defaultTxDecoder(cdc, true, true)
 }
 
 // DefaultTxDecoderWithoutBodyBloatRejection returns a protobuf TxDecoder that
@@ -23,10 +23,18 @@ func DefaultTxDecoder(cdc codec.ProtoCodecMarshaler) sdk.TxDecoder {
 // non-canonical TxBody or AuthInfo wire encodings. Do not use this for
 // mempool, CheckTx, or DeliverTx paths.
 func DefaultTxDecoderWithoutBodyBloatRejection(cdc codec.ProtoCodecMarshaler) sdk.TxDecoder {
-	return defaultTxDecoder(cdc, false)
+	return defaultTxDecoder(cdc, false, false)
 }
 
-func defaultTxDecoder(cdc codec.ProtoCodecMarshaler, rejectBloat bool) sdk.TxDecoder {
+// DefaultTxDecoderWithoutAuthInfoBloatRejection returns a protobuf TxDecoder that
+// rejects non-canonical TxBody encodings (v6.5+) but not non-canonical AuthInfo
+// encodings. Used for historical tooling that replays the v6.5-to-v6.8 window.
+// Do not use this for mempool, CheckTx, or DeliverTx paths.
+func DefaultTxDecoderWithoutAuthInfoBloatRejection(cdc codec.ProtoCodecMarshaler) sdk.TxDecoder {
+	return defaultTxDecoder(cdc, true, false)
+}
+
+func defaultTxDecoder(cdc codec.ProtoCodecMarshaler, rejectBodyBloat, rejectAuthInfoBloat bool) sdk.TxDecoder {
 	return func(txBytes []byte) (sdk.Tx, error) {
 		// Make sure txBytes follow ADR-027.
 		err := rejectNonADR027TxRaw(txBytes)
@@ -60,7 +68,7 @@ func defaultTxDecoder(cdc codec.ProtoCodecMarshaler, rejectBloat bool) sdk.TxDec
 			return nil, sdkerrors.Wrap(sdkerrors.ErrTxDecode, err.Error())
 		}
 
-		if rejectBloat {
+		if rejectBodyBloat {
 			if err := rejectBloatedProto(raw.BodyBytes, &body, "tx body"); err != nil {
 				return nil, sdkerrors.Wrap(sdkerrors.ErrTxDecode, err.Error())
 			}
@@ -79,7 +87,7 @@ func defaultTxDecoder(cdc codec.ProtoCodecMarshaler, rejectBloat bool) sdk.TxDec
 			return nil, sdkerrors.Wrap(sdkerrors.ErrTxDecode, err.Error())
 		}
 
-		if rejectBloat {
+		if rejectAuthInfoBloat {
 			if err := rejectBloatedProto(raw.AuthInfoBytes, &authInfo, "tx auth info"); err != nil {
 				return nil, sdkerrors.Wrap(sdkerrors.ErrTxDecode, err.Error())
 			}
@@ -176,7 +184,7 @@ func rejectBloatedProto(rawBytes []byte, msg proto.Message, name string) error {
 		return fmt.Errorf("failed to re-marshal %s: %w", name, err)
 	}
 	if len(rawBytes) != len(canonicalBytes) {
-		return fmt.Errorf("%s wire size (%d) exceeds canonical size (%d)", name, len(rawBytes), len(canonicalBytes))
+		return fmt.Errorf("%s wire size (%d) does not match canonical size (%d)", name, len(rawBytes), len(canonicalBytes))
 	}
 	return nil
 }

--- a/sei-cosmos/x/auth/tx/encode_decode_test.go
+++ b/sei-cosmos/x/auth/tx/encode_decode_test.go
@@ -94,6 +94,72 @@ func TestDefaultTxDecoderWithoutBodyBloatRejection(t *testing.T) {
 	}
 }
 
+func TestDefaultTxDecoderRejectsAuthInfoBloat(t *testing.T) {
+	registry := codectypes.NewInterfaceRegistry()
+	testdata.RegisterInterfaces(registry)
+	cdc := codec.NewProtoCodec(registry)
+
+	builder := newBuilder()
+	require.NoError(t, builder.SetMsgs(testdata.NewTestMsg()))
+	builder.SetGasLimit(127)
+
+	txBz, err := DefaultTxEncoder()(builder.GetTx())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name   string
+		mutate func([]byte) []byte
+		assert func(*testing.T, *wrapper)
+	}{
+		{
+			name: "fee field encoded twice",
+			mutate: func(authInfoBytes []byte) []byte {
+				fee := &tx.Fee{GasLimit: 127}
+				feeBz, err := fee.Marshal()
+				require.NoError(t, err)
+				extra := protowire.AppendTag(nil, 2, protowire.BytesType)
+				extra = protowire.AppendBytes(extra, feeBz)
+				return append(authInfoBytes, extra...)
+			},
+			assert: func(t *testing.T, decoded *wrapper) {
+				require.Equal(t, uint64(127), decoded.GetGas())
+			},
+		},
+		{
+			name: "payer explicitly encoded as default empty string inside fee",
+			mutate: func(authInfoBytes []byte) []byte {
+				// Fee tag 2 with an inner payer="" (tag 3, empty bytes).
+				feeBz := []byte{0x1a, 0x00}
+				extra := protowire.AppendTag(nil, 2, protowire.BytesType)
+				extra = protowire.AppendBytes(extra, feeBz)
+				return append(authInfoBytes, extra...)
+			},
+			assert: func(t *testing.T, decoded *wrapper) {
+				require.Equal(t, uint64(127), decoded.GetGas())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var raw tx.TxRaw
+			require.NoError(t, raw.Unmarshal(txBz))
+			raw.AuthInfoBytes = tt.mutate(raw.AuthInfoBytes)
+			bloatedTxBz, err := raw.Marshal()
+			require.NoError(t, err)
+
+			_, err = DefaultTxDecoder(cdc)(bloatedTxBz)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "exceeds canonical size")
+			require.Contains(t, err.Error(), "auth info")
+
+			decoded, err := DefaultTxDecoderWithoutBodyBloatRejection(cdc)(bloatedTxBz)
+			require.NoError(t, err)
+			tt.assert(t, decoded.(*wrapper))
+		})
+	}
+}
+
 func TestUnknownFields(t *testing.T) {
 	registry := codectypes.NewInterfaceRegistry()
 	cdc := codec.NewProtoCodec(registry)

--- a/sei-cosmos/x/auth/tx/encode_decode_test.go
+++ b/sei-cosmos/x/auth/tx/encode_decode_test.go
@@ -187,7 +187,7 @@ func TestDefaultTxDecoderRejectsAuthInfoBloat(t *testing.T) {
 			require.Contains(t, err.Error(), "does not match canonical size")
 			require.Contains(t, err.Error(), "auth info")
 
-			// v6.5-to-v6.8 window: body checks on, AuthInfo checks off.
+			// v6.5-to-v6.7 window: body checks on, AuthInfo checks off.
 			decoded, err := DefaultTxDecoderWithoutAuthInfoBloatRejection(cdc)(bloatedTxBz)
 			require.NoError(t, err)
 			tt.assert(t, decoded.(*wrapper))

--- a/sei-cosmos/x/auth/tx/encode_decode_test.go
+++ b/sei-cosmos/x/auth/tx/encode_decode_test.go
@@ -6,13 +6,14 @@ import (
 	"math"
 	"testing"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protowire"
 
 	"github.com/sei-protocol/sei-chain/sei-cosmos/codec"
 	codectypes "github.com/sei-protocol/sei-chain/sei-cosmos/codec/types"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/testutil/testdata"
-
+	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/types/tx"
 	signingtypes "github.com/sei-protocol/sei-chain/sei-cosmos/types/tx/signing"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/signing"
@@ -85,13 +86,33 @@ func TestDefaultTxDecoderWithoutBodyBloatRejection(t *testing.T) {
 
 			_, err = DefaultTxDecoder(cdc)(bloatedTxBz)
 			require.Error(t, err)
-			require.Contains(t, err.Error(), "exceeds canonical size")
+			require.Contains(t, err.Error(), "does not match canonical size")
 
 			decoded, err := DefaultTxDecoderWithoutBodyBloatRejection(cdc)(bloatedTxBz)
 			require.NoError(t, err)
 			tt.assert(t, decoded.(*wrapper))
 		})
 	}
+}
+
+func TestDefaultTxDecoderAcceptsCanonicalAuthInfo(t *testing.T) {
+	registry := codectypes.NewInterfaceRegistry()
+	testdata.RegisterInterfaces(registry)
+	cdc := codec.NewProtoCodec(registry)
+
+	builder := newBuilder()
+	require.NoError(t, builder.SetMsgs(testdata.NewTestMsg()))
+	builder.SetGasLimit(127)
+	builder.SetFeeAmount(sdk.NewCoins(sdk.NewInt64Coin("stake", 5)))
+
+	txBz, err := DefaultTxEncoder()(builder.GetTx())
+	require.NoError(t, err)
+
+	decoded, err := DefaultTxDecoder(cdc)(txBz)
+	require.NoError(t, err)
+	w := decoded.(*wrapper)
+	require.Equal(t, uint64(127), w.GetGas())
+	require.Equal(t, sdk.NewCoins(sdk.NewInt64Coin("stake", 5)), w.GetFee())
 }
 
 func TestDefaultTxDecoderRejectsAuthInfoBloat(t *testing.T) {
@@ -108,12 +129,12 @@ func TestDefaultTxDecoderRejectsAuthInfoBloat(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		mutate func([]byte) []byte
+		mutate func(*testing.T, []byte) []byte
 		assert func(*testing.T, *wrapper)
 	}{
 		{
 			name: "fee field encoded twice",
-			mutate: func(authInfoBytes []byte) []byte {
+			mutate: func(t *testing.T, authInfoBytes []byte) []byte {
 				fee := &tx.Fee{GasLimit: 127}
 				feeBz, err := fee.Marshal()
 				require.NoError(t, err)
@@ -127,12 +148,25 @@ func TestDefaultTxDecoderRejectsAuthInfoBloat(t *testing.T) {
 		},
 		{
 			name: "payer explicitly encoded as default empty string inside fee",
-			mutate: func(authInfoBytes []byte) []byte {
-				// Fee tag 2 with an inner payer="" (tag 3, empty bytes).
-				feeBz := []byte{0x1a, 0x00}
-				extra := protowire.AppendTag(nil, 2, protowire.BytesType)
-				extra = protowire.AppendBytes(extra, feeBz)
-				return append(authInfoBytes, extra...)
+			mutate: func(t *testing.T, authInfoBytes []byte) []byte {
+				var authInfo tx.AuthInfo
+				require.NoError(t, authInfo.Unmarshal(authInfoBytes))
+				require.NotNil(t, authInfo.Fee)
+
+				out := make([]byte, 0, len(authInfoBytes)+2)
+				for _, si := range authInfo.SignerInfos {
+					siBz, err := proto.Marshal(si)
+					require.NoError(t, err)
+					out = protowire.AppendTag(out, 1, protowire.BytesType)
+					out = protowire.AppendBytes(out, siBz)
+				}
+				feeBz, err := proto.Marshal(authInfo.Fee)
+				require.NoError(t, err)
+				// Explicit empty payer (tag 3) inside the single Fee message.
+				feeBz = append(feeBz, 0x1a, 0x00)
+				out = protowire.AppendTag(out, 2, protowire.BytesType)
+				out = protowire.AppendBytes(out, feeBz)
+				return out
 			},
 			assert: func(t *testing.T, decoded *wrapper) {
 				require.Equal(t, uint64(127), decoded.GetGas())
@@ -144,16 +178,21 @@ func TestDefaultTxDecoderRejectsAuthInfoBloat(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var raw tx.TxRaw
 			require.NoError(t, raw.Unmarshal(txBz))
-			raw.AuthInfoBytes = tt.mutate(raw.AuthInfoBytes)
+			raw.AuthInfoBytes = tt.mutate(t, raw.AuthInfoBytes)
 			bloatedTxBz, err := raw.Marshal()
 			require.NoError(t, err)
 
 			_, err = DefaultTxDecoder(cdc)(bloatedTxBz)
 			require.Error(t, err)
-			require.Contains(t, err.Error(), "exceeds canonical size")
+			require.Contains(t, err.Error(), "does not match canonical size")
 			require.Contains(t, err.Error(), "auth info")
 
-			decoded, err := DefaultTxDecoderWithoutBodyBloatRejection(cdc)(bloatedTxBz)
+			// v6.5-to-v6.8 window: body checks on, AuthInfo checks off.
+			decoded, err := DefaultTxDecoderWithoutAuthInfoBloatRejection(cdc)(bloatedTxBz)
+			require.NoError(t, err)
+			tt.assert(t, decoded.(*wrapper))
+
+			decoded, err = DefaultTxDecoderWithoutBodyBloatRejection(cdc)(bloatedTxBz)
 			require.NoError(t, err)
 			tt.assert(t, decoded.(*wrapper))
 		})

--- a/sei-cosmos/x/auth/tx/encode_decode_test.go
+++ b/sei-cosmos/x/auth/tx/encode_decode_test.go
@@ -461,7 +461,7 @@ func TestDefaultTxDecoderRejectsTxRawBloat(t *testing.T) {
 
 	bodyField := protowire.AppendTag(nil, 1, protowire.BytesType)
 	bodyField = protowire.AppendBytes(bodyField, raw.BodyBytes)
-	// Explicit empty auth_info_bytes (omitted by canonical remashal).
+	// Explicit empty auth_info_bytes (omitted by canonical remarshal).
 	emptyAuthField := protowire.AppendTag(nil, 2, protowire.BytesType)
 	emptyAuthField = protowire.AppendBytes(emptyAuthField, []byte{})
 	bloatedTxBz := append(bodyField, emptyAuthField...)
@@ -471,11 +471,11 @@ func TestDefaultTxDecoderRejectsTxRawBloat(t *testing.T) {
 	require.Contains(t, err.Error(), "does not match canonical size")
 	require.Contains(t, err.Error(), "tx raw")
 
-	// Fully lenient decoder skips the TxRaw remashal check.
+	// Fully lenient decoder skips the TxRaw remarshal check.
 	_, err = DefaultTxDecoderWithoutBodyBloatRejection(cdc)(bloatedTxBz)
 	require.NoError(t, err)
 
-	// v6.5-to-v6.7 body-strict / AuthInfo-lenient also skips the TxRaw remashal
+	// v6.5-to-v6.7 body-strict / AuthInfo-lenient also skips the TxRaw remarshal
 	// check (it did not exist during live execution in that window).
 	_, err = DefaultTxDecoderWithoutAuthInfoBloatRejection(cdc)(bloatedTxBz)
 	require.NoError(t, err)

--- a/sei-cosmos/x/auth/tx/encode_decode_test.go
+++ b/sei-cosmos/x/auth/tx/encode_decode_test.go
@@ -428,6 +428,20 @@ func TestRejectNonADR027(t *testing.T) {
 			}
 		})
 	}
+
+	// Lenient decoders must still accept last-wins duplicates of singular TxRaw
+	// fields that were valid before the v6.7 singularity check.
+	dupBodyBz := append(append(append(bodyBz, bodyBz...), authInfoBz...), sigsBz...)
+	_, err = DefaultTxDecoderWithoutBodyBloatRejection(cdc)(dupBodyBz)
+	require.NoError(t, err)
+	_, err = DefaultTxDecoderWithoutAuthInfoBloatRejection(cdc)(dupBodyBz)
+	require.NoError(t, err)
+
+	dupAuthBz := append(append(append(bodyBz, authInfoBz...), authInfoBz...), sigsBz...)
+	_, err = DefaultTxDecoderWithoutBodyBloatRejection(cdc)(dupAuthBz)
+	require.NoError(t, err)
+	_, err = DefaultTxDecoderWithoutAuthInfoBloatRejection(cdc)(dupAuthBz)
+	require.NoError(t, err)
 }
 
 func TestDefaultTxDecoderRejectsTxRawBloat(t *testing.T) {
@@ -461,10 +475,10 @@ func TestDefaultTxDecoderRejectsTxRawBloat(t *testing.T) {
 	_, err = DefaultTxDecoderWithoutBodyBloatRejection(cdc)(bloatedTxBz)
 	require.NoError(t, err)
 
-	// body-strict / AuthInfo-lenient still applies the TxRaw remashal check.
+	// v6.5-to-v6.7 body-strict / AuthInfo-lenient also skips the TxRaw remashal
+	// check (it did not exist during live execution in that window).
 	_, err = DefaultTxDecoderWithoutAuthInfoBloatRejection(cdc)(bloatedTxBz)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "tx raw")
+	require.NoError(t, err)
 }
 
 func TestVarintMinLength(t *testing.T) {

--- a/sei-cosmos/x/auth/tx/encode_decode_test.go
+++ b/sei-cosmos/x/auth/tx/encode_decode_test.go
@@ -400,6 +400,21 @@ func TestRejectNonADR027(t *testing.T) {
 			append(append(longVarintBodyBz, authInfoBz...), sigsBz...),
 			true,
 		},
+		{
+			"body_bytes field encoded twice",
+			append(append(append(bodyBz, bodyBz...), authInfoBz...), sigsBz...),
+			true,
+		},
+		{
+			"auth_info_bytes field encoded twice",
+			append(append(append(bodyBz, authInfoBz...), authInfoBz...), sigsBz...),
+			true,
+		},
+		{
+			"signatures field encoded twice (valid repeated field)",
+			append(append(append(bodyBz, authInfoBz...), sigsBz...), sigsBz...),
+			false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -413,6 +428,43 @@ func TestRejectNonADR027(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDefaultTxDecoderRejectsTxRawBloat(t *testing.T) {
+	registry := codectypes.NewInterfaceRegistry()
+	testdata.RegisterInterfaces(registry)
+	cdc := codec.NewProtoCodec(registry)
+
+	builder := newBuilder()
+	require.NoError(t, builder.SetMsgs(testdata.NewTestMsg()))
+	builder.SetGasLimit(127)
+
+	txBz, err := DefaultTxEncoder()(builder.GetTx())
+	require.NoError(t, err)
+
+	var raw tx.TxRaw
+	require.NoError(t, raw.Unmarshal(txBz))
+
+	bodyField := protowire.AppendTag(nil, 1, protowire.BytesType)
+	bodyField = protowire.AppendBytes(bodyField, raw.BodyBytes)
+	// Explicit empty auth_info_bytes (omitted by canonical remashal).
+	emptyAuthField := protowire.AppendTag(nil, 2, protowire.BytesType)
+	emptyAuthField = protowire.AppendBytes(emptyAuthField, []byte{})
+	bloatedTxBz := append(bodyField, emptyAuthField...)
+
+	_, err = DefaultTxDecoder(cdc)(bloatedTxBz)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not match canonical size")
+	require.Contains(t, err.Error(), "tx raw")
+
+	// Fully lenient decoder skips the TxRaw remashal check.
+	_, err = DefaultTxDecoderWithoutBodyBloatRejection(cdc)(bloatedTxBz)
+	require.NoError(t, err)
+
+	// body-strict / AuthInfo-lenient still applies the TxRaw remashal check.
+	_, err = DefaultTxDecoderWithoutAuthInfoBloatRejection(cdc)(bloatedTxBz)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tx raw")
 }
 
 func TestVarintMinLength(t *testing.T) {


### PR DESCRIPTION
## Summary
- Apply the existing TxBody wire-vs-remarshal size check to AuthInfo in `DefaultTxDecoder` (live CheckTx/DeliverTx)
- Reject duplicate singular TxRaw fields (`body_bytes` / `auth_info_bytes`) and TxRaw envelope remashal on the **v6.7+** (fully strict) path only
- Split decoder strictness so `debug_trace*` can use:
  - pre-v6.5: body + AuthInfo + TxRaw envelope lenient
  - v6.5 to v6.7: body strict; AuthInfo + TxRaw envelope + singular-dup lenient
  - v6.7+: fully strict
- Historical-replay builds still use the fully lenient decoder

## Test plan
- [x] `GOWORK=off go test github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/tx -count=1 -run 'TestDefaultTxDecoder|TestRejectNonADR027|TestUnknownFields'`
- [x] `GOWORK=off go test github.com/sei-protocol/sei-chain/evmrpc -count=1 -run 'TestTraceBlockByNumberUsesCompatDecoder'`
- [ ] CI package tests