### PR TITLE
perf(evm): memoize deliver GetCode (+ giga); fix pointer upsert Multistore write target (CON-361)

### DIFF
--- a/evmrpc/tests/mock_contracts.go
+++ b/evmrpc/tests/mock_contracts.go
@@ -3,13 +3,11 @@ package tests
 import (
 	"encoding/hex"
 	"fmt"
-	"math"
 	"os"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/sei-protocol/sei-chain/app"
@@ -17,7 +15,6 @@ import (
 	"github.com/sei-protocol/sei-chain/utils"
 	"github.com/sei-protocol/sei-chain/x/evm/derived"
 	"github.com/sei-protocol/sei-chain/x/evm/keeper"
-	"github.com/sei-protocol/sei-chain/x/evm/state"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 	"github.com/sei-protocol/sei-chain/x/evm/types/ethtx"
 )
@@ -43,13 +40,13 @@ func cw20Initializer(mnemonic string, pointer bool) func(ctx sdk.Context, a *app
 		a.EvmKeeper.SetAddressMapping(ctx, contractAddr, evmAddr)
 
 		if pointer {
-			blockCtx, err := a.EvmKeeper.GetVMBlockContext(ctx, core.GasPool(math.MaxUint64))
-			if err != nil {
-				panic(err)
-			}
-			cfg := types.DefaultChainConfig().EthereumConfig(a.EvmKeeper.ChainID(ctx))
-			evmInstance := vm.NewEVM(*blockCtx, state.NewDBImpl(ctx, &a.EvmKeeper, false), cfg, vm.Config{}, a.EvmKeeper.CustomPrecompiles(ctx))
-			_, err = a.EvmKeeper.UpsertERCCW20Pointer(ctx, evmInstance, contractAddr.String(), utils.ERCMetadata{Name: "test", Symbol: "test"})
+			// Upsert writes via StateDB; Finalize so pointer registry persists.
+			err = a.EvmKeeper.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
+				_, err := a.EvmKeeper.UpsertERCCW20Pointer(ctx, e, contractAddr.String(), utils.ERCMetadata{Name: "test", Symbol: "test"})
+				return err
+			}, func(step, msg string) {
+				panic(fmt.Sprintf("UpsertERCCW20Pointer %s: %s", step, msg))
+			})
 			if err != nil {
 				panic(err)
 			}

--- a/giga/deps/xevm/state/code.go
+++ b/giga/deps/xevm/state/code.go
@@ -10,7 +10,24 @@ func (s *DBImpl) GetCodeHash(addr common.Address) common.Hash {
 }
 
 func (s *DBImpl) GetCode(addr common.Address) []byte {
-	return s.k.GetCode(s.ctx, addr)
+	// nil codeCache means caching is disabled (simulation/RPC/trace); never allocate here.
+	if s.codeCache != nil {
+		if code, ok := s.codeCache[addr]; ok {
+			return code
+		}
+	}
+	code := s.k.GetCode(s.ctx, addr)
+	if s.codeCache == nil {
+		return code
+	}
+	// Keep empty code as nil to match Keeper.GetCode, and store a copy so the
+	// memo is not aliased to the keeper/store-backed slice.
+	if len(code) == 0 {
+		s.codeCache[addr] = nil
+		return nil
+	}
+	s.putCodeCache(addr, code)
+	return s.codeCache[addr]
 }
 
 func (s *DBImpl) SetCode(addr common.Address, code []byte) []byte {
@@ -23,7 +40,40 @@ func (s *DBImpl) SetCode(addr common.Address, code []byte) []byte {
 	}
 
 	s.k.SetCode(s.ctx, addr, code)
+	s.journalCodeCacheMutation(addr)
+	s.putCodeCache(addr, code)
 	return oldCode
+}
+
+// RefreshCodeCache updates the deliver-tx code memo after a keeper store write
+// that bypassed SetCode (so gas can be charged against a different ctx meter).
+func (s *DBImpl) RefreshCodeCache(addr common.Address, code []byte) {
+	s.journalCodeCacheMutation(addr)
+	s.putCodeCache(addr, code)
+}
+
+// journalCodeCacheMutation records the prior memo entry so RevertToSnapshot can
+// restore this address only. Call before putCodeCache / delete on mutation paths;
+// pure GetCode fills must not journal (nested reverts should keep those warms).
+func (s *DBImpl) journalCodeCacheMutation(addr common.Address) {
+	if s.codeCache == nil {
+		return
+	}
+	prev, had := s.codeCache[addr]
+	s.journal = append(s.journal, &codeCacheChange{account: addr, prev: prev, had: had})
+}
+
+func (s *DBImpl) putCodeCache(addr common.Address, code []byte) {
+	if s.codeCache == nil {
+		return
+	}
+	if len(code) == 0 {
+		s.codeCache[addr] = nil
+		return
+	}
+	cached := make([]byte, len(code))
+	copy(cached, code)
+	s.codeCache[addr] = cached
 }
 
 func (s *DBImpl) GetCodeSize(addr common.Address) int {

--- a/giga/deps/xevm/state/code_test.go
+++ b/giga/deps/xevm/state/code_test.go
@@ -27,3 +27,158 @@ func TestCode(t *testing.T) {
 	require.Equal(t, code, statedb.GetCode(addr))
 	require.Equal(t, 5, statedb.GetCodeSize(addr))
 }
+
+func TestCodeCacheHitAndSetCodeUpdate(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	_, addr := testkeeper.MockAddressPair()
+	statedb := state.NewDBImpl(ctx, k, false)
+
+	code := []byte{1, 2, 3, 4, 5}
+	statedb.SetCode(addr, code)
+	require.Equal(t, code, statedb.GetCode(addr))
+	require.Equal(t, code, statedb.GetCode(addr))
+
+	updated := []byte{9, 8, 7}
+	statedb.SetCode(addr, updated)
+	require.Equal(t, updated, statedb.GetCode(addr))
+	require.Equal(t, crypto.Keccak256Hash(updated), statedb.GetCodeHash(addr))
+}
+
+func TestCodeCacheClearedOnRevert(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	_, addr := testkeeper.MockAddressPair()
+	statedb := state.NewDBImpl(ctx, k, false)
+
+	initial := []byte{1, 2, 3}
+	statedb.SetCode(addr, initial)
+	require.Equal(t, initial, statedb.GetCode(addr))
+
+	rev := statedb.Snapshot()
+	updated := []byte{4, 5, 6, 7}
+	statedb.SetCode(addr, updated)
+	require.Equal(t, updated, statedb.GetCode(addr))
+
+	statedb.RevertToSnapshot(rev)
+	require.Equal(t, initial, statedb.GetCode(addr))
+}
+
+// TestCodeCacheUnrelatedWarmSurvivesRevert pins address-level journal restore
+// (parity with x/evm/state): nested reverts must not wipe unrelated warms.
+func TestCodeCacheUnrelatedWarmSurvivesRevert(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	_, addrA := testkeeper.MockAddressPair()
+	_, addrB := testkeeper.MockAddressPair()
+	statedb := state.NewDBImpl(ctx, k, false)
+
+	codeA := []byte{1, 2, 3}
+	codeB := []byte{10, 11, 12, 13}
+	statedb.SetCode(addrA, codeA)
+	statedb.SetCode(addrB, codeB)
+	require.Equal(t, codeB, statedb.GetCode(addrB))
+
+	rev := statedb.Snapshot()
+	statedb.SetCode(addrA, []byte{9, 9, 9})
+	statedb.RevertToSnapshot(rev)
+	require.Equal(t, codeA, statedb.GetCode(addrA))
+
+	poison := []byte{7, 7, 7, 7, 7}
+	k.SetCode(statedb.Ctx(), addrB, poison)
+	require.Equal(t, codeB, statedb.GetCode(addrB), "unrelated warm must survive revert (not re-read poison)")
+	require.Equal(t, poison, k.GetCode(statedb.Ctx(), addrB))
+}
+
+func TestCodeCacheInvalidatedOnCreateAccount(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	_, addr := testkeeper.MockAddressPair()
+	statedb := state.NewDBImpl(ctx, k, false)
+
+	statedb.CreateAccount(addr)
+	statedb.SetCode(addr, []byte("code"))
+	require.Equal(t, []byte("code"), statedb.GetCode(addr))
+
+	statedb.CreateAccount(addr)
+	require.Nil(t, statedb.GetCode(addr))
+	require.Equal(t, 0, statedb.GetCodeSize(addr))
+}
+
+func TestCodeCacheEmptyMatchesKeeperNil(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	_, addr := testkeeper.MockAddressPair()
+	statedb := state.NewDBImpl(ctx, k, false)
+
+	statedb.SetCode(addr, []byte{})
+	require.Nil(t, statedb.GetCode(addr))
+	require.Equal(t, 0, statedb.GetCodeSize(addr))
+	require.Nil(t, statedb.GetCode(addr))
+}
+
+func TestCodeCacheMissHitFromPreSeededKeeperCode(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	_, addr := testkeeper.MockAddressPair()
+
+	code := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	k.SetCode(ctx, addr, code)
+
+	statedb := state.NewDBImpl(ctx, k, false)
+	require.Equal(t, code, statedb.GetCode(addr))
+	require.Equal(t, code, statedb.GetCode(addr))
+	require.Equal(t, len(code), statedb.GetCodeSize(addr))
+}
+
+func TestCodeCacheCopyStartsEmptyAndIndependent(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	_, addr := testkeeper.MockAddressPair()
+	parent := state.NewDBImpl(ctx, k, false)
+
+	initial := []byte{1, 2, 3}
+	parent.SetCode(addr, initial)
+	require.Equal(t, initial, parent.GetCode(addr))
+
+	child := parent.Copy().(*state.DBImpl)
+	require.Equal(t, initial, child.GetCode(addr))
+
+	updated := []byte{9, 9, 9}
+	parent.SetCode(addr, updated)
+	require.Equal(t, updated, parent.GetCode(addr))
+	require.Equal(t, initial, child.GetCode(addr))
+
+	childUpdated := []byte{7, 7}
+	child.SetCode(addr, childUpdated)
+	require.Equal(t, childUpdated, child.GetCode(addr))
+	require.Equal(t, updated, parent.GetCode(addr))
+}
+
+func TestCodeCacheDisabledForSimulation(t *testing.T) {
+	k, ctx := testkeeper.MockEVMKeeper(t)
+	ctx = ctx.WithBlockTime(time.Now())
+	_, addr := testkeeper.MockAddressPair()
+
+	initial := []byte{1, 2, 3}
+	updated := []byte{9, 9, 9, 9}
+
+	deliver := state.NewDBImpl(ctx, k, false)
+	deliver.SetCode(addr, initial)
+	require.Equal(t, initial, deliver.GetCode(addr))
+	deliver.SetCode(addr, updated)
+	require.Equal(t, updated, deliver.GetCode(addr))
+
+	_, addr2 := testkeeper.MockAddressPair()
+	deliver.SetCode(addr2, initial)
+	require.Equal(t, initial, deliver.GetCode(addr2))
+	k.SetCode(deliver.Ctx(), addr2, updated)
+	deliver.RefreshCodeCache(addr2, updated)
+	require.Equal(t, updated, deliver.GetCode(addr2))
+
+	sim := state.NewDBImpl(ctx, k, true)
+	sim.SetCode(addr, initial)
+	require.Equal(t, initial, sim.GetCode(addr))
+	k.SetCode(sim.Ctx(), addr, updated)
+	require.Equal(t, updated, sim.GetCode(addr))
+}

--- a/giga/deps/xevm/state/journal.go
+++ b/giga/deps/xevm/state/journal.go
@@ -66,6 +66,15 @@ type (
 		delta sdk.Int
 	}
 
+	// codeCacheChange restores a single memo entry on revert. GetCode fills are
+	// not journaled — only SetCode / RefreshCodeCache / account-code clears —
+	// so nested reverts do not wipe unrelated warmed bytecode.
+	codeCacheChange struct {
+		account common.Address
+		prev    []byte
+		had     bool // whether account was present in the memo before the mutation
+	}
+
 	watermark struct {
 		version int
 	}
@@ -158,6 +167,17 @@ func (e *storageOverrideInstall) revert(s *DBImpl) {
 }
 
 func (e *watermark) revert(s *DBImpl) {}
+
+func (e *codeCacheChange) revert(s *DBImpl) {
+	if s.codeCache == nil {
+		return
+	}
+	if e.had {
+		s.codeCache[e.account] = e.prev
+		return
+	}
+	delete(s.codeCache, e.account)
+}
 
 func (e *accountStatusChange) revert(s *DBImpl) {
 	accts := s.tempState.transientAccounts

--- a/giga/deps/xevm/state/journal_test.go
+++ b/giga/deps/xevm/state/journal_test.go
@@ -138,3 +138,29 @@ func TestStorageOverrideInstallRevert_Restore(t *testing.T) {
 	change.revert(db)
 	require.Equal(t, common.Hash{15}, db.tempState.storageOverrides[addr].current[slot.Hex()])
 }
+
+func TestCodeCacheChangeRevert_Restore(t *testing.T) {
+	db := &DBImpl{codeCache: map[common.Address][]byte{}}
+	addr := common.Address{20}
+	prev := []byte{1, 2, 3}
+	db.codeCache[addr] = []byte{9, 9}
+	change := &codeCacheChange{account: addr, prev: prev, had: true}
+	change.revert(db)
+	require.Equal(t, prev, db.codeCache[addr])
+}
+
+func TestCodeCacheChangeRevert_Delete(t *testing.T) {
+	db := &DBImpl{codeCache: map[common.Address][]byte{}}
+	addr := common.Address{21}
+	db.codeCache[addr] = []byte{4, 5}
+	change := &codeCacheChange{account: addr, had: false}
+	change.revert(db)
+	_, ok := db.codeCache[addr]
+	require.False(t, ok)
+}
+
+func TestCodeCacheChangeRevert_NilCacheNoop(t *testing.T) {
+	db := &DBImpl{}
+	change := &codeCacheChange{account: common.Address{22}, prev: []byte{1}, had: true}
+	require.NotPanics(t, func() { change.revert(db) })
+}

--- a/giga/deps/xevm/state/state.go
+++ b/giga/deps/xevm/state/state.go
@@ -169,7 +169,8 @@ func (s *DBImpl) RevertToSnapshot(rev int) {
 		}
 	}
 
-	// Truncate the journal to remove reverted entries
+	// Truncate the journal to remove reverted entries. codeCache mutations are
+	// journaled per address (codeCacheChange), so unrelated warmed entries survive.
 	if watermarkIndex >= 0 {
 		s.journal = s.journal[:watermarkIndex]
 	}
@@ -218,6 +219,10 @@ func (s *DBImpl) clearAccountCodeAndNonce(acc common.Address) {
 	deleteIfExists(s.k.PrefixStore(s.ctx, types.CodeKeyPrefix), acc[:])
 	deleteIfExists(s.k.PrefixStore(s.ctx, types.CodeSizeKeyPrefix), acc[:])
 	deleteIfExists(s.k.PrefixStore(s.ctx, types.NonceKeyPrefix), acc[:])
+	s.journalCodeCacheMutation(acc)
+	if s.codeCache != nil {
+		delete(s.codeCache, acc)
+	}
 }
 
 func (s *DBImpl) MarkAccount(acc common.Address, status []byte) {

--- a/giga/deps/xevm/state/statedb.go
+++ b/giga/deps/xevm/state/statedb.go
@@ -23,6 +23,14 @@ type DBImpl struct {
 	tempState *TemporaryState
 	journal   []journalEntry
 
+	// codeCache memos runtime bytecode so repeated GetCode calls do not re-read
+	// the KV store. nil disables caching (never lazily allocated): simulation /
+	// RPC / trace DBs leave it nil. Mutations (SetCode / RefreshCodeCache /
+	// account-code clear) are journaled per address so RevertToSnapshot restores
+	// only those entries; GetCode fills are not journaled. Cleanup / tracer reset
+	// clear the whole map. Copy() starts empty when the parent had caching enabled.
+	codeCache map[common.Address][]byte
+
 	// If err is not nil at the end of the execution, the transaction will be rolled
 	// back.
 	err error
@@ -57,6 +65,10 @@ func NewDBImpl(ctx sdk.Context, k EVMKeeper, simulation bool) *DBImpl {
 		journal:            []journalEntry{},
 		coinbaseEvmAddress: feeCollector,
 	}
+	// Enable the memo only for ordinary deliver txs (parity with x/evm/state).
+	if !simulation {
+		s.codeCache = make(map[common.Address][]byte)
+	}
 	s.Snapshot() // take an initial snapshot for GetCommitted
 	return s
 }
@@ -86,6 +98,7 @@ func (s *DBImpl) Cleanup() {
 	s.tempState = nil
 	s.logger = nil
 	s.snapshottedCtxs = nil
+	clear(s.codeCache)
 }
 
 func (s *DBImpl) CleanupForTracer() {
@@ -98,6 +111,7 @@ func (s *DBImpl) CleanupForTracer() {
 	s.tempState = NewTemporaryState()
 	s.journal = []journalEntry{}
 	s.snapshottedCtxs = []sdk.Context{}
+	clear(s.codeCache)
 	s.Snapshot()
 }
 
@@ -110,6 +124,7 @@ func (s *DBImpl) ResetForTracer() {
 	s.coinbaseEvmAddress = feeCollector
 	s.tempState = NewTemporaryState()
 	s.journal = []journalEntry{}
+	clear(s.codeCache)
 	s.Snapshot()
 }
 
@@ -175,7 +190,7 @@ func (s *DBImpl) Copy() vm.StateDB {
 	snapshots := make([]sdk.Context, len(s.snapshottedCtxs)+1)
 	copy(snapshots, s.snapshottedCtxs)
 	snapshots[len(s.snapshottedCtxs)] = s.ctx
-	return &DBImpl{
+	copied := &DBImpl{
 		ctx:                newCtx,
 		snapshottedCtxs:    snapshots,
 		tempState:          s.tempState.DeepCopy(),
@@ -188,6 +203,12 @@ func (s *DBImpl) Copy() vm.StateDB {
 		precompileErr:      s.precompileErr,
 		logger:             s.logger,
 	}
+	// Deliver copies start with an empty cache (reload on demand). If the parent
+	// had caching disabled (nil), keep it disabled — do not allocate.
+	if s.codeCache != nil {
+		copied.codeCache = make(map[common.Address][]byte)
+	}
+	return copied
 }
 
 func (s *DBImpl) Finalise(bool) {

--- a/x/evm/AGENTS.md
+++ b/x/evm/AGENTS.md
@@ -69,6 +69,7 @@ Key design choices:
 
 - **Balance representation** — Sei uses 6-decimal `usei` while EVM expects 18-decimal wei. The StateDB converts between them, tracking the sub-usei remainder (`wei`) separately.
 - **Snapshots and reverts** — uses Cosmos `CacheMultiStore` for state snapshots. A journal records every state mutation so it can be rolled back on revert.
+- **Deliver-tx code memo** — ordinary deliver `DBImpl` memos `GetCode` bytecode (`codeCache`). Simulation / RPC / trace / wasmd-entry leave it nil. Mutations go through `SetCode` or `RefreshCodeCache` (keeper bypasses) and are journaled per address so nested reverts do not wipe unrelated warms. `GetCodeSize` / `GetCodeHash` still read the store.
 - **Transient state** — logs, transient storage (EIP-1153), access lists, and gas refunds are held in memory per-transaction and not persisted until finalization.
 - **Coinbase collection** — each transaction gets a deterministic coinbase address for collecting fee surplus, which is swept to the fee collector at end-of-block.
 

--- a/x/evm/keeper/code_size_invariant_test.go
+++ b/x/evm/keeper/code_size_invariant_test.go
@@ -54,7 +54,6 @@ func TestGetCodeSizeMatchesGetCodeLength(t *testing.T) {
 
 	t.Run("max code size", func(t *testing.T) {
 		code := make([]byte, params.MaxCodeSize)
-		code[0] = 0x00
 		k.SetCode(ctx, addr, code)
 		assertInvariant(t)
 		require.Equal(t, params.MaxCodeSize, k.GetCodeSize(ctx, addr))

--- a/x/evm/keeper/code_size_invariant_test.go
+++ b/x/evm/keeper/code_size_invariant_test.go
@@ -1,0 +1,74 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetCodeSizeMatchesGetCodeLength pins the invariant that go-ethereum's
+// EIP-7702 CALL-family size gate relies on: GetCodeSize(addr) == len(GetCode(addr)).
+// This holds on Sei's keeper without bumping go-ethereum.
+func TestGetCodeSizeMatchesGetCodeLength(t *testing.T) {
+	k := &keeper.EVMTestApp.EvmKeeper
+	ctx := keeper.EVMTestApp.GetContextForDeliverTx([]byte{})
+	_, addr := keeper.MockAddressPair()
+
+	assertInvariant := func(t *testing.T) {
+		t.Helper()
+		code := k.GetCode(ctx, addr)
+		require.Equal(t, len(code), k.GetCodeSize(ctx, addr), "GetCodeSize must equal len(GetCode)")
+	}
+
+	t.Run("empty account", func(t *testing.T) {
+		assertInvariant(t)
+		require.Equal(t, 0, k.GetCodeSize(ctx, addr))
+	})
+
+	t.Run("nil SetCode", func(t *testing.T) {
+		k.SetCode(ctx, addr, nil)
+		assertInvariant(t)
+		require.Nil(t, k.GetCode(ctx, addr))
+		require.Equal(t, 0, k.GetCodeSize(ctx, addr))
+		require.Equal(t, ethtypes.EmptyCodeHash, k.GetCodeHash(ctx, addr))
+	})
+
+	t.Run("small code", func(t *testing.T) {
+		k.SetCode(ctx, addr, []byte{1, 2, 3, 4, 5})
+		assertInvariant(t)
+	})
+
+	t.Run("eip7702 designator length", func(t *testing.T) {
+		designator := ethtypes.AddressToDelegation(common.BytesToAddress([]byte("delegate-target")))
+		require.Equal(t, 23, len(designator))
+		_, ok := ethtypes.ParseDelegation(designator)
+		require.True(t, ok)
+		k.SetCode(ctx, addr, designator)
+		assertInvariant(t)
+		require.Equal(t, 23, k.GetCodeSize(ctx, addr))
+	})
+
+	t.Run("max code size", func(t *testing.T) {
+		code := make([]byte, params.MaxCodeSize)
+		code[0] = 0x00
+		k.SetCode(ctx, addr, code)
+		assertInvariant(t)
+		require.Equal(t, params.MaxCodeSize, k.GetCodeSize(ctx, addr))
+	})
+
+	t.Run("overwrite shrinks size metadata", func(t *testing.T) {
+		k.SetCode(ctx, addr, []byte{9})
+		assertInvariant(t)
+		require.Equal(t, 1, k.GetCodeSize(ctx, addr))
+	})
+
+	t.Run("empty slice clears to zero size", func(t *testing.T) {
+		k.SetCode(ctx, addr, []byte{})
+		assertInvariant(t)
+		require.Equal(t, 0, k.GetCodeSize(ctx, addr))
+	})
+}

--- a/x/evm/keeper/code_size_invariant_test.go
+++ b/x/evm/keeper/code_size_invariant_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/sei-protocol/sei-chain/testutil/keeper"
+	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,9 +14,9 @@ import (
 // EIP-7702 CALL-family size gate relies on: GetCodeSize(addr) == len(GetCode(addr)).
 // This holds on Sei's keeper without bumping go-ethereum.
 func TestGetCodeSizeMatchesGetCodeLength(t *testing.T) {
-	k := &keeper.EVMTestApp.EvmKeeper
-	ctx := keeper.EVMTestApp.GetContextForDeliverTx([]byte{})
-	_, addr := keeper.MockAddressPair()
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{})
+	_, addr := testkeeper.MockAddressPair()
 
 	assertInvariant := func(t *testing.T) {
 		t.Helper()

--- a/x/evm/keeper/pointer_upgrade.go
+++ b/x/evm/keeper/pointer_upgrade.go
@@ -105,8 +105,13 @@ func (k *Keeper) UpsertERCPointer(
 		var ret []byte
 		contractAddr = existingAddr
 		ret, remainingGas, err = evm.GetDeploymentCode(evmModuleAddress, bin, suppliedGas, utils.Big0, existingAddr)
+		if err != nil {
+			return
+		}
 		// Prefer the StateDB Multistore (correct for RunWithOneOff nested CMS) while
 		// billing KV gas to the caller's meter (finite precompile meter in deliver).
+		// Only write on success: a failed GetDeploymentCode can leave ret as nil or
+		// revert data, which must not clobber live pointer bytecode (even transiently).
 		if sdb := state.GetDBImpl(evm.StateDB); sdb != nil {
 			k.SetCode(sdb.Ctx().WithGasMeter(ctx.GasMeter()), contractAddr, ret)
 			sdb.RefreshCodeCache(contractAddr, ret)

--- a/x/evm/keeper/pointer_upgrade.go
+++ b/x/evm/keeper/pointer_upgrade.go
@@ -105,12 +105,11 @@ func (k *Keeper) UpsertERCPointer(
 		var ret []byte
 		contractAddr = existingAddr
 		ret, remainingGas, err = evm.GetDeploymentCode(evmModuleAddress, bin, suppliedGas, utils.Big0, existingAddr)
-		// Prefer StateDB.SetCode so a live deliver codeCache stays coherent with
-		// the store (keeper SetCode alone would leave a warm memo stale).
-		// Called even when GetDeploymentCode returned an error to preserve prior
-		// write-before-check ordering (callers typically revert the snapshot).
+		// Prefer the StateDB Multistore (correct for RunWithOneOff nested CMS) while
+		// billing KV gas to the caller's meter (finite precompile meter in deliver).
 		if sdb := state.GetDBImpl(evm.StateDB); sdb != nil {
-			sdb.SetCode(contractAddr, ret)
+			k.SetCode(sdb.Ctx().WithGasMeter(ctx.GasMeter()), contractAddr, ret)
+			sdb.RefreshCodeCache(contractAddr, ret)
 		} else {
 			k.SetCode(ctx, contractAddr, ret)
 		}

--- a/x/evm/keeper/pointer_upgrade.go
+++ b/x/evm/keeper/pointer_upgrade.go
@@ -102,22 +102,19 @@ func (k *Keeper) UpsertERCPointer(
 	// Exists-lookup and commits must use the live unfrozen top (sdb.Ctx): cachekv
 	// forbids writing a frozen layer, and same-tx readers that skip frozen-empty
 	// parents would miss those writes. The precompile Prepare `ctx` is that top at
-	// Prepare time, but is frozen once this Upsert snapshots. Bill KV gas to the
-	// caller's meter (finite precompile meter in deliver).
+	// Prepare time, but is frozen once this Upsert snapshots. Always attach the
+	// caller's gas meter (finite precompile meter in deliver) — sdb.Ctx() alone
+	// carries the infinite EVM meter.
 	sdb := state.GetDBImpl(evm.StateDB)
-	lookupCtx := ctx
-	if sdb != nil {
-		lookupCtx = sdb.Ctx()
-	}
-	existingAddr, _, exists := getter(lookupCtx, pointee)
-	suppliedGas := k.getEvmGasLimitFromCtx(ctx)
-	var remainingGas uint64
-	liveWriteCtx := func() sdk.Context {
+	liveCtx := func() sdk.Context {
 		if sdb == nil {
 			return ctx
 		}
 		return sdb.Ctx().WithGasMeter(ctx.GasMeter())
 	}
+	existingAddr, _, exists := getter(liveCtx(), pointee)
+	suppliedGas := k.getEvmGasLimitFromCtx(ctx)
+	var remainingGas uint64
 	if exists {
 		var ret []byte
 		contractAddr = existingAddr
@@ -127,7 +124,7 @@ func (k *Keeper) UpsertERCPointer(
 		}
 		// Only write on success: a failed GetDeploymentCode can leave ret as nil or
 		// revert data, which must not clobber live pointer bytecode (even transiently).
-		writeCtx := liveWriteCtx()
+		writeCtx := liveCtx()
 		k.SetCode(writeCtx, contractAddr, ret)
 		if sdb != nil {
 			sdb.RefreshCodeCache(contractAddr, ret)
@@ -139,7 +136,7 @@ func (k *Keeper) UpsertERCPointer(
 		return
 	}
 	ctx.GasMeter().ConsumeGas(k.GetCosmosGasLimitFromEVMGas(ctx, suppliedGas-remainingGas), "ERC pointer deployment")
-	if err = setter(liveWriteCtx(), pointee, contractAddr); err != nil {
+	if err = setter(liveCtx(), pointee, contractAddr); err != nil {
 		return
 	}
 	ctx.EventManager().EmitEvent(sdk.NewEvent(

--- a/x/evm/keeper/pointer_upgrade.go
+++ b/x/evm/keeper/pointer_upgrade.go
@@ -98,9 +98,26 @@ func (k *Keeper) UpsertERCPointer(
 		panic(err)
 	}
 	bin = append(artifacts.GetBin(typ), bin...)
-	existingAddr, _, exists := getter(ctx, pointee)
+	// GetDeploymentCode / Create take EVM snapshots that Freeze() Multistore layers.
+	// Exists-lookup and commits must use the live unfrozen top (sdb.Ctx): cachekv
+	// forbids writing a frozen layer, and same-tx readers that skip frozen-empty
+	// parents would miss those writes. The precompile Prepare `ctx` is that top at
+	// Prepare time, but is frozen once this Upsert snapshots. Bill KV gas to the
+	// caller's meter (finite precompile meter in deliver).
+	sdb := state.GetDBImpl(evm.StateDB)
+	lookupCtx := ctx
+	if sdb != nil {
+		lookupCtx = sdb.Ctx()
+	}
+	existingAddr, _, exists := getter(lookupCtx, pointee)
 	suppliedGas := k.getEvmGasLimitFromCtx(ctx)
 	var remainingGas uint64
+	liveWriteCtx := func() sdk.Context {
+		if sdb == nil {
+			return ctx
+		}
+		return sdb.Ctx().WithGasMeter(ctx.GasMeter())
+	}
 	if exists {
 		var ret []byte
 		contractAddr = existingAddr
@@ -108,15 +125,12 @@ func (k *Keeper) UpsertERCPointer(
 		if err != nil {
 			return
 		}
-		// Prefer the StateDB Multistore (correct for RunWithOneOff nested CMS) while
-		// billing KV gas to the caller's meter (finite precompile meter in deliver).
 		// Only write on success: a failed GetDeploymentCode can leave ret as nil or
 		// revert data, which must not clobber live pointer bytecode (even transiently).
-		if sdb := state.GetDBImpl(evm.StateDB); sdb != nil {
-			k.SetCode(sdb.Ctx().WithGasMeter(ctx.GasMeter()), contractAddr, ret)
+		writeCtx := liveWriteCtx()
+		k.SetCode(writeCtx, contractAddr, ret)
+		if sdb != nil {
 			sdb.RefreshCodeCache(contractAddr, ret)
-		} else {
-			k.SetCode(ctx, contractAddr, ret)
 		}
 	} else {
 		_, contractAddr, remainingGas, err = evm.Create(evmModuleAddress, bin, suppliedGas, uint256.NewInt(0))
@@ -125,7 +139,7 @@ func (k *Keeper) UpsertERCPointer(
 		return
 	}
 	ctx.GasMeter().ConsumeGas(k.GetCosmosGasLimitFromEVMGas(ctx, suppliedGas-remainingGas), "ERC pointer deployment")
-	if err = setter(ctx, pointee, contractAddr); err != nil {
+	if err = setter(liveWriteCtx(), pointee, contractAddr); err != nil {
 		return
 	}
 	ctx.EventManager().EmitEvent(sdk.NewEvent(

--- a/x/evm/keeper/pointer_upgrade.go
+++ b/x/evm/keeper/pointer_upgrade.go
@@ -105,7 +105,15 @@ func (k *Keeper) UpsertERCPointer(
 		var ret []byte
 		contractAddr = existingAddr
 		ret, remainingGas, err = evm.GetDeploymentCode(evmModuleAddress, bin, suppliedGas, utils.Big0, existingAddr)
-		k.SetCode(ctx, contractAddr, ret)
+		// Prefer StateDB.SetCode so a live deliver codeCache stays coherent with
+		// the store (keeper SetCode alone would leave a warm memo stale).
+		// Called even when GetDeploymentCode returned an error to preserve prior
+		// write-before-check ordering (callers typically revert the snapshot).
+		if sdb := state.GetDBImpl(evm.StateDB); sdb != nil {
+			sdb.SetCode(contractAddr, ret)
+		} else {
+			k.SetCode(ctx, contractAddr, ret)
+		}
 	} else {
 		_, contractAddr, remainingGas, err = evm.Create(evmModuleAddress, bin, suppliedGas, uint256.NewInt(0))
 	}

--- a/x/evm/keeper/pointer_upgrade_test.go
+++ b/x/evm/keeper/pointer_upgrade_test.go
@@ -70,8 +70,8 @@ func TestUpsertERCNativePointer(t *testing.T) {
 }
 
 // TestUpsertERCNativePointerKeepsCodeCacheCoherent covers the mid-tx redeploy
-// path: plant a warm memo, re-upsert (exists → StateDB.SetCode with real
-// deployment bytecode), and assert GetCode follows the store.
+// path: plant a warm memo, re-upsert (exists → keeper SetCode + RefreshCodeCache),
+// and assert GetCode follows the store.
 func TestUpsertERCNativePointerKeepsCodeCacheCoherent(t *testing.T) {
 	k := &testkeeper.EVMTestApp.EvmKeeper
 	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())

--- a/x/evm/keeper/pointer_upgrade_test.go
+++ b/x/evm/keeper/pointer_upgrade_test.go
@@ -118,6 +118,55 @@ func TestUpsertERCNativePointerKeepsCodeCacheCoherent(t *testing.T) {
 	require.Equal(t, codeAfter, storeCode)
 }
 
+// TestUpsertERCNativePointerFailedRedeployPreservesCode ensures a failed
+// GetDeploymentCode path does not SetCode (or RefreshCodeCache) over live
+// pointer bytecode — even briefly — before returning the error.
+func TestUpsertERCNativePointerFailedRedeployPreservesCode(t *testing.T) {
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeterWithMultiplier(ctx))
+
+	preserved := []byte{9, 8, 7, 6, 5}
+	var codeAfterFail, storeAfterFail []byte
+	var sizeAfterFail int
+	err := k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
+		addr, err := k.UpsertERCNativePointer(ctx, e, "fail-preserves", utils.ERCMetadata{
+			Name:     "before",
+			Symbol:   "before",
+			Decimals: 6,
+		})
+		if err != nil {
+			return err
+		}
+		sdb := state.GetDBImpl(e.StateDB)
+		if sdb == nil {
+			return errors.New("expected DBImpl StateDB")
+		}
+		sdb.SetCode(addr, preserved)
+		require.Equal(t, preserved, sdb.GetCode(addr))
+
+		// Finite cosmos meter large enough for the pointer-registry getter reads, but
+		// small enough that GetDeploymentCode OOGs (normalizer is 1 in tests). StateDB
+		// KV metering stays on the infinite RunWithOneOff meter.
+		lowGasCtx := ctx.WithGasMeter(sdk.NewGasMeterWithMultiplier(ctx, 50_000))
+		_, err = k.UpsertERCNativePointer(lowGasCtx, e, "fail-preserves", utils.ERCMetadata{
+			Name:     "after",
+			Symbol:   "after",
+			Decimals: 8,
+		})
+		require.Error(t, err)
+
+		codeAfterFail = sdb.GetCode(addr)
+		sizeAfterFail = sdb.GetCodeSize(addr)
+		storeAfterFail = k.GetCode(sdb.Ctx(), addr)
+		return nil
+	}, func(string, string) {})
+	require.NoError(t, err)
+	require.Equal(t, preserved, codeAfterFail)
+	require.Equal(t, len(preserved), sizeAfterFail)
+	require.Equal(t, preserved, storeAfterFail)
+}
+
 func TestUpsertERC20Pointer(t *testing.T) {
 	k := &testkeeper.EVMTestApp.EvmKeeper
 	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())

--- a/x/evm/keeper/pointer_upgrade_test.go
+++ b/x/evm/keeper/pointer_upgrade_test.go
@@ -10,6 +10,7 @@ import (
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
 	"github.com/sei-protocol/sei-chain/utils"
+	"github.com/sei-protocol/sei-chain/x/evm/state"
 	"github.com/stretchr/testify/require"
 )
 
@@ -66,6 +67,55 @@ func TestUpsertERCNativePointer(t *testing.T) {
 	require.Equal(t, uint8(12), res.(uint8))
 	_, err = k.QueryERCSingleOutput(ctx, "native", addr, "nonexist")
 	require.NotNil(t, err)
+}
+
+// TestUpsertERCNativePointerKeepsCodeCacheCoherent covers the mid-tx redeploy
+// path: plant a warm memo, re-upsert (exists → StateDB.SetCode with real
+// deployment bytecode), and assert GetCode follows the store.
+func TestUpsertERCNativePointerKeepsCodeCacheCoherent(t *testing.T) {
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeterWithMultiplier(ctx))
+
+	stalePlant := []byte{1, 2, 3, 4, 5}
+	var warmed, codeAfter, storeCode []byte
+	var sizeAfter int
+	err := k.RunWithOneOffEVMInstance(ctx, func(e *vm.EVM) error {
+		addr, err := k.UpsertERCNativePointer(ctx, e, "cache-coherent", utils.ERCMetadata{
+			Name:     "before",
+			Symbol:   "before",
+			Decimals: 6,
+		})
+		if err != nil {
+			return err
+		}
+		sdb := state.GetDBImpl(e.StateDB)
+		if sdb == nil {
+			return errors.New("expected DBImpl StateDB")
+		}
+		// Distinct warm entry so a missed memo update is observable (metadata-only
+		// redeploys often produce identical runtime bytecode).
+		sdb.SetCode(addr, stalePlant)
+		warmed = sdb.GetCode(addr)
+
+		_, err = k.UpsertERCNativePointer(ctx, e, "cache-coherent", utils.ERCMetadata{
+			Name:     "after",
+			Symbol:   "after",
+			Decimals: 8,
+		})
+		if err != nil {
+			return err
+		}
+		codeAfter = sdb.GetCode(addr)
+		sizeAfter = sdb.GetCodeSize(addr)
+		storeCode = k.GetCode(sdb.Ctx(), addr)
+		return nil
+	}, func(string, string) {})
+	require.NoError(t, err)
+	require.Equal(t, stalePlant, warmed)
+	require.NotEqual(t, warmed, codeAfter)
+	require.Equal(t, len(codeAfter), sizeAfter)
+	require.Equal(t, codeAfter, storeCode)
 }
 
 func TestUpsertERC20Pointer(t *testing.T) {

--- a/x/evm/keeper/pointer_upgrade_test.go
+++ b/x/evm/keeper/pointer_upgrade_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -109,6 +110,12 @@ func TestUpsertERCNativePointerKeepsCodeCacheCoherent(t *testing.T) {
 		codeAfter = sdb.GetCode(addr)
 		sizeAfter = sdb.GetCodeSize(addr)
 		storeCode = k.GetCode(sdb.Ctx(), addr)
+		// Registry must be written on the live Multistore layer (sdb.Ctx), not the
+		// Prepare-time ctx that GetDeploymentCode may have frozen.
+		got, _, found := k.GetERC20NativePointer(sdb.Ctx(), "cache-coherent")
+		if !found || got != addr {
+			return fmt.Errorf("pointer registry not visible on live StateDB ctx: found=%v got=%s want=%s", found, got.Hex(), addr.Hex())
+		}
 		return nil
 	}, func(string, string) {})
 	require.NoError(t, err)

--- a/x/evm/state/code.go
+++ b/x/evm/state/code.go
@@ -44,6 +44,7 @@ func (s *DBImpl) SetCode(addr common.Address, code []byte) []byte {
 	}
 
 	s.k.SetCode(s.ctx, addr, code)
+	s.journalCodeCacheMutation(addr)
 	s.putCodeCache(addr, code)
 	return oldCode
 }
@@ -51,7 +52,19 @@ func (s *DBImpl) SetCode(addr common.Address, code []byte) []byte {
 // RefreshCodeCache updates the deliver-tx code memo after a keeper store write
 // that bypassed SetCode (so gas can be charged against a different ctx meter).
 func (s *DBImpl) RefreshCodeCache(addr common.Address, code []byte) {
+	s.journalCodeCacheMutation(addr)
 	s.putCodeCache(addr, code)
+}
+
+// journalCodeCacheMutation records the prior memo entry so RevertToSnapshot can
+// restore this address only. Call before putCodeCache / delete on mutation paths;
+// pure GetCode fills must not journal (nested reverts should keep those warms).
+func (s *DBImpl) journalCodeCacheMutation(addr common.Address) {
+	if s.codeCache == nil {
+		return
+	}
+	prev, had := s.codeCache[addr]
+	s.journal = append(s.journal, &codeCacheChange{account: addr, prev: prev, had: had})
 }
 
 func (s *DBImpl) putCodeCache(addr common.Address, code []byte) {

--- a/x/evm/state/code.go
+++ b/x/evm/state/code.go
@@ -12,7 +12,7 @@ func (s *DBImpl) GetCodeHash(addr common.Address) common.Hash {
 
 func (s *DBImpl) GetCode(addr common.Address) []byte {
 	s.k.PrepareReplayedAddr(s.ctx, addr)
-	// nil codeCache means caching is disabled (simulation/RPC/trace); never allocate here.
+	// nil codeCache means caching is disabled (simulation/RPC/trace/wasmd-entry); never allocate here.
 	if s.codeCache != nil {
 		if code, ok := s.codeCache[addr]; ok {
 			return code

--- a/x/evm/state/code.go
+++ b/x/evm/state/code.go
@@ -22,16 +22,14 @@ func (s *DBImpl) GetCode(addr common.Address) []byte {
 	if s.codeCache == nil {
 		return code
 	}
-	// Cache a copy so callers cannot mutate the keeper/store-backed slice into
-	// the tx memo, and keep empty code as nil to match Keeper.GetCode.
+	// Keep empty code as nil to match Keeper.GetCode, and store a copy so the
+	// memo is not aliased to the keeper/store-backed slice.
 	if len(code) == 0 {
 		s.codeCache[addr] = nil
 		return nil
 	}
-	cached := make([]byte, len(code))
-	copy(cached, code)
-	s.codeCache[addr] = cached
-	return cached
+	s.putCodeCache(addr, code)
+	return s.codeCache[addr]
 }
 
 func (s *DBImpl) SetCode(addr common.Address, code []byte) []byte {
@@ -46,18 +44,27 @@ func (s *DBImpl) SetCode(addr common.Address, code []byte) []byte {
 	}
 
 	s.k.SetCode(s.ctx, addr, code)
+	s.putCodeCache(addr, code)
+	return oldCode
+}
+
+// RefreshCodeCache updates the deliver-tx code memo after a keeper store write
+// that bypassed SetCode (so gas can be charged against a different ctx meter).
+func (s *DBImpl) RefreshCodeCache(addr common.Address, code []byte) {
+	s.putCodeCache(addr, code)
+}
+
+func (s *DBImpl) putCodeCache(addr common.Address, code []byte) {
 	if s.codeCache == nil {
-		return oldCode
+		return
 	}
 	if len(code) == 0 {
 		s.codeCache[addr] = nil
-	} else {
-		// Store a copy so later mutations of the caller's slice cannot corrupt the cache.
-		cached := make([]byte, len(code))
-		copy(cached, code)
-		s.codeCache[addr] = cached
+		return
 	}
-	return oldCode
+	cached := make([]byte, len(code))
+	copy(cached, code)
+	s.codeCache[addr] = cached
 }
 
 func (s *DBImpl) GetCodeSize(addr common.Address) int {

--- a/x/evm/state/code.go
+++ b/x/evm/state/code.go
@@ -12,7 +12,26 @@ func (s *DBImpl) GetCodeHash(addr common.Address) common.Hash {
 
 func (s *DBImpl) GetCode(addr common.Address) []byte {
 	s.k.PrepareReplayedAddr(s.ctx, addr)
-	return s.k.GetCode(s.ctx, addr)
+	// nil codeCache means caching is disabled (simulation/RPC/trace); never allocate here.
+	if s.codeCache != nil {
+		if code, ok := s.codeCache[addr]; ok {
+			return code
+		}
+	}
+	code := s.k.GetCode(s.ctx, addr)
+	if s.codeCache == nil {
+		return code
+	}
+	// Cache a copy so callers cannot mutate the keeper/store-backed slice into
+	// the tx memo, and keep empty code as nil to match Keeper.GetCode.
+	if len(code) == 0 {
+		s.codeCache[addr] = nil
+		return nil
+	}
+	cached := make([]byte, len(code))
+	copy(cached, code)
+	s.codeCache[addr] = cached
+	return cached
 }
 
 func (s *DBImpl) SetCode(addr common.Address, code []byte) []byte {
@@ -27,6 +46,17 @@ func (s *DBImpl) SetCode(addr common.Address, code []byte) []byte {
 	}
 
 	s.k.SetCode(s.ctx, addr, code)
+	if s.codeCache == nil {
+		return oldCode
+	}
+	if len(code) == 0 {
+		s.codeCache[addr] = nil
+	} else {
+		// Store a copy so later mutations of the caller's slice cannot corrupt the cache.
+		cached := make([]byte, len(code))
+		copy(cached, code)
+		s.codeCache[addr] = cached
+	}
 	return oldCode
 }
 

--- a/x/evm/state/code_size_invariant_test.go
+++ b/x/evm/state/code_size_invariant_test.go
@@ -1,0 +1,76 @@
+package state_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/x/evm/state"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStateDBGetCodeSizeMatchesGetCodeLength pins the same size/code invariant
+// through the EVM StateDB bridge (including snapshot/revert and account recreate).
+func TestStateDBGetCodeSizeMatchesGetCodeLength(t *testing.T) {
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	_, addr := testkeeper.MockAddressPair()
+	statedb := state.NewDBImpl(ctx, k, false)
+
+	assertInvariant := func(t *testing.T) {
+		t.Helper()
+		code := statedb.GetCode(addr)
+		require.Equal(t, len(code), statedb.GetCodeSize(addr), "GetCodeSize must equal len(GetCode)")
+	}
+
+	t.Run("empty", func(t *testing.T) {
+		assertInvariant(t)
+	})
+
+	t.Run("set and resize", func(t *testing.T) {
+		statedb.SetCode(addr, []byte{1, 2, 3})
+		assertInvariant(t)
+
+		designator := ethtypes.AddressToDelegation(common.BytesToAddress([]byte("target")))
+		statedb.SetCode(addr, designator)
+		assertInvariant(t)
+		require.Equal(t, 23, statedb.GetCodeSize(addr))
+
+		large := make([]byte, params.MaxCodeSize)
+		statedb.SetCode(addr, large)
+		assertInvariant(t)
+
+		statedb.SetCode(addr, nil)
+		assertInvariant(t)
+		require.Equal(t, 0, statedb.GetCodeSize(addr))
+	})
+
+	t.Run("snapshot revert restores matching size", func(t *testing.T) {
+		statedb.SetCode(addr, []byte{1, 2, 3, 4})
+		assertInvariant(t)
+		rev := statedb.Snapshot()
+		statedb.SetCode(addr, make([]byte, params.MaxCodeSize))
+		assertInvariant(t)
+		statedb.RevertToSnapshot(rev)
+		assertInvariant(t)
+		require.Equal(t, 4, statedb.GetCodeSize(addr))
+	})
+
+	t.Run("recreate clears code and size together", func(t *testing.T) {
+		statedb.CreateAccount(addr)
+		statedb.SetCode(addr, []byte("code"))
+		statedb.AddBalance(addr, uint256.NewInt(1), tracing.BalanceChangeUnspecified)
+		assertInvariant(t)
+
+		// CreateAccount clears prior code/state for the account.
+		statedb.CreateAccount(addr)
+		assertInvariant(t)
+		require.Equal(t, 0, statedb.GetCodeSize(addr))
+		require.Nil(t, statedb.GetCode(addr))
+	})
+}

--- a/x/evm/state/code_test.go
+++ b/x/evm/state/code_test.go
@@ -144,12 +144,13 @@ func TestCodeCacheDisabledForSimulation(t *testing.T) {
 	initial := []byte{1, 2, 3}
 	updated := []byte{9, 9, 9, 9}
 
-	// Deliver DB memos GetCode: a keeper write that bypasses SetCode stays hidden.
+	// Deliver DB: StateDB.SetCode must refresh the memo after a warm GetCode.
 	deliver := state.NewDBImpl(ctx, k, false)
 	deliver.SetCode(addr, initial)
 	require.Equal(t, initial, deliver.GetCode(addr))
-	k.SetCode(deliver.Ctx(), addr, updated)
-	require.Equal(t, initial, deliver.GetCode(addr))
+	deliver.SetCode(addr, updated)
+	require.Equal(t, updated, deliver.GetCode(addr))
+	require.Equal(t, len(updated), deliver.GetCodeSize(addr))
 
 	// Simulation/RPC DB always reads the store (caching disabled).
 	sim := state.NewDBImpl(ctx, k, true)

--- a/x/evm/state/code_test.go
+++ b/x/evm/state/code_test.go
@@ -152,6 +152,15 @@ func TestCodeCacheDisabledForSimulation(t *testing.T) {
 	require.Equal(t, updated, deliver.GetCode(addr))
 	require.Equal(t, len(updated), deliver.GetCodeSize(addr))
 
+	// Keeper write billed on a separate meter: refresh memo without SetCode.
+	_, addr2 := testkeeper.MockAddressPair()
+	deliver.SetCode(addr2, initial)
+	require.Equal(t, initial, deliver.GetCode(addr2))
+	k.SetCode(deliver.Ctx(), addr2, updated)
+	deliver.RefreshCodeCache(addr2, updated)
+	require.Equal(t, updated, deliver.GetCode(addr2))
+	require.Equal(t, len(updated), deliver.GetCodeSize(addr2))
+
 	// Simulation/RPC DB always reads the store (caching disabled).
 	sim := state.NewDBImpl(ctx, k, true)
 	sim.SetCode(addr, initial)

--- a/x/evm/state/code_test.go
+++ b/x/evm/state/code_test.go
@@ -65,6 +65,36 @@ func TestCodeCacheClearedOnRevert(t *testing.T) {
 	require.Equal(t, initial, statedb.GetCode(addr))
 }
 
+// TestCodeCacheUnrelatedWarmSurvivesRevert pins address-level journal restore:
+// nested reverts must not wipe warmed entries for accounts that were not
+// mutated, otherwise an attacker can force wholesale code re-fetch via
+// reverting subcalls. After revert we poison the Multistore for the
+// unrelated address without RefreshCodeCache; a surviving memo returns the
+// pre-poison bytes, while a blanket clear would re-read the poison.
+func TestCodeCacheUnrelatedWarmSurvivesRevert(t *testing.T) {
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	_, addrA := testkeeper.MockAddressPair()
+	_, addrB := testkeeper.MockAddressPair()
+	statedb := state.NewDBImpl(ctx, k, false)
+
+	codeA := []byte{1, 2, 3}
+	codeB := []byte{10, 11, 12, 13}
+	statedb.SetCode(addrA, codeA)
+	statedb.SetCode(addrB, codeB)
+	require.Equal(t, codeB, statedb.GetCode(addrB))
+
+	rev := statedb.Snapshot()
+	statedb.SetCode(addrA, []byte{9, 9, 9})
+	statedb.RevertToSnapshot(rev)
+	require.Equal(t, codeA, statedb.GetCode(addrA))
+
+	poison := []byte{7, 7, 7, 7, 7}
+	k.SetCode(statedb.Ctx(), addrB, poison)
+	require.Equal(t, codeB, statedb.GetCode(addrB), "unrelated warm must survive revert (not re-read poison)")
+	require.Equal(t, poison, k.GetCode(statedb.Ctx(), addrB))
+}
+
 func TestCodeCacheInvalidatedOnCreateAccount(t *testing.T) {
 	k := &testkeeper.EVMTestApp.EvmKeeper
 	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())

--- a/x/evm/state/code_test.go
+++ b/x/evm/state/code_test.go
@@ -27,3 +27,134 @@ func TestCode(t *testing.T) {
 	require.Equal(t, code, statedb.GetCode(addr))
 	require.Equal(t, 5, statedb.GetCodeSize(addr))
 }
+
+func TestCodeCacheHitAndSetCodeUpdate(t *testing.T) {
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	_, addr := testkeeper.MockAddressPair()
+	statedb := state.NewDBImpl(ctx, k, false)
+
+	code := []byte{1, 2, 3, 4, 5}
+	statedb.SetCode(addr, code)
+	require.Equal(t, code, statedb.GetCode(addr))
+	// Second read must return the same bytes (served from the tx code cache).
+	require.Equal(t, code, statedb.GetCode(addr))
+
+	updated := []byte{9, 8, 7}
+	statedb.SetCode(addr, updated)
+	require.Equal(t, updated, statedb.GetCode(addr))
+	require.Equal(t, crypto.Keccak256Hash(updated), statedb.GetCodeHash(addr))
+}
+
+func TestCodeCacheClearedOnRevert(t *testing.T) {
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	_, addr := testkeeper.MockAddressPair()
+	statedb := state.NewDBImpl(ctx, k, false)
+
+	initial := []byte{1, 2, 3}
+	statedb.SetCode(addr, initial)
+	require.Equal(t, initial, statedb.GetCode(addr))
+
+	rev := statedb.Snapshot()
+	updated := []byte{4, 5, 6, 7}
+	statedb.SetCode(addr, updated)
+	require.Equal(t, updated, statedb.GetCode(addr))
+
+	statedb.RevertToSnapshot(rev)
+	require.Equal(t, initial, statedb.GetCode(addr))
+}
+
+func TestCodeCacheInvalidatedOnCreateAccount(t *testing.T) {
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	_, addr := testkeeper.MockAddressPair()
+	statedb := state.NewDBImpl(ctx, k, false)
+
+	statedb.CreateAccount(addr)
+	statedb.SetCode(addr, []byte("code"))
+	require.Equal(t, []byte("code"), statedb.GetCode(addr))
+
+	statedb.CreateAccount(addr)
+	require.Nil(t, statedb.GetCode(addr))
+	require.Equal(t, 0, statedb.GetCodeSize(addr))
+}
+
+func TestCodeCacheEmptyMatchesKeeperNil(t *testing.T) {
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	_, addr := testkeeper.MockAddressPair()
+	statedb := state.NewDBImpl(ctx, k, false)
+
+	statedb.SetCode(addr, []byte{})
+	require.Nil(t, statedb.GetCode(addr))
+	require.Equal(t, 0, statedb.GetCodeSize(addr))
+
+	// Second read must still be nil (cached empty normalized to nil).
+	require.Nil(t, statedb.GetCode(addr))
+}
+
+func TestCodeCacheMissHitFromPreSeededKeeperCode(t *testing.T) {
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	_, addr := testkeeper.MockAddressPair()
+
+	// Seed bytecode via the keeper so StateDB's first GetCode is a true store miss
+	// (the CALL-family hot path: repeated GetCode against already-committed contracts).
+	code := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	k.SetCode(ctx, addr, code)
+
+	statedb := state.NewDBImpl(ctx, k, false)
+	require.Equal(t, code, statedb.GetCode(addr))
+	require.Equal(t, code, statedb.GetCode(addr))
+	require.Equal(t, len(code), statedb.GetCodeSize(addr))
+}
+
+func TestCodeCacheCopyStartsEmptyAndIndependent(t *testing.T) {
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	_, addr := testkeeper.MockAddressPair()
+	parent := state.NewDBImpl(ctx, k, false)
+
+	initial := []byte{1, 2, 3}
+	parent.SetCode(addr, initial)
+	require.Equal(t, initial, parent.GetCode(addr))
+
+	child := parent.Copy().(*state.DBImpl)
+	// Copy does not clone parent bytecode; child loads from Multistore then caches.
+	require.Equal(t, initial, child.GetCode(addr))
+
+	// Separate maps: after the child has warmed, parent writes do not poison it.
+	updated := []byte{9, 9, 9}
+	parent.SetCode(addr, updated)
+	require.Equal(t, updated, parent.GetCode(addr))
+	require.Equal(t, initial, child.GetCode(addr))
+
+	childUpdated := []byte{7, 7}
+	child.SetCode(addr, childUpdated)
+	require.Equal(t, childUpdated, child.GetCode(addr))
+	require.Equal(t, updated, parent.GetCode(addr))
+}
+
+func TestCodeCacheDisabledForSimulation(t *testing.T) {
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
+	_, addr := testkeeper.MockAddressPair()
+
+	initial := []byte{1, 2, 3}
+	updated := []byte{9, 9, 9, 9}
+
+	// Deliver DB memos GetCode: a keeper write that bypasses SetCode stays hidden.
+	deliver := state.NewDBImpl(ctx, k, false)
+	deliver.SetCode(addr, initial)
+	require.Equal(t, initial, deliver.GetCode(addr))
+	k.SetCode(deliver.Ctx(), addr, updated)
+	require.Equal(t, initial, deliver.GetCode(addr))
+
+	// Simulation/RPC DB always reads the store (caching disabled).
+	sim := state.NewDBImpl(ctx, k, true)
+	sim.SetCode(addr, initial)
+	require.Equal(t, initial, sim.GetCode(addr))
+	k.SetCode(sim.Ctx(), addr, updated)
+	require.Equal(t, updated, sim.GetCode(addr))
+}

--- a/x/evm/state/code_test.go
+++ b/x/evm/state/code_test.go
@@ -136,7 +136,7 @@ func TestCodeCacheCopyStartsEmptyAndIndependent(t *testing.T) {
 	require.Equal(t, updated, parent.GetCode(addr))
 }
 
-func TestCodeCacheDisabledForSimulation(t *testing.T) {
+func TestCodeCacheDisabledForSimulationAndWasmdEntry(t *testing.T) {
 	k := &testkeeper.EVMTestApp.EvmKeeper
 	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
 	_, addr := testkeeper.MockAddressPair()
@@ -167,4 +167,13 @@ func TestCodeCacheDisabledForSimulation(t *testing.T) {
 	require.Equal(t, initial, sim.GetCode(addr))
 	k.SetCode(sim.Ctx(), addr, updated)
 	require.Equal(t, updated, sim.GetCode(addr))
+
+	// Wasmd-entry deliver DB also skips the memo so nested CallEVM Finalizes
+	// cannot leave a stale outer GetCode (see NewDBImpl).
+	_, addr3 := testkeeper.MockAddressPair()
+	wasmdEntry := state.NewDBImpl(ctx.WithEVMEntryViaWasmdPrecompile(true), k, false)
+	wasmdEntry.SetCode(addr3, initial)
+	require.Equal(t, initial, wasmdEntry.GetCode(addr3))
+	k.SetCode(wasmdEntry.Ctx(), addr3, updated)
+	require.Equal(t, updated, wasmdEntry.GetCode(addr3))
 }

--- a/x/evm/state/journal.go
+++ b/x/evm/state/journal.go
@@ -66,6 +66,15 @@ type (
 		delta sdk.Int
 	}
 
+	// codeCacheChange restores a single memo entry on revert. GetCode fills are
+	// not journaled — only SetCode / RefreshCodeCache / account-code clears —
+	// so nested reverts do not wipe unrelated warmed bytecode.
+	codeCacheChange struct {
+		account common.Address
+		prev    []byte
+		had     bool // whether account was present in the memo before the mutation
+	}
+
 	watermark struct {
 		version int
 	}
@@ -158,6 +167,17 @@ func (e *storageOverrideInstall) revert(s *DBImpl) {
 }
 
 func (e *watermark) revert(s *DBImpl) {}
+
+func (e *codeCacheChange) revert(s *DBImpl) {
+	if s.codeCache == nil {
+		return
+	}
+	if e.had {
+		s.codeCache[e.account] = e.prev
+		return
+	}
+	delete(s.codeCache, e.account)
+}
 
 func (e *accountStatusChange) revert(s *DBImpl) {
 	accts := s.tempState.transientAccounts

--- a/x/evm/state/journal_test.go
+++ b/x/evm/state/journal_test.go
@@ -139,3 +139,29 @@ func TestStorageOverrideInstallRevert_Restore(t *testing.T) {
 	change.revert(db)
 	require.Equal(t, common.Hash{15}, db.tempState.storageOverrides[addr].current[slot.Hex()])
 }
+
+func TestCodeCacheChangeRevert_Restore(t *testing.T) {
+	db := &DBImpl{codeCache: map[common.Address][]byte{}}
+	addr := common.Address{20}
+	prev := []byte{1, 2, 3}
+	db.codeCache[addr] = []byte{9, 9}
+	change := &codeCacheChange{account: addr, prev: prev, had: true}
+	change.revert(db)
+	require.Equal(t, prev, db.codeCache[addr])
+}
+
+func TestCodeCacheChangeRevert_Delete(t *testing.T) {
+	db := &DBImpl{codeCache: map[common.Address][]byte{}}
+	addr := common.Address{21}
+	db.codeCache[addr] = []byte{4, 5}
+	change := &codeCacheChange{account: addr, had: false}
+	change.revert(db)
+	_, ok := db.codeCache[addr]
+	require.False(t, ok)
+}
+
+func TestCodeCacheChangeRevert_NilCacheNoop(t *testing.T) {
+	db := &DBImpl{}
+	change := &codeCacheChange{account: common.Address{22}, prev: []byte{1}, had: true}
+	require.NotPanics(t, func() { change.revert(db) })
+}

--- a/x/evm/state/state.go
+++ b/x/evm/state/state.go
@@ -166,13 +166,11 @@ func (s *DBImpl) RevertToSnapshot(rev int) {
 		}
 	}
 
-	// Truncate the journal to remove reverted entries
+	// Truncate the journal to remove reverted entries. codeCache mutations are
+	// journaled per address (codeCacheChange), so unrelated warmed entries survive.
 	if watermarkIndex >= 0 {
 		s.journal = s.journal[:watermarkIndex]
 	}
-
-	// Store was rewound via CacheMultiStore; drop any cached code that may now be stale.
-	clear(s.codeCache)
 }
 
 func (s *DBImpl) handleResidualFundsInDestructedAccounts(st *TemporaryState) {
@@ -219,6 +217,7 @@ func (s *DBImpl) clearAccountCodeAndNonce(acc common.Address) {
 	deleteIfExists(s.k.PrefixStore(s.ctx, types.CodeKeyPrefix), acc[:])
 	deleteIfExists(s.k.PrefixStore(s.ctx, types.CodeSizeKeyPrefix), acc[:])
 	deleteIfExists(s.k.PrefixStore(s.ctx, types.NonceKeyPrefix), acc[:])
+	s.journalCodeCacheMutation(acc)
 	if s.codeCache != nil {
 		delete(s.codeCache, acc)
 	}

--- a/x/evm/state/state.go
+++ b/x/evm/state/state.go
@@ -170,6 +170,9 @@ func (s *DBImpl) RevertToSnapshot(rev int) {
 	if watermarkIndex >= 0 {
 		s.journal = s.journal[:watermarkIndex]
 	}
+
+	// Store was rewound via CacheMultiStore; drop any cached code that may now be stale.
+	clear(s.codeCache)
 }
 
 func (s *DBImpl) handleResidualFundsInDestructedAccounts(st *TemporaryState) {
@@ -216,6 +219,9 @@ func (s *DBImpl) clearAccountCodeAndNonce(acc common.Address) {
 	deleteIfExists(s.k.PrefixStore(s.ctx, types.CodeKeyPrefix), acc[:])
 	deleteIfExists(s.k.PrefixStore(s.ctx, types.CodeSizeKeyPrefix), acc[:])
 	deleteIfExists(s.k.PrefixStore(s.ctx, types.NonceKeyPrefix), acc[:])
+	if s.codeCache != nil {
+		delete(s.codeCache, acc)
+	}
 }
 
 func (s *DBImpl) MarkAccount(acc common.Address, status []byte) {

--- a/x/evm/state/statedb.go
+++ b/x/evm/state/statedb.go
@@ -28,9 +28,11 @@ type DBImpl struct {
 	// RPC / trace DBs leave it nil so those paths do not retain large bytecode
 	// for the statedb lifetime. Wasmd-entry deliver txs also leave it nil (see
 	// NewDBImpl) so a nested CallEVM DBImpl cannot Finalize code into the same
-	// Multistore while this memo stays warm. Non-nil (ordinary deliver) is
-	// cleared on snapshot revert and Cleanup, and kept in sync by SetCode.
-	// Copy() starts empty when the parent had caching enabled.
+	// Multistore while this memo stays warm. Mutations (SetCode /
+	// RefreshCodeCache / account-code clear) are journaled per address so
+	// RevertToSnapshot restores only those entries; GetCode fills are not
+	// journaled. Cleanup / tracer reset clear the whole map. Copy() starts
+	// empty when the parent had caching enabled.
 	codeCache map[common.Address][]byte
 
 	// If err is not nil at the end of the execution, the transaction will be rolled

--- a/x/evm/state/statedb.go
+++ b/x/evm/state/statedb.go
@@ -26,9 +26,11 @@ type DBImpl struct {
 	// codeCache memos runtime bytecode so repeated GetCode calls do not re-read
 	// the KV store. nil disables caching (never lazily allocated): simulation /
 	// RPC / trace DBs leave it nil so those paths do not retain large bytecode
-	// for the statedb lifetime. Non-nil (deliver) is cleared on snapshot revert
-	// and Cleanup, and kept in sync by SetCode. Copy() starts empty when the
-	// parent had caching enabled.
+	// for the statedb lifetime. Wasmd-entry deliver txs also leave it nil (see
+	// NewDBImpl) so a nested CallEVM DBImpl cannot Finalize code into the same
+	// Multistore while this memo stays warm. Non-nil (ordinary deliver) is
+	// cleared on snapshot revert and Cleanup, and kept in sync by SetCode.
+	// Copy() starts empty when the parent had caching enabled.
 	codeCache map[common.Address][]byte
 
 	// If err is not nil at the end of the execution, the transaction will be rolled
@@ -65,7 +67,12 @@ func NewDBImpl(ctx sdk.Context, k EVMKeeper, simulation bool) *DBImpl {
 		journal:            []journalEntry{},
 		coinbaseEvmAddress: feeCollector,
 	}
-	if !simulation {
+	// Enable the memo only for ordinary deliver txs. Wasmd-entry txs can nest a
+	// second deliver DBImpl via CallEVM that Finalizes into this Multistore; a
+	// warm outer memo would then disagree with store. Leave nil until wasm is
+	// decommissioned and that nest path is gone. Nested CallEVM itself clears
+	// EVMEntryViaWasmdPrecompile before NewDBImpl, so the inner DB still memos.
+	if !simulation && !ctx.EVMEntryViaWasmdPrecompile() {
 		s.codeCache = make(map[common.Address][]byte)
 	}
 	s.Snapshot() // take an initial snapshot for GetCommitted

--- a/x/evm/state/statedb.go
+++ b/x/evm/state/statedb.go
@@ -23,6 +23,14 @@ type DBImpl struct {
 	tempState *TemporaryState
 	journal   []journalEntry
 
+	// codeCache memos runtime bytecode so repeated GetCode calls do not re-read
+	// the KV store. nil disables caching (never lazily allocated): simulation /
+	// RPC / trace DBs leave it nil so those paths do not retain large bytecode
+	// for the statedb lifetime. Non-nil (deliver) is cleared on snapshot revert
+	// and Cleanup, and kept in sync by SetCode. Copy() starts empty when the
+	// parent had caching enabled.
+	codeCache map[common.Address][]byte
+
 	// If err is not nil at the end of the execution, the transaction will be rolled
 	// back.
 	err error
@@ -57,6 +65,9 @@ func NewDBImpl(ctx sdk.Context, k EVMKeeper, simulation bool) *DBImpl {
 		journal:            []journalEntry{},
 		coinbaseEvmAddress: feeCollector,
 	}
+	if !simulation {
+		s.codeCache = make(map[common.Address][]byte)
+	}
 	s.Snapshot() // take an initial snapshot for GetCommitted
 	return s
 }
@@ -86,6 +97,7 @@ func (s *DBImpl) Cleanup() {
 	s.tempState = nil
 	s.logger = nil
 	s.snapshottedCtxs = nil
+	clear(s.codeCache)
 }
 
 func (s *DBImpl) CleanupForTracer() {
@@ -98,6 +110,7 @@ func (s *DBImpl) CleanupForTracer() {
 	s.tempState = NewTemporaryState()
 	s.journal = []journalEntry{}
 	s.snapshottedCtxs = []sdk.Context{}
+	clear(s.codeCache)
 	s.Snapshot()
 }
 
@@ -110,6 +123,7 @@ func (s *DBImpl) ResetForTracer() {
 	s.coinbaseEvmAddress = feeCollector
 	s.tempState = NewTemporaryState()
 	s.journal = []journalEntry{}
+	clear(s.codeCache)
 	s.Snapshot()
 }
 
@@ -174,7 +188,7 @@ func (s *DBImpl) Copy() vm.StateDB {
 	snapshots := make([]sdk.Context, len(s.snapshottedCtxs)+1)
 	copy(snapshots, s.snapshottedCtxs)
 	snapshots[len(s.snapshottedCtxs)] = s.ctx
-	return &DBImpl{
+	copied := &DBImpl{
 		ctx:                newCtx,
 		snapshottedCtxs:    snapshots,
 		tempState:          s.tempState.DeepCopy(),
@@ -187,6 +201,12 @@ func (s *DBImpl) Copy() vm.StateDB {
 		precompileErr:      s.precompileErr,
 		logger:             s.logger,
 	}
+	// Deliver copies start with an empty cache (reload on demand). If the parent
+	// had caching disabled (nil), keep it disabled — do not allocate.
+	if s.codeCache != nil {
+		copied.codeCache = make(map[common.Address][]byte)
+	}
+	return copied
 }
 
 func (s *DBImpl) Finalise(bool) {


### PR DESCRIPTION
## Summary
- Memoize bytecode in deliver-tx `StateDB` (`codeCache`) so repeated `GetCode` calls avoid re-reading the KV store on CALL-family paths.
- Same memo + per-address journal invalidation is ported to `giga/deps/xevm/state` so `GigaExecutorEnabled` deliver txs get the win (simulation still leaves the memo nil).
- Leave `codeCache` nil for simulation/RPC/trace and wasmd-entry deliver statedbs in `x/evm` (nested `CallEVM` can Finalize into the same Multistore). `Copy()` starts empty when caching is enabled and stays nil when disabled.
- Keep the memo coherent on `SetCode`, account recreate, and via `RefreshCodeCache` for keeper bypasses. Snapshot revert restores **only journaled** code mutations (not a wholesale `clear`), so unrelated warmed entries survive nested reverts.
- Pin `GetCodeSize(addr) == len(GetCode(addr))` on keeper and StateDB (EIP-7702 size-gate expectations with Sei’s separate code-size metadata).

### Pointer upsert Multistore fix (`app-hash-breaking`)
`UpsertERCPointer` runs `GetDeploymentCode` / `Create`, which snapshot and `Freeze()` Multistore layers after precompile Prepare. Exists-lookup, redeploy `SetCode`, and registry writes now go through the live unfrozen top (`sdb.Ctx()`) with the caller’s finite precompile gas meter, instead of the Prepare-time `ctx` that may already be frozen. Failed `GetDeploymentCode` returns before any code write. This changes same-tx visibility / revert scope of those writes vs main and is why the PR is labeled `app-hash-breaking`.

## Test plan
- [x] `GOWORK=off go test ./x/evm/state/ -run 'TestCode|TestStateDBGetCodeSize' -count=1`
- [x] `GOWORK=off go test ./x/evm/keeper/ -run 'TestGetCodeSizeMatchesGetCodeLength|TestUpsertERCNativePointer' -count=1`
- [x] `GOWORK=off go test ./giga/deps/xevm/state/ -run 'TestCode|TestCodeCache' -count=1`
- [ ] Confirm CI green on this PR