### PR TITLE
Bump sei go-ethereum to v1.15.7-sei-19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -279,7 +279,7 @@ replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
 	github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.23.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.15.7-sei-18
+	github.com/ethereum/go-ethereum => github.com/sei-protocol/go-ethereum v1.15.7-sei-19
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/keybase/go-keychain => github.com/keybase/go-keychain v0.0.0-20190712205309-48d3d31d256d

--- a/go.sum
+++ b/go.sum
@@ -1807,8 +1807,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/segmentio/kafka-go v0.4.50 h1:mcyC3tT5WeyWzrFbd6O374t+hmcu1NKt2Pu1L3QaXmc=
 github.com/segmentio/kafka-go v0.4.50/go.mod h1:Y1gn60kzLEEaW28YshXyk2+VCUKbJ3Qr6DrnT3i4+9E=
-github.com/sei-protocol/go-ethereum v1.15.7-sei-18 h1:de8M2eVCTF/UXgLZ7DyGMmQH3pUxonvtIzK9fBqenNc=
-github.com/sei-protocol/go-ethereum v1.15.7-sei-18/go.mod h1:+S9k+jFzlyVTNcYGvqFhzN/SFhI6vA+aOY4T5tLSPL0=
+github.com/sei-protocol/go-ethereum v1.15.7-sei-19 h1:PHnkoWn/Ajwru784Jy6ZSItcfEP+cI6PQq3Y+Y4U9R4=
+github.com/sei-protocol/go-ethereum v1.15.7-sei-19/go.mod h1:+S9k+jFzlyVTNcYGvqFhzN/SFhI6vA+aOY4T5tLSPL0=
 github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQpIbXDA=
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-config v0.0.21 h1:0VXOz91v9YeM2dmpKi1XaIFy+p3EamDAJtnj02XLKIw=


### PR DESCRIPTION
## Describe your changes and provide context

Bumps the `sei-protocol/go-ethereum` fork dependency from `v1.15.7-sei-18` to `v1.15.7-sei-19`.

Notable changes picked up in this bump:
- WebSocket admission-control hardening: bounded in-progress frame decode with `wsAdmissionTimeout`, fixed a handler-shadowing bug, added an admission event hook for oversized frames, and closed budget-commit/timeout-misclassification edge cases.
- Restored `io.EOF` -> `io.ErrUnexpectedEOF` mapping in `websocketCodec.readBatch` that was previously provided by gorilla.
- `core/vm`: skip a full code load when the code cannot possibly be a 7702 delegation designator, gating CALL-family gas and `resolveCodeHash` on `GetCodeSize`/`IsDelegationDesignatorLength`.

## Testing performed to validate your change

- `go.sum` updated via `go mod tidy`/`go mod verify` against the new fork tag; no source changes required in this repo beyond the dependency bump.
