### PR TITLE
removed defaults for RouterOptions.Dial/AcceptRate

### DIFF
--- a/sei-tendermint/internal/p2p/giga_router_validator_test.go
+++ b/sei-tendermint/internal/p2p/giga_router_validator_test.go
@@ -111,8 +111,8 @@ func TestGigaRouter_FinalizeBlocks(t *testing.T) {
 					Endpoint:                 e,
 					Connection:               conn.DefaultMConnConfig(),
 					IncomingConnectionWindow: utils.Some(time.Duration(0)),
-					MaxAcceptRate:            utils.Some(rate.Inf),
-					MaxDialRate:              utils.Some(rate.Limit(30)),
+					MaxAcceptRate:            rate.Inf,
+					MaxDialRate:              rate.Limit(30),
 					Giga:                     utils.Some[GigaRouter](giga),
 				},
 			)

--- a/sei-tendermint/internal/p2p/handshake_deadline_test.go
+++ b/sei-tendermint/internal/p2p/handshake_deadline_test.go
@@ -41,7 +41,7 @@ func TestRouter_InboundNodeInfoBoundedByHandshakeDeadline(t *testing.T) {
 			Connection:               conn.DefaultMConnConfig(),
 			IncomingConnectionWindow: utils.Some[time.Duration](0),
 			MaxAcceptRate:            rate.Inf,
-			MaxDialRate:              rate.Inf,
+			MaxDialRate:              rate.Every(10 * time.Second),
 			// Short, so the test fails fast rather than waiting out the 10s default.
 			HandshakeTimeout: utils.Some(100 * time.Millisecond),
 		},

--- a/sei-tendermint/internal/p2p/handshake_deadline_test.go
+++ b/sei-tendermint/internal/p2p/handshake_deadline_test.go
@@ -40,7 +40,8 @@ func TestRouter_InboundNodeInfoBoundedByHandshakeDeadline(t *testing.T) {
 			Endpoint:                 endpoint,
 			Connection:               conn.DefaultMConnConfig(),
 			IncomingConnectionWindow: utils.Some[time.Duration](0),
-			MaxAcceptRate:            utils.Some(rate.Inf),
+			MaxAcceptRate:            rate.Inf,
+			MaxDialRate:              rate.Inf,
 			// Short, so the test fails fast rather than waiting out the 10s default.
 			HandshakeTimeout: utils.Some(100 * time.Millisecond),
 		},

--- a/sei-tendermint/internal/p2p/peermanager_test.go
+++ b/sei-tendermint/internal/p2p/peermanager_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/crypto/ed25519"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/scope"
+	"golang.org/x/time/rate"
 
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/require"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
@@ -101,6 +102,8 @@ func TestRouterOptions(t *testing.T) {
 		addrs2 := utils.Slice(makeAddr(rng))
 		ids := utils.Slice(addrs[0].NodeID, addrs[2].NodeID)
 		return RouterOptions{
+			MaxDialRate:        rate.Inf,
+			MaxAcceptRate:      rate.Inf,
 			PersistentPeers:    addrs,
 			BootstrapPeers:     addrs2,
 			BlockSyncPeers:     ids,
@@ -119,12 +122,18 @@ func TestRouterOptions(t *testing.T) {
 	optsBadUnconditional.UnconditionalPeers[0] = "Z"
 	optsBadPrivate := makeOpts(rng)
 	optsBadPrivate.PrivatePeers[1] = "W"
+	optsMissingMaxDialRate := makeOpts(rng)
+	optsMissingMaxDialRate.MaxDialRate = 0
+	optsMissingMaxAcceptRate := makeOpts(rng)
+	optsMissingMaxAcceptRate.MaxAcceptRate = 0
 	testcases := map[string]struct {
 		options RouterOptions
 		ok      bool
 	}{
-		"empty":                  {RouterOptions{}, true},
+		"empty":                  {RouterOptions{}, false},
 		"valid":                  {optsOk, true},
+		"missing MaxDialRate":    {optsMissingMaxDialRate, false},
+		"missing MaxAcceptRate":  {optsMissingMaxAcceptRate, false},
 		"bad PersistentPeers":    {optsBadPersistent, false},
 		"bad BootstrapPeers":     {optsBadBootstrap, false},
 		"bad BlockSyncPeers":     {optsBadBlockSync, false},

--- a/sei-tendermint/internal/p2p/router_test.go
+++ b/sei-tendermint/internal/p2p/router_test.go
@@ -270,8 +270,8 @@ func makeRouterOptions() *RouterOptions {
 	c := conn.DefaultMConnConfig()
 	c.PongTimeout = time.Hour
 	return &RouterOptions{
-		MaxAcceptRate: utils.Some(rate.Inf),
-		MaxDialRate:   utils.Some(rate.Inf),
+		MaxAcceptRate: rate.Inf,
+		MaxDialRate:   rate.Inf,
 		Endpoint:      Endpoint{tcp.TestReserveAddr()},
 		Connection:    c,
 		// 0 to allow immediate retries from peers.

--- a/sei-tendermint/internal/p2p/routeroptions.go
+++ b/sei-tendermint/internal/p2p/routeroptions.go
@@ -65,11 +65,11 @@ type RouterOptions struct {
 	// can attempt to create a new connection. Defaults to 100ms.
 	IncomingConnectionWindow utils.Option[time.Duration]
 
-	// MaxDialRate limits the rate at which router is dialing peers. Defaults to 0.1/s.
-	MaxDialRate utils.Option[rate.Limit]
+	// MaxDialRate limits the rate at which router is dialing peers.
+	MaxDialRate rate.Limit
 
-	// MaxAcceptRate limits the rate at which router is accepting TCP connections. Defaults to 1/s.
-	MaxAcceptRate utils.Option[rate.Limit]
+	// MaxAcceptRate limits the rate at which router is accepting TCP connections.
+	MaxAcceptRate rate.Limit
 
 	// ResolveTimeout is the timeout for resolving NodeAddress URLs.
 	ResolveTimeout utils.Option[time.Duration]
@@ -132,6 +132,12 @@ func (o *RouterOptions) peerStoreInterval() time.Duration {
 
 // Validate validates the options.
 func (o *RouterOptions) Validate() error {
+	if o.MaxDialRate <= 0 {
+		return fmt.Errorf("MaxDialRate = %v, want > 0", o.MaxDialRate)
+	}
+	if o.MaxAcceptRate <= 0 {
+		return fmt.Errorf("MaxAcceptRate = %v, want > 0", o.MaxAcceptRate)
+	}
 	for _, addr := range o.BootstrapPeers {
 		if err := addr.Validate(); err != nil {
 			return fmt.Errorf("invalid BoodstrapPeer address %v: %w", addr, err)
@@ -161,11 +167,11 @@ func (o *RouterOptions) Validate() error {
 }
 
 func (o *RouterOptions) maxDialRate() rate.Limit {
-	return o.MaxDialRate.Or(rate.Every(10 * time.Second))
+	return o.MaxDialRate
 }
 
 func (o *RouterOptions) maxAcceptRate() rate.Limit {
-	return o.MaxAcceptRate.Or(rate.Every(time.Second))
+	return o.MaxAcceptRate
 }
 
 func (o *RouterOptions) incomingConnectionWindow() time.Duration {

--- a/sei-tendermint/internal/p2p/testonly.go
+++ b/sei-tendermint/internal/p2p/testonly.go
@@ -293,8 +293,8 @@ func (n *TestNetwork) MakeNode(t *testing.T, opts TestNodeOptions) *TestNode {
 		Endpoint:                 endpoint,
 		Connection:               conn.DefaultMConnConfig(),
 		IncomingConnectionWindow: utils.Some[time.Duration](0),
-		MaxAcceptRate:            utils.Some(rate.Inf),
-		MaxDialRate:              utils.Some(rate.Limit(30.)),
+		MaxAcceptRate:            rate.Inf,
+		MaxDialRate:              rate.Limit(30.),
 		MaxInbound:               opts.MaxConnected,
 		MaxOutbound:              opts.MaxConnected,
 	}

--- a/sei-tendermint/node/setup.go
+++ b/sei-tendermint/node/setup.go
@@ -500,7 +500,8 @@ func createRouter(
 	options := &p2p.RouterOptions{
 		Endpoint:                      ep,
 		MaxIncomingConnectionAttempts: utils.Some(cfg.P2P.MaxIncomingConnectionAttempts),
-		MaxDialRate:                   utils.Some(rate.Every(cfg.P2P.DialInterval)),
+		MaxDialRate:                   rate.Every(cfg.P2P.DialInterval),
+		MaxAcceptRate:                 rate.Every(time.Second),
 		HandshakeTimeout:              utils.Some(cfg.P2P.HandshakeTimeout),
 		DialTimeout:                   utils.Some(cfg.P2P.DialTimeout),
 		PexOnHandshake:                cfg.P2P.PexReactor,


### PR DESCRIPTION
Defaults are set on the sei-tendermint/config level, no need to duplicate.