### PR TITLE
goreleaser: drop duplicate changelog + Full Changelog link from release notes

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -49,10 +49,23 @@ checksum:
 snapshot:
   version_template: '{{ incpatch .Version }}-snapshot-{{ .ShortCommit }}'
 
-# The GitHub Release itself already carries an auto-generated "What's Changed"
-# commit list and a "Full Changelog" compare link (release-publish.yml creates the
-# release with generate_release_notes). Disable goreleaser's changelog (and drop the
-# footer below) so we don't append a duplicate list and link.
+# The GitHub Release already carries an auto-generated "What's Changed" commit list and
+# a "Full Changelog" compare link: the uci reusable workflow
+# sei-protocol/uci/.github/workflows/release-publish.yml creates the release with
+# generate_release_notes: true, and the goreleaser job then appends to it (release.mode
+# below). goreleaser was adding a second copy of both, so its changelog is disabled here
+# and its footer removed.
+#
+# Disabling the changelog does NOT drop the release.header block below: header/footer are
+# applied by goreleaser's release pipe (internal/pipe/release/body.go), not the changelog
+# pipe, so `disable` only empties the middle of the release body. It is also the only
+# config-only way to get a header-only body: filtering out every commit still emits a bare
+# "## Changelog" heading. Deleting release.footer is likewise the only way to drop the
+# duplicate compare link, since footer rendering is independent of the changelog pipe.
+#
+# Caveat if the release args ever change: `disable` also discards flag-supplied notes
+# (--release-notes / --release-header / --release-footer). uci passes a fixed
+# `release --clean`, so nothing here relies on those.
 changelog:
   disable: true
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -49,18 +49,12 @@ checksum:
 snapshot:
   version_template: '{{ incpatch .Version }}-snapshot-{{ .ShortCommit }}'
 
+# The GitHub Release itself already carries an auto-generated "What's Changed"
+# commit list and a "Full Changelog" compare link (release-publish.yml creates the
+# release with generate_release_notes). Disable goreleaser's changelog (and drop the
+# footer below) so we don't append a duplicate list and link.
 changelog:
-  use: github
-  sort: asc
-  filters:
-    exclude:
-      - '^docs:'
-      - '^test:'
-      - '^chore:'
-      - 'merge conflict'
-      - Merge pull request
-      - Merge remote-tracking branch
-      - Merge branch
+  disable: true
 
 release:
   github:
@@ -82,5 +76,3 @@ release:
     ```
 
     For Docker images, see `ghcr.io/sei-protocol/sei`.
-  footer: |
-    **Full Changelog**: https://github.com/sei-protocol/sei-chain/compare/{{ .PreviousTag }}...{{ .Tag }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,11 +57,17 @@ snapshot:
 # and its footer removed.
 #
 # Disabling the changelog does NOT drop the release.header block below: header/footer are
-# applied by goreleaser's release pipe (internal/pipe/release/body.go), not the changelog
-# pipe, so `disable` only empties the middle of the release body. It is also the only
-# config-only way to get a header-only body: filtering out every commit still emits a bare
-# "## Changelog" heading. Deleting release.footer is likewise the only way to drop the
-# duplicate compare link, since footer rendering is independent of the changelog pipe.
+# applied by goreleaser's release pipe, not the changelog pipe, so `disable` only empties
+# the middle of the release body. It is also the only config-only way to get a header-only
+# body: filtering out every commit still emits a bare "## Changelog" heading. Deleting
+# release.footer is likewise the only way to drop the duplicate compare link, since footer
+# rendering is independent of the changelog pipe.
+#
+# Verified against goreleaser v2.15.4 (release pipe composes the body from release.header +
+# ctx.ReleaseNotes + release.footer in internal/pipe/release/body.go; changelog.disable only
+# empties ctx.ReleaseNotes). uci pins the floating range `~> v2`, so if a future v2.x ever
+# drops the header from a release body, re-check that composition first. The header content
+# includes the checksum-verification instructions, so losing it would be user-visible.
 #
 # Caveat if the release args ever change: `disable` also discards flag-supplied notes
 # (--release-notes / --release-header / --release-footer). uci passes a fixed


### PR DESCRIPTION
## What

The GitHub Release already contains an auto-generated **What's Changed** commit list and a **Full Changelog** compare link — the uci reusable workflow `sei-protocol/uci/.github/workflows/release-publish.yml` creates the release with `generate_release_notes: true`, and the goreleaser job then appends to it (`release.mode: append`). goreleaser was adding a **second** copy of both.

This disables goreleaser's changelog (`changelog.disable: true`) and removes its `footer`, so the block goreleaser appends is just the header: the static-binary note, the `sha256sum -c` verification instructions, and the Docker pointer.

## Verification: the header is preserved

`goreleaser check` is schema-only, so it can't confirm the rendered body. Verified two ways instead.

**1. Source (goreleaser v2.15.4).** `release.header`/`release.footer` are applied by the **release** pipe, not the changelog pipe — a repo-wide grep for `Release\.Header|Release\.Footer` returns exactly two hits, neither in `internal/pipe/changelog/`:

- `internal/pipe/release/body.go:48` — `header, err := t.Apply(ctx.Config.Release.Header)`
- `internal/pipe/release/body.go:52` — the footer

composed by `describeBody` (`body.go:58-66`) and called from `release.go:133`. `changelog.disable` makes `Skip()` return true (`changelog.go:45-51`), which only leaves `ctx.ReleaseNotes` empty — the *middle* slot of the body template (`body.go:13-16`), between header and footer. (What the changelog pipe loads at `changelog.go:77-82` is `ctx.ReleaseHeaderFile/Tmpl`, the **CLI-flag** values from `cmd/release.go:139-144` — a different thing from the YAML `release.header`.)

**2. Empirical.** Scratch module, real tag, `github_urls` pointed at a loopback fake GitHub API so the verbatim JSON POST to `/repos/.../releases` could be captured (all traffic on 127.0.0.1; nothing contacted github.com). Note `dist/CHANGELOG.md` never contains header/footer in *any* variant — including the working control — so checking that file would be a false negative; these are the actual posted bodies:

| variant | posted release body |
|---|---|
| `changelog: {disable: true}` + header + footer | `HEADER_SENTINEL\n\n\nFOOTER_SENTINEL\n\n` |
| `changelog: {filters: {exclude: ['.*']}}` | `HEADER_SENTINEL\n\n## Changelog\n\nFOOTER_SENTINEL\n\n` |
| control — `changelog: {use: git, sort: asc}` | header + 3 commit lines + footer |
| **`disable: true` + header, footer omitted (= this PR)** | **`HEADER_SENTINEL\n\n\n`** |

The last row is exactly this PR's config: **header only, no commit lines, no `## Changelog` heading, no footer.** All variants exited 0.

Two things this also settled:

- **Keeping the changelog pipe enabled and neutralising its output is worse.** `formatChangelog` starts with `result := []string{title("Changelog", 2)}` (`changelog.go:152-153`), so the heading is emitted unconditionally — the exclude-everything variants leave a stranded, content-free `## Changelog` between header and footer, and `changelog.title` is Pro-only. `disable: true` is the only config-only route to a clean header-only body.
- **No changelog setting suppresses the footer** (it rendered in every variant), so deleting `release.footer` is required. Both halves of this PR are individually necessary.

## Notes

- No build/runtime change; `.goreleaser.yaml` release-notes formatting only.
- Since `.goreleaser.yaml` is a static-build input, the `Linux AMD64 (static)` job runs on this PR.
- `disable` does discard flag-supplied notes (`--release-notes`/`--release-header`/`--release-footer`); uci passes a fixed `release --clean`, so nothing here depends on them.
- uci pins the floating `~> v2`, so the verified version (v2.15.4) and what to re-check are recorded in the config comment.
