### PR TITLE
fix: restore LCD pagination semantics

### DIFF
--- a/sei-cosmos/types/query/filtered_pagination.go
+++ b/sei-cosmos/types/query/filtered_pagination.go
@@ -5,17 +5,16 @@ import (
 
 	"github.com/sei-protocol/sei-chain/sei-cosmos/codec"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store/types"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // FilteredPaginate does pagination of all the results in the PrefixStore based on the
-// provided PageRequest. onResult does the unmarshaling and filtering.
-// Key-based pagination is optimized; offset-based pagination lazily walks all records.
-//
-// Iteration is capped at MaxScanLimit entries to prevent unbounded store walks. Use key-based
-// pagination for reliable traversal of sparse datasets, as the nextKey could be nil when the
-// page is full and the scan limit is reached.
+// provided PageRequest. onResult should be used to do actual unmarshaling and filter the results.
+// If key is provided, the pagination uses the optimized querying.
+// If offset is used, the pagination uses lazy filtering i.e., searches through all the records.
+// The accumulate parameter represents if the response is valid based on the offset given.
+// It will be false for the results (filtered) < offset and true for offset <= accumulate < end.
+// When accumulate is true, the current result should be appended to the result set returned
+// to the client.
 func FilteredPaginate(
 	prefixStore types.KVStore,
 	pageRequest *PageRequest,
@@ -37,16 +36,8 @@ func FilteredPaginate(
 		return nil, fmt.Errorf("invalid request, either offset or key is expected, got both")
 	}
 
-	if err := VerifyPaginationOffset(offset); err != nil {
-		return nil, err
-	}
-
 	if limit == 0 {
 		limit = DefaultLimit
-	}
-
-	if err := VerifyPaginationLimit(limit); err != nil {
-		return nil, err
 	}
 
 	if len(key) != 0 {
@@ -54,20 +45,14 @@ func FilteredPaginate(
 		defer func() { _ = iterator.Close() }()
 
 		var (
-			numHits   uint64
-			nextKey   []byte
-			totalIter uint64
+			numHits uint64
+			nextKey []byte
 		)
 
 		for ; iterator.Valid(); iterator.Next() {
-			totalIter++
 			if numHits == limit {
 				nextKey = iterator.Key()
 				break
-			}
-			if totalIter > MaxScanLimit {
-				return nil, status.Errorf(codes.InvalidArgument,
-					"scanned more than %d entries without filling the page; use a more specific key prefix or reduce limit", MaxScanLimit)
 			}
 
 			if iterator.Error() != nil {
@@ -92,33 +77,14 @@ func FilteredPaginate(
 	iterator := getIterator(prefixStore, nil, reverse)
 	defer func() { _ = iterator.Close() }()
 
-	end := offset + limit
+	end := paginationEnd(offset, limit)
 
 	var (
-		numHits          uint64
-		nextKey          []byte
-		totalIter        uint64
-		pageCompleteIter uint64
+		numHits uint64
+		nextKey []byte
 	)
 
 	for ; iterator.Valid(); iterator.Next() {
-		totalIter++
-		// Phase 1: page not yet complete — cap raw iterations to prevent full-store
-		// walks when the filter produces too few hits to fill the page.
-		if numHits < end && totalIter > offset+MaxScanLimit {
-			return nil, status.Errorf(codes.InvalidArgument,
-				"scanned more than %d entries without filling the page; use key-based pagination instead", MaxScanLimit)
-		}
-		// Phase 2: page complete — cap how far past the page we scan for nextKey/count_total.
-		if pageCompleteIter > MaxScanLimit {
-			if !countTotal {
-				// Page is already assembled; no next hit found within scan window → no next page.
-				break
-			}
-			return nil, status.Errorf(codes.InvalidArgument,
-				"scanned more than %d entries past the end of the page; use key-based pagination instead", MaxScanLimit)
-		}
-
 		if iterator.Error() != nil {
 			return nil, iterator.Error()
 		}
@@ -133,11 +99,7 @@ func FilteredPaginate(
 			numHits++
 		}
 
-		if numHits >= end {
-			pageCompleteIter++
-		}
-
-		if numHits == end+1 {
+		if numHits > end {
 			nextKey = iterator.Key()
 
 			if !countTotal {
@@ -162,8 +124,6 @@ func FilteredPaginate(
 // If offset is used, the pagination uses lazy filtering i.e., searches through all the records.
 // The resulting slice (of type F) can be of a different type than the one being iterated through
 // (type T), so it's possible to do any necessary transformation inside the onResult function.
-//
-// Scan limits: same semantics as FilteredPaginate — see its documentation for details.
 func GenericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 	cdc codec.BinaryCodec,
 	prefixStore types.KVStore,
@@ -187,16 +147,8 @@ func GenericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 		return results, nil, fmt.Errorf("invalid request, either offset or key is expected, got both")
 	}
 
-	if err := VerifyPaginationOffset(offset); err != nil {
-		return results, nil, err
-	}
-
 	if limit == 0 {
 		limit = DefaultLimit
-	}
-
-	if err := VerifyPaginationLimit(limit); err != nil {
-		return results, nil, err
 	}
 
 	if len(key) != 0 {
@@ -204,20 +156,14 @@ func GenericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 		defer func() { _ = iterator.Close() }()
 
 		var (
-			numHits   uint64
-			nextKey   []byte
-			totalIter uint64
+			numHits uint64
+			nextKey []byte
 		)
 
 		for ; iterator.Valid(); iterator.Next() {
-			totalIter++
 			if numHits == limit {
 				nextKey = iterator.Key()
 				break
-			}
-			if totalIter > MaxScanLimit {
-				return nil, nil, status.Errorf(codes.InvalidArgument,
-					"scanned more than %d entries without filling the page; use a more specific key prefix or reduce limit", MaxScanLimit)
 			}
 
 			if iterator.Error() != nil {
@@ -250,33 +196,14 @@ func GenericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 	iterator := getIterator(prefixStore, nil, reverse)
 	defer func() { _ = iterator.Close() }()
 
-	end := offset + limit
+	end := paginationEnd(offset, limit)
 
 	var (
-		numHits          uint64
-		nextKey          []byte
-		totalIter        uint64
-		pageCompleteIter uint64
+		numHits uint64
+		nextKey []byte
 	)
 
 	for ; iterator.Valid(); iterator.Next() {
-		totalIter++
-		// Phase 1: page not yet complete — cap raw iterations to prevent full-store
-		// walks when the filter produces too few hits to fill the page.
-		if numHits < end && totalIter > offset+MaxScanLimit {
-			return nil, nil, status.Errorf(codes.InvalidArgument,
-				"scanned more than %d entries without filling the page; use key-based pagination instead", MaxScanLimit)
-		}
-		// Phase 2: page complete — cap how far past the page we scan for nextKey/count_total.
-		if pageCompleteIter > MaxScanLimit {
-			if !countTotal {
-				// Page is already assembled; no next hit found within scan window → no next page.
-				break
-			}
-			return nil, nil, status.Errorf(codes.InvalidArgument,
-				"scanned more than %d entries past the end of the page; use key-based pagination instead", MaxScanLimit)
-		}
-
 		if iterator.Error() != nil {
 			return nil, nil, iterator.Error()
 		}
@@ -301,11 +228,7 @@ func GenericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 			numHits++
 		}
 
-		if numHits >= end {
-			pageCompleteIter++
-		}
-
-		if numHits == end+1 {
+		if numHits > end {
 			if nextKey == nil {
 				nextKey = iterator.Key()
 			}

--- a/sei-cosmos/types/query/filtered_pagination.go
+++ b/sei-cosmos/types/query/filtered_pagination.go
@@ -100,7 +100,9 @@ func FilteredPaginate(
 		}
 
 		if numHits > end {
-			nextKey = iterator.Key()
+			if nextKey == nil {
+				nextKey = iterator.Key()
+			}
 
 			if !countTotal {
 				break

--- a/sei-cosmos/types/query/filtered_pagination_test.go
+++ b/sei-cosmos/types/query/filtered_pagination_test.go
@@ -42,6 +42,14 @@ func (s *paginationTestSuite) TestFilteredPaginations() {
 	s.Require().NotNil(res)
 	s.Require().Equal(4, len(balances))
 
+	s.T().Log("verify maximum uint64 limit returns all filtered values")
+	pageReq = &query.PageRequest{Limit: query.MaxLimit}
+	balances, res, err = execFilterPaginate(store, pageReq, appCodec)
+	s.Require().NoError(err)
+	s.Require().NotNil(res)
+	s.Require().Equal(4, len(balances))
+	s.Require().Nil(res.NextKey)
+
 	s.T().Log("verify empty request")
 	balances, res, err = execFilterPaginate(store, nil, appCodec)
 	s.Require().NoError(err)
@@ -170,73 +178,54 @@ func (s *paginationTestSuite) TestReverseFilteredPaginations() {
 
 }
 
-func (s *paginationTestSuite) TestFilteredPaginateMaxLimitExceeded() {
+func (s *paginationTestSuite) TestFilteredPaginateCountTotalLargeSparseStore() {
 	app, ctx, _ := setupTest(s.T())
-	store := ctx.KVStore(app.GetKey(types.StoreKey))
+	kvStore := prefix.NewStore(ctx.KVStore(app.GetKey(types.StoreKey)), []byte("filteredlargetotal/"))
 
-	_, err := query.FilteredPaginate(store, &query.PageRequest{Limit: query.MaxLimit + 1}, func(_ []byte, _ []byte, _ bool) (bool, error) {
-		return false, nil
-	})
-	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "exceeds maximum allowed limit")
-}
+	const numItems = 10_002
+	for i := 0; i < numItems; i++ {
+		kvStore.Set([]byte(fmt.Sprintf("%08d", i)), []byte("v"))
+	}
 
-func (s *paginationTestSuite) TestFilteredPaginateOffsetExceedsMax() {
-	app, ctx, _ := setupTest(s.T())
-	kvStore := ctx.KVStore(app.GetKey(types.StoreKey))
-
-	_, err := query.FilteredPaginate(kvStore, &query.PageRequest{Offset: query.MaxOffset + 1}, func(_ []byte, _ []byte, _ bool) (bool, error) {
-		return false, nil
-	})
-	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "exceeds maximum allowed offset")
-
-	_, err = query.FilteredPaginate(kvStore, &query.PageRequest{Offset: query.MaxOffset}, func(_ []byte, _ []byte, _ bool) (bool, error) {
-		return false, nil
+	res, err := query.FilteredPaginate(kvStore, &query.PageRequest{Limit: 3, CountTotal: true}, func(key []byte, _ []byte, _ bool) (bool, error) {
+		return string(key) == "00000000" || string(key) == "00005000" || string(key) == "00010000", nil
 	})
 	s.Require().NoError(err)
+	s.Require().Equal(uint64(3), res.Total)
+	s.Require().Nil(res.NextKey)
 }
 
-func (s *paginationTestSuite) TestFilteredPaginateCountTotalScanLimitExceeded() {
+func (s *paginationTestSuite) TestFilteredPaginateLimitExceedsHitsInLargeStore() {
 	app, ctx, _ := setupTest(s.T())
-	kvStore := prefix.NewStore(ctx.KVStore(app.GetKey(types.StoreKey)), []byte("filteredscanlimit/"))
+	kvStore := prefix.NewStore(ctx.KVStore(app.GetKey(types.StoreKey)), []byte("filteredlargelimit/"))
 
-	numItems := int(query.MaxScanLimit) + 2
+	const numItems = 10_002
 	for i := 0; i < numItems; i++ {
-		kvStore.Set([]byte(fmt.Sprintf("%08d", i)), []byte("v"))
+		value := []byte("miss")
+		if i%100 == 0 {
+			value = []byte("hit")
+		}
+		kvStore.Set([]byte(fmt.Sprintf("%08d", i)), value)
 	}
 
-	_, err := query.FilteredPaginate(kvStore, &query.PageRequest{Limit: 1, CountTotal: true}, func(_ []byte, _ []byte, _ bool) (bool, error) {
-		return true, nil
+	var hits int
+	res, err := query.FilteredPaginate(kvStore, &query.PageRequest{Limit: 250}, func(_ []byte, value []byte, accumulate bool) (bool, error) {
+		hit := string(value) == "hit"
+		if hit && accumulate {
+			hits++
+		}
+		return hit, nil
 	})
-	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "scanned more than")
+	s.Require().NoError(err)
+	s.Require().Equal(101, hits)
+	s.Require().Nil(res.NextKey)
 }
 
-func (s *paginationTestSuite) TestFilteredPaginateCountTotalScanLimitExceededNoHits() {
-	app, ctx, _ := setupTest(s.T())
-	kvStore := prefix.NewStore(ctx.KVStore(app.GetKey(types.StoreKey)), []byte("filteredscanlimitnohits/"))
-
-	// Phase 1 fires when totalIter > offset + MaxScanLimit = 10001
-	pageReq := &query.PageRequest{Offset: 1, CountTotal: true}
-	numItems := int(query.MaxScanLimit) + 2
-	for i := 0; i < numItems; i++ {
-		kvStore.Set([]byte(fmt.Sprintf("%08d", i)), []byte("v"))
-	}
-
-	// filter returns no hits — numHits never reaches end, Phase 1 guard must fire
-	_, err := query.FilteredPaginate(kvStore, pageReq, func(_ []byte, _ []byte, _ bool) (bool, error) {
-		return false, nil
-	})
-	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "scanned more than")
-}
-
-func (s *paginationTestSuite) TestFilteredPaginateSparseFilterFillsPageWithinScanLimit() {
+func (s *paginationTestSuite) TestFilteredPaginateSparseFilter() {
 	app, ctx, _ := setupTest(s.T())
 	kvStore := prefix.NewStore(ctx.KVStore(app.GetKey(types.StoreKey)), []byte("filteredsparse/"))
 
-	numItems := int(query.MaxScanLimit)
+	const numItems = 10_000
 	for i := 0; i < numItems; i++ {
 		value := "miss"
 		if i%1000 == 0 {
@@ -264,7 +253,7 @@ func (s *paginationTestSuite) TestFilteredPaginateSparseFilterFillsPageWithinSca
 	s.Require().Equal("00004000", string(hits[4]))
 	s.Require().Equal("00005000", string(res.NextKey))
 
-	s.T().Log("count_total scans the rest of the store, still within the Phase 2 cap")
+	s.T().Log("count_total scans the rest of the store")
 	hits = nil
 	res, err = query.FilteredPaginate(kvStore, &query.PageRequest{Limit: 5, CountTotal: true}, onResult)
 	s.Require().NoError(err)

--- a/sei-cosmos/types/query/pagination.go
+++ b/sei-cosmos/types/query/pagination.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store/types"
 	db "github.com/tendermint/tm-db"
@@ -13,15 +14,16 @@ import (
 // if the `limit` is not supplied, paginate will use `DefaultLimit`
 const DefaultLimit = 100
 
-// MaxLimit is the maximum limit per page the paginate function can handle
-const MaxLimit = uint64(1_000)
+// MaxLimit is the maximum limit the paginate function can handle.
+const MaxLimit = uint64(math.MaxUint64)
 
-// MaxScanLimit is the maximum number of store entries the paginate function
-// will iterate past the page end when count_total is requested.
-const MaxScanLimit = uint64(10_000)
+// MaxOffset is retained for compatibility. Pagination no longer applies an
+// application-level offset cap.
+const MaxOffset = uint64(math.MaxUint64)
 
-// MaxOffset is the maximum offset allowed in a PageRequest.
-const MaxOffset = uint64(10_000)
+// MaxScanLimit is retained for compatibility. Pagination no longer stops a
+// valid request before the iterator is exhausted.
+const MaxScanLimit = uint64(math.MaxUint64)
 
 // ParsePagination validate PageRequest and returns page number & limit.
 func ParsePagination(pageReq *PageRequest) (page, limit int, err error) {
@@ -35,20 +37,10 @@ func ParsePagination(pageReq *PageRequest) (page, limit int, err error) {
 	if offset < 0 {
 		return 1, 0, status.Error(codes.InvalidArgument, "offset must greater than 0")
 	}
-	// #nosec G115 -- offset is non-negative after validation above; fits in uint64
-	if offsetErr := VerifyPaginationOffset(uint64(offset)); offsetErr != nil {
-		return 1, 0, offsetErr
-	}
-
 	if limit < 0 {
 		return 1, 0, status.Error(codes.InvalidArgument, "limit must greater than 0")
 	} else if limit == 0 {
 		limit = DefaultLimit
-	}
-
-	// #nosec G115 -- limit is positive after validation above; fits in uint64
-	if limitErr := VerifyPaginationLimit(uint64(limit)); limitErr != nil {
-		return 1, 0, limitErr
 	}
 
 	page = offset/limit + 1
@@ -56,17 +48,13 @@ func ParsePagination(pageReq *PageRequest) (page, limit int, err error) {
 	return page, limit, nil
 }
 
-func VerifyPaginationLimit(limit uint64) error {
-	if limit > MaxLimit {
-		return status.Errorf(codes.InvalidArgument, "limit %d exceeds maximum allowed limit %d", limit, MaxLimit)
-	}
+// VerifyPaginationLimit is retained for compatibility. Every uint64 limit is valid.
+func VerifyPaginationLimit(uint64) error {
 	return nil
 }
 
-func VerifyPaginationOffset(offset uint64) error {
-	if offset > MaxOffset {
-		return status.Errorf(codes.InvalidArgument, "offset %d exceeds maximum allowed offset %d", offset, MaxOffset)
-	}
+// VerifyPaginationOffset is retained for compatibility. Every uint64 offset is valid.
+func VerifyPaginationOffset(uint64) error {
 	return nil
 }
 
@@ -83,20 +71,14 @@ func Paginate(
 	offset := pageRequest.Offset
 	key := pageRequest.Key
 	limit := pageRequest.Limit
+	countTotal := pageRequest.CountTotal
+	reverse := pageRequest.Reverse
 	if limit == 0 {
 		limit = DefaultLimit
 	}
 	if offset > 0 && key != nil {
 		return nil, fmt.Errorf("invalid request, either offset or key is expected, got both")
 	}
-	if err := VerifyPaginationLimit(limit); err != nil {
-		return nil, err
-	}
-	if err := VerifyPaginationOffset(offset); err != nil {
-		return nil, err
-	}
-	countTotal := pageRequest.CountTotal
-	reverse := pageRequest.Reverse
 
 	if len(key) != 0 {
 		iterator := getIterator(prefixStore, key, reverse)
@@ -128,18 +110,13 @@ func Paginate(
 	iterator := getIterator(prefixStore, nil, reverse)
 	defer func() { _ = iterator.Close() }()
 
-	end := offset + limit
+	end := paginationEnd(offset, limit)
 
 	var count uint64
 	var nextKey []byte
 
 	for ; iterator.Valid(); iterator.Next() {
 		count++
-
-		if count > end+MaxScanLimit {
-			return nil, status.Errorf(codes.InvalidArgument,
-				"scanned more than %d entries past the end of the page; use key-based pagination instead", MaxScanLimit)
-		}
 
 		if count <= offset {
 			continue
@@ -167,6 +144,13 @@ func Paginate(
 	}
 
 	return res, nil
+}
+
+func paginationEnd(offset, limit uint64) uint64 {
+	if limit > math.MaxUint64-offset {
+		return math.MaxUint64
+	}
+	return offset + limit
 }
 
 func getIterator(prefixStore types.KVStore, start []byte, reverse bool) db.Iterator {

--- a/sei-cosmos/types/query/pagination_test.go
+++ b/sei-cosmos/types/query/pagination_test.go
@@ -57,37 +57,6 @@ func (s *paginationTestSuite) TestParsePagination() {
 	s.Require().NoError(err)
 	s.Require().Equal(page, 1)
 	s.Require().Equal(limit, 10)
-
-	s.T().Log("verify limit equal to MaxLimit is accepted")
-	pageReq = &query.PageRequest{Limit: query.MaxLimit}
-	_, _, err = query.ParsePagination(pageReq)
-	s.Require().NoError(err)
-
-	s.T().Log("verify limit exceeding MaxLimit is rejected")
-	pageReq = &query.PageRequest{Limit: query.MaxLimit + 1}
-	_, _, err = query.ParsePagination(pageReq)
-	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "exceeds maximum allowed limit")
-
-	s.T().Log("verify offset equal to MaxOffset is accepted")
-	pageReq = &query.PageRequest{Offset: query.MaxOffset, Limit: 1}
-	_, _, err = query.ParsePagination(pageReq)
-	s.Require().NoError(err)
-
-	s.T().Log("verify offset exceeding MaxOffset is rejected")
-	pageReq = &query.PageRequest{Offset: query.MaxOffset + 1, Limit: 1}
-	_, _, err = query.ParsePagination(pageReq)
-	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "exceeds maximum allowed offset")
-}
-
-func (s *paginationTestSuite) TestPaginateMaxLimitExceeded() {
-	app, ctx, _ := setupTest(s.T())
-	store := ctx.KVStore(app.GetKey(types.StoreKey))
-
-	_, err := query.Paginate(store, &query.PageRequest{Limit: query.MaxLimit + 1}, func(_, _ []byte) error { return nil })
-	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "exceeds maximum allowed limit")
 }
 
 func (s *paginationTestSuite) TestPagination() {
@@ -323,33 +292,18 @@ func (s *paginationTestSuite) TestReversePagination() {
 	s.Require().Nil(res.Pagination.NextKey)
 }
 
-func (s *paginationTestSuite) TestPaginateOffsetExceedsMax() {
+func (s *paginationTestSuite) TestPaginateCountTotalLargeStore() {
 	app, ctx, _ := setupTest(s.T())
-	kvStore := ctx.KVStore(app.GetKey(types.StoreKey))
+	kvStore := prefix.NewStore(ctx.KVStore(app.GetKey(types.StoreKey)), []byte("largetotal/"))
 
-	_, err := query.Paginate(kvStore, &query.PageRequest{Offset: query.MaxOffset + 1}, func(_, _ []byte) error { return nil })
-	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "exceeds maximum allowed offset")
-
-	_, err = query.Paginate(kvStore, &query.PageRequest{Offset: query.MaxOffset}, func(_, _ []byte) error { return nil })
-	s.Require().NoError(err)
-}
-
-func (s *paginationTestSuite) TestPaginateCountTotalScanLimitExceeded() {
-	app, ctx, _ := setupTest(s.T())
-	// Use a dedicated prefix to isolate test data from other store entries.
-	kvStore := prefix.NewStore(ctx.KVStore(app.GetKey(types.StoreKey)), []byte("scanlimit/"))
-
-	// With offset=1, scan cap fires when count > offset+MaxScanLimit = 10,001.
-	// Insert 10,002 items to guarantee the cap is exceeded.
-	numItems := int(query.MaxScanLimit) + 2
+	const numItems = 10_002
 	for i := 0; i < numItems; i++ {
 		kvStore.Set([]byte(fmt.Sprintf("%08d", i)), []byte("v"))
 	}
 
-	_, err := query.Paginate(kvStore, &query.PageRequest{Limit: 1, CountTotal: true}, func(_, _ []byte) error { return nil })
-	s.Require().Error(err)
-	s.Require().Contains(err.Error(), fmt.Sprintf("scanned more than %d entries", query.MaxScanLimit))
+	res, err := query.Paginate(kvStore, &query.PageRequest{Limit: 1, CountTotal: true}, func(_, _ []byte) error { return nil })
+	s.Require().NoError(err)
+	s.Require().Equal(uint64(numItems), res.Total)
 }
 
 func setupTest(t *testing.T) (*app.App, sdk.Context, codec.Codec) {

--- a/sei-cosmos/x/auth/tx/service.go
+++ b/sei-cosmos/x/auth/tx/service.go
@@ -192,9 +192,6 @@ func (s txServer) GetBlockWithTxs(ctx context.Context, req *txtypes.GetBlockWith
 	if req.Pagination != nil {
 		offset = req.Pagination.Offset
 		limit = req.Pagination.Limit
-		if err = pagination.VerifyPaginationLimit(limit); err != nil {
-			return nil, sdkerrors.ErrInvalidRequest.Wrapf("invalid pagination limit: %d. Max allowed limit is %d", limit, pagination.MaxLimit)
-		}
 	}
 	if limit == 0 {
 		limit = pagination.DefaultLimit
@@ -202,10 +199,10 @@ func (s txServer) GetBlockWithTxs(ctx context.Context, req *txtypes.GetBlockWith
 
 	blockTxs := block.Data.Txs
 	blockTxsLn := uint64(len(blockTxs))
-	txs := make([]*txtypes.Tx, 0, limit)
 	if offset >= blockTxsLn {
 		return nil, sdkerrors.ErrInvalidRequest.Wrapf("out of range: cannot paginate %d txs with offset %d and limit %d", blockTxsLn, offset, limit)
 	}
+	txs := make([]*txtypes.Tx, 0, min(limit, blockTxsLn))
 	decodeTxAt := func(i uint64) error {
 		tx := blockTxs[i]
 		txb, err := s.txConfig.TxDecoder()(tx)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes and provide context

Restore pre-v6.6 pagination behavior for valid `uint64` limits and offsets. Remove the fixed 1,000-result and 10,000-entry scan cutoffs that caused filtered LCD queries to fail when a page contained fewer matches than requested and when `count_total` needed to scan a large store.

The pagination end calculation now saturates on `uint64` overflow, and filtered totals retain the first valid `next_key` while scanning the remaining entries. `GetBlockWithTxs` keeps allocation bounded by the actual number of block transactions instead of trusting the requested limit.

Regression coverage includes sparse filtered stores larger than 10,000 entries, limits larger than the number of matches, accurate `count_total`, and `MaxUint64` limits.

## Testing performed to validate your change

- `go test ./sei-cosmos/types/query`
- `go test ./sei-cosmos/x/auth/tx`
- `go test ./sei-cosmos/x/staking/keeper`
- `gofmt -s -l` on all changed Go files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dfb45aa5-21e2-4ca2-8258-c92e80102176?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dfb45aa5-21e2-4ca2-8258-c92e80102176&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

