### PR TITLE
test(config): check which indexer and whether tracing is off, and stop one test changing another's config (PLT-893)

### DIFF
--- a/sei-cosmos/baseapp/config_fuzz_test.go
+++ b/sei-cosmos/baseapp/config_fuzz_test.go
@@ -1,9 +1,12 @@
 package baseapp
 
 import (
+	"context"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sei-protocol/sei-chain/sei-cosmos/server/config"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store"
@@ -13,6 +16,10 @@ import (
 	"github.com/sei-protocol/sei-chain/testutil/fuzzing"
 	"github.com/spf13/cast"
 	dbm "github.com/tendermint/tm-db"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 // BaseApp reads four keys straight out of appOpts during construction, after every
@@ -288,20 +295,282 @@ func TestBaseAppArchivalVersionZeroSkipsTheArchivalStore(t *testing.T) {
 // during construction and, when false, a no-op provider is installed — construction
 // never reaches the real tracer builder, which panics on failure.
 //
-// Enabling it is not driven here: it constructs a real tracer provider against a
-// hardcoded URL and replaces the process-global OTEL provider, neither of which
-// belongs in a config characterization run.
+// The property is that nothing traces, so that is what is asserted. Surviving construction
+// does not show it: the builder panics only when the exporter cannot be created, and an
+// unreachable Jaeger endpoint creates fine, so a build that installed a real provider would
+// construct just as quietly. Both things the read controls are checked — the flag it stores on
+// TracingInfo, which gates every ABCI path, and the process-global provider it installs for
+// every otel caller in the process.
+//
+// A live span context is checked alongside IsRecording because IsRecording alone cannot tell
+// the no-op provider from a real Jaeger provider whose sampler is off. Both report false,
+// while the second has already started the exporter goroutine, so a build that traded the flag
+// for a sampler would pass on IsRecording. SpanContext().IsValid() is false for the no-op
+// provider and true for any SDK provider whatever its sampler.
+//
+// TestBaseAppTracingEnabledInstallsAProviderNothingShutsDown drives the other value.
 func TestBaseAppTracingDisabledByDefault(t *testing.T) {
 	opts := baseOpts()
 	opts[tracing.FlagTracing] = false
-
-	if !panicsNot(t, func() { _ = newTestBaseApp(t, opts) }) {
-		t.Fatal("tracing = false must install the no-op provider without failing")
-	}
+	checkNothingTraces(t, opts, "tracing = false")
 
 	// An absent key resolves the same way, since the read is an unguarded cast.ToBool.
-	if !panicsNot(t, func() { _ = newTestBaseApp(t, baseOpts()) }) {
-		t.Fatal("an absent tracing key must behave as false")
+	checkNothingTraces(t, baseOpts(), "an absent tracing key")
+
+	// A positive control, so the two signals above are known to distinguish the cases rather
+	// than to always report false, for the same reason archivalWiring is paired with one. A
+	// provider with no exporter still records, and it still mints a span context. The sampler
+	// is passed explicitly because the SDK applies OTEL_TRACES_SAMPLER first and a passed
+	// option overrides it: without this, always_off in the environment reddens the shard here
+	// and blames sei for it.
+	control := sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.AlwaysSample()))
+	_, span := control.Tracer("component-main").Start(context.Background(), "control")
+	if !span.IsRecording() || !span.SpanContext().IsValid() {
+		t.Fatalf("a provider that definitely samples reported recording=%v valid=%v (%T); the "+
+			"assertions above prove nothing until both hold", span.IsRecording(),
+			span.SpanContext().IsValid(), span)
+	}
+}
+
+// checkNothingTraces constructs an app from opts and asserts it traces nowhere, on two signals:
+// what TracingInfo hands back, and the process-global provider.
+//
+// The first covers the flag, not the tracer. Info.Start returns the tracing package's NoOpSpan
+// on !tracingEnabled.Load() and never reaches i.tracer, so what it pins is that construction
+// stored a false flag — the gate every ABCI path passes through, which is the property. The
+// tracer stored beside it is deferred rather than covered: behind that short-circuit a live one
+// cannot produce a span either way. If the short-circuit ever goes, this signal starts covering
+// the tracer, and that is the change to notice here.
+//
+// It captures the global before constructing so the failure can name both values. Reading it
+// after is sound because construction installs the no-op provider unconditionally before
+// consulting the flag, so the window between that install and this read is the whole exposure.
+// A build that dropped the unconditional install would make the same read report a provider
+// some earlier row left behind, which is why the message says the global traces after
+// construction rather than that construction installed it.
+//
+// It is also why no row in this file calls t.Parallel. Being the only file to abstain is not
+// enough on its own: TestBaseAppCreateQueryContext and
+// TestCreateQueryContextUsesCheckStateBeforeFirstCommit do call it, and they construct
+// BaseApps that set the same global. What keeps them out of the window is that Go parks a
+// top-level parallel test until every sequential top-level test in the binary has finished, so
+// a parallel row cannot overlap a sequential one. A row here that called t.Parallel would join
+// that pool and give the guarantee up.
+func checkNothingTraces(t *testing.T, opts configtest.AppOpts, what string) {
+	t.Helper()
+
+	globalBefore := otel.GetTracerProvider()
+
+	var app *BaseApp
+	if !panicsNot(t, func() { app = newTestBaseApp(t, opts) }) {
+		t.Fatalf("%s: construction must install the no-op provider without failing", what)
+	}
+	if app == nil {
+		t.Fatalf("%s: construction must succeed", what)
+	}
+	if app.TracingInfo == nil {
+		t.Fatalf("%s: the app carries no TracingInfo, so nothing here can tell whether tracing "+
+			"is on", what)
+	}
+	if _, span := app.TracingInfo.Start("component-main"); span.IsRecording() || span.SpanContext().IsValid() {
+		t.Errorf("%s: the app handed back a live span through TracingInfo (%T, recording=%v "+
+			"valid=%v), so every ABCI path allocates and records a span for a node that asked for "+
+			"none", what, span, span.IsRecording(), span.SpanContext().IsValid())
+	}
+	global := otel.GetTracerProvider()
+	_, span := global.Tracer("component-main").Start(context.Background(), "probe")
+	if span.IsRecording() || span.SpanContext().IsValid() {
+		t.Errorf("%s: the process-global tracer provider traces after construction (%T, "+
+			"recording=%v valid=%v; it was %T before), so every otel caller in the process gets a "+
+			"live tracer for a node that asked for none", what, global, span.IsRecording(),
+			span.SpanContext().IsValid(), globalBefore)
+	}
+	// And a Set is known to have happened, because otherwise the assertion above is a
+	// tautology. otel's untouched global is a delegating placeholder whose Start returns a
+	// non-recording span with no span context, so a build that dropped the unconditional
+	// otel.SetTracerProvider call would read false on both signals forever while leaving
+	// whatever the process already had in place.
+	if _, ok := global.(noop.TracerProvider); !ok {
+		t.Errorf("%s: the process-global provider is %T, not the no-op provider construction "+
+			"installs. Installing a different one is a behavior change to record here; installing "+
+			"none leaves the assertion above unable to fail", what, global)
+	}
+}
+
+// TestBaseAppTracingEnabledInstallsAProviderNothingShutsDown drives the other value of the
+// flag and pins the two things construction leaves behind.
+//
+// tracing = true builds a real Jaeger provider with trace.WithBatcher, which starts one
+// background goroutine that stops only on Shutdown. NewBaseApp never calls it: the enabled
+// branch declares its own tp with :=, shadowing the one the function opened with. The provider
+// stays referenced — the tracer it hands TracingInfo holds it on an unexported field, and the
+// provider's own named-tracer map holds that tracer — but no exported handle reaches it, which
+// is why this row goes through otel.GetTracerProvider to clean up what construction started. A
+// node with tracing on therefore pays one goroutine per BaseApp for the life of the process, and
+// nothing in baseapp gives it back: app.Close, production's lifecycle close, releases the db, the
+// commit store, the snapshot manager and the close handler, and never touches the provider. This
+// row drives Close so that claim is falsifiable rather than narrated — see the assertion below.
+//
+// A live span context is asserted rather than IsRecording because the provider is built with
+// no sampler option, so OTEL_TRACES_SAMPLER in the environment decides whether it records.
+// Whether a real provider was installed is the property; whether it samples is not, and
+// making the row depend on it would hand a stray environment variable a red shard.
+//
+// No span is ended, so nothing is ever enqueued and nothing here touches the network: the
+// collector exporter is a struct holding an http.Client it has not called yet, so neither
+// construction nor Shutdown opens a connection and an unreachable collector is not a
+// dependency of this row.
+func TestBaseAppTracingEnabledInstallsAProviderNothingShutsDown(t *testing.T) {
+	globalBefore := otel.GetTracerProvider()
+	// Registered first so it runs last, because the Shutdown registered below has to precede it.
+	// Restoring the handle is not all of what construction changed: otel wires the placeholder
+	// global's delegate to the first real provider it is handed and never unwires it, so after
+	// this restore the placeholder still resolves tracers through this row's provider. That is
+	// harmless only because a provider that has been shut down hands out no-op tracers — which
+	// is why the Shutdown is a Cleanup rather than the last statement of the body, where a
+	// Fatalf above it would skip it and leave the process global delegating to a live provider.
+	t.Cleanup(func() { otel.SetTracerProvider(globalBefore) })
+	exportersBefore := batchSpanProcessorGoroutines()
+
+	opts := baseOpts()
+	opts[tracing.FlagTracing] = true
+
+	var app *BaseApp
+	if !panicsNot(t, func() { app = newTestBaseApp(t, opts) }) {
+		t.Fatal("tracing = true must construct without failing: the exporter is created rather " +
+			"than connected, so an unreachable collector cannot stop a node booting")
+	}
+	if app == nil || app.TracingInfo == nil {
+		t.Fatal("construction must succeed and carry TracingInfo")
+	}
+
+	if _, span := app.TracingInfo.Start("component-main"); !span.SpanContext().IsValid() {
+		t.Errorf("tracing = true left the app's tracer on the no-op provider (%T), so no ABCI path "+
+			"would produce a span on a node that asked for tracing", span)
+	}
+	global := otel.GetTracerProvider()
+	if _, span := global.Tracer("component-main").Start(context.Background(), "probe"); !span.SpanContext().IsValid() {
+		t.Errorf("tracing = true left the process-global provider on the no-op one (%T), so every "+
+			"otel caller outside baseapp would keep dropping spans", global)
+	}
+
+	// The leak as a measurement rather than a note.
+	provider, ok := global.(*sdktrace.TracerProvider)
+	if !ok {
+		t.Fatalf("the process-global provider is %T, so this row has no handle to shut down what "+
+			"construction installed and would leak it into every later row", global)
+	}
+	t.Cleanup(func() {
+		// Bounded, because Shutdown flushes through the exporter and this row must not be able to
+		// hang a shard on a collector endpoint that neither refuses nor answers.
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := provider.Shutdown(ctx); err != nil {
+			t.Errorf("Shutdown of the provider construction installed failed (%v), so the goroutine "+
+				"it started cannot be given back and this row leaks it into the rest of the binary", err)
+		}
+		if got := waitForBatchSpanProcessorGoroutines(exportersBefore) - exportersBefore; got != 0 {
+			t.Errorf("%d batch-processor goroutines outlived Shutdown, so this row leaks what it "+
+				"created", got)
+		}
+	})
+
+	leaked := batchSpanProcessorGoroutines() - exportersBefore
+	if leaked != 1 {
+		t.Errorf("tracing = true started %d batch-processor goroutines, want 1. Zero has four causes "+
+			"and this line cannot tell them apart: construction now shuts the provider down, the "+
+			"provider is built with WithSyncer, it is built with no span-processor option at all, or "+
+			"the SDK renamed the frame the counter matches — which is what the control at the end of "+
+			"this row separates from the other three. More than one means the enabled branch builds "+
+			"more than one batcher. Each is a change to record here rather than a number to widen; "+
+			"while it stays at one, this is what a node with tracing on pays for the life of the "+
+			"process", leaked)
+	}
+
+	// The name's claim, driven rather than read off the shape of the code. Close is production's
+	// only lifecycle close and it does not release the provider, so the count has to survive it.
+	// A build that unshadowed the enabled branch's tp, kept the handle on BaseApp and shut it down
+	// here — the fix this row's own message asks for — reddens the two assertions below. Without
+	// driving Close, nothing in this row can see that fix land.
+	if err := app.Close(); err != nil {
+		t.Fatalf("app.Close failed (%v), so this row cannot say whether Close releases the provider",
+			err)
+	}
+	// Asked of the provider rather than only of the goroutine count, because a shut-down provider
+	// answers Tracer with a no-op one the moment its flag flips, while its goroutine takes a
+	// moment to unwind. The delta below measures the cost; this decides the question.
+	if _, span := provider.Tracer("component-main").Start(context.Background(), "after-close"); !span.SpanContext().IsValid() {
+		t.Errorf("app.Close shut the tracer provider down (its tracer is now %T), so a node with "+
+			"tracing on stops paying for it at shutdown. That is the fix this row exists to record — "+
+			"rewrite the row against the new lifecycle rather than deleting this line", span)
+	}
+	// Compared against the count taken before Close rather than against a literal 1, so that a
+	// build which never started a batch processor reddens only the assertion above — the one whose
+	// message names that cause — instead of also being reported here as a change to Close.
+	if got := batchSpanProcessorGoroutines() - exportersBefore; got != leaked {
+		t.Errorf("app.Close took the batch-processor delta from %d to %d: Close now releases the "+
+			"tracer provider, so a node with tracing on stops paying for it at shutdown. That is the "+
+			"fix this row exists to record — rewrite the row against the new lifecycle rather than "+
+			"deleting this line", leaked, got)
+	}
+
+	// A positive control, so the counter is known to see a batch processor rather than to always
+	// report none, for the same reason archivalWiring and the disabled row's two signals are each
+	// paired with one. It is what separates a renamed SDK frame from a change in sei: on a rename
+	// this fails too, and on a change in sei only the assertions above do.
+	controlBefore := batchSpanProcessorGoroutines()
+	control := sdktrace.NewTracerProvider(sdktrace.WithBatcher(tracetest.NewInMemoryExporter()))
+	if got := batchSpanProcessorGoroutines() - controlBefore; got != 1 {
+		t.Errorf("a provider built with exactly one batcher moved the count by %d, want 1. The frame "+
+			"batchSpanProcessorGoroutines matches no longer names a batch-processor goroutine, so "+
+			"every count in this row reads zero and none of its assertions can fail", got)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := control.Shutdown(ctx); err != nil {
+		t.Errorf("shutting down the control provider failed (%v), so this row leaks the goroutine it "+
+			"started to prove the counter works", err)
+	}
+	if got := waitForBatchSpanProcessorGoroutines(controlBefore) - controlBefore; got != 0 {
+		t.Errorf("%d batch-processor goroutines outlived the control provider's Shutdown", got)
+	}
+}
+
+// batchSpanProcessorGoroutines counts the batch-processor goroutines the otel SDK has running.
+// Every trace.WithBatcher starts exactly one and only Shutdown stops it, so the count is how
+// the row above sees a provider nobody owns rather than describing one.
+//
+// It counts the creator line the runtime records for each such goroutine. That line is present
+// from creation rather than from first scheduling, since runtime.Stack dumps runnable goroutines
+// too and the creator PC is set before the new goroutine becomes runnable; it appears exactly
+// once per goroutine; and it names an exported constructor rather than an internal. If the SDK
+// renames it this reads zero for every provider, sei's and the row's control alike — which is
+// why the row above pairs it with one, since a zero delta on its own says nothing about whether
+// sei stopped leaking.
+func batchSpanProcessorGoroutines() int {
+	const frame = "created by go.opentelemetry.io/otel/sdk/trace.NewBatchSpanProcessor"
+	buf := make([]byte, 1<<16)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return strings.Count(string(buf[:n]), frame)
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+}
+
+// waitForBatchSpanProcessorGoroutines polls until the count reaches want, or gives up and
+// reports what it saw. Shutdown returns once the processor has signalled completion, which is
+// a moment before the goroutine itself finishes unwinding, so an immediate read can still see
+// it and the wait is what keeps that from being a flake.
+func waitForBatchSpanProcessorGoroutines(want int) int {
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		got := batchSpanProcessorGoroutines()
+		if got == want || time.Now().After(deadline) {
+			return got
+		}
+		time.Sleep(time.Millisecond)
 	}
 }
 

--- a/sei-cosmos/server/config/config_test.go
+++ b/sei-cosmos/server/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 	"time"
 
@@ -368,16 +369,50 @@ func TestParseConfig(t *testing.T) {
 	require.Equal(t, DefaultMinGasPrices, cfg.MinGasPrices)
 }
 
+// TestSetConfigTemplate installs a custom template into the package-global configTemplate
+// that every row rendering app.toml reads, so it puts the default back. Without that, this
+// row decides what the rest of the package renders, and the package passes only in the one
+// order a single -count=1 run happens to take.
+//
+// The restore is asserted rather than only performed. A t.Cleanup on its own is not testable
+// here: seedViperWithDefaultConfig's callers both sit above this row, CI runs go test with
+// neither -count nor -shuffle, and nothing below reads the template — so deleting the restore
+// keeps the package green and the protection is invisible. Rendering the default back inside
+// the body is what makes its absence a failure in the same run.
+//
+// It is also why no row in this package may call t.Parallel: configTemplate is a
+// package-global, and a parallel row rendering app.toml while this one holds the custom
+// template would read the wrong one.
 func TestSetConfigTemplate(t *testing.T) {
 	customTemplate := `# Custom Template
 [telemetry]
 enabled = {{ .Telemetry.Enabled }}
 `
 
+	original := configTemplate
+	// Kept for the panic path: SetConfigTemplate panics on a template that will not parse,
+	// and the explicit restore below is then never reached.
+	t.Cleanup(func() { configTemplate = original })
+
 	// Should not panic
 	require.NotPanics(t, func() {
 		SetConfigTemplate(customTemplate)
 	})
+
+	// And the handed template is the one installed. Asserting only that the call survived
+	// passes for a setter that parses and installs nothing, and this setter is how seid
+	// init and InterceptConfigsPreRunHandler decide what app.toml says.
+	var buf bytes.Buffer
+	require.NoError(t, configTemplate.Execute(&buf, DefaultConfig()))
+	firstLine, _, _ := strings.Cut(buf.String(), "\n")
+	require.Equal(t, "# Custom Template", firstLine)
+
+	configTemplate = original
+	var restored bytes.Buffer
+	require.NoError(t, configTemplate.Execute(&restored, DefaultConfig()))
+	require.Contains(t, restored.String(), "minimum-gas-prices",
+		"the default template must be back before this row returns, or every later row renders "+
+			"the one-section template installed above")
 }
 
 func TestGetConcurrencyWorkers(t *testing.T) {

--- a/sei-tendermint/internal/state/indexer/sink/sink_fuzz_test.go
+++ b/sei-tendermint/internal/state/indexer/sink/sink_fuzz_test.go
@@ -1,6 +1,7 @@
 package sink_test
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
@@ -8,6 +9,7 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/sei-protocol/sei-chain/sei-tendermint/config"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/state/indexer"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/state/indexer/sink"
 )
 
@@ -36,6 +38,36 @@ import (
 // exercises sink selection without touching disk.
 func memDBProvider(*config.DBContext) (dbm.DB, error) { return dbm.NewMemDB(), nil }
 
+// closeCounted records whether anything ever closed the store it wraps, which is the
+// difference between a store that was opened and one that was handed back.
+type closeCounted struct {
+	dbm.DB
+	closes *int
+}
+
+func (c closeCounted) Close() error {
+	*c.closes++
+	return c.DB.Close()
+}
+
+// resolvedTypes reports which sinks came back, sorted, since selection ranges over a map
+// and the slice order is not fixed even when the set is.
+//
+// The rows assert on these types rather than on the count because a count of one is equally
+// true of the null sink and of the kv sink null is supposed to have replaced: a node
+// indexing every transaction and a node indexing none agree on every count.
+func resolvedTypes(sinks []indexer.EventSink) []indexer.EventSinkType {
+	types := make([]indexer.EventSinkType, 0, len(sinks))
+	for _, s := range sinks {
+		types = append(types, s.Type())
+	}
+	slices.Sort(types)
+	return types
+}
+
+// nullAlone is what the null-wins rule promises: the null sink and nothing else.
+func nullAlone() []indexer.EventSinkType { return []indexer.EventSinkType{indexer.NULL} }
+
 // FuzzEventSinksFromConfig pins the list semantics: the null-wins rule, the
 // duplicate rejection, the unknown-name rejection, and the empty-list default.
 //
@@ -55,19 +87,19 @@ func FuzzEventSinksFromConfig(f *testing.F) {
 	f.Add("null,null") // duplicate null still counts as a duplicate
 
 	f.Fuzz(func(t *testing.T, list string) {
-		var indexer []string
+		var names []string
 		if list != "" {
-			indexer = strings.Split(list, ",")
+			names = strings.Split(list, ",")
 		}
 
 		cfg := config.DefaultConfig()
-		cfg.TxIndex.Indexer = indexer
+		cfg.TxIndex.Indexer = names
 
 		sinks, err := sink.EventSinksFromConfig(cfg, memDBProvider, "sei-test")
 
 		// Restate the rules independently of the implementation.
-		lowered := make([]string, 0, len(indexer))
-		for _, s := range indexer {
+		lowered := make([]string, 0, len(names))
+		for _, s := range names {
 			lowered = append(lowered, strings.ToLower(s))
 		}
 		hasDuplicate := false
@@ -80,20 +112,20 @@ func FuzzEventSinksFromConfig(f *testing.F) {
 		}
 
 		switch {
-		case len(indexer) == 0:
+		case len(names) == 0:
 			// An absent or empty list is not an error: the node gets the null sink,
 			// so transactions are simply not indexed.
 			if err != nil {
 				t.Fatalf("an empty indexer list must default to the null sink, got %v", err)
 			}
-			if len(sinks) != 1 {
-				t.Fatalf("an empty indexer list must yield exactly one sink, got %d", len(sinks))
+			if got := resolvedTypes(sinks); !slices.Equal(got, nullAlone()) {
+				t.Fatalf("an empty indexer list resolved to %v, want the null sink alone", got)
 			}
 			return
 
 		case hasDuplicate:
 			if err == nil {
-				t.Fatalf("indexer = %v repeats a sink and must be rejected", indexer)
+				t.Fatalf("indexer = %v repeats a sink and must be rejected", names)
 			}
 			return
 
@@ -115,11 +147,11 @@ func FuzzEventSinksFromConfig(f *testing.F) {
 			}
 			if err != nil {
 				t.Fatalf("indexer = %v contains null alongside supported names and must resolve to "+
-					"the null sink, got %v", indexer, err)
+					"the null sink, got %v", names, err)
 			}
-			if len(sinks) != 1 {
-				t.Fatalf("indexer = %v contains null, so every other sink must be discarded; got %d sinks",
-					indexer, len(sinks))
+			if got := resolvedTypes(sinks); !slices.Equal(got, nullAlone()) {
+				t.Fatalf("indexer = %v contains null, so every other sink must be discarded; resolved "+
+					"to %v", names, got)
 			}
 			return
 		}
@@ -134,15 +166,20 @@ func FuzzEventSinksFromConfig(f *testing.F) {
 		}
 		if !supported || slices.Contains(lowered, "psql") {
 			if err == nil {
-				t.Fatalf("indexer = %v must be rejected (unsupported name, or psql with no conn)", indexer)
+				t.Fatalf("indexer = %v must be rejected (unsupported name, or psql with no conn)", names)
 			}
 			return
 		}
 		if err != nil {
-			t.Fatalf("indexer = %v is all-supported and must be accepted, got %v", indexer, err)
+			t.Fatalf("indexer = %v is all-supported and must be accepted, got %v", names, err)
 		}
-		if len(sinks) != len(lowered) {
-			t.Fatalf("indexer = %v resolved to %d sinks, want %d", indexer, len(sinks), len(lowered))
+		want := make([]indexer.EventSinkType, 0, len(lowered))
+		for _, s := range lowered {
+			want = append(want, indexer.EventSinkType(s))
+		}
+		slices.Sort(want)
+		if got := resolvedTypes(sinks); !slices.Equal(got, want) {
+			t.Fatalf("indexer = %v resolved to %v, want %v", names, got, want)
 		}
 	})
 }
@@ -165,8 +202,10 @@ func FuzzEventSinksFromConfig(f *testing.F) {
 // The run count is sized so that a minority branch of the order this row was written against
 // is missed with negligible probability, and a one-sided sample escalates rather than failing
 // outright, so the exact split does not have to hold for the row to stay correct. The split
-// measured at authoring was about 16% minority over 200 runs; treat that as the origin of the
-// sizing, not as an invariant the code depends on.
+// comes from where the two names land: a two-key map puts the first-listed one in the first of
+// its eight slots and iteration starts at a slot chosen at random, so the second name is
+// reached first one time in eight. Measured 12.8% over 4000 runs. Treat that as the origin of
+// the sizing, not as an invariant the code depends on.
 func TestNullMixedWithAnUnsupportedSinkIsUnspecified(t *testing.T) {
 	const runs = 250
 	booted, failed := countMixedOutcomes(runs)
@@ -208,8 +247,8 @@ func countMixedOutcomes(n int) (booted, failed int) {
 // 2 from the others, but it cannot separate 1 from 3: at 250 runs a collapsed-but-nonzero
 // split and a deterministic outcome look identical. Drawing a much larger sample separates
 // them, and it costs nothing in the common case because it only runs when a row is about to
-// fail. Without it a split moving from the observed 16% to a fraction of a percent would
-// redden the shard while blaming a change in selection that never happened.
+// fail. Without it a split moving from the measured one-in-eight to a fraction of a percent
+// would redden the shard while blaming a change in selection that never happened.
 //
 // label names what the two counts mean, because the callers count different things.
 func resolveOneSidedOutcome(t *testing.T, label string, runs, majority, minority int, resample func(int) (int, int)) {
@@ -243,7 +282,8 @@ func resolveOneSidedOutcome(t *testing.T, label string, runs, majority, minority
 // smallMapIterationVaries reports whether this runtime still starts a two-element map range
 // at a varying key, which is the mechanism both probabilistic rows depend on.
 //
-// The split is not close to even in practice, around 90/10 for a two-element map. That is
+// The split is not close to even in practice: the two keys sit in the first two of eight slots
+// and the range starts at a slot chosen at random, so it runs 7 to 1. That is
 // enough to answer "does the order vary at all", which is all this is asked, and it is not a
 // yardstick for the sink's own split.
 func smallMapIterationVaries(runs int) bool {
@@ -312,77 +352,107 @@ func TestNullSinkAlwaysWinsOverARecognizedSink(t *testing.T) {
 			if err != nil {
 				t.Fatalf("indexer = %v: %v", list, err)
 			}
-			if len(sinks) != 1 {
-				t.Fatalf("indexer = %v resolved to %d sinks; null must discard the kv sink",
-					list, len(sinks))
+			if got := resolvedTypes(sinks); !slices.Equal(got, nullAlone()) {
+				t.Fatalf("indexer = %v resolved to %v; null must discard the kv sink", list, got)
 			}
 		}
 	}
 
-	// kv alone does produce a sink, so the assertion above is about null rather than
-	// about kv never working.
+	// kv alone does produce a kv sink, so the assertion above is about null rather than
+	// about kv never working — and it is the case the null rows have to be distinguished
+	// from, since a node that indexes everything and one that indexes nothing agree on
+	// every count.
 	cfg := config.DefaultConfig()
 	cfg.TxIndex.Indexer = []string{"kv"}
 	sinks, err := sink.EventSinksFromConfig(cfg, memDBProvider, "sei-test")
 	if err != nil {
 		t.Fatalf("indexer = [kv]: %v", err)
 	}
-	if len(sinks) != 1 {
-		t.Fatalf("indexer = [kv] resolved to %d sinks, want 1", len(sinks))
+	if got := resolvedTypes(sinks); !slices.Equal(got, []indexer.EventSinkType{indexer.KV}) {
+		t.Fatalf("indexer = [kv] resolved to %v, want the kv sink alone", got)
 	}
 }
 
 // TestNullSinkCanOpenAnIndexStoreItThenDiscards records the side effect the stable
 // result hides.
 //
-// With ["null","kv"], if the range reaches kv first the kv branch calls dbProvider,
-// opens the tx_index store and appends the sink — and then null is reached, returns a
-// fresh one-element slice, and the opened store goes out of scope with nothing left
-// holding it to close. The resolved config is identical either way, so the leak is
-// invisible from the configuration: it depends only on map order.
+// If the range reaches kv first, the kv branch calls dbProvider, opens the tx_index store
+// and appends the sink — and then null is reached, returns a fresh one-element slice, and
+// nothing ever closes what was opened. The resolved config is identical either way, so the
+// leak is invisible from the configuration: it depends only on map order.
 //
-// It is asserted as "sometimes" because that is what it is. The point is that the
-// config does not determine whether a store is opened, which is the fact a
-// replacement manager needs to know before it reuses this selection logic.
+// The discarded store is not garbage either. On the production provider it is a goleveldb
+// handle, and opening one starts five goroutines that hold a reference to it for the life of
+// the process — session.refLoop, DB.compactionError, DB.mpoolDrain, DB.tCompaction,
+// DB.mCompaction — so the memory is not reclaimable and the exclusive flock is never
+// released. A second open of the same path in the same process fails with
+// "resource temporarily unavailable", and a data/tendermint/tx_index.db directory with a
+// LOCK, a CURRENT, a MANIFEST and a write-ahead log materialises on a node configured to
+// index nothing.
+//
+// Both list orders are driven, because they are not the same measurement. A two-key map puts
+// the first-listed name in the first bucket slot and iteration starts at a random slot, so
+// the first name listed is reached first roughly seven times in eight: ["kv","null"] opens a
+// store on about 7/8 of boots and ["null","kv"] on about 1/8. ["kv","null"] is the order an
+// operator produces by appending null to an existing list, so it is the common case and it
+// is the worse one.
+//
+// It is asserted as "sometimes" because that is what it is. The point is that the config does
+// not determine whether a store is opened, which is the fact a replacement manager needs to
+// know before it reuses this selection logic.
 func TestNullSinkCanOpenAnIndexStoreItThenDiscards(t *testing.T) {
 	const runs = 250
 
-	// countNullKVOpens resolves ["null", "kv"] n times and reports how often the kv branch
-	// opened a store first. It also holds the invariant that must be true on every run,
-	// whichever order the range takes: exactly one sink comes back, and it is the null one.
-	countNullKVOpens := func(n int) (quiet, opened int) {
-		for range n {
-			opens := 0
-			provider := func(*config.DBContext) (dbm.DB, error) {
-				opens++
-				return dbm.NewMemDB(), nil
-			}
-			cfg := config.DefaultConfig()
-			cfg.TxIndex.Indexer = []string{"null", "kv"}
+	// countOpens resolves the given list n times and reports how often the kv branch opened a
+	// store first. It also holds the two invariants that must be true on every run, whichever
+	// order the range takes: exactly the null sink comes back, and nothing closes a store the
+	// kv branch opened.
+	countOpens := func(list []string) func(int) (quiet, opened int) {
+		return func(n int) (quiet, opened int) {
+			for range n {
+				opens, closes := 0, 0
+				provider := func(*config.DBContext) (dbm.DB, error) {
+					opens++
+					return closeCounted{DB: dbm.NewMemDB(), closes: &closes}, nil
+				}
+				cfg := config.DefaultConfig()
+				cfg.TxIndex.Indexer = list
 
-			sinks, err := sink.EventSinksFromConfig(cfg, provider, "sei-test")
-			if err != nil {
-				t.Fatalf("indexer = [null kv]: %v", err)
+				sinks, err := sink.EventSinksFromConfig(cfg, provider, "sei-test")
+				if err != nil {
+					t.Fatalf("indexer = %v: %v", list, err)
+				}
+				if got := resolvedTypes(sinks); !slices.Equal(got, nullAlone()) {
+					t.Fatalf("indexer = %v resolved to %v, want the null sink alone", list, got)
+				}
+				// Counting the opens alone cannot see the leak: it stays true of a build that
+				// closes what it discards. Closing it is the fix, and this is where that has to
+				// be recorded rather than merged as a green diff.
+				if closes > 0 {
+					t.Fatalf("indexer = %v: the discarded store was closed %d times. Selection now "+
+						"releases what it opens, which is a fix — record it here, and drop the leak "+
+						"this row describes", list, closes)
+				}
+				if opens > 0 {
+					opened++
+				} else {
+					quiet++
+				}
 			}
-			if len(sinks) != 1 {
-				t.Fatalf("indexer = [null kv] resolved to %d sinks, want the null sink alone", len(sinks))
-			}
-			if opens > 0 {
-				opened++
-			} else {
-				quiet++
-			}
+			return quiet, opened
 		}
-		return quiet, opened
 	}
 
-	quiet, opened := countNullKVOpens(runs)
-	if opened == 0 || quiet == 0 {
-		// Both directions are one-sided results of the same coin, so the shared resolver
-		// decides between a deterministic selection, a runtime that stopped randomizing, and a
-		// split that skewed past this sample.
-		resolveOneSidedOutcome(t, "runs without a store opened / runs with one", runs, quiet, opened,
-			countNullKVOpens)
-		return
+	for _, list := range [][]string{{"kv", "null"}, {"null", "kv"}} {
+		count := countOpens(list)
+		quiet, opened := count(runs)
+		t.Logf("indexer = %v: %d of %d runs opened a store", list, opened, runs)
+		if opened == 0 || quiet == 0 {
+			// Both directions are one-sided results of the same coin, so the shared resolver
+			// decides between a deterministic selection, a runtime that stopped randomizing, and a
+			// split that skewed past this sample.
+			resolveOneSidedOutcome(t, fmt.Sprintf("indexer = %v: runs without a store opened / runs "+
+				"with one", list), runs, quiet, opened, count)
+		}
 	}
 }


### PR DESCRIPTION
## What

Three tests that provably could not fail, each found by mutating the code the test names and watching it pass. **Test-only** — no production file changes. Second slice of PLT-893; the first was #3851.

## Proven, not asserted

Every row below was verified by applying the mutation, observing the pre-change test pass, observing the post-change test fail, then restoring and confirming green. Production files verified byte-identical after each.

| What could not fail | Mutation that proved it |
|---|---|
| `sei-cosmos/server/config` was red under `go test -count=2` | `TestSetConfigTemplate` wrote the package-global template and never restored it; three later rows rendered a one-section template |
| The same row passed against a setter that **installed nothing** | A parse-and-discard `SetConfigTemplate` passed before; it now fails |
| Event sinks compared by `len(sinks)` at **six** sites | An early `return eventSinks[:1]` in the `NULL` branch keeps arity at 1 and flips identity to `kv` — old suite green, new suite fails at three sites |
| `TestBaseAppTracingDisabledByDefault` asserted only that construction didn't panic | Flipping the tracing read passed while installing a provider with recording spans |

## Why the sink assertion matters

A node that indexes every transaction and one that indexes none **agree on every count**. `null` is documented to discard the whole set, and the row that stated that rule was arity-only. Both list orders are now driven: selection ranges a map, the first-listed name lands in the first of its eight slots, and the range starts at a random slot, so the minority order appears about one time in eight — measured 12.4% over 400,000 runs, against 12.5% structural.

## The tracing rows

The disabled row asserts that neither the app's tracing gate nor the process-global provider yields a live span. It uses `SpanContext().IsValid()` rather than `IsRecording()` deliberately: a real provider with an always-off sampler is non-recording but valid, so `IsRecording()` alone passes a build that installs a batcher for a node that asked for none — and `IsValid()` is immune to a stray `OTEL_TRACES_SAMPLER` in the environment.

A companion row pins the enabled path: it measures the batch-processor goroutine the provider leaves behind, calls `app.Close()` to establish that production's lifecycle close does **not** release it, then shuts the provider down itself and asserts the count returns. The `app.Close()` step is what earns the row its name — without it the row stayed green through the obvious fix, which two reviewers independently demonstrated by writing that fix.

## Recorded, not repaired

Per the standing decision not to change shipped behavior:

- **`EventSinksFromConfig` discards an opened `tx_index` store without closing it** on the orders that reach `kv` first — holding a goleveldb `LOCK` that blocks an in-process reopen, five background goroutines, and a `tx_index.db` directory that materialises on a node configured to index nothing. Once per boot. Filed thinking: fixing it is a three-line generic loop, since `Stop()` is on the `EventSink` interface, but it is a production change and belongs in its own review.
- **`NewBaseApp` writes the process-global tracer provider from a constructor** and shadows the handle at `baseapp.go:268`, so nothing can shut it down. See PLT-945.

Each row says what a fix looks like and asks for the record to be updated rather than the assertion widened. **A fix to either will redden its row deliberately** — that is the polarity a characterization suite wants, and the failure message says so.

## Review

Four blinded reviewers (`systems-engineer`, `security-specialist`, `sei-network-specialist` as assigned dissenter, `idiomatic-reviewer`), then two confirmation passes. Four rounds. The reviews found, among other things: a comment that stated a false fact about the OTel API and used it to justify leaving a path untested; a restore that itself could not fail under CI's own invocation; a leak row that could not fail on the leak it named; and an assertion whose message named one of four causes it admits. All resolved and re-proven.

## Testing

`go test` and `go test -race -count=1` green on all three packages. `sei-cosmos/server/config` green under `-count=2 -shuffle=on`. `go vet`, `gofmt -s -l`, `goimports -l` clean.

**Note for anyone re-running:** `sei-cosmos/baseapp` is stable across **three separate invocations** of `-shuffle=on`, not under `-count=3`. Under `-count=3` the package dies on a pre-existing `sdkerrors.Register("fakeError", 100500, …)` panic at `deliver_tx_test.go:888`, reproducible on a clean tree with `-run TestCustomRunTxPanicHandler -count=3`. Unrelated to this change.

## Known gaps

`app` still has no `CheckDefaults` or `CheckAbsent`. CI runs neither `-count>1` nor `-shuffle`, so the restore this PR adds is exercised by no CI invocation — the durable fix is putting those modes in CI, which is out of scope here. The remaining four of PLT-893's seven cannot-fail tests, plus deliverables 2 and 3, are untouched.

Refs PLT-893. Related PLT-945, PLT-946.
