### PR TITLE
fix(ci): stop the autobahn sidecar deadline from timing the image build

### DIFF
--- a/integration_test/autobahn/autobahn_test.go
+++ b/integration_test/autobahn/autobahn_test.go
@@ -14,6 +14,7 @@ package autobahn
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -433,9 +434,27 @@ func countSeiContainers() (int, error) {
 // `go install` cycle. The autobahn role itself comes from mode = "full"
 // in docker/rpcnode/config/config.toml — setup.go picks the fullnode
 // constructor when there's no local validator key.
+//
+// The image build is run to completion before the readiness deadline opens.
+// `skipbuild` names the seid `go install` it skips, not the image build: the
+// target still depends on build-rpc-node, whose cost is entirely a function of
+// the docker layer cache. On a cache miss that step rebuilds
+// docker/rpcnode/Dockerfile from ubuntu:latest — an apt-get install of
+// build-essential plus a network foundry install — which has been measured at
+// roughly nine minutes, so sharing one deadline with it made a cold cache
+// indistinguishable from a sidecar that never came up. Building first costs the
+// same wall clock and leaves fullnodeBootTimeout measuring only what it names.
 func setupFullnodeNode() error {
 	fmt.Println("=== Starting fullnode sidecar ===")
 	_ = runMake(nil, "kill-rpc-node") // best-effort cleanup
+
+	// Synchronous and unbudgeted, so a slow or failing build reports as itself.
+	// Idempotent against the same dependency inside run-rpc-node-skipbuild
+	// below, which is a cache hit once this returns.
+	fmt.Println("=== Building rpc-node image (before the readiness deadline) ===")
+	if err := runMake(nil, "build-rpc-node"); err != nil {
+		return fmt.Errorf("build rpc-node image: %w", err)
+	}
 
 	// Discover the cluster size from docker so the rpc-node's autobahn config
 	// covers exactly the validators that came up — non-four-node test runs
@@ -454,10 +473,13 @@ func setupFullnodeNode() error {
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start make run-rpc-node-skipbuild: %w", err)
 	}
-	// Reap the process when it eventually exits (e.g. on container kill);
-	// not blocking on Wait here since the container runs for the duration
-	// of the test suite.
-	go func() { _ = cmd.Wait() }()
+	// Reap the process when it eventually exits (e.g. on container kill), and
+	// keep the result: `docker run --rm` holds the foreground for the suite's
+	// duration, so an exit during startup means the container never came up.
+	// Discarding it here would surface every such failure as the readiness
+	// timeout below, naming the sidecar for something that failed earlier.
+	exited := make(chan error, 1)
+	go func() { exited <- cmd.Wait() }()
 
 	deadline := time.Now().Add(fullnodeBootTimeout)
 	for time.Now().Before(deadline) {
@@ -465,9 +487,19 @@ func setupFullnodeNode() error {
 			fmt.Println("fullnode sidecar is ready")
 			return nil
 		}
-		time.Sleep(fullnodeBootPoll)
+		select {
+		case err := <-exited:
+			if err != nil {
+				return fmt.Errorf("make run-rpc-node-skipbuild exited before the sidecar was ready: %w", err)
+			}
+			return errors.New("make run-rpc-node-skipbuild exited cleanly before the sidecar was ready, " +
+				"so the container stopped on its own; check the rpc-node logs above")
+		case <-time.After(fullnodeBootPoll):
+		}
 	}
-	return fmt.Errorf("fullnode sidecar didn't come up within %s", fullnodeBootTimeout)
+	return fmt.Errorf("fullnode sidecar didn't come up within %s of the container starting "+
+		"(the image build completed before this deadline opened, so this is a container start "+
+		"or RPC readiness failure rather than a slow build)", fullnodeBootTimeout)
 }
 
 func fullnodeRunning() bool {


### PR DESCRIPTION
## The failure

The autobahn integration test has been failing **repo-wide** — on `main` and on four unrelated branches today — with:

```
fullnode sidecar setup failed: fullnode sidecar didn't come up within 5m0s
```

That message names the wrong component. Nothing is wrong with the sidecar.

## The cause

`setupFullnodeNode` starts `make run-rpc-node-skipbuild` and *then* opens a five-minute readiness deadline. But `skipbuild` names the seid `go install` it skips, **not** the image build:

```make
run-rpc-node-skipbuild: build-rpc-node
```

So the deadline was timing a docker build whose cost is entirely a function of the layer cache. Measured across the two runs:

| | layers `CACHED` |
|---|---|
| passing run | **20** |
| failing run | **1** |

On a cache miss, `build-rpc-node` rebuilds `docker/rpcnode/Dockerfile` from `ubuntu:latest` — an `apt-get install` of `build-essential` plus a network `foundry` install with a five-attempt retry loop. In the failing run that took roughly **nine minutes**. The timestamps line up exactly:

```
16:48:57  === Starting fullnode sidecar ===     (deadline opens)
16:48:58  #0 building with "default" instance   (docker build begins)
16:53:58  didn't come up within 5m0s            (deadline expires)
16:57:09  ...apt-get still downloading
```

## The fix

**The image build now completes before the deadline opens.** Synchronous, unbudgeted, and idempotent against the same dependency inside `run-rpc-node-skipbuild`, which becomes a cache hit. Total wall clock is unchanged — but `fullnodeBootTimeout` now measures only container start and RPC readiness, which is what it is named for. Raising the timeout instead would only move the cliff.

**The subprocess error is no longer discarded.** `go func() { _ = cmd.Wait() }()` became a channel the poll loop selects on. `docker run --rm` holds the foreground for the suite's duration, so an exit during startup means the container never came up — and previously that surfaced as the readiness timeout above. That is why every failure in this path looked identical regardless of cause, and why this took a log dig to attribute.

## What this does not include, deliberately

Pinning `FROM ubuntu:latest` in `docker/rpcnode/Dockerfile`.

The base image did **not** float here — I checked, the digest is identical across the passing and failing runs (`678c6550cc43`), so that was not the trigger. But an unpinned base guarantees a future cache-invalidating flip that reproduces this exact failure with no code change to blame. Pinning trades that for stale packages until someone bumps the digest, which is a policy call rather than part of a bugfix. Worth a separate decision.

## Verification, and its limit

Compiles clean under the `autobahn_integration` build tag; `gofmt -s`, `goimports` and `go vet` clean.

**I have not run this end to end.** The failure only reproduces on a cold docker layer cache, and reproducing it locally needs Docker, a four-node cluster and ~30 minutes. So this fix is reasoned and compile-verified, not behavior-verified — stating that explicitly rather than implying otherwise.

The useful signal from CI is not a pass. It is that on a cold cache the error will now name the **build** rather than the sidecar. A correctly-attributed failure would prove more here than a green run.

---

## Addendum: root cause is a missed integration, not just cache luck

Tracing the history changes the framing above. The *shape* is old — `run-rpc-node-skipbuild: build-rpc-node` dates to 2023-06-30 (#944) — but the bug arrived with the sidecar:

- **2026-06-16** — #3582, *"ci: fix flaky integration tests by distributing images via GHCR"*, added the prebuild-and-push mechanism plus the `*-integration-ci` make targets that consume it via `ensure-integration-ci-images`.
- **2026-06-23** — #3525, *"Add Autobahn fullnode"*, wired the sidecar to `run-rpc-node-skipbuild`, the **pre-GHCR** target that rebuilds.

So the autobahn path opted out of the mechanism added the week before to stop integration flakiness. This job already receives a prebuilt `sei-chain/rpcnode` image, pushed to GHCR by `prepare-cluster` for exactly this purpose — and then rebuilds it locally anyway.

It has been latent since June because `cache-to` is restricted to `push` events (workflow lines 112, 124), so PR runs only *read* a registry cache that only main's successful pushes *write*. Warm cache, instant build, green. Cold cache, nine-minute rebuild, blown deadline. A coin flip on cache warmth rather than anything in the PR under test.

## What this PR does and does not fix

**Fixes:** the misattribution and the failure. The job budget is 45 minutes and the failing run used 31m24s, so with the build outside the readiness deadline there is roughly 14 minutes of headroom. Cold-cache runs become slow rather than red, and a genuine container failure now reports itself.

**Does not fix:** the wasted rebuild. Roughly nine minutes per cold run, rebuilding an image this job already has.

The deeper fix is to consume the prebuilt image, and it is not a one-line target swap — `run-rpc-node-integration-ci` does not pass `AUTOBAHN` or `CLUSTER_SIZE` (autobahn's role and committee size come from those), and it prepends a block-100 wait whose comment states that `SKIP_BUILD=true` otherwise reads a trust height of ~10-20, finds no snapshot, and crashes. Since the autobahn sidecar also runs `SKIP_BUILD=true`, it may share that hazard without the guard. That wants its own change and its own review.

Two hardening items also surfaced and are deliberately out of scope: `FROM ubuntu:latest` is unpinned in `docker/rpcnode/Dockerfile`, and `foundry` installs from the network inside the image build behind a five-attempt retry loop.
