### PR TITLE
Bump version in prep to cut v6.6.1

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v6.6.0-rc5"
+  "version": "v6.6.1"
 }


### PR DESCRIPTION
Bump the version file to v6.6.1.

Note that v6.6.0 did not bump the version because a commit we did not want to release during upgrade was already merged to head, and life is too short to not move fast.
