### PR TITLE
Remove redundant libstdc++6 installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM docker.io/ubuntu:24.04@sha256:104ae83764a5119017b8e8d6218fa0832b09df65aae7d5a6de29a85d813da2fb
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates libstdc++6 && \
+    apt-get install -y --no-install-recommends ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /go/bin/seid /usr/bin/


### PR DESCRIPTION
Ubuntu 24.04’s runtime image already includes a distro-provided libstdc++6 with GLIBCXX_3.4.32 support. Remove the redundant explicit installation while retaining CA certificate setup.

