### PR TITLE
Restore LCD pagination while preserving v6.6 precompile semantics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,7 @@ export PROJECT_HOME=$(shell git rev-parse --show-toplevel)
 export GO_PKG_PATH=$(shell dirname $(shell go env GOMODCACHE))
 export GO111MODULE = on
 
-# process build tags
-
+# Process build tags.
 LEDGER_ENABLED ?= true
 build_tags = netgo
 ifeq ($(LEDGER_ENABLED),true)

--- a/sei-cosmos/baseapp/abci.go
+++ b/sei-cosmos/baseapp/abci.go
@@ -725,7 +725,9 @@ func (app *BaseApp) CreateQueryContext(height int64, prove bool) (sdk.Context, e
 	// branch the commit-multistore for safety
 	ctx := sdk.NewContext(
 		cacheMS, checkStateCtx.BlockHeader(), true,
-	).WithMinGasPrices(app.minGasPrices).WithBlockHeight(height)
+	).WithMinGasPrices(app.minGasPrices).
+		WithBlockHeight(height).
+		WithIsABCIQuery(true)
 
 	return ctx, nil
 }

--- a/sei-cosmos/baseapp/abci.go
+++ b/sei-cosmos/baseapp/abci.go
@@ -629,7 +629,9 @@ func (app *BaseApp) handleQueryGRPC(handler GRPCQueryHandler, req abci.RequestQu
 		return sdkerrors.QueryResultWithDebug(err, app.trace)
 	}
 
-	res, err := handler(ctx, req)
+	// Only Cosmos ABCI gRPC queries may use client-facing pagination semantics.
+	// Historical EVM RPC also calls CreateQueryContext and must remain unmarked.
+	res, err := handler(ctx.WithIsABCIQuery(true), req)
 	if err != nil {
 		res = sdkerrors.QueryResultWithDebug(gRPCErrorToSDKError(err), app.trace)
 		res.Height = req.Height
@@ -725,9 +727,7 @@ func (app *BaseApp) CreateQueryContext(height int64, prove bool) (sdk.Context, e
 	// branch the commit-multistore for safety
 	ctx := sdk.NewContext(
 		cacheMS, checkStateCtx.BlockHeader(), true,
-	).WithMinGasPrices(app.minGasPrices).
-		WithBlockHeight(height).
-		WithIsABCIQuery(true)
+	).WithMinGasPrices(app.minGasPrices).WithBlockHeight(height)
 
 	return ctx, nil
 }

--- a/sei-cosmos/baseapp/grpcserver.go
+++ b/sei-cosmos/baseapp/grpcserver.go
@@ -57,7 +57,9 @@ func (app *BaseApp) RegisterGRPCServer(server gogogrpc.Server) {
 			height = sdkCtx.BlockHeight() // If height was not set in the request, set it to the latest
 		}
 
-		// Attach the sdk.Context into the gRPC's context.Context.
+		// Direct Cosmos gRPC queries may use client-facing pagination semantics.
+		// Other CreateQueryContext consumers remain v6.6-compatible by default.
+		sdkCtx = sdkCtx.WithIsABCIQuery(true)
 		grpcCtx = context.WithValue(grpcCtx, sdk.SdkContextKey, sdkCtx)
 
 		md = metadata.Pairs(grpctypes.GRPCBlockHeightHeader, strconv.FormatInt(height, 10))

--- a/sei-cosmos/types/context.go
+++ b/sei-cosmos/types/context.go
@@ -41,6 +41,7 @@ type Context struct {
 	blockGasMeter      GasMeter
 	checkTx            bool
 	recheckTx          bool // if recheckTx == true, then checkTx must also be true
+	abciQuery          bool // true only for BaseApp.Query; never transaction/block execution
 	isGenesis          bool
 	minGasPrice        DecCoins
 	consParams         *tmproto.ConsensusParams
@@ -131,6 +132,10 @@ func (c Context) IsCheckTx() bool {
 
 func (c Context) IsReCheckTx() bool {
 	return c.recheckTx
+}
+
+func (c Context) IsABCIQuery() bool {
+	return c.abciQuery
 }
 
 func (c Context) IsGenesis() bool {
@@ -381,6 +386,11 @@ func (c Context) WithIsReCheckTx(isRecheckTx bool) Context {
 		c.checkTx = true
 	}
 	c.recheckTx = isRecheckTx
+	return c
+}
+
+func (c Context) WithIsABCIQuery(isABCIQuery bool) Context {
+	c.abciQuery = isABCIQuery
 	return c
 }
 

--- a/sei-cosmos/types/query/filtered_pagination.go
+++ b/sei-cosmos/types/query/filtered_pagination.go
@@ -5,17 +5,16 @@ import (
 
 	"github.com/sei-protocol/sei-chain/sei-cosmos/codec"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store/types"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // FilteredPaginate does pagination of all the results in the PrefixStore based on the
-// provided PageRequest. onResult does the unmarshaling and filtering.
-// Key-based pagination is optimized; offset-based pagination lazily walks all records.
-//
-// Iteration is capped at MaxScanLimit entries to prevent unbounded store walks. Use key-based
-// pagination for reliable traversal of sparse datasets, as the nextKey could be nil when the
-// page is full and the scan limit is reached.
+// provided PageRequest. onResult should be used to do actual unmarshaling and filter the results.
+// If key is provided, the pagination uses the optimized querying.
+// If offset is used, the pagination uses lazy filtering i.e., searches through all the records.
+// The accumulate parameter represents if the response is valid based on the offset given.
+// It will be false for the results (filtered) < offset and true for offset <= accumulate < end.
+// When accumulate is true, the current result should be appended to the result set returned
+// to the client.
 func FilteredPaginate(
 	prefixStore types.KVStore,
 	pageRequest *PageRequest,
@@ -37,16 +36,10 @@ func FilteredPaginate(
 		return nil, fmt.Errorf("invalid request, either offset or key is expected, got both")
 	}
 
-	if err := VerifyPaginationOffset(offset); err != nil {
-		return nil, err
-	}
-
+	// Note: unlike upstream cosmos-sdk, limit == 0 must NOT implicitly enable
+	// countTotal; see the note in Paginate.
 	if limit == 0 {
 		limit = DefaultLimit
-	}
-
-	if err := VerifyPaginationLimit(limit); err != nil {
-		return nil, err
 	}
 
 	if len(key) != 0 {
@@ -54,20 +47,14 @@ func FilteredPaginate(
 		defer func() { _ = iterator.Close() }()
 
 		var (
-			numHits   uint64
-			nextKey   []byte
-			totalIter uint64
+			numHits uint64
+			nextKey []byte
 		)
 
 		for ; iterator.Valid(); iterator.Next() {
-			totalIter++
 			if numHits == limit {
 				nextKey = iterator.Key()
 				break
-			}
-			if totalIter > MaxScanLimit {
-				return nil, status.Errorf(codes.InvalidArgument,
-					"scanned more than %d entries without filling the page; use a more specific key prefix or reduce limit", MaxScanLimit)
 			}
 
 			if iterator.Error() != nil {
@@ -92,33 +79,14 @@ func FilteredPaginate(
 	iterator := getIterator(prefixStore, nil, reverse)
 	defer func() { _ = iterator.Close() }()
 
-	end := offset + limit
+	end := paginationEnd(offset, limit)
 
 	var (
-		numHits          uint64
-		nextKey          []byte
-		totalIter        uint64
-		pageCompleteIter uint64
+		numHits uint64
+		nextKey []byte
 	)
 
 	for ; iterator.Valid(); iterator.Next() {
-		totalIter++
-		// Phase 1: page not yet complete — cap raw iterations to prevent full-store
-		// walks when the filter produces too few hits to fill the page.
-		if numHits < end && totalIter > offset+MaxScanLimit {
-			return nil, status.Errorf(codes.InvalidArgument,
-				"scanned more than %d entries without filling the page; use key-based pagination instead", MaxScanLimit)
-		}
-		// Phase 2: page complete — cap how far past the page we scan for nextKey/count_total.
-		if pageCompleteIter > MaxScanLimit {
-			if !countTotal {
-				// Page is already assembled; no next hit found within scan window → no next page.
-				break
-			}
-			return nil, status.Errorf(codes.InvalidArgument,
-				"scanned more than %d entries past the end of the page; use key-based pagination instead", MaxScanLimit)
-		}
-
 		if iterator.Error() != nil {
 			return nil, iterator.Error()
 		}
@@ -133,12 +101,12 @@ func FilteredPaginate(
 			numHits++
 		}
 
-		if numHits >= end {
-			pageCompleteIter++
-		}
-
-		if numHits == end+1 {
-			nextKey = iterator.Key()
+		if numHits > end {
+			// Only the first entry past the end of the page is the next key;
+			// do not overwrite it while scanning the remainder for countTotal.
+			if nextKey == nil {
+				nextKey = iterator.Key()
+			}
 
 			if !countTotal {
 				break
@@ -162,8 +130,6 @@ func FilteredPaginate(
 // If offset is used, the pagination uses lazy filtering i.e., searches through all the records.
 // The resulting slice (of type F) can be of a different type than the one being iterated through
 // (type T), so it's possible to do any necessary transformation inside the onResult function.
-//
-// Scan limits: same semantics as FilteredPaginate — see its documentation for details.
 func GenericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 	cdc codec.BinaryCodec,
 	prefixStore types.KVStore,
@@ -187,16 +153,10 @@ func GenericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 		return results, nil, fmt.Errorf("invalid request, either offset or key is expected, got both")
 	}
 
-	if err := VerifyPaginationOffset(offset); err != nil {
-		return results, nil, err
-	}
-
+	// Note: unlike upstream cosmos-sdk, limit == 0 must NOT implicitly enable
+	// countTotal; see the note in Paginate.
 	if limit == 0 {
 		limit = DefaultLimit
-	}
-
-	if err := VerifyPaginationLimit(limit); err != nil {
-		return results, nil, err
 	}
 
 	if len(key) != 0 {
@@ -204,20 +164,14 @@ func GenericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 		defer func() { _ = iterator.Close() }()
 
 		var (
-			numHits   uint64
-			nextKey   []byte
-			totalIter uint64
+			numHits uint64
+			nextKey []byte
 		)
 
 		for ; iterator.Valid(); iterator.Next() {
-			totalIter++
 			if numHits == limit {
 				nextKey = iterator.Key()
 				break
-			}
-			if totalIter > MaxScanLimit {
-				return nil, nil, status.Errorf(codes.InvalidArgument,
-					"scanned more than %d entries without filling the page; use a more specific key prefix or reduce limit", MaxScanLimit)
 			}
 
 			if iterator.Error() != nil {
@@ -250,33 +204,14 @@ func GenericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 	iterator := getIterator(prefixStore, nil, reverse)
 	defer func() { _ = iterator.Close() }()
 
-	end := offset + limit
+	end := paginationEnd(offset, limit)
 
 	var (
-		numHits          uint64
-		nextKey          []byte
-		totalIter        uint64
-		pageCompleteIter uint64
+		numHits uint64
+		nextKey []byte
 	)
 
 	for ; iterator.Valid(); iterator.Next() {
-		totalIter++
-		// Phase 1: page not yet complete — cap raw iterations to prevent full-store
-		// walks when the filter produces too few hits to fill the page.
-		if numHits < end && totalIter > offset+MaxScanLimit {
-			return nil, nil, status.Errorf(codes.InvalidArgument,
-				"scanned more than %d entries without filling the page; use key-based pagination instead", MaxScanLimit)
-		}
-		// Phase 2: page complete — cap how far past the page we scan for nextKey/count_total.
-		if pageCompleteIter > MaxScanLimit {
-			if !countTotal {
-				// Page is already assembled; no next hit found within scan window → no next page.
-				break
-			}
-			return nil, nil, status.Errorf(codes.InvalidArgument,
-				"scanned more than %d entries past the end of the page; use key-based pagination instead", MaxScanLimit)
-		}
-
 		if iterator.Error() != nil {
 			return nil, nil, iterator.Error()
 		}
@@ -301,11 +236,9 @@ func GenericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 			numHits++
 		}
 
-		if numHits >= end {
-			pageCompleteIter++
-		}
-
-		if numHits == end+1 {
+		if numHits > end {
+			// Only the first entry past the end of the page is the next key;
+			// do not overwrite it while scanning the remainder for countTotal.
 			if nextKey == nil {
 				nextKey = iterator.Key()
 			}

--- a/sei-cosmos/types/query/filtered_pagination.go
+++ b/sei-cosmos/types/query/filtered_pagination.go
@@ -83,7 +83,7 @@ func filteredPaginate(
 				break
 			}
 			if enforceV66ScanLimit && totalIter > MaxScanLimit {
-				return nil, nil, status.Errorf(codes.InvalidArgument,
+				return nil, status.Errorf(codes.InvalidArgument,
 					"scanned more than %d entries without filling the page; use a more specific key prefix or reduce limit", MaxScanLimit)
 			}
 
@@ -247,7 +247,7 @@ func genericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 				break
 			}
 			if enforceV66ScanLimit && totalIter > MaxScanLimit {
-				return nil, status.Errorf(codes.InvalidArgument,
+				return nil, nil, status.Errorf(codes.InvalidArgument,
 					"scanned more than %d entries without filling the page; use a more specific key prefix or reduce limit", MaxScanLimit)
 			}
 

--- a/sei-cosmos/types/query/filtered_pagination.go
+++ b/sei-cosmos/types/query/filtered_pagination.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/sei-protocol/sei-chain/sei-cosmos/codec"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // FilteredPaginate does pagination of all the results in the PrefixStore based on the
@@ -20,7 +22,29 @@ func FilteredPaginate(
 	pageRequest *PageRequest,
 	onResult func(key []byte, value []byte, accumulate bool) (bool, error),
 ) (*PageResponse, error) {
+	return filteredPaginate(prefixStore, pageRequest, onResult, false)
+}
 
+// FilteredPaginateV66 preserves release/v6.6 behavior for EVM precompiles.
+//
+// Precompiles invoke Cosmos query handlers during transaction execution.
+// Relaxing the historical scan limit there can change gas consumption and
+// success/revert control flow, causing AppHash and LastResultsHash divergence.
+// Node-local LCD/gRPC queries must continue using FilteredPaginate.
+func FilteredPaginateV66(
+	prefixStore types.KVStore,
+	pageRequest *PageRequest,
+	onResult func(key []byte, value []byte, accumulate bool) (bool, error),
+) (*PageResponse, error) {
+	return filteredPaginate(prefixStore, pageRequest, onResult, true)
+}
+
+func filteredPaginate(
+	prefixStore types.KVStore,
+	pageRequest *PageRequest,
+	onResult func(key []byte, value []byte, accumulate bool) (bool, error),
+	enforceV66ScanLimit bool,
+) (*PageResponse, error) {
 	// if the PageRequest is nil, use default PageRequest
 	if pageRequest == nil {
 		pageRequest = &PageRequest{}
@@ -47,14 +71,20 @@ func FilteredPaginate(
 		defer func() { _ = iterator.Close() }()
 
 		var (
-			numHits uint64
-			nextKey []byte
+			numHits   uint64
+			nextKey   []byte
+			totalIter uint64
 		)
 
 		for ; iterator.Valid(); iterator.Next() {
+			totalIter++
 			if numHits == limit {
 				nextKey = iterator.Key()
 				break
+			}
+			if enforceV66ScanLimit && totalIter > MaxScanLimit {
+				return nil, nil, status.Errorf(codes.InvalidArgument,
+					"scanned more than %d entries without filling the page; use a more specific key prefix or reduce limit", MaxScanLimit)
 			}
 
 			if iterator.Error() != nil {
@@ -80,13 +110,27 @@ func FilteredPaginate(
 	defer func() { _ = iterator.Close() }()
 
 	end := paginationEnd(offset, limit)
-
 	var (
-		numHits uint64
-		nextKey []byte
+		numHits          uint64
+		nextKey          []byte
+		totalIter        uint64
+		pageCompleteIter uint64
 	)
 
 	for ; iterator.Valid(); iterator.Next() {
+		totalIter++
+		if enforceV66ScanLimit && numHits < end && totalIter > paginationEnd(offset, MaxScanLimit) {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"scanned more than %d entries without filling the page; use key-based pagination instead", MaxScanLimit)
+		}
+		if enforceV66ScanLimit && pageCompleteIter > MaxScanLimit {
+			if !countTotal {
+				break
+			}
+			return nil, status.Errorf(codes.InvalidArgument,
+				"scanned more than %d entries past the end of the page; use key-based pagination instead", MaxScanLimit)
+		}
+
 		if iterator.Error() != nil {
 			return nil, iterator.Error()
 		}
@@ -99,6 +143,10 @@ func FilteredPaginate(
 
 		if hit {
 			numHits++
+		}
+
+		if numHits >= end {
+			pageCompleteIter++
 		}
 
 		if numHits > end {
@@ -137,6 +185,29 @@ func GenericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 	onResult func(key []byte, value T) (F, error),
 	constructor func() T,
 ) ([]F, *PageResponse, error) {
+	return genericFilteredPaginate(cdc, prefixStore, pageRequest, onResult, constructor, false)
+}
+
+// GenericFilteredPaginateV66 preserves release/v6.6 behavior for EVM
+// precompiles. Node-local LCD/gRPC queries must use GenericFilteredPaginate.
+func GenericFilteredPaginateV66[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
+	cdc codec.BinaryCodec,
+	prefixStore types.KVStore,
+	pageRequest *PageRequest,
+	onResult func(key []byte, value T) (F, error),
+	constructor func() T,
+) ([]F, *PageResponse, error) {
+	return genericFilteredPaginate(cdc, prefixStore, pageRequest, onResult, constructor, true)
+}
+
+func genericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
+	cdc codec.BinaryCodec,
+	prefixStore types.KVStore,
+	pageRequest *PageRequest,
+	onResult func(key []byte, value T) (F, error),
+	constructor func() T,
+	enforceV66ScanLimit bool,
+) ([]F, *PageResponse, error) {
 	// if the PageRequest is nil, use default PageRequest
 	if pageRequest == nil {
 		pageRequest = &PageRequest{}
@@ -164,14 +235,20 @@ func GenericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 		defer func() { _ = iterator.Close() }()
 
 		var (
-			numHits uint64
-			nextKey []byte
+			numHits   uint64
+			nextKey   []byte
+			totalIter uint64
 		)
 
 		for ; iterator.Valid(); iterator.Next() {
+			totalIter++
 			if numHits == limit {
 				nextKey = iterator.Key()
 				break
+			}
+			if enforceV66ScanLimit && totalIter > MaxScanLimit {
+				return nil, status.Errorf(codes.InvalidArgument,
+					"scanned more than %d entries without filling the page; use a more specific key prefix or reduce limit", MaxScanLimit)
 			}
 
 			if iterator.Error() != nil {
@@ -205,13 +282,27 @@ func GenericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 	defer func() { _ = iterator.Close() }()
 
 	end := paginationEnd(offset, limit)
-
 	var (
-		numHits uint64
-		nextKey []byte
+		numHits          uint64
+		nextKey          []byte
+		totalIter        uint64
+		pageCompleteIter uint64
 	)
 
 	for ; iterator.Valid(); iterator.Next() {
+		totalIter++
+		if enforceV66ScanLimit && numHits < end && totalIter > paginationEnd(offset, MaxScanLimit) {
+			return nil, nil, status.Errorf(codes.InvalidArgument,
+				"scanned more than %d entries without filling the page; use key-based pagination instead", MaxScanLimit)
+		}
+		if enforceV66ScanLimit && pageCompleteIter > MaxScanLimit {
+			if !countTotal {
+				break
+			}
+			return nil, nil, status.Errorf(codes.InvalidArgument,
+				"scanned more than %d entries past the end of the page; use key-based pagination instead", MaxScanLimit)
+		}
+
 		if iterator.Error() != nil {
 			return nil, nil, iterator.Error()
 		}
@@ -234,6 +325,10 @@ func GenericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 				results = append(results, val)
 			}
 			numHits++
+		}
+
+		if numHits >= end {
+			pageCompleteIter++
 		}
 
 		if numHits > end {

--- a/sei-cosmos/types/query/filtered_pagination_test.go
+++ b/sei-cosmos/types/query/filtered_pagination_test.go
@@ -42,6 +42,14 @@ func (s *paginationTestSuite) TestFilteredPaginations() {
 	s.Require().NotNil(res)
 	s.Require().Equal(4, len(balances))
 
+	s.T().Log("verify maximum uint64 limit returns all filtered values")
+	pageReq = &query.PageRequest{Limit: query.MaxLimit}
+	balances, res, err = execFilterPaginate(store, pageReq, appCodec)
+	s.Require().NoError(err)
+	s.Require().NotNil(res)
+	s.Require().Equal(4, len(balances))
+	s.Require().Nil(res.NextKey)
+
 	s.T().Log("verify empty request")
 	balances, res, err = execFilterPaginate(store, nil, appCodec)
 	s.Require().NoError(err)
@@ -170,73 +178,54 @@ func (s *paginationTestSuite) TestReverseFilteredPaginations() {
 
 }
 
-func (s *paginationTestSuite) TestFilteredPaginateMaxLimitExceeded() {
+func (s *paginationTestSuite) TestFilteredPaginateCountTotalLargeSparseStore() {
 	app, ctx, _ := setupTest(s.T())
-	store := ctx.KVStore(app.GetKey(types.StoreKey))
+	kvStore := prefix.NewStore(ctx.KVStore(app.GetKey(types.StoreKey)), []byte("filteredlargetotal/"))
 
-	_, err := query.FilteredPaginate(store, &query.PageRequest{Limit: query.MaxLimit + 1}, func(_ []byte, _ []byte, _ bool) (bool, error) {
-		return false, nil
-	})
-	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "exceeds maximum allowed limit")
-}
+	const numItems = 10_002
+	for i := 0; i < numItems; i++ {
+		kvStore.Set([]byte(fmt.Sprintf("%08d", i)), []byte("v"))
+	}
 
-func (s *paginationTestSuite) TestFilteredPaginateOffsetExceedsMax() {
-	app, ctx, _ := setupTest(s.T())
-	kvStore := ctx.KVStore(app.GetKey(types.StoreKey))
-
-	_, err := query.FilteredPaginate(kvStore, &query.PageRequest{Offset: query.MaxOffset + 1}, func(_ []byte, _ []byte, _ bool) (bool, error) {
-		return false, nil
-	})
-	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "exceeds maximum allowed offset")
-
-	_, err = query.FilteredPaginate(kvStore, &query.PageRequest{Offset: query.MaxOffset}, func(_ []byte, _ []byte, _ bool) (bool, error) {
-		return false, nil
+	res, err := query.FilteredPaginate(kvStore, &query.PageRequest{Limit: 3, CountTotal: true}, func(key []byte, _ []byte, _ bool) (bool, error) {
+		return string(key) == "00000000" || string(key) == "00005000" || string(key) == "00010000", nil
 	})
 	s.Require().NoError(err)
+	s.Require().Equal(uint64(3), res.Total)
+	s.Require().Nil(res.NextKey)
 }
 
-func (s *paginationTestSuite) TestFilteredPaginateCountTotalScanLimitExceeded() {
+func (s *paginationTestSuite) TestFilteredPaginateLimitExceedsHitsInLargeStore() {
 	app, ctx, _ := setupTest(s.T())
-	kvStore := prefix.NewStore(ctx.KVStore(app.GetKey(types.StoreKey)), []byte("filteredscanlimit/"))
+	kvStore := prefix.NewStore(ctx.KVStore(app.GetKey(types.StoreKey)), []byte("filteredlargelimit/"))
 
-	numItems := int(query.MaxScanLimit) + 2
+	const numItems = 10_002
 	for i := 0; i < numItems; i++ {
-		kvStore.Set([]byte(fmt.Sprintf("%08d", i)), []byte("v"))
+		value := []byte("miss")
+		if i%100 == 0 {
+			value = []byte("hit")
+		}
+		kvStore.Set([]byte(fmt.Sprintf("%08d", i)), value)
 	}
 
-	_, err := query.FilteredPaginate(kvStore, &query.PageRequest{Limit: 1, CountTotal: true}, func(_ []byte, _ []byte, _ bool) (bool, error) {
-		return true, nil
+	var hits int
+	res, err := query.FilteredPaginate(kvStore, &query.PageRequest{Limit: 250}, func(_ []byte, value []byte, accumulate bool) (bool, error) {
+		hit := string(value) == "hit"
+		if hit && accumulate {
+			hits++
+		}
+		return hit, nil
 	})
-	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "scanned more than")
+	s.Require().NoError(err)
+	s.Require().Equal(101, hits)
+	s.Require().Nil(res.NextKey)
 }
 
-func (s *paginationTestSuite) TestFilteredPaginateCountTotalScanLimitExceededNoHits() {
-	app, ctx, _ := setupTest(s.T())
-	kvStore := prefix.NewStore(ctx.KVStore(app.GetKey(types.StoreKey)), []byte("filteredscanlimitnohits/"))
-
-	// Phase 1 fires when totalIter > offset + MaxScanLimit = 10001
-	pageReq := &query.PageRequest{Offset: 1, CountTotal: true}
-	numItems := int(query.MaxScanLimit) + 2
-	for i := 0; i < numItems; i++ {
-		kvStore.Set([]byte(fmt.Sprintf("%08d", i)), []byte("v"))
-	}
-
-	// filter returns no hits — numHits never reaches end, Phase 1 guard must fire
-	_, err := query.FilteredPaginate(kvStore, pageReq, func(_ []byte, _ []byte, _ bool) (bool, error) {
-		return false, nil
-	})
-	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "scanned more than")
-}
-
-func (s *paginationTestSuite) TestFilteredPaginateSparseFilterFillsPageWithinScanLimit() {
+func (s *paginationTestSuite) TestFilteredPaginateSparseFilter() {
 	app, ctx, _ := setupTest(s.T())
 	kvStore := prefix.NewStore(ctx.KVStore(app.GetKey(types.StoreKey)), []byte("filteredsparse/"))
 
-	numItems := int(query.MaxScanLimit)
+	const numItems = 10_000
 	for i := 0; i < numItems; i++ {
 		value := "miss"
 		if i%1000 == 0 {
@@ -264,7 +253,7 @@ func (s *paginationTestSuite) TestFilteredPaginateSparseFilterFillsPageWithinSca
 	s.Require().Equal("00004000", string(hits[4]))
 	s.Require().Equal("00005000", string(res.NextKey))
 
-	s.T().Log("count_total scans the rest of the store, still within the Phase 2 cap")
+	s.T().Log("count_total scans the rest of the store")
 	hits = nil
 	res, err = query.FilteredPaginate(kvStore, &query.PageRequest{Limit: 5, CountTotal: true}, onResult)
 	s.Require().NoError(err)

--- a/sei-cosmos/types/query/pagination.go
+++ b/sei-cosmos/types/query/pagination.go
@@ -18,6 +18,9 @@ const DefaultLimit = 100
 // which equals the maximum value that can be stored in uint64
 const MaxLimit = uint64(math.MaxUint64)
 
+// MaxScanLimit is retained by the v6.6-compatible precompile paginators.
+const MaxScanLimit = uint64(10_000)
+
 // ParsePagination validate PageRequest and returns page number & limit.
 // Note that page math is performed in int space, so limits and offsets above
 // math.MaxInt64 are rejected as negative values.

--- a/sei-cosmos/types/query/pagination.go
+++ b/sei-cosmos/types/query/pagination.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store/types"
 	db "github.com/tendermint/tm-db"
@@ -13,31 +14,23 @@ import (
 // if the `limit` is not supplied, paginate will use `DefaultLimit`
 const DefaultLimit = 100
 
-// MaxLimit is the maximum limit per page the paginate function can handle
-const MaxLimit = uint64(1_000)
-
-// MaxScanLimit is the maximum number of store entries the paginate function
-// will iterate past the page end when count_total is requested.
-const MaxScanLimit = uint64(10_000)
-
-// MaxOffset is the maximum offset allowed in a PageRequest.
-const MaxOffset = uint64(10_000)
+// MaxLimit is the maximum limit the paginate function can handle
+// which equals the maximum value that can be stored in uint64
+const MaxLimit = uint64(math.MaxUint64)
 
 // ParsePagination validate PageRequest and returns page number & limit.
+// Note that page math is performed in int space, so limits and offsets above
+// math.MaxInt64 are rejected as negative values.
 func ParsePagination(pageReq *PageRequest) (page, limit int, err error) {
 	offset := 0
 	limit = DefaultLimit
 
 	if pageReq != nil {
-		offset = int(pageReq.Offset) // #nosec G115 -- overflow checked below
-		limit = int(pageReq.Limit)   // #nosec G115 -- overflow checked below
+		offset = int(pageReq.Offset) // #nosec G115 -- negative on overflow, rejected below
+		limit = int(pageReq.Limit)   // #nosec G115 -- negative on overflow, rejected below
 	}
 	if offset < 0 {
 		return 1, 0, status.Error(codes.InvalidArgument, "offset must greater than 0")
-	}
-	// #nosec G115 -- offset is non-negative after validation above; fits in uint64
-	if offsetErr := VerifyPaginationOffset(uint64(offset)); offsetErr != nil {
-		return 1, 0, offsetErr
 	}
 
 	if limit < 0 {
@@ -46,28 +39,9 @@ func ParsePagination(pageReq *PageRequest) (page, limit int, err error) {
 		limit = DefaultLimit
 	}
 
-	// #nosec G115 -- limit is positive after validation above; fits in uint64
-	if limitErr := VerifyPaginationLimit(uint64(limit)); limitErr != nil {
-		return 1, 0, limitErr
-	}
-
 	page = offset/limit + 1
 
 	return page, limit, nil
-}
-
-func VerifyPaginationLimit(limit uint64) error {
-	if limit > MaxLimit {
-		return status.Errorf(codes.InvalidArgument, "limit %d exceeds maximum allowed limit %d", limit, MaxLimit)
-	}
-	return nil
-}
-
-func VerifyPaginationOffset(offset uint64) error {
-	if offset > MaxOffset {
-		return status.Errorf(codes.InvalidArgument, "offset %d exceeds maximum allowed offset %d", offset, MaxOffset)
-	}
-	return nil
 }
 
 // Paginate does pagination of all the results in the PrefixStore based on the
@@ -77,26 +51,30 @@ func Paginate(
 	pageRequest *PageRequest,
 	onResult func(key []byte, value []byte) error,
 ) (*PageResponse, error) {
+
+	// if the PageRequest is nil, use default PageRequest
 	if pageRequest == nil {
 		pageRequest = &PageRequest{}
 	}
+
 	offset := pageRequest.Offset
 	key := pageRequest.Key
 	limit := pageRequest.Limit
-	if limit == 0 {
-		limit = DefaultLimit
-	}
+	countTotal := pageRequest.CountTotal
+	reverse := pageRequest.Reverse
+
 	if offset > 0 && key != nil {
 		return nil, fmt.Errorf("invalid request, either offset or key is expected, got both")
 	}
-	if err := VerifyPaginationLimit(limit); err != nil {
-		return nil, err
+
+	// Note: unlike upstream cosmos-sdk, limit == 0 must NOT implicitly enable
+	// countTotal. EVM precompiles (e.g. precompiles/staking) call query
+	// handlers during transaction execution with Limit: 0; an implicit
+	// full-store count would change their gas consumption and therefore
+	// break AppHash and LastResultsHash across versions.
+	if limit == 0 {
+		limit = DefaultLimit
 	}
-	if err := VerifyPaginationOffset(offset); err != nil {
-		return nil, err
-	}
-	countTotal := pageRequest.CountTotal
-	reverse := pageRequest.Reverse
 
 	if len(key) != 0 {
 		iterator := getIterator(prefixStore, key, reverse)
@@ -128,18 +106,13 @@ func Paginate(
 	iterator := getIterator(prefixStore, nil, reverse)
 	defer func() { _ = iterator.Close() }()
 
-	end := offset + limit
+	end := paginationEnd(offset, limit)
 
 	var count uint64
 	var nextKey []byte
 
 	for ; iterator.Valid(); iterator.Next() {
 		count++
-
-		if count > end+MaxScanLimit {
-			return nil, status.Errorf(codes.InvalidArgument,
-				"scanned more than %d entries past the end of the page; use key-based pagination instead", MaxScanLimit)
-		}
 
 		if count <= offset {
 			continue
@@ -167,6 +140,16 @@ func Paginate(
 	}
 
 	return res, nil
+}
+
+// paginationEnd returns the index one past the last entry of the requested
+// page, saturating at math.MaxUint64 instead of wrapping around when
+// offset+limit overflows.
+func paginationEnd(offset, limit uint64) uint64 {
+	if limit > math.MaxUint64-offset {
+		return math.MaxUint64
+	}
+	return offset + limit
 }
 
 func getIterator(prefixStore types.KVStore, start []byte, reverse bool) db.Iterator {

--- a/sei-cosmos/types/query/pagination_test.go
+++ b/sei-cosmos/types/query/pagination_test.go
@@ -3,6 +3,7 @@ package query_test
 import (
 	gocontext "context"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/sei-protocol/sei-chain/app"
@@ -58,36 +59,15 @@ func (s *paginationTestSuite) TestParsePagination() {
 	s.Require().Equal(page, 1)
 	s.Require().Equal(limit, 10)
 
-	s.T().Log("verify limit equal to MaxLimit is accepted")
-	pageReq = &query.PageRequest{Limit: query.MaxLimit}
-	_, _, err = query.ParsePagination(pageReq)
-	s.Require().NoError(err)
-
-	s.T().Log("verify limit exceeding MaxLimit is rejected")
-	pageReq = &query.PageRequest{Limit: query.MaxLimit + 1}
+	s.T().Log("verify limits above MaxInt64 are rejected: page math is int-based")
+	pageReq = &query.PageRequest{Limit: uint64(math.MaxInt64) + 1}
 	_, _, err = query.ParsePagination(pageReq)
 	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "exceeds maximum allowed limit")
 
-	s.T().Log("verify offset equal to MaxOffset is accepted")
-	pageReq = &query.PageRequest{Offset: query.MaxOffset, Limit: 1}
-	_, _, err = query.ParsePagination(pageReq)
-	s.Require().NoError(err)
-
-	s.T().Log("verify offset exceeding MaxOffset is rejected")
-	pageReq = &query.PageRequest{Offset: query.MaxOffset + 1, Limit: 1}
+	s.T().Log("verify offsets above MaxInt64 are rejected: page math is int-based")
+	pageReq = &query.PageRequest{Offset: uint64(math.MaxInt64) + 1, Limit: 1}
 	_, _, err = query.ParsePagination(pageReq)
 	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "exceeds maximum allowed offset")
-}
-
-func (s *paginationTestSuite) TestPaginateMaxLimitExceeded() {
-	app, ctx, _ := setupTest(s.T())
-	store := ctx.KVStore(app.GetKey(types.StoreKey))
-
-	_, err := query.Paginate(store, &query.PageRequest{Limit: query.MaxLimit + 1}, func(_, _ []byte) error { return nil })
-	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "exceeds maximum allowed limit")
 }
 
 func (s *paginationTestSuite) TestPagination() {
@@ -323,33 +303,40 @@ func (s *paginationTestSuite) TestReversePagination() {
 	s.Require().Nil(res.Pagination.NextKey)
 }
 
-func (s *paginationTestSuite) TestPaginateOffsetExceedsMax() {
-	app, ctx, _ := setupTest(s.T())
-	kvStore := ctx.KVStore(app.GetKey(types.StoreKey))
-
-	_, err := query.Paginate(kvStore, &query.PageRequest{Offset: query.MaxOffset + 1}, func(_, _ []byte) error { return nil })
-	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "exceeds maximum allowed offset")
-
-	_, err = query.Paginate(kvStore, &query.PageRequest{Offset: query.MaxOffset}, func(_, _ []byte) error { return nil })
-	s.Require().NoError(err)
-}
-
-func (s *paginationTestSuite) TestPaginateCountTotalScanLimitExceeded() {
+func (s *paginationTestSuite) TestPaginateCountTotalLargeStore() {
 	app, ctx, _ := setupTest(s.T())
 	// Use a dedicated prefix to isolate test data from other store entries.
-	kvStore := prefix.NewStore(ctx.KVStore(app.GetKey(types.StoreKey)), []byte("scanlimit/"))
+	kvStore := prefix.NewStore(ctx.KVStore(app.GetKey(types.StoreKey)), []byte("largetotal/"))
 
-	// With offset=1, scan cap fires when count > offset+MaxScanLimit = 10,001.
-	// Insert 10,002 items to guarantee the cap is exceeded.
-	numItems := int(query.MaxScanLimit) + 2
+	const numItems = 10_002
 	for i := 0; i < numItems; i++ {
 		kvStore.Set([]byte(fmt.Sprintf("%08d", i)), []byte("v"))
 	}
 
-	_, err := query.Paginate(kvStore, &query.PageRequest{Limit: 1, CountTotal: true}, func(_, _ []byte) error { return nil })
-	s.Require().Error(err)
-	s.Require().Contains(err.Error(), fmt.Sprintf("scanned more than %d entries", query.MaxScanLimit))
+	s.T().Log("count_total scans the whole store and returns an accurate total")
+	res, err := query.Paginate(kvStore, &query.PageRequest{Limit: 1, CountTotal: true}, func(_, _ []byte) error { return nil })
+	s.Require().NoError(err)
+	s.Require().Equal(uint64(numItems), res.Total)
+
+	s.T().Log("a large offset skips entries instead of being rejected")
+	var count int
+	res, err = query.Paginate(kvStore, &query.PageRequest{Offset: 10_001, Limit: 5}, func(_, _ []byte) error {
+		count++
+		return nil
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(1, count)
+	s.Require().Nil(res.NextKey)
+
+	s.T().Log("a maximum uint64 limit returns everything without overflowing")
+	count = 0
+	res, err = query.Paginate(kvStore, &query.PageRequest{Offset: 1, Limit: query.MaxLimit}, func(_, _ []byte) error {
+		count++
+		return nil
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(numItems-1, count)
+	s.Require().Nil(res.NextKey)
 }
 
 func setupTest(t *testing.T) (*app.App, sdk.Context, codec.Codec) {

--- a/sei-cosmos/x/auth/tx/service.go
+++ b/sei-cosmos/x/auth/tx/service.go
@@ -192,9 +192,6 @@ func (s txServer) GetBlockWithTxs(ctx context.Context, req *txtypes.GetBlockWith
 	if req.Pagination != nil {
 		offset = req.Pagination.Offset
 		limit = req.Pagination.Limit
-		if err = pagination.VerifyPaginationLimit(limit); err != nil {
-			return nil, sdkerrors.ErrInvalidRequest.Wrapf("invalid pagination limit: %d. Max allowed limit is %d", limit, pagination.MaxLimit)
-		}
 	}
 	if limit == 0 {
 		limit = pagination.DefaultLimit
@@ -202,10 +199,12 @@ func (s txServer) GetBlockWithTxs(ctx context.Context, req *txtypes.GetBlockWith
 
 	blockTxs := block.Data.Txs
 	blockTxsLn := uint64(len(blockTxs))
-	txs := make([]*txtypes.Tx, 0, limit)
 	if offset >= blockTxsLn {
 		return nil, sdkerrors.ErrInvalidRequest.Wrapf("out of range: cannot paginate %d txs with offset %d and limit %d", blockTxsLn, offset, limit)
 	}
+	// Cap the allocation by the number of txs actually in the block so a huge
+	// user-supplied limit cannot trigger a huge allocation.
+	txs := make([]*txtypes.Tx, 0, min(limit, blockTxsLn))
 	decodeTxAt := func(i uint64) error {
 		tx := blockTxs[i]
 		txb, err := s.txConfig.TxDecoder()(tx)

--- a/sei-cosmos/x/authz/keeper/grpc_query.go
+++ b/sei-cosmos/x/authz/keeper/grpc_query.go
@@ -53,9 +53,9 @@ func (k Keeper) Grants(c context.Context, req *authz.QueryGrantsRequest) (*authz
 	key := grantStoreKey(grantee, granter, "")
 	grantsStore := prefix.NewStore(store, key)
 
-	paginate := query.GenericFilteredPaginate[*authz.Grant, *authz.Grant]
-	if ctx.IsEVM() {
-		paginate = query.GenericFilteredPaginateV66[*authz.Grant, *authz.Grant]
+	paginate := query.GenericFilteredPaginateV66[*authz.Grant, *authz.Grant]
+	if ctx.IsABCIQuery() {
+		paginate = query.GenericFilteredPaginate[*authz.Grant, *authz.Grant]
 	}
 
 	authorizations, pageRes, err := paginate(k.cdc, grantsStore, req.Pagination, func(key []byte, auth *authz.Grant) (*authz.Grant, error) {
@@ -100,9 +100,9 @@ func (k Keeper) GranterGrants(c context.Context, req *authz.QueryGranterGrantsRe
 	store := ctx.KVStore(k.storeKey)
 	authzStore := prefix.NewStore(store, grantStoreKey(nil, granter, ""))
 
-	paginate := query.GenericFilteredPaginate[*authz.Grant, *authz.GrantAuthorization]
-	if ctx.IsEVM() {
-		paginate = query.GenericFilteredPaginateV66[*authz.Grant, *authz.GrantAuthorization]
+	paginate := query.GenericFilteredPaginateV66[*authz.Grant, *authz.GrantAuthorization]
+	if ctx.IsABCIQuery() {
+		paginate = query.GenericFilteredPaginate[*authz.Grant, *authz.GrantAuthorization]
 	}
 
 	grants, pageRes, err := paginate(k.cdc, authzStore, req.Pagination, func(key []byte, auth *authz.Grant) (*authz.GrantAuthorization, error) {
@@ -152,9 +152,9 @@ func (k Keeper) GranteeGrants(c context.Context, req *authz.QueryGranteeGrantsRe
 	ctx := sdk.UnwrapSDKContext(c)
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), GrantKey)
 
-	paginate := query.GenericFilteredPaginate[*authz.Grant, *authz.GrantAuthorization]
-	if ctx.IsEVM() {
-		paginate = query.GenericFilteredPaginateV66[*authz.Grant, *authz.GrantAuthorization]
+	paginate := query.GenericFilteredPaginateV66[*authz.Grant, *authz.GrantAuthorization]
+	if ctx.IsABCIQuery() {
+		paginate = query.GenericFilteredPaginate[*authz.Grant, *authz.GrantAuthorization]
 	}
 
 	authorizations, pageRes, err := paginate(k.cdc, store, req.Pagination, func(key []byte, auth *authz.Grant) (*authz.GrantAuthorization, error) {

--- a/sei-cosmos/x/authz/keeper/grpc_query.go
+++ b/sei-cosmos/x/authz/keeper/grpc_query.go
@@ -53,7 +53,12 @@ func (k Keeper) Grants(c context.Context, req *authz.QueryGrantsRequest) (*authz
 	key := grantStoreKey(grantee, granter, "")
 	grantsStore := prefix.NewStore(store, key)
 
-	authorizations, pageRes, err := query.GenericFilteredPaginate(k.cdc, grantsStore, req.Pagination, func(key []byte, auth *authz.Grant) (*authz.Grant, error) {
+	paginate := query.GenericFilteredPaginate[*authz.Grant, *authz.Grant]
+	if ctx.IsEVM() {
+		paginate = query.GenericFilteredPaginateV66[*authz.Grant, *authz.Grant]
+	}
+
+	authorizations, pageRes, err := paginate(k.cdc, grantsStore, req.Pagination, func(key []byte, auth *authz.Grant) (*authz.Grant, error) {
 		auth1 := auth.GetAuthorization()
 		if err != nil {
 			return nil, err
@@ -95,7 +100,12 @@ func (k Keeper) GranterGrants(c context.Context, req *authz.QueryGranterGrantsRe
 	store := ctx.KVStore(k.storeKey)
 	authzStore := prefix.NewStore(store, grantStoreKey(nil, granter, ""))
 
-	grants, pageRes, err := query.GenericFilteredPaginate(k.cdc, authzStore, req.Pagination, func(key []byte, auth *authz.Grant) (*authz.GrantAuthorization, error) {
+	paginate := query.GenericFilteredPaginate[*authz.Grant, *authz.GrantAuthorization]
+	if ctx.IsEVM() {
+		paginate = query.GenericFilteredPaginateV66[*authz.Grant, *authz.GrantAuthorization]
+	}
+
+	grants, pageRes, err := paginate(k.cdc, authzStore, req.Pagination, func(key []byte, auth *authz.Grant) (*authz.GrantAuthorization, error) {
 		auth1 := auth.GetAuthorization()
 		if err != nil {
 			return nil, err
@@ -142,7 +152,12 @@ func (k Keeper) GranteeGrants(c context.Context, req *authz.QueryGranteeGrantsRe
 	ctx := sdk.UnwrapSDKContext(c)
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), GrantKey)
 
-	authorizations, pageRes, err := query.GenericFilteredPaginate(k.cdc, store, req.Pagination, func(key []byte, auth *authz.Grant) (*authz.GrantAuthorization, error) {
+	paginate := query.GenericFilteredPaginate[*authz.Grant, *authz.GrantAuthorization]
+	if ctx.IsEVM() {
+		paginate = query.GenericFilteredPaginateV66[*authz.Grant, *authz.GrantAuthorization]
+	}
+
+	authorizations, pageRes, err := paginate(k.cdc, store, req.Pagination, func(key []byte, auth *authz.Grant) (*authz.GrantAuthorization, error) {
 		auth1 := auth.GetAuthorization()
 		if err != nil {
 			return nil, err

--- a/sei-cosmos/x/bank/keeper/keeper.go
+++ b/sei-cosmos/x/bank/keeper/keeper.go
@@ -106,10 +106,15 @@ func (k BaseKeeper) GetPaginatedTotalSupply(ctx sdk.Context, pagination *query.P
 	return supply, pageRes, nil
 }
 
-// CollectAllTotalSupply returns the full supply by paging with MaxLimit.
+// supplyPageSize bounds how many supply entries CollectAllTotalSupply fetches
+// per page while merging the full supply.
+const supplyPageSize = uint64(1_000)
+
+// CollectAllTotalSupply returns the full supply by following next_key until
+// the supply store is exhausted.
 func CollectAllTotalSupply(ctx sdk.Context, k Keeper) (sdk.Coins, error) {
 	totalSupply := sdk.NewCoins()
-	pageReq := &query.PageRequest{Limit: query.MaxLimit}
+	pageReq := &query.PageRequest{Limit: supplyPageSize}
 
 	for {
 		page, pageRes, err := k.GetPaginatedTotalSupply(ctx, pageReq)
@@ -123,7 +128,7 @@ func CollectAllTotalSupply(ctx sdk.Context, k Keeper) (sdk.Coins, error) {
 		}
 		pageReq = &query.PageRequest{
 			Key:   pageRes.NextKey,
-			Limit: query.MaxLimit,
+			Limit: supplyPageSize,
 		}
 	}
 }

--- a/sei-cosmos/x/bank/keeper/keeper_test.go
+++ b/sei-cosmos/x/bank/keeper/keeper_test.go
@@ -157,10 +157,9 @@ func (suite *IntegrationTestSuite) TestSendCoinsAndWei() {
 	require.Equal(sdk.NewInt(53), keeper.GetBalance(ctx, addr3, sdk.DefaultBondDenom).Amount)
 }
 
-func (suite *IntegrationTestSuite) TestGetPaginatedTotalSupplyMaxLimitExceeded() {
-	_, _, err := suite.app.BankKeeper.GetPaginatedTotalSupply(suite.ctx, &query.PageRequest{Limit: query.MaxLimit + 1})
-	suite.Require().Error(err)
-	suite.Require().Contains(err.Error(), "exceeds maximum allowed limit")
+func (suite *IntegrationTestSuite) TestGetPaginatedTotalSupplyMaxLimit() {
+	_, _, err := suite.app.BankKeeper.GetPaginatedTotalSupply(suite.ctx, &query.PageRequest{Limit: query.MaxLimit})
+	suite.Require().NoError(err)
 }
 
 func (suite *IntegrationTestSuite) TestSupply() {
@@ -199,10 +198,10 @@ func (suite *IntegrationTestSuite) TestCollectAllTotalSupplyMultiPage() {
 
 	_, bk := suite.initKeepersWithmAccPerms(make(map[string]bool))
 
-	// 2.5x MaxLimit denoms so CollectAllTotalSupply must merge three pages (two
-	// full, one partial). Distinct amounts per denom so a dropped or duplicated
-	// page boundary changes the result, not just the count.
-	numDenoms := int(query.MaxLimit*2 + query.MaxLimit/2)
+	// 2.5x CollectAllTotalSupply's internal page size (1,000) so it must merge
+	// three pages (two full, one partial). Distinct amounts per denom so a
+	// dropped or duplicated page boundary changes the result, not just the count.
+	const numDenoms = 2_500
 	coins := make(sdk.Coins, numDenoms)
 	for i := 0; i < numDenoms; i++ {
 		coins[i] = sdk.NewInt64Coin(fmt.Sprintf("denom%05d", i), int64(i+1))

--- a/sei-cosmos/x/distribution/keeper/grpc_query.go
+++ b/sei-cosmos/x/distribution/keeper/grpc_query.go
@@ -90,7 +90,12 @@ func (k Keeper) ValidatorSlashes(c context.Context, req *types.QueryValidatorSla
 	}
 	slashesStore := prefix.NewStore(store, types.GetValidatorSlashEventPrefix(valAddr))
 
-	pageRes, err := query.FilteredPaginate(slashesStore, req.Pagination, func(key []byte, value []byte, accumulate bool) (bool, error) {
+	paginate := query.FilteredPaginate
+	if ctx.IsEVM() {
+		paginate = query.FilteredPaginateV66
+	}
+
+	pageRes, err := paginate(slashesStore, req.Pagination, func(key []byte, value []byte, accumulate bool) (bool, error) {
 		var result types.ValidatorSlashEvent
 		err := k.cdc.Unmarshal(value, &result)
 

--- a/sei-cosmos/x/distribution/keeper/grpc_query.go
+++ b/sei-cosmos/x/distribution/keeper/grpc_query.go
@@ -90,9 +90,9 @@ func (k Keeper) ValidatorSlashes(c context.Context, req *types.QueryValidatorSla
 	}
 	slashesStore := prefix.NewStore(store, types.GetValidatorSlashEventPrefix(valAddr))
 
-	paginate := query.FilteredPaginate
-	if ctx.IsEVM() {
-		paginate = query.FilteredPaginateV66
+	paginate := query.FilteredPaginateV66
+	if ctx.IsABCIQuery() {
+		paginate = query.FilteredPaginate
 	}
 
 	pageRes, err := paginate(slashesStore, req.Pagination, func(key []byte, value []byte, accumulate bool) (bool, error) {

--- a/sei-cosmos/x/feegrant/keeper/grpc_query.go
+++ b/sei-cosmos/x/feegrant/keeper/grpc_query.go
@@ -112,9 +112,9 @@ func (q Keeper) AllowancesByGranter(c context.Context, req *feegrant.QueryAllowa
 	store := ctx.KVStore(q.storeKey)
 	prefixStore := prefix.NewStore(store, feegrant.FeeAllowanceKeyPrefix)
 
-	paginate := query.FilteredPaginate
-	if ctx.IsEVM() {
-		paginate = query.FilteredPaginateV66
+	paginate := query.FilteredPaginateV66
+	if ctx.IsABCIQuery() {
+		paginate = query.FilteredPaginate
 	}
 	pageRes, err := paginate(prefixStore, req.Pagination, func(key []byte, value []byte, accumulate bool) (bool, error) {
 		// ParseAddressesFromFeeAllowanceKey expects the full key including the prefix.

--- a/sei-cosmos/x/feegrant/keeper/grpc_query.go
+++ b/sei-cosmos/x/feegrant/keeper/grpc_query.go
@@ -111,7 +111,12 @@ func (q Keeper) AllowancesByGranter(c context.Context, req *feegrant.QueryAllowa
 
 	store := ctx.KVStore(q.storeKey)
 	prefixStore := prefix.NewStore(store, feegrant.FeeAllowanceKeyPrefix)
-	pageRes, err := query.FilteredPaginate(prefixStore, req.Pagination, func(key []byte, value []byte, accumulate bool) (bool, error) {
+
+	paginate := query.FilteredPaginate
+	if ctx.IsEVM() {
+		paginate = query.FilteredPaginateV66
+	}
+	pageRes, err := paginate(prefixStore, req.Pagination, func(key []byte, value []byte, accumulate bool) (bool, error) {
 		// ParseAddressesFromFeeAllowanceKey expects the full key including the prefix.
 		granter, _ := feegrant.ParseAddressesFromFeeAllowanceKey(append(feegrant.FeeAllowanceKeyPrefix, key...))
 		if !granter.Equals(granterAddr) {

--- a/sei-cosmos/x/gov/keeper/grpc_query.go
+++ b/sei-cosmos/x/gov/keeper/grpc_query.go
@@ -42,7 +42,12 @@ func (q Keeper) Proposals(c context.Context, req *types.QueryProposalsRequest) (
 	store := ctx.KVStore(q.storeKey)
 	proposalStore := prefix.NewStore(store, types.ProposalsKeyPrefix)
 
-	pageRes, err := query.FilteredPaginate(proposalStore, req.Pagination, func(key []byte, value []byte, accumulate bool) (bool, error) {
+	paginate := query.FilteredPaginate
+	if ctx.IsEVM() {
+		paginate = query.FilteredPaginateV66
+	}
+
+	pageRes, err := paginate(proposalStore, req.Pagination, func(key []byte, value []byte, accumulate bool) (bool, error) {
 		var p types.Proposal
 		if err := q.cdc.Unmarshal(value, &p); err != nil {
 			return false, status.Error(codes.Internal, err.Error())

--- a/sei-cosmos/x/gov/keeper/grpc_query.go
+++ b/sei-cosmos/x/gov/keeper/grpc_query.go
@@ -42,9 +42,9 @@ func (q Keeper) Proposals(c context.Context, req *types.QueryProposalsRequest) (
 	store := ctx.KVStore(q.storeKey)
 	proposalStore := prefix.NewStore(store, types.ProposalsKeyPrefix)
 
-	paginate := query.FilteredPaginate
-	if ctx.IsEVM() {
-		paginate = query.FilteredPaginateV66
+	paginate := query.FilteredPaginateV66
+	if ctx.IsABCIQuery() {
+		paginate = query.FilteredPaginate
 	}
 
 	pageRes, err := paginate(proposalStore, req.Pagination, func(key []byte, value []byte, accumulate bool) (bool, error) {

--- a/sei-cosmos/x/staking/keeper/grpc_query.go
+++ b/sei-cosmos/x/staking/keeper/grpc_query.go
@@ -37,7 +37,12 @@ func (k Querier) Validators(c context.Context, req *types.QueryValidatorsRequest
 	store := ctx.KVStore(k.storeKey)
 	valStore := prefix.NewStore(store, types.ValidatorsKey)
 
-	pageRes, err := query.FilteredPaginate(valStore, req.Pagination, func(key []byte, value []byte, accumulate bool) (bool, error) {
+	paginate := query.FilteredPaginate
+	if ctx.IsEVM() {
+		paginate = query.FilteredPaginateV66
+	}
+
+	pageRes, err := paginate(valStore, req.Pagination, func(key []byte, value []byte, accumulate bool) (bool, error) {
 		val, err := types.UnmarshalValidator(k.cdc, value)
 		if err != nil {
 			return false, err
@@ -99,7 +104,15 @@ func (k Querier) ValidatorDelegations(c context.Context, req *types.QueryValidat
 
 	store := ctx.KVStore(k.storeKey)
 	valStore := prefix.NewStore(store, types.DelegationKey)
-	pageRes, err := query.FilteredPaginate(valStore, req.Pagination, func(key []byte, value []byte, accumulate bool) (bool, error) {
+
+	// LCD/gRPC receives the repaired behavior. EVM precompiles must retain
+	// release/v6.6 behavior because this query executes inside transactions.
+	paginate := query.FilteredPaginate
+	if ctx.IsEVM() {
+		paginate = query.FilteredPaginateV66
+	}
+
+	pageRes, err := paginate(valStore, req.Pagination, func(key []byte, value []byte, accumulate bool) (bool, error) {
 		delegation, err := types.UnmarshalDelegation(k.cdc, value)
 		if err != nil {
 			return false, err

--- a/sei-cosmos/x/staking/keeper/grpc_query.go
+++ b/sei-cosmos/x/staking/keeper/grpc_query.go
@@ -37,9 +37,9 @@ func (k Querier) Validators(c context.Context, req *types.QueryValidatorsRequest
 	store := ctx.KVStore(k.storeKey)
 	valStore := prefix.NewStore(store, types.ValidatorsKey)
 
-	paginate := query.FilteredPaginate
-	if ctx.IsEVM() {
-		paginate = query.FilteredPaginateV66
+	paginate := query.FilteredPaginateV66
+	if ctx.IsABCIQuery() {
+		paginate = query.FilteredPaginate
 	}
 
 	pageRes, err := paginate(valStore, req.Pagination, func(key []byte, value []byte, accumulate bool) (bool, error) {
@@ -105,11 +105,11 @@ func (k Querier) ValidatorDelegations(c context.Context, req *types.QueryValidat
 	store := ctx.KVStore(k.storeKey)
 	valStore := prefix.NewStore(store, types.DelegationKey)
 
-	// LCD/gRPC receives the repaired behavior. EVM precompiles must retain
-	// release/v6.6 behavior because this query executes inside transactions.
-	paginate := query.FilteredPaginate
-	if ctx.IsEVM() {
-		paginate = query.FilteredPaginateV66
+	// Consensus execution defaults to release/v6.6 behavior. Only contexts
+	// created by BaseApp.Query may use the repaired LCD/gRPC behavior.
+	paginate := query.FilteredPaginateV66
+	if ctx.IsABCIQuery() {
+		paginate = query.FilteredPaginate
 	}
 
 	pageRes, err := paginate(valStore, req.Pagination, func(key []byte, value []byte, accumulate bool) (bool, error) {

--- a/x/evm/keeper/evm.go
+++ b/x/evm/keeper/evm.go
@@ -155,6 +155,10 @@ func (k *Keeper) CallEVM(ctx sdk.Context, from common.Address, to *common.Addres
 }
 
 func (k *Keeper) StaticCallEVM(ctx sdk.Context, from sdk.AccAddress, to *common.Address, data []byte) ([]byte, error) {
+	// Static EVM execution must reproduce consensus precompile behavior, even
+	// when entered from an ABCI query or historical RPC context.
+	ctx = ctx.WithIsABCIQuery(false)
+
 	evm, err := k.createReadOnlyEVM(ctx, from)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The query hardening introduced in #3494 broke previously valid LCD and gRPC pagination requests. Large limits and offsets were rejected, sparse filtered queries failed after scanning 10,000 entries, and count_total could not calculate totals for large stores.

Restore the pre-v6.6 client-facing pagination behavior:

- allow store-backed queries to use limits and offsets across the uint64
  range
- permit sparse filtered LCD/gRPC queries to scan the complete store
- calculate count_total across stores larger than 10,000 entries
- saturate offset+limit calculations instead of allowing uint64 overflow
- preserve the first next_key while count_total scans the remaining store
- cap GetBlockWithTxs allocation by the block's actual transaction count
- keep CollectAllTotalSupply internally paged at 1,000 entries

Do not restore the upstream behavior that implicitly enables count_total when limit is omitted.

EVM precompiles invoke several Cosmos query handlers during transaction execution. Changing their filtered scan limits after v6.6 can alter gas consumption and success/revert control flow, producing AppHash and
LastResultsHash divergence.

Add explicit v6.6-compatible filtered paginator variants and select them for EVM execution in the transaction-reachable staking, governance, feegrant, distribution, and authz query handlers. LCD and gRPC requests continue using the repaired unrestricted implementations, while precompiles retain the released v6.6 consensus behavior.