### PR TITLE
fix(flatkv): preserve empty misc values and reject malformed empty node imports

### DIFF
--- a/sei-db/state_db/sc/flatkv/empty_value_replay_test.go
+++ b/sei-db/state_db/sc/flatkv/empty_value_replay_test.go
@@ -74,3 +74,41 @@ func TestEmptyValueSurvivesWALReplay(t *testing.T) {
 		"WAL-replay (read-only clone) committed root must match the live store; "+
 			"empty-value keys must not be dropped on replay")
 }
+
+func TestEmptyValueVisibleBeforeCommit(t *testing.T) {
+	cfg := config.DefaultTestConfig(t)
+	s := setupTestStoreWithConfig(t, cfg)
+	defer func() { require.NoError(t, s.Close()) }()
+
+	key := []byte("empty-marker")
+	require.NoError(t, s.ApplyChangeSets(s.Version()+1, emptyValueBankCS(&proto.KVPair{
+		Key:   key,
+		Value: []byte{},
+	})))
+
+	value, found := s.Get("bank", key)
+	require.True(t, found)
+	require.NotNil(t, value, "empty value is present data, not absence")
+	require.Empty(t, value)
+	require.True(t, s.Has("bank", key))
+
+	iter, err := s.Iterator("bank", nil, nil, true)
+	require.NoError(t, err)
+	require.True(t, iter.Valid())
+	require.Equal(t, key, iter.Key())
+	require.NotNil(t, iter.Value(), "pending iterator should preserve empty value presence")
+	require.Empty(t, iter.Value())
+	iter.Next()
+	require.False(t, iter.Valid())
+	require.NoError(t, iter.Error())
+	require.NoError(t, iter.Close())
+
+	_, err = s.Commit(s.Version() + 1)
+	require.NoError(t, err)
+
+	value, found = s.Get("bank", key)
+	require.True(t, found)
+	require.NotNil(t, value)
+	require.Empty(t, value)
+	require.True(t, s.Has("bank", key))
+}

--- a/sei-db/state_db/sc/flatkv/importer.go
+++ b/sei-db/state_db/sc/flatkv/importer.go
@@ -281,6 +281,14 @@ func (imp *KVImporter) AddNode(node *types.SnapshotNode) {
 	if node.Height != 0 || node.Key == nil || node.Version != imp.version {
 		return
 	}
+	// FlatKV import nodes carry already-serialized physical values. Even an
+	// empty logical misc value has a non-empty serialized header, so a
+	// zero-length physical value is malformed. Reject it instead of writing a
+	// Pebble row that LtHash and verification would both skip.
+	if len(node.Value) == 0 {
+		imp.setErr(fmt.Errorf("flatkv import: empty physical value for key %x", node.Key))
+		return
+	}
 	select {
 	case imp.ingestCh <- rawKVPair{Key: node.Key, Value: node.Value}:
 	case <-imp.done:

--- a/sei-db/state_db/sc/flatkv/importer_test.go
+++ b/sei-db/state_db/sc/flatkv/importer_test.go
@@ -101,6 +101,36 @@ func TestKVImporter_EmptyModuleNameRejected(t *testing.T) {
 	require.Contains(t, err.Error(), "empty module name")
 }
 
+func TestKVImporter_EmptyPhysicalValueRejected(t *testing.T) {
+	tests := []struct {
+		name  string
+		value []byte
+	}{
+		{name: "nil", value: nil},
+		{name: "zero-length", value: []byte{}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s, imp := newKVImporterForTest(t, 1)
+			defer func() { require.NoError(t, s.Close()) }()
+
+			imp.AddNode(&types.SnapshotNode{
+				Key:     ktype.ModulePhysicalKey("bank", []byte("empty-marker")),
+				Value:   tc.value,
+				Version: 1,
+			})
+
+			require.Error(t, imp.Err())
+			require.Contains(t, imp.Err().Error(), "empty physical value")
+
+			err := imp.Close()
+			require.ErrorIs(t, err, imp.Err())
+			require.Zero(t, s.Version(), "failed import must not advance the committed version")
+		})
+	}
+}
+
 // TestKVImporter_ErrLifecycle locks in the contract that Err() returns the
 // first pipeline error as soon as it propagates, before Close is invoked.
 // This is the path the seidb tool relies on to short-circuit a failing import

--- a/sei-db/state_db/sc/flatkv/vtype/misc_data.go
+++ b/sei-db/state_db/sc/flatkv/vtype/misc_data.go
@@ -126,7 +126,8 @@ func (l *MiscData) SetValue(value []byte) *MiscData {
 	if l == nil {
 		l = NewMiscData()
 	}
-	l.value = append([]byte(nil), value...)
+	l.value = make([]byte, len(value))
+	copy(l.value, value)
 	l.isDelete = false
 	return l
 }

--- a/sei-db/state_db/sc/flatkv/vtype/misc_data_test.go
+++ b/sei-db/state_db/sc/flatkv/vtype/misc_data_test.go
@@ -99,6 +99,8 @@ func TestMiscIsDelete_Default(t *testing.T) {
 
 func TestMiscIsDelete_EmptySliceIsNotDelete(t *testing.T) {
 	ld := NewMiscData().SetValue([]byte{})
+	require.NotNil(t, ld.GetValue(), "empty value is present data, not absence")
+	require.Empty(t, ld.GetValue())
 	require.False(t, ld.IsDelete(), "empty value is a valid write, not a deletion")
 }
 
@@ -221,6 +223,7 @@ func TestMiscData_SetValueOverwrite(t *testing.T) {
 func TestMiscData_SetValueNil(t *testing.T) {
 	ld := NewMiscData().SetValue([]byte{0x01})
 	ld = ld.SetValue(nil)
+	require.NotNil(t, ld.GetValue(), "nil input is normalized to present empty data")
 	require.Empty(t, ld.GetValue())
 	require.False(t, ld.IsDelete(), "SetValue(nil) is a write of empty data, not a deletion")
 }


### PR DESCRIPTION
## Summary

Fix FlatKV empty-value handling so explicit empty misc values remain present
before and after commit, and malformed snapshot leaves cannot create
zero-length physical rows.

- Fix `MiscData.SetValue` to preserve nil and zero-length logical values as
  non-nil empty slices, keeping pending `Get`, `Has`, and iterator behavior
  consistent with committed reads and WAL replay.
- Harden `KVImporter.AddNode` to reject nil or zero-length physical values.
  Importer nodes already contain serialized FlatKV values, so a legitimate
  empty logical misc value is represented by a non-empty 9-byte header.
- Fail malformed imports through `Err()` and `Close()` before enqueueing the
  row or advancing the imported version. This prevents physical rows that
  cannot be deserialized and would be skipped by LtHash.
- Add value-level, pending-read, committed-read, iterator, WAL replay, and
  importer regression coverage. Importer tests cover both nil and explicit
  zero-length physical values and verify failed imports are not finalized.

## Test plan

- [x] `go test ./sei-db/state_db/sc/flatkv/vtype`
- [x] `go test ./sei-db/state_db/sc/flatkv -run 'TestKVImporter_EmptyPhysicalValueRejected|TestEmptyValue'`
- [x] `go test ./sei-db/state_db/sc/flatkv`
- [x] `gofmt -s` and `goimports`
