### PR TITLE
test(receipt): pin logHeapStructOverhead against types.Log layout (PLT-958)

### DIFF
--- a/sei-db/ledger_db/receipt/log_budget_test.go
+++ b/sei-db/ledger_db/receipt/log_budget_test.go
@@ -16,6 +16,8 @@ func TestLogHeapStructOverheadMatchesStructSize(t *testing.T) {
 	require.Equal(t,
 		int64(unsafe.Sizeof(ethtypes.Log{}))-int64(common.AddressLength)-logTopicsSliceHeader,
 		logHeapStructOverhead,
+		"ethtypes.Log layout changed: update logHeapStructOverhead, and if the new field "+
+			"references heap data, count it in EstimateLogHeapBytes too",
 	)
 	require.Equal(t, int64(unsafe.Sizeof([]common.Hash{})), logTopicsSliceHeader)
 

--- a/sei-db/ledger_db/receipt/log_budget_test.go
+++ b/sei-db/ledger_db/receipt/log_budget_test.go
@@ -17,6 +17,8 @@ func TestLogHeapStructOverheadMatchesStructSize(t *testing.T) {
 		int64(unsafe.Sizeof(ethtypes.Log{}))-int64(common.AddressLength)-logTopicsSliceHeader,
 		logHeapStructOverhead,
 	)
+	require.Equal(t, int64(unsafe.Sizeof([]common.Hash{})), logTopicsSliceHeader)
+
 }
 
 func TestLogBudgetCountLimit(t *testing.T) {

--- a/sei-db/ledger_db/receipt/log_budget_test.go
+++ b/sei-db/ledger_db/receipt/log_budget_test.go
@@ -4,11 +4,20 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"unsafe"
 
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
+
+func TestLogHeapStructOverheadMatchesStructSize(t *testing.T) {
+	t.Parallel()
+	require.Equal(t,
+		int64(unsafe.Sizeof(ethtypes.Log{}))-int64(common.AddressLength)-logTopicsSliceHeader,
+		logHeapStructOverhead,
+	)
+}
 
 func TestLogBudgetCountLimit(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

Follow-up to #3826: `logHeapStructOverhead` was corrected from 64 → 124 for the 64-bit `types.Log` layout, but it remains a hand-maintained constant with no guard against future drift.

Existing log budget tests derive limits from `EstimateLogHeapBytes` itself, so they pass for any value of this constant — including the wrong one. If the pinned geth fork ever adds a field to `types.Log`, the constant would silently undercount again and weaken the OOM guard with no test failure.

Adds `TestLogHeapStructOverheadMatchesStructSize`, which asserts:

```
logHeapStructOverhead == unsafe.Sizeof(ethtypes.Log{}) - AddressLength - logTopicsSliceHeader
```

A future struct layout change now fails CI instead of quietly regressing the budget.

Closes PLT-958.

## Test plan

- [x] `go test ./sei-db/ledger_db/receipt/... -run TestLogHeapStructOverheadMatchesStructSize`
- [x] `go test ./sei-db/ledger_db/receipt/...`