### PR TITLE
fix(config): correct the minimum-gas-prices help text separator

### DIFF
--- a/cmd/seid/cmd/mingasprices_config_fuzz_test.go
+++ b/cmd/seid/cmd/mingasprices_config_fuzz_test.go
@@ -14,26 +14,21 @@ import (
 	serverconfig "github.com/sei-protocol/sei-chain/sei-cosmos/server/config"
 )
 
-// minimum-gas-prices is the one key in this tree whose accepted syntax is contradicted by its own
-// documentation, and this file holds all three parties still.
+// minimum-gas-prices is resolved by one reader whose way of rejecting a value is to panic, and this
+// file holds that reader, the example the flag advertises, and the one artifact that still describes
+// a different syntax.
 //
-// One reader governs a node. root.go:296 hands cast.ToString of the key to baseapp.SetMinGasPrices,
-// which calls sdk.ParseDecCoins and panics on anything it cannot parse (options.go:24-28). That
-// panic is the whole boot, and ParseDecCoins separates denominations with a comma.
+// root.go:296 hands cast.ToString of the key to baseapp.SetMinGasPrices, which calls
+// sdk.ParseDecCoins and panics on anything it cannot parse (options.go:24-28). That panic is the
+// whole boot, so an example an operator is shown has to be a value that parses. The assertion below
+// reads the example out of the live help text rather than comparing it against a copy, so a later
+// edit to that text is checked against the reader it has to satisfy instead of being taken on trust.
 //
-// Two places document a semicolon instead. The start flag's own help text offers
-// "0.01photino;0.0001stake" as its example (start.go:208), and Config.GetMinGasPrices splits the
-// value on ";" (config.go:323). So the two syntaxes are disjoint rather than merely different: no
-// multi-denomination value is accepted by both, and the spelling an operator is shown is the
-// spelling that panics.
-//
-// The reason this has never been reported is that both agree on one denomination, which is the shape
-// of the default and of nearly every deployment. It surfaces the first time an operator prices a
-// second fee token by following the flag's example.
-//
-// GetMinGasPrices has no caller outside itself, so it is the documentation of an intent and not a
-// second live resolution. That is what keeps this a sharp edge rather than a split: there is one
-// answer at runtime, and two artifacts describing a different one.
+// ParseDecCoins separates denominations with a comma. Config.GetMinGasPrices splits on ";"
+// (config.go:323) and has no caller anywhere in the tree, so it describes a syntax no reader
+// accepts. The two are disjoint rather than merely different: no multi-denomination value satisfies
+// both. Single denominations are where they agree, which is the shape of the default and of nearly
+// every deployment, and is why this stayed quiet.
 //
 // What this file does not pin is the call site. resolveMinGasPrices below runs the expression
 // root.go:296 runs rather than driving root.go:296, because that argument is built inline inside
@@ -44,9 +39,8 @@ import (
 // and it is stated here for the same reason: a reader who assumed otherwise would trust a pin that is
 // not there.
 //
-// Recorded rather than repaired. Teaching ParseDecCoins the semicolon widens what a node accepts,
-// and correcting the help text changes what operators are told a working value looks like; both are
-// decisions for the reader that replaces this one.
+// The getter is recorded rather than repaired. Changing its separator or deleting it both move
+// something no code reads today, and that call belongs to the reader which replaces this one.
 
 // resolveMinGasPrices runs the expression root.go:296 runs, through the viper type production hands
 // it, and reports the panic rather than the option because the panic is the behavior under test.
@@ -62,14 +56,30 @@ func resolveMinGasPrices(raw string) (panicMessage string) {
 	return ""
 }
 
+// advertisedExample returns the value a flag's help text offers as its example, which is what an
+// operator copies. It is the text between "e.g. " and the parenthesis that closes it.
+func advertisedExample(usage string) (string, bool) {
+	const marker = "e.g. "
+	start := strings.Index(usage, marker)
+	if start < 0 {
+		return "", false
+	}
+	rest := usage[start+len(marker):]
+	end := strings.Index(rest, ")")
+	if end < 0 {
+		return "", false
+	}
+	return strings.TrimSpace(rest[:end]), true
+}
+
 // FuzzMinGasPricesLiveReaderTakesCommasAndRejectsSemicolons pins which separator boots a node.
 func FuzzMinGasPricesLiveReaderTakesCommasAndRejectsSemicolons(f *testing.F) {
 	f.Add(serverconfig.DefaultMinGasPrices) // the shipped default, one denomination
 	f.Add("")                               // absent, and accepted: ParseDecCoins reads it as no floor
 	f.Add("0.01usei")
 	f.Add("0.01usei,0.02uatom") // the separator the live reader accepts
-	f.Add("0.01usei;0.02uatom") // the separator both documents show, and the live reader panics on
-	f.Add("0.01photino;0.0001stake")
+	f.Add("0.01usei;0.02uatom") // the separator GetMinGasPrices splits on, and this reader panics on
+	f.Add("0.01photino,0.0001stake")
 	f.Add("abc")
 	f.Add("1")
 	f.Add("usei")
@@ -82,9 +92,9 @@ func FuzzMinGasPricesLiveReaderTakesCommasAndRejectsSemicolons(f *testing.F) {
 		// the disjointness this file records to hold.
 		if strings.Contains(raw, ";") && panicMessage == "" {
 			t.Errorf("minimum-gas-prices=%q carries a semicolon and booted anyway. ParseDecCoins now "+
-				"accepts the separator the flag's help text and Config.GetMinGasPrices already use, so "+
-				"the two syntaxes have stopped being disjoint. That is a fine end state and it changes "+
-				"what a node accepts, so update this file in the PR that widens the parser", raw)
+				"accepts the separator Config.GetMinGasPrices splits on, so the two syntaxes have "+
+				"stopped being disjoint. That is a fine end state and it changes what a node accepts, "+
+				"so update this file in the PR that widens the parser", raw)
 		}
 		// Where the rejection happens, not just that it happens. Every rejection reachable from a
 		// string arrives as an error ParseDecCoins returns and SetMinGasPrices wraps, so the wrap is
@@ -100,9 +110,9 @@ func FuzzMinGasPricesLiveReaderTakesCommasAndRejectsSemicolons(f *testing.F) {
 	})
 }
 
-// TestMinGasPricesFlagHelpShowsASeparatorTheLiveReaderPanicsOn reads the help text off the real
-// command rather than a copy of it, so correcting either side lands in a diff.
-func TestMinGasPricesFlagHelpShowsASeparatorTheLiveReaderPanicsOn(t *testing.T) {
+// TestMinGasPricesFlagAdvertisesAValueThatBoots holds the help text against the reader that has to
+// accept it, reading both off the real command so neither can drift alone.
+func TestMinGasPricesFlagAdvertisesAValueThatBoots(t *testing.T) {
 	cmd := server.StartCmd(nil, "/foobar", []trace.TracerProviderOption{})
 	flag := cmd.Flags().Lookup(server.FlagMinGasPrices)
 	if flag == nil {
@@ -110,16 +120,15 @@ func TestMinGasPricesFlagHelpShowsASeparatorTheLiveReaderPanicsOn(t *testing.T) 
 			"and an absent value stops being the empty string this file records", server.FlagMinGasPrices)
 	}
 
-	// The example in the help text, held against the reader that would have to accept it.
-	const documented = "0.01photino;0.0001stake"
-	if !strings.Contains(flag.Usage, documented) {
-		t.Fatalf("the %s help text no longer offers %q as its example, so the contradiction this file "+
-			"records may be closed. Confirm the new example parses, then delete this test rather than "+
-			"loosening it. Usage is now %q", server.FlagMinGasPrices, documented, flag.Usage)
+	example, ok := advertisedExample(flag.Usage)
+	if !ok {
+		t.Fatalf("the %s help text no longer offers an example, so there is nothing to check a value "+
+			"an operator copies against. Usage is %q", server.FlagMinGasPrices, flag.Usage)
 	}
-	if panicMessage := resolveMinGasPrices(documented); panicMessage == "" {
-		t.Fatalf("the documented example %q now boots, so the help text and the reader agree and this "+
-			"recording is stale", documented)
+	if panicMessage := resolveMinGasPrices(example); panicMessage != "" {
+		t.Fatalf("the %s help text advertises %q, and handing that to the reader root.go:296 uses "+
+			"panics with %v. An operator following the flag's own example cannot start a node, so "+
+			"either the example or the parser has to move", server.FlagMinGasPrices, example, panicMessage)
 	}
 
 	// The flag's default is what an operator gets by writing nothing, and it is not the package
@@ -139,9 +148,9 @@ func TestMinGasPricesFlagHelpShowsASeparatorTheLiveReaderPanicsOn(t *testing.T) 
 	}
 }
 
-// TestMinGasPricesGetterAcceptsOnlyWhatTheLiveReaderRejects pins the inversion itself, which is the
-// part a reader would otherwise have to discover twice.
-func TestMinGasPricesGetterAcceptsOnlyWhatTheLiveReaderRejects(t *testing.T) {
+// TestMinGasPricesGetterDescribesASyntaxNoReaderAccepts pins the inversion itself, which is the part
+// a reader would otherwise have to discover twice.
+func TestMinGasPricesGetterDescribesASyntaxNoReaderAccepts(t *testing.T) {
 	const (
 		commaSeparated     = "0.01usei,0.02uatom"
 		semicolonSeparated = "0.01usei;0.02uatom"
@@ -177,7 +186,7 @@ func TestMinGasPricesGetterAcceptsOnlyWhatTheLiveReaderRejects(t *testing.T) {
 			commaSeparated)
 	}
 	if resolveMinGasPrices(semicolonSeparated) == "" {
-		t.Errorf("the live reader now accepts %q, so the documented separator boots and this "+
-			"inversion is closed", semicolonSeparated)
+		t.Errorf("the live reader now accepts %q, so the getter's separator boots and this inversion "+
+			"is closed", semicolonSeparated)
 	}
 }

--- a/sei-cosmos/server/start.go
+++ b/sei-cosmos/server/start.go
@@ -205,7 +205,7 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 func addStartNodeFlags(cmd *cobra.Command, defaultNodeHome string) {
 	cmd.Flags().String(flags.FlagHome, defaultNodeHome, "The application home directory")
 	cmd.Flags().String(flagTraceStore, "", "Enable KVStore tracing to an output file")
-	cmd.Flags().String(FlagMinGasPrices, "", "Minimum gas prices to accept for transactions; Any fee in a tx must meet this minimum (e.g. 0.01photino;0.0001stake)")
+	cmd.Flags().String(FlagMinGasPrices, "", "Minimum gas prices to accept for transactions; Any fee in a tx must meet this minimum (e.g. 0.01photino,0.0001stake)")
 	cmd.Flags().IntSlice(FlagUnsafeSkipUpgrades, []int{}, "Skip a set of upgrade heights to continue the old binary")
 	cmd.Flags().Uint64(FlagHaltHeight, 0, "Block height at which to gracefully halt the chain and shutdown the node")
 	cmd.Flags().Uint64(FlagHaltTime, 0, "Minimum block time (in Unix seconds) at which to gracefully halt the chain and shutdown the node")

--- a/sei-cosmos/x/auth/spec/01_concepts.md
+++ b/sei-cosmos/x/auth/spec/01_concepts.md
@@ -26,7 +26,7 @@ signature verification, as well as costs proportional to the tx size. Operators
 should set minimum gas prices when starting their nodes. They must set the unit
 costs of gas in each token denomination they wish to support:
 
-`simd start ... --minimum-gas-prices=0.00001stake;0.05photinos`
+`simd start ... --minimum-gas-prices=0.00001stake,0.05photinos`
 
 When adding transactions to mempool or gossipping transactions, validators check
 if the transaction's gas prices, which are determined by the provided fees, meet


### PR DESCRIPTION
Stacked on #3890. Base is `test/plt-851-live-node-config-reads`, so the diff shown here is the two production lines plus the assertion they change. Review #3890 first.

## Motivation

`seid start --help` advertises `0.01photino;0.0001stake` as its `minimum-gas-prices` example, and a semicolon is not a separator `sdk.ParseDecCoins` accepts. `cmd/seid/cmd/root.go:296` hands the key to `baseapp.SetMinGasPrices`, which panics on a value `ParseDecCoins` rejects, and that panic is the whole boot.

So an operator pricing a second fee token by copying the flag's own example cannot start a node. Single-denomination values are unaffected, which is the shipped default and nearly every deployment, and is why this has stayed quiet.

The auth spec carries the identical defect at `sei-cosmos/x/auth/spec/01_concepts.md:29`, in the multi-denomination case it is describing.

## Why the comma is the correct direction

The sibling registration already in this tree uses a comma: `sei-ibc-go/testing/simapp/simd/cmd/testnet.go:90` reads `(e.g. 0.01photino,0.001usei)`. That is what identifies the semicolon as an outlier rather than a convention, so this moves toward the tree's own existing form rather than introducing a new one.

Both corrected examples were checked against the parser before being written: `0.01photino,0.0001stake` and `0.00001stake,0.05photinos` both parse, and their semicolon forms both return `invalid decimal coin expression`.

## Risk

Only the separator changes, so every value that started a node before still starts one. The change strictly adds a working example where a broken one stood. A tree-wide sweep finds no remaining semicolon-separated `minimum-gas-prices` examples.

## The assertion changes with it

The characterization suite pinned this as a defect, so the assertion that recorded it has to move in the same change rather than be loosened. It previously asserted the help text contains the broken literal. It now reads whatever example the help text advertises and hands it to the reader that has to accept it, which is the invariant the fix establishes and re-arms against any later edit to the text.

Verified by mutation: reverting the help text to the semicolon fails the test, naming the value and the panic. Changing the example to a different invalid value fails. Removing the example entirely fails.
