### PR TITLE
Update go-releaser heading with experimental notice

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -84,7 +84,7 @@ release:
   mode: append
   name_template: '{{ .Tag }}'
   header: |
-    # Sei {{ .Tag }}
+    ## Experimental Pre-built Binaries
 
     Pre-built **statically-linked** `seid` binary attached below for `linux/amd64`.
 


### PR DESCRIPTION
To avoid confusing validators and to test the whole process more in terms of templating, make it clear that statically linked binaries are experimental and use a H2 header.