### PR TITLE
Close temporary rootmulti store in connection types setup

### DIFF
--- a/sei-ibc-go/modules/core/03-connection/types/msgs_test.go
+++ b/sei-ibc-go/modules/core/03-connection/types/msgs_test.go
@@ -55,6 +55,9 @@ func (suite *MsgTestSuite) SetupTest() {
 	scConfig.MemIAVLConfig.SnapshotMinTimeInterval = 0
 	ssConfig := seidbconfig.StateStoreConfig{}
 	store := storev2rootmulti.NewStore(suite.T().TempDir(), scConfig, ssConfig, nil)
+	defer func() {
+		suite.Require().NoError(store.Close())
+	}()
 	storeKey := storetypes.NewKVStoreKey("iavlStoreKey")
 
 	store.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, nil)


### PR DESCRIPTION
Close the rootmulti store after generating the connection proof fixture.

Committing the store starts asynchronous hash logger work. Leaving the store open allows that work to race with t.TempDir cleanup, intermittently causing "directory not empty" failures in the race-detection job.


Flaked in [unrelated changes](https://github.com/sei-protocol/sei-chain/actions/runs/31164366980/job/92821709890?pr=3867)
