### PR TITLE
Migrate evmrpc, gaskv, and bank new-account metrics to OTel (PLT-911)

### DIFF
--- a/evmrpc/worker_pool_metrics.go
+++ b/evmrpc/worker_pool_metrics.go
@@ -112,36 +112,37 @@ var (
 	meter = otel.Meter("evmrpc_workerpool")
 
 	otelMetrics = struct {
-		workersTotal          metric.Int64Gauge
-		workersActive         metric.Int64Gauge
-		workersIdle           metric.Int64Gauge
-		queueCapacity         metric.Int64Gauge
-		queueDepth            metric.Int64Gauge
-		queuePeak             metric.Int64Gauge
-		queueUtilizationPct   metric.Float64Gauge
-		tasksSubmittedTotal   metric.Int64Gauge
-		tasksCompletedTotal   metric.Int64Gauge
-		tasksRejectedTotal    metric.Int64Gauge
-		tasksPanickedTotal    metric.Int64Gauge
-		dbSemaphoreCapacity   metric.Int64Gauge
-		dbSemaphoreInUse      metric.Int64Gauge
-		dbSemaphoreAvailable  metric.Int64Gauge
-		dbSemaphoreWaitCount  metric.Int64Gauge
-		subscriptionsActive   metric.Int64Gauge
-		getLogsRequestsTotal  metric.Int64Gauge
-		getLogsSuccessTotal   metric.Int64Gauge
-		getLogsErrorsTotal    metric.Int64Gauge
-		getLogsTPS            metric.Float64Gauge
-		getLogsAvgBlockRange  metric.Float64Gauge
-		getLogsPeakBlockRange metric.Int64Gauge
-		getLogsAvgLatencyMs   metric.Float64Gauge
-		getLogsMaxLatencyMs   metric.Float64Gauge
-		errRangeTooLarge      metric.Int64Gauge
-		errRateLimited        metric.Int64Gauge
-		errBackpressure       metric.Int64Gauge
-		avgQueueWaitMs        metric.Float64Gauge
-		avgExecTimeMs         metric.Float64Gauge
-		avgDBWaitMs           metric.Float64Gauge
+		workersTotal            metric.Int64Gauge
+		workersActive           metric.Int64Gauge
+		workersIdle             metric.Int64Gauge
+		queueCapacity           metric.Int64Gauge
+		queueDepth              metric.Int64Gauge
+		queuePeak               metric.Int64Gauge
+		queueUtilizationPct     metric.Float64Gauge
+		tasksSubmittedTotal     metric.Int64Gauge
+		tasksCompletedTotal     metric.Int64Gauge
+		tasksRejectedTotal      metric.Int64Gauge
+		tasksPanickedTotal      metric.Int64Gauge
+		dbSemaphoreCapacity     metric.Int64Gauge
+		dbSemaphoreInUse        metric.Int64Gauge
+		dbSemaphoreAvailable    metric.Int64Gauge
+		dbSemaphoreWaitCount    metric.Int64Gauge
+		subscriptionsActive     metric.Int64Gauge
+		subscriptionErrorsTotal metric.Int64Counter
+		getLogsRequestsTotal    metric.Int64Gauge
+		getLogsSuccessTotal     metric.Int64Gauge
+		getLogsErrorsTotal      metric.Int64Gauge
+		getLogsTPS              metric.Float64Gauge
+		getLogsAvgBlockRange    metric.Float64Gauge
+		getLogsPeakBlockRange   metric.Int64Gauge
+		getLogsAvgLatencyMs     metric.Float64Gauge
+		getLogsMaxLatencyMs     metric.Float64Gauge
+		errRangeTooLarge        metric.Int64Gauge
+		errRateLimited          metric.Int64Gauge
+		errBackpressure         metric.Int64Gauge
+		avgQueueWaitMs          metric.Float64Gauge
+		avgExecTimeMs           metric.Float64Gauge
+		avgDBWaitMs             metric.Float64Gauge
 	}{
 		workersTotal: must(meter.Int64Gauge(
 			"evmrpc_workerpool_workers_total",
@@ -221,6 +222,11 @@ var (
 		subscriptionsActive: must(meter.Int64Gauge(
 			"evmrpc_subscriptions_active",
 			metric.WithDescription("Active subscriptions"),
+			metric.WithUnit("{count}"),
+		)),
+		subscriptionErrorsTotal: must(meter.Int64Counter(
+			"evmrpc_subscriptions_errors_total",
+			metric.WithDescription("Total subscription errors"),
 			metric.WithUnit("{count}"),
 		)),
 		getLogsRequestsTotal: must(meter.Int64Gauge(
@@ -548,7 +554,8 @@ func (m *WorkerPoolMetrics) RecordSubscriptionEnd() {
 // RecordSubscriptionError records a subscription error
 func (m *WorkerPoolMetrics) RecordSubscriptionError() {
 	m.SubscriptionErrors.Add(1)
-	// Export to Prometheus
+	otelMetrics.subscriptionErrorsTotal.Add(context.Background(), 1)
+	// TODO(PLT-326): remove once evmrpc_subscriptions_errors_total verified
 	telemetry.IncrCounter(1, "sei", "evm", "subscriptions", "errors")
 }
 

--- a/sei-cosmos/store/gaskv/metrics.go
+++ b/sei-cosmos/store/gaskv/metrics.go
@@ -1,0 +1,40 @@
+package gaskv
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+)
+
+var (
+	meter = otel.Meter("seicosmos_store_gaskv")
+
+	// latencyBuckets units are in seconds.
+	latencyBuckets = metric.WithExplicitBucketBoundaries(
+		0.000025, 0.000050, 0.0001, 0.0005, 0.001, 0.0025, 0.005, 0.010, 0.020, 0.050, 0.075, 0.1, 0.25, 0.5, 1, 10,
+	)
+
+	gaskvMetrics = struct {
+		hasDuration    metric.Float64Histogram
+		deleteDuration metric.Float64Histogram
+	}{
+		hasDuration: must(meter.Float64Histogram(
+			"gaskv_has_duration",
+			metric.WithDescription("Duration of gaskv Has operations in seconds"),
+			latencyBuckets,
+			metric.WithUnit("s"),
+		)),
+		deleteDuration: must(meter.Float64Histogram(
+			"gaskv_delete_duration",
+			metric.WithDescription("Duration of gaskv Delete operations in seconds"),
+			latencyBuckets,
+			metric.WithUnit("s"),
+		)),
+	}
+)
+
+func must[V any](v V, err error) V {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}

--- a/sei-cosmos/store/gaskv/metrics.go
+++ b/sei-cosmos/store/gaskv/metrics.go
@@ -8,8 +8,8 @@ import (
 var (
 	meter = otel.Meter("seicosmos_store_gaskv")
 
-	// latencyBuckets units are in seconds.
-	latencyBuckets = metric.WithExplicitBucketBoundaries(
+	// finerGrainedBuckets units are in seconds.
+	finerGrainedBuckets = metric.WithExplicitBucketBoundaries(
 		0.000025, 0.000050, 0.0001, 0.0005, 0.001, 0.0025, 0.005, 0.010, 0.020, 0.050, 0.075, 0.1, 0.25, 0.5, 1, 10,
 	)
 
@@ -20,13 +20,13 @@ var (
 		hasDuration: must(meter.Float64Histogram(
 			"gaskv_has_duration",
 			metric.WithDescription("Duration of gaskv Has operations in seconds"),
-			latencyBuckets,
+			finerGrainedBuckets,
 			metric.WithUnit("s"),
 		)),
 		deleteDuration: must(meter.Float64Histogram(
 			"gaskv_delete_duration",
 			metric.WithDescription("Duration of gaskv Delete operations in seconds"),
-			latencyBuckets,
+			finerGrainedBuckets,
 			metric.WithUnit("s"),
 		)),
 	}

--- a/sei-cosmos/store/gaskv/store.go
+++ b/sei-cosmos/store/gaskv/store.go
@@ -1,6 +1,7 @@
 package gaskv
 
 import (
+	"context"
 	"io"
 	"time"
 
@@ -95,7 +96,12 @@ func (gs *Store) Set(key []byte, value []byte) {
 
 // Implements KVStore.
 func (gs *Store) Has(key []byte) bool {
-	defer telemetry.MeasureSince(time.Now(), "store", "gaskv", "has")
+	opStart := time.Now()
+	defer func() {
+		gaskvMetrics.hasDuration.Record(context.Background(), time.Since(opStart).Seconds())
+		// TODO(PLT-353): remove once store_gaskv_has_duration verified
+		telemetry.MeasureSince(opStart, "store", "gaskv", "has")
+	}()
 	gs.gasMeter.ConsumeGas(gs.gasConfig.HasCost, types.GasHasDesc)
 	start := traceStart(gs.tracer)
 	res := gs.parent.Has(key)
@@ -107,7 +113,12 @@ func (gs *Store) Has(key []byte) bool {
 
 // Implements KVStore.
 func (gs *Store) Delete(key []byte) {
-	defer telemetry.MeasureSince(time.Now(), "store", "gaskv", "delete")
+	opStart := time.Now()
+	defer func() {
+		gaskvMetrics.deleteDuration.Record(context.Background(), time.Since(opStart).Seconds())
+		// TODO(PLT-353): remove once store_gaskv_delete_duration verified
+		telemetry.MeasureSince(opStart, "store", "gaskv", "delete")
+	}()
 	// charge gas to prevent certain attack vectors even though space is being freed
 	gs.gasMeter.ConsumeGas(gs.gasConfig.DeleteCost, types.GasDeleteDesc)
 	start := traceStart(gs.tracer)

--- a/sei-cosmos/x/bank/keeper/metrics.go
+++ b/sei-cosmos/x/bank/keeper/metrics.go
@@ -18,7 +18,7 @@ var (
 			metric.WithUnit("{utoken}"),
 		)),
 		newAccount: must(meter.Int64Counter(
-			"new_account",
+			"bank_new_account",
 			metric.WithDescription("Number of new accounts created during bank transfers"),
 			metric.WithUnit("{count}"),
 		)),

--- a/sei-cosmos/x/bank/keeper/metrics.go
+++ b/sei-cosmos/x/bank/keeper/metrics.go
@@ -10,11 +10,17 @@ var (
 
 	bankMetrics = struct {
 		sendAmount metric.Int64Gauge
+		newAccount metric.Int64Counter
 	}{
 		sendAmount: must(meter.Int64Gauge(
 			"last_send_amount",
 			metric.WithDescription("Amount sent in the last MsgSend transaction by denomination"),
 			metric.WithUnit("{utoken}"),
+		)),
+		newAccount: must(meter.Int64Counter(
+			"new_account",
+			metric.WithDescription("Number of new accounts created during bank transfers"),
+			metric.WithUnit("{count}"),
 		)),
 	}
 )

--- a/sei-cosmos/x/bank/keeper/send.go
+++ b/sei-cosmos/x/bank/keeper/send.go
@@ -145,7 +145,11 @@ func (k BaseSendKeeper) InputOutputCoins(ctx sdk.Context, inputs []types.Input, 
 		// such as delegated fee messages.
 		accExists := k.ak.HasAccount(ctx, outAddress)
 		if !accExists {
-			defer telemetry.IncrCounter(1, "new", "account")
+			defer func() {
+				bankMetrics.newAccount.Add(ctx.Context(), 1)
+				// TODO(PLT-353): remove once bank_new_account verified
+				telemetry.IncrCounter(1, "new", "account")
+			}()
 			k.ak.SetAccount(ctx, k.ak.NewAccountWithAddress(ctx, outAddress))
 		}
 	}
@@ -166,7 +170,11 @@ func (k BaseSendKeeper) SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAd
 	// such as delegated fee messages.
 	accExists := k.ak.HasAccount(ctx, toAddr)
 	if !accExists {
-		defer telemetry.IncrCounter(1, "new", "account")
+		defer func() {
+			bankMetrics.newAccount.Add(ctx.Context(), 1)
+			// TODO(PLT-353): remove once bank_new_account verified
+			telemetry.IncrCounter(1, "new", "account")
+		}()
 		k.ak.SetAccount(ctx, k.ak.NewAccountWithAddress(ctx, toAddr))
 	}
 


### PR DESCRIPTION
## Summary

Part of the sei-chain OTel metrics migration ([PLT-911](https://linear.app/seilabs/issue/PLT-911/)). Adds OTel dual-emit at five legacy-only call sites that were missed in earlier migration PRs. Legacy metric names and labels are unchanged for dashboard-safe cutover.

- **evmrpc** — `RecordSubscriptionError` now emits `evmrpc_subscriptions_errors_total` alongside the existing `sei.evm.subscriptions.errors` counter
- **gaskv** — new `gaskv_has_duration` and `gaskv_delete_duration` histograms dual-emit with existing `store.gaskv.has` / `store.gaskv.delete` latencies
- **bank** — new `new_account` counter dual-emits with existing `new.account` counter at both account-creation sites in `send.go`

Each site records OTel first and retains the legacy call with a removal TODO (`PLT-326` for evmrpc, `PLT-353` for cosmos).

## Test plan

- [x] `go test ./sei-cosmos/store/gaskv/...`
- [x] `go test ./sei-cosmos/x/bank/keeper/...`
- [x] `go test ./evmrpc/...`