### PR TITLE
fix(evmrpc): fail closed on pruned receipt heights for getBlock* endpoints (PLT-979)

### DIFF
--- a/evmrpc/block.go
+++ b/evmrpc/block.go
@@ -239,7 +239,10 @@ func (a *BlockAPI) getBlockByHash(ctx context.Context, blockHash common.Hash, fu
 
 	// Validate EVM block height for pacific-1 chain
 	sdkCtx := a.ctxProvider(LatestCtxHeight)
-	if err := ValidateEVMBlockHeight(sdkCtx.ChainID(), block.Block.Height); err != nil {
+	if err = ValidateEVMBlockHeight(sdkCtx.ChainID(), block.Block.Height); err != nil {
+		return nil, err
+	}
+	if err = a.watermarks.EnsureReceiptHeightAvailable(block.Block.Height); err != nil {
 		return nil, err
 	}
 
@@ -286,6 +289,9 @@ func (a *BlockAPI) getBlockByNumber(
 	if block == nil {
 		return nil, nil
 	}
+	if err = a.watermarks.EnsureReceiptHeightAvailable(block.Block.Height); err != nil {
+		return nil, err
+	}
 	return EncodeTmBlock(a.ctxProvider, a.txConfigProvider, block, a.keeper, fullTx, a.includeBankTransfers, includeSyntheticTxs, excludeUntraceable, a.globalBlockCache, a.cacheCreationMutex)
 }
 
@@ -328,6 +334,9 @@ func (a *BlockAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.Block
 	}
 	if block == nil {
 		return nil, nil
+	}
+	if err = a.watermarks.EnsureReceiptHeightAvailable(block.Block.Height); err != nil {
+		return nil, err
 	}
 
 	// Get all tx hashes for the block

--- a/evmrpc/height_availability_test.go
+++ b/evmrpc/height_availability_test.go
@@ -379,6 +379,45 @@ func TestGetBlockTransactionCountByHashReceiptsPruned(t *testing.T) {
 	require.Contains(t, err.Error(), "receipts have been pruned")
 }
 
+func TestGetBlockByNumberReceiptsPruned(t *testing.T) {
+	t.Parallel()
+
+	client := newHeightTestClient(100, 1, 200)
+	rs := &fakeReceiptStore{latest: 200, earliest: 150}
+	watermarks := NewWatermarkManager(client, testCtxProvider, nil, rs)
+	api := NewBlockAPI(client, nil, testCtxProvider, testTxConfigProvider, ConnectionTypeHTTP, watermarks, nil, nil)
+
+	_, err := api.GetBlockByNumber(context.Background(), rpc.BlockNumber(100), false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "receipts have been pruned")
+}
+
+func TestGetBlockByHashReceiptsPruned(t *testing.T) {
+	t.Parallel()
+
+	client := newHeightTestClient(100, 1, 200)
+	rs := &fakeReceiptStore{latest: 200, earliest: 150}
+	watermarks := NewWatermarkManager(client, testCtxProvider, nil, rs)
+	api := NewBlockAPI(client, nil, testCtxProvider, testTxConfigProvider, ConnectionTypeHTTP, watermarks, nil, nil)
+
+	_, err := api.GetBlockByHash(context.Background(), common.HexToHash(highBlockHashHex), false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "receipts have been pruned")
+}
+
+func TestGetBlockReceiptsReceiptsPruned(t *testing.T) {
+	t.Parallel()
+
+	client := newHeightTestClient(100, 1, 200)
+	rs := &fakeReceiptStore{latest: 200, earliest: 150}
+	watermarks := NewWatermarkManager(client, testCtxProvider, nil, rs)
+	api := NewBlockAPI(client, nil, testCtxProvider, testTxConfigProvider, ConnectionTypeHTTP, watermarks, nil, nil)
+
+	_, err := api.GetBlockReceipts(context.Background(), rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(100)))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "receipts have been pruned")
+}
+
 func TestStateAPIGetProofUnavailableHeight(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Describe your changes and provide context

After #3216 (PLT-256), `eth_getBlockTransactionCountByNumber` / `ByHash` fail closed when receipts for a block height have been pruned, but `getBlockByNumber`, `getBlockByHash`, and `GetBlockReceipts` still returned truncated responses — `EncodeTmBlock` silently skips EVM transactions whose receipts are missing, which can also corrupt aggregate fields like `gasUsed` and `logsBloom`.

This PR applies the same `EnsureReceiptHeightAvailable` guard at the shared choke points before encoding:

- **`getBlockByNumber`** — covers `eth_getBlockByNumber`, `sei_getBlockByNumber`, `sei2_getBlockByNumber`, and `*ExcludeTraceFail` variants
- **`getBlockByHash`** — covers `eth_getBlockByHash`, `sei_getBlockByHash`, etc.
- **`GetBlockReceipts`** — covers `eth_getBlockReceipts` and sei/sei2 variants

Fixes PLT-979.

## Testing performed to validate your change

- [x] Added unit tests for `GetBlockByNumber`, `GetBlockByHash`, and `GetBlockReceipts` rejecting pruned receipt heights with explicit `"receipts have been pruned"` errors (mirroring existing count-endpoint tests)