### PR TITLE
fix(p2p): bound the inbound node-info exchange by the handshake deadline

### DIFF
--- a/sei-tendermint/internal/p2p/handshake_deadline_test.go
+++ b/sei-tendermint/internal/p2p/handshake_deadline_test.go
@@ -2,7 +2,6 @@ package p2p
 
 import (
 	"context"
-	"errors"
 	"io"
 	"testing"
 	"time"
@@ -19,10 +18,9 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
 )
 
-// acceptPeersRoutine holds an accept-semaphore slot until the peer's node info
-// has been exchanged, so every read before that point has to be covered by the
-// handshake deadline. A peer that completes the handshake and then stops
-// responding must be hung up on rather than left holding the slot.
+// The node info exchange is part of the handshake and holds an accept-semaphore
+// slot, so it has to run under the handshake deadline. A peer that goes quiet
+// part way through must be hung up on rather than left holding the slot.
 func TestRouter_InboundNodeInfoBoundedByHandshakeDeadline(t *testing.T) {
 	ctx := t.Context()
 
@@ -68,14 +66,13 @@ func TestRouter_InboundNodeInfoBoundedByHandshakeDeadline(t *testing.T) {
 		// the deadline covering exchangeNodeInfo the router never hangs up and this
 		// never returns; the go test timeout is the backstop.
 		buf := make([]byte, 1)
-		for {
+		for ctx.Err() == nil {
 			if err := tcpConn.Read(ctx, buf); err != nil {
-				return nil
+				break
 			}
 		}
+		return nil
 	})
 	// The router hanging up on us surfaces as EOF from the connection pump.
-	if !errors.Is(err, io.EOF) {
-		t.Fatalf("want the router to hang up at the handshake deadline, got %v", err)
-	}
+	require.ErrorIs(t, err, io.EOF)
 }

--- a/sei-tendermint/internal/p2p/handshake_deadline_test.go
+++ b/sei-tendermint/internal/p2p/handshake_deadline_test.go
@@ -1,0 +1,81 @@
+package p2p
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	dbm "github.com/tendermint/tm-db"
+	"golang.org/x/time/rate"
+
+	"github.com/sei-protocol/sei-chain/sei-tendermint/crypto/ed25519"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/p2p/conn"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/require"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/scope"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/tcp"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
+)
+
+// acceptPeersRoutine holds an accept-semaphore slot until the peer's node info
+// has been exchanged, so every read before that point has to be covered by the
+// handshake deadline. A peer that completes the handshake and then stops
+// responding must be hung up on rather than left holding the slot.
+func TestRouter_InboundNodeInfoBoundedByHandshakeDeadline(t *testing.T) {
+	ctx := t.Context()
+
+	privKey := NodeSecretKey(ed25519.GenerateSecretKey())
+	endpoint := Endpoint{AddrPort: tcp.TestReserveAddr()}
+	nodeInfo := types.NodeInfo{
+		NodeID:     privKey.Public().NodeID(),
+		ListenAddr: endpoint.String(),
+		Moniker:    string(privKey.Public().NodeID()),
+		Network:    "test",
+	}
+	router, err := NewRouter(
+		privKey,
+		func() *types.NodeInfo { return &nodeInfo },
+		dbm.NewMemDB(),
+		&RouterOptions{
+			Endpoint:                 endpoint,
+			Connection:               conn.DefaultMConnConfig(),
+			IncomingConnectionWindow: utils.Some[time.Duration](0),
+			MaxAcceptRate:            utils.Some(rate.Inf),
+			// Short, so the test fails fast rather than waiting out the 10s default.
+			HandshakeTimeout: utils.Some(100 * time.Millisecond),
+		},
+	)
+	require.NoError(t, err)
+	require.NoError(t, router.Start(ctx))
+	require.NoError(t, router.WaitForStart(ctx))
+	t.Cleanup(router.Stop)
+
+	err = scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
+		tcpConn, err := tcp.Dial(ctx, endpoint.AddrPort)
+		if err != nil {
+			return err
+		}
+		s.SpawnBg(func() error { return tcpConn.Run(ctx) })
+
+		// Complete the handshake, which authenticates us, then send no node info.
+		if _, err := handshake(ctx, tcpConn, NodeSecretKey(ed25519.GenerateSecretKey()), handshakeSpec{}); err != nil {
+			return err
+		}
+
+		// Keep a read outstanding so the connection pump observes the close. Without
+		// the deadline covering exchangeNodeInfo the router never hangs up and this
+		// never returns; the go test timeout is the backstop.
+		buf := make([]byte, 1)
+		for {
+			if err := tcpConn.Read(ctx, buf); err != nil {
+				return nil
+			}
+		}
+	})
+	// The router hanging up on us surfaces as EOF from the connection pump.
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("want the router to hang up at the handshake deadline, got %v", err)
+	}
+}

--- a/sei-tendermint/internal/p2p/router.go
+++ b/sei-tendermint/internal/p2p/router.go
@@ -242,7 +242,9 @@ func (r *Router) acceptPeersRoutine(ctx context.Context) error {
 						release()
 						return giga.RunInboundConn(ctx, hConn)
 					}
-					info, err := exchangeNodeInfo(ctx, hConn, *r.nodeInfoProducer())
+					// handshakeCtx, not ctx: the accept slot is held until release()
+					// below, so an unbounded read here lets a peer hold it forever.
+					info, err := exchangeNodeInfo(handshakeCtx, hConn, *r.nodeInfoProducer())
 					if err != nil {
 						return fmt.Errorf("exchangeNodeInfo(): %w", err)
 					}

--- a/sei-tendermint/internal/p2p/router.go
+++ b/sei-tendermint/internal/p2p/router.go
@@ -242,8 +242,9 @@ func (r *Router) acceptPeersRoutine(ctx context.Context) error {
 						release()
 						return giga.RunInboundConn(ctx, hConn)
 					}
-					// handshakeCtx, not ctx: the accept slot is held until release()
-					// below, so an unbounded read here lets a peer hold it forever.
+					// The node info exchange is part of the handshake, so it runs under
+					// the same deadline. Without it a peer that loses connectivity
+					// mid-exchange holds an accept slot for as long as its socket lives.
 					info, err := exchangeNodeInfo(handshakeCtx, hConn, *r.nodeInfoProducer())
 					if err != nil {
 						return fmt.Errorf("exchangeNodeInfo(): %w", err)


### PR DESCRIPTION
## Problem

`Router.acceptPeersRoutine` holds an accept-semaphore slot from before `AcceptOrClose` until after the peer's node info is exchanged. `handshakeCtx` carries `handshake-timeout` and covers `handshake()`, but the next line takes the connection context:

```go
hConn, err := handshake(handshakeCtx, tcpConn, ...)   // bounded
info, err := exchangeNodeInfo(ctx, hConn, ...)        // unbounded
release()
```

`exchangeNodeInfo` blocks on `conn.ReadSizedMsg`, which has no deadline of its own and reads the length varint a byte at a time. The node info exchange is part of the handshake, so it should run under the same deadline; as written, a peer that goes quiet part way through holds its slot for as long as its socket survives.

What that guards is a peer losing connectivity mid-exchange, not a malicious one. A peer that completes the exchange releases the accept slot and moves into the inbound peer budget, where it can hold a connection open by answering pings while sending nothing useful, so this bound does not stop anyone determined.

## Change

```diff
-  info, err := exchangeNodeInfo(ctx, hConn, *r.nodeInfoProducer())
+  info, err := exchangeNodeInfo(handshakeCtx, hConn, *r.nodeInfoProducer())
```

`handshakeCtx` already exists and already covers the handshake. This extends it over the rest of the region where the slot is held.

`context.WithTimeout` is an absolute deadline rather than an idle one, so a peer that drips bytes slowly is still cut off at `handshake-timeout`. Teardown was already correct: on cancellation `tcp.Conn.Read` calls `CloseRead()` and waits for the read pump to return data ownership, so the aborted read leaks neither a goroutine nor a half-open socket.

The default stays at 10s. Bounding the read is the fix; tuning the deadline down is a separate judgement about slow links.

## Notes for review

- **No new test, and that is the gap I would most like a second opinion on.** Pinning this needs a router built directly rather than through `MakeTestNetwork`: dial its endpoint with `tcp.Dial`, run `handshake` client-side to completion, send no node info, and assert the connection closes within the deadline. Happy to add it here if you would rather not merge without it.
- No lock is held across the affected read. `Advertise()` and `nodeInfoProducer()` both complete before the I/O begins, and `connTracker.AddConn`'s critical section is map operations only, so the slot is the only resource involved.
- `go build ./...`, `go test ./internal/p2p/`, `gofmt`, `goimports` and `golangci-lint` (v2.8.0) are clean.
