### PR TITLE
Use unique hashes in concurrent nonce test

### DIFF
--- a/giga/deps/xevm/keeper/keeper_test.go
+++ b/giga/deps/xevm/keeper/keeper_test.go
@@ -212,7 +212,7 @@ func TestKeeper_CalculateNextNonce(t *testing.T) {
 					wg.Add(1)
 					go func(nonce int) {
 						defer wg.Done()
-						key := tmtypes.TxHash(rand.NewRand().Bytes(32))
+						key := tmtypes.TxHash(common.BigToHash(big.NewInt(int64(nonce))))
 						// call this just to exercise locks
 						k.CalculateNextNonce(ctx, address1, true)
 						k.AddPendingNonce(key, address1, uint64(nonce), 0)


### PR DESCRIPTION
Derive each pending transaction hash from its nonce instead of generating it randomly. This guarantees unique hashes and prevents AddPendingNonce from discarding a nonce after an accidental hash collision, which caused the
concurrency test to fail intermittently.

Flaked in [unrelated changes](https://github.com/sei-protocol/sei-chain/actions/runs/31791935604/job/94740633149?pr=3921).
