### PR TITLE
Upgreade UCI AI review and assist pipeline to latest

### DIFF
--- a/.github/workflows/ai-assist.yml
+++ b/.github/workflows/ai-assist.yml
@@ -8,8 +8,8 @@ on:
     types: [ submitted ]
 jobs:
   assistant:
-    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.13
-    uses: sei-protocol/uci/.github/workflows/ai-assistant.yml@29a9c73301b2218e1940cf3f9a2c3d34c86fbd9a
+    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.16
+    uses: sei-protocol/uci/.github/workflows/ai-assistant.yml@bfe76dc895ec073672fba57805ba976b55276b20
     permissions:
       contents: read
       pull-requests: write
@@ -17,6 +17,6 @@ jobs:
       id-token: write
     secrets: inherit
     with:
-      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.13
-      uci-ref: 29a9c73301b2218e1940cf3f9a2c3d34c86fbd9a
+      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.16
+      uci-ref: bfe76dc895ec073672fba57805ba976b55276b20
       allowed-team: 'sei-protocol/sei-core'

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -4,8 +4,8 @@ on:
     types: [ opened, ready_for_review, synchronize, reopened ]
 jobs:
   ai-review:
-    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.13
-    uses: sei-protocol/uci/.github/workflows/ai-review.yml@29a9c73301b2218e1940cf3f9a2c3d34c86fbd9a
+    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.16
+    uses: sei-protocol/uci/.github/workflows/ai-review.yml@bfe76dc895ec073672fba57805ba976b55276b20
     permissions:
       contents: read
       pull-requests: write
@@ -13,6 +13,6 @@ jobs:
       id-token: write
     secrets: inherit
     with:
-      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.13
-      uci-ref: 29a9c73301b2218e1940cf3f9a2c3d34c86fbd9a
+      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.16
+      uci-ref: bfe76dc895ec073672fba57805ba976b55276b20
       enable-cursor: false # Disabled for now since there is a dedicated Bugbot flow built into Cursor currently enabled on repo.


### PR DESCRIPTION
* Reviews once on PR ready for review, then on explicit `@seidroid review` only
* Considers previous review and discussion comments in next review
* Marks fixedc and out of date comments made by Seidroid as resolved
* Refines review comment verbosity
* Seprarates pre-existing issues from issues introduced by the PR

See: https://github.com/sei-protocol/uci/releases/tag/v0.0.16
