### PR TITLE
Complete multi-epoch ownership across Autobahn layers (CON-358)

### DIFF
--- a/sei-tendermint/autobahn/types/block.go
+++ b/sei-tendermint/autobahn/types/block.go
@@ -139,7 +139,7 @@ func (b *Block) Header() *BlockHeader { return b.header }
 // Payload .
 func (b *Block) Payload() *Payload { return b.payload }
 
-// Verify checks that the payload hashes to the header payload hash.
+// Verify checks the block's internal integrity.
 func (b *Block) Verify() error {
 	if got, want := b.payload.Hash(), b.header.payloadHash; got != want {
 		return fmt.Errorf("payload.Hash() = %v, want %v", got, want)

--- a/sei-tendermint/autobahn/types/block.go
+++ b/sei-tendermint/autobahn/types/block.go
@@ -139,6 +139,14 @@ func (b *Block) Header() *BlockHeader { return b.header }
 // Payload .
 func (b *Block) Payload() *Payload { return b.payload }
 
+// Verify checks that the payload hashes to the header payload hash.
+func (b *Block) Verify() error {
+	if got, want := b.payload.Hash(), b.header.payloadHash; got != want {
+		return fmt.Errorf("payload.Hash() = %v, want %v", got, want)
+	}
+	return nil
+}
+
 // Hash of the BlockHeader.
 func (h *BlockHeader) Hash() BlockHeaderHash {
 	return BlockHeaderHash(hashable.ToHash(BlockHeaderConv.Encode(h)))

--- a/sei-tendermint/autobahn/types/block.go
+++ b/sei-tendermint/autobahn/types/block.go
@@ -139,17 +139,6 @@ func (b *Block) Header() *BlockHeader { return b.header }
 // Payload .
 func (b *Block) Payload() *Payload { return b.payload }
 
-// Verify validates the Block.
-func (b *Block) Verify(c *Committee) error {
-	if err := b.Header().Verify(c); err != nil {
-		return fmt.Errorf("header.Verify(): %w", err)
-	}
-	if got, want := b.Payload().Hash(), b.Header().PayloadHash(); got != want {
-		return fmt.Errorf("payload.Hash() = %v, want %v", got, want)
-	}
-	return nil
-}
-
 // Hash of the BlockHeader.
 func (h *BlockHeader) Hash() BlockHeaderHash {
 	return BlockHeaderHash(hashable.ToHash(BlockHeaderConv.Encode(h)))

--- a/sei-tendermint/autobahn/types/committee_test.go
+++ b/sei-tendermint/autobahn/types/committee_test.go
@@ -108,7 +108,7 @@ func TestLaneQCVerifyChecksWeight(t *testing.T) {
 func TestPrepareQCVerifyChecksWeight(t *testing.T) {
 	rng := utils.TestRng()
 	ep, keys := makeEpoch(rng)
-	vote := NewPrepareVote(ProposalAt(ep, View{EpochIndex: ep.EpochIndex(), Index: ep.RoadRange().First}))
+	vote := NewPrepareVote(ProposalAt(ep, View{EpochIndex: ep.EpochIndex(), Index: ep.RoadRange().First}, ep.FirstBlock()))
 
 	heavyOnly := NewPrepareQC([]*Signed[*PrepareVote]{
 		Sign(keys[0], vote),
@@ -128,7 +128,7 @@ func TestPrepareQCVerifyChecksEpochBinding(t *testing.T) {
 		return NewPrepareQC([]*Signed[*PrepareVote]{Sign(keys[0], NewPrepareVote(p))})
 	}
 
-	require.NoError(t, sign(ProposalAt(ep, View{Index: ep.RoadRange().First})).Verify(ep))
+	require.NoError(t, sign(ProposalAt(ep, View{Index: ep.RoadRange().First}, ep.FirstBlock())).Verify(ep))
 
 	wrongEpoch := newProposal(View{Index: ep.RoadRange().First, EpochIndex: ep.EpochIndex() + 1}, time.Time{}, nil, ep.FirstBlock())
 	require.Error(t, sign(wrongEpoch).Verify(ep))
@@ -144,7 +144,7 @@ func TestCommitQCVerifyChecksEpochBinding(t *testing.T) {
 		return NewCommitQC([]*Signed[*CommitVote]{Sign(keys[0], NewCommitVote(p))})
 	}
 
-	require.NoError(t, sign(ProposalAt(ep, View{Index: ep.RoadRange().First})).Verify(ep))
+	require.NoError(t, sign(ProposalAt(ep, View{Index: ep.RoadRange().First}, ep.FirstBlock())).Verify(ep))
 
 	wrongEpoch := newProposal(View{Index: ep.RoadRange().First, EpochIndex: ep.EpochIndex() + 1}, time.Time{}, nil, ep.FirstBlock())
 	require.Error(t, sign(wrongEpoch).Verify(ep))
@@ -156,7 +156,7 @@ func TestCommitQCVerifyChecksEpochBinding(t *testing.T) {
 func TestCommitQCVerifyChecksWeight(t *testing.T) {
 	rng := utils.TestRng()
 	ep, keys := makeEpoch(rng)
-	vote := NewCommitVote(ProposalAt(ep, View{EpochIndex: ep.EpochIndex(), Index: ep.RoadRange().First}))
+	vote := NewCommitVote(ProposalAt(ep, View{EpochIndex: ep.EpochIndex(), Index: ep.RoadRange().First}, ep.FirstBlock()))
 
 	heavyOnly := NewCommitQC([]*Signed[*CommitVote]{
 		Sign(keys[0], vote),
@@ -172,7 +172,7 @@ func TestCommitQCVerifyChecksWeight(t *testing.T) {
 func TestAppQCVerifyChecksWeight(t *testing.T) {
 	rng := utils.TestRng()
 	ep, keys := makeEpoch(rng)
-	vote := NewAppVote(NewAppProposal(ProposalAt(ep, View{EpochIndex: ep.EpochIndex(), Index: ep.RoadRange().First}), GenAppHash(rng)))
+	vote := NewAppVote(NewAppProposal(ProposalAt(ep, View{EpochIndex: ep.EpochIndex(), Index: ep.RoadRange().First}, ep.FirstBlock()), GenAppHash(rng)))
 
 	heavyOnly := NewAppQC([]*Signed[*AppVote]{
 		Sign(keys[0], vote),

--- a/sei-tendermint/autobahn/types/epoch.go
+++ b/sei-tendermint/autobahn/types/epoch.go
@@ -15,10 +15,18 @@ type RoadRange struct {
 	Next  RoadIndex
 }
 
+// EpochRange is a half-open epoch-index range [First, Next).
+type EpochRange struct {
+	First EpochIndex
+	Next  EpochIndex
+}
+
 // OpenRoadRange returns a RoadRange covering all road indices from 0.
 func OpenRoadRange() RoadRange { return RoadRange{First: 0, Next: utils.Max[RoadIndex]()} }
 
 func (r RoadRange) Has(idx RoadIndex) bool { return r.First <= idx && idx < r.Next }
+
+func (r EpochRange) Has(idx EpochIndex) bool { return r.First <= idx && idx < r.Next }
 
 // Epoch holds the complete context for a single epoch.
 // Retrieved from the local Registry; never transmitted on the wire.

--- a/sei-tendermint/autobahn/types/epoch.go
+++ b/sei-tendermint/autobahn/types/epoch.go
@@ -9,17 +9,15 @@ import (
 // EpochIndex is the epoch number.
 type EpochIndex uint64
 
-// RoadRange is an inclusive range of RoadIndex values [First, Last].
+// RoadRange is a half-open road range [First, Next).
 type RoadRange struct {
 	First RoadIndex
 	Next  RoadIndex
 }
 
 // OpenRoadRange returns a RoadRange covering all road indices from 0.
-// Use in tests and genesis epochs where no upper bound is known yet.
 func OpenRoadRange() RoadRange { return RoadRange{First: 0, Next: utils.Max[RoadIndex]()} }
 
-// Has reports whether idx falls within this range.
 func (r RoadRange) Has(idx RoadIndex) bool { return r.First <= idx && idx < r.Next }
 
 // Epoch holds the complete context for a single epoch.

--- a/sei-tendermint/autobahn/types/epoch_test.go
+++ b/sei-tendermint/autobahn/types/epoch_test.go
@@ -8,6 +8,14 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/require"
 )
 
+func TestRoadRange_Has(t *testing.T) {
+	r := RoadRange{First: 10, Next: 13}
+	require.False(t, r.Has(9))
+	require.True(t, r.Has(10))
+	require.True(t, r.Has(12))
+	require.False(t, r.Has(13))
+}
+
 func TestEpochIsClosed(t *testing.T) {
 	rng := utils.TestRng()
 	a := GenSecretKey(rng).Public()

--- a/sei-tendermint/autobahn/types/lane_proposal.go
+++ b/sei-tendermint/autobahn/types/lane_proposal.go
@@ -22,9 +22,30 @@ func NewLaneProposal(block *Block) *LaneProposal {
 // Block .
 func (m *LaneProposal) Block() *Block { return m.block }
 
-// Verify verifies that the LaneProposal is consistent with the Committee.
-func (m *LaneProposal) Verify(c *Committee) error {
-	return m.block.Verify(c)
+// VerifyPayload checks that the payload hashes to the header payload hash.
+func (m *LaneProposal) VerifyPayload() error {
+	b := m.block
+	if got, want := b.payload.Hash(), b.header.payloadHash; got != want {
+		return fmt.Errorf("payload.Hash() = %v, want %v", got, want)
+	}
+	return nil
+}
+
+// VerifyCommitteeMembership checks that the proposal's lane is in the committee.
+func (m *LaneProposal) VerifyCommitteeMembership(c *Committee) error {
+	return m.block.header.Verify(c)
+}
+
+// VerifyLaneProposalPayloadAndSignature verifies payload hash and signature. It
+// does not check committee membership.
+func VerifyLaneProposalPayloadAndSignature(p *Signed[*LaneProposal]) error {
+	if err := p.Msg().VerifyPayload(); err != nil {
+		return fmt.Errorf("VerifyPayload(): %w", err)
+	}
+	if err := p.VerifySignature(); err != nil {
+		return fmt.Errorf("VerifySignature(): %w", err)
+	}
+	return nil
 }
 
 // LaneProposalConv is a protobuf converter for LaneProposal.

--- a/sei-tendermint/autobahn/types/lane_proposal.go
+++ b/sei-tendermint/autobahn/types/lane_proposal.go
@@ -22,8 +22,7 @@ func NewLaneProposal(block *Block) *LaneProposal {
 // Block .
 func (m *LaneProposal) Block() *Block { return m.block }
 
-// Verify checks the proposal's internal integrity (payload hash). Committee
-// membership is separate: a lane is not tied to a single committee/epoch.
+// Verify checks the proposal's internal integrity.
 func (m *LaneProposal) Verify() error {
 	return m.block.Verify()
 }

--- a/sei-tendermint/autobahn/types/lane_proposal.go
+++ b/sei-tendermint/autobahn/types/lane_proposal.go
@@ -22,30 +22,10 @@ func NewLaneProposal(block *Block) *LaneProposal {
 // Block .
 func (m *LaneProposal) Block() *Block { return m.block }
 
-// VerifyPayload checks that the payload hashes to the header payload hash.
-func (m *LaneProposal) VerifyPayload() error {
-	b := m.block
-	if got, want := b.payload.Hash(), b.header.payloadHash; got != want {
-		return fmt.Errorf("payload.Hash() = %v, want %v", got, want)
-	}
-	return nil
-}
-
-// VerifyCommitteeMembership checks that the proposal's lane is in the committee.
-func (m *LaneProposal) VerifyCommitteeMembership(c *Committee) error {
-	return m.block.header.Verify(c)
-}
-
-// VerifyLaneProposalPayloadAndSignature verifies payload hash and signature. It
-// does not check committee membership.
-func VerifyLaneProposalPayloadAndSignature(p *Signed[*LaneProposal]) error {
-	if err := p.Msg().VerifyPayload(); err != nil {
-		return fmt.Errorf("VerifyPayload(): %w", err)
-	}
-	if err := p.VerifySignature(); err != nil {
-		return fmt.Errorf("VerifySignature(): %w", err)
-	}
-	return nil
+// Verify checks the proposal's internal integrity (payload hash). Committee
+// membership is separate: a lane is not tied to a single committee/epoch.
+func (m *LaneProposal) Verify() error {
+	return m.block.Verify()
 }
 
 // LaneProposalConv is a protobuf converter for LaneProposal.

--- a/sei-tendermint/autobahn/types/msg.go
+++ b/sei-tendermint/autobahn/types/msg.go
@@ -188,17 +188,9 @@ func (m *Signed[T]) Sig() *Signature { return m.sig }
 // Key returns the key whish signed the message.
 func (m *Signed[T]) Key() PublicKey { return m.sig.key }
 
-// VerifySignature verifies the cryptographic signature.
-func (m *Signed[T]) VerifySignature() error {
+// VerifySig verifies the cryptographic signature.
+func (m *Signed[T]) VerifySig() error {
 	return m.sig.key.key.VerifyWithTag(autobahnTag, m.hashed.hash[:], m.sig.sig)
-}
-
-// VerifySig verifies the signer is a committee replica and the signature.
-func (m *Signed[T]) VerifySig(c *Committee) error {
-	if !c.HasReplica(m.sig.key) {
-		return fmt.Errorf("%q is not a replica", m.sig.key)
-	}
-	return m.VerifySignature()
 }
 
 // verifyQC verifies a slice of signatures and checks if they form a quorum.
@@ -212,7 +204,10 @@ func (m *Hashed[T]) verifyQC(c *Committee, quorumWeight uint64, sigs []*Signatur
 		done[sig.key] = struct{}{}
 		weight += c.Weight(sig.key)
 		sm := &Signed[T]{hashed: m, sig: sig}
-		if err := sm.VerifySig(c); err != nil {
+		if !c.HasReplica(sm.Key()) {
+			return fmt.Errorf("%q is not a replica", sm.Key())
+		}
+		if err := sm.VerifySig(); err != nil {
 			return err
 		}
 	}

--- a/sei-tendermint/autobahn/types/msg.go
+++ b/sei-tendermint/autobahn/types/msg.go
@@ -188,12 +188,17 @@ func (m *Signed[T]) Sig() *Signature { return m.sig }
 // Key returns the key whish signed the message.
 func (m *Signed[T]) Key() PublicKey { return m.sig.key }
 
-// VerifySig verifies the signature of the message.
+// VerifySignature verifies the cryptographic signature.
+func (m *Signed[T]) VerifySignature() error {
+	return m.sig.key.key.VerifyWithTag(autobahnTag, m.hashed.hash[:], m.sig.sig)
+}
+
+// VerifySig verifies the signer is a committee replica and the signature.
 func (m *Signed[T]) VerifySig(c *Committee) error {
 	if !c.HasReplica(m.sig.key) {
 		return fmt.Errorf("%q is not a replica", m.sig.key)
 	}
-	return m.sig.key.key.VerifyWithTag(autobahnTag, m.hashed.hash[:], m.sig.sig)
+	return m.VerifySignature()
 }
 
 // verifyQC verifies a slice of signatures and checks if they form a quorum.

--- a/sei-tendermint/autobahn/types/proposal.go
+++ b/sei-tendermint/autobahn/types/proposal.go
@@ -125,10 +125,10 @@ func (v View) Next() View {
 	return v
 }
 
-// ConsensusSpec is the durable CommitQC tip paired with the epoch of the view
-// that follows it. CommitQC is None before the first tip; until then Epoch is
-// genesis epoch 0 (and FirstBlock is the next global block). Consensus installs
-// a spec verbatim.
+// ConsensusSpec is the durable CommitQC tip paired with the epoch of the
+// RoadIndex that follows it. CommitQC is None before the first tip; until then
+// Epoch is genesis epoch 0 (and FirstBlock is the next global block). Consensus
+// installs a spec verbatim.
 type ConsensusSpec struct {
 	CommitQC utils.Option[*CommitQC]
 	Epoch    *Epoch

--- a/sei-tendermint/autobahn/types/proposal.go
+++ b/sei-tendermint/autobahn/types/proposal.go
@@ -126,10 +126,11 @@ func (v View) Next() View {
 }
 
 // ConsensusSpec is the durable CommitQC tip paired with the epoch of the view
-// that follows it. Avail publishes Option[ConsensusSpec] (None until a tip
-// exists); consensus installs Some values verbatim.
+// that follows it. CommitQC is None before the first tip; until then Epoch is
+// genesis epoch 0 (and FirstBlock is the next global block). Consensus installs
+// a spec verbatim.
 type ConsensusSpec struct {
-	CommitQC *CommitQC
+	CommitQC utils.Option[*CommitQC]
 	Epoch    *Epoch
 }
 

--- a/sei-tendermint/autobahn/types/proposal.go
+++ b/sei-tendermint/autobahn/types/proposal.go
@@ -128,7 +128,7 @@ func (v View) Next() View {
 // ConsensusSpec is the durable CommitQC tip paired with the epoch of the
 // RoadIndex that follows it. CommitQC is None before the first tip; until then
 // Epoch is genesis epoch 0 (and FirstBlock is the next global block). Consensus
-// installs a spec verbatim.
+// advances with a spec verbatim.
 type ConsensusSpec struct {
 	CommitQC utils.Option[*CommitQC]
 	Epoch    *Epoch

--- a/sei-tendermint/autobahn/types/proposal.go
+++ b/sei-tendermint/autobahn/types/proposal.go
@@ -420,7 +420,10 @@ func (m *FullProposal) Verify(vs ViewSpec) error {
 			return fmt.Errorf("proposer %q, want %q", got, want)
 		}
 		// Verify the proposer's signature.
-		if err := m.proposal.VerifySig(c); err != nil {
+		if !c.HasReplica(m.proposal.Key()) {
+			return fmt.Errorf("%q is not a replica", m.proposal.Key())
+		}
+		if err := m.proposal.VerifySig(); err != nil {
 			return fmt.Errorf("proposal signature: %w", err)
 		}
 		// Do we have the required timeoutQC?

--- a/sei-tendermint/autobahn/types/proposal.go
+++ b/sei-tendermint/autobahn/types/proposal.go
@@ -125,6 +125,14 @@ func (v View) Next() View {
 	return v
 }
 
+// ConsensusSpec is the durable CommitQC tip paired with the epoch of the view
+// that follows it. Avail publishes Option[ConsensusSpec] (None until a tip
+// exists); consensus installs Some values verbatim.
+type ConsensusSpec struct {
+	CommitQC *CommitQC
+	Epoch    *Epoch
+}
+
 // ViewSpec is the full local context for starting a view: justification QCs plus
 // the epoch active at that view. Epoch is required; View(), NextGlobalBlock(), and
 // NextTimestamp() panic if it is nil.

--- a/sei-tendermint/autobahn/types/proposal.go
+++ b/sei-tendermint/autobahn/types/proposal.go
@@ -134,16 +134,19 @@ type ConsensusSpec struct {
 	Epoch    *Epoch
 }
 
-// ViewSpec is the full local context for starting a view: justification QCs plus
-// the epoch active at that view. Epoch is required; View(), NextGlobalBlock(), and
-// NextTimestamp() panic if it is nil.
+// Index is the RoadIndex of the next view: CommitQC.Index()+1, or 0 if there is no tip.
+func (s ConsensusSpec) Index() RoadIndex {
+	return NextIndexOpt(s.CommitQC)
+}
+
+// ViewSpec is ConsensusSpec plus the TimeoutQC for the current view number.
+// Epoch is required; View(), NextGlobalBlock(), and NextTimestamp() panic if it is nil.
 type ViewSpec struct {
+	ConsensusSpec
 	// WARNING: currently we have implicit assumption that
 	// TimeoutQC.View().Index == CommitQC.Index.Next(),
 	// I.e. that TimeoutQC comes from the expected consensus instance.
-	CommitQC  utils.Option[*CommitQC]
 	TimeoutQC utils.Option[*TimeoutQC]
-	Epoch     *Epoch
 }
 
 // NextGlobalBlock returns the first global block number expected in the next proposal.
@@ -158,7 +161,7 @@ func (vs *ViewSpec) NextGlobalBlock() GlobalBlockNumber {
 
 // View is the view justified by vs.
 func (vs *ViewSpec) View() View {
-	idx := NextIndexOpt(vs.CommitQC)
+	idx := vs.Index()
 	if view := NextViewOpt(vs.TimeoutQC); view.Index == idx {
 		view.EpochIndex = vs.Epoch.EpochIndex()
 		return view

--- a/sei-tendermint/autobahn/types/proposal.go
+++ b/sei-tendermint/autobahn/types/proposal.go
@@ -420,9 +420,6 @@ func (m *FullProposal) Verify(vs ViewSpec) error {
 			return fmt.Errorf("proposer %q, want %q", got, want)
 		}
 		// Verify the proposer's signature.
-		if !c.HasReplica(m.proposal.Key()) {
-			return fmt.Errorf("%q is not a replica", m.proposal.Key())
-		}
 		if err := m.proposal.VerifySig(); err != nil {
 			return fmt.Errorf("proposal signature: %w", err)
 		}

--- a/sei-tendermint/autobahn/types/proposal_test.go
+++ b/sei-tendermint/autobahn/types/proposal_test.go
@@ -64,7 +64,7 @@ func TestProposalVerifyRejectsEmptyTipcut(t *testing.T) {
 	rng := utils.TestRng()
 	committee, _ := GenCommittee(rng, 4)
 	ep := genFreshEpoch(rng, committee)
-	vs := ViewSpec{Epoch: ep}
+	vs := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}}
 
 	// Direct Proposal.Verify rejects empty tipcuts (no LaneQCs / zero GlobalRange).
 	// Local propose waits via WaitForLaneQCs; verification must refuse empty tipcuts
@@ -86,7 +86,7 @@ func TestProposalVerifyFreshWithBlocks(t *testing.T) {
 	rng := utils.TestRng()
 	committee, keys := GenCommittee(rng, 4)
 	ep := genFreshEpoch(rng, committee)
-	vs := ViewSpec{Epoch: ep}
+	vs := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}}
 	proposerKey := leaderKey(committee, keys, vs.View())
 
 	// Produce a LaneQC for the proposer's lane.
@@ -102,7 +102,7 @@ func TestNewProposalRejectsLaneRangeLongerThanMaxLaneRangeInProposal(t *testing.
 	rng := utils.TestRng()
 	committee, keys := GenCommittee(rng, 4)
 	ep := genFreshEpoch(rng, committee)
-	vs := ViewSpec{Epoch: ep}
+	vs := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}}
 	proposerKey := leaderKey(committee, keys, vs.View())
 	lane := committee.Lane(proposerKey.Public()).OrPanic("missing lane")
 
@@ -121,7 +121,7 @@ func TestProposalBlockTimestampStrictlyMonotone(t *testing.T) {
 	committee, keys := GenCommittee(rng, 4)
 	ep := genFreshEpoch(rng, committee)
 	firstBlock := ep.FirstBlock()
-	vs0 := ViewSpec{Epoch: ep}
+	vs0 := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}}
 	proposer0 := leaderKey(committee, keys, vs0.View())
 	lane := committee.Lane(proposer0.Public()).OrPanic("missing lane")
 
@@ -143,7 +143,7 @@ func TestProposalBlockTimestampStrictlyMonotone(t *testing.T) {
 	require.True(t, second0.Before(third0), "block timestamps within one proposal must be strictly increasing")
 
 	commitQC0 := makeCommitQCFromProposal(keys, firstProposal)
-	vs1 := ViewSpec{CommitQC: utils.Some(commitQC0), Epoch: ep}
+	vs1 := ViewSpec{ConsensusSpec: ConsensusSpec{CommitQC: utils.Some(commitQC0), Epoch: ep}}
 	proposer1 := leaderKey(committee, keys, vs1.View())
 
 	secondProposal := utils.OrPanic1(NewProposal(
@@ -167,7 +167,7 @@ func TestProposalVerifyRejectsNonMonotoneTimestamp(t *testing.T) {
 		committee, keys := GenCommittee(rng, 4)
 		genesisTimestamp := time.Now()
 		ep := NewEpoch(GenEpochIndex(rng), OpenRoadRange(), genesisTimestamp, committee, GlobalBlockNumber(rng.Uint64()%1000000)+1)
-		vs := ViewSpec{Epoch: ep}
+		vs := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}}
 		k := leaderKey(committee, keys, vs.View())
 		fp := utils.OrPanic1(NewProposal(k, vs, genesisTimestamp, oneLaneQCMap(rng, committee, keys, vs)))
 		require.NoError(t, fp.Verify(vs))
@@ -181,7 +181,7 @@ func TestProposalVerifyRejectsNonMonotoneTimestamp(t *testing.T) {
 		rng := utils.TestRng()
 		committee, keys := GenCommittee(rng, 4)
 		ep := genFreshEpoch(rng, committee)
-		vs0 := ViewSpec{Epoch: ep}
+		vs0 := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}}
 		proposer0 := leaderKey(committee, keys, vs0.View())
 		lane := committee.Lane(proposer0.Public()).OrPanic("missing lane")
 		lQC := makeLaneQC(rng, committee, keys, lane, 0, GenBlockHeaderHash(rng))
@@ -197,8 +197,8 @@ func TestProposalVerifyRejectsNonMonotoneTimestamp(t *testing.T) {
 			map[LaneID]*LaneQC{lane: lQC},
 		))
 
-		vs1a := ViewSpec{CommitQC: utils.Some(makeCommitQCFromProposal(keys, fp0a)), Epoch: ep}
-		vs1b := ViewSpec{CommitQC: utils.Some(makeCommitQCFromProposal(keys, fp0b)), Epoch: ep}
+		vs1a := ViewSpec{ConsensusSpec: ConsensusSpec{CommitQC: utils.Some(makeCommitQCFromProposal(keys, fp0a)), Epoch: ep}}
+		vs1b := ViewSpec{ConsensusSpec: ConsensusSpec{CommitQC: utils.Some(makeCommitQCFromProposal(keys, fp0b)), Epoch: ep}}
 		proposer1 := leaderKey(committee, keys, vs1a.View())
 
 		fp1a := utils.OrPanic1(NewProposal(
@@ -218,13 +218,13 @@ func TestProposalVerifyRejectsViewMismatch(t *testing.T) {
 	ep := genFreshEpoch(rng, committee)
 
 	// Build a valid proposal at genesis view (0, 0).
-	vs0 := ViewSpec{Epoch: ep}
+	vs0 := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}}
 	leader0 := leaderKey(committee, keys, vs0.View())
 	fp := utils.OrPanic1(NewProposal(leader0, vs0, time.Now(), oneLaneQCMap(rng, committee, keys, vs0)))
 
 	// Verify it against a different ViewSpec (view 1, 0).
 	commitQC := makeCommitQCFromProposal(keys, fp)
-	vs1 := ViewSpec{CommitQC: utils.Some(commitQC), Epoch: ep}
+	vs1 := ViewSpec{ConsensusSpec: ConsensusSpec{CommitQC: utils.Some(commitQC), Epoch: ep}}
 	err := fp.Verify(vs1)
 	require.Error(t, err)
 }
@@ -233,7 +233,7 @@ func TestProposalVerifyRejectsForgedSignature(t *testing.T) {
 	rng := utils.TestRng()
 	committee, keys := GenCommittee(rng, 4)
 	ep := genFreshEpoch(rng, committee)
-	vs := ViewSpec{Epoch: ep}
+	vs := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}}
 	proposerKey := leaderKey(committee, keys, vs.View())
 
 	// Build two valid proposals with different timestamps.
@@ -250,7 +250,7 @@ func TestProposalVerifyRejectsWrongProposer(t *testing.T) {
 	rng := utils.TestRng()
 	committee, keys := GenCommittee(rng, 4)
 	ep := genFreshEpoch(rng, committee)
-	vs := ViewSpec{Epoch: ep}
+	vs := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}}
 	correctLeader := leaderKey(committee, keys, vs.View())
 
 	fp := utils.OrPanic1(NewProposal(correctLeader, vs, time.Now(), oneLaneQCMap(rng, committee, keys, vs)))
@@ -276,7 +276,7 @@ func TestProposalVerifyRejectsInconsistentTimeoutQC(t *testing.T) {
 	rng := utils.TestRng()
 	committee, keys := GenCommittee(rng, 4)
 	ep := genFreshEpoch(rng, committee)
-	vs := ViewSpec{Epoch: ep} // no timeoutQC
+	vs := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}} // no timeoutQC
 	proposerKey := leaderKey(committee, keys, vs.View())
 
 	fp := utils.OrPanic1(NewProposal(proposerKey, vs, time.Now(), oneLaneQCMap(rng, committee, keys, vs)))
@@ -301,7 +301,7 @@ func TestProposalVerifyRejectsNonCommitteeLane(t *testing.T) {
 	rng := utils.TestRng()
 	committee, keys := GenCommittee(rng, 4)
 	ep := genFreshEpoch(rng, committee)
-	vs := ViewSpec{Epoch: ep}
+	vs := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}}
 	proposerKey := leaderKey(committee, keys, vs.View())
 
 	fp := utils.OrPanic1(NewProposal(proposerKey, vs, time.Now(), oneLaneQCMap(rng, committee, keys, vs)))
@@ -332,7 +332,7 @@ func TestProposalVerifyAcceptsImplicitLaneRange(t *testing.T) {
 	rng := utils.TestRng()
 	committee, keys := GenCommittee(rng, 4)
 	ep := genFreshEpoch(rng, committee)
-	vs := ViewSpec{Epoch: ep}
+	vs := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}}
 	proposerKey := leaderKey(committee, keys, vs.View())
 
 	fp := utils.OrPanic1(NewProposal(proposerKey, vs, time.Now(), oneLaneQCMap(rng, committee, keys, vs)))
@@ -364,7 +364,7 @@ func TestProposalVerifyAcceptsNonContiguousImplicitRanges(t *testing.T) {
 	rng := utils.TestRng()
 	committee, keys := GenCommittee(rng, 4)
 	ep := genFreshEpoch(rng, committee)
-	vs := ViewSpec{Epoch: ep}
+	vs := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}}
 	proposerKey := leaderKey(committee, keys, vs.View())
 
 	fp := utils.OrPanic1(NewProposal(proposerKey, vs, time.Now(), oneLaneQCMap(rng, committee, keys, vs)))
@@ -396,7 +396,7 @@ func TestProposalVerifyRejectsLaneRangeFirstMismatch(t *testing.T) {
 	rng := utils.TestRng()
 	committee, keys := GenCommittee(rng, 4)
 	ep := genFreshEpoch(rng, committee)
-	vs := ViewSpec{Epoch: ep}
+	vs := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}}
 	proposerKey := leaderKey(committee, keys, vs.View())
 
 	fp := utils.OrPanic1(NewProposal(proposerKey, vs, time.Now(), oneLaneQCMap(rng, committee, keys, vs)))
@@ -434,7 +434,7 @@ func TestProposalVerifyRejectsMissingLaneQC(t *testing.T) {
 	rng := utils.TestRng()
 	committee, keys := GenCommittee(rng, 4)
 	ep := genFreshEpoch(rng, committee)
-	vs := ViewSpec{Epoch: ep}
+	vs := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}}
 	proposerKey := leaderKey(committee, keys, vs.View())
 
 	lane := committee.Lane(keys[0].Public()).OrPanic("missing lane")
@@ -456,7 +456,7 @@ func TestProposalVerifyRejectsLaneQCBlockNumberMismatch(t *testing.T) {
 	rng := utils.TestRng()
 	committee, keys := GenCommittee(rng, 4)
 	ep := genFreshEpoch(rng, committee)
-	vs := ViewSpec{Epoch: ep}
+	vs := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}}
 	proposerKey := leaderKey(committee, keys, vs.View())
 
 	lane := committee.Lane(keys[0].Public()).OrPanic("missing lane")
@@ -480,7 +480,7 @@ func TestProposalVerifyRejectsInvalidLaneQCSignature(t *testing.T) {
 	rng := utils.TestRng()
 	committee, keys := GenCommittee(rng, 4)
 	ep := genFreshEpoch(rng, committee)
-	vs := ViewSpec{Epoch: ep}
+	vs := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}}
 	proposerKey := leaderKey(committee, keys, vs.View())
 
 	lane := committee.Lane(keys[0].Public()).OrPanic("missing lane")
@@ -540,7 +540,7 @@ func makeFullProposal(
 	appQC utils.Option[*AppQC],
 ) *FullProposal {
 	committee := ep.Committee()
-	vs := ViewSpec{CommitQC: prev, Epoch: ep}
+	vs := ViewSpec{ConsensusSpec: ConsensusSpec{CommitQC: prev, Epoch: ep}}
 	return utils.OrPanic1(NewProposal(
 		leaderKey(committee, keys, vs.View()),
 		vs, time.Now(),
@@ -561,7 +561,7 @@ func TestProposalVerifyRejectsLaneQCHeaderHashMismatch(t *testing.T) {
 	rng := utils.TestRng()
 	committee, keys := GenCommittee(rng, 4)
 	ep := genFreshEpoch(rng, committee)
-	vs := ViewSpec{Epoch: ep}
+	vs := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}}
 	proposerKey := leaderKey(committee, keys, vs.View())
 
 	lane := committee.Lane(proposerKey.Public()).OrPanic("missing lane")
@@ -590,7 +590,7 @@ func TestProposalVerifyValidReproposal(t *testing.T) {
 	// firstBlock > 0 ensures a reproposal bug that passes GlobalRange().First
 	// (= sum(lane.First)+firstBlock) instead of firstBlock would be caught.
 	ep := genFreshEpoch(rng, committee)
-	vs0 := ViewSpec{Epoch: ep}
+	vs0 := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}}
 	leader0 := leaderKey(committee, keys, vs0.View())
 	lane := committee.Lane(committee.Leader(vs0.View())).OrPanic("missing lane")
 	laneQC0 := makeLaneQC(rng, committee, keys, lane, 0, GenBlockHeaderHash(rng))
@@ -611,7 +611,7 @@ func TestProposalVerifyValidReproposal(t *testing.T) {
 	}
 	timeoutQC := NewTimeoutQC(timeoutVotes)
 
-	vs1 := ViewSpec{TimeoutQC: utils.Some(timeoutQC), Epoch: ep}
+	vs1 := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}, TimeoutQC: utils.Some(timeoutQC)}
 	require.Equal(t, View{Index: 0, Number: 1, EpochIndex: ep.EpochIndex()}, vs1.View())
 
 	leader1 := leaderKey(committee, keys, vs1.View())
@@ -628,7 +628,7 @@ func TestProposalVerifyRejectsReproposalWithUnnecessaryData(t *testing.T) {
 	ep := genFreshEpoch(rng, committee)
 
 	// Build a PrepareQC at (0, 0).
-	vs0 := ViewSpec{Epoch: ep}
+	vs0 := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}}
 	leader0 := leaderKey(committee, keys, vs0.View())
 	fp0 := utils.OrPanic1(NewProposal(leader0, vs0, time.Now(), oneLaneQCMap(rng, committee, keys, vs0)))
 
@@ -644,7 +644,7 @@ func TestProposalVerifyRejectsReproposalWithUnnecessaryData(t *testing.T) {
 	}
 	timeoutQC := NewTimeoutQC(timeoutVotes)
 
-	vs1 := ViewSpec{TimeoutQC: utils.Some(timeoutQC), Epoch: ep}
+	vs1 := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}, TimeoutQC: utils.Some(timeoutQC)}
 	leader1 := leaderKey(committee, keys, vs1.View())
 
 	// Create a valid reproposal, then tamper it with unnecessary laneQCs.
@@ -667,7 +667,7 @@ func TestProposalVerifyRejectsReproposalHashMismatch(t *testing.T) {
 	ep := genFreshEpoch(rng, committee)
 
 	// Build a PrepareQC at (0, 0).
-	vs0 := ViewSpec{Epoch: ep}
+	vs0 := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}}
 	leader0 := leaderKey(committee, keys, vs0.View())
 	fp0 := utils.OrPanic1(NewProposal(leader0, vs0, time.Now(), oneLaneQCMap(rng, committee, keys, vs0)))
 
@@ -683,7 +683,7 @@ func TestProposalVerifyRejectsReproposalHashMismatch(t *testing.T) {
 	}
 	timeoutQC := NewTimeoutQC(timeoutVotes)
 
-	vs1 := ViewSpec{TimeoutQC: utils.Some(timeoutQC), Epoch: ep}
+	vs1 := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}, TimeoutQC: utils.Some(timeoutQC)}
 	leader1 := leaderKey(committee, keys, vs1.View())
 
 	// Build the valid reproposal, then tamper its timestamp to get a different hash.
@@ -719,7 +719,7 @@ func TestProposalVerifyRejectsInvalidTimeoutQCSignature(t *testing.T) {
 	}
 	badTimeoutQC := NewTimeoutQC(timeoutVotes)
 
-	vs := ViewSpec{TimeoutQC: utils.Some(badTimeoutQC), Epoch: ep}
+	vs := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}, TimeoutQC: utils.Some(badTimeoutQC)}
 	leader := leaderKey(committee, keys, vs.View())
 
 	fp := utils.OrPanic1(NewProposal(leader, vs, time.Now(), oneLaneQCMap(rng, committee, keys, vs)))
@@ -735,7 +735,7 @@ func TestViewSpecViewStampsEpochIndex(t *testing.T) {
 	ep := NewEpoch(epochIdx, OpenRoadRange(), time.Time{}, committee, 0)
 
 	// Without TimeoutQC: epoch index must come from vs.Epoch.
-	vs0 := ViewSpec{Epoch: ep}
+	vs0 := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}}
 	if got := vs0.View().EpochIndex; got != epochIdx {
 		t.Fatalf("no-TimeoutQC path: EpochIndex = %d, want %d", got, epochIdx)
 	}
@@ -744,7 +744,7 @@ func TestViewSpecViewStampsEpochIndex(t *testing.T) {
 	tqc := NewTimeoutQC([]*FullTimeoutVote{
 		NewFullTimeoutVote(keys[0], View{EpochIndex: 0}, utils.None[*PrepareQC]()),
 	})
-	vs1 := ViewSpec{TimeoutQC: utils.Some(tqc), Epoch: ep}
+	vs1 := ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: ep}, TimeoutQC: utils.Some(tqc)}
 	if got := vs1.View().EpochIndex; got != epochIdx {
 		t.Fatalf("TimeoutQC path: EpochIndex = %d, want %d", got, epochIdx)
 	}

--- a/sei-tendermint/autobahn/types/testonly.go
+++ b/sei-tendermint/autobahn/types/testonly.go
@@ -146,7 +146,7 @@ func SignedForTesting[T Msg](msg T, sig *Signature) *Signed[T] {
 
 // NewBlockForTesting builds a Block with an injected payload hash instead of computing
 // payload.Hash(). FOR TESTS/BENCHMARKS ONLY: the header's payloadHash need not match the
-// payload, so LaneProposal.VerifyPayload will fail. This skips a full marshal + SHA-256 of the payload.
+// payload, so LaneProposal.Verify will fail. This skips a full marshal + SHA-256 of the payload.
 func NewBlockForTesting(
 	lane LaneID,
 	blockNumber BlockNumber,

--- a/sei-tendermint/autobahn/types/testonly.go
+++ b/sei-tendermint/autobahn/types/testonly.go
@@ -22,7 +22,7 @@ func BuildCommitQC(
 	prev utils.Option[*CommitQC],
 	laneQCs map[LaneID]*LaneQC,
 ) *CommitQC {
-	vs := ViewSpec{CommitQC: prev, Epoch: epoch}
+	vs := ViewSpec{ConsensusSpec: ConsensusSpec{CommitQC: prev, Epoch: epoch}}
 	if len(laneQCs) == 0 {
 		laneQCs = oneBlockLaneQCMap(vs, keys)
 	}

--- a/sei-tendermint/autobahn/types/testonly.go
+++ b/sei-tendermint/autobahn/types/testonly.go
@@ -146,7 +146,7 @@ func SignedForTesting[T Msg](msg T, sig *Signature) *Signed[T] {
 
 // NewBlockForTesting builds a Block with an injected payload hash instead of computing
 // payload.Hash(). FOR TESTS/BENCHMARKS ONLY: the header's payloadHash need not match the
-// payload, so Block.Verify will fail. This skips a full marshal + SHA-256 of the payload.
+// payload, so LaneProposal.VerifyPayload will fail. This skips a full marshal + SHA-256 of the payload.
 func NewBlockForTesting(
 	lane LaneID,
 	blockNumber BlockNumber,

--- a/sei-tendermint/autobahn/types/testonly.go
+++ b/sei-tendermint/autobahn/types/testonly.go
@@ -308,7 +308,7 @@ func GenEpochWithCommittee(rng utils.Rng, committee *Committee) *Epoch {
 
 // CommitQCAt creates a CommitQC at ep.RoadRange().First, signed by all keys.
 func CommitQCAt(ep *Epoch, keys []SecretKey) *CommitQC {
-	vote := NewCommitVote(ProposalAt(ep, View{EpochIndex: ep.EpochIndex(), Index: ep.RoadRange().First}))
+	vote := NewCommitVote(ProposalAt(ep, View{EpochIndex: ep.EpochIndex(), Index: ep.RoadRange().First}, ep.FirstBlock()))
 	votes := make([]*Signed[*CommitVote], len(keys))
 	for i, k := range keys {
 		votes[i] = Sign(k, vote)
@@ -326,15 +326,15 @@ func GenProposalAt(rng utils.Rng, view View) *Proposal {
 	return newProposal(view, utils.GenTimestamp(rng), utils.GenSlice(rng, GenLaneRange), GlobalBlockNumber(rng.Uint64()))
 }
 
-// ProposalAt returns a minimal non-empty Proposal at view, consistent with ep.
-// Includes a single 1-block lane range so Proposal.Verify accepts it (empty
-// tipcuts are forbidden). For tests that care about signature weight or epoch
-// binding rather than real lane/app data.
-func ProposalAt(ep *Epoch, view View) *Proposal {
+// ProposalAt returns a minimal non-empty Proposal at view, consistent with ep,
+// starting at globalFirst. Includes a single 1-block lane range so
+// Proposal.Verify accepts it (empty tipcuts are forbidden). For tests that care
+// about signature weight or epoch binding rather than real lane/app data.
+func ProposalAt(ep *Epoch, view View, globalFirst GlobalBlockNumber) *Proposal {
 	view.EpochIndex = ep.EpochIndex()
 	lane := ep.Committee().Lanes().At(0)
 	header := NewBlock(lane, 0, BlockHeaderHash{}, &Payload{}).Header()
-	return newProposal(view, time.Time{}, []*LaneRange{NewLaneRange(lane, 0, utils.Some(header))}, ep.FirstBlock())
+	return newProposal(view, time.Time{}, []*LaneRange{NewLaneRange(lane, 0, utils.Some(header))}, globalFirst)
 }
 
 // GenProposalForEpoch generates a Proposal at a specific view whose epochIndex,

--- a/sei-tendermint/autobahn/types/timeout.go
+++ b/sei-tendermint/autobahn/types/timeout.go
@@ -79,7 +79,10 @@ func (m *FullTimeoutVote) Verify(ep *Epoch) error {
 		return err
 	}
 	c := ep.Committee()
-	if err := m.vote.VerifySig(c); err != nil {
+	if !c.HasReplica(m.vote.Key()) {
+		return fmt.Errorf("%q is not a replica", m.vote.Key())
+	}
+	if err := m.vote.VerifySig(); err != nil {
 		return err
 	}
 	if want, ok := m.vote.Msg().latestPrepareQCView().Get(); ok {
@@ -166,7 +169,10 @@ func (m *TimeoutQC) Verify(ep *Epoch, prev utils.Option[*CommitQC]) error {
 		}
 		weight += c.Weight(v.sig.key)
 		done[v.sig.key] = struct{}{}
-		if err := v.VerifySig(c); err != nil {
+		if !c.HasReplica(v.Key()) {
+			return fmt.Errorf("%q is not a replica", v.Key())
+		}
+		if err := v.VerifySig(); err != nil {
 			return err
 		}
 	}

--- a/sei-tendermint/autobahn/types/types_test.go
+++ b/sei-tendermint/autobahn/types/types_test.go
@@ -148,7 +148,7 @@ func TestNewTimeoutQC_MixedPrepareQCs(t *testing.T) {
 	ep := NewEpoch(GenEpochIndex(rng), OpenRoadRange(), utils.GenTimestamp(rng), committee, GlobalBlockNumber(rng.Uint64()%1000000)+1)
 	view := View{Index: 0, Number: 0, EpochIndex: ep.EpochIndex()}
 
-	pqc := makePrepareQC(keys, NewPrepareVote(ProposalAt(ep, view)))
+	pqc := makePrepareQC(keys, NewPrepareVote(ProposalAt(ep, view, ep.FirstBlock())))
 
 	// Only keys[0] carries the PrepareQC; the rest carry None.
 	votes := make([]*FullTimeoutVote, len(keys))
@@ -202,7 +202,7 @@ func TestTimeoutQCVerify_HighestPrepareQCSelected(t *testing.T) {
 
 	makePQCAt := func(vn ViewNumber) *PrepareQC {
 		pView := View{Index: 0, Number: vn, EpochIndex: ep.EpochIndex()}
-		return makePrepareQC(keys, NewPrepareVote(ProposalAt(ep, pView)))
+		return makePrepareQC(keys, NewPrepareVote(ProposalAt(ep, pView, ep.FirstBlock())))
 	}
 
 	// keys[0] has PrepareQC at view number 2, keys[1] at 4, rest None.

--- a/sei-tendermint/autobahn/types/wireguard_test.go
+++ b/sei-tendermint/autobahn/types/wireguard_test.go
@@ -197,7 +197,7 @@ func TestFullProposalWireguardAcceptsMaxValidators(t *testing.T) {
 	}
 	proposal, err := NewProposal(
 		secretKeyFor(keys, committee.Leader(View{})),
-		ViewSpec{Epoch: NewEpoch(0, OpenRoadRange(), time.Time{}, committee, 0)},
+		ViewSpec{ConsensusSpec: ConsensusSpec{Epoch: NewEpoch(0, OpenRoadRange(), time.Time{}, committee, 0)}},
 		time.Unix(1, 2),
 		laneQCs,
 	)

--- a/sei-tendermint/internal/autobahn/autobahn.proto
+++ b/sei-tendermint/internal/autobahn/autobahn.proto
@@ -205,8 +205,7 @@ message FullTimeoutVote {
 message PersistedInner {
   reserved "commit_vote", "prepare_vote", "commit_qc";
   reserved 4, 5, 1;
-  // Tip CommitQC road index for ErrAvailBehindConsensus on restore.
-  // Absent means no tip yet (genesis view 0). Runtime tip comes from ConsensusSpec.
+  // Index is the current view RoadIndex (ConsensusSpec.Index; 0 at genesis).
   optional uint64 commit_qc_index = 9;
   optional PrepareQC prepare_qc = 2;
   optional TimeoutQC timeout_qc = 3;

--- a/sei-tendermint/internal/autobahn/autobahn.proto
+++ b/sei-tendermint/internal/autobahn/autobahn.proto
@@ -203,9 +203,11 @@ message FullTimeoutVote {
 // Do NOT persist internal derived fields (e.g., cached computations, runtime state).
 // Derived fields are implementation-dependent and should be recomputed on load.
 message PersistedInner {
-  reserved "commit_vote", "prepare_vote";
-  reserved 4, 5;
-  optional CommitQC commit_qc = 1;
+  reserved "commit_vote", "prepare_vote", "commit_qc";
+  reserved 4, 5, 1;
+  // Tip CommitQC road index for ErrAvailBehindConsensus on restore.
+  // Absent means no tip yet (genesis view 0). Runtime tip comes from ConsensusSpec.
+  optional uint64 commit_qc_index = 9;
   optional PrepareQC prepare_qc = 2;
   optional TimeoutQC timeout_qc = 3;
 

--- a/sei-tendermint/internal/autobahn/autobahn.proto
+++ b/sei-tendermint/internal/autobahn/autobahn.proto
@@ -206,7 +206,7 @@ message PersistedInner {
   reserved "commit_vote", "prepare_vote", "commit_qc";
   reserved 4, 5, 1;
   // Index is the current view RoadIndex (ConsensusSpec.Index; 0 at genesis).
-  optional uint64 commit_qc_index = 9;
+  optional uint64 index = 9;
   optional PrepareQC prepare_qc = 2;
   optional TimeoutQC timeout_qc = 3;
 

--- a/sei-tendermint/internal/autobahn/avail/block_votes.go
+++ b/sei-tendermint/internal/autobahn/avail/block_votes.go
@@ -2,45 +2,76 @@ package avail
 
 import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/autobahn/types"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 )
 
+// LaneVotes have two jobs: byKey keeps headers for FullCommitQC; byHash
+// accumulates applied-epoch weight for LaneQC. byKey is retained even after the
+// latest CommitQC moves into a new epoch, since a FullCommitQC in the previous
+// epoch may still need those headers — so we can't clear it on epoch change.
+// qc is set once weight reaches quorum under the applied committee and cleared
+// on reweight.
 type blockVotes struct {
 	byKey  map[types.PublicKey]*types.Signed[*types.LaneVote]
 	byHash map[types.BlockHeaderHash]*voteSet[*types.Signed[*types.LaneVote]]
+	qc     utils.Option[*types.LaneQC]
 }
 
-func newBlockVotes() blockVotes {
-	return blockVotes{
+func newBlockVotes() *blockVotes {
+	return &blockVotes{
 		byKey:  map[types.PublicKey]*types.Signed[*types.LaneVote]{},
 		byHash: map[types.BlockHeaderHash]*voteSet[*types.Signed[*types.LaneVote]]{},
 	}
 }
 
-// Returns true iff a new QC has been constructed.
-// Weight is counted under ep's committee (PushVote passes the applied epoch).
-// TODO: votes accepted only under the Anchor epoch can have Weight 0 under the
-// applied committee but are still appended into the LaneQC sig list; filter
-// those out when forming a LaneQC (leave-across-epochs).
-func (bv blockVotes) pushVote(ep *types.Epoch, vote *types.Signed[*types.LaneVote]) (*types.LaneQC, bool) {
-	c := ep.Committee()
+// return true iff the vote is newly stored in byKey.
+func (bv *blockVotes) pushVote(ep *types.Epoch, vote *types.Signed[*types.LaneVote]) bool {
 	k := vote.Key()
-	h := vote.Msg().Header().Hash()
 	if _, ok := bv.byKey[k]; ok {
-		return nil, false
+		return false
 	}
 	bv.byKey[k] = vote
+	bv.credit(ep, vote)
+	return true
+}
+
+func (bv *blockVotes) reweight(ep *types.Epoch) {
+	bv.qc = utils.None[*types.LaneQC]()
+	clear(bv.byHash)
+	for _, vote := range bv.byKey {
+		bv.credit(ep, vote)
+	}
+}
+
+func (bv *blockVotes) credit(ep *types.Epoch, vote *types.Signed[*types.LaneVote]) {
+	if bv.qc.IsPresent() {
+		return
+	}
+	c := ep.Committee()
+	k := vote.Key()
+	w := c.Weight(k)
+	if w == 0 {
+		return
+	}
+	h := vote.Msg().Header().Hash()
 	byHash, ok := bv.byHash[h]
 	if !ok {
 		byHash = &voteSet[*types.Signed[*types.LaneVote]]{}
 		bv.byHash[h] = byHash
 	}
-	if byHash.weight >= c.LaneQuorum() {
-		return nil, false
-	}
-	byHash.weight += c.Weight(k)
+	byHash.weight += w
 	byHash.votes = append(byHash.votes, vote)
 	if byHash.weight >= c.LaneQuorum() {
-		return types.NewLaneQC(byHash.votes), true
+		bv.qc = utils.Some(types.NewLaneQC(byHash.votes))
 	}
-	return nil, false
+}
+
+func (bv *blockVotes) header(want types.BlockHeaderHash) utils.Option[*types.BlockHeader] {
+	for _, vote := range bv.byKey {
+		h := vote.Msg().Header()
+		if h.Hash() == want {
+			return utils.Some(h)
+		}
+	}
+	return utils.None[*types.BlockHeader]()
 }

--- a/sei-tendermint/internal/autobahn/avail/block_votes_test.go
+++ b/sei-tendermint/internal/autobahn/avail/block_votes_test.go
@@ -74,3 +74,68 @@ func TestBlockVotes_ZeroWeightNotCreditedUnderApplied(t *testing.T) {
 	require.False(t, bv.qc.IsPresent())
 	require.Equal(t, 1, len(bv.byKey))
 }
+
+// A alone reaches lane quorum; after a weight cut with the same membership, reweight drops the QC.
+func TestBlockVotes_ReweightInvalidatesLaneQC(t *testing.T) {
+	rng := utils.TestRng()
+	a := types.GenSecretKey(rng)
+	b := types.GenSecretKey(rng)
+	c := types.GenSecretKey(rng)
+	d := types.GenSecretKey(rng)
+
+	ep0 := types.NewEpoch(0, types.RoadRange{First: 0, Next: 10}, time.Time{},
+		utils.OrPanic1(types.NewCommittee(map[types.PublicKey]uint64{
+			a.Public(): 3, b.Public(): 1, c.Public(): 1, d.Public(): 1,
+		})), 0)
+	require.Equal(t, uint64(2), ep0.Committee().LaneQuorum())
+	lane := ep0.Committee().Lane(a.Public()).OrPanic("lane")
+	header := types.NewBlock(lane, 0, types.BlockHeaderHash{}, &types.Payload{}).Header()
+
+	bv := newBlockVotes()
+	require.True(t, bv.pushVote(ep0, types.Sign(a, types.NewLaneVote(header))))
+	require.True(t, bv.qc.IsPresent())
+
+	ep1 := types.NewEpoch(1, types.RoadRange{First: 10, Next: 20}, time.Time{},
+		utils.OrPanic1(ep0.Committee().DeriveNext(map[types.PublicKey]uint64{
+			a.Public(): 1, b.Public(): 1, c.Public(): 5, d.Public(): 5,
+		}, 1)), 0)
+	require.Equal(t, uint64(4), ep1.Committee().LaneQuorum())
+	bv.reweight(ep1)
+	require.False(t, bv.qc.IsPresent())
+	require.True(t, bv.header(header.Hash()).IsPresent())
+}
+
+// A+B are short of lane quorum; after a weight increase with the same membership, reweight forms a QC.
+func TestBlockVotes_ReweightFormsLaneQC(t *testing.T) {
+	rng := utils.TestRng()
+	a := types.GenSecretKey(rng)
+	b := types.GenSecretKey(rng)
+	c := types.GenSecretKey(rng)
+	d := types.GenSecretKey(rng)
+
+	ep0 := types.NewEpoch(0, types.RoadRange{First: 0, Next: 10}, time.Time{},
+		utils.OrPanic1(types.NewCommittee(map[types.PublicKey]uint64{
+			a.Public(): 1, b.Public(): 1, c.Public(): 5, d.Public(): 5,
+		})), 0)
+	require.Equal(t, uint64(4), ep0.Committee().LaneQuorum())
+	lane := ep0.Committee().Lane(a.Public()).OrPanic("lane")
+	header := types.NewBlock(lane, 0, types.BlockHeaderHash{}, &types.Payload{}).Header()
+	vote := func(sk types.SecretKey) *types.Signed[*types.LaneVote] {
+		return types.Sign(sk, types.NewLaneVote(header))
+	}
+
+	bv := newBlockVotes()
+	require.True(t, bv.pushVote(ep0, vote(a)))
+	require.True(t, bv.pushVote(ep0, vote(b)))
+	require.False(t, bv.qc.IsPresent())
+
+	ep1 := types.NewEpoch(1, types.RoadRange{First: 10, Next: 20}, time.Time{},
+		utils.OrPanic1(ep0.Committee().DeriveNext(map[types.PublicKey]uint64{
+			a.Public(): 5, b.Public(): 5, c.Public(): 1, d.Public(): 1,
+		}, 1)), 0)
+	require.Equal(t, uint64(4), ep1.Committee().LaneQuorum())
+	bv.reweight(ep1)
+	qc, ok := bv.qc.Get()
+	require.True(t, ok)
+	require.Equal(t, header.Hash(), qc.Header().Hash())
+}

--- a/sei-tendermint/internal/autobahn/avail/block_votes_test.go
+++ b/sei-tendermint/internal/autobahn/avail/block_votes_test.go
@@ -9,133 +9,97 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/require"
 )
 
-func TestBlockVotes_RecountStayFormsLaneQC(t *testing.T) {
+func TestBlockVotes_Reweight(t *testing.T) {
 	rng := utils.TestRng()
 	a := types.GenSecretKey(rng)
 	b := types.GenSecretKey(rng)
 	c := types.GenSecretKey(rng)
 	d := types.GenSecretKey(rng)
-
-	ep0 := types.NewEpoch(0, types.RoadRange{First: 0, Next: 10}, time.Time{},
-		utils.OrPanic1(types.NewCommittee(map[types.PublicKey]uint64{
-			a.Public(): 1, b.Public(): 1, c.Public(): 1, d.Public(): 1,
-		})), 0)
-	lane := ep0.Committee().Lane(a.Public()).OrPanic("lane")
-	header := types.NewBlock(lane, 0, types.BlockHeaderHash{}, &types.Payload{}).Header()
-	vote := func(sk types.SecretKey) *types.Signed[*types.LaneVote] {
-		return types.Sign(sk, types.NewLaneVote(header))
+	mk := func(weights map[types.PublicKey]uint64, idx types.EpochIndex, first, next types.RoadIndex) *types.Epoch {
+		return types.NewEpoch(idx, types.RoadRange{First: first, Next: next}, time.Time{},
+			utils.OrPanic1(types.NewCommittee(weights)), 0)
+	}
+	headerOn := func(ep *types.Epoch, sk types.SecretKey) *types.BlockHeader {
+		lane := ep.Committee().Lane(sk.Public()).OrPanic("lane")
+		return types.NewBlock(lane, 0, types.BlockHeaderHash{}, &types.Payload{}).Header()
 	}
 
-	bv := newBlockVotes()
-	require.True(t, bv.pushVote(ep0, vote(a)))
-	require.False(t, bv.qc.IsPresent())
-	require.True(t, bv.pushVote(ep0, vote(b)))
-	qc, ok := bv.qc.Get()
-	require.True(t, ok)
-	require.Equal(t, header.Hash(), qc.Header().Hash())
-	require.True(t, bv.pushVote(ep0, vote(d)))
+	t.Run("stay still has quorum", func(t *testing.T) {
+		ep0 := mk(map[types.PublicKey]uint64{a.Public(): 1, b.Public(): 1, c.Public(): 1, d.Public(): 1}, 0, 0, 10)
+		h := headerOn(ep0, a)
+		vote := func(sk types.SecretKey) *types.Signed[*types.LaneVote] {
+			return types.Sign(sk, types.NewLaneVote(h))
+		}
+		bv := newBlockVotes()
+		require.True(t, bv.pushVote(ep0, vote(a)))
+		require.False(t, bv.qc.IsPresent())
+		require.True(t, bv.pushVote(ep0, vote(b)))
+		require.True(t, bv.qc.IsPresent())
+		require.True(t, bv.pushVote(ep0, vote(d)))
 
-	require.True(t, bv.header(header.Hash()).IsPresent())
-	require.Equal(t, 3, len(bv.byKey))
+		ep1 := types.NewEpoch(1, types.RoadRange{First: 10, Next: 20}, time.Time{},
+			utils.OrPanic1(ep0.Committee().DeriveNext(map[types.PublicKey]uint64{
+				a.Public(): 1, b.Public(): 1, c.Public(): 1,
+			}, 1)), 0)
+		bv.reweight(ep1)
+		qc, ok := bv.qc.Get()
+		require.True(t, ok)
+		require.Equal(t, h.Hash(), qc.Header().Hash())
+		require.Equal(t, 3, len(bv.byKey))
+		require.True(t, bv.header(h.Hash()).IsPresent())
+	})
 
-	ep1 := types.NewEpoch(1, types.RoadRange{First: 10, Next: 20}, time.Time{},
-		utils.OrPanic1(ep0.Committee().DeriveNext(map[types.PublicKey]uint64{
-			a.Public(): 1, b.Public(): 1, c.Public(): 1,
-		}, 1)), 0)
-	bv.reweight(ep1)
-
-	qc, ok = bv.qc.Get()
-	require.True(t, ok)
-	require.Equal(t, header.Hash(), qc.Header().Hash())
-	require.Equal(t, 3, len(bv.byKey))
-	require.True(t, bv.header(header.Hash()).IsPresent())
-}
-
-func TestBlockVotes_ZeroWeightNotCreditedUnderApplied(t *testing.T) {
-	rng := utils.TestRng()
-	stay := types.GenSecretKey(rng)
-	leaver := types.GenSecretKey(rng)
-	ep0 := types.NewEpoch(0, types.RoadRange{First: 0, Next: 10}, time.Time{},
-		utils.OrPanic1(types.NewCommittee(map[types.PublicKey]uint64{
-			stay.Public(): 1, leaver.Public(): 1,
+	t.Run("leaver not credited", func(t *testing.T) {
+		ep0 := mk(map[types.PublicKey]uint64{
+			a.Public(): 1, d.Public(): 1,
 			types.GenSecretKey(rng).Public(): 1, types.GenSecretKey(rng).Public(): 1,
-		})), 0)
-	lane := ep0.Committee().Lane(stay.Public()).OrPanic("lane")
-	header := types.NewBlock(lane, 0, types.BlockHeaderHash{}, &types.Payload{}).Header()
+		}, 0, 0, 10)
+		h := headerOn(ep0, a)
+		bv := newBlockVotes()
+		bv.pushVote(ep0, types.Sign(d, types.NewLaneVote(h)))
+		ep1 := types.NewEpoch(1, types.RoadRange{First: 10, Next: 20}, time.Time{},
+			utils.OrPanic1(ep0.Committee().DeriveNext(map[types.PublicKey]uint64{a.Public(): 1}, 1)), 0)
+		bv.reweight(ep1)
+		require.False(t, bv.qc.IsPresent())
+		require.Equal(t, 1, len(bv.byKey))
+	})
 
-	bv := newBlockVotes()
-	bv.pushVote(ep0, types.Sign(leaver, types.NewLaneVote(header)))
+	t.Run("weight cut drops QC", func(t *testing.T) {
+		ep0 := mk(map[types.PublicKey]uint64{a.Public(): 3, b.Public(): 1, c.Public(): 1, d.Public(): 1}, 0, 0, 10)
+		require.Equal(t, uint64(2), ep0.Committee().LaneQuorum())
+		h := headerOn(ep0, a)
+		bv := newBlockVotes()
+		require.True(t, bv.pushVote(ep0, types.Sign(a, types.NewLaneVote(h))))
+		require.True(t, bv.qc.IsPresent())
+		ep1 := types.NewEpoch(1, types.RoadRange{First: 10, Next: 20}, time.Time{},
+			utils.OrPanic1(ep0.Committee().DeriveNext(map[types.PublicKey]uint64{
+				a.Public(): 1, b.Public(): 1, c.Public(): 5, d.Public(): 5,
+			}, 1)), 0)
+		require.Equal(t, uint64(4), ep1.Committee().LaneQuorum())
+		bv.reweight(ep1)
+		require.False(t, bv.qc.IsPresent())
+		require.True(t, bv.header(h.Hash()).IsPresent())
+	})
 
-	ep1 := types.NewEpoch(1, types.RoadRange{First: 10, Next: 20}, time.Time{},
-		utils.OrPanic1(ep0.Committee().DeriveNext(map[types.PublicKey]uint64{
-			stay.Public(): 1,
-		}, 1)), 0)
-	bv.reweight(ep1)
-	require.False(t, bv.qc.IsPresent())
-	require.Equal(t, 1, len(bv.byKey))
-}
-
-// A alone reaches lane quorum; after a weight cut with the same membership, reweight drops the QC.
-func TestBlockVotes_ReweightInvalidatesLaneQC(t *testing.T) {
-	rng := utils.TestRng()
-	a := types.GenSecretKey(rng)
-	b := types.GenSecretKey(rng)
-	c := types.GenSecretKey(rng)
-	d := types.GenSecretKey(rng)
-
-	ep0 := types.NewEpoch(0, types.RoadRange{First: 0, Next: 10}, time.Time{},
-		utils.OrPanic1(types.NewCommittee(map[types.PublicKey]uint64{
-			a.Public(): 3, b.Public(): 1, c.Public(): 1, d.Public(): 1,
-		})), 0)
-	require.Equal(t, uint64(2), ep0.Committee().LaneQuorum())
-	lane := ep0.Committee().Lane(a.Public()).OrPanic("lane")
-	header := types.NewBlock(lane, 0, types.BlockHeaderHash{}, &types.Payload{}).Header()
-
-	bv := newBlockVotes()
-	require.True(t, bv.pushVote(ep0, types.Sign(a, types.NewLaneVote(header))))
-	require.True(t, bv.qc.IsPresent())
-
-	ep1 := types.NewEpoch(1, types.RoadRange{First: 10, Next: 20}, time.Time{},
-		utils.OrPanic1(ep0.Committee().DeriveNext(map[types.PublicKey]uint64{
-			a.Public(): 1, b.Public(): 1, c.Public(): 5, d.Public(): 5,
-		}, 1)), 0)
-	require.Equal(t, uint64(4), ep1.Committee().LaneQuorum())
-	bv.reweight(ep1)
-	require.False(t, bv.qc.IsPresent())
-	require.True(t, bv.header(header.Hash()).IsPresent())
-}
-
-// A+B are short of lane quorum; after a weight increase with the same membership, reweight forms a QC.
-func TestBlockVotes_ReweightFormsLaneQC(t *testing.T) {
-	rng := utils.TestRng()
-	a := types.GenSecretKey(rng)
-	b := types.GenSecretKey(rng)
-	c := types.GenSecretKey(rng)
-	d := types.GenSecretKey(rng)
-
-	ep0 := types.NewEpoch(0, types.RoadRange{First: 0, Next: 10}, time.Time{},
-		utils.OrPanic1(types.NewCommittee(map[types.PublicKey]uint64{
-			a.Public(): 1, b.Public(): 1, c.Public(): 5, d.Public(): 5,
-		})), 0)
-	require.Equal(t, uint64(4), ep0.Committee().LaneQuorum())
-	lane := ep0.Committee().Lane(a.Public()).OrPanic("lane")
-	header := types.NewBlock(lane, 0, types.BlockHeaderHash{}, &types.Payload{}).Header()
-	vote := func(sk types.SecretKey) *types.Signed[*types.LaneVote] {
-		return types.Sign(sk, types.NewLaneVote(header))
-	}
-
-	bv := newBlockVotes()
-	require.True(t, bv.pushVote(ep0, vote(a)))
-	require.True(t, bv.pushVote(ep0, vote(b)))
-	require.False(t, bv.qc.IsPresent())
-
-	ep1 := types.NewEpoch(1, types.RoadRange{First: 10, Next: 20}, time.Time{},
-		utils.OrPanic1(ep0.Committee().DeriveNext(map[types.PublicKey]uint64{
-			a.Public(): 5, b.Public(): 5, c.Public(): 1, d.Public(): 1,
-		}, 1)), 0)
-	require.Equal(t, uint64(4), ep1.Committee().LaneQuorum())
-	bv.reweight(ep1)
-	qc, ok := bv.qc.Get()
-	require.True(t, ok)
-	require.Equal(t, header.Hash(), qc.Header().Hash())
+	t.Run("weight bump forms QC", func(t *testing.T) {
+		ep0 := mk(map[types.PublicKey]uint64{a.Public(): 1, b.Public(): 1, c.Public(): 5, d.Public(): 5}, 0, 0, 10)
+		require.Equal(t, uint64(4), ep0.Committee().LaneQuorum())
+		h := headerOn(ep0, a)
+		vote := func(sk types.SecretKey) *types.Signed[*types.LaneVote] {
+			return types.Sign(sk, types.NewLaneVote(h))
+		}
+		bv := newBlockVotes()
+		require.True(t, bv.pushVote(ep0, vote(a)))
+		require.True(t, bv.pushVote(ep0, vote(b)))
+		require.False(t, bv.qc.IsPresent())
+		ep1 := types.NewEpoch(1, types.RoadRange{First: 10, Next: 20}, time.Time{},
+			utils.OrPanic1(ep0.Committee().DeriveNext(map[types.PublicKey]uint64{
+				a.Public(): 5, b.Public(): 5, c.Public(): 1, d.Public(): 1,
+			}, 1)), 0)
+		require.Equal(t, uint64(4), ep1.Committee().LaneQuorum())
+		bv.reweight(ep1)
+		qc, ok := bv.qc.Get()
+		require.True(t, ok)
+		require.Equal(t, h.Hash(), qc.Header().Hash())
+	})
 }

--- a/sei-tendermint/internal/autobahn/avail/block_votes_test.go
+++ b/sei-tendermint/internal/autobahn/avail/block_votes_test.go
@@ -1,0 +1,76 @@
+package avail
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sei-protocol/sei-chain/sei-tendermint/autobahn/types"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/require"
+)
+
+func TestBlockVotes_RecountStayFormsLaneQC(t *testing.T) {
+	rng := utils.TestRng()
+	a := types.GenSecretKey(rng)
+	b := types.GenSecretKey(rng)
+	c := types.GenSecretKey(rng)
+	d := types.GenSecretKey(rng)
+
+	ep0 := types.NewEpoch(0, types.RoadRange{First: 0, Next: 10}, time.Time{},
+		utils.OrPanic1(types.NewCommittee(map[types.PublicKey]uint64{
+			a.Public(): 1, b.Public(): 1, c.Public(): 1, d.Public(): 1,
+		})), 0)
+	lane := ep0.Committee().Lane(a.Public()).OrPanic("lane")
+	header := types.NewBlock(lane, 0, types.BlockHeaderHash{}, &types.Payload{}).Header()
+	vote := func(sk types.SecretKey) *types.Signed[*types.LaneVote] {
+		return types.Sign(sk, types.NewLaneVote(header))
+	}
+
+	bv := newBlockVotes()
+	require.True(t, bv.pushVote(ep0, vote(a)))
+	require.False(t, bv.qc.IsPresent())
+	require.True(t, bv.pushVote(ep0, vote(b)))
+	qc, ok := bv.qc.Get()
+	require.True(t, ok)
+	require.Equal(t, header.Hash(), qc.Header().Hash())
+	require.True(t, bv.pushVote(ep0, vote(d)))
+
+	require.True(t, bv.header(header.Hash()).IsPresent())
+	require.Equal(t, 3, len(bv.byKey))
+
+	ep1 := types.NewEpoch(1, types.RoadRange{First: 10, Next: 20}, time.Time{},
+		utils.OrPanic1(ep0.Committee().DeriveNext(map[types.PublicKey]uint64{
+			a.Public(): 1, b.Public(): 1, c.Public(): 1,
+		}, 1)), 0)
+	bv.reweight(ep1)
+
+	qc, ok = bv.qc.Get()
+	require.True(t, ok)
+	require.Equal(t, header.Hash(), qc.Header().Hash())
+	require.Equal(t, 3, len(bv.byKey))
+	require.True(t, bv.header(header.Hash()).IsPresent())
+}
+
+func TestBlockVotes_ZeroWeightNotCreditedUnderApplied(t *testing.T) {
+	rng := utils.TestRng()
+	stay := types.GenSecretKey(rng)
+	leaver := types.GenSecretKey(rng)
+	ep0 := types.NewEpoch(0, types.RoadRange{First: 0, Next: 10}, time.Time{},
+		utils.OrPanic1(types.NewCommittee(map[types.PublicKey]uint64{
+			stay.Public(): 1, leaver.Public(): 1,
+			types.GenSecretKey(rng).Public(): 1, types.GenSecretKey(rng).Public(): 1,
+		})), 0)
+	lane := ep0.Committee().Lane(stay.Public()).OrPanic("lane")
+	header := types.NewBlock(lane, 0, types.BlockHeaderHash{}, &types.Payload{}).Header()
+
+	bv := newBlockVotes()
+	bv.pushVote(ep0, types.Sign(leaver, types.NewLaneVote(header)))
+
+	ep1 := types.NewEpoch(1, types.RoadRange{First: 10, Next: 20}, time.Time{},
+		utils.OrPanic1(ep0.Committee().DeriveNext(map[types.PublicKey]uint64{
+			stay.Public(): 1,
+		}, 1)), 0)
+	bv.reweight(ep1)
+	require.False(t, bv.qc.IsPresent())
+	require.Equal(t, 1, len(bv.byKey))
+}

--- a/sei-tendermint/internal/autobahn/avail/inner.go
+++ b/sei-tendermint/internal/autobahn/avail/inner.go
@@ -268,8 +268,7 @@ func (i *inner) dropLanes(lanes []types.LaneID) int {
 	return n
 }
 
-// laneQC returns the LaneQC for (lane, n) under the applied epoch's vote
-// weighting (i.epoch), if one has formed.
+// laneQC returns the LaneQC for (lane, n) under i.epoch, if one has formed.
 func (i *inner) laneQC(lane types.LaneID, n types.BlockNumber) utils.Option[*types.LaneQC] {
 	votes, ok := i.votes[lane]
 	if !ok {

--- a/sei-tendermint/internal/autobahn/avail/inner.go
+++ b/sei-tendermint/internal/autobahn/avail/inner.go
@@ -13,7 +13,7 @@ import (
 // inner holds roads and per-LaneID block/vote maps.
 type inner struct {
 	persistedCommitQC utils.AtomicSend[utils.Option[*types.CommitQC]] // latest persisted CommitQC
-	consensusSpec     utils.AtomicSend[utils.Option[types.ConsensusSpec]]
+	consensusSpec     utils.AtomicSend[types.ConsensusSpec]
 	roads             *queue[types.RoadIndex, *road]
 
 	// epoch is the applied (next-CommitQC) epoch. installEpoch is the sole
@@ -52,9 +52,13 @@ type loadedState struct {
 
 func newInner(ds *data.State, loaded *loadedState) (*inner, error) {
 	start := ds.Registry().LatestEpoch()
+	genesis, ok := ds.Registry().EpochByIndex(0)
+	if !ok {
+		return nil, fmt.Errorf("genesis epoch 0 not registered")
+	}
 	i := &inner{
 		persistedCommitQC:  utils.NewAtomicSend(utils.None[*types.CommitQC]()),
-		consensusSpec:      utils.NewAtomicSend(utils.None[types.ConsensusSpec]()),
+		consensusSpec:      utils.NewAtomicSend(types.ConsensusSpec{CommitQC: utils.None[*types.CommitQC](), Epoch: genesis}),
 		roads:              newQueue[types.RoadIndex, *road](),
 		epoch:              utils.NewAtomicSend(start),
 		blocks:             map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]{},
@@ -134,12 +138,8 @@ func newInner(ds *data.State, loaded *loadedState) (*inner, error) {
 	}
 	// Restart catch-up: install every epoch the durable leashes already allow.
 	// The live path (runEpochAdvance) installs one waited-for epoch at a time.
-	for {
-		next, ok := i.nextInstallableEpoch(ds).Get()
-		if !ok {
-			break
-		}
-		i.installEpoch(next)
+	if err := i.installReadyEpochs(ds); err != nil {
+		return nil, err
 	}
 	i.refreshConsensusSpec()
 	return i, nil
@@ -170,18 +170,19 @@ func (i *inner) leashesMet() bool {
 	return ok && ae.EpochIndex() >= ep.EpochIndex()
 }
 
-// nextInstallableEpoch returns the next registry epoch when the applied epoch
-// is sealed, its prune leash is met, and the execution leash is met (next epoch
-// registered).
-func (i *inner) nextInstallableEpoch(ds *data.State) utils.Option[*types.Epoch] {
-	if !i.leashesMet() {
-		return utils.None[*types.Epoch]()
+// installReadyEpochs installs every epoch whose seal and prune leashes are
+// already met. A missing next registry epoch in that state is an invariant
+// violation (execution leash should already have registered it).
+func (i *inner) installReadyEpochs(ds *data.State) error {
+	for i.leashesMet() {
+		nextIdx := i.epoch.Load().EpochIndex() + 1
+		next, ok := ds.Registry().EpochByIndex(nextIdx)
+		if !ok {
+			return fmt.Errorf("epoch %d not registered with seal+prune leashes met", nextIdx)
+		}
+		i.installEpoch(next)
 	}
-	next, ok := ds.Registry().EpochByIndex(i.epoch.Load().EpochIndex() + 1)
-	if !ok {
-		return utils.None[*types.Epoch]()
-	}
-	return utils.Some(next)
+	return nil
 }
 
 // refreshConsensusSpec publishes ConsensusSpec for the durable tip, paired with
@@ -194,7 +195,8 @@ func (i *inner) nextInstallableEpoch(ds *data.State) utils.Option[*types.Epoch] 
 // not be handed a predecessor of the tip it holds: installing it would roll the
 // view backwards and discard that view's votes.
 func (i *inner) refreshConsensusSpec() {
-	cqc, ok := i.persistedCommitQC.Load().Get()
+	tip := i.persistedCommitQC.Load()
+	cqc, ok := tip.Get()
 	if !ok {
 		return
 	}
@@ -206,7 +208,7 @@ func (i *inner) refreshConsensusSpec() {
 	if !ok {
 		return
 	}
-	i.consensusSpec.Store(utils.Some(types.ConsensusSpec{CommitQC: cqc, Epoch: ep}))
+	i.consensusSpec.Store(types.ConsensusSpec{CommitQC: tip, Epoch: ep})
 }
 
 func (i *inner) epochForRoad(road types.RoadIndex) utils.Option[*types.Epoch] {

--- a/sei-tendermint/internal/autobahn/avail/inner.go
+++ b/sei-tendermint/internal/autobahn/avail/inner.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/autobahn/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/consensus/persist"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/data"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/epoch"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 )
 
@@ -139,6 +140,18 @@ func (i *inner) advanceEpoch(ep *types.Epoch) {
 	}
 	i.consensusSpec.Store(types.ConsensusSpec{CommitQC: i.persistedCommitQC.Load(), Epoch: ep})
 	i.reweightVotes()
+}
+
+// advanceTarget is the epoch to install next: the epoch of the road following
+// the durable tip, or applied+1 while that road is still inside the applied
+// epoch.
+func (i *inner) advanceTarget() types.EpochIndex {
+	next := i.applied().EpochIndex() + 1
+	tip, ok := i.persistedCommitQC.Load().Get()
+	if !ok {
+		return next
+	}
+	return max(next, epoch.IndexForRoad(tip.Index()+1))
 }
 
 // canAdvanceEpoch reports whether the applied epoch is sealed and its prune leash is

--- a/sei-tendermint/internal/autobahn/avail/inner.go
+++ b/sei-tendermint/internal/autobahn/avail/inner.go
@@ -30,7 +30,7 @@ type inner struct {
 	// RecvBatch only yields blocks below this cursor for voting.
 	// Always initialized (even when persistence is disabled — the no-op persist
 	// goroutine bumps it immediately). Not persisted to disk: on restart it is
-	// reconstructed from the blocks already on disk (see newInner).
+	// reconstructed from the blocks already on disk (see restoreInner).
 	//
 	// TODO: consider giving this its own AtomicSend to avoid waking unrelated
 	// inner waiters (PushVote, PushCommitQC, etc.) on setNextBlockToPersist calls.
@@ -43,7 +43,7 @@ type inner struct {
 
 // loadedState holds data loaded from disk on restart.
 // commitQCs are sorted by road index; blocks are sorted by number per lane.
-// newInner requires both to be contiguous and returns an error on gaps. That
+// restoreInner requires both to be contiguous and returns an error on gaps. That
 // requirement is what makes persist.contiguousSuffix safe: it silently drops
 // everything before the last hole it finds, so this is the only thing that
 // distinguishes a lazily pruned record from genuinely lost data.
@@ -52,74 +52,42 @@ type loadedState struct {
 	blocks    map[types.LaneID][]persist.LoadedBlock
 }
 
-func newInner(ds *data.State, loaded *loadedState) (*inner, error) {
-	genesis, err := ds.Registry().EpochByIndex(0)
-	if err != nil {
-		return nil, fmt.Errorf("genesis epoch 0: %w", err)
-	}
+func newInner(ep *types.Epoch, first types.RoadIndex) *inner {
+	roads := newQueue[types.RoadIndex, *road]()
+	roads.first = first
+	roads.next = first
 	i := &inner{
 		persistedCommitQC:  utils.NewAtomicSend(utils.None[*types.CommitQC]()),
-		consensusSpec:      utils.NewAtomicSend(types.ConsensusSpec{CommitQC: utils.None[*types.CommitQC](), Epoch: genesis}),
-		roads:              newQueue[types.RoadIndex, *road](),
+		consensusSpec:      utils.NewAtomicSend(types.ConsensusSpec{CommitQC: utils.None[*types.CommitQC](), Epoch: ep}),
+		roads:              roads,
 		blocks:             map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]{},
 		votes:              map[types.LaneID]*queue[types.BlockNumber, *blockVotes]{},
 		nextBlockToPersist: map[types.LaneID]types.BlockNumber{},
 	}
-	for lane := range genesis.Committee().Lanes().All() {
+	for lane := range ep.Committee().Lanes().All() {
 		i.addLane(lane)
 	}
-	for lane := range loaded.blocks {
-		i.addLane(lane)
-	}
+	return i
+}
 
-	// Apply the persisted prune anchor from the data.State.
-	if anchor, ok := ds.Anchor().Load().Get(); ok {
-		i.prune(anchor)
-	}
-
-	// Restore persisted CommitQCs. prune() may have already pushed the
-	// anchor's CommitQC, so skip entries below commitQCs.next.
-	for _, qc := range loaded.commitQCs {
-		if qc.Index() < i.roads.next {
-			continue
-		}
-		if qc.Index() != i.roads.next {
-			return nil, fmt.Errorf("non-contiguous persisted commitQCs: expected %d, got %d", i.roads.next, qc.Index())
-		}
-		ep, err := ds.Registry().EpochByIndex(qc.Proposal().EpochIndex())
-		if err != nil {
-			return nil, fmt.Errorf("persisted commitQC %d epoch: %w", qc.Index(), err)
-		}
-		if err := qc.Verify(ep); err != nil {
-			return nil, fmt.Errorf("persisted commitQC %d verify: %w", qc.Index(), err)
-		}
-		i.roads.pushBack(newRoad(qc, ep))
-	}
-	if i.roads.Len() > 0 {
-		last := i.roads.q[i.roads.next-1]
-		i.persistedCommitQC.Store(utils.Some(last.commitQC))
-		i.seedApplied(last.epoch)
-	} else if ae, ok := i.anchorEpoch.Get(); ok {
-		i.seedApplied(ae)
-	}
-
-	// Restore persisted blocks. Since the anchor is persisted first and
-	// blocks are written sequentially per lane, gaps, parent-hash
-	// mismatches, and over-capacity indicate corruption or a bug.
-	for lane, bs := range loaded.blocks {
+// restoreBlocks loads WAL proposals into lane queues. The anchor is persisted
+// first and blocks are written sequentially per lane, so gaps, parent-hash
+// mismatches, and over-capacity indicate corruption or a bug.
+func (i *inner) restoreBlocks(blocks map[types.LaneID][]persist.LoadedBlock) error {
+	for lane, bs := range blocks {
 		q, ok := i.blocks[lane]
 		if !ok || len(bs) == 0 {
 			continue
 		}
 		for _, b := range bs {
 			if q.Len() >= BlocksPerLane {
-				return nil, fmt.Errorf("lane %s: loaded %d blocks exceeds capacity %d", lane, len(bs), BlocksPerLane)
+				return fmt.Errorf("lane %s: loaded %d blocks exceeds capacity %d", lane, len(bs), BlocksPerLane)
 			}
 			if b.Number < q.next {
 				continue
 			}
 			if b.Number != q.next {
-				return nil, fmt.Errorf("lane %s: non-contiguous persisted blocks: expected %d, got %d", lane, q.next, b.Number)
+				return fmt.Errorf("lane %s: non-contiguous persisted blocks: expected %d, got %d", lane, q.next, b.Number)
 			}
 			// We check the parent hash only for the blocks above the anchor, because:
 			// * node can cast LaneVote for the block of the lane without checking the parent hash,
@@ -128,20 +96,14 @@ func newInner(ds *data.State, loaded *loadedState) (*inner, error) {
 			if q.Len() > 0 {
 				ph := b.Proposal.Msg().Block().Header().ParentHash()
 				if q.q[q.next-1].Msg().Block().Header().Hash() != ph {
-					return nil, fmt.Errorf("lane %s: parent hash mismatch at block %d", lane, b.Number)
+					return fmt.Errorf("lane %s: parent hash mismatch at block %d", lane, b.Number)
 				}
 			}
 			q.pushBack(b.Proposal)
 		}
 		i.nextBlockToPersist[lane] = q.next
 	}
-	// seedApplied jumped to the last restored QC's epoch (or the Anchor).
-	// One more step covers a LastRoad tip whose next epoch is already registered.
-	if err := i.tryAdvanceEpoch(ds); err != nil {
-		return nil, err
-	}
-	i.refreshConsensusSpec()
-	return i, nil
+	return nil
 }
 
 func (i *inner) applied() *types.Epoch {
@@ -167,16 +129,6 @@ func (i *inner) epochForVote(vote *types.Signed[*types.LaneVote]) utils.Option[*
 		return utils.None[*types.Epoch]()
 	}
 	return utils.Some(ae)
-}
-
-// seedApplied sets applied to ep and opens its lanes. Construction only;
-// live advances go through advanceEpoch.
-func (i *inner) seedApplied(ep *types.Epoch) {
-	for lane := range ep.Committee().Lanes().All() {
-		i.addLane(lane)
-	}
-	spec := i.consensusSpec.Load()
-	i.consensusSpec.Store(types.ConsensusSpec{CommitQC: spec.CommitQC, Epoch: ep})
 }
 
 // advanceEpoch makes ep the applied epoch: opens its lanes, reweights votes,
@@ -206,22 +158,6 @@ func (i *inner) canAdvanceEpoch() bool {
 	}
 	ae, ok := i.anchorEpoch.Get()
 	return ok && ae.EpochIndex() >= ep.EpochIndex()
-}
-
-// tryAdvanceEpoch advances applied by one epoch when the seal and prune
-// leashes are already met. A missing next registry epoch in that state is an
-// invariant violation (execution leash should already have registered it).
-func (i *inner) tryAdvanceEpoch(ds *data.State) error {
-	if !i.canAdvanceEpoch() {
-		return nil
-	}
-	nextIdx := i.applied().EpochIndex() + 1
-	next, err := ds.Registry().EpochByIndex(nextIdx)
-	if err != nil {
-		return fmt.Errorf("epoch %d with seal+prune leashes met: %w", nextIdx, err)
-	}
-	i.advanceEpoch(next)
-	return nil
 }
 
 // refreshConsensusSpec publishes the durable tip when the following RoadIndex
@@ -289,25 +225,24 @@ func (i *inner) reweightVotes() {
 }
 
 // prune advances the state up to the data Anchor and drops lanes closed as of
-// anchor.Epoch. It updates anchorEpoch only — applied is advanced by
-// runEpochAdvance. Returns the number of lanes dropped.
+// anchor.Epoch. It updates anchorEpoch and refreshes ConsensusSpec's tip.
+// Construction sets Epoch via newInner; live rotation uses runEpochAdvance.
+// Returns the number of lanes dropped.
 func (i *inner) prune(anchor data.Anchor) int {
 	anchorEpoch := anchor.Epoch
 	idx := anchor.CommitQC.Index()
-	if idx >= i.roads.first {
-		i.roads.prune(idx + 1)
-		for lane, vq := range i.votes {
-			lr := anchor.CommitQC.LaneRange(lane)
-			bq := i.blocks[lane]
-			vq.prune(lr.Next())
-			bq.prune(lr.Next())
-			if i.nextBlockToPersist[lane] < lr.Next() {
-				i.nextBlockToPersist[lane] = lr.Next()
-			}
+	i.roads.prune(idx + 1)
+	for lane, vq := range i.votes {
+		lr := anchor.CommitQC.LaneRange(lane)
+		bq := i.blocks[lane]
+		vq.prune(lr.Next())
+		bq.prune(lr.Next())
+		if i.nextBlockToPersist[lane] < lr.Next() {
+			i.nextBlockToPersist[lane] = lr.Next()
 		}
-		if i.roads.Len() == 0 {
-			i.persistedCommitQC.Store(utils.Some(anchor.CommitQC))
-		}
+	}
+	if i.roads.Len() == 0 {
+		i.persistedCommitQC.Store(utils.Some(anchor.CommitQC))
 	}
 	i.anchorEpoch = utils.Some(anchorEpoch)
 	var closed []types.LaneID
@@ -316,5 +251,7 @@ func (i *inner) prune(anchor data.Anchor) int {
 			closed = append(closed, lane)
 		}
 	}
-	return i.dropLanes(closed)
+	n := i.dropLanes(closed)
+	i.refreshConsensusSpec()
+	return n
 }

--- a/sei-tendermint/internal/autobahn/avail/inner.go
+++ b/sei-tendermint/internal/autobahn/avail/inner.go
@@ -57,21 +57,20 @@ type loadedState struct {
 }
 
 func newInner(ds *data.State, loaded *loadedState) (*inner, error) {
-	start := ds.Registry().LatestEpoch()
-	genesis, ok := ds.Registry().EpochByIndex(0)
-	if !ok {
-		return nil, fmt.Errorf("genesis epoch 0 not registered")
+	genesis, err := ds.Registry().EpochByIndex(0)
+	if err != nil {
+		return nil, fmt.Errorf("genesis epoch 0: %w", err)
 	}
 	i := &inner{
 		persistedCommitQC:  utils.NewAtomicSend(utils.None[*types.CommitQC]()),
 		consensusSpec:      utils.NewAtomicSend(types.ConsensusSpec{CommitQC: utils.None[*types.CommitQC](), Epoch: genesis}),
 		roads:              newQueue[types.RoadIndex, *road](),
-		epoch:              utils.NewAtomicSend(start),
+		epoch:              utils.NewAtomicSend(genesis),
 		blocks:             map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]{},
 		votes:              map[types.LaneID]*queue[types.BlockNumber, *blockVotes]{},
 		nextBlockToPersist: map[types.LaneID]types.BlockNumber{},
 	}
-	for lane := range start.Committee().Lanes().All() {
+	for lane := range genesis.Committee().Lanes().All() {
 		i.addLane(lane)
 	}
 	for lane := range loaded.blocks {
@@ -92,22 +91,21 @@ func newInner(ds *data.State, loaded *loadedState) (*inner, error) {
 		if qc.Index() != i.roads.next {
 			return nil, fmt.Errorf("non-contiguous persisted commitQCs: expected %d, got %d", i.roads.next, qc.Index())
 		}
-		epoch, ok := ds.Registry().EpochByIndex(qc.Proposal().EpochIndex())
-		if !ok {
-			return nil, fmt.Errorf("epoch not found")
+		ep, err := ds.Registry().EpochByIndex(qc.Proposal().EpochIndex())
+		if err != nil {
+			return nil, fmt.Errorf("persisted commitQC %d epoch: %w", qc.Index(), err)
 		}
-		if err := qc.Verify(epoch); err != nil {
+		if err := qc.Verify(ep); err != nil {
 			return nil, fmt.Errorf("persisted commitQC %d verify: %w", qc.Index(), err)
 		}
-		i.roads.pushBack(newRoad(qc, epoch))
+		i.roads.pushBack(newRoad(qc, ep))
 	}
 	if i.roads.Len() > 0 {
 		last := i.roads.q[i.roads.next-1]
 		i.persistedCommitQC.Store(utils.Some(last.commitQC))
-		// Floor applied at the durable tip's epoch. Bare Store on
-		// purpose: this is a rewind from LatestEpoch, not an advanceEpoch.
-		// The advance loop below re-drives it from the durable leashes.
-		i.epoch.Store(last.epoch)
+		i.seedApplied(last.epoch)
+	} else if ae, ok := i.anchorEpoch.Get(); ok {
+		i.seedApplied(ae)
 	}
 
 	// Restore persisted blocks. Since the anchor is persisted first and
@@ -151,6 +149,15 @@ func newInner(ds *data.State, loaded *loadedState) (*inner, error) {
 	return i, nil
 }
 
+// seedApplied sets applied to ep and opens its lanes. Construction only;
+// live advances go through advanceEpoch.
+func (i *inner) seedApplied(ep *types.Epoch) {
+	for lane := range ep.Committee().Lanes().All() {
+		i.addLane(lane)
+	}
+	i.epoch.Store(ep)
+}
+
 // advanceEpoch makes ep the applied epoch: opens its lanes, reweights votes,
 // and republishes ConsensusSpec.
 func (i *inner) advanceEpoch(ep *types.Epoch) {
@@ -185,9 +192,9 @@ func (i *inner) canAdvanceEpoch() bool {
 func (i *inner) advanceReadyEpochs(ds *data.State) error {
 	for i.canAdvanceEpoch() {
 		nextIdx := i.epoch.Load().EpochIndex() + 1
-		next, ok := ds.Registry().EpochByIndex(nextIdx)
-		if !ok {
-			return fmt.Errorf("epoch %d not registered with seal+prune leashes met", nextIdx)
+		next, err := ds.Registry().EpochByIndex(nextIdx)
+		if err != nil {
+			return fmt.Errorf("epoch %d with seal+prune leashes met: %w", nextIdx, err)
 		}
 		i.advanceEpoch(next)
 	}

--- a/sei-tendermint/internal/autobahn/avail/inner.go
+++ b/sei-tendermint/internal/autobahn/avail/inner.go
@@ -13,16 +13,17 @@ import (
 // inner holds roads and per-LaneID block/vote maps.
 type inner struct {
 	persistedCommitQC utils.AtomicSend[utils.Option[*types.CommitQC]] // latest persisted CommitQC
+	consensusSpec     utils.AtomicSend[utils.Option[types.ConsensusSpec]]
 	roads             *queue[types.RoadIndex, *road]
 
-	// epoch is the applied (next-CommitQC) epoch. ApplyEpoch is the sole
+	// epoch is the applied (next-CommitQC) epoch. installEpoch is the sole
 	// writer after construction.
 	epoch utils.AtomicSend[*types.Epoch]
-	// anchorEpoch is the epoch of data's Anchor CommitQC. Before any Anchor
-	// exists it equals the applied epoch.
-	anchorEpoch *types.Epoch
+	// anchorEpoch is the epoch of data's Anchor CommitQC when one exists.
+	// None until the first Anchor arrives (construction prune or runEvict).
+	anchorEpoch utils.Option[*types.Epoch]
 	blocks      map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]
-	votes       map[types.LaneID]*queue[types.BlockNumber, blockVotes]
+	votes       map[types.LaneID]*queue[types.BlockNumber, *blockVotes]
 	// nextBlockToPersist tracks per-lane how far block persistence has progressed.
 	// RecvBatch only yields blocks below this cursor for voting.
 	// Always initialized (even when persistence is disabled — the no-op persist
@@ -44,7 +45,6 @@ type inner struct {
 // requirement is what makes persist.contiguousSuffix safe: it silently drops
 // everything before the last hole it finds, so this is the only thing that
 // distinguishes a lazily pruned record from genuinely lost data.
-// newInner requires both to be contiguous and returns an error on gaps.
 type loadedState struct {
 	commitQCs []*types.CommitQC
 	blocks    map[types.LaneID][]persist.LoadedBlock
@@ -54,11 +54,11 @@ func newInner(ds *data.State, loaded *loadedState) (*inner, error) {
 	start := ds.Registry().LatestEpoch()
 	i := &inner{
 		persistedCommitQC:  utils.NewAtomicSend(utils.None[*types.CommitQC]()),
+		consensusSpec:      utils.NewAtomicSend(utils.None[types.ConsensusSpec]()),
 		roads:              newQueue[types.RoadIndex, *road](),
 		epoch:              utils.NewAtomicSend(start),
-		anchorEpoch:        start,
 		blocks:             map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]{},
-		votes:              map[types.LaneID]*queue[types.BlockNumber, blockVotes]{},
+		votes:              map[types.LaneID]*queue[types.BlockNumber, *blockVotes]{},
 		nextBlockToPersist: map[types.LaneID]types.BlockNumber{},
 	}
 	for lane := range start.Committee().Lanes().All() {
@@ -70,11 +70,7 @@ func newInner(ds *data.State, loaded *loadedState) (*inner, error) {
 
 	// Apply the persisted prune anchor from the data.State.
 	if anchor, ok := ds.Anchor().Load().Get(); ok {
-		ep, err := anchorEpochOf(ds.Registry(), anchor)
-		if err != nil {
-			return nil, err
-		}
-		i.prune(anchor, ep)
+		i.prune(anchor)
 	}
 
 	// Restore persisted CommitQCs. prune() may have already pushed the
@@ -90,10 +86,18 @@ func newInner(ds *data.State, loaded *loadedState) (*inner, error) {
 		if !ok {
 			return nil, fmt.Errorf("epoch not found")
 		}
+		if err := qc.Verify(epoch); err != nil {
+			return nil, fmt.Errorf("persisted commitQC %d verify: %w", qc.Index(), err)
+		}
 		i.roads.pushBack(newRoad(qc, epoch))
 	}
 	if i.roads.Len() > 0 {
-		i.persistedCommitQC.Store(utils.Some(i.roads.q[i.roads.next-1].commitQC))
+		last := i.roads.q[i.roads.next-1]
+		i.persistedCommitQC.Store(utils.Some(last.commitQC))
+		// Floor applied at the durable tip's verify-epoch. Bare Store on
+		// purpose: this is a rewind from LatestEpoch, not an install.
+		// The install loop below re-drives it from the durable leashes.
+		i.epoch.Store(last.epoch)
 	}
 
 	// Restore persisted blocks. Since the anchor is persisted first and
@@ -128,38 +132,108 @@ func newInner(ds *data.State, loaded *loadedState) (*inner, error) {
 		}
 		i.nextBlockToPersist[lane] = q.next
 	}
+	// Restart catch-up: install every epoch the durable leashes already allow.
+	// The live path (runEpochAdvance) installs one waited-for epoch at a time.
+	for {
+		next, ok := i.nextInstallableEpoch(ds).Get()
+		if !ok {
+			break
+		}
+		i.installEpoch(next)
+	}
+	i.refreshConsensusSpec()
 	return i, nil
 }
 
-// laneQC returns a LaneQC for (lane, n) if weight under the applied epoch's
-// committee meets LaneQuorum. Does not reweight votes when the committee changes.
-func (i *inner) laneQC(lane types.LaneID, n types.BlockNumber) (*types.LaneQC, bool) {
-	c := i.epoch.Load().Committee()
-	votes, ok := i.votes[lane]
-	if !ok {
-		return nil, false
+// installEpoch makes ep the applied epoch: opens its lanes, reweights votes,
+// and republishes ConsensusSpec.
+func (i *inner) installEpoch(ep *types.Epoch) {
+	for lane := range ep.Committee().Lanes().All() {
+		i.addLane(lane)
 	}
-	entry, ok := votes.q[n]
-	if !ok {
-		return nil, false
-	}
-	for _, byHash := range entry.byHash {
-		if byHash.weight >= c.LaneQuorum() {
-			return types.NewLaneQC(byHash.votes[:]), true
-		}
-	}
-	return nil, false
+	i.reweightVotes(ep)
+	i.epoch.Store(ep)
+	i.refreshConsensusSpec()
 }
 
-// addLane ensures empty block/vote queues and a zero persist cursor for lane.
-// No-op if the lane is already present.
-func (i *inner) addLane(lane types.LaneID) {
-	if _, ok := i.blocks[lane]; ok {
+// leashesMet reports whether the applied epoch is sealed and its prune leash is
+// met. Sealed means roads hold the epoch's last CommitQC. The prune leash is met
+// when the Anchor epoch covers the applied epoch (an AppQC for that epoch
+// exists). The execution leash — registry contains the next epoch — is checked
+// separately so live waiters are not parked on avail's lock for a registry update.
+func (i *inner) leashesMet() bool {
+	ep := i.epoch.Load()
+	if i.roads.next < ep.RoadRange().Next {
+		return false
+	}
+	ae, ok := i.anchorEpoch.Get()
+	return ok && ae.EpochIndex() >= ep.EpochIndex()
+}
+
+// nextInstallableEpoch returns the next registry epoch when the applied epoch
+// is sealed, its prune leash is met, and the execution leash is met (next epoch
+// registered).
+func (i *inner) nextInstallableEpoch(ds *data.State) utils.Option[*types.Epoch] {
+	if !i.leashesMet() {
+		return utils.None[*types.Epoch]()
+	}
+	next, ok := ds.Registry().EpochByIndex(i.epoch.Load().EpochIndex() + 1)
+	if !ok {
+		return utils.None[*types.Epoch]()
+	}
+	return utils.Some(next)
+}
+
+// refreshConsensusSpec publishes ConsensusSpec for the durable tip, paired with
+// the epoch of the view that follows it. The spec is withheld — the previously
+// published one stands — until that epoch is applied and resolvable.
+//
+// Withholding rather than publishing an earlier tip is what keeps the spec
+// monotonic. At an epoch boundary the durable tip sits on LastRoad(E) while
+// applied is still E, and a node that already entered E+1 before a restart must
+// not be handed a predecessor of the tip it holds: installing it would roll the
+// view backwards and discard that view's votes.
+func (i *inner) refreshConsensusSpec() {
+	cqc, ok := i.persistedCommitQC.Load().Get()
+	if !ok {
 		return
 	}
+	next := cqc.Index() + 1
+	if epoch.IndexForRoad(next) > i.epoch.Load().EpochIndex() {
+		return
+	}
+	ep, ok := i.epochForRoad(next).Get()
+	if !ok {
+		return
+	}
+	i.consensusSpec.Store(utils.Some(types.ConsensusSpec{CommitQC: cqc, Epoch: ep}))
+}
+
+func (i *inner) epochForRoad(road types.RoadIndex) utils.Option[*types.Epoch] {
+	if ep := i.epoch.Load(); ep.RoadRange().Has(road) {
+		return utils.Some(ep)
+	}
+	if road >= i.roads.first && road < i.roads.next {
+		return utils.Some(i.roads.q[road].epoch)
+	}
+	// Persist may lag installEpoch: tip's next view can sit in an earlier epoch
+	// still present on some admitted road.
+	for idx := i.roads.first; idx < i.roads.next; idx++ {
+		if ep := i.roads.q[idx].epoch; ep.RoadRange().Has(road) {
+			return utils.Some(ep)
+		}
+	}
+	return utils.None[*types.Epoch]()
+}
+
+func (i *inner) addLane(lane types.LaneID) bool {
+	if _, ok := i.blocks[lane]; ok {
+		return false
+	}
 	i.blocks[lane] = newQueue[types.BlockNumber, *types.Signed[*types.LaneProposal]]()
-	i.votes[lane] = newQueue[types.BlockNumber, blockVotes]()
+	i.votes[lane] = newQueue[types.BlockNumber, *blockVotes]()
 	i.nextBlockToPersist[lane] = 0
+	return true
 }
 
 func (i *inner) dropLanes(lanes []types.LaneID) int {
@@ -176,19 +250,30 @@ func (i *inner) dropLanes(lanes []types.LaneID) int {
 	return n
 }
 
-// anchorEpochOf returns the epoch of anchor's CommitQC from the registry.
-func anchorEpochOf(registry *epoch.Registry, anchor data.Anchor) (*types.Epoch, error) {
-	ei := anchor.CommitQC.Proposal().EpochIndex()
-	ep, ok := registry.EpochByIndex(ei)
+func (i *inner) laneQC(lane types.LaneID, n types.BlockNumber) utils.Option[*types.LaneQC] {
+	votes, ok := i.votes[lane]
 	if !ok {
-		return nil, fmt.Errorf("unknown epoch_index %d for anchor", ei)
+		return utils.None[*types.LaneQC]()
 	}
-	return ep, nil
+	entry, ok := votes.q[n]
+	if !ok {
+		return utils.None[*types.LaneQC]()
+	}
+	return entry.qc
+}
+
+func (i *inner) reweightVotes(ep *types.Epoch) {
+	for _, vq := range i.votes {
+		for n := vq.first; n < vq.next; n++ {
+			vq.q[n].reweight(ep)
+		}
+	}
 }
 
 // prune advances the state up to the data Anchor and drops lanes closed as of
-// anchorEpoch. Returns the number of lanes dropped.
-func (i *inner) prune(anchor data.Anchor, anchorEpoch *types.Epoch) int {
+// anchor.Epoch. Returns the number of lanes dropped.
+func (i *inner) prune(anchor data.Anchor) int {
+	anchorEpoch := anchor.Epoch
 	idx := anchor.CommitQC.Index()
 	if idx >= i.roads.first {
 		i.roads.prune(idx + 1)
@@ -205,7 +290,7 @@ func (i *inner) prune(anchor data.Anchor, anchorEpoch *types.Epoch) int {
 			i.persistedCommitQC.Store(utils.Some(anchor.CommitQC))
 		}
 	}
-	i.anchorEpoch = anchorEpoch
+	i.anchorEpoch = utils.Some(anchorEpoch)
 	var closed []types.LaneID
 	for lane := range i.blocks {
 		if anchorEpoch.IsClosed(lane) {

--- a/sei-tendermint/internal/autobahn/avail/inner.go
+++ b/sei-tendermint/internal/autobahn/avail/inner.go
@@ -12,10 +12,10 @@ import (
 // inner holds roads and per-LaneID block/vote maps.
 type inner struct {
 	persistedCommitQC utils.AtomicSend[utils.Option[*types.CommitQC]] // latest persisted CommitQC
-	// consensusSpec.Epoch is the applied (next-CommitQC) epoch. advanceEpoch is
-	// the sole writer after construction. blockVotes are weighted under this
-	// epoch at all times. CommitQC may lag that epoch while withheld at LastRoad
-	// (durable tip is persistedCommitQC).
+	// consensusSpec is the applied (next-CommitQC) epoch paired with a persisted
+	// CommitQC tip (None before the first tip). CommitQC never exceeds
+	// persistedCommitQC. advanceEpoch is the sole writer of Epoch after
+	// construction. blockVotes are always weighted under this Epoch.
 	consensusSpec utils.AtomicSend[types.ConsensusSpec]
 	roads         *queue[types.RoadIndex, *road]
 
@@ -137,9 +137,9 @@ func newInner(ds *data.State, loaded *loadedState) (*inner, error) {
 		}
 		i.nextBlockToPersist[lane] = q.next
 	}
-	// Restart catch-up: advance every epoch the durable leashes already allow.
-	// The live path (runEpochAdvance) advances one waited-for epoch at a time.
-	if err := i.advanceReadyEpochs(ds); err != nil {
+	// seedApplied jumped to the last restored QC's epoch (or the Anchor).
+	// One more step covers a LastRoad tip whose next epoch is already registered.
+	if err := i.tryAdvanceEpoch(ds); err != nil {
 		return nil, err
 	}
 	i.refreshConsensusSpec()
@@ -189,18 +189,19 @@ func (i *inner) canAdvanceEpoch() bool {
 	return ok && ae.EpochIndex() >= ep.EpochIndex()
 }
 
-// advanceReadyEpochs advances to every epoch whose seal and prune leashes are
-// already met. A missing next registry epoch in that state is an invariant
-// violation (execution leash should already have registered it).
-func (i *inner) advanceReadyEpochs(ds *data.State) error {
-	for i.canAdvanceEpoch() {
-		nextIdx := i.applied().EpochIndex() + 1
-		next, err := ds.Registry().EpochByIndex(nextIdx)
-		if err != nil {
-			return fmt.Errorf("epoch %d with seal+prune leashes met: %w", nextIdx, err)
-		}
-		i.advanceEpoch(next)
+// tryAdvanceEpoch advances applied by one epoch when the seal and prune
+// leashes are already met. A missing next registry epoch in that state is an
+// invariant violation (execution leash should already have registered it).
+func (i *inner) tryAdvanceEpoch(ds *data.State) error {
+	if !i.canAdvanceEpoch() {
+		return nil
 	}
+	nextIdx := i.applied().EpochIndex() + 1
+	next, err := ds.Registry().EpochByIndex(nextIdx)
+	if err != nil {
+		return fmt.Errorf("epoch %d with seal+prune leashes met: %w", nextIdx, err)
+	}
+	i.advanceEpoch(next)
 	return nil
 }
 
@@ -269,8 +270,8 @@ func (i *inner) reweightVotes() {
 }
 
 // prune advances the state up to the data Anchor and drops lanes closed as of
-// anchor.Epoch. It updates anchorEpoch only — applied epoch catch-up is left to
-// advanceReadyEpochs / runEpochAdvance. Returns the number of lanes dropped.
+// anchor.Epoch. It updates anchorEpoch only — applied is advanced by
+// runEpochAdvance. Returns the number of lanes dropped.
 func (i *inner) prune(anchor data.Anchor) int {
 	anchorEpoch := anchor.Epoch
 	idx := anchor.CommitQC.Index()

--- a/sei-tendermint/internal/autobahn/avail/inner.go
+++ b/sei-tendermint/internal/autobahn/avail/inner.go
@@ -14,16 +14,15 @@ type inner struct {
 	persistedCommitQC utils.AtomicSend[utils.Option[*types.CommitQC]] // latest persisted CommitQC
 	// consensusSpec is the applied (next-CommitQC) epoch paired with a persisted
 	// CommitQC tip (None before the first tip). CommitQC never exceeds
-	// persistedCommitQC. advanceEpoch installs Epoch; runEpochAdvance is the live
-	// writer, and prune jumps applied when the Anchor has skipped ahead.
-	// blockVotes are always weighted under this Epoch.
+	// persistedCommitQC. advanceEpoch installs Epoch; construction and
+	// runEpochAdvance are the writers. blockVotes are always weighted under this Epoch.
 	consensusSpec utils.AtomicSend[types.ConsensusSpec]
 	roads         *queue[types.RoadIndex, *road]
 
 	// anchorEpoch is the epoch of data's Anchor CommitQC when one exists.
 	// None until the first Anchor arrives (construction prune or runEvict).
 	// When it lags applied, epochForVote falls back to this committee for
-	// departing-lane voters. When it leads, prune jumps applied to it.
+	// departing-lane voters.
 	anchorEpoch utils.Option[*types.Epoch]
 	blocks      map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]
 	votes       map[types.LaneID]*queue[types.BlockNumber, *blockVotes]
@@ -143,11 +142,9 @@ func (i *inner) advanceEpoch(ep *types.Epoch) {
 }
 
 // canAdvanceEpoch reports whether the applied epoch is sealed and its prune leash is
-// met. Sealed means roads and persistedCommitQC hold the epoch's last CommitQC.
-// Waiting on persist keeps applied in lockstep with consensusSpec.Epoch.
-// The prune leash is met when the Anchor epoch covers the applied epoch.
-// The execution leash — registry contains the next epoch — is checked
-// separately so live waiters are not parked on avail's lock for a registry update.
+// met for a one-step advance to applied+1. Sealed means roads and persistedCommitQC
+// hold the epoch's last CommitQC. The prune leash is met when the Anchor epoch
+// covers the applied epoch. The execution leash is checked separately.
 func (i *inner) canAdvanceEpoch() bool {
 	ep := i.applied()
 	if i.roads.next < ep.RoadRange().Next {
@@ -227,8 +224,7 @@ func (i *inner) reweightVotes() {
 
 // prune advances the state up to the data Anchor and drops lanes closed as of
 // anchor.Epoch. It updates anchorEpoch and refreshes ConsensusSpec's tip.
-// Construction sets Epoch via newInner; live rotation uses runEpochAdvance;
-// catch-up (Anchor skipped ahead of applied) jumps here.
+// Applied epoch changes belong to construction and runEpochAdvance.
 // Returns the number of lanes dropped.
 func (i *inner) prune(anchor data.Anchor) int {
 	anchorEpoch := anchor.Epoch
@@ -254,9 +250,6 @@ func (i *inner) prune(anchor data.Anchor) int {
 		}
 	}
 	n := i.dropLanes(closed)
-	if i.applied().EpochIndex() < anchorEpoch.EpochIndex() {
-		i.advanceEpoch(anchorEpoch)
-	}
 	i.refreshConsensusSpec()
 	return n
 }

--- a/sei-tendermint/internal/autobahn/avail/inner.go
+++ b/sei-tendermint/internal/autobahn/avail/inner.go
@@ -16,7 +16,7 @@ type inner struct {
 	consensusSpec     utils.AtomicSend[types.ConsensusSpec]
 	roads             *queue[types.RoadIndex, *road]
 
-	// epoch is the applied (next-CommitQC) epoch. installEpoch is the sole
+	// epoch is the applied (next-CommitQC) epoch. advanceEpoch is the sole
 	// writer after construction. Distinct from consensusSpec.Epoch, which is the
 	// epoch of the RoadIndex after the publishable tip and may lag while withheld.
 	// blockVotes are always weighted under this epoch.
@@ -24,9 +24,9 @@ type inner struct {
 	// anchorEpoch is the epoch of data's Anchor CommitQC when one exists.
 	// None until the first Anchor arrives (construction prune or runEvict).
 	// It may exceed the applied epoch while runEpochAdvance is parked on
-	// WaitForEpoch, or briefly between prune and the next install: admission
+	// WaitForEpoch, or briefly between prune and the next advance: admission
 	// falls back to the Anchor committee via epochForVote / epochForLane.
-	// prune never advances i.epoch — only installEpoch does.
+	// prune never advances i.epoch — only advanceEpoch does.
 	anchorEpoch utils.Option[*types.Epoch]
 	blocks      map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]
 	votes       map[types.LaneID]*queue[types.BlockNumber, *blockVotes]
@@ -105,8 +105,8 @@ func newInner(ds *data.State, loaded *loadedState) (*inner, error) {
 		last := i.roads.q[i.roads.next-1]
 		i.persistedCommitQC.Store(utils.Some(last.commitQC))
 		// Floor applied at the durable tip's epoch. Bare Store on
-		// purpose: this is a rewind from LatestEpoch, not an install.
-		// The install loop below re-drives it from the durable leashes.
+		// purpose: this is a rewind from LatestEpoch, not an advanceEpoch.
+		// The advance loop below re-drives it from the durable leashes.
 		i.epoch.Store(last.epoch)
 	}
 
@@ -142,18 +142,18 @@ func newInner(ds *data.State, loaded *loadedState) (*inner, error) {
 		}
 		i.nextBlockToPersist[lane] = q.next
 	}
-	// Restart catch-up: install every epoch the durable leashes already allow.
-	// The live path (runEpochAdvance) installs one waited-for epoch at a time.
-	if err := i.installReadyEpochs(ds); err != nil {
+	// Restart catch-up: advance every epoch the durable leashes already allow.
+	// The live path (runEpochAdvance) advances one waited-for epoch at a time.
+	if err := i.advanceReadyEpochs(ds); err != nil {
 		return nil, err
 	}
 	i.refreshConsensusSpec()
 	return i, nil
 }
 
-// installEpoch makes ep the applied epoch: opens its lanes, reweights votes,
+// advanceEpoch makes ep the applied epoch: opens its lanes, reweights votes,
 // and republishes ConsensusSpec.
-func (i *inner) installEpoch(ep *types.Epoch) {
+func (i *inner) advanceEpoch(ep *types.Epoch) {
 	for lane := range ep.Committee().Lanes().All() {
 		i.addLane(lane)
 	}
@@ -165,12 +165,12 @@ func (i *inner) installEpoch(ep *types.Epoch) {
 	i.refreshConsensusSpec()
 }
 
-// leashesMet reports whether the applied epoch is sealed and its prune leash is
+// canAdvanceEpoch reports whether the applied epoch is sealed and its prune leash is
 // met. Sealed means roads hold the epoch's last CommitQC. The prune leash is met
 // when the Anchor epoch covers the applied epoch (an AppQC for that epoch
 // exists). The execution leash — registry contains the next epoch — is checked
 // separately so live waiters are not parked on avail's lock for a registry update.
-func (i *inner) leashesMet() bool {
+func (i *inner) canAdvanceEpoch() bool {
 	ep := i.epoch.Load()
 	if i.roads.next < ep.RoadRange().Next {
 		return false
@@ -179,17 +179,17 @@ func (i *inner) leashesMet() bool {
 	return ok && ae.EpochIndex() >= ep.EpochIndex()
 }
 
-// installReadyEpochs installs every epoch whose seal and prune leashes are
+// advanceReadyEpochs advances to every epoch whose seal and prune leashes are
 // already met. A missing next registry epoch in that state is an invariant
 // violation (execution leash should already have registered it).
-func (i *inner) installReadyEpochs(ds *data.State) error {
-	for i.leashesMet() {
+func (i *inner) advanceReadyEpochs(ds *data.State) error {
+	for i.canAdvanceEpoch() {
 		nextIdx := i.epoch.Load().EpochIndex() + 1
 		next, ok := ds.Registry().EpochByIndex(nextIdx)
 		if !ok {
 			return fmt.Errorf("epoch %d not registered with seal+prune leashes met", nextIdx)
 		}
-		i.installEpoch(next)
+		i.advanceEpoch(next)
 	}
 	return nil
 }
@@ -201,7 +201,7 @@ func (i *inner) installReadyEpochs(ds *data.State) error {
 // Withholding rather than publishing an earlier tip is what keeps the spec
 // monotonic. At an epoch boundary the durable tip sits on LastRoad(E) while
 // applied is still E, and a node that already entered E+1 before a restart must
-// not be handed a predecessor of the tip it holds: installing it would roll the
+// not be handed a predecessor of the tip it holds: advancing to it would roll the
 // tip backwards and discard that view's votes.
 func (i *inner) refreshConsensusSpec() {
 	tip := i.persistedCommitQC.Load()
@@ -227,7 +227,7 @@ func (i *inner) epochForRoad(road types.RoadIndex) utils.Option[*types.Epoch] {
 	if road >= i.roads.first && road < i.roads.next {
 		return utils.Some(i.roads.q[road].epoch)
 	}
-	// Persist may lag installEpoch: tip's next RoadIndex can sit in an earlier epoch
+	// Persist may lag advanceEpoch: tip's next RoadIndex can sit in an earlier epoch
 	// still present on some admitted road.
 	for idx := i.roads.first; idx < i.roads.next; idx++ {
 		if ep := i.roads.q[idx].epoch; ep.RoadRange().Has(road) {
@@ -287,7 +287,7 @@ func (i *inner) reweightVotes() {
 
 // prune advances the state up to the data Anchor and drops lanes closed as of
 // anchor.Epoch. It updates anchorEpoch only — applied epoch catch-up is left to
-// installReadyEpochs / runEpochAdvance. Returns the number of lanes dropped.
+// advanceReadyEpochs / runEpochAdvance. Returns the number of lanes dropped.
 func (i *inner) prune(anchor data.Anchor) int {
 	anchorEpoch := anchor.Epoch
 	idx := anchor.CommitQC.Index()

--- a/sei-tendermint/internal/autobahn/avail/inner.go
+++ b/sei-tendermint/internal/autobahn/avail/inner.go
@@ -6,27 +6,25 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/autobahn/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/consensus/persist"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/data"
-	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/epoch"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 )
 
 // inner holds roads and per-LaneID block/vote maps.
 type inner struct {
 	persistedCommitQC utils.AtomicSend[utils.Option[*types.CommitQC]] // latest persisted CommitQC
-	consensusSpec     utils.AtomicSend[types.ConsensusSpec]
-	roads             *queue[types.RoadIndex, *road]
+	// consensusSpec.Epoch is the applied (next-CommitQC) epoch. advanceEpoch is
+	// the sole writer after construction. blockVotes are weighted under it.
+	// CommitQC may lag that epoch while withheld at LastRoad (durable tip is
+	// persistedCommitQC).
+	consensusSpec utils.AtomicSend[types.ConsensusSpec]
+	roads         *queue[types.RoadIndex, *road]
 
-	// epoch is the applied (next-CommitQC) epoch. advanceEpoch is the sole
-	// writer after construction. Distinct from consensusSpec.Epoch, which is the
-	// epoch of the RoadIndex after the publishable tip and may lag while withheld.
-	// blockVotes are always weighted under this epoch.
-	epoch utils.AtomicSend[*types.Epoch]
 	// anchorEpoch is the epoch of data's Anchor CommitQC when one exists.
 	// None until the first Anchor arrives (construction prune or runEvict).
 	// It may exceed the applied epoch while runEpochAdvance is parked on
 	// WaitForEpoch, or briefly between prune and the next advance: admission
 	// falls back to the Anchor committee via epochForVote / epochForLane.
-	// prune never advances i.epoch — only advanceEpoch does.
+	// prune never advances applied — only advanceEpoch does.
 	anchorEpoch utils.Option[*types.Epoch]
 	blocks      map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]
 	votes       map[types.LaneID]*queue[types.BlockNumber, *blockVotes]
@@ -65,7 +63,6 @@ func newInner(ds *data.State, loaded *loadedState) (*inner, error) {
 		persistedCommitQC:  utils.NewAtomicSend(utils.None[*types.CommitQC]()),
 		consensusSpec:      utils.NewAtomicSend(types.ConsensusSpec{CommitQC: utils.None[*types.CommitQC](), Epoch: genesis}),
 		roads:              newQueue[types.RoadIndex, *road](),
-		epoch:              utils.NewAtomicSend(genesis),
 		blocks:             map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]{},
 		votes:              map[types.LaneID]*queue[types.BlockNumber, *blockVotes]{},
 		nextBlockToPersist: map[types.LaneID]types.BlockNumber{},
@@ -149,37 +146,43 @@ func newInner(ds *data.State, loaded *loadedState) (*inner, error) {
 	return i, nil
 }
 
+func (i *inner) applied() *types.Epoch {
+	return i.consensusSpec.Load().Epoch
+}
+
 // seedApplied sets applied to ep and opens its lanes. Construction only;
 // live advances go through advanceEpoch.
 func (i *inner) seedApplied(ep *types.Epoch) {
 	for lane := range ep.Committee().Lanes().All() {
 		i.addLane(lane)
 	}
-	i.epoch.Store(ep)
+	spec := i.consensusSpec.Load()
+	i.consensusSpec.Store(types.ConsensusSpec{CommitQC: spec.CommitQC, Epoch: ep})
 }
 
 // advanceEpoch makes ep the applied epoch: opens its lanes, reweights votes,
-// and republishes ConsensusSpec.
+// and publishes ConsensusSpec for the durable tip.
 func (i *inner) advanceEpoch(ep *types.Epoch) {
 	for lane := range ep.Committee().Lanes().All() {
 		i.addLane(lane)
 	}
-	// Publish applied epoch before reweight so reweightVotes reads i.epoch.
-	// Callers hold the avail lock, so Epoch() waiters cannot observe votes
-	// between the Store and the reweight.
-	i.epoch.Store(ep)
+	i.consensusSpec.Store(types.ConsensusSpec{CommitQC: i.persistedCommitQC.Load(), Epoch: ep})
 	i.reweightVotes()
-	i.refreshConsensusSpec()
 }
 
 // canAdvanceEpoch reports whether the applied epoch is sealed and its prune leash is
-// met. Sealed means roads hold the epoch's last CommitQC. The prune leash is met
-// when the Anchor epoch covers the applied epoch (an AppQC for that epoch
-// exists). The execution leash — registry contains the next epoch — is checked
+// met. Sealed means roads and persistedCommitQC hold the epoch's last CommitQC.
+// Waiting on persist keeps applied in lockstep with consensusSpec.Epoch.
+// The prune leash is met when the Anchor epoch covers the applied epoch.
+// The execution leash — registry contains the next epoch — is checked
 // separately so live waiters are not parked on avail's lock for a registry update.
 func (i *inner) canAdvanceEpoch() bool {
-	ep := i.epoch.Load()
+	ep := i.applied()
 	if i.roads.next < ep.RoadRange().Next {
+		return false
+	}
+	tip, ok := i.persistedCommitQC.Load().Get()
+	if !ok || tip.Index()+1 < ep.RoadRange().Next {
 		return false
 	}
 	ae, ok := i.anchorEpoch.Get()
@@ -191,7 +194,7 @@ func (i *inner) canAdvanceEpoch() bool {
 // violation (execution leash should already have registered it).
 func (i *inner) advanceReadyEpochs(ds *data.State) error {
 	for i.canAdvanceEpoch() {
-		nextIdx := i.epoch.Load().EpochIndex() + 1
+		nextIdx := i.applied().EpochIndex() + 1
 		next, err := ds.Registry().EpochByIndex(nextIdx)
 		if err != nil {
 			return fmt.Errorf("epoch %d with seal+prune leashes met: %w", nextIdx, err)
@@ -201,15 +204,9 @@ func (i *inner) advanceReadyEpochs(ds *data.State) error {
 	return nil
 }
 
-// refreshConsensusSpec publishes ConsensusSpec for the durable tip, paired with
-// the epoch of the RoadIndex that follows it. The spec is withheld — the
-// previously published one stands — until that epoch is applied and resolvable.
-//
-// Withholding rather than publishing an earlier tip is what keeps the spec
-// monotonic. At an epoch boundary the durable tip sits on LastRoad(E) while
-// applied is still E, and a node that already entered E+1 before a restart must
-// not be handed a predecessor of the tip it holds: advancing to it would roll the
-// tip backwards and discard that view's votes.
+// refreshConsensusSpec publishes the durable tip when the following RoadIndex
+// sits in the applied epoch. Otherwise the previous spec stands (withhold at
+// LastRoad until advanceEpoch). It does not change Epoch; advanceEpoch does.
 func (i *inner) refreshConsensusSpec() {
 	tip := i.persistedCommitQC.Load()
 	cqc, ok := tip.Get()
@@ -217,29 +214,9 @@ func (i *inner) refreshConsensusSpec() {
 		return
 	}
 	next := cqc.Index() + 1
-	ep := i.epoch.Load()
-	if epoch.IndexForRoad(next) > ep.EpochIndex() {
-		return
-	}
+	ep := i.applied()
 	if !ep.RoadRange().Has(next) {
-		// Persist may lag advanceEpoch: tip's next RoadIndex can sit in an
-		// earlier epoch still present on some admitted road.
-		found := false
-		if next >= i.roads.first && next < i.roads.next {
-			ep = i.roads.q[next].epoch
-			found = true
-		} else {
-			for idx := i.roads.first; idx < i.roads.next; idx++ {
-				if r := i.roads.q[idx].epoch; r.RoadRange().Has(next) {
-					ep = r
-					found = true
-					break
-				}
-			}
-		}
-		if !found {
-			return
-		}
+		return
 	}
 	i.consensusSpec.Store(types.ConsensusSpec{CommitQC: tip, Epoch: ep})
 }
@@ -268,7 +245,7 @@ func (i *inner) dropLanes(lanes []types.LaneID) int {
 	return n
 }
 
-// laneQC returns the LaneQC for (lane, n) under i.epoch, if one has formed.
+// laneQC returns the LaneQC for (lane, n) under the applied epoch, if one has formed.
 func (i *inner) laneQC(lane types.LaneID, n types.BlockNumber) utils.Option[*types.LaneQC] {
 	votes, ok := i.votes[lane]
 	if !ok {
@@ -281,9 +258,9 @@ func (i *inner) laneQC(lane types.LaneID, n types.BlockNumber) utils.Option[*typ
 	return entry.qc
 }
 
-// reweightVotes recounts retained block votes under the applied epoch (i.epoch).
+// reweightVotes recounts retained block votes under the applied epoch.
 func (i *inner) reweightVotes() {
-	ep := i.epoch.Load()
+	ep := i.applied()
 	for _, vq := range i.votes {
 		for n := vq.first; n < vq.next; n++ {
 			vq.q[n].reweight(ep)

--- a/sei-tendermint/internal/autobahn/avail/inner.go
+++ b/sei-tendermint/internal/autobahn/avail/inner.go
@@ -18,10 +18,15 @@ type inner struct {
 
 	// epoch is the applied (next-CommitQC) epoch. installEpoch is the sole
 	// writer after construction. Distinct from consensusSpec.Epoch, which is the
-	// next-view epoch paired with the publishable tip and may lag while withheld.
+	// epoch of the RoadIndex after the publishable tip and may lag while withheld.
+	// blockVotes are always weighted under this epoch.
 	epoch utils.AtomicSend[*types.Epoch]
 	// anchorEpoch is the epoch of data's Anchor CommitQC when one exists.
 	// None until the first Anchor arrives (construction prune or runEvict).
+	// It may exceed the applied epoch while runEpochAdvance is parked on
+	// WaitForEpoch, or briefly between prune and the next install: admission
+	// falls back to the Anchor committee via epochForVote / epochForLane.
+	// prune never advances i.epoch — only installEpoch does.
 	anchorEpoch utils.Option[*types.Epoch]
 	blocks      map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]
 	votes       map[types.LaneID]*queue[types.BlockNumber, *blockVotes]
@@ -99,7 +104,7 @@ func newInner(ds *data.State, loaded *loadedState) (*inner, error) {
 	if i.roads.Len() > 0 {
 		last := i.roads.q[i.roads.next-1]
 		i.persistedCommitQC.Store(utils.Some(last.commitQC))
-		// Floor applied at the durable tip's verify-epoch. Bare Store on
+		// Floor applied at the durable tip's epoch. Bare Store on
 		// purpose: this is a rewind from LatestEpoch, not an install.
 		// The install loop below re-drives it from the durable leashes.
 		i.epoch.Store(last.epoch)
@@ -190,14 +195,14 @@ func (i *inner) installReadyEpochs(ds *data.State) error {
 }
 
 // refreshConsensusSpec publishes ConsensusSpec for the durable tip, paired with
-// the epoch of the view that follows it. The spec is withheld — the previously
-// published one stands — until that epoch is applied and resolvable.
+// the epoch of the RoadIndex that follows it. The spec is withheld — the
+// previously published one stands — until that epoch is applied and resolvable.
 //
 // Withholding rather than publishing an earlier tip is what keeps the spec
 // monotonic. At an epoch boundary the durable tip sits on LastRoad(E) while
 // applied is still E, and a node that already entered E+1 before a restart must
 // not be handed a predecessor of the tip it holds: installing it would roll the
-// view backwards and discard that view's votes.
+// tip backwards and discard that view's votes.
 func (i *inner) refreshConsensusSpec() {
 	tip := i.persistedCommitQC.Load()
 	cqc, ok := tip.Get()
@@ -222,7 +227,7 @@ func (i *inner) epochForRoad(road types.RoadIndex) utils.Option[*types.Epoch] {
 	if road >= i.roads.first && road < i.roads.next {
 		return utils.Some(i.roads.q[road].epoch)
 	}
-	// Persist may lag installEpoch: tip's next view can sit in an earlier epoch
+	// Persist may lag installEpoch: tip's next RoadIndex can sit in an earlier epoch
 	// still present on some admitted road.
 	for idx := i.roads.first; idx < i.roads.next; idx++ {
 		if ep := i.roads.q[idx].epoch; ep.RoadRange().Has(road) {
@@ -281,7 +286,8 @@ func (i *inner) reweightVotes() {
 }
 
 // prune advances the state up to the data Anchor and drops lanes closed as of
-// anchor.Epoch. Returns the number of lanes dropped.
+// anchor.Epoch. It updates anchorEpoch only — applied epoch catch-up is left to
+// installReadyEpochs / runEpochAdvance. Returns the number of lanes dropped.
 func (i *inner) prune(anchor data.Anchor) int {
 	anchorEpoch := anchor.Epoch
 	idx := anchor.CommitQC.Index()

--- a/sei-tendermint/internal/autobahn/avail/inner.go
+++ b/sei-tendermint/internal/autobahn/avail/inner.go
@@ -17,7 +17,8 @@ type inner struct {
 	roads             *queue[types.RoadIndex, *road]
 
 	// epoch is the applied (next-CommitQC) epoch. installEpoch is the sole
-	// writer after construction.
+	// writer after construction. Distinct from consensusSpec.Epoch, which is the
+	// next-view epoch paired with the publishable tip and may lag while withheld.
 	epoch utils.AtomicSend[*types.Epoch]
 	// anchorEpoch is the epoch of data's Anchor CommitQC when one exists.
 	// None until the first Anchor arrives (construction prune or runEvict).
@@ -151,8 +152,11 @@ func (i *inner) installEpoch(ep *types.Epoch) {
 	for lane := range ep.Committee().Lanes().All() {
 		i.addLane(lane)
 	}
-	i.reweightVotes(ep)
+	// Publish applied epoch before reweight so reweightVotes reads i.epoch.
+	// Callers hold the avail lock, so Epoch() waiters cannot observe votes
+	// between the Store and the reweight.
 	i.epoch.Store(ep)
+	i.reweightVotes()
 	i.refreshConsensusSpec()
 }
 
@@ -252,6 +256,8 @@ func (i *inner) dropLanes(lanes []types.LaneID) int {
 	return n
 }
 
+// laneQC returns the LaneQC for (lane, n) under the applied epoch's vote
+// weighting (i.epoch), if one has formed.
 func (i *inner) laneQC(lane types.LaneID, n types.BlockNumber) utils.Option[*types.LaneQC] {
 	votes, ok := i.votes[lane]
 	if !ok {
@@ -264,7 +270,9 @@ func (i *inner) laneQC(lane types.LaneID, n types.BlockNumber) utils.Option[*typ
 	return entry.qc
 }
 
-func (i *inner) reweightVotes(ep *types.Epoch) {
+// reweightVotes recounts retained block votes under the applied epoch (i.epoch).
+func (i *inner) reweightVotes() {
+	ep := i.epoch.Load()
 	for _, vq := range i.votes {
 		for n := vq.first; n < vq.next; n++ {
 			vq.q[n].reweight(ep)

--- a/sei-tendermint/internal/autobahn/avail/inner.go
+++ b/sei-tendermint/internal/autobahn/avail/inner.go
@@ -21,10 +21,8 @@ type inner struct {
 
 	// anchorEpoch is the epoch of data's Anchor CommitQC when one exists.
 	// None until the first Anchor arrives (construction prune or runEvict).
-	// It may exceed the applied epoch while runEpochAdvance is parked on
-	// WaitForEpoch, or briefly between prune and the next advance: admission
-	// falls back to the Anchor committee via epochForVote / epochForLane.
-	// prune never advances applied — only advanceEpoch does.
+	// When it lags applied, epochForVote falls back to this committee for
+	// departing-lane voters. prune never advances applied — only advanceEpoch does.
 	anchorEpoch utils.Option[*types.Epoch]
 	blocks      map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]
 	votes       map[types.LaneID]*queue[types.BlockNumber, *blockVotes]
@@ -148,6 +146,27 @@ func newInner(ds *data.State, loaded *loadedState) (*inner, error) {
 
 func (i *inner) applied() *types.Epoch {
 	return i.consensusSpec.Load().Epoch
+}
+
+// epochForVote returns the applied or Anchor epoch the vote belongs to
+// (lane + signer in that committee). Prefers applied; falls back to Anchor
+// when that is a different EpochIndex.
+func (i *inner) epochForVote(vote *types.Signed[*types.LaneVote]) utils.Option[*types.Epoch] {
+	lane := vote.Msg().Header().Lane()
+	key := vote.Key()
+	belongs := func(ep *types.Epoch) bool {
+		c := ep.Committee()
+		return c.HasLane(lane) && c.HasReplica(key)
+	}
+	applied := i.applied()
+	if belongs(applied) {
+		return utils.Some(applied)
+	}
+	ae, ok := i.anchorEpoch.Get()
+	if !ok || ae.EpochIndex() == applied.EpochIndex() || !belongs(ae) {
+		return utils.None[*types.Epoch]()
+	}
+	return utils.Some(ae)
 }
 
 // seedApplied sets applied to ep and opens its lanes. Construction only;

--- a/sei-tendermint/internal/autobahn/avail/inner.go
+++ b/sei-tendermint/internal/autobahn/avail/inner.go
@@ -14,15 +14,16 @@ type inner struct {
 	persistedCommitQC utils.AtomicSend[utils.Option[*types.CommitQC]] // latest persisted CommitQC
 	// consensusSpec is the applied (next-CommitQC) epoch paired with a persisted
 	// CommitQC tip (None before the first tip). CommitQC never exceeds
-	// persistedCommitQC. advanceEpoch is the sole writer of Epoch after
-	// construction. blockVotes are always weighted under this Epoch.
+	// persistedCommitQC. advanceEpoch installs Epoch; runEpochAdvance is the live
+	// writer, and prune jumps applied when the Anchor has skipped ahead.
+	// blockVotes are always weighted under this Epoch.
 	consensusSpec utils.AtomicSend[types.ConsensusSpec]
 	roads         *queue[types.RoadIndex, *road]
 
 	// anchorEpoch is the epoch of data's Anchor CommitQC when one exists.
 	// None until the first Anchor arrives (construction prune or runEvict).
 	// When it lags applied, epochForVote falls back to this committee for
-	// departing-lane voters. prune never advances applied — only advanceEpoch does.
+	// departing-lane voters. When it leads, prune jumps applied to it.
 	anchorEpoch utils.Option[*types.Epoch]
 	blocks      map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]
 	votes       map[types.LaneID]*queue[types.BlockNumber, *blockVotes]
@@ -226,7 +227,8 @@ func (i *inner) reweightVotes() {
 
 // prune advances the state up to the data Anchor and drops lanes closed as of
 // anchor.Epoch. It updates anchorEpoch and refreshes ConsensusSpec's tip.
-// Construction sets Epoch via newInner; live rotation uses runEpochAdvance.
+// Construction sets Epoch via newInner; live rotation uses runEpochAdvance;
+// catch-up (Anchor skipped ahead of applied) jumps here.
 // Returns the number of lanes dropped.
 func (i *inner) prune(anchor data.Anchor) int {
 	anchorEpoch := anchor.Epoch
@@ -252,6 +254,9 @@ func (i *inner) prune(anchor data.Anchor) int {
 		}
 	}
 	n := i.dropLanes(closed)
+	if i.applied().EpochIndex() < anchorEpoch.EpochIndex() {
+		i.advanceEpoch(anchorEpoch)
+	}
 	i.refreshConsensusSpec()
 	return n
 }

--- a/sei-tendermint/internal/autobahn/avail/inner.go
+++ b/sei-tendermint/internal/autobahn/avail/inner.go
@@ -13,9 +13,9 @@ import (
 type inner struct {
 	persistedCommitQC utils.AtomicSend[utils.Option[*types.CommitQC]] // latest persisted CommitQC
 	// consensusSpec.Epoch is the applied (next-CommitQC) epoch. advanceEpoch is
-	// the sole writer after construction. blockVotes are weighted under it.
-	// CommitQC may lag that epoch while withheld at LastRoad (durable tip is
-	// persistedCommitQC).
+	// the sole writer after construction. blockVotes are weighted under this
+	// epoch at all times. CommitQC may lag that epoch while withheld at LastRoad
+	// (durable tip is persistedCommitQC).
 	consensusSpec utils.AtomicSend[types.ConsensusSpec]
 	roads         *queue[types.RoadIndex, *road]
 

--- a/sei-tendermint/internal/autobahn/avail/inner.go
+++ b/sei-tendermint/internal/autobahn/avail/inner.go
@@ -210,31 +210,31 @@ func (i *inner) refreshConsensusSpec() {
 		return
 	}
 	next := cqc.Index() + 1
-	if epoch.IndexForRoad(next) > i.epoch.Load().EpochIndex() {
+	ep := i.epoch.Load()
+	if epoch.IndexForRoad(next) > ep.EpochIndex() {
 		return
 	}
-	ep, ok := i.epochForRoad(next).Get()
-	if !ok {
-		return
-	}
-	i.consensusSpec.Store(types.ConsensusSpec{CommitQC: tip, Epoch: ep})
-}
-
-func (i *inner) epochForRoad(road types.RoadIndex) utils.Option[*types.Epoch] {
-	if ep := i.epoch.Load(); ep.RoadRange().Has(road) {
-		return utils.Some(ep)
-	}
-	if road >= i.roads.first && road < i.roads.next {
-		return utils.Some(i.roads.q[road].epoch)
-	}
-	// Persist may lag advanceEpoch: tip's next RoadIndex can sit in an earlier epoch
-	// still present on some admitted road.
-	for idx := i.roads.first; idx < i.roads.next; idx++ {
-		if ep := i.roads.q[idx].epoch; ep.RoadRange().Has(road) {
-			return utils.Some(ep)
+	if !ep.RoadRange().Has(next) {
+		// Persist may lag advanceEpoch: tip's next RoadIndex can sit in an
+		// earlier epoch still present on some admitted road.
+		found := false
+		if next >= i.roads.first && next < i.roads.next {
+			ep = i.roads.q[next].epoch
+			found = true
+		} else {
+			for idx := i.roads.first; idx < i.roads.next; idx++ {
+				if r := i.roads.q[idx].epoch; r.RoadRange().Has(next) {
+					ep = r
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			return
 		}
 	}
-	return utils.None[*types.Epoch]()
+	i.consensusSpec.Store(types.ConsensusSpec{CommitQC: tip, Epoch: ep})
 }
 
 func (i *inner) addLane(lane types.LaneID) bool {

--- a/sei-tendermint/internal/autobahn/avail/inner_test.go
+++ b/sei-tendermint/internal/autobahn/avail/inner_test.go
@@ -270,3 +270,29 @@ func TestRefreshConsensusSpec_WithholdsTipUntilNextViewEpochApplied(t *testing.T
 	require.Equal(t, last, cqc.Index())
 	require.Equal(t, types.EpochIndex(1), spec.Epoch.EpochIndex())
 }
+
+func TestPrune_AdvancesAppliedWhenAnchorAhead(t *testing.T) {
+	rng := utils.TestRng()
+	registry, keys := epoch.GenRegistry(rng, 4)
+	registry.AdvanceIfNeeded(epoch.LastRoad(1))
+	registry.AdvanceIfNeeded(epoch.LastRoad(2))
+	ep0 := registry.MustEpoch(0)
+	ep1 := registry.MustEpoch(1)
+	ep2 := registry.MustEpoch(2)
+	i := newInner(ep0, 0)
+	require.Equal(t, types.EpochIndex(0), i.applied().EpochIndex())
+
+	prev := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
+		types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep1, types.View{Index: epoch.LastRoad(1), Number: 0}, ep1.FirstBlock()))),
+	})
+	qc := types.BuildCommitQC(ep2, keys, utils.Some(prev), nil)
+	i.prune(data.Anchor{
+		CommitQC: qc,
+		AppQC:    data.TestAppQC(keys, types.NewAppProposal(qc.Proposal(), types.AppHash{})),
+		Epoch:    ep2,
+	})
+	require.Equal(t, types.EpochIndex(2), i.applied().EpochIndex())
+	ae, ok := i.anchorEpoch.Get()
+	require.True(t, ok)
+	require.Equal(t, types.EpochIndex(2), ae.EpochIndex())
+}

--- a/sei-tendermint/internal/autobahn/avail/inner_test.go
+++ b/sei-tendermint/internal/autobahn/avail/inner_test.go
@@ -271,7 +271,7 @@ func TestRefreshConsensusSpec_WithholdsTipUntilNextViewEpochApplied(t *testing.T
 	require.Equal(t, types.EpochIndex(1), spec.Epoch.EpochIndex())
 }
 
-func TestPrune_AdvancesAppliedWhenAnchorAhead(t *testing.T) {
+func TestPrune_LeavesAppliedToEpochAdvance(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
 	registry.AdvanceIfNeeded(epoch.LastRoad(1))
@@ -291,7 +291,7 @@ func TestPrune_AdvancesAppliedWhenAnchorAhead(t *testing.T) {
 		AppQC:    data.TestAppQC(keys, types.NewAppProposal(qc.Proposal(), types.AppHash{})),
 		Epoch:    ep2,
 	})
-	require.Equal(t, types.EpochIndex(2), i.applied().EpochIndex())
+	require.Equal(t, types.EpochIndex(0), i.applied().EpochIndex())
 	ae, ok := i.anchorEpoch.Get()
 	require.True(t, ok)
 	require.Equal(t, types.EpochIndex(2), ae.EpochIndex())

--- a/sei-tendermint/internal/autobahn/avail/inner_test.go
+++ b/sei-tendermint/internal/autobahn/avail/inner_test.go
@@ -225,12 +225,12 @@ func TestAddLane_ReportsNewLaneForEachMembershipPeriod(t *testing.T) {
 	require.True(t, i.addLane(types.LaneID{Validator: a.Public(), Joined: 3}))
 }
 
-// TestInstallReadyEpochs_BoundaryTipUsesDataAppQC: tip at LastRoad(0) with
+// TestAdvanceReadyEpochs_BoundaryTipUsesDataAppQC: tip at LastRoad(0) with
 // applied floored to 0 (restart), data's Anchor already covers epoch 0, registry
-// has epoch 1 → install walks to 1 so ConsensusSpec republishes the tip.
+// has epoch 1 → advance walks to 1 so ConsensusSpec republishes the tip.
 // This is the avail half of the blind-Spec restore invariant: consensus may
 // refuse to start if Spec stays behind a WAL tip at LastRoad(0) after catch-up.
-func TestInstallReadyEpochs_BoundaryTipUsesDataAppQC(t *testing.T) {
+func TestAdvanceReadyEpochs_BoundaryTipUsesDataAppQC(t *testing.T) {
 	ctx := t.Context()
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
@@ -298,8 +298,8 @@ func TestInstallReadyEpochs_BoundaryTipUsesDataAppQC(t *testing.T) {
 	i.epoch.Store(ep0)
 
 	require.False(t, i.roads.q[last].appQC.IsPresent(), "road AppQC empty; prune leash is the Anchor")
-	require.True(t, i.leashesMet())
-	require.NoError(t, i.installReadyEpochs(ds))
+	require.True(t, i.canAdvanceEpoch())
+	require.NoError(t, i.advanceReadyEpochs(ds))
 
 	require.Equal(t, ep1.EpochIndex(), i.epoch.Load().EpochIndex())
 	spec := i.consensusSpec.Load()
@@ -309,7 +309,7 @@ func TestInstallReadyEpochs_BoundaryTipUsesDataAppQC(t *testing.T) {
 	require.Equal(t, types.EpochIndex(1), spec.Epoch.EpochIndex())
 }
 
-func TestInstallReadyEpochs_MissingNextEpochErrors(t *testing.T) {
+func TestAdvanceReadyEpochs_MissingNextEpochErrors(t *testing.T) {
 	rng := utils.TestRng()
 	// Fresh registry has epochs 0 and 1; seal epoch 1 so the next lookup is 2.
 	registry, keys := epoch.GenRegistry(rng, 3)
@@ -343,8 +343,8 @@ func TestInstallReadyEpochs_MissingNextEpochErrors(t *testing.T) {
 	i.roads.pushBack(newRoad(qcLast, ep1))
 	i.persistedCommitQC.Store(utils.Some(qcLast))
 
-	require.True(t, i.leashesMet())
-	require.Error(t, i.installReadyEpochs(newTestDataState(&data.Config{Registry: registry})))
+	require.True(t, i.canAdvanceEpoch())
+	require.Error(t, i.advanceReadyEpochs(newTestDataState(&data.Config{Registry: registry})))
 }
 
 // TestRefreshConsensusSpec_WithholdsTipUntilNextViewEpochApplied: the durable tip
@@ -385,7 +385,7 @@ func TestRefreshConsensusSpec_WithholdsTipUntilNextViewEpochApplied(t *testing.T
 	i.refreshConsensusSpec()
 	require.False(t, i.consensusSpec.Load().CommitQC.IsPresent(), "spec must be withheld, not published at the predecessor")
 
-	i.installEpoch(ep1)
+	i.advanceEpoch(ep1)
 	spec := i.consensusSpec.Load()
 	cqc, ok := spec.CommitQC.Get()
 	require.True(t, ok)

--- a/sei-tendermint/internal/autobahn/avail/inner_test.go
+++ b/sei-tendermint/internal/autobahn/avail/inner_test.go
@@ -280,7 +280,6 @@ func TestAdvanceReadyEpochs_BoundaryTipUsesDataAppQC(t *testing.T) {
 		persistedCommitQC:  utils.NewAtomicSend(utils.None[*types.CommitQC]()),
 		consensusSpec:      utils.NewAtomicSend(types.ConsensusSpec{CommitQC: utils.None[*types.CommitQC](), Epoch: ep0}),
 		roads:              newQueue[types.RoadIndex, *road](),
-		epoch:              utils.NewAtomicSend(ep0),
 		anchorEpoch:        utils.Some(anchor.Epoch),
 		blocks:             map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]{},
 		votes:              map[types.LaneID]*queue[types.BlockNumber, *blockVotes]{},
@@ -293,13 +292,12 @@ func TestAdvanceReadyEpochs_BoundaryTipUsesDataAppQC(t *testing.T) {
 	i.roads.next = last
 	i.roads.pushBack(newRoad(qcLast, ep0))
 	i.persistedCommitQC.Store(utils.Some(qcLast))
-	i.epoch.Store(ep0)
 
 	require.False(t, i.roads.q[last].appQC.IsPresent(), "road AppQC empty; prune leash is the Anchor")
 	require.True(t, i.canAdvanceEpoch())
 	require.NoError(t, i.advanceReadyEpochs(ds))
 
-	require.Equal(t, ep1.EpochIndex(), i.epoch.Load().EpochIndex())
+	require.Equal(t, ep1.EpochIndex(), i.applied().EpochIndex())
 	spec := i.consensusSpec.Load()
 	cqc, ok := spec.CommitQC.Get()
 	require.True(t, ok)
@@ -326,7 +324,6 @@ func TestAdvanceReadyEpochs_MissingNextEpochErrors(t *testing.T) {
 		persistedCommitQC:  utils.NewAtomicSend(utils.None[*types.CommitQC]()),
 		consensusSpec:      utils.NewAtomicSend(types.ConsensusSpec{CommitQC: utils.None[*types.CommitQC](), Epoch: ep1}),
 		roads:              newQueue[types.RoadIndex, *road](),
-		epoch:              utils.NewAtomicSend(ep1),
 		anchorEpoch:        utils.Some(ep1),
 		blocks:             map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]{},
 		votes:              map[types.LaneID]*queue[types.BlockNumber, *blockVotes]{},
@@ -366,7 +363,6 @@ func TestRefreshConsensusSpec_WithholdsTipUntilNextViewEpochApplied(t *testing.T
 		persistedCommitQC:  utils.NewAtomicSend(utils.None[*types.CommitQC]()),
 		consensusSpec:      utils.NewAtomicSend(types.ConsensusSpec{CommitQC: utils.None[*types.CommitQC](), Epoch: ep0}),
 		roads:              newQueue[types.RoadIndex, *road](),
-		epoch:              utils.NewAtomicSend(ep0),
 		blocks:             map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]{},
 		votes:              map[types.LaneID]*queue[types.BlockNumber, *blockVotes]{},
 		nextBlockToPersist: map[types.LaneID]types.BlockNumber{},

--- a/sei-tendermint/internal/autobahn/avail/inner_test.go
+++ b/sei-tendermint/internal/autobahn/avail/inner_test.go
@@ -273,7 +273,7 @@ func TestNextInstallableEpoch_BoundaryTipUsesDataAppQC(t *testing.T) {
 
 	last := epoch.LastRoad(0)
 	prev := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
-		types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep0, types.View{Index: last - 1, Number: 0}))),
+		types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep0, types.View{Index: last - 1, Number: 0}, ep0.FirstBlock()))),
 	})
 	qcLast := types.BuildCommitQC(ep0, keys, utils.Some(prev), nil)
 	require.Equal(t, last, qcLast.Index())

--- a/sei-tendermint/internal/autobahn/avail/inner_test.go
+++ b/sei-tendermint/internal/autobahn/avail/inner_test.go
@@ -1,6 +1,7 @@
 package avail
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sei-protocol/sei-chain/sei-db/ledger_db/block/memblock"
@@ -10,7 +11,8 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/data"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/epoch"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
-	"github.com/stretchr/testify/require"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/require"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/scope"
 )
 
 func newTestDataState(cfg *data.Config) *data.State {
@@ -23,7 +25,18 @@ func testSignedBlock(key types.SecretKey, lane types.LaneID, n types.BlockNumber
 	return types.Sign(key, types.NewLaneProposal(block))
 }
 
-func TestNewInnerFreshStart(t *testing.T) {
+func contiguousBlocks(key types.SecretKey, lane types.LaneID, n int, rng utils.Rng) []persist.LoadedBlock {
+	var parent types.BlockHeaderHash
+	bs := make([]persist.LoadedBlock, 0, n)
+	for i := range types.BlockNumber(n) {
+		b := testSignedBlock(key, lane, i, parent, rng)
+		parent = b.Msg().Block().Header().Hash()
+		bs = append(bs, persist.LoadedBlock{Number: i, Proposal: b})
+	}
+	return bs
+}
+
+func TestNewInner_Empty(t *testing.T) {
 	rng := utils.TestRng()
 	registry, _ := epoch.GenRegistry(rng, 4)
 
@@ -32,6 +45,8 @@ func TestNewInnerFreshStart(t *testing.T) {
 
 	require.Equal(t, types.RoadIndex(0), i.roads.first)
 	require.Equal(t, types.RoadIndex(0), i.roads.next)
+	_, ok := i.persistedCommitQC.Load().Get()
+	require.False(t, ok)
 	require.NotNil(t, i.nextBlockToPersist)
 	for lane := range registry.LatestEpoch().Committee().Lanes().All() {
 		require.Equal(t, types.BlockNumber(0), i.blocks[lane].first)
@@ -41,211 +56,309 @@ func TestNewInnerFreshStart(t *testing.T) {
 	}
 }
 
-func TestNewInnerLoadedBlocksContiguous(t *testing.T) {
-	rng := utils.TestRng()
-	registry, keys := epoch.GenRegistry(rng, 4)
-	lane := registry.LatestEpoch().Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
-
-	var parent types.BlockHeaderHash
-	var bs []persist.LoadedBlock
-	for n := range types.BlockNumber(3) {
-		b := testSignedBlock(keys[0], lane, n, parent, rng)
-		parent = b.Msg().Block().Header().Hash()
-		bs = append(bs, persist.LoadedBlock{Number: n, Proposal: b})
-	}
-
-	i, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
-		blocks: map[types.LaneID][]persist.LoadedBlock{lane: bs},
-	})
-	require.NoError(t, err)
-
-	q := i.blocks[lane]
-	require.Equal(t, types.BlockNumber(0), q.first)
-	require.Equal(t, types.BlockNumber(3), q.next)
-	for j, b := range bs {
-		require.Equal(t, b.Proposal, q.q[types.BlockNumber(j)])
-	}
-	require.Equal(t, types.BlockNumber(3), i.nextBlockToPersist[lane])
-	for other := range registry.LatestEpoch().Committee().Lanes().All() {
-		if other != lane {
-			require.Equal(t, types.BlockNumber(0), i.nextBlockToPersist[other])
+func TestNewInner_LoadedBlocks(t *testing.T) {
+	t.Run("contiguous", func(t *testing.T) {
+		rng := utils.TestRng()
+		registry, keys := epoch.GenRegistry(rng, 4)
+		lane0 := registry.LatestEpoch().Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
+		ds := newTestDataState(&data.Config{Registry: registry})
+		bs := contiguousBlocks(keys[0], lane0, 3, rng)
+		i, err := newInner(ds, &loadedState{blocks: map[types.LaneID][]persist.LoadedBlock{lane0: bs}})
+		require.NoError(t, err)
+		q := i.blocks[lane0]
+		require.Equal(t, types.BlockNumber(0), q.first)
+		require.Equal(t, types.BlockNumber(3), q.next)
+		for j, b := range bs {
+			require.Equal(t, b.Proposal, q.q[types.BlockNumber(j)])
 		}
-	}
-}
-
-func TestNewInnerLoadedBlocksEmptySlice(t *testing.T) {
-	rng := utils.TestRng()
-	registry, keys := epoch.GenRegistry(rng, 4)
-	lane := registry.LatestEpoch().Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
-
-	i, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
-		blocks: map[types.LaneID][]persist.LoadedBlock{lane: {}},
+		require.Equal(t, types.BlockNumber(3), i.nextBlockToPersist[lane0])
+		for other := range registry.LatestEpoch().Committee().Lanes().All() {
+			if other != lane0 {
+				require.Equal(t, types.BlockNumber(0), i.nextBlockToPersist[other])
+			}
+		}
 	})
-	require.NoError(t, err)
 
-	q := i.blocks[lane]
-	require.Equal(t, types.BlockNumber(0), q.first)
-	require.Equal(t, types.BlockNumber(0), q.next)
-}
-
-func TestNewInnerLoadedBlocksUnknownLane(t *testing.T) {
-	rng := utils.TestRng()
-	registry, keys := epoch.GenRegistry(rng, 4)
-
-	unknownKey := types.GenSecretKey(rng)
-	unknownLane := types.LaneID{Validator: unknownKey.Public(), Joined: 0}
-	b := testSignedBlock(unknownKey, unknownLane, 0, types.BlockHeaderHash{}, rng)
-
-	i, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
-		blocks: map[types.LaneID][]persist.LoadedBlock{unknownLane: {{Number: 0, Proposal: b}}},
-	})
-	require.NoError(t, err)
-
-	for lane := range registry.LatestEpoch().Committee().Lanes().All() {
-		q := i.blocks[lane]
+	t.Run("empty slice", func(t *testing.T) {
+		rng := utils.TestRng()
+		registry, keys := epoch.GenRegistry(rng, 4)
+		lane0 := registry.LatestEpoch().Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
+		i, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
+			blocks: map[types.LaneID][]persist.LoadedBlock{lane0: {}},
+		})
+		require.NoError(t, err)
+		q := i.blocks[lane0]
 		require.Equal(t, types.BlockNumber(0), q.first)
 		require.Equal(t, types.BlockNumber(0), q.next)
-	}
-	_ = keys
-}
-
-func TestNewInnerLoadedBlocksMultipleLanes(t *testing.T) {
-	rng := utils.TestRng()
-	registry, keys := epoch.GenRegistry(rng, 4)
-	lane0 := registry.LatestEpoch().Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
-	lane1 := registry.LatestEpoch().Committee().Lane(keys[1].Public()).OrPanic("keys[1]")
-
-	var parent0 types.BlockHeaderHash
-	var bs0 []persist.LoadedBlock
-	for n := range types.BlockNumber(2) {
-		b := testSignedBlock(keys[0], lane0, n, parent0, rng)
-		parent0 = b.Msg().Block().Header().Hash()
-		bs0 = append(bs0, persist.LoadedBlock{Number: n, Proposal: b})
-	}
-
-	var parent1 types.BlockHeaderHash
-	var bs1 []persist.LoadedBlock
-	for n := range types.BlockNumber(3) {
-		b := testSignedBlock(keys[1], lane1, n, parent1, rng)
-		parent1 = b.Msg().Block().Header().Hash()
-		bs1 = append(bs1, persist.LoadedBlock{Number: n, Proposal: b})
-	}
-
-	i, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
-		blocks: map[types.LaneID][]persist.LoadedBlock{lane0: bs0, lane1: bs1},
 	})
-	require.NoError(t, err)
 
-	require.Equal(t, types.BlockNumber(2), i.blocks[lane0].next)
-	require.Equal(t, types.BlockNumber(3), i.blocks[lane1].next)
-	require.Equal(t, types.BlockNumber(2), i.nextBlockToPersist[lane0])
-	require.Equal(t, types.BlockNumber(3), i.nextBlockToPersist[lane1])
-}
-
-func TestNewInnerLoadedCommitQCsNoAppQC(t *testing.T) {
-	rng := utils.TestRng()
-	registry, keys := epoch.GenRegistry(rng, 4)
-
-	qcs := make([]*types.CommitQC, 3)
-	prev := utils.None[*types.CommitQC]()
-	for i := range qcs {
-		qcs[i] = types.BuildCommitQC(registry.LatestEpoch(), keys, prev, nil)
-		prev = utils.Some(qcs[i])
-	}
-
-	inner, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{commitQCs: qcs})
-	require.NoError(t, err)
-
-	require.Equal(t, types.RoadIndex(0), inner.roads.first)
-	require.Equal(t, types.RoadIndex(3), inner.roads.next)
-	for i, qc := range qcs {
-		require.NoError(t, utils.TestDiff(qc, inner.roads.q[types.RoadIndex(i)].commitQC))
-	}
-	require.NoError(t, utils.TestDiff(utils.Some(qcs[2]), inner.persistedCommitQC.Load()))
-}
-
-func TestNewInnerLoadedCommitQCsGapReturnsError(t *testing.T) {
-	rng := utils.TestRng()
-	registry, keys := epoch.GenRegistry(rng, 4)
-
-	qc0 := types.BuildCommitQC(registry.LatestEpoch(), keys, utils.None[*types.CommitQC](), nil)
-	qc1 := types.BuildCommitQC(registry.LatestEpoch(), keys, utils.Some(qc0), nil)
-	qc2 := types.BuildCommitQC(registry.LatestEpoch(), keys, utils.Some(qc1), nil)
-
-	_, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{commitQCs: []*types.CommitQC{qc0, qc2}})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "non-contiguous")
-}
-
-func TestNewInnerLoadedCommitQCsEmpty(t *testing.T) {
-	rng := utils.TestRng()
-	registry, _ := epoch.GenRegistry(rng, 4)
-
-	inner, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{})
-	require.NoError(t, err)
-
-	require.Equal(t, types.RoadIndex(0), inner.roads.first)
-	require.Equal(t, types.RoadIndex(0), inner.roads.next)
-	_, ok := inner.persistedCommitQC.Load().Get()
-	require.False(t, ok)
-}
-
-func TestNewInnerLoadedBlocksGapReturnsError(t *testing.T) {
-	rng := utils.TestRng()
-	registry, keys := epoch.GenRegistry(rng, 4)
-	lane := registry.LatestEpoch().Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
-
-	var bs []persist.LoadedBlock
-	for _, n := range []types.BlockNumber{3, 4, 6, 7} {
-		bs = append(bs, persist.LoadedBlock{Number: n, Proposal: testSignedBlock(keys[0], lane, n, types.BlockHeaderHash{}, rng)})
-	}
-
-	_, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
-		blocks: map[types.LaneID][]persist.LoadedBlock{lane: bs},
+	t.Run("foreign loaded lane does not touch committee queues", func(t *testing.T) {
+		rng := utils.TestRng()
+		registry, _ := epoch.GenRegistry(rng, 4)
+		unknownKey := types.GenSecretKey(rng)
+		unknownLane := types.LaneID{Validator: unknownKey.Public(), Joined: 0}
+		b := testSignedBlock(unknownKey, unknownLane, 0, types.BlockHeaderHash{}, rng)
+		i, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
+			blocks: map[types.LaneID][]persist.LoadedBlock{unknownLane: {{Number: 0, Proposal: b}}},
+		})
+		require.NoError(t, err)
+		q := i.blocks[unknownLane]
+		require.Equal(t, types.BlockNumber(0), q.first)
+		require.Equal(t, types.BlockNumber(1), q.next)
+		require.Equal(t, b, q.q[0])
+		for lane := range registry.LatestEpoch().Committee().Lanes().All() {
+			cq := i.blocks[lane]
+			require.Equal(t, types.BlockNumber(0), cq.first)
+			require.Equal(t, types.BlockNumber(0), cq.next)
+		}
 	})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "non-contiguous")
-}
 
-func TestNewInnerLoadedBlocksParentHashMismatchReturnsError(t *testing.T) {
-	rng := utils.TestRng()
-	registry, keys := epoch.GenRegistry(rng, 4)
-	lane := registry.LatestEpoch().Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
+	t.Run("multiple lanes", func(t *testing.T) {
+		rng := utils.TestRng()
+		registry, keys := epoch.GenRegistry(rng, 4)
+		lane0 := registry.LatestEpoch().Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
+		lane1 := registry.LatestEpoch().Committee().Lane(keys[1].Public()).OrPanic("keys[1]")
+		bs0 := contiguousBlocks(keys[0], lane0, 2, rng)
+		bs1 := contiguousBlocks(keys[1], lane1, 3, rng)
+		i, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
+			blocks: map[types.LaneID][]persist.LoadedBlock{lane0: bs0, lane1: bs1},
+		})
+		require.NoError(t, err)
+		require.Equal(t, types.BlockNumber(2), i.blocks[lane0].next)
+		require.Equal(t, types.BlockNumber(3), i.blocks[lane1].next)
+		require.Equal(t, types.BlockNumber(2), i.nextBlockToPersist[lane0])
+		require.Equal(t, types.BlockNumber(3), i.nextBlockToPersist[lane1])
+	})
 
-	var parent types.BlockHeaderHash
-	b0 := testSignedBlock(keys[0], lane, 0, parent, rng)
-	parent = b0.Msg().Block().Header().Hash()
-	b1 := testSignedBlock(keys[0], lane, 1, parent, rng)
-	b2 := testSignedBlock(keys[0], lane, 2, types.GenBlockHeaderHash(rng), rng)
+	t.Run("gap", func(t *testing.T) {
+		rng := utils.TestRng()
+		registry, keys := epoch.GenRegistry(rng, 4)
+		lane0 := registry.LatestEpoch().Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
+		var bs []persist.LoadedBlock
+		for _, n := range []types.BlockNumber{3, 4, 6, 7} {
+			bs = append(bs, persist.LoadedBlock{Number: n, Proposal: testSignedBlock(keys[0], lane0, n, types.BlockHeaderHash{}, rng)})
+		}
+		_, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
+			blocks: map[types.LaneID][]persist.LoadedBlock{lane0: bs},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "non-contiguous")
+	})
 
-	_, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
-		blocks: map[types.LaneID][]persist.LoadedBlock{lane: {
+	t.Run("parent hash mismatch", func(t *testing.T) {
+		rng := utils.TestRng()
+		registry, keys := epoch.GenRegistry(rng, 4)
+		lane0 := registry.LatestEpoch().Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
+		var parent types.BlockHeaderHash
+		b0 := testSignedBlock(keys[0], lane0, 0, parent, rng)
+		parent = b0.Msg().Block().Header().Hash()
+		b1 := testSignedBlock(keys[0], lane0, 1, parent, rng)
+		b2 := testSignedBlock(keys[0], lane0, 2, types.GenBlockHeaderHash(rng), rng)
+		_, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{blocks: map[types.LaneID][]persist.LoadedBlock{lane0: {
 			{Number: 0, Proposal: b0},
 			{Number: 1, Proposal: b1},
 			{Number: 2, Proposal: b2},
-		}},
+		}}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "parent hash mismatch")
 	})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "parent hash mismatch")
+
+	t.Run("over capacity", func(t *testing.T) {
+		rng := utils.TestRng()
+		registry, keys := epoch.GenRegistry(rng, 4)
+		lane0 := registry.LatestEpoch().Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
+		bs := contiguousBlocks(keys[0], lane0, BlocksPerLane+5, rng)
+		_, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
+			blocks: map[types.LaneID][]persist.LoadedBlock{lane0: bs},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds capacity")
+	})
 }
 
-func TestNewInnerLoadedBlocksOverCapacityReturnsError(t *testing.T) {
+func TestNewInner_LoadedCommitQCs(t *testing.T) {
+	t.Run("contiguous", func(t *testing.T) {
+		rng := utils.TestRng()
+		registry, keys := epoch.GenRegistry(rng, 4)
+		ds := newTestDataState(&data.Config{Registry: registry})
+		qcs := make([]*types.CommitQC, 3)
+		prev := utils.None[*types.CommitQC]()
+		for i := range qcs {
+			qcs[i] = types.BuildCommitQC(registry.LatestEpoch(), keys, prev, nil)
+			prev = utils.Some(qcs[i])
+		}
+		inner, err := newInner(ds, &loadedState{commitQCs: qcs})
+		require.NoError(t, err)
+		require.Equal(t, types.RoadIndex(0), inner.roads.first)
+		require.Equal(t, types.RoadIndex(3), inner.roads.next)
+		for i, qc := range qcs {
+			require.NoError(t, utils.TestDiff(qc, inner.roads.q[types.RoadIndex(i)].commitQC))
+		}
+		require.NoError(t, utils.TestDiff(utils.Some(qcs[2]), inner.persistedCommitQC.Load()))
+	})
+
+	t.Run("gap", func(t *testing.T) {
+		rng := utils.TestRng()
+		registry, keys := epoch.GenRegistry(rng, 4)
+		ds := newTestDataState(&data.Config{Registry: registry})
+		qc0 := types.BuildCommitQC(registry.LatestEpoch(), keys, utils.None[*types.CommitQC](), nil)
+		qc1 := types.BuildCommitQC(registry.LatestEpoch(), keys, utils.Some(qc0), nil)
+		qc2 := types.BuildCommitQC(registry.LatestEpoch(), keys, utils.Some(qc1), nil)
+		_, err := newInner(ds, &loadedState{commitQCs: []*types.CommitQC{qc0, qc2}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "non-contiguous")
+	})
+}
+
+func TestAddLane_ReportsNewLaneForEachMembershipPeriod(t *testing.T) {
+	rng := utils.TestRng()
+	a := types.GenSecretKey(rng)
+
+	i := &inner{
+		blocks:             map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]{},
+		votes:              map[types.LaneID]*queue[types.BlockNumber, *blockVotes]{},
+		nextBlockToPersist: map[types.LaneID]types.BlockNumber{},
+	}
+	lane := types.LaneID{Validator: a.Public(), Joined: 1}
+	require.True(t, i.addLane(lane))
+	require.False(t, i.addLane(lane))
+	require.True(t, i.addLane(types.LaneID{Validator: a.Public(), Joined: 3}))
+}
+
+// TestNextInstallableEpoch_BoundaryTipUsesDataAppQC: tip at LastRoad(0) with
+// applied floored to 0 (restart), data's Anchor already covers epoch 0, registry
+// has epoch 1 → install walks to 1 so ConsensusSpec republishes the tip.
+// This is the avail half of the blind-Spec restore invariant: consensus may
+// refuse to start if Spec stays behind a WAL tip at LastRoad(0) after catch-up.
+func TestNextInstallableEpoch_BoundaryTipUsesDataAppQC(t *testing.T) {
+	ctx := t.Context()
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
-	lane := registry.LatestEpoch().Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
+	ds := newTestDataState(&data.Config{Registry: registry})
 
-	count := BlocksPerLane + 5
-	var parent types.BlockHeaderHash
-	var bs []persist.LoadedBlock
-	for n := types.BlockNumber(0); n < types.BlockNumber(count); n++ {
-		b := testSignedBlock(keys[0], lane, n, parent, rng)
-		parent = b.Msg().Block().Header().Hash()
-		bs = append(bs, persist.LoadedBlock{Number: n, Proposal: b})
-	}
+	ep0, ok := registry.EpochByIndex(0)
+	require.True(t, ok)
 
-	_, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
-		blocks: map[types.LaneID][]persist.LoadedBlock{lane: bs},
+	require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
+		s.SpawnBgNamed("data.Run", func() error {
+			return utils.IgnoreCancel(ds.Run(ctx))
+		})
+		qc0, blocks := data.TestCommitQC(rng, ep0, keys, utils.None[*types.CommitQC]())
+		if err := ds.PushQC(ctx, qc0, blocks); err != nil {
+			return err
+		}
+		if err := ds.PushAppHash(ctx, qc0.QC().GlobalRange().Next-1, types.GenAppHash(rng)); err != nil {
+			return err
+		}
+		vote, err := ds.AppVote(ctx, qc0.QC().GlobalRange().First)
+		if err != nil {
+			return err
+		}
+		if err := ds.PushAppQC(ctx, data.TestAppQC(keys, vote.Proposal())); err != nil {
+			return err
+		}
+		_, err = ds.Anchor().Wait(ctx, func(a utils.Option[data.Anchor]) bool {
+			got, ok := a.Get()
+			return ok && got.CommitQC.Index() == qc0.QC().Index()
+		})
+		return err
+	}))
+	anchor, ok := ds.Anchor().Load().Get()
+	require.True(t, ok)
+	require.Equal(t, types.EpochIndex(0), anchor.Epoch.EpochIndex())
+
+	registry.AdvanceIfNeeded(epoch.LastRoad(0))
+	ep1, ok := registry.EpochByIndex(1)
+	require.True(t, ok)
+
+	last := epoch.LastRoad(0)
+	prev := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
+		types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep0, types.View{Index: last - 1, Number: 0}))),
 	})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "exceeds capacity")
+	qcLast := types.BuildCommitQC(ep0, keys, utils.Some(prev), nil)
+	require.Equal(t, last, qcLast.Index())
+
+	i := &inner{
+		persistedCommitQC:  utils.NewAtomicSend(utils.None[*types.CommitQC]()),
+		consensusSpec:      utils.NewAtomicSend(utils.None[types.ConsensusSpec]()),
+		roads:              newQueue[types.RoadIndex, *road](),
+		epoch:              utils.NewAtomicSend(ep0),
+		anchorEpoch:        utils.Some(anchor.Epoch),
+		blocks:             map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]{},
+		votes:              map[types.LaneID]*queue[types.BlockNumber, *blockVotes]{},
+		nextBlockToPersist: map[types.LaneID]types.BlockNumber{},
+	}
+	for lane := range ep0.Committee().Lanes().All() {
+		i.addLane(lane)
+	}
+	i.roads.first = last
+	i.roads.next = last
+	i.roads.pushBack(newRoad(qcLast, ep0))
+	i.persistedCommitQC.Store(utils.Some(qcLast))
+	i.epoch.Store(ep0)
+
+	require.False(t, i.roads.q[last].appQC.IsPresent(), "road AppQC empty; prune leash is the Anchor")
+	require.True(t, i.leashesMet())
+	require.True(t, i.nextInstallableEpoch(ds).IsPresent())
+	require.Equal(t, types.EpochIndex(1), i.nextInstallableEpoch(ds).OrPanic("installable").EpochIndex())
+
+	for {
+		next, ok := i.nextInstallableEpoch(ds).Get()
+		if !ok {
+			break
+		}
+		i.installEpoch(next)
+	}
+	i.refreshConsensusSpec()
+
+	require.Equal(t, ep1.EpochIndex(), i.epoch.Load().EpochIndex())
+	spec, ok := i.consensusSpec.Load().Get()
+	require.True(t, ok)
+	require.Equal(t, last, spec.CommitQC.Index(), "must not walk tip back to LastRoad(0)-1")
+	require.Equal(t, types.EpochIndex(1), spec.Epoch.EpochIndex())
+}
+
+// TestRefreshConsensusSpec_WithholdsTipUntilNextViewEpochApplied: the durable tip
+// sits on LastRoad(0) while applied is still epoch 0, and the tip's predecessor is
+// retained. The spec must be withheld rather than published at that predecessor —
+// a node that already entered epoch 1 holds the tip and must not be rolled back.
+func TestRefreshConsensusSpec_WithholdsTipUntilNextViewEpochApplied(t *testing.T) {
+	rng := utils.TestRng()
+	registry, keys := epoch.GenRegistry(rng, 4)
+	registry.AdvanceIfNeeded(epoch.LastRoad(0))
+
+	ep0, ok := registry.EpochByIndex(0)
+	require.True(t, ok)
+	ep1, ok := registry.EpochByIndex(1)
+	require.True(t, ok)
+
+	last := epoch.LastRoad(0)
+	qcPrev := types.BuildCommitQC(ep0, keys, utils.Some(tipLink(ep0, keys[0], last-2)), nil)
+	qcLast := types.BuildCommitQC(ep0, keys, utils.Some(qcPrev), nil)
+	require.Equal(t, last-1, qcPrev.Index())
+	require.Equal(t, last, qcLast.Index())
+
+	i := &inner{
+		persistedCommitQC:  utils.NewAtomicSend(utils.None[*types.CommitQC]()),
+		consensusSpec:      utils.NewAtomicSend(utils.None[types.ConsensusSpec]()),
+		roads:              newQueue[types.RoadIndex, *road](),
+		epoch:              utils.NewAtomicSend(ep0),
+		blocks:             map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]{},
+		votes:              map[types.LaneID]*queue[types.BlockNumber, *blockVotes]{},
+		nextBlockToPersist: map[types.LaneID]types.BlockNumber{},
+	}
+	i.roads.first = last - 1
+	i.roads.next = last - 1
+	i.roads.pushBack(newRoad(qcPrev, ep0))
+	i.roads.pushBack(newRoad(qcLast, ep0))
+	i.persistedCommitQC.Store(utils.Some(qcLast))
+
+	i.refreshConsensusSpec()
+	require.False(t, i.consensusSpec.Load().IsPresent(), "spec must be withheld, not published at the predecessor")
+
+	i.installEpoch(ep1)
+	spec, ok := i.consensusSpec.Load().Get()
+	require.True(t, ok)
+	require.Equal(t, last, spec.CommitQC.Index())
+	require.Equal(t, types.EpochIndex(1), spec.Epoch.EpochIndex())
 }

--- a/sei-tendermint/internal/autobahn/avail/inner_test.go
+++ b/sei-tendermint/internal/autobahn/avail/inner_test.go
@@ -48,7 +48,7 @@ func TestNewInner_Empty(t *testing.T) {
 	_, ok := i.persistedCommitQC.Load().Get()
 	require.False(t, ok)
 	require.NotNil(t, i.nextBlockToPersist)
-	for lane := range registry.LatestEpoch().Committee().Lanes().All() {
+	for lane := range registry.MustEpoch(0).Committee().Lanes().All() {
 		require.Equal(t, types.BlockNumber(0), i.blocks[lane].first)
 		require.Equal(t, types.BlockNumber(0), i.blocks[lane].next)
 		require.Equal(t, types.BlockNumber(0), i.votes[lane].first)
@@ -60,7 +60,7 @@ func TestNewInner_LoadedBlocks(t *testing.T) {
 	t.Run("contiguous", func(t *testing.T) {
 		rng := utils.TestRng()
 		registry, keys := epoch.GenRegistry(rng, 4)
-		lane0 := registry.LatestEpoch().Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
+		lane0 := registry.MustEpoch(0).Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
 		ds := newTestDataState(&data.Config{Registry: registry})
 		bs := contiguousBlocks(keys[0], lane0, 3, rng)
 		i, err := newInner(ds, &loadedState{blocks: map[types.LaneID][]persist.LoadedBlock{lane0: bs}})
@@ -72,7 +72,7 @@ func TestNewInner_LoadedBlocks(t *testing.T) {
 			require.Equal(t, b.Proposal, q.q[types.BlockNumber(j)])
 		}
 		require.Equal(t, types.BlockNumber(3), i.nextBlockToPersist[lane0])
-		for other := range registry.LatestEpoch().Committee().Lanes().All() {
+		for other := range registry.MustEpoch(0).Committee().Lanes().All() {
 			if other != lane0 {
 				require.Equal(t, types.BlockNumber(0), i.nextBlockToPersist[other])
 			}
@@ -82,7 +82,7 @@ func TestNewInner_LoadedBlocks(t *testing.T) {
 	t.Run("empty slice", func(t *testing.T) {
 		rng := utils.TestRng()
 		registry, keys := epoch.GenRegistry(rng, 4)
-		lane0 := registry.LatestEpoch().Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
+		lane0 := registry.MustEpoch(0).Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
 		i, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
 			blocks: map[types.LaneID][]persist.LoadedBlock{lane0: {}},
 		})
@@ -106,7 +106,7 @@ func TestNewInner_LoadedBlocks(t *testing.T) {
 		require.Equal(t, types.BlockNumber(0), q.first)
 		require.Equal(t, types.BlockNumber(1), q.next)
 		require.Equal(t, b, q.q[0])
-		for lane := range registry.LatestEpoch().Committee().Lanes().All() {
+		for lane := range registry.MustEpoch(0).Committee().Lanes().All() {
 			cq := i.blocks[lane]
 			require.Equal(t, types.BlockNumber(0), cq.first)
 			require.Equal(t, types.BlockNumber(0), cq.next)
@@ -116,8 +116,8 @@ func TestNewInner_LoadedBlocks(t *testing.T) {
 	t.Run("multiple lanes", func(t *testing.T) {
 		rng := utils.TestRng()
 		registry, keys := epoch.GenRegistry(rng, 4)
-		lane0 := registry.LatestEpoch().Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
-		lane1 := registry.LatestEpoch().Committee().Lane(keys[1].Public()).OrPanic("keys[1]")
+		lane0 := registry.MustEpoch(0).Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
+		lane1 := registry.MustEpoch(0).Committee().Lane(keys[1].Public()).OrPanic("keys[1]")
 		bs0 := contiguousBlocks(keys[0], lane0, 2, rng)
 		bs1 := contiguousBlocks(keys[1], lane1, 3, rng)
 		i, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
@@ -133,7 +133,7 @@ func TestNewInner_LoadedBlocks(t *testing.T) {
 	t.Run("gap", func(t *testing.T) {
 		rng := utils.TestRng()
 		registry, keys := epoch.GenRegistry(rng, 4)
-		lane0 := registry.LatestEpoch().Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
+		lane0 := registry.MustEpoch(0).Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
 		var bs []persist.LoadedBlock
 		for _, n := range []types.BlockNumber{3, 4, 6, 7} {
 			bs = append(bs, persist.LoadedBlock{Number: n, Proposal: testSignedBlock(keys[0], lane0, n, types.BlockHeaderHash{}, rng)})
@@ -148,7 +148,7 @@ func TestNewInner_LoadedBlocks(t *testing.T) {
 	t.Run("parent hash mismatch", func(t *testing.T) {
 		rng := utils.TestRng()
 		registry, keys := epoch.GenRegistry(rng, 4)
-		lane0 := registry.LatestEpoch().Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
+		lane0 := registry.MustEpoch(0).Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
 		var parent types.BlockHeaderHash
 		b0 := testSignedBlock(keys[0], lane0, 0, parent, rng)
 		parent = b0.Msg().Block().Header().Hash()
@@ -166,7 +166,7 @@ func TestNewInner_LoadedBlocks(t *testing.T) {
 	t.Run("over capacity", func(t *testing.T) {
 		rng := utils.TestRng()
 		registry, keys := epoch.GenRegistry(rng, 4)
-		lane0 := registry.LatestEpoch().Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
+		lane0 := registry.MustEpoch(0).Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
 		bs := contiguousBlocks(keys[0], lane0, BlocksPerLane+5, rng)
 		_, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
 			blocks: map[types.LaneID][]persist.LoadedBlock{lane0: bs},
@@ -184,7 +184,7 @@ func TestNewInner_LoadedCommitQCs(t *testing.T) {
 		qcs := make([]*types.CommitQC, 3)
 		prev := utils.None[*types.CommitQC]()
 		for i := range qcs {
-			qcs[i] = types.BuildCommitQC(registry.LatestEpoch(), keys, prev, nil)
+			qcs[i] = types.BuildCommitQC(registry.MustEpoch(0), keys, prev, nil)
 			prev = utils.Some(qcs[i])
 		}
 		inner, err := newInner(ds, &loadedState{commitQCs: qcs})
@@ -201,9 +201,9 @@ func TestNewInner_LoadedCommitQCs(t *testing.T) {
 		rng := utils.TestRng()
 		registry, keys := epoch.GenRegistry(rng, 4)
 		ds := newTestDataState(&data.Config{Registry: registry})
-		qc0 := types.BuildCommitQC(registry.LatestEpoch(), keys, utils.None[*types.CommitQC](), nil)
-		qc1 := types.BuildCommitQC(registry.LatestEpoch(), keys, utils.Some(qc0), nil)
-		qc2 := types.BuildCommitQC(registry.LatestEpoch(), keys, utils.Some(qc1), nil)
+		qc0 := types.BuildCommitQC(registry.MustEpoch(0), keys, utils.None[*types.CommitQC](), nil)
+		qc1 := types.BuildCommitQC(registry.MustEpoch(0), keys, utils.Some(qc0), nil)
+		qc2 := types.BuildCommitQC(registry.MustEpoch(0), keys, utils.Some(qc1), nil)
 		_, err := newInner(ds, &loadedState{commitQCs: []*types.CommitQC{qc0, qc2}})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "non-contiguous")
@@ -236,8 +236,7 @@ func TestAdvanceReadyEpochs_BoundaryTipUsesDataAppQC(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 4)
 	ds := newTestDataState(&data.Config{Registry: registry})
 
-	ep0, ok := registry.EpochByIndex(0)
-	require.True(t, ok)
+	ep0 := registry.MustEpoch(0)
 
 	require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
 		s.SpawnBgNamed("data.Run", func() error {
@@ -268,8 +267,7 @@ func TestAdvanceReadyEpochs_BoundaryTipUsesDataAppQC(t *testing.T) {
 	require.Equal(t, types.EpochIndex(0), anchor.Epoch.EpochIndex())
 
 	registry.AdvanceIfNeeded(epoch.LastRoad(0))
-	ep1, ok := registry.EpochByIndex(1)
-	require.True(t, ok)
+	ep1 := registry.MustEpoch(1)
 
 	last := epoch.LastRoad(0)
 	prev := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
@@ -313,8 +311,7 @@ func TestAdvanceReadyEpochs_MissingNextEpochErrors(t *testing.T) {
 	rng := utils.TestRng()
 	// Fresh registry has epochs 0 and 1; seal epoch 1 so the next lookup is 2.
 	registry, keys := epoch.GenRegistry(rng, 3)
-	ep1, ok := registry.EpochByIndex(1)
-	require.True(t, ok)
+	ep1 := registry.MustEpoch(1)
 	_, err := registry.EpochAt(epoch.FirstRoad(2))
 	require.Error(t, err)
 
@@ -356,10 +353,8 @@ func TestRefreshConsensusSpec_WithholdsTipUntilNextViewEpochApplied(t *testing.T
 	registry, keys := epoch.GenRegistry(rng, 4)
 	registry.AdvanceIfNeeded(epoch.LastRoad(0))
 
-	ep0, ok := registry.EpochByIndex(0)
-	require.True(t, ok)
-	ep1, ok := registry.EpochByIndex(1)
-	require.True(t, ok)
+	ep0 := registry.MustEpoch(0)
+	ep1 := registry.MustEpoch(1)
 
 	last := epoch.LastRoad(0)
 	qcPrev := types.BuildCommitQC(ep0, keys, utils.Some(tipLink(ep0, keys[0], last-2)), nil)

--- a/sei-tendermint/internal/autobahn/avail/inner_test.go
+++ b/sei-tendermint/internal/autobahn/avail/inner_test.go
@@ -225,12 +225,12 @@ func TestAddLane_ReportsNewLaneForEachMembershipPeriod(t *testing.T) {
 	require.True(t, i.addLane(types.LaneID{Validator: a.Public(), Joined: 3}))
 }
 
-// TestNextInstallableEpoch_BoundaryTipUsesDataAppQC: tip at LastRoad(0) with
+// TestInstallReadyEpochs_BoundaryTipUsesDataAppQC: tip at LastRoad(0) with
 // applied floored to 0 (restart), data's Anchor already covers epoch 0, registry
 // has epoch 1 → install walks to 1 so ConsensusSpec republishes the tip.
 // This is the avail half of the blind-Spec restore invariant: consensus may
 // refuse to start if Spec stays behind a WAL tip at LastRoad(0) after catch-up.
-func TestNextInstallableEpoch_BoundaryTipUsesDataAppQC(t *testing.T) {
+func TestInstallReadyEpochs_BoundaryTipUsesDataAppQC(t *testing.T) {
 	ctx := t.Context()
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
@@ -280,7 +280,7 @@ func TestNextInstallableEpoch_BoundaryTipUsesDataAppQC(t *testing.T) {
 
 	i := &inner{
 		persistedCommitQC:  utils.NewAtomicSend(utils.None[*types.CommitQC]()),
-		consensusSpec:      utils.NewAtomicSend(utils.None[types.ConsensusSpec]()),
+		consensusSpec:      utils.NewAtomicSend(types.ConsensusSpec{CommitQC: utils.None[*types.CommitQC](), Epoch: ep0}),
 		roads:              newQueue[types.RoadIndex, *road](),
 		epoch:              utils.NewAtomicSend(ep0),
 		anchorEpoch:        utils.Some(anchor.Epoch),
@@ -299,23 +299,52 @@ func TestNextInstallableEpoch_BoundaryTipUsesDataAppQC(t *testing.T) {
 
 	require.False(t, i.roads.q[last].appQC.IsPresent(), "road AppQC empty; prune leash is the Anchor")
 	require.True(t, i.leashesMet())
-	require.True(t, i.nextInstallableEpoch(ds).IsPresent())
-	require.Equal(t, types.EpochIndex(1), i.nextInstallableEpoch(ds).OrPanic("installable").EpochIndex())
-
-	for {
-		next, ok := i.nextInstallableEpoch(ds).Get()
-		if !ok {
-			break
-		}
-		i.installEpoch(next)
-	}
-	i.refreshConsensusSpec()
+	require.NoError(t, i.installReadyEpochs(ds))
 
 	require.Equal(t, ep1.EpochIndex(), i.epoch.Load().EpochIndex())
-	spec, ok := i.consensusSpec.Load().Get()
+	spec := i.consensusSpec.Load()
+	cqc, ok := spec.CommitQC.Get()
 	require.True(t, ok)
-	require.Equal(t, last, spec.CommitQC.Index(), "must not walk tip back to LastRoad(0)-1")
+	require.Equal(t, last, cqc.Index(), "must not walk tip back to LastRoad(0)-1")
 	require.Equal(t, types.EpochIndex(1), spec.Epoch.EpochIndex())
+}
+
+func TestInstallReadyEpochs_MissingNextEpochErrors(t *testing.T) {
+	rng := utils.TestRng()
+	// Fresh registry has epochs 0 and 1; seal epoch 1 so the next lookup is 2.
+	registry, keys := epoch.GenRegistry(rng, 3)
+	ep1, ok := registry.EpochByIndex(1)
+	require.True(t, ok)
+	_, err := registry.EpochAt(epoch.FirstRoad(2))
+	require.Error(t, err)
+
+	last := epoch.LastRoad(1)
+	prev := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
+		types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep1, types.View{Index: last - 1, Number: 0}, ep1.FirstBlock()))),
+	})
+	qcLast := types.BuildCommitQC(ep1, keys, utils.Some(prev), nil)
+	require.Equal(t, last, qcLast.Index())
+
+	i := &inner{
+		persistedCommitQC:  utils.NewAtomicSend(utils.None[*types.CommitQC]()),
+		consensusSpec:      utils.NewAtomicSend(types.ConsensusSpec{CommitQC: utils.None[*types.CommitQC](), Epoch: ep1}),
+		roads:              newQueue[types.RoadIndex, *road](),
+		epoch:              utils.NewAtomicSend(ep1),
+		anchorEpoch:        utils.Some(ep1),
+		blocks:             map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]{},
+		votes:              map[types.LaneID]*queue[types.BlockNumber, *blockVotes]{},
+		nextBlockToPersist: map[types.LaneID]types.BlockNumber{},
+	}
+	for lane := range ep1.Committee().Lanes().All() {
+		i.addLane(lane)
+	}
+	i.roads.first = last
+	i.roads.next = last
+	i.roads.pushBack(newRoad(qcLast, ep1))
+	i.persistedCommitQC.Store(utils.Some(qcLast))
+
+	require.True(t, i.leashesMet())
+	require.Error(t, i.installReadyEpochs(newTestDataState(&data.Config{Registry: registry})))
 }
 
 // TestRefreshConsensusSpec_WithholdsTipUntilNextViewEpochApplied: the durable tip
@@ -340,7 +369,7 @@ func TestRefreshConsensusSpec_WithholdsTipUntilNextViewEpochApplied(t *testing.T
 
 	i := &inner{
 		persistedCommitQC:  utils.NewAtomicSend(utils.None[*types.CommitQC]()),
-		consensusSpec:      utils.NewAtomicSend(utils.None[types.ConsensusSpec]()),
+		consensusSpec:      utils.NewAtomicSend(types.ConsensusSpec{CommitQC: utils.None[*types.CommitQC](), Epoch: ep0}),
 		roads:              newQueue[types.RoadIndex, *road](),
 		epoch:              utils.NewAtomicSend(ep0),
 		blocks:             map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]{},
@@ -354,11 +383,12 @@ func TestRefreshConsensusSpec_WithholdsTipUntilNextViewEpochApplied(t *testing.T
 	i.persistedCommitQC.Store(utils.Some(qcLast))
 
 	i.refreshConsensusSpec()
-	require.False(t, i.consensusSpec.Load().IsPresent(), "spec must be withheld, not published at the predecessor")
+	require.False(t, i.consensusSpec.Load().CommitQC.IsPresent(), "spec must be withheld, not published at the predecessor")
 
 	i.installEpoch(ep1)
-	spec, ok := i.consensusSpec.Load().Get()
+	spec := i.consensusSpec.Load()
+	cqc, ok := spec.CommitQC.Get()
 	require.True(t, ok)
-	require.Equal(t, last, spec.CommitQC.Index())
+	require.Equal(t, last, cqc.Index())
 	require.Equal(t, types.EpochIndex(1), spec.Epoch.EpochIndex())
 }

--- a/sei-tendermint/internal/autobahn/avail/inner_test.go
+++ b/sei-tendermint/internal/autobahn/avail/inner_test.go
@@ -1,7 +1,6 @@
 package avail
 
 import (
-	"context"
 	"testing"
 
 	"github.com/sei-protocol/sei-chain/sei-db/ledger_db/block/memblock"
@@ -12,7 +11,6 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/epoch"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/require"
-	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/scope"
 )
 
 func newTestDataState(cfg *data.Config) *data.State {
@@ -36,11 +34,11 @@ func contiguousBlocks(key types.SecretKey, lane types.LaneID, n int, rng utils.R
 	return bs
 }
 
-func TestNewInner_Empty(t *testing.T) {
+func TestRestoreInner_Empty(t *testing.T) {
 	rng := utils.TestRng()
 	registry, _ := epoch.GenRegistry(rng, 4)
 
-	i, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{})
+	i, err := restoreInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{})
 	require.NoError(t, err)
 
 	require.Equal(t, types.RoadIndex(0), i.roads.first)
@@ -56,14 +54,14 @@ func TestNewInner_Empty(t *testing.T) {
 	}
 }
 
-func TestNewInner_LoadedBlocks(t *testing.T) {
+func TestRestoreInner_LoadedBlocks(t *testing.T) {
 	t.Run("contiguous", func(t *testing.T) {
 		rng := utils.TestRng()
 		registry, keys := epoch.GenRegistry(rng, 4)
 		lane0 := registry.MustEpoch(0).Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
 		ds := newTestDataState(&data.Config{Registry: registry})
 		bs := contiguousBlocks(keys[0], lane0, 3, rng)
-		i, err := newInner(ds, &loadedState{blocks: map[types.LaneID][]persist.LoadedBlock{lane0: bs}})
+		i, err := restoreInner(ds, &loadedState{blocks: map[types.LaneID][]persist.LoadedBlock{lane0: bs}})
 		require.NoError(t, err)
 		q := i.blocks[lane0]
 		require.Equal(t, types.BlockNumber(0), q.first)
@@ -83,7 +81,7 @@ func TestNewInner_LoadedBlocks(t *testing.T) {
 		rng := utils.TestRng()
 		registry, keys := epoch.GenRegistry(rng, 4)
 		lane0 := registry.MustEpoch(0).Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
-		i, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
+		i, err := restoreInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
 			blocks: map[types.LaneID][]persist.LoadedBlock{lane0: {}},
 		})
 		require.NoError(t, err)
@@ -98,7 +96,7 @@ func TestNewInner_LoadedBlocks(t *testing.T) {
 		unknownKey := types.GenSecretKey(rng)
 		unknownLane := types.LaneID{Validator: unknownKey.Public(), Joined: 0}
 		b := testSignedBlock(unknownKey, unknownLane, 0, types.BlockHeaderHash{}, rng)
-		i, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
+		i, err := restoreInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
 			blocks: map[types.LaneID][]persist.LoadedBlock{unknownLane: {{Number: 0, Proposal: b}}},
 		})
 		require.NoError(t, err)
@@ -120,7 +118,7 @@ func TestNewInner_LoadedBlocks(t *testing.T) {
 		lane1 := registry.MustEpoch(0).Committee().Lane(keys[1].Public()).OrPanic("keys[1]")
 		bs0 := contiguousBlocks(keys[0], lane0, 2, rng)
 		bs1 := contiguousBlocks(keys[1], lane1, 3, rng)
-		i, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
+		i, err := restoreInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
 			blocks: map[types.LaneID][]persist.LoadedBlock{lane0: bs0, lane1: bs1},
 		})
 		require.NoError(t, err)
@@ -138,7 +136,7 @@ func TestNewInner_LoadedBlocks(t *testing.T) {
 		for _, n := range []types.BlockNumber{3, 4, 6, 7} {
 			bs = append(bs, persist.LoadedBlock{Number: n, Proposal: testSignedBlock(keys[0], lane0, n, types.BlockHeaderHash{}, rng)})
 		}
-		_, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
+		_, err := restoreInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
 			blocks: map[types.LaneID][]persist.LoadedBlock{lane0: bs},
 		})
 		require.Error(t, err)
@@ -154,7 +152,7 @@ func TestNewInner_LoadedBlocks(t *testing.T) {
 		parent = b0.Msg().Block().Header().Hash()
 		b1 := testSignedBlock(keys[0], lane0, 1, parent, rng)
 		b2 := testSignedBlock(keys[0], lane0, 2, types.GenBlockHeaderHash(rng), rng)
-		_, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{blocks: map[types.LaneID][]persist.LoadedBlock{lane0: {
+		_, err := restoreInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{blocks: map[types.LaneID][]persist.LoadedBlock{lane0: {
 			{Number: 0, Proposal: b0},
 			{Number: 1, Proposal: b1},
 			{Number: 2, Proposal: b2},
@@ -168,7 +166,7 @@ func TestNewInner_LoadedBlocks(t *testing.T) {
 		registry, keys := epoch.GenRegistry(rng, 4)
 		lane0 := registry.MustEpoch(0).Committee().Lane(keys[0].Public()).OrPanic("keys[0]")
 		bs := contiguousBlocks(keys[0], lane0, BlocksPerLane+5, rng)
-		_, err := newInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
+		_, err := restoreInner(newTestDataState(&data.Config{Registry: registry}), &loadedState{
 			blocks: map[types.LaneID][]persist.LoadedBlock{lane0: bs},
 		})
 		require.Error(t, err)
@@ -176,7 +174,7 @@ func TestNewInner_LoadedBlocks(t *testing.T) {
 	})
 }
 
-func TestNewInner_LoadedCommitQCs(t *testing.T) {
+func TestRestoreInner_LoadedCommitQCs(t *testing.T) {
 	t.Run("contiguous", func(t *testing.T) {
 		rng := utils.TestRng()
 		registry, keys := epoch.GenRegistry(rng, 4)
@@ -187,7 +185,7 @@ func TestNewInner_LoadedCommitQCs(t *testing.T) {
 			qcs[i] = types.BuildCommitQC(registry.MustEpoch(0), keys, prev, nil)
 			prev = utils.Some(qcs[i])
 		}
-		inner, err := newInner(ds, &loadedState{commitQCs: qcs})
+		inner, err := restoreInner(ds, &loadedState{commitQCs: qcs})
 		require.NoError(t, err)
 		require.Equal(t, types.RoadIndex(0), inner.roads.first)
 		require.Equal(t, types.RoadIndex(3), inner.roads.next)
@@ -195,6 +193,11 @@ func TestNewInner_LoadedCommitQCs(t *testing.T) {
 			require.NoError(t, utils.TestDiff(qc, inner.roads.q[types.RoadIndex(i)].commitQC))
 		}
 		require.NoError(t, utils.TestDiff(utils.Some(qcs[2]), inner.persistedCommitQC.Load()))
+		spec := inner.consensusSpec.Load()
+		require.Equal(t, types.EpochIndex(0), spec.Epoch.EpochIndex())
+		got, ok := spec.CommitQC.Get()
+		require.True(t, ok)
+		require.NoError(t, utils.TestDiff(qcs[2], got))
 	})
 
 	t.Run("gap", func(t *testing.T) {
@@ -204,7 +207,7 @@ func TestNewInner_LoadedCommitQCs(t *testing.T) {
 		qc0 := types.BuildCommitQC(registry.MustEpoch(0), keys, utils.None[*types.CommitQC](), nil)
 		qc1 := types.BuildCommitQC(registry.MustEpoch(0), keys, utils.Some(qc0), nil)
 		qc2 := types.BuildCommitQC(registry.MustEpoch(0), keys, utils.Some(qc1), nil)
-		_, err := newInner(ds, &loadedState{commitQCs: []*types.CommitQC{qc0, qc2}})
+		_, err := restoreInner(ds, &loadedState{commitQCs: []*types.CommitQC{qc0, qc2}})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "non-contiguous")
 	})
@@ -223,122 +226,6 @@ func TestAddLane_ReportsNewLaneForEachMembershipPeriod(t *testing.T) {
 	require.True(t, i.addLane(lane))
 	require.False(t, i.addLane(lane))
 	require.True(t, i.addLane(types.LaneID{Validator: a.Public(), Joined: 3}))
-}
-
-// TestTryAdvanceEpoch_BoundaryTipUsesDataAppQC: tip at LastRoad(0) with
-// applied floored to 0 (restart), data's Anchor already covers epoch 0, registry
-// has epoch 1 → applied advances to 1 so ConsensusSpec republishes the tip.
-// This is the avail half of the blind-Spec restore invariant: consensus may
-// refuse to start if Spec stays behind a WAL tip at LastRoad(0) after catch-up.
-func TestTryAdvanceEpoch_BoundaryTipUsesDataAppQC(t *testing.T) {
-	ctx := t.Context()
-	rng := utils.TestRng()
-	registry, keys := epoch.GenRegistry(rng, 4)
-	ds := newTestDataState(&data.Config{Registry: registry})
-
-	ep0 := registry.MustEpoch(0)
-
-	require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
-		s.SpawnBgNamed("data.Run", func() error {
-			return utils.IgnoreCancel(ds.Run(ctx))
-		})
-		qc0, blocks := data.TestCommitQC(rng, ep0, keys, utils.None[*types.CommitQC]())
-		if err := ds.PushQC(ctx, qc0, blocks); err != nil {
-			return err
-		}
-		if err := ds.PushAppHash(ctx, qc0.QC().GlobalRange().Next-1, types.GenAppHash(rng)); err != nil {
-			return err
-		}
-		vote, err := ds.AppVote(ctx, qc0.QC().GlobalRange().First)
-		if err != nil {
-			return err
-		}
-		if err := ds.PushAppQC(ctx, data.TestAppQC(keys, vote.Proposal())); err != nil {
-			return err
-		}
-		_, err = ds.Anchor().Wait(ctx, func(a utils.Option[data.Anchor]) bool {
-			got, ok := a.Get()
-			return ok && got.CommitQC.Index() == qc0.QC().Index()
-		})
-		return err
-	}))
-	anchor, ok := ds.Anchor().Load().Get()
-	require.True(t, ok)
-	require.Equal(t, types.EpochIndex(0), anchor.Epoch.EpochIndex())
-
-	registry.AdvanceIfNeeded(epoch.LastRoad(0))
-	ep1 := registry.MustEpoch(1)
-
-	last := epoch.LastRoad(0)
-	prev := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
-		types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep0, types.View{Index: last - 1, Number: 0}, ep0.FirstBlock()))),
-	})
-	qcLast := types.BuildCommitQC(ep0, keys, utils.Some(prev), nil)
-	require.Equal(t, last, qcLast.Index())
-
-	i := &inner{
-		persistedCommitQC:  utils.NewAtomicSend(utils.None[*types.CommitQC]()),
-		consensusSpec:      utils.NewAtomicSend(types.ConsensusSpec{CommitQC: utils.None[*types.CommitQC](), Epoch: ep0}),
-		roads:              newQueue[types.RoadIndex, *road](),
-		anchorEpoch:        utils.Some(anchor.Epoch),
-		blocks:             map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]{},
-		votes:              map[types.LaneID]*queue[types.BlockNumber, *blockVotes]{},
-		nextBlockToPersist: map[types.LaneID]types.BlockNumber{},
-	}
-	for lane := range ep0.Committee().Lanes().All() {
-		i.addLane(lane)
-	}
-	i.roads.first = last
-	i.roads.next = last
-	i.roads.pushBack(newRoad(qcLast, ep0))
-	i.persistedCommitQC.Store(utils.Some(qcLast))
-
-	require.False(t, i.roads.q[last].appQC.IsPresent(), "road AppQC empty; prune leash is the Anchor")
-	require.True(t, i.canAdvanceEpoch())
-	require.NoError(t, i.tryAdvanceEpoch(ds))
-
-	require.Equal(t, ep1.EpochIndex(), i.applied().EpochIndex())
-	spec := i.consensusSpec.Load()
-	cqc, ok := spec.CommitQC.Get()
-	require.True(t, ok)
-	require.Equal(t, last, cqc.Index(), "must not walk tip back to LastRoad(0)-1")
-	require.Equal(t, types.EpochIndex(1), spec.Epoch.EpochIndex())
-}
-
-func TestTryAdvanceEpoch_MissingNextEpochErrors(t *testing.T) {
-	rng := utils.TestRng()
-	// Fresh registry has epochs 0 and 1; seal epoch 1 so the next lookup is 2.
-	registry, keys := epoch.GenRegistry(rng, 3)
-	ep1 := registry.MustEpoch(1)
-	_, err := registry.EpochAt(epoch.FirstRoad(2))
-	require.Error(t, err)
-
-	last := epoch.LastRoad(1)
-	prev := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
-		types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep1, types.View{Index: last - 1, Number: 0}, ep1.FirstBlock()))),
-	})
-	qcLast := types.BuildCommitQC(ep1, keys, utils.Some(prev), nil)
-	require.Equal(t, last, qcLast.Index())
-
-	i := &inner{
-		persistedCommitQC:  utils.NewAtomicSend(utils.None[*types.CommitQC]()),
-		consensusSpec:      utils.NewAtomicSend(types.ConsensusSpec{CommitQC: utils.None[*types.CommitQC](), Epoch: ep1}),
-		roads:              newQueue[types.RoadIndex, *road](),
-		anchorEpoch:        utils.Some(ep1),
-		blocks:             map[types.LaneID]*queue[types.BlockNumber, *types.Signed[*types.LaneProposal]]{},
-		votes:              map[types.LaneID]*queue[types.BlockNumber, *blockVotes]{},
-		nextBlockToPersist: map[types.LaneID]types.BlockNumber{},
-	}
-	for lane := range ep1.Committee().Lanes().All() {
-		i.addLane(lane)
-	}
-	i.roads.first = last
-	i.roads.next = last
-	i.roads.pushBack(newRoad(qcLast, ep1))
-	i.persistedCommitQC.Store(utils.Some(qcLast))
-
-	require.True(t, i.canAdvanceEpoch())
-	require.Error(t, i.tryAdvanceEpoch(newTestDataState(&data.Config{Registry: registry})))
 }
 
 // TestRefreshConsensusSpec_WithholdsTipUntilNextViewEpochApplied: the durable tip

--- a/sei-tendermint/internal/autobahn/avail/inner_test.go
+++ b/sei-tendermint/internal/autobahn/avail/inner_test.go
@@ -225,12 +225,12 @@ func TestAddLane_ReportsNewLaneForEachMembershipPeriod(t *testing.T) {
 	require.True(t, i.addLane(types.LaneID{Validator: a.Public(), Joined: 3}))
 }
 
-// TestAdvanceReadyEpochs_BoundaryTipUsesDataAppQC: tip at LastRoad(0) with
+// TestTryAdvanceEpoch_BoundaryTipUsesDataAppQC: tip at LastRoad(0) with
 // applied floored to 0 (restart), data's Anchor already covers epoch 0, registry
-// has epoch 1 → advance walks to 1 so ConsensusSpec republishes the tip.
+// has epoch 1 → applied advances to 1 so ConsensusSpec republishes the tip.
 // This is the avail half of the blind-Spec restore invariant: consensus may
 // refuse to start if Spec stays behind a WAL tip at LastRoad(0) after catch-up.
-func TestAdvanceReadyEpochs_BoundaryTipUsesDataAppQC(t *testing.T) {
+func TestTryAdvanceEpoch_BoundaryTipUsesDataAppQC(t *testing.T) {
 	ctx := t.Context()
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
@@ -295,7 +295,7 @@ func TestAdvanceReadyEpochs_BoundaryTipUsesDataAppQC(t *testing.T) {
 
 	require.False(t, i.roads.q[last].appQC.IsPresent(), "road AppQC empty; prune leash is the Anchor")
 	require.True(t, i.canAdvanceEpoch())
-	require.NoError(t, i.advanceReadyEpochs(ds))
+	require.NoError(t, i.tryAdvanceEpoch(ds))
 
 	require.Equal(t, ep1.EpochIndex(), i.applied().EpochIndex())
 	spec := i.consensusSpec.Load()
@@ -305,7 +305,7 @@ func TestAdvanceReadyEpochs_BoundaryTipUsesDataAppQC(t *testing.T) {
 	require.Equal(t, types.EpochIndex(1), spec.Epoch.EpochIndex())
 }
 
-func TestAdvanceReadyEpochs_MissingNextEpochErrors(t *testing.T) {
+func TestTryAdvanceEpoch_MissingNextEpochErrors(t *testing.T) {
 	rng := utils.TestRng()
 	// Fresh registry has epochs 0 and 1; seal epoch 1 so the next lookup is 2.
 	registry, keys := epoch.GenRegistry(rng, 3)
@@ -338,7 +338,7 @@ func TestAdvanceReadyEpochs_MissingNextEpochErrors(t *testing.T) {
 	i.persistedCommitQC.Store(utils.Some(qcLast))
 
 	require.True(t, i.canAdvanceEpoch())
-	require.Error(t, i.advanceReadyEpochs(newTestDataState(&data.Config{Registry: registry})))
+	require.Error(t, i.tryAdvanceEpoch(newTestDataState(&data.Config{Registry: registry})))
 }
 
 // TestRefreshConsensusSpec_WithholdsTipUntilNextViewEpochApplied: the durable tip

--- a/sei-tendermint/internal/autobahn/avail/state.go
+++ b/sei-tendermint/internal/autobahn/avail/state.go
@@ -35,9 +35,6 @@ const BlocksPerLane = 3 * types.MaxLaneRangeInProposal
 // Lane maps and WALs outlive committee membership until the anchor epoch
 // IsClosed that LaneID. Before any Anchor exists, the anchor epoch is the
 // applied epoch.
-//
-// Per-lane vote queues supply LaneQC weight under the applied epoch, and
-// FullCommitQC headers until the anchor epoch IsClosed that LaneID.
 type State struct {
 	key   types.SecretKey
 	data  *data.State
@@ -54,7 +51,7 @@ func (s *State) PublicKey() types.PublicKey {
 	return s.key.Public()
 }
 
-// Epoch returns the applied (next-CommitQC) epoch. ApplyEpoch advances it.
+// Epoch returns the applied (next-CommitQC) epoch. runEpochAdvance advances it.
 func (s *State) Epoch() utils.AtomicRecv[*types.Epoch] {
 	return s.epoch
 }
@@ -76,16 +73,6 @@ func (s *State) WaitUntilClosed(ctx context.Context, lane types.LaneID) error {
 		return ep.IsClosed(lane)
 	})
 	return err
-}
-
-func (s *State) ApplyEpoch(ep *types.Epoch) {
-	for inner, ctrl := range s.inner.Lock() {
-		for lane := range ep.Committee().Lanes().All() {
-			inner.addLane(lane)
-		}
-		inner.epoch.Store(ep)
-		ctrl.Updated()
-	}
 }
 
 // persisters holds all disk persistence components. Either all are present
@@ -185,6 +172,15 @@ func (s *State) LastCommitQC() utils.AtomicRecv[utils.Option[*types.CommitQC]] {
 	panic("unreachable")
 }
 
+// SubscribeConsensusSpec returns a receiver of the durable CommitQC tip paired
+// with the epoch governing the view that follows it. None until a tip exists.
+func (s *State) SubscribeConsensusSpec() utils.AtomicRecv[utils.Option[types.ConsensusSpec]] {
+	for inner := range s.inner.Lock() {
+		return inner.consensusSpec.Subscribe()
+	}
+	panic("unreachable")
+}
+
 func (s *State) appQC(ctx context.Context, idx types.RoadIndex) (*types.AppQC, error) {
 	for inner, ctrl := range s.inner.Lock() {
 		for {
@@ -223,10 +219,32 @@ func (s *State) CommitQC(ctx context.Context, idx types.RoadIndex) (*types.Commi
 	return qc, err
 }
 
-// PushCommitQC pushes a CommitQC to the state.
-// Waits until all previous CommitQCs are pushed.
+// waitUntilApplied blocks until the applied (next-CommitQC) epoch equals i.
+// Returns ErrPruned if applied has already passed i (see types.ErrPruned).
+func (s *State) waitUntilApplied(ctx context.Context, i types.EpochIndex) (*types.Epoch, error) {
+	epoch, err := s.epoch.Wait(ctx, func(epoch *types.Epoch) bool {
+		return i <= epoch.EpochIndex()
+	})
+	if err != nil {
+		return nil, err
+	}
+	if epoch.EpochIndex() != i {
+		return nil, types.ErrPruned
+	}
+	return epoch, nil
+}
+
+// PushCommitQC admits a CommitQC once its epoch is applied (ingress wait).
+// Stale QCs are a no-op.
 func (s *State) PushCommitQC(ctx context.Context, qc *types.CommitQC) error {
 	idx := qc.Proposal().Index()
+	epoch, err := s.waitUntilApplied(ctx, qc.Proposal().EpochIndex())
+	if err != nil {
+		if errors.Is(err, types.ErrPruned) {
+			return nil
+		}
+		return err
+	}
 	for inner, ctrl := range s.inner.Lock() {
 		if err := ctrl.WaitUntil(ctx, func() bool { return idx <= inner.roads.next }); err != nil {
 			return err
@@ -234,10 +252,6 @@ func (s *State) PushCommitQC(ctx context.Context, qc *types.CommitQC) error {
 		if inner.roads.next > idx {
 			return nil
 		}
-	}
-	epoch, ok := s.data.Registry().EpochByIndex(qc.Proposal().EpochIndex())
-	if !ok {
-		return fmt.Errorf("unknown epoch_index %d", qc.Proposal().EpochIndex())
 	}
 	if err := qc.Verify(epoch); err != nil {
 		return fmt.Errorf("qc.Verify(): %w", err)
@@ -323,22 +337,20 @@ func (s *State) Block(ctx context.Context, lane types.LaneID, n types.BlockNumbe
 // Waits until all previous blocks are available.
 // A missing map (closed lane, or a LaneID never admitted) is a silent no-op —
 // future lanes are not waited on.
+// Accepts a proposal valid under the applied or Anchor epoch.
 func (s *State) PushBlock(ctx context.Context, p *types.Signed[*types.LaneProposal]) error {
 	h := p.Msg().Block().Header()
 	if p.Key() != h.Lane().Validator {
 		return fmt.Errorf("signer %v does not match lane %v", p.Key(), h.Lane())
 	}
-	if _, err := s.data.Registry().VerifyInWindow(func(c *types.Committee) error {
-		if err := p.Msg().Verify(c); err != nil {
-			return err
-		}
-		return p.VerifySig(c)
-	}); err != nil {
-		return fmt.Errorf("block.Verify(): %w", err)
-	}
 	lane := h.Lane()
 	n := h.BlockNumber()
 	for inner, ctrl := range s.inner.Lock() {
+		if !laneAcceptedUnder(inner, func(ep *types.Epoch) bool {
+			return laneProposalAcceptedByEpoch(ep, p)
+		}) {
+			return nil
+		}
 		if err := ctrl.WaitUntil(ctx, func() bool {
 			q, ok := inner.blocks[lane]
 			if !ok {
@@ -385,8 +397,8 @@ func (s *State) PushBlock(ctx context.Context, p *types.Signed[*types.LanePropos
 // PushVote pushes a LaneVote to the state.
 // Waits until the lane has enough capacity for the new vote.
 // It does NOT wait for the previous votes.
-// Accepts a vote valid under the applied epoch or the Anchor epoch; LaneQC
-// weight always uses the applied epoch.
+// Accepts a vote valid under the applied or Anchor epoch (header evidence may
+// come from either); LaneQC weight uses only the applied epoch.
 func (s *State) PushVote(ctx context.Context, vote *types.Signed[*types.LaneVote]) error {
 	h := vote.Msg().Header()
 	lane := h.Lane()
@@ -409,26 +421,46 @@ func (s *State) PushVote(ctx context.Context, vote *types.Signed[*types.LaneVote
 			return nil
 		}
 		applied := inner.epoch.Load()
-		// TODO: return a meaningful validation error when the vote
-		// matches neither epoch, or when verification fails under a matching epoch.
-		if !laneVoteAccepted(applied, vote) &&
-			(applied.EpochIndex() == inner.anchorEpoch.EpochIndex() || !laneVoteAccepted(inner.anchorEpoch, vote)) {
+		// TODO: accept future-epoch joiner votes.
+		if !laneAcceptedUnder(inner, func(ep *types.Epoch) bool {
+			return laneVoteAcceptedByEpoch(ep, vote)
+		}) {
 			return nil
 		}
 		for q.next <= n {
 			q.pushBack(newBlockVotes())
 		}
-		if _, ok := q.q[n].pushVote(applied, vote); ok {
+		if q.q[n].pushVote(applied, vote) {
 			ctrl.Updated()
 		}
 	}
 	return nil
 }
 
-// laneVoteAccepted reports whether vote verifies under ep's committee.
-func laneVoteAccepted(ep *types.Epoch, vote *types.Signed[*types.LaneVote]) bool {
+// laneVoteAcceptedByEpoch reports whether vote verifies under ep's committee.
+func laneVoteAcceptedByEpoch(ep *types.Epoch, vote *types.Signed[*types.LaneVote]) bool {
 	c := ep.Committee()
 	return vote.Msg().Verify(c) == nil && vote.VerifySig(c) == nil
+}
+
+// laneProposalAcceptedByEpoch reports whether p verifies under ep's committee.
+func laneProposalAcceptedByEpoch(ep *types.Epoch, p *types.Signed[*types.LaneProposal]) bool {
+	c := ep.Committee()
+	return p.Msg().Verify(c) == nil && p.VerifySig(c) == nil
+}
+
+// laneAcceptedUnder reports whether accept holds for the applied epoch, or for
+// the Anchor epoch when present and a different EpochIndex.
+func laneAcceptedUnder(inner *inner, accept func(*types.Epoch) bool) bool {
+	applied := inner.epoch.Load()
+	if accept(applied) {
+		return true
+	}
+	ae, ok := inner.anchorEpoch.Get()
+	if !ok || ae.EpochIndex() == applied.EpochIndex() {
+		return false
+	}
+	return accept(ae)
 }
 
 // headers collects headers for the given range under ep (the CommitQC's road epoch).
@@ -457,11 +489,12 @@ func (s *State) headers(ctx context.Context, ep *types.Epoch, lr *types.LaneRang
 					return nil, types.ErrPruned
 				}
 				// Check if we have the header.
-				if entry, ok := q.q[n].byHash[want]; ok {
-					h := entry.votes[0].Msg().Header()
-					want = h.ParentHash()
-					headers[len(headers)-i-1] = h
-					break
+				if bv, ok := q.q[n]; ok {
+					if h, ok := bv.header(want).Get(); ok {
+						want = h.ParentHash()
+						headers[len(headers)-i-1] = h
+						break
+					}
 				}
 				// Otherwise, wait.
 				if err := ctrl.Wait(ctx); err != nil {
@@ -524,7 +557,7 @@ func (s *State) WaitForLaneQCs(
 			for lane := range ep.Committee().Lanes().All() {
 				first := types.LaneRangeOpt(prev, lane).Next()
 				for i := range types.BlockNumber(types.MaxLaneRangeInProposal) {
-					if qc, ok := inner.laneQC(lane, first+i); ok {
+					if qc, ok := inner.laneQC(lane, first+i).Get(); ok {
 						laneQCs[lane] = qc
 					} else {
 						break
@@ -632,11 +665,9 @@ func (s *State) runEvict(ctx context.Context) error {
 		}
 		for inner, ctrl := range s.inner.Lock() {
 			if anchor.CommitQC.Index() >= inner.roads.first {
-				ep, err := anchorEpochOf(s.data.Registry(), anchor)
-				if err != nil {
-					return err
-				}
-				inner.prune(anchor, ep)
+				inner.prune(anchor)
+				// Mostly for catch-up: tip jumps to the Anchor when roads empty.
+				inner.refreshConsensusSpec()
 			}
 			ctrl.Updated()
 		}
@@ -644,9 +675,35 @@ func (s *State) runEvict(ctx context.Context) error {
 	})
 }
 
+// runEpochAdvance is the sole writer of inner.epoch after construction. It waits
+// for the execution leash on the registry, then seal and the prune leash on
+// avail's inner watch (leashesMet), and installs one epoch per wake.
+func (s *State) runEpochAdvance(ctx context.Context) error {
+	for {
+		next := s.epoch.Load().EpochIndex() + 1
+		ep, err := s.data.Registry().WaitForEpoch(ctx, next)
+		if err != nil {
+			return err
+		}
+		for inner, ctrl := range s.inner.Lock() {
+			if err := ctrl.WaitUntil(ctx, func() bool {
+				return inner.leashesMet()
+			}); err != nil {
+				return err
+			}
+			if got := inner.epoch.Load().EpochIndex(); got+1 != next {
+				return fmt.Errorf("runEpochAdvance: applied %d, want %d before install", got, next-1)
+			}
+			inner.installEpoch(ep)
+			ctrl.Updated()
+		}
+	}
+}
+
 // Run runs the background tasks of the state.
 func (s *State) Run(ctx context.Context) error {
 	return scope.Run(ctx, func(ctx context.Context, scope scope.Scope) error {
+		scope.SpawnNamed("runEpochAdvance", func() error { return s.runEpochAdvance(ctx) })
 		scope.SpawnNamed("runEvict", func() error { return s.runEvict(ctx) })
 		scope.SpawnNamed("runPersist", func() error { return s.runPersist(ctx) })
 		scope.SpawnNamed("runPushQC", func() error { return s.runPushQC(ctx) })
@@ -729,9 +786,12 @@ func (s *State) setNextBlockToPersist(lane types.LaneID, next types.BlockNumber)
 
 // markCommitQCsPersisted publishes the latest persisted CommitQC,
 // gating consensus from advancing until the QC is durable.
+// ConsensusSpec is refreshed here so tip catch-up stays visible even while
+// runEpochAdvance is parked on WaitForEpoch.
 func (s *State) markCommitQCsPersisted(qc *types.CommitQC) {
 	for inner := range s.inner.Lock() {
 		inner.persistedCommitQC.Store(utils.Some(qc))
+		inner.refreshConsensusSpec()
 	}
 }
 

--- a/sei-tendermint/internal/autobahn/avail/state.go
+++ b/sei-tendermint/internal/autobahn/avail/state.go
@@ -39,8 +39,7 @@ type State struct {
 	key   types.SecretKey
 	data  *data.State
 	inner utils.Watch[*inner]
-	// epoch is a Load-only view of inner.epoch (applied / next-CommitQC epoch).
-	epoch utils.AtomicRecv[*types.Epoch]
+	spec  utils.AtomicRecv[types.ConsensusSpec]
 
 	// persisters groups all disk persistence components.
 	// Always initialized: real when stateDir is set, no-op otherwise.
@@ -51,9 +50,24 @@ func (s *State) PublicKey() types.PublicKey {
 	return s.key.Public()
 }
 
+// appliedEpoch is Load/Wait over consensusSpec.Epoch.
+type appliedEpoch struct {
+	spec utils.AtomicRecv[types.ConsensusSpec]
+}
+
+func (e appliedEpoch) Load() *types.Epoch { return e.spec.Load().Epoch }
+
+func (e appliedEpoch) Wait(ctx context.Context, pred func(*types.Epoch) bool) (*types.Epoch, error) {
+	sp, err := e.spec.Wait(ctx, func(sp types.ConsensusSpec) bool { return pred(sp.Epoch) })
+	if err != nil {
+		return nil, err
+	}
+	return sp.Epoch, nil
+}
+
 // Epoch returns the applied (next-CommitQC) epoch. runEpochAdvance advances it.
-func (s *State) Epoch() utils.AtomicRecv[*types.Epoch] {
-	return s.epoch
+func (s *State) Epoch() appliedEpoch {
+	return appliedEpoch{s.spec}
 }
 
 func (s *State) LocalLane() utils.Option[types.LaneID] {
@@ -61,7 +75,7 @@ func (s *State) LocalLane() utils.Option[types.LaneID] {
 }
 
 func (s *State) Lane(pk types.PublicKey) utils.Option[types.LaneID] {
-	return s.epoch.Load().Committee().Lane(pk)
+	return s.Epoch().Load().Committee().Lane(pk)
 }
 
 func (s *State) WaitForLocalLane(ctx context.Context) (types.LaneID, error) {
@@ -69,7 +83,7 @@ func (s *State) WaitForLocalLane(ctx context.Context) (types.LaneID, error) {
 }
 
 func (s *State) WaitUntilClosed(ctx context.Context, lane types.LaneID) error {
-	_, err := s.epoch.Wait(ctx, func(ep *types.Epoch) bool {
+	_, err := s.Epoch().Wait(ctx, func(ep *types.Epoch) bool {
 		return ep.IsClosed(lane)
 	})
 	return err
@@ -133,7 +147,7 @@ func NewState(key types.SecretKey, data *data.State, stateDir utils.Option[strin
 		key:        key,
 		data:       data,
 		inner:      utils.NewWatch(inner),
-		epoch:      inner.epoch.Subscribe(),
+		spec:       inner.consensusSpec.Subscribe(),
 		persisters: pers,
 	}, nil
 }
@@ -176,10 +190,7 @@ func (s *State) LastCommitQC() utils.AtomicRecv[utils.Option[*types.CommitQC]] {
 // with the epoch of the RoadIndex that follows it. CommitQC is None before
 // the first tip; until then Epoch is genesis epoch 0.
 func (s *State) SubscribeConsensusSpec() utils.AtomicRecv[types.ConsensusSpec] {
-	for inner := range s.inner.Lock() {
-		return inner.consensusSpec.Subscribe()
-	}
-	panic("unreachable")
+	return s.spec
 }
 
 func (s *State) appQC(ctx context.Context, idx types.RoadIndex) (*types.AppQC, error) {
@@ -223,7 +234,7 @@ func (s *State) CommitQC(ctx context.Context, idx types.RoadIndex) (*types.Commi
 // waitUntilAdvanced blocks until the applied (next-CommitQC) epoch equals i.
 // Returns ErrPruned if applied has already passed i (see types.ErrPruned).
 func (s *State) waitUntilAdvanced(ctx context.Context, i types.EpochIndex) (*types.Epoch, error) {
-	epoch, err := s.epoch.Wait(ctx, func(epoch *types.Epoch) bool {
+	epoch, err := s.Epoch().Wait(ctx, func(epoch *types.Epoch) bool {
 		return i <= epoch.EpochIndex()
 	})
 	if err != nil {
@@ -440,7 +451,7 @@ func (s *State) PushVote(ctx context.Context, vote *types.Signed[*types.LaneVote
 		if err := vote.Msg().Verify(ep.Committee()); err != nil {
 			return nil
 		}
-		applied := inner.epoch.Load()
+		applied := inner.applied()
 		for q.next <= n {
 			q.pushBack(newBlockVotes())
 		}
@@ -461,7 +472,7 @@ func epochForVote(inner *inner, vote *types.Signed[*types.LaneVote]) utils.Optio
 		c := ep.Committee()
 		return c.HasLane(lane) && c.HasReplica(key)
 	}
-	applied := inner.epoch.Load()
+	applied := inner.applied()
 	if belongs(applied) {
 		return utils.Some(applied)
 	}
@@ -475,7 +486,7 @@ func epochForVote(inner *inner, vote *types.Signed[*types.LaneVote]) utils.Optio
 // epochForLane returns the applied epoch if it has lane, otherwise the Anchor
 // epoch when that is a different EpochIndex and has lane.
 func epochForLane(inner *inner, lane types.LaneID) utils.Option[*types.Epoch] {
-	applied := inner.epoch.Load()
+	applied := inner.applied()
 	if applied.Committee().HasLane(lane) {
 		return utils.Some(applied)
 	}
@@ -698,12 +709,12 @@ func (s *State) runEvict(ctx context.Context) error {
 	})
 }
 
-// runEpochAdvance is the sole writer of inner.epoch after construction. It waits
+// runEpochAdvance is the sole writer of applied epoch (consensusSpec.Epoch) after construction. It waits
 // for the execution leash on the registry, then seal and the prune leash on
 // avail's inner watch (canAdvanceEpoch), and advances one epoch per wake.
 func (s *State) runEpochAdvance(ctx context.Context) error {
 	for {
-		next := s.epoch.Load().EpochIndex() + 1
+		next := s.Epoch().Load().EpochIndex() + 1
 		// ErrPruned is not expected here: PushCommitQC withholds a CommitQC
 		// until its epoch is applied, so the Anchor never leads applied by more
 		// than one epoch and PruneBefore cannot drop next.
@@ -717,7 +728,7 @@ func (s *State) runEpochAdvance(ctx context.Context) error {
 			}); err != nil {
 				return err
 			}
-			if got := inner.epoch.Load().EpochIndex(); got+1 != next {
+			if got := inner.applied().EpochIndex(); got+1 != next {
 				return fmt.Errorf("runEpochAdvance: applied %d, want %d before advance", got, next-1)
 			}
 			inner.advanceEpoch(ep)
@@ -815,9 +826,10 @@ func (s *State) setNextBlockToPersist(lane types.LaneID, next types.BlockNumber)
 // ConsensusSpec is refreshed here so tip catch-up stays visible even while
 // runEpochAdvance is parked on WaitForEpoch.
 func (s *State) markCommitQCsPersisted(qc *types.CommitQC) {
-	for inner := range s.inner.Lock() {
+	for inner, ctrl := range s.inner.Lock() {
 		inner.persistedCommitQC.Store(utils.Some(qc))
 		inner.refreshConsensusSpec()
+		ctrl.Updated()
 	}
 }
 

--- a/sei-tendermint/internal/autobahn/avail/state.go
+++ b/sei-tendermint/internal/autobahn/avail/state.go
@@ -286,7 +286,11 @@ func (s *State) PushAppVote(ctx context.Context, v *types.Signed[*types.AppVote]
 	if err := v.Msg().Proposal().Verify(commitQC); err != nil {
 		return fmt.Errorf("invalid vote: %w", err)
 	}
-	if err := v.VerifySig(epoch.Committee()); err != nil {
+	c := epoch.Committee()
+	if !c.HasReplica(v.Key()) {
+		return fmt.Errorf("%q is not a replica", v.Key())
+	}
+	if err := v.VerifySig(); err != nil {
 		return fmt.Errorf("v.VerifySig(): %w", err)
 	}
 	for inner, ctrl := range s.inner.Lock() {
@@ -346,13 +350,14 @@ func (s *State) PushBlock(ctx context.Context, p *types.Signed[*types.LanePropos
 	}
 	lane := h.Lane()
 	n := h.BlockNumber()
-	if err := types.VerifyLaneProposalPayloadAndSignature(p); err != nil {
-		return err
+	if err := p.Msg().Verify(); err != nil {
+		return fmt.Errorf("Verify(): %w", err)
+	}
+	if err := p.VerifySig(); err != nil {
+		return fmt.Errorf("VerifySig(): %w", err)
 	}
 	for inner, ctrl := range s.inner.Lock() {
-		if !laneAcceptedUnder(inner, func(ep *types.Epoch) bool {
-			return p.Msg().VerifyCommitteeMembership(ep.Committee()) == nil
-		}) {
+		if !epochForLane(inner, lane).IsPresent() {
 			return nil
 		}
 		if err := ctrl.WaitUntil(ctx, func() bool {
@@ -407,8 +412,8 @@ func (s *State) PushVote(ctx context.Context, vote *types.Signed[*types.LaneVote
 	h := vote.Msg().Header()
 	lane := h.Lane()
 	n := h.BlockNumber()
-	if err := vote.VerifySignature(); err != nil {
-		return fmt.Errorf("VerifySignature(): %w", err)
+	if err := vote.VerifySig(); err != nil {
+		return fmt.Errorf("VerifySig(): %w", err)
 	}
 	for inner, ctrl := range s.inner.Lock() {
 		if err := ctrl.WaitUntil(ctx, func() bool {
@@ -428,9 +433,7 @@ func (s *State) PushVote(ctx context.Context, vote *types.Signed[*types.LaneVote
 			return nil
 		}
 		// TODO: accept future-epoch joiner votes.
-		if !laneAcceptedUnder(inner, func(ep *types.Epoch) bool {
-			return laneVoteCommitteeOK(ep, vote)
-		}) {
+		if !epochForVote(inner, vote).IsPresent() {
 			return nil
 		}
 		applied := inner.epoch.Load()
@@ -444,24 +447,37 @@ func (s *State) PushVote(ctx context.Context, vote *types.Signed[*types.LaneVote
 	return nil
 }
 
-// laneVoteCommitteeOK reports whether the vote's header lane and signer are in ep's committee.
-func laneVoteCommitteeOK(ep *types.Epoch, vote *types.Signed[*types.LaneVote]) bool {
-	c := ep.Committee()
-	return vote.Msg().Verify(c) == nil && c.HasReplica(vote.Key())
-}
-
-// laneAcceptedUnder reports whether accept holds for the applied epoch, or for
-// the Anchor epoch when present and a different EpochIndex.
-func laneAcceptedUnder(inner *inner, accept func(*types.Epoch) bool) bool {
+// epochForVote returns the applied or Anchor epoch under which vote's lane and
+// signer verify. Prefers applied; falls back to Anchor when that is a different
+// EpochIndex.
+func epochForVote(inner *inner, vote *types.Signed[*types.LaneVote]) utils.Option[*types.Epoch] {
+	match := func(ep *types.Epoch) bool {
+		c := ep.Committee()
+		return vote.Msg().Verify(c) == nil && c.HasReplica(vote.Key())
+	}
 	applied := inner.epoch.Load()
-	if accept(applied) {
-		return true
+	if match(applied) {
+		return utils.Some(applied)
 	}
 	ae, ok := inner.anchorEpoch.Get()
-	if !ok || ae.EpochIndex() == applied.EpochIndex() {
-		return false
+	if !ok || ae.EpochIndex() == applied.EpochIndex() || !match(ae) {
+		return utils.None[*types.Epoch]()
 	}
-	return accept(ae)
+	return utils.Some(ae)
+}
+
+// epochForLane returns the applied epoch if it has lane, otherwise the Anchor
+// epoch when that is a different EpochIndex and has lane.
+func epochForLane(inner *inner, lane types.LaneID) utils.Option[*types.Epoch] {
+	applied := inner.epoch.Load()
+	if applied.Committee().HasLane(lane) {
+		return utils.Some(applied)
+	}
+	ae, ok := inner.anchorEpoch.Get()
+	if !ok || ae.EpochIndex() == applied.EpochIndex() || !ae.Committee().HasLane(lane) {
+		return utils.None[*types.Epoch]()
+	}
+	return utils.Some(ae)
 }
 
 // headers collects headers for the given range under ep (the CommitQC's road epoch).

--- a/sei-tendermint/internal/autobahn/avail/state.go
+++ b/sei-tendermint/internal/autobahn/avail/state.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/avail/metrics"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/consensus/persist"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/data"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/epoch"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/scope"
 )
@@ -133,7 +134,7 @@ func NewState(key types.SecretKey, data *data.State, stateDir utils.Option[strin
 	if err != nil {
 		return nil, err
 	}
-	inner, err := newInner(data, loaded)
+	inner, err := restoreInner(data, loaded)
 	if err != nil {
 		_ = pers.close()
 		return nil, err
@@ -150,6 +151,101 @@ func NewState(key types.SecretKey, data *data.State, stateDir utils.Option[strin
 		spec:       inner.consensusSpec.Subscribe(),
 		persisters: pers,
 	}, nil
+}
+
+// restoreInner constructs inner from persisted WAL records and data.State.
+func restoreInner(ds *data.State, loaded *loadedState) (*inner, error) {
+	applied, first, qcs, err := restorePlan(ds, loaded)
+	if err != nil {
+		return nil, err
+	}
+	i := newInner(applied, first)
+	for lane := range loaded.blocks {
+		i.addLane(lane)
+	}
+	if anchor, ok := ds.Anchor().Load().Get(); ok {
+		i.prune(anchor)
+	}
+	for _, r := range qcs {
+		i.roads.pushBack(newRoad(r.qc, r.ep))
+	}
+	if i.roads.Len() > 0 {
+		last := i.roads.q[i.roads.next-1]
+		i.persistedCommitQC.Store(utils.Some(last.commitQC))
+	}
+	if err := i.restoreBlocks(loaded.blocks); err != nil {
+		return nil, err
+	}
+	i.refreshConsensusSpec()
+	return i, nil
+}
+
+type restoredQC struct {
+	qc *types.CommitQC
+	ep *types.Epoch
+}
+
+// restorePlan is the applied epoch, first RoadIndex (0 or Anchor+1), and
+// verified CommitQCs for construction. The epoch is genesis when there is no
+// tip, otherwise nextViewEpoch of the persisted tip (last restored QC, or the
+// Anchor QC when the queue is empty).
+func restorePlan(ds *data.State, loaded *loadedState) (*types.Epoch, types.RoadIndex, []restoredQC, error) {
+	registry := ds.Registry()
+	genesis, err := registry.EpochByIndex(0)
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("genesis epoch 0: %w", err)
+	}
+	var first types.RoadIndex
+	var tip *types.CommitQC
+	var tipEpoch *types.Epoch
+	if anchor, ok := ds.Anchor().Load().Get(); ok {
+		first = anchor.CommitQC.Index() + 1
+		tip = anchor.CommitQC
+		tipEpoch = anchor.Epoch
+	}
+	var qcs []restoredQC
+	for _, qc := range loaded.commitQCs {
+		if qc.Index() < first {
+			continue
+		}
+		want := first + types.RoadIndex(len(qcs))
+		if qc.Index() != want {
+			return nil, 0, nil, fmt.Errorf("non-contiguous persisted commitQCs: expected %d, got %d", want, qc.Index())
+		}
+		ep, err := registry.EpochByIndex(qc.Proposal().EpochIndex())
+		if err != nil {
+			return nil, 0, nil, fmt.Errorf("persisted commitQC %d epoch: %w", qc.Index(), err)
+		}
+		if err := qc.Verify(ep); err != nil {
+			return nil, 0, nil, fmt.Errorf("persisted commitQC %d verify: %w", qc.Index(), err)
+		}
+		qcs = append(qcs, restoredQC{qc: qc, ep: ep})
+		tip = qc
+		tipEpoch = ep
+	}
+	if tip == nil {
+		return genesis, first, qcs, nil
+	}
+	applied, err := nextViewEpoch(registry, tip, tipEpoch)
+	if err != nil {
+		return nil, 0, nil, err
+	}
+	return applied, first, qcs, nil
+}
+
+// nextViewEpoch is the epoch of the road after tip: tipEpoch, or the next
+// registry epoch when tip sits on tipEpoch's last road. Consensus reads
+// ConsensusSpec once at construction, so a boundary tip has to be paired
+// here rather than left to runEpochAdvance.
+func nextViewEpoch(registry *epoch.Registry, tip *types.CommitQC, tipEpoch *types.Epoch) (*types.Epoch, error) {
+	if tipEpoch.RoadRange().Has(tip.Index() + 1) {
+		return tipEpoch, nil
+	}
+	next, err := registry.EpochByIndex(tipEpoch.EpochIndex() + 1)
+	if err != nil {
+		return nil, fmt.Errorf("epoch %d after sealed tip %d: %w", tipEpoch.EpochIndex()+1, tip.Index(), err)
+	}
+	return next, nil
 }
 
 // Close releases the WALs this state owns, and with them the exclusive lock each holds on its
@@ -647,8 +743,6 @@ func (s *State) runEvict(ctx context.Context) error {
 		for inner, ctrl := range s.inner.Lock() {
 			if anchor.CommitQC.Index() >= inner.roads.first {
 				inner.prune(anchor)
-				// Mostly for catch-up: tip jumps to the Anchor when roads empty.
-				inner.refreshConsensusSpec()
 			}
 			ctrl.Updated()
 		}

--- a/sei-tendermint/internal/autobahn/avail/state.go
+++ b/sei-tendermint/internal/autobahn/avail/state.go
@@ -231,9 +231,9 @@ func (s *State) CommitQC(ctx context.Context, idx types.RoadIndex) (*types.Commi
 	return qc, err
 }
 
-// waitUntilAdvanced blocks until the applied (next-CommitQC) epoch equals i.
+// waitForEpoch blocks until the applied (next-CommitQC) epoch equals i.
 // Returns ErrPruned if applied has already passed i (see types.ErrPruned).
-func (s *State) waitUntilAdvanced(ctx context.Context, i types.EpochIndex) (*types.Epoch, error) {
+func (s *State) waitForEpoch(ctx context.Context, i types.EpochIndex) (*types.Epoch, error) {
 	epoch, err := s.Epoch().Wait(ctx, func(epoch *types.Epoch) bool {
 		return i <= epoch.EpochIndex()
 	})
@@ -250,7 +250,7 @@ func (s *State) waitUntilAdvanced(ctx context.Context, i types.EpochIndex) (*typ
 // Stale QCs are a no-op.
 func (s *State) PushCommitQC(ctx context.Context, qc *types.CommitQC) error {
 	idx := qc.Proposal().Index()
-	epoch, err := s.waitUntilAdvanced(ctx, qc.Proposal().EpochIndex())
+	epoch, err := s.waitForEpoch(ctx, qc.Proposal().EpochIndex())
 	if err != nil {
 		if errors.Is(err, types.ErrPruned) {
 			return nil

--- a/sei-tendermint/internal/autobahn/avail/state.go
+++ b/sei-tendermint/internal/autobahn/avail/state.go
@@ -173,8 +173,9 @@ func (s *State) LastCommitQC() utils.AtomicRecv[utils.Option[*types.CommitQC]] {
 }
 
 // SubscribeConsensusSpec returns a receiver of the durable CommitQC tip paired
-// with the epoch governing the view that follows it. None until a tip exists.
-func (s *State) SubscribeConsensusSpec() utils.AtomicRecv[utils.Option[types.ConsensusSpec]] {
+// with the epoch governing the view that follows it. CommitQC is None before
+// the first tip; until then Epoch is genesis epoch 0.
+func (s *State) SubscribeConsensusSpec() utils.AtomicRecv[types.ConsensusSpec] {
 	for inner := range s.inner.Lock() {
 		return inner.consensusSpec.Subscribe()
 	}

--- a/sei-tendermint/internal/autobahn/avail/state.go
+++ b/sei-tendermint/internal/autobahn/avail/state.go
@@ -66,7 +66,7 @@ func (e appliedEpoch) Wait(ctx context.Context, pred func(*types.Epoch) bool) (*
 	return sp.Epoch, nil
 }
 
-// Epoch returns the applied (next-CommitQC) epoch. runEpochAdvance advances it.
+// Epoch returns the applied (next-CommitQC) epoch. runEpochAdvance and catch-up prune advance it.
 func (s *State) Epoch() appliedEpoch {
 	return appliedEpoch{s.spec}
 }
@@ -750,16 +750,32 @@ func (s *State) runEvict(ctx context.Context) error {
 	})
 }
 
-// runEpochAdvance is the sole writer of applied epoch (consensusSpec.Epoch) after construction. It waits
-// for the execution leash on the registry, then seal and the prune leash on
-// avail's inner watch (canAdvanceEpoch), and advances one epoch per wake.
+// runEpochAdvance advances applied one epoch per wake after the registry,
+// seal, and prune leashes. Catch-up that skips epochs is handled by prune
+// (Anchor jumped) and by jumping to Live().First when WaitForEpoch returns ErrPruned.
 func (s *State) runEpochAdvance(ctx context.Context) error {
 	for {
 		next := s.Epoch().Load().EpochIndex() + 1
-		// ErrPruned is not expected here: PushCommitQC withholds a CommitQC
-		// until its epoch is applied, so the Anchor never leads applied by more
-		// than one epoch and PruneBefore cannot drop next.
 		ep, err := s.data.Registry().WaitForEpoch(ctx, next)
+		if errors.Is(err, types.ErrPruned) {
+			// data.PushQC catch-up can prune past applied. Jump to the live
+			// floor; intermediate epochs are gone so their seal wait cannot complete.
+			floor := s.data.Registry().Live().First
+			ep, err = s.data.Registry().WaitForEpoch(ctx, floor)
+			if errors.Is(err, types.ErrPruned) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			for inner, ctrl := range s.inner.Lock() {
+				if inner.applied().EpochIndex() < ep.EpochIndex() {
+					inner.advanceEpoch(ep)
+					ctrl.Updated()
+				}
+			}
+			continue
+		}
 		if err != nil {
 			return err
 		}
@@ -769,7 +785,11 @@ func (s *State) runEpochAdvance(ctx context.Context) error {
 			}); err != nil {
 				return err
 			}
-			if got := inner.applied().EpochIndex(); got+1 != next {
+			got := inner.applied().EpochIndex()
+			if got >= next {
+				continue // prune already jumped past this step
+			}
+			if got+1 != next {
 				return fmt.Errorf("runEpochAdvance: applied %d, want %d before advance", got, next-1)
 			}
 			inner.advanceEpoch(ep)

--- a/sei-tendermint/internal/autobahn/avail/state.go
+++ b/sei-tendermint/internal/autobahn/avail/state.go
@@ -196,12 +196,10 @@ func restorePlan(ds *data.State, loaded *loadedState) (*types.Epoch, types.RoadI
 		return nil, 0, nil, fmt.Errorf("genesis epoch 0: %w", err)
 	}
 	var first types.RoadIndex
-	var tip *types.CommitQC
-	var tipEpoch *types.Epoch
+	tip := utils.None[restoredQC]()
 	if anchor, ok := ds.Anchor().Load().Get(); ok {
 		first = anchor.CommitQC.Index() + 1
-		tip = anchor.CommitQC
-		tipEpoch = anchor.Epoch
+		tip = utils.Some(restoredQC{qc: anchor.CommitQC, ep: anchor.Epoch})
 	}
 	var qcs []restoredQC
 	for _, qc := range loaded.commitQCs {
@@ -219,31 +217,27 @@ func restorePlan(ds *data.State, loaded *loadedState) (*types.Epoch, types.RoadI
 		if err := qc.Verify(ep); err != nil {
 			return nil, 0, nil, fmt.Errorf("persisted commitQC %d verify: %w", qc.Index(), err)
 		}
-		qcs = append(qcs, restoredQC{qc: qc, ep: ep})
-		tip = qc
-		tipEpoch = ep
+		r := restoredQC{qc: qc, ep: ep}
+		qcs = append(qcs, r)
+		tip = utils.Some(r)
 	}
-	if tip == nil {
-		return genesis, first, qcs, nil
+	if tip, ok := tip.Get(); ok {
+		applied, err := nextViewEpoch(registry, tip.qc)
+		if err != nil {
+			return nil, 0, nil, err
+		}
+		return applied, first, qcs, nil
 	}
-	applied, err := nextViewEpoch(registry, tip, tipEpoch)
-	if err != nil {
-		return nil, 0, nil, err
-	}
-	return applied, first, qcs, nil
+	return genesis, first, qcs, nil
 }
 
-// nextViewEpoch is the epoch of the road after tip: tipEpoch, or the next
-// registry epoch when tip sits on tipEpoch's last road.
-func nextViewEpoch(registry *epoch.Registry, tip *types.CommitQC, tipEpoch *types.Epoch) (*types.Epoch, error) {
-	if tipEpoch.RoadRange().Has(tip.Index() + 1) {
-		return tipEpoch, nil
-	}
-	next, err := registry.EpochByIndex(tipEpoch.EpochIndex() + 1)
+// nextViewEpoch is the registered epoch of the road after tip.
+func nextViewEpoch(registry *epoch.Registry, tip *types.CommitQC) (*types.Epoch, error) {
+	ep, err := registry.EpochAt(tip.Index() + 1)
 	if err != nil {
-		return nil, fmt.Errorf("epoch %d after sealed tip %d: %w", tipEpoch.EpochIndex()+1, tip.Index(), err)
+		return nil, fmt.Errorf("epoch after tip %d: %w", tip.Index(), err)
 	}
-	return next, nil
+	return ep, nil
 }
 
 // Close releases the WALs this state owns, and with them the exclusive lock each holds on its

--- a/sei-tendermint/internal/autobahn/avail/state.go
+++ b/sei-tendermint/internal/autobahn/avail/state.go
@@ -234,9 +234,7 @@ func restorePlan(ds *data.State, loaded *loadedState) (*types.Epoch, types.RoadI
 }
 
 // nextViewEpoch is the epoch of the road after tip: tipEpoch, or the next
-// registry epoch when tip sits on tipEpoch's last road. Consensus reads
-// ConsensusSpec once at construction, so a boundary tip has to be paired
-// here rather than left to runEpochAdvance.
+// registry epoch when tip sits on tipEpoch's last road.
 func nextViewEpoch(registry *epoch.Registry, tip *types.CommitQC, tipEpoch *types.Epoch) (*types.Epoch, error) {
 	if tipEpoch.RoadRange().Has(tip.Index() + 1) {
 		return tipEpoch, nil
@@ -750,52 +748,91 @@ func (s *State) runEvict(ctx context.Context) error {
 	})
 }
 
-// runEpochAdvance advances applied one epoch per wake after the registry,
-// seal, and prune leashes. Catch-up that skips epochs is handled by prune
-// (Anchor jumped) and by jumping to Live().First when WaitForEpoch returns ErrPruned.
+// runEpochAdvance advances applied one epoch when the registry, seal, and prune
+// leashes are met. If the durable tip's following road is already past next, it
+// jumps to that epoch instead of installing next.
 func (s *State) runEpochAdvance(ctx context.Context) error {
 	for {
 		next := s.Epoch().Load().EpochIndex() + 1
 		ep, err := s.data.Registry().WaitForEpoch(ctx, next)
 		if errors.Is(err, types.ErrPruned) {
-			// data.PushQC catch-up can prune past applied. Jump to the live
-			// floor; intermediate epochs are gone so their seal wait cannot complete.
-			floor := s.data.Registry().Live().First
-			ep, err = s.data.Registry().WaitForEpoch(ctx, floor)
-			if errors.Is(err, types.ErrPruned) {
-				continue
-			}
-			if err != nil {
-				return err
-			}
-			for inner, ctrl := range s.inner.Lock() {
-				if inner.applied().EpochIndex() < ep.EpochIndex() {
-					inner.advanceEpoch(ep)
-					ctrl.Updated()
+			if err := s.catchUpToFollowing(ctx, s.data.Registry().Live().First); err != nil {
+				if errors.Is(err, types.ErrPruned) {
+					continue
 				}
+				return err
 			}
 			continue
 		}
 		if err != nil {
 			return err
 		}
+		var skip types.EpochIndex
+		jumped := false
 		for inner, ctrl := range s.inner.Lock() {
 			if err := ctrl.WaitUntil(ctx, func() bool {
-				return inner.canAdvanceEpoch()
+				return inner.followingEpochIndex() > next || inner.canAdvanceEpoch()
 			}); err != nil {
 				return err
 			}
-			got := inner.applied().EpochIndex()
-			if got >= next {
-				continue // prune already jumped past this step
+			if idx := inner.followingEpochIndex(); idx > next {
+				skip = idx
+				jumped = true
+				break
 			}
+			got := inner.applied().EpochIndex()
 			if got+1 != next {
 				return fmt.Errorf("runEpochAdvance: applied %d, want %d before advance", got, next-1)
 			}
 			inner.advanceEpoch(ep)
 			ctrl.Updated()
 		}
+		if jumped {
+			if err := s.advanceFollowing(ctx, skip); err != nil {
+				if errors.Is(err, types.ErrPruned) {
+					continue
+				}
+				return err
+			}
+		}
 	}
+}
+
+func (i *inner) followingEpochIndex() types.EpochIndex {
+	tip, ok := i.persistedCommitQC.Load().Get()
+	if !ok {
+		return 0
+	}
+	return epoch.IndexForRoad(tip.Index() + 1)
+}
+
+func (s *State) catchUpToFollowing(ctx context.Context, min types.EpochIndex) error {
+	var follow types.EpochIndex
+	for inner, ctrl := range s.inner.Lock() {
+		if err := ctrl.WaitUntil(ctx, func() bool {
+			idx := inner.followingEpochIndex()
+			return idx >= min && idx > inner.applied().EpochIndex()
+		}); err != nil {
+			return err
+		}
+		follow = inner.followingEpochIndex()
+	}
+	return s.advanceFollowing(ctx, follow)
+}
+
+func (s *State) advanceFollowing(ctx context.Context, follow types.EpochIndex) error {
+	ep, err := s.data.Registry().WaitForEpoch(ctx, follow)
+	if err != nil {
+		return err
+	}
+	for inner, ctrl := range s.inner.Lock() {
+		if inner.followingEpochIndex() != follow {
+			return nil
+		}
+		inner.advanceEpoch(ep)
+		ctrl.Updated()
+	}
+	return nil
 }
 
 // Run runs the background tasks of the state.

--- a/sei-tendermint/internal/autobahn/avail/state.go
+++ b/sei-tendermint/internal/autobahn/avail/state.go
@@ -867,12 +867,15 @@ func (s *State) setNextBlockToPersist(lane types.LaneID, next types.BlockNumber)
 	}
 }
 
-// markCommitQCsPersisted publishes the latest persisted CommitQC,
-// gating consensus from advancing until the QC is durable.
-// ConsensusSpec is refreshed here so tip catch-up stays visible even while
-// runEpochAdvance is parked.
+// markCommitQCsPersisted publishes qc as the durable tip when it is not behind
+// the current tip, then refreshes ConsensusSpec.
 func (s *State) markCommitQCsPersisted(qc *types.CommitQC) {
 	for inner, ctrl := range s.inner.Lock() {
+		if cur, ok := inner.persistedCommitQC.Load().Get(); ok && qc.Index() < cur.Index() {
+			// prune may have jumped the empty-queue tip to the Anchor while this
+			// persist batch was still on disk.
+			return
+		}
 		inner.persistedCommitQC.Store(utils.Some(qc))
 		inner.refreshConsensusSpec()
 		ctrl.Updated()
@@ -883,12 +886,8 @@ func (s *State) markCommitQCsPersisted(qc *types.CommitQC) {
 // collects a persist batch.
 func (s *State) collectPersistBatch(ctx context.Context) (*persistBatch, error) {
 	for inner, ctrl := range s.inner.Lock() {
-		// Derive the CommitQC persist cursor from persistedCommitQC. This is
-		// safe because persistedCommitQC is only advanced by markCommitQCsPersisted
-		// (after disk write) and on startup (from disk). prune() does NOT
-		// update persistedCommitQC, so this always reflects persistence state.
-		// The max clamp with roads.first handles the case where prune()
-		// fast-forwarded the queue past the cursor.
+		// Start after the durable tip, clamped to roads.first after prune has
+		// dropped the prefix (and possibly jumped the empty-queue tip to the Anchor).
 		next := types.NextIndexOpt(inner.persistedCommitQC.Load())
 		if err := ctrl.WaitUntil(ctx, func() bool {
 			for lane, q := range inner.blocks {

--- a/sei-tendermint/internal/autobahn/avail/state.go
+++ b/sei-tendermint/internal/autobahn/avail/state.go
@@ -231,45 +231,28 @@ func (s *State) CommitQC(ctx context.Context, idx types.RoadIndex) (*types.Commi
 	return qc, err
 }
 
-// waitForEpoch blocks until the applied (next-CommitQC) epoch equals i.
-// Returns ErrPruned if applied has already passed i (see types.ErrPruned).
-func (s *State) waitForEpoch(ctx context.Context, i types.EpochIndex) (*types.Epoch, error) {
-	epoch, err := s.Epoch().Wait(ctx, func(epoch *types.Epoch) bool {
-		return i <= epoch.EpochIndex()
-	})
-	if err != nil {
-		return nil, err
-	}
-	if epoch.EpochIndex() != i {
-		return nil, types.ErrPruned
-	}
-	return epoch, nil
-}
-
-// PushCommitQC admits a CommitQC once its epoch is applied (ingress wait).
-// Stale QCs are a no-op.
+// PushCommitQC admits a CommitQC once its epoch is applied and it is the next
+// road. Stale QCs are a no-op.
 func (s *State) PushCommitQC(ctx context.Context, qc *types.CommitQC) error {
 	idx := qc.Proposal().Index()
-	epoch, err := s.waitForEpoch(ctx, qc.Proposal().EpochIndex())
-	if err != nil {
-		if errors.Is(err, types.ErrPruned) {
-			return nil
-		}
-		return err
-	}
+	want := qc.Proposal().EpochIndex()
+	var epoch *types.Epoch
 	for inner, ctrl := range s.inner.Lock() {
-		if err := ctrl.WaitUntil(ctx, func() bool { return idx <= inner.roads.next }); err != nil {
+		if err := ctrl.WaitUntil(ctx, func() bool {
+			return inner.applied().EpochIndex() >= want && idx <= inner.roads.next
+		}); err != nil {
 			return err
 		}
-		if inner.roads.next > idx {
+		if inner.applied().EpochIndex() != want || inner.roads.next > idx {
 			return nil
 		}
+		epoch = inner.applied()
 	}
 	if err := qc.Verify(epoch); err != nil {
 		return fmt.Errorf("qc.Verify(): %w", err)
 	}
 	for inner, ctrl := range s.inner.Lock() {
-		if idx != inner.roads.next {
+		if idx != inner.roads.next || inner.applied().EpochIndex() != want {
 			return nil
 		}
 		inner.roads.pushBack(newRoad(qc, epoch))
@@ -353,7 +336,7 @@ func (s *State) Block(ctx context.Context, lane types.LaneID, n types.BlockNumbe
 // Waits until all previous blocks are available.
 // A missing map (closed lane, or a LaneID never admitted) is a silent no-op —
 // future lanes are not waited on.
-// Accepts a proposal valid under the applied or Anchor epoch.
+// The lane must be in the applied committee.
 func (s *State) PushBlock(ctx context.Context, p *types.Signed[*types.LaneProposal]) error {
 	h := p.Msg().Block().Header()
 	if p.Key() != h.Lane().Validator {
@@ -368,10 +351,10 @@ func (s *State) PushBlock(ctx context.Context, p *types.Signed[*types.LanePropos
 		return fmt.Errorf("VerifySig(): %w", err)
 	}
 	for inner, ctrl := range s.inner.Lock() {
-		if !epochForLane(inner, lane).IsPresent() {
-			return nil
-		}
 		if err := ctrl.WaitUntil(ctx, func() bool {
+			if !inner.applied().Committee().HasLane(lane) {
+				return true
+			}
 			q, ok := inner.blocks[lane]
 			if !ok {
 				return true
@@ -379,6 +362,9 @@ func (s *State) PushBlock(ctx context.Context, p *types.Signed[*types.LanePropos
 			return n <= min(q.next, q.first+BlocksPerLane-1)
 		}); err != nil {
 			return err
+		}
+		if !inner.applied().Committee().HasLane(lane) {
+			return nil
 		}
 		q, ok := inner.blocks[lane]
 		if !ok {
@@ -444,11 +430,7 @@ func (s *State) PushVote(ctx context.Context, vote *types.Signed[*types.LaneVote
 			return nil
 		}
 		// TODO: accept future-epoch joiner votes.
-		ep, ok := epochForVote(inner, vote).Get()
-		if !ok {
-			return nil
-		}
-		if err := vote.Msg().Verify(ep.Committee()); err != nil {
+		if !inner.epochForVote(vote).IsPresent() {
 			return nil
 		}
 		applied := inner.applied()
@@ -460,41 +442,6 @@ func (s *State) PushVote(ctx context.Context, vote *types.Signed[*types.LaneVote
 		}
 	}
 	return nil
-}
-
-// epochForVote returns the applied or Anchor epoch the vote belongs to
-// (lane + signer in that committee). Prefers applied; falls back to Anchor
-// when that is a different EpochIndex.
-func epochForVote(inner *inner, vote *types.Signed[*types.LaneVote]) utils.Option[*types.Epoch] {
-	lane := vote.Msg().Header().Lane()
-	key := vote.Key()
-	belongs := func(ep *types.Epoch) bool {
-		c := ep.Committee()
-		return c.HasLane(lane) && c.HasReplica(key)
-	}
-	applied := inner.applied()
-	if belongs(applied) {
-		return utils.Some(applied)
-	}
-	ae, ok := inner.anchorEpoch.Get()
-	if !ok || ae.EpochIndex() == applied.EpochIndex() || !belongs(ae) {
-		return utils.None[*types.Epoch]()
-	}
-	return utils.Some(ae)
-}
-
-// epochForLane returns the applied epoch if it has lane, otherwise the Anchor
-// epoch when that is a different EpochIndex and has lane.
-func epochForLane(inner *inner, lane types.LaneID) utils.Option[*types.Epoch] {
-	applied := inner.applied()
-	if applied.Committee().HasLane(lane) {
-		return utils.Some(applied)
-	}
-	ae, ok := inner.anchorEpoch.Get()
-	if !ok || ae.EpochIndex() == applied.EpochIndex() || !ae.Committee().HasLane(lane) {
-		return utils.None[*types.Epoch]()
-	}
-	return utils.Some(ae)
 }
 
 // headers collects headers for the given range under ep (the CommitQC's road epoch).

--- a/sei-tendermint/internal/autobahn/avail/state.go
+++ b/sei-tendermint/internal/autobahn/avail/state.go
@@ -173,7 +173,7 @@ func (s *State) LastCommitQC() utils.AtomicRecv[utils.Option[*types.CommitQC]] {
 }
 
 // SubscribeConsensusSpec returns a receiver of the durable CommitQC tip paired
-// with the epoch governing the view that follows it. CommitQC is None before
+// with the epoch of the RoadIndex that follows it. CommitQC is None before
 // the first tip; until then Epoch is genesis epoch 0.
 func (s *State) SubscribeConsensusSpec() utils.AtomicRecv[types.ConsensusSpec] {
 	for inner := range s.inner.Lock() {

--- a/sei-tendermint/internal/autobahn/avail/state.go
+++ b/sei-tendermint/internal/autobahn/avail/state.go
@@ -345,9 +345,12 @@ func (s *State) PushBlock(ctx context.Context, p *types.Signed[*types.LanePropos
 	}
 	lane := h.Lane()
 	n := h.BlockNumber()
+	if err := types.VerifyLaneProposalPayloadAndSignature(p); err != nil {
+		return err
+	}
 	for inner, ctrl := range s.inner.Lock() {
 		if !laneAcceptedUnder(inner, func(ep *types.Epoch) bool {
-			return laneProposalAcceptedByEpoch(ep, p)
+			return p.Msg().VerifyCommitteeMembership(ep.Committee()) == nil
 		}) {
 			return nil
 		}
@@ -403,6 +406,9 @@ func (s *State) PushVote(ctx context.Context, vote *types.Signed[*types.LaneVote
 	h := vote.Msg().Header()
 	lane := h.Lane()
 	n := h.BlockNumber()
+	if err := vote.VerifySignature(); err != nil {
+		return fmt.Errorf("VerifySignature(): %w", err)
+	}
 	for inner, ctrl := range s.inner.Lock() {
 		if err := ctrl.WaitUntil(ctx, func() bool {
 			q, ok := inner.votes[lane]
@@ -420,13 +426,13 @@ func (s *State) PushVote(ctx context.Context, vote *types.Signed[*types.LaneVote
 		if n < q.first {
 			return nil
 		}
-		applied := inner.epoch.Load()
 		// TODO: accept future-epoch joiner votes.
 		if !laneAcceptedUnder(inner, func(ep *types.Epoch) bool {
-			return laneVoteAcceptedByEpoch(ep, vote)
+			return laneVoteCommitteeOK(ep, vote)
 		}) {
 			return nil
 		}
+		applied := inner.epoch.Load()
 		for q.next <= n {
 			q.pushBack(newBlockVotes())
 		}
@@ -437,16 +443,10 @@ func (s *State) PushVote(ctx context.Context, vote *types.Signed[*types.LaneVote
 	return nil
 }
 
-// laneVoteAcceptedByEpoch reports whether vote verifies under ep's committee.
-func laneVoteAcceptedByEpoch(ep *types.Epoch, vote *types.Signed[*types.LaneVote]) bool {
+// laneVoteCommitteeOK reports whether the vote's header lane and signer are in ep's committee.
+func laneVoteCommitteeOK(ep *types.Epoch, vote *types.Signed[*types.LaneVote]) bool {
 	c := ep.Committee()
-	return vote.Msg().Verify(c) == nil && vote.VerifySig(c) == nil
-}
-
-// laneProposalAcceptedByEpoch reports whether p verifies under ep's committee.
-func laneProposalAcceptedByEpoch(ep *types.Epoch, p *types.Signed[*types.LaneProposal]) bool {
-	c := ep.Committee()
-	return p.Msg().Verify(c) == nil && p.VerifySig(c) == nil
+	return vote.Msg().Verify(c) == nil && c.HasReplica(vote.Key())
 }
 
 // laneAcceptedUnder reports whether accept holds for the applied epoch, or for

--- a/sei-tendermint/internal/autobahn/avail/state.go
+++ b/sei-tendermint/internal/autobahn/avail/state.go
@@ -433,7 +433,11 @@ func (s *State) PushVote(ctx context.Context, vote *types.Signed[*types.LaneVote
 			return nil
 		}
 		// TODO: accept future-epoch joiner votes.
-		if !epochForVote(inner, vote).IsPresent() {
+		ep, ok := epochForVote(inner, vote).Get()
+		if !ok {
+			return nil
+		}
+		if err := vote.Msg().Verify(ep.Committee()); err != nil {
 			return nil
 		}
 		applied := inner.epoch.Load()
@@ -447,20 +451,22 @@ func (s *State) PushVote(ctx context.Context, vote *types.Signed[*types.LaneVote
 	return nil
 }
 
-// epochForVote returns the applied or Anchor epoch under which vote's lane and
-// signer verify. Prefers applied; falls back to Anchor when that is a different
-// EpochIndex.
+// epochForVote returns the applied or Anchor epoch the vote belongs to
+// (lane + signer in that committee). Prefers applied; falls back to Anchor
+// when that is a different EpochIndex.
 func epochForVote(inner *inner, vote *types.Signed[*types.LaneVote]) utils.Option[*types.Epoch] {
-	match := func(ep *types.Epoch) bool {
+	lane := vote.Msg().Header().Lane()
+	key := vote.Key()
+	belongs := func(ep *types.Epoch) bool {
 		c := ep.Committee()
-		return vote.Msg().Verify(c) == nil && c.HasReplica(vote.Key())
+		return c.HasLane(lane) && c.HasReplica(key)
 	}
 	applied := inner.epoch.Load()
-	if match(applied) {
+	if belongs(applied) {
 		return utils.Some(applied)
 	}
 	ae, ok := inner.anchorEpoch.Get()
-	if !ok || ae.EpochIndex() == applied.EpochIndex() || !match(ae) {
+	if !ok || ae.EpochIndex() == applied.EpochIndex() || !belongs(ae) {
 		return utils.None[*types.Epoch]()
 	}
 	return utils.Some(ae)

--- a/sei-tendermint/internal/autobahn/avail/state.go
+++ b/sei-tendermint/internal/autobahn/avail/state.go
@@ -742,72 +742,45 @@ func (s *State) runEvict(ctx context.Context) error {
 	})
 }
 
-// runEpochAdvance advances applied one epoch when the registry, seal, and prune
-// leashes are met. If next is pruned or the durable tip's following road is
-// already past next, it jumps to that following epoch instead.
+// runEpochAdvance is the sole writer of the applied epoch after construction.
 func (s *State) runEpochAdvance(ctx context.Context) error {
 	for {
-		next := s.Epoch().Load().EpochIndex() + 1
-		ep, err := s.data.Registry().WaitForEpoch(ctx, next)
-		pruned := errors.Is(err, types.ErrPruned)
-		if err != nil && !pruned {
-			return err
-		}
-		var floor types.EpochIndex
-		if pruned {
-			floor = s.data.Registry().Live().First
-		}
-
-		var follow types.EpochIndex
-		jump := false
+		var next types.EpochIndex
 		for inner, ctrl := range s.inner.Lock() {
 			if err := ctrl.WaitUntil(ctx, func() bool {
-				idx := inner.followingEpochIndex()
-				if pruned {
-					return idx >= floor && idx > inner.applied().EpochIndex()
-				}
-				return idx > next || inner.canAdvanceEpoch()
+				next = inner.advanceTarget()
+				return next > inner.applied().EpochIndex()+1 || inner.canAdvanceEpoch()
 			}); err != nil {
 				return err
 			}
-			idx := inner.followingEpochIndex()
-			if pruned || idx > next {
-				follow = idx
-				jump = true
-				break
+		}
+		ep, err := s.data.Registry().WaitForEpoch(ctx, next)
+		if err != nil {
+			if !errors.Is(err, types.ErrPruned) {
+				return err
 			}
-			got := inner.applied().EpochIndex()
-			if got+1 != next {
-				return fmt.Errorf("runEpochAdvance: applied %d, want %d before advance", got, next-1)
+			// Data never re-registers a pruned epoch, so wait until the tip
+			// names a different one.
+			for inner, ctrl := range s.inner.Lock() {
+				if err := ctrl.WaitUntil(ctx, func() bool {
+					return inner.advanceTarget() != next
+				}); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+		for inner, ctrl := range s.inner.Lock() {
+			// The tip may have moved while WaitForEpoch was parked. Installing
+			// next now would pair it with a tip whose next road is in a later
+			// epoch, so recompute instead.
+			if inner.advanceTarget() != next {
+				break
 			}
 			inner.advanceEpoch(ep)
 			ctrl.Updated()
 		}
-		if jump {
-			ep, err = s.data.Registry().WaitForEpoch(ctx, follow)
-			if errors.Is(err, types.ErrPruned) {
-				continue
-			}
-			if err != nil {
-				return err
-			}
-			for inner, ctrl := range s.inner.Lock() {
-				if inner.followingEpochIndex() != follow {
-					break
-				}
-				inner.advanceEpoch(ep)
-				ctrl.Updated()
-			}
-		}
 	}
-}
-
-func (i *inner) followingEpochIndex() types.EpochIndex {
-	tip, ok := i.persistedCommitQC.Load().Get()
-	if !ok {
-		return 0
-	}
-	return epoch.IndexForRoad(tip.Index() + 1)
 }
 
 // Run runs the background tasks of the state.
@@ -897,7 +870,7 @@ func (s *State) setNextBlockToPersist(lane types.LaneID, next types.BlockNumber)
 // markCommitQCsPersisted publishes the latest persisted CommitQC,
 // gating consensus from advancing until the QC is durable.
 // ConsensusSpec is refreshed here so tip catch-up stays visible even while
-// runEpochAdvance is parked on WaitForEpoch.
+// runEpochAdvance is parked.
 func (s *State) markCommitQCsPersisted(qc *types.CommitQC) {
 	for inner, ctrl := range s.inner.Lock() {
 		inner.persistedCommitQC.Store(utils.Some(qc))

--- a/sei-tendermint/internal/autobahn/avail/state.go
+++ b/sei-tendermint/internal/autobahn/avail/state.go
@@ -220,9 +220,9 @@ func (s *State) CommitQC(ctx context.Context, idx types.RoadIndex) (*types.Commi
 	return qc, err
 }
 
-// waitUntilApplied blocks until the applied (next-CommitQC) epoch equals i.
+// waitUntilAdvanced blocks until the applied (next-CommitQC) epoch equals i.
 // Returns ErrPruned if applied has already passed i (see types.ErrPruned).
-func (s *State) waitUntilApplied(ctx context.Context, i types.EpochIndex) (*types.Epoch, error) {
+func (s *State) waitUntilAdvanced(ctx context.Context, i types.EpochIndex) (*types.Epoch, error) {
 	epoch, err := s.epoch.Wait(ctx, func(epoch *types.Epoch) bool {
 		return i <= epoch.EpochIndex()
 	})
@@ -239,7 +239,7 @@ func (s *State) waitUntilApplied(ctx context.Context, i types.EpochIndex) (*type
 // Stale QCs are a no-op.
 func (s *State) PushCommitQC(ctx context.Context, qc *types.CommitQC) error {
 	idx := qc.Proposal().Index()
-	epoch, err := s.waitUntilApplied(ctx, qc.Proposal().EpochIndex())
+	epoch, err := s.waitUntilAdvanced(ctx, qc.Proposal().EpochIndex())
 	if err != nil {
 		if errors.Is(err, types.ErrPruned) {
 			return nil
@@ -694,7 +694,7 @@ func (s *State) runEvict(ctx context.Context) error {
 
 // runEpochAdvance is the sole writer of inner.epoch after construction. It waits
 // for the execution leash on the registry, then seal and the prune leash on
-// avail's inner watch (leashesMet), and installs one epoch per wake.
+// avail's inner watch (canAdvanceEpoch), and advances one epoch per wake.
 func (s *State) runEpochAdvance(ctx context.Context) error {
 	for {
 		next := s.epoch.Load().EpochIndex() + 1
@@ -704,14 +704,14 @@ func (s *State) runEpochAdvance(ctx context.Context) error {
 		}
 		for inner, ctrl := range s.inner.Lock() {
 			if err := ctrl.WaitUntil(ctx, func() bool {
-				return inner.leashesMet()
+				return inner.canAdvanceEpoch()
 			}); err != nil {
 				return err
 			}
 			if got := inner.epoch.Load().EpochIndex(); got+1 != next {
-				return fmt.Errorf("runEpochAdvance: applied %d, want %d before install", got, next-1)
+				return fmt.Errorf("runEpochAdvance: applied %d, want %d before advance", got, next-1)
 			}
-			inner.installEpoch(ep)
+			inner.advanceEpoch(ep)
 			ctrl.Updated()
 		}
 	}

--- a/sei-tendermint/internal/autobahn/avail/state.go
+++ b/sei-tendermint/internal/autobahn/avail/state.go
@@ -66,7 +66,7 @@ func (e appliedEpoch) Wait(ctx context.Context, pred func(*types.Epoch) bool) (*
 	return sp.Epoch, nil
 }
 
-// Epoch returns the applied (next-CommitQC) epoch. runEpochAdvance and catch-up prune advance it.
+// Epoch returns the applied (next-CommitQC) epoch.
 func (s *State) Epoch() appliedEpoch {
 	return appliedEpoch{s.spec}
 }
@@ -749,35 +749,37 @@ func (s *State) runEvict(ctx context.Context) error {
 }
 
 // runEpochAdvance advances applied one epoch when the registry, seal, and prune
-// leashes are met. If the durable tip's following road is already past next, it
-// jumps to that epoch instead of installing next.
+// leashes are met. If next is pruned or the durable tip's following road is
+// already past next, it jumps to that following epoch instead.
 func (s *State) runEpochAdvance(ctx context.Context) error {
 	for {
 		next := s.Epoch().Load().EpochIndex() + 1
 		ep, err := s.data.Registry().WaitForEpoch(ctx, next)
-		if errors.Is(err, types.ErrPruned) {
-			if err := s.catchUpToFollowing(ctx, s.data.Registry().Live().First); err != nil {
-				if errors.Is(err, types.ErrPruned) {
-					continue
-				}
-				return err
-			}
-			continue
-		}
-		if err != nil {
+		pruned := errors.Is(err, types.ErrPruned)
+		if err != nil && !pruned {
 			return err
 		}
-		var skip types.EpochIndex
-		jumped := false
+		var floor types.EpochIndex
+		if pruned {
+			floor = s.data.Registry().Live().First
+		}
+
+		var follow types.EpochIndex
+		jump := false
 		for inner, ctrl := range s.inner.Lock() {
 			if err := ctrl.WaitUntil(ctx, func() bool {
-				return inner.followingEpochIndex() > next || inner.canAdvanceEpoch()
+				idx := inner.followingEpochIndex()
+				if pruned {
+					return idx >= floor && idx > inner.applied().EpochIndex()
+				}
+				return idx > next || inner.canAdvanceEpoch()
 			}); err != nil {
 				return err
 			}
-			if idx := inner.followingEpochIndex(); idx > next {
-				skip = idx
-				jumped = true
+			idx := inner.followingEpochIndex()
+			if pruned || idx > next {
+				follow = idx
+				jump = true
 				break
 			}
 			got := inner.applied().EpochIndex()
@@ -787,12 +789,20 @@ func (s *State) runEpochAdvance(ctx context.Context) error {
 			inner.advanceEpoch(ep)
 			ctrl.Updated()
 		}
-		if jumped {
-			if err := s.advanceFollowing(ctx, skip); err != nil {
-				if errors.Is(err, types.ErrPruned) {
-					continue
-				}
+		if jump {
+			ep, err = s.data.Registry().WaitForEpoch(ctx, follow)
+			if errors.Is(err, types.ErrPruned) {
+				continue
+			}
+			if err != nil {
 				return err
+			}
+			for inner, ctrl := range s.inner.Lock() {
+				if inner.followingEpochIndex() != follow {
+					break
+				}
+				inner.advanceEpoch(ep)
+				ctrl.Updated()
 			}
 		}
 	}
@@ -804,35 +814,6 @@ func (i *inner) followingEpochIndex() types.EpochIndex {
 		return 0
 	}
 	return epoch.IndexForRoad(tip.Index() + 1)
-}
-
-func (s *State) catchUpToFollowing(ctx context.Context, min types.EpochIndex) error {
-	var follow types.EpochIndex
-	for inner, ctrl := range s.inner.Lock() {
-		if err := ctrl.WaitUntil(ctx, func() bool {
-			idx := inner.followingEpochIndex()
-			return idx >= min && idx > inner.applied().EpochIndex()
-		}); err != nil {
-			return err
-		}
-		follow = inner.followingEpochIndex()
-	}
-	return s.advanceFollowing(ctx, follow)
-}
-
-func (s *State) advanceFollowing(ctx context.Context, follow types.EpochIndex) error {
-	ep, err := s.data.Registry().WaitForEpoch(ctx, follow)
-	if err != nil {
-		return err
-	}
-	for inner, ctrl := range s.inner.Lock() {
-		if inner.followingEpochIndex() != follow {
-			return nil
-		}
-		inner.advanceEpoch(ep)
-		ctrl.Updated()
-	}
-	return nil
 }
 
 // Run runs the background tasks of the state.

--- a/sei-tendermint/internal/autobahn/avail/state.go
+++ b/sei-tendermint/internal/autobahn/avail/state.go
@@ -704,6 +704,9 @@ func (s *State) runEvict(ctx context.Context) error {
 func (s *State) runEpochAdvance(ctx context.Context) error {
 	for {
 		next := s.epoch.Load().EpochIndex() + 1
+		// ErrPruned is not expected here: PushCommitQC withholds a CommitQC
+		// until its epoch is applied, so the Anchor never leads applied by more
+		// than one epoch and PruneBefore cannot drop next.
 		ep, err := s.data.Registry().WaitForEpoch(ctx, next)
 		if err != nil {
 			return err

--- a/sei-tendermint/internal/autobahn/avail/state_test.go
+++ b/sei-tendermint/internal/autobahn/avail/state_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/sei-protocol/sei-chain/sei-tendermint/autobahn/types"
@@ -34,6 +35,13 @@ func pushPeerLaneBlock(state *State, key types.SecretKey, payload *types.Payload
 		ctrl.Updated()
 	}
 	return b, nil
+}
+
+func nextRoad(s *State) types.RoadIndex {
+	for inner := range s.inner.Lock() {
+		return inner.roads.next
+	}
+	panic("unreachable")
 }
 
 type byLane[T any] map[types.LaneID][]T
@@ -116,62 +124,69 @@ func TestPrune_AnchorEpochDropsClosedLane(t *testing.T) {
 		if err != nil {
 			return fmt.Errorf("NewState: %w", err)
 		}
+		sc.SpawnBgNamed("runEpochAdvance", func() error { return utils.IgnoreCancel(state.runEpochAdvance(ctx)) })
+
 		lane0 := state.LocalLane().OrPanic("genesis")
 		sub := state.SubscribeLaneProposals(lane0, 0)
 
-		ep1, err := registry.ActivateEpoch(
+		epLeave, err := registry.ActivateEpoch(
 			map[types.PublicKey]uint64{b.Public(): 1},
-			types.OpenRoadRange(), time.Time{}, registry.FirstBlock(),
+			time.Time{}, registry.FirstBlock(),
 		)
 		if err != nil {
 			return err
 		}
-		state.ApplyEpoch(ep1)
-
-		for inner := range state.inner.Lock() {
-			if _, ok := inner.blocks[lane0]; !ok {
-				return fmt.Errorf("ApplyEpoch must not drop closing-lane maps")
-			}
+		if epLeave.EpochIndex() != 2 {
+			return fmt.Errorf("leave epoch = %d, want 2 (epoch 1 is genesis-seeded)", epLeave.EpochIndex())
 		}
-
-		qc1, blocks1 := data.TestCommitQC(rng, ep1, []types.SecretKey{b}, utils.Some(qc0.QC()))
-		if err := ds.PushQC(ctx, qc1, blocks1); err != nil {
+		// Data already holds an AppQC for epoch 0; NewState's prune stamped the
+		// Anchor. Advance the seal cursor without admitting LastRoad tips — runEvict
+		// is not running, and the rest of this test expects empty roads.
+		seekRoads(state, epoch.FirstRoad(1))
+		if _, err := state.Epoch().Wait(ctx, func(ep *types.Epoch) bool {
+			return ep.EpochIndex() >= 1
+		}); err != nil {
 			return err
 		}
-		appHash1 := types.GenAppHash(rng)
-		if err := ds.PushAppHash(ctx, qc1.QC().GlobalRange().Next-1, appHash1); err != nil {
-			return err
+		ep1, ok := registry.EpochByIndex(1)
+		if !ok {
+			return fmt.Errorf("epoch 1 missing")
 		}
-		if err := ds.PushAppQC(ctx, data.TestAppQC([]types.SecretKey{b}, types.NewAppProposal(qc1.QC().Proposal(), appHash1))); err != nil {
-			return err
+		for inner, ctrl := range state.inner.Lock() {
+			inner.anchorEpoch = utils.Some(ep1)
+			ctrl.Updated()
 		}
-		var anchor data.Anchor
-		if _, err := ds.Anchor().Wait(ctx, func(a utils.Option[data.Anchor]) bool {
-			got, ok := a.Get()
-			if ok && got.CommitQC.Index() == qc1.QC().Index() {
-				anchor = got
-				return true
-			}
-			return false
+		seekRoads(state, epoch.FirstRoad(2))
+		if _, err := state.Epoch().Wait(ctx, func(ep *types.Epoch) bool {
+			return ep.EpochIndex() >= epLeave.EpochIndex()
 		}); err != nil {
 			return err
 		}
 
+		for inner := range state.inner.Lock() {
+			if _, ok := inner.blocks[lane0]; !ok {
+				return fmt.Errorf("epoch advance must not drop closing-lane maps")
+			}
+		}
+
+		// Construct a leave-epoch Anchor locally: data still holds only qc0, so a
+		// FirstRoad(2) CommitQC cannot be pushed without filling the road gap.
+		prev := tipLink(ep1, keys[0], epoch.LastRoad(1))
+		qcLeave := types.BuildCommitQC(epLeave, []types.SecretKey{b}, utils.Some(prev), nil)
+		anchor := data.Anchor{
+			CommitQC: qcLeave,
+			AppQC:    data.TestAppQC([]types.SecretKey{b}, types.NewAppProposal(qcLeave.Proposal(), types.AppHash{})),
+			Epoch:    epLeave,
+		}
+
 		for inner, ctrl := range state.inner.Lock() {
 			if inner.roads.first < inner.roads.next {
-				return fmt.Errorf("roads should be empty after tip prune")
+				return fmt.Errorf("roads should still be empty (seekRoads, no runEvict)")
 			}
 			if _, ok := inner.blocks[lane0]; !ok {
 				return fmt.Errorf("closing lane maps should still be present before anchor prune")
 			}
-			ep, err := anchorEpochOf(registry, anchor)
-			if err != nil {
-				return fmt.Errorf("anchorEpochOf: %w", err)
-			}
-			if ep.EpochIndex() != ep1.EpochIndex() {
-				return fmt.Errorf("anchorEpochOf: got epoch %d, want %d", ep.EpochIndex(), ep1.EpochIndex())
-			}
-			n := inner.prune(anchor, ep)
+			n := inner.prune(anchor)
 			if n != 1 {
 				return fmt.Errorf("prune dropped %d lanes, want 1", n)
 			}
@@ -616,5 +631,391 @@ func TestNewStateWithPersistence(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "out of sequence")
 		require.NoError(t, cp.Close())
+	})
+}
+
+// TestHeaders_WaitsForPrevEpochLaneVote checks that after the applied epoch
+// advances, a LaneVote that only verifies under the Anchor (prev) committee is
+// still ingested into byKey and unblocks headers() for a prior-epoch LaneRange.
+func TestHeaders_WaitsForPrevEpochLaneVote(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+		rng := utils.TestRng()
+		stay := types.GenSecretKey(rng)
+		leaver := types.GenSecretKey(rng)
+		a := types.GenSecretKey(rng)
+		b := types.GenSecretKey(rng)
+
+		genesis, err := types.NewCommittee(map[types.PublicKey]uint64{
+			stay.Public(): 1, leaver.Public(): 1, a.Public(): 1, b.Public(): 1,
+		})
+		require.NoError(t, err)
+		registry, err := epoch.NewRegistry(genesis, 0, time.Time{})
+		require.NoError(t, err)
+		ds := newTestDataState(&data.Config{Registry: registry})
+		state, err := NewState(stay, ds, utils.None[string]())
+		require.NoError(t, err)
+
+		require.NoError(t, scope.Run(ctx, func(ctx context.Context, sc scope.Scope) error {
+			sc.SpawnBgNamed("runEpochAdvance", func() error {
+				return utils.IgnoreCancel(state.runEpochAdvance(ctx))
+			})
+
+			ep0 := registry.LatestEpoch()
+			lane := ep0.Committee().Lane(stay.Public()).OrPanic("stay lane")
+			header := types.NewBlock(lane, 0, types.BlockHeaderHash{}, &types.Payload{}).Header()
+			leaverVote := types.Sign(leaver, types.NewLaneVote(header))
+
+			epLeave, err := registry.ActivateEpoch(
+				map[types.PublicKey]uint64{stay.Public(): 1, a.Public(): 1, b.Public(): 1},
+				time.Time{}, registry.FirstBlock(),
+			)
+			if err != nil {
+				return err
+			}
+			keys := []types.SecretKey{stay, leaver, a, b}
+			if err := DriveAdvance(ctx, state, keys, epLeave.EpochIndex()); err != nil {
+				return err
+			}
+
+			for inner := range state.inner.Lock() {
+				if inner.epoch.Load().EpochIndex() != epLeave.EpochIndex() {
+					return fmt.Errorf("applied epoch = %d, want %d", inner.epoch.Load().EpochIndex(), epLeave.EpochIndex())
+				}
+				ae, ok := inner.anchorEpoch.Get()
+				if !ok {
+					return fmt.Errorf("anchor epoch missing")
+				}
+				if ae.EpochIndex() >= epLeave.EpochIndex() {
+					return fmt.Errorf("anchor epoch = %d, want < %d", ae.EpochIndex(), epLeave.EpochIndex())
+				}
+			}
+			if laneVoteAcceptedByEpoch(epLeave, leaverVote) {
+				return fmt.Errorf("leaver must fail under applied")
+			}
+			if !laneVoteAcceptedByEpoch(ep0, leaverVote) {
+				return fmt.Errorf("leaver must pass under anchor")
+			}
+
+			lr := types.NewLaneRange(lane, 0, utils.Some(header))
+			var got []*types.BlockHeader
+			var herr error
+			done := false
+			sc.Spawn(func() error {
+				got, herr = state.headers(ctx, ep0, lr)
+				done = true
+				return nil
+			})
+			synctest.Wait()
+			if done {
+				return fmt.Errorf("headers should wait for a matching LaneVote")
+			}
+
+			if err := state.PushVote(ctx, leaverVote); err != nil {
+				return err
+			}
+			synctest.Wait()
+			if !done {
+				return fmt.Errorf("headers did not complete after LaneVote")
+			}
+			if herr != nil {
+				return herr
+			}
+			if len(got) != 1 {
+				return fmt.Errorf("headers len = %d, want 1", len(got))
+			}
+			if got[0].Hash() != header.Hash() {
+				return fmt.Errorf("header hash mismatch")
+			}
+			return nil
+		}))
+	})
+}
+
+func TestPushCommitQC_MidEpochNoWait(t *testing.T) {
+	f := newSealFixture(t)
+	_, err := f.registry.EpochAt(epoch.FirstRoad(f.m + 1))
+	require.Error(t, err)
+
+	seekRoads(f.state, epoch.FirstRoad(f.m))
+	epPrev, ok := f.registry.EpochByIndex(f.m - 1)
+	require.True(t, ok)
+	prev := tipLink(epPrev, f.keys[0], epoch.LastRoad(f.m-1))
+	qc := types.BuildCommitQC(f.ep, f.keys, utils.Some(prev), nil)
+	require.Equal(t, epoch.FirstRoad(f.m), qc.Proposal().Index())
+
+	require.NoError(t, f.state.PushCommitQC(t.Context(), qc))
+	require.Equal(t, epoch.FirstRoad(f.m)+1, nextRoad(f.state))
+}
+
+func TestPushCommitQC_FutureEpochParksUntilAdvance(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		rng := utils.TestRng()
+		f := newSealFixture(t)
+
+		prev := tipLink(f.ep, f.keys[0], epoch.LastRoad(f.m)-1)
+		qcLast := types.BuildCommitQC(f.ep, f.keys, utils.Some(prev), nil)
+		require.NoError(t, f.state.PushCommitQC(ctx, qcLast))
+		setRoadAppQC(f.state, qcLast.Index(), data.TestAppQC(f.keys, types.NewAppProposal(qcLast.Proposal(), types.GenAppHash(rng))))
+
+		f.registry.AdvanceIfNeeded(epoch.LastRoad(f.m))
+		ep2, ok := f.registry.EpochByIndex(f.m + 1)
+		require.True(t, ok)
+		qcNext := types.BuildCommitQC(ep2, f.keys, utils.Some(qcLast), nil)
+		require.Equal(t, epoch.FirstRoad(f.m+1), qcNext.Proposal().Index())
+
+		var pushErr error
+		go func() { pushErr = f.state.PushCommitQC(ctx, qcNext) }()
+		synctest.Wait()
+		require.Equal(t, f.m, f.state.Epoch().Load().EpochIndex())
+		require.Equal(t, epoch.LastRoad(f.m)+1, nextRoad(f.state), "future QC must stay parked")
+
+		var runErr error
+		go func() { runErr = f.state.runEpochAdvance(ctx) }()
+		_, err := f.state.epoch.Wait(t.Context(), func(ep *types.Epoch) bool {
+			return ep.EpochIndex() >= f.m+1
+		})
+		require.NoError(t, err)
+		synctest.Wait()
+		require.NoError(t, pushErr)
+		require.Equal(t, epoch.FirstRoad(f.m+1)+1, nextRoad(f.state))
+		cancel()
+		synctest.Wait()
+		require.ErrorIs(t, runErr, context.Canceled)
+	})
+}
+
+func TestPushCommitQC_StaleAfterAdvanceSoftDrops(t *testing.T) {
+	rng := utils.TestRng()
+	registry, keys := epoch.GenRegistry(rng, 4)
+	ds := newTestDataState(&data.Config{Registry: registry})
+	state, err := NewState(keys[0], ds, utils.None[string]())
+	require.NoError(t, err)
+
+	ep1, ok := registry.EpochByIndex(1)
+	require.True(t, ok)
+	require.NoError(t, scope.Run(t.Context(), func(ctx context.Context, sc scope.Scope) error {
+		sc.SpawnBgNamed("runEpochAdvance", func() error {
+			return utils.IgnoreCancel(state.runEpochAdvance(ctx))
+		})
+		return DriveAdvance(ctx, state, keys, ep1.EpochIndex())
+	}))
+
+	ep0, ok := registry.EpochByIndex(0)
+	require.True(t, ok)
+	before := nextRoad(state)
+	qc0 := types.BuildCommitQC(ep0, keys, utils.None[*types.CommitQC](), nil)
+	require.Equal(t, types.EpochIndex(0), qc0.Proposal().EpochIndex())
+	require.NoError(t, state.PushCommitQC(t.Context(), qc0))
+	require.Equal(t, before, nextRoad(state))
+}
+
+type sealFixture struct {
+	registry *epoch.Registry
+	keys     []types.SecretKey
+	state    *State
+	ep       *types.Epoch
+	m        types.EpochIndex
+}
+
+func newSealFixture(t *testing.T) *sealFixture {
+	t.Helper()
+	rng := utils.TestRng()
+	registry, keys := epoch.GenRegistry(rng, 4)
+	ds := newTestDataState(&data.Config{Registry: registry})
+	state, err := NewState(keys[0], ds, utils.None[string]())
+	require.NoError(t, err)
+
+	const m types.EpochIndex = 1
+	ep, ok := registry.EpochByIndex(m)
+	require.True(t, ok, "epoch 1 is present from NewRegistry")
+	_, err = registry.EpochAt(epoch.FirstRoad(m + 1))
+	require.Error(t, err, "epoch 2 must be absent for exec-leash tests")
+
+	require.NoError(t, scope.Run(t.Context(), func(ctx context.Context, sc scope.Scope) error {
+		sc.SpawnBgNamed("runEpochAdvance", func() error {
+			return utils.IgnoreCancel(state.runEpochAdvance(ctx))
+		})
+		return DriveAdvance(ctx, state, keys, m)
+	}))
+	seekRoads(state, epoch.LastRoad(m))
+	return &sealFixture{registry: registry, keys: keys, state: state, ep: ep, m: m}
+}
+
+func TestWaitUntilApplied_ParksUntilEpochAdvance(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+		rng := utils.TestRng()
+		registry, keys := epoch.GenRegistry(rng, 2)
+		ds := newTestDataState(&data.Config{Registry: registry})
+		state, err := NewState(keys[0], ds, utils.None[string]())
+		require.NoError(t, err)
+
+		ep1, ok := registry.EpochByIndex(1)
+		require.True(t, ok, "epoch 1 is present from NewRegistry")
+
+		require.NoError(t, scope.Run(ctx, func(ctx context.Context, sc scope.Scope) error {
+			sc.SpawnBgNamed("runEpochAdvance", func() error {
+				return utils.IgnoreCancel(state.runEpochAdvance(ctx))
+			})
+
+			var got *types.Epoch
+			var waitErr error
+			sc.Spawn(func() error {
+				got, waitErr = state.waitUntilApplied(ctx, 1)
+				return nil
+			})
+			synctest.Wait()
+			if got != nil {
+				return fmt.Errorf("waitUntilApplied returned before epoch advance")
+			}
+
+			if err := DriveAdvance(ctx, state, keys, ep1.EpochIndex()); err != nil {
+				return err
+			}
+			synctest.Wait()
+			if waitErr != nil {
+				return waitErr
+			}
+			if got.EpochIndex() != 1 {
+				return fmt.Errorf("waitUntilApplied epoch = %d, want 1", got.EpochIndex())
+			}
+			return nil
+		}))
+	})
+}
+
+func TestRunEpochAdvance_AdvancesWhenBothLeashesMet(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		rng := utils.TestRng()
+		f := newSealFixture(t)
+		f.registry.AdvanceIfNeeded(epoch.LastRoad(f.m))
+
+		prev := tipLink(f.ep, f.keys[0], epoch.LastRoad(f.m)-1)
+		qcLast := types.BuildCommitQC(f.ep, f.keys, utils.Some(prev), nil)
+		require.Equal(t, epoch.LastRoad(f.m), qcLast.Proposal().Index())
+		require.NoError(t, f.state.PushCommitQC(ctx, qcLast))
+		setRoadAppQC(f.state, qcLast.Index(), data.TestAppQC(f.keys, types.NewAppProposal(qcLast.Proposal(), types.GenAppHash(rng))))
+		require.Equal(t, f.m, f.state.Epoch().Load().EpochIndex())
+
+		var runErr error
+		go func() { runErr = f.state.runEpochAdvance(ctx) }()
+
+		ep, err := f.state.epoch.Wait(t.Context(), func(ep *types.Epoch) bool {
+			return ep.EpochIndex() >= f.m+1
+		})
+		require.NoError(t, err)
+		require.Equal(t, f.m+1, ep.EpochIndex())
+		require.Equal(t, f.m+1, f.state.Epoch().Load().EpochIndex())
+
+		cancel()
+		synctest.Wait()
+		require.ErrorIs(t, runErr, context.Canceled)
+	})
+}
+
+func TestRunEpochAdvance_WaitsForRegistry(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		rng := utils.TestRng()
+		f := newSealFixture(t)
+
+		prev := tipLink(f.ep, f.keys[0], epoch.LastRoad(f.m)-1)
+		qcLast := types.BuildCommitQC(f.ep, f.keys, utils.Some(prev), nil)
+		require.Equal(t, epoch.LastRoad(f.m), qcLast.Proposal().Index())
+		require.NoError(t, f.state.PushCommitQC(ctx, qcLast))
+		setRoadAppQC(f.state, qcLast.Index(), data.TestAppQC(f.keys, types.NewAppProposal(qcLast.Proposal(), types.GenAppHash(rng))))
+
+		var runErr error
+		go func() { runErr = f.state.runEpochAdvance(ctx) }()
+		synctest.Wait()
+		require.Equal(t, f.m, f.state.Epoch().Load().EpochIndex(), "parked on WaitForEpoch(M+1)")
+
+		f.registry.AdvanceIfNeeded(epoch.LastRoad(f.m))
+		_, err := f.state.epoch.Wait(t.Context(), func(ep *types.Epoch) bool {
+			return ep.EpochIndex() >= f.m+1
+		})
+		require.NoError(t, err)
+		cancel()
+		synctest.Wait()
+		require.ErrorIs(t, runErr, context.Canceled)
+	})
+}
+
+// A durable-tip catch-up refreshes ConsensusSpec at the persist write site,
+// even while epoch advance is parked on WaitForEpoch.
+func TestMarkCommitQCsPersisted_RefreshesSpecWhileEpochAdvanceWaitsForRegistry(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		rng := utils.TestRng()
+		f := newSealFixture(t)
+
+		last := epoch.LastRoad(f.m)
+		seekRoads(f.state, last-2)
+		prev := tipLink(f.ep, f.keys[0], last-3)
+		qcA := types.BuildCommitQC(f.ep, f.keys, utils.Some(prev), nil)
+		qcB := types.BuildCommitQC(f.ep, f.keys, utils.Some(qcA), nil)
+		qcC := types.BuildCommitQC(f.ep, f.keys, utils.Some(qcB), nil)
+		require.Equal(t, last-2, qcA.Index())
+		require.Equal(t, last-1, qcB.Index())
+		require.Equal(t, last, qcC.Index())
+		require.NoError(t, f.state.PushCommitQC(ctx, qcA))
+		require.NoError(t, f.state.PushCommitQC(ctx, qcB))
+		require.NoError(t, f.state.PushCommitQC(ctx, qcC))
+		setRoadAppQC(f.state, qcC.Index(), data.TestAppQC(f.keys, types.NewAppProposal(qcC.Proposal(), types.GenAppHash(rng))))
+		f.state.markCommitQCsPersisted(qcA)
+
+		spec := f.state.SubscribeConsensusSpec()
+		var advanceErr error
+		go func() { advanceErr = f.state.runEpochAdvance(ctx) }()
+		synctest.Wait()
+		require.Equal(t, f.m, f.state.Epoch().Load().EpochIndex(), "parked on WaitForEpoch(M+1)")
+		got, ok := spec.Load().Get()
+		require.True(t, ok)
+		require.Equal(t, qcA.Index(), got.CommitQC.Index())
+
+		f.state.markCommitQCsPersisted(qcB)
+		got, ok = spec.Load().Get()
+		require.True(t, ok)
+		require.Equal(t, qcB.Index(), got.CommitQC.Index())
+		require.Equal(t, f.m, f.state.Epoch().Load().EpochIndex(), "still waiting on registry")
+
+		cancel()
+		synctest.Wait()
+		require.ErrorIs(t, advanceErr, context.Canceled)
+	})
+}
+
+func TestRunEpochAdvance_WaitsForAppQC(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		rng := utils.TestRng()
+		f := newSealFixture(t)
+		f.registry.AdvanceIfNeeded(epoch.LastRoad(f.m))
+
+		prev := tipLink(f.ep, f.keys[0], epoch.LastRoad(f.m)-1)
+		qcLast := types.BuildCommitQC(f.ep, f.keys, utils.Some(prev), nil)
+		require.NoError(t, f.state.PushCommitQC(ctx, qcLast))
+
+		var runErr error
+		go func() { runErr = f.state.runEpochAdvance(ctx) }()
+		synctest.Wait()
+		require.Equal(t, f.m, f.state.Epoch().Load().EpochIndex(), "parked without AppQC covering M")
+
+		setRoadAppQC(f.state, qcLast.Index(), data.TestAppQC(f.keys, types.NewAppProposal(qcLast.Proposal(), types.GenAppHash(rng))))
+		_, err := f.state.epoch.Wait(t.Context(), func(ep *types.Epoch) bool {
+			return ep.EpochIndex() >= f.m+1
+		})
+		require.NoError(t, err)
+		cancel()
+		synctest.Wait()
+		require.ErrorIs(t, runErr, context.Canceled)
 	})
 }

--- a/sei-tendermint/internal/autobahn/avail/state_test.go
+++ b/sei-tendermint/internal/autobahn/avail/state_test.go
@@ -377,10 +377,61 @@ func testState(t *testing.T, rng utils.Rng, stateDir utils.Option[string]) {
 	}
 }
 
+// TestNextViewEpoch_BoundaryTipPairsNextEpoch: a LastRoad(0) tip is paired
+// with epoch 1 before newInner, so ConsensusSpec can publish that tip.
+func TestNextViewEpoch_BoundaryTipPairsNextEpoch(t *testing.T) {
+	rng := utils.TestRng()
+	registry, keys := epoch.GenRegistry(rng, 4)
+	registry.AdvanceIfNeeded(epoch.LastRoad(0))
+	ep0 := registry.MustEpoch(0)
+	ep1 := registry.MustEpoch(1)
+
+	last := epoch.LastRoad(0)
+	prev := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
+		types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep0, types.View{Index: last - 1, Number: 0}, ep0.FirstBlock()))),
+	})
+	qcLast := types.BuildCommitQC(ep0, keys, utils.Some(prev), nil)
+	require.Equal(t, last, qcLast.Index())
+
+	applied, err := nextViewEpoch(registry, qcLast, ep0)
+	require.NoError(t, err)
+	require.Equal(t, ep1.EpochIndex(), applied.EpochIndex())
+
+	i := newInner(applied, last)
+	i.roads.pushBack(newRoad(qcLast, ep0))
+	i.persistedCommitQC.Store(utils.Some(qcLast))
+	i.refreshConsensusSpec()
+
+	spec := i.consensusSpec.Load()
+	cqc, ok := spec.CommitQC.Get()
+	require.True(t, ok)
+	require.Equal(t, last, cqc.Index(), "must not walk tip back to LastRoad(0)-1")
+	require.Equal(t, types.EpochIndex(1), spec.Epoch.EpochIndex())
+}
+
+func TestNextViewEpoch_MissingNextEpochErrors(t *testing.T) {
+	rng := utils.TestRng()
+	// Fresh registry has epochs 0 and 1; seal epoch 1 so the next lookup is 2.
+	registry, keys := epoch.GenRegistry(rng, 3)
+	ep1 := registry.MustEpoch(1)
+	_, err := registry.EpochAt(epoch.FirstRoad(2))
+	require.Error(t, err)
+
+	last := epoch.LastRoad(1)
+	prev := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
+		types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep1, types.View{Index: last - 1, Number: 0}, ep1.FirstBlock()))),
+	})
+	qcLast := types.BuildCommitQC(ep1, keys, utils.Some(prev), nil)
+	require.Equal(t, last, qcLast.Index())
+
+	_, err = nextViewEpoch(registry, qcLast, ep1)
+	require.Error(t, err)
+}
+
 // TestStateRestartFromPersisted runs the state with persistence through 2
 // iterations (blocks → votes → commitQC → appQC each), stops, and restarts
 // from the same directory. This verifies that what the runtime persist
-// goroutine writes can be correctly loaded back by loadPersistedState/newInner.
+// goroutine writes can be correctly loaded back by loadPersistedState/restoreInner.
 //
 // The restarted state uses a fresh in-memory data.State, so this covers the
 // availability persisters themselves: CommitQCs and local blocks are loaded back

--- a/sei-tendermint/internal/autobahn/avail/state_test.go
+++ b/sei-tendermint/internal/autobahn/avail/state_test.go
@@ -690,10 +690,10 @@ func TestHeaders_WaitsForPrevEpochLaneVote(t *testing.T) {
 					return fmt.Errorf("anchor epoch = %d, want < %d", ae.EpochIndex(), epLeave.EpochIndex())
 				}
 			}
-			if laneVoteAcceptedByEpoch(epLeave, leaverVote) {
+			if laneVoteCommitteeOK(epLeave, leaverVote) {
 				return fmt.Errorf("leaver must fail under applied")
 			}
-			if !laneVoteAcceptedByEpoch(ep0, leaverVote) {
+			if !laneVoteCommitteeOK(ep0, leaverVote) {
 				return fmt.Errorf("leaver must pass under anchor")
 			}
 

--- a/sei-tendermint/internal/autobahn/avail/state_test.go
+++ b/sei-tendermint/internal/autobahn/avail/state_test.go
@@ -726,7 +726,7 @@ func TestHeaders_WaitsForPrevEpochLaneVote(t *testing.T) {
 				return err
 			}
 			keys := []types.SecretKey{stay, leaver, a, b}
-			if err := DriveAdvance(ctx, state, keys, epLeave.EpochIndex()); err != nil {
+			if err := TestDriveAdvance(ctx, state, keys, epLeave.EpochIndex()); err != nil {
 				return err
 			}
 
@@ -811,7 +811,7 @@ func TestPushCommitQC_StaleAfterAdvanceSoftDrops(t *testing.T) {
 		sc.SpawnBgNamed("runEpochAdvance", func() error {
 			return utils.IgnoreCancel(state.runEpochAdvance(ctx))
 		})
-		return DriveAdvance(ctx, state, keys, ep1.EpochIndex())
+		return TestDriveAdvance(ctx, state, keys, ep1.EpochIndex())
 	}))
 
 	ep0 := registry.MustEpoch(0)
@@ -847,7 +847,7 @@ func newSealFixture(t *testing.T) *sealFixture {
 		sc.SpawnBgNamed("runEpochAdvance", func() error {
 			return utils.IgnoreCancel(state.runEpochAdvance(ctx))
 		})
-		return DriveAdvance(ctx, state, keys, m)
+		return TestDriveAdvance(ctx, state, keys, m)
 	}))
 	seekRoads(state, epoch.LastRoad(m))
 	return &sealFixture{registry: registry, keys: keys, state: state, ep: ep, m: m}

--- a/sei-tendermint/internal/autobahn/avail/state_test.go
+++ b/sei-tendermint/internal/autobahn/avail/state_test.go
@@ -377,55 +377,54 @@ func testState(t *testing.T, rng utils.Rng, stateDir utils.Option[string]) {
 	}
 }
 
-// TestNextViewEpoch_BoundaryTipPairsNextEpoch: a LastRoad(0) tip is paired
-// with epoch 1 before newInner, so ConsensusSpec can publish that tip.
-func TestNextViewEpoch_BoundaryTipPairsNextEpoch(t *testing.T) {
-	rng := utils.TestRng()
-	registry, keys := epoch.GenRegistry(rng, 4)
-	registry.AdvanceIfNeeded(epoch.LastRoad(0))
-	ep0 := registry.MustEpoch(0)
-	ep1 := registry.MustEpoch(1)
+func TestNextViewEpoch(t *testing.T) {
+	t.Run("LastRoad tip pairs next epoch", func(t *testing.T) {
+		rng := utils.TestRng()
+		registry, keys := epoch.GenRegistry(rng, 4)
+		registry.AdvanceIfNeeded(epoch.LastRoad(0))
+		ep0 := registry.MustEpoch(0)
+		ep1 := registry.MustEpoch(1)
 
-	last := epoch.LastRoad(0)
-	prev := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
-		types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep0, types.View{Index: last - 1, Number: 0}, ep0.FirstBlock()))),
+		last := epoch.LastRoad(0)
+		prev := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
+			types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep0, types.View{Index: last - 1, Number: 0}, ep0.FirstBlock()))),
+		})
+		qcLast := types.BuildCommitQC(ep0, keys, utils.Some(prev), nil)
+		require.Equal(t, last, qcLast.Index())
+
+		applied, err := nextViewEpoch(registry, qcLast, ep0)
+		require.NoError(t, err)
+		require.Equal(t, ep1.EpochIndex(), applied.EpochIndex())
+
+		i := newInner(applied, last)
+		i.roads.pushBack(newRoad(qcLast, ep0))
+		i.persistedCommitQC.Store(utils.Some(qcLast))
+		i.refreshConsensusSpec()
+
+		spec := i.consensusSpec.Load()
+		cqc, ok := spec.CommitQC.Get()
+		require.True(t, ok)
+		require.Equal(t, last, cqc.Index(), "must not walk tip back to LastRoad(0)-1")
+		require.Equal(t, types.EpochIndex(1), spec.Epoch.EpochIndex())
 	})
-	qcLast := types.BuildCommitQC(ep0, keys, utils.Some(prev), nil)
-	require.Equal(t, last, qcLast.Index())
 
-	applied, err := nextViewEpoch(registry, qcLast, ep0)
-	require.NoError(t, err)
-	require.Equal(t, ep1.EpochIndex(), applied.EpochIndex())
+	t.Run("missing next epoch errors", func(t *testing.T) {
+		rng := utils.TestRng()
+		registry, keys := epoch.GenRegistry(rng, 3)
+		ep1 := registry.MustEpoch(1)
+		_, err := registry.EpochAt(epoch.FirstRoad(2))
+		require.Error(t, err)
 
-	i := newInner(applied, last)
-	i.roads.pushBack(newRoad(qcLast, ep0))
-	i.persistedCommitQC.Store(utils.Some(qcLast))
-	i.refreshConsensusSpec()
+		last := epoch.LastRoad(1)
+		prev := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
+			types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep1, types.View{Index: last - 1, Number: 0}, ep1.FirstBlock()))),
+		})
+		qcLast := types.BuildCommitQC(ep1, keys, utils.Some(prev), nil)
+		require.Equal(t, last, qcLast.Index())
 
-	spec := i.consensusSpec.Load()
-	cqc, ok := spec.CommitQC.Get()
-	require.True(t, ok)
-	require.Equal(t, last, cqc.Index(), "must not walk tip back to LastRoad(0)-1")
-	require.Equal(t, types.EpochIndex(1), spec.Epoch.EpochIndex())
-}
-
-func TestNextViewEpoch_MissingNextEpochErrors(t *testing.T) {
-	rng := utils.TestRng()
-	// Fresh registry has epochs 0 and 1; seal epoch 1 so the next lookup is 2.
-	registry, keys := epoch.GenRegistry(rng, 3)
-	ep1 := registry.MustEpoch(1)
-	_, err := registry.EpochAt(epoch.FirstRoad(2))
-	require.Error(t, err)
-
-	last := epoch.LastRoad(1)
-	prev := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
-		types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep1, types.View{Index: last - 1, Number: 0}, ep1.FirstBlock()))),
+		_, err = nextViewEpoch(registry, qcLast, ep1)
+		require.Error(t, err)
 	})
-	qcLast := types.BuildCommitQC(ep1, keys, utils.Some(prev), nil)
-	require.Equal(t, last, qcLast.Index())
-
-	_, err = nextViewEpoch(registry, qcLast, ep1)
-	require.Error(t, err)
 }
 
 // TestStateRestartFromPersisted runs the state with persistence through 2
@@ -932,69 +931,71 @@ func TestRunEpochAdvance_Leashes(t *testing.T) {
 	}
 }
 
-func TestRunEpochAdvance_PrunedNextContinues(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		ctx, cancel := context.WithCancel(t.Context())
-		defer cancel()
-		rng := utils.TestRng()
-		registry, keys := epoch.GenRegistry(rng, 2)
-		ds := newTestDataState(&data.Config{Registry: registry})
-		state, err := NewState(keys[0], ds, utils.None[string]())
-		require.NoError(t, err)
-		require.Equal(t, types.EpochIndex(0), state.Epoch().Load().EpochIndex())
+func TestRunEpochAdvance_CatchUpDoesNotKill(t *testing.T) {
+	t.Run("ErrPruned jumps to live floor", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			rng := utils.TestRng()
+			registry, keys := epoch.GenRegistry(rng, 2)
+			ds := newTestDataState(&data.Config{Registry: registry})
+			state, err := NewState(keys[0], ds, utils.None[string]())
+			require.NoError(t, err)
+			require.Equal(t, types.EpochIndex(0), state.Epoch().Load().EpochIndex())
 
-		registry.AdvanceIfNeeded(epoch.LastRoad(1))
-		registry.AdvanceIfNeeded(epoch.LastRoad(2))
-		registry.PruneBefore(3)
+			registry.AdvanceIfNeeded(epoch.LastRoad(1))
+			registry.AdvanceIfNeeded(epoch.LastRoad(2))
+			registry.PruneBefore(3)
 
-		var runErr error
-		go func() { runErr = state.runEpochAdvance(ctx) }()
-		synctest.Wait()
-		require.Equal(t, types.EpochIndex(3), state.Epoch().Load().EpochIndex())
-		require.Nil(t, runErr)
+			var runErr error
+			go func() { runErr = state.runEpochAdvance(ctx) }()
+			synctest.Wait()
+			require.Equal(t, types.EpochIndex(3), state.Epoch().Load().EpochIndex())
+			require.Nil(t, runErr)
 
-		cancel()
-		synctest.Wait()
-		require.ErrorIs(t, runErr, context.Canceled)
-		require.False(t, errors.Is(runErr, types.ErrPruned))
+			cancel()
+			synctest.Wait()
+			require.ErrorIs(t, runErr, context.Canceled)
+			require.False(t, errors.Is(runErr, types.ErrPruned))
+		})
 	})
-}
 
-func TestRunEpochAdvance_PruneJumpDuringWaitDoesNotKill(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		ctx, cancel := context.WithCancel(t.Context())
-		defer cancel()
-		rng := utils.TestRng()
-		registry, keys := epoch.GenRegistry(rng, 4)
-		registry.AdvanceIfNeeded(epoch.LastRoad(1))
-		registry.AdvanceIfNeeded(epoch.LastRoad(2))
-		ds := newTestDataState(&data.Config{Registry: registry})
-		state, err := NewState(keys[0], ds, utils.None[string]())
-		require.NoError(t, err)
+	t.Run("prune jump during seal wait", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			rng := utils.TestRng()
+			registry, keys := epoch.GenRegistry(rng, 4)
+			registry.AdvanceIfNeeded(epoch.LastRoad(1))
+			registry.AdvanceIfNeeded(epoch.LastRoad(2))
+			ds := newTestDataState(&data.Config{Registry: registry})
+			state, err := NewState(keys[0], ds, utils.None[string]())
+			require.NoError(t, err)
 
-		var runErr error
-		go func() { runErr = state.runEpochAdvance(ctx) }()
-		synctest.Wait()
-		require.Equal(t, types.EpochIndex(0), state.Epoch().Load().EpochIndex())
+			var runErr error
+			go func() { runErr = state.runEpochAdvance(ctx) }()
+			synctest.Wait()
+			require.Equal(t, types.EpochIndex(0), state.Epoch().Load().EpochIndex())
 
-		ep2 := registry.MustEpoch(2)
-		qc := types.BuildCommitQC(ep2, keys, utils.Some(tipLink(ep2, keys[0], epoch.LastRoad(2)-1)), nil)
-		require.Equal(t, epoch.LastRoad(2), qc.Index())
-		for inner, ctrl := range state.inner.Lock() {
-			inner.prune(data.Anchor{
-				CommitQC: qc,
-				AppQC:    data.TestAppQC(keys, types.NewAppProposal(qc.Proposal(), types.AppHash{})),
-				Epoch:    ep2,
-			})
-			ctrl.Updated()
-		}
-		synctest.Wait()
-		require.Nil(t, runErr)
-		require.GreaterOrEqual(t, state.Epoch().Load().EpochIndex(), types.EpochIndex(2))
+			ep2 := registry.MustEpoch(2)
+			qc := types.BuildCommitQC(ep2, keys, utils.Some(tipLink(ep2, keys[0], epoch.LastRoad(2)-1)), nil)
+			require.Equal(t, epoch.LastRoad(2), qc.Index())
+			for inner, ctrl := range state.inner.Lock() {
+				inner.prune(data.Anchor{
+					CommitQC: qc,
+					AppQC:    data.TestAppQC(keys, types.NewAppProposal(qc.Proposal(), types.AppHash{})),
+					Epoch:    ep2,
+				})
+				ctrl.Updated()
+			}
+			synctest.Wait()
+			require.Nil(t, runErr)
+			require.GreaterOrEqual(t, state.Epoch().Load().EpochIndex(), types.EpochIndex(2))
 
-		cancel()
-		synctest.Wait()
-		require.ErrorIs(t, runErr, context.Canceled)
+			cancel()
+			synctest.Wait()
+			require.ErrorIs(t, runErr, context.Canceled)
+		})
 	})
 }
 

--- a/sei-tendermint/internal/autobahn/avail/state_test.go
+++ b/sei-tendermint/internal/autobahn/avail/state_test.go
@@ -931,8 +931,31 @@ func TestRunEpochAdvance_Leashes(t *testing.T) {
 	}
 }
 
+func pruneToLastRoad2(t *testing.T, registry *epoch.Registry, keys []types.SecretKey, state *State) *types.CommitQC {
+	t.Helper()
+	ep2 := registry.MustEpoch(2)
+	qc := types.BuildCommitQC(ep2, keys, utils.Some(tipLink(ep2, keys[0], epoch.LastRoad(2)-1)), nil)
+	require.Equal(t, epoch.LastRoad(2), qc.Index())
+	for inner, ctrl := range state.inner.Lock() {
+		inner.prune(data.Anchor{
+			CommitQC: qc,
+			AppQC:    data.TestAppQC(keys, types.NewAppProposal(qc.Proposal(), types.AppHash{})),
+			Epoch:    ep2,
+		})
+		ctrl.Updated()
+	}
+	return qc
+}
+
+func requireSpec(t *testing.T, state *State, qc *types.CommitQC, idx types.EpochIndex) {
+	t.Helper()
+	spec := state.SubscribeConsensusSpec().Load()
+	require.Equal(t, qc.Index(), spec.CommitQC.OrPanic("CommitQC").Index())
+	require.Equal(t, idx, spec.Epoch.EpochIndex())
+}
+
 func TestRunEpochAdvance_CatchUpDoesNotKill(t *testing.T) {
-	t.Run("ErrPruned jumps to live floor", func(t *testing.T) {
+	t.Run("ErrPruned jumps to durable tip next epoch", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
@@ -945,13 +968,16 @@ func TestRunEpochAdvance_CatchUpDoesNotKill(t *testing.T) {
 
 			registry.AdvanceIfNeeded(epoch.LastRoad(1))
 			registry.AdvanceIfNeeded(epoch.LastRoad(2))
-			registry.PruneBefore(3)
+			qc := pruneToLastRoad2(t, registry, keys, state)
+			require.Equal(t, types.EpochIndex(0), state.Epoch().Load().EpochIndex())
+			registry.PruneBefore(2)
 
 			var runErr error
 			go func() { runErr = state.runEpochAdvance(ctx) }()
 			synctest.Wait()
 			require.Equal(t, types.EpochIndex(3), state.Epoch().Load().EpochIndex())
 			require.Nil(t, runErr)
+			requireSpec(t, state, qc, 3)
 
 			cancel()
 			synctest.Wait()
@@ -960,7 +986,46 @@ func TestRunEpochAdvance_CatchUpDoesNotKill(t *testing.T) {
 		})
 	})
 
-	t.Run("prune jump during seal wait", func(t *testing.T) {
+	t.Run("ErrPruned waits until prune moves a stale tip", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			rng := utils.TestRng()
+			registry, keys := epoch.GenRegistry(rng, 2)
+			ds := newTestDataState(&data.Config{Registry: registry})
+			state, err := NewState(keys[0], ds, utils.None[string]())
+			require.NoError(t, err)
+
+			registry.AdvanceIfNeeded(epoch.LastRoad(1))
+			registry.AdvanceIfNeeded(epoch.LastRoad(2))
+			ep0 := registry.MustEpoch(0)
+			qc0 := types.BuildCommitQC(ep0, keys, utils.None[*types.CommitQC](), nil)
+			require.Equal(t, types.RoadIndex(0), qc0.Index())
+			for inner, ctrl := range state.inner.Lock() {
+				inner.persistedCommitQC.Store(utils.Some(qc0))
+				ctrl.Updated()
+			}
+			registry.PruneBefore(2)
+
+			var runErr error
+			go func() { runErr = state.runEpochAdvance(ctx) }()
+			synctest.Wait()
+			require.Nil(t, runErr)
+			require.Equal(t, types.EpochIndex(0), state.Epoch().Load().EpochIndex())
+
+			qc := pruneToLastRoad2(t, registry, keys, state)
+			synctest.Wait()
+			require.Nil(t, runErr)
+			require.Equal(t, types.EpochIndex(3), state.Epoch().Load().EpochIndex())
+			requireSpec(t, state, qc, 3)
+
+			cancel()
+			synctest.Wait()
+			require.ErrorIs(t, runErr, context.Canceled)
+		})
+	})
+
+	t.Run("prune unblocks epoch owner during seal wait", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
@@ -977,20 +1042,11 @@ func TestRunEpochAdvance_CatchUpDoesNotKill(t *testing.T) {
 			synctest.Wait()
 			require.Equal(t, types.EpochIndex(0), state.Epoch().Load().EpochIndex())
 
-			ep2 := registry.MustEpoch(2)
-			qc := types.BuildCommitQC(ep2, keys, utils.Some(tipLink(ep2, keys[0], epoch.LastRoad(2)-1)), nil)
-			require.Equal(t, epoch.LastRoad(2), qc.Index())
-			for inner, ctrl := range state.inner.Lock() {
-				inner.prune(data.Anchor{
-					CommitQC: qc,
-					AppQC:    data.TestAppQC(keys, types.NewAppProposal(qc.Proposal(), types.AppHash{})),
-					Epoch:    ep2,
-				})
-				ctrl.Updated()
-			}
+			qc := pruneToLastRoad2(t, registry, keys, state)
 			synctest.Wait()
 			require.Nil(t, runErr)
-			require.GreaterOrEqual(t, state.Epoch().Load().EpochIndex(), types.EpochIndex(2))
+			require.Equal(t, types.EpochIndex(3), state.Epoch().Load().EpochIndex())
+			requireSpec(t, state, qc, 3)
 
 			cancel()
 			synctest.Wait()

--- a/sei-tendermint/internal/autobahn/avail/state_test.go
+++ b/sei-tendermint/internal/autobahn/avail/state_test.go
@@ -932,6 +932,72 @@ func TestRunEpochAdvance_Leashes(t *testing.T) {
 	}
 }
 
+func TestRunEpochAdvance_PrunedNextContinues(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		rng := utils.TestRng()
+		registry, keys := epoch.GenRegistry(rng, 2)
+		ds := newTestDataState(&data.Config{Registry: registry})
+		state, err := NewState(keys[0], ds, utils.None[string]())
+		require.NoError(t, err)
+		require.Equal(t, types.EpochIndex(0), state.Epoch().Load().EpochIndex())
+
+		registry.AdvanceIfNeeded(epoch.LastRoad(1))
+		registry.AdvanceIfNeeded(epoch.LastRoad(2))
+		registry.PruneBefore(3)
+
+		var runErr error
+		go func() { runErr = state.runEpochAdvance(ctx) }()
+		synctest.Wait()
+		require.Equal(t, types.EpochIndex(3), state.Epoch().Load().EpochIndex())
+		require.Nil(t, runErr)
+
+		cancel()
+		synctest.Wait()
+		require.ErrorIs(t, runErr, context.Canceled)
+		require.False(t, errors.Is(runErr, types.ErrPruned))
+	})
+}
+
+func TestRunEpochAdvance_PruneJumpDuringWaitDoesNotKill(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		rng := utils.TestRng()
+		registry, keys := epoch.GenRegistry(rng, 4)
+		registry.AdvanceIfNeeded(epoch.LastRoad(1))
+		registry.AdvanceIfNeeded(epoch.LastRoad(2))
+		ds := newTestDataState(&data.Config{Registry: registry})
+		state, err := NewState(keys[0], ds, utils.None[string]())
+		require.NoError(t, err)
+
+		var runErr error
+		go func() { runErr = state.runEpochAdvance(ctx) }()
+		synctest.Wait()
+		require.Equal(t, types.EpochIndex(0), state.Epoch().Load().EpochIndex())
+
+		ep2 := registry.MustEpoch(2)
+		qc := types.BuildCommitQC(ep2, keys, utils.Some(tipLink(ep2, keys[0], epoch.LastRoad(2)-1)), nil)
+		require.Equal(t, epoch.LastRoad(2), qc.Index())
+		for inner, ctrl := range state.inner.Lock() {
+			inner.prune(data.Anchor{
+				CommitQC: qc,
+				AppQC:    data.TestAppQC(keys, types.NewAppProposal(qc.Proposal(), types.AppHash{})),
+				Epoch:    ep2,
+			})
+			ctrl.Updated()
+		}
+		synctest.Wait()
+		require.Nil(t, runErr)
+		require.GreaterOrEqual(t, state.Epoch().Load().EpochIndex(), types.EpochIndex(2))
+
+		cancel()
+		synctest.Wait()
+		require.ErrorIs(t, runErr, context.Canceled)
+	})
+}
+
 // A durable-tip catch-up refreshes ConsensusSpec at the persist write site,
 // even while epoch advance is parked on WaitForEpoch.
 func TestMarkCommitQCsPersisted_RefreshesSpecWhileEpochAdvanceWaitsForRegistry(t *testing.T) {

--- a/sei-tendermint/internal/autobahn/avail/state_test.go
+++ b/sei-tendermint/internal/autobahn/avail/state_test.go
@@ -802,48 +802,6 @@ func newSealFixture(t *testing.T) *sealFixture {
 	return &sealFixture{registry: registry, keys: keys, state: state, ep: ep, m: m}
 }
 
-func TestWaitForEpoch_ParksUntilEpochAdvance(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		ctx := t.Context()
-		rng := utils.TestRng()
-		registry, keys := epoch.GenRegistry(rng, 2)
-		ds := newTestDataState(&data.Config{Registry: registry})
-		state, err := NewState(keys[0], ds, utils.None[string]())
-		require.NoError(t, err)
-
-		ep1 := registry.MustEpoch(1)
-
-		require.NoError(t, scope.Run(ctx, func(ctx context.Context, sc scope.Scope) error {
-			sc.SpawnBgNamed("runEpochAdvance", func() error {
-				return utils.IgnoreCancel(state.runEpochAdvance(ctx))
-			})
-
-			var got *types.Epoch
-			var waitErr error
-			sc.Spawn(func() error {
-				got, waitErr = state.waitForEpoch(ctx, 1)
-				return nil
-			})
-			synctest.Wait()
-			if got != nil {
-				return fmt.Errorf("waitForEpoch returned before epoch advance")
-			}
-
-			if err := DriveAdvance(ctx, state, keys, ep1.EpochIndex()); err != nil {
-				return err
-			}
-			synctest.Wait()
-			if waitErr != nil {
-				return waitErr
-			}
-			if got.EpochIndex() != 1 {
-				return fmt.Errorf("waitForEpoch epoch = %d, want 1", got.EpochIndex())
-			}
-			return nil
-		}))
-	})
-}
-
 func TestRunEpochAdvance_Leashes(t *testing.T) {
 	type missing int
 	const (

--- a/sei-tendermint/internal/autobahn/avail/state_test.go
+++ b/sei-tendermint/internal/autobahn/avail/state_test.go
@@ -392,7 +392,7 @@ func TestNextViewEpoch(t *testing.T) {
 		qcLast := types.BuildCommitQC(ep0, keys, utils.Some(prev), nil)
 		require.Equal(t, last, qcLast.Index())
 
-		applied, err := nextViewEpoch(registry, qcLast, ep0)
+		applied, err := nextViewEpoch(registry, qcLast)
 		require.NoError(t, err)
 		require.Equal(t, ep1.EpochIndex(), applied.EpochIndex())
 
@@ -422,7 +422,7 @@ func TestNextViewEpoch(t *testing.T) {
 		qcLast := types.BuildCommitQC(ep1, keys, utils.Some(prev), nil)
 		require.Equal(t, last, qcLast.Index())
 
-		_, err = nextViewEpoch(registry, qcLast, ep1)
+		_, err = nextViewEpoch(registry, qcLast)
 		require.Error(t, err)
 	})
 }

--- a/sei-tendermint/internal/autobahn/avail/state_test.go
+++ b/sei-tendermint/internal/autobahn/avail/state_test.go
@@ -1120,3 +1120,30 @@ func TestMarkCommitQCsPersisted_RefreshesSpecWhileEpochAdvanceParked(t *testing.
 		require.ErrorIs(t, advanceErr, context.Canceled)
 	})
 }
+
+func TestMarkCommitQCsPersisted_DoesNotRewindPruneTip(t *testing.T) {
+	rng := utils.TestRng()
+	registry, keys := epoch.GenRegistry(rng, 2)
+	registry.AdvanceIfNeeded(epoch.LastRoad(1))
+	registry.AdvanceIfNeeded(epoch.LastRoad(2))
+	ds := newTestDataState(&data.Config{Registry: registry})
+	state, err := NewState(keys[0], ds, utils.None[string]())
+	require.NoError(t, err)
+
+	qc0 := types.BuildCommitQC(registry.MustEpoch(0), keys, utils.None[*types.CommitQC](), nil)
+	state.markCommitQCsPersisted(qc0)
+
+	qc := pruneToAnchors(state, anchorWalk(t, registry, keys))
+	for inner := range state.inner.Lock() {
+		got, ok := inner.persistedCommitQC.Load().Get()
+		require.True(t, ok)
+		require.Equal(t, qc.Index(), got.Index())
+	}
+
+	state.markCommitQCsPersisted(qc0)
+	for inner := range state.inner.Lock() {
+		got, ok := inner.persistedCommitQC.Load().Get()
+		require.True(t, ok)
+		require.Equal(t, qc.Index(), got.Index())
+	}
+}

--- a/sei-tendermint/internal/autobahn/avail/state_test.go
+++ b/sei-tendermint/internal/autobahn/avail/state_test.go
@@ -976,14 +976,14 @@ func TestMarkCommitQCsPersisted_RefreshesSpecWhileEpochAdvanceWaitsForRegistry(t
 		go func() { advanceErr = f.state.runEpochAdvance(ctx) }()
 		synctest.Wait()
 		require.Equal(t, f.m, f.state.Epoch().Load().EpochIndex(), "parked on WaitForEpoch(M+1)")
-		got, ok := spec.Load().Get()
+		got, ok := spec.Load().CommitQC.Get()
 		require.True(t, ok)
-		require.Equal(t, qcA.Index(), got.CommitQC.Index())
+		require.Equal(t, qcA.Index(), got.Index())
 
 		f.state.markCommitQCsPersisted(qcB)
-		got, ok = spec.Load().Get()
+		got, ok = spec.Load().CommitQC.Get()
 		require.True(t, ok)
-		require.Equal(t, qcB.Index(), got.CommitQC.Index())
+		require.Equal(t, qcB.Index(), got.Index())
 		require.Equal(t, f.m, f.state.Epoch().Load().EpochIndex(), "still waiting on registry")
 
 		cancel()

--- a/sei-tendermint/internal/autobahn/avail/state_test.go
+++ b/sei-tendermint/internal/autobahn/avail/state_test.go
@@ -690,10 +690,10 @@ func TestHeaders_WaitsForPrevEpochLaneVote(t *testing.T) {
 					return fmt.Errorf("anchor epoch = %d, want < %d", ae.EpochIndex(), epLeave.EpochIndex())
 				}
 			}
-			if laneVoteCommitteeOK(epLeave, leaverVote) {
+			if leaverVote.Msg().Verify(epLeave.Committee()) == nil && epLeave.Committee().HasReplica(leaverVote.Key()) {
 				return fmt.Errorf("leaver must fail under applied")
 			}
-			if !laneVoteCommitteeOK(ep0, leaverVote) {
+			if leaverVote.Msg().Verify(ep0.Committee()) != nil || !ep0.Committee().HasReplica(leaverVote.Key()) {
 				return fmt.Errorf("leaver must pass under anchor")
 			}
 

--- a/sei-tendermint/internal/autobahn/avail/state_test.go
+++ b/sei-tendermint/internal/autobahn/avail/state_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func pushPeerLaneBlock(state *State, key types.SecretKey, payload *types.Payload) (*types.Signed[*types.LaneProposal], error) {
-	lane := state.data.Registry().LatestEpoch().Committee().Lane(key.Public()).OrPanic("lane")
+	lane := state.data.Registry().MustEpoch(0).Committee().Lane(key.Public()).OrPanic("lane")
 	var b *types.Signed[*types.LaneProposal]
 	for inner, ctrl := range state.inner.Lock() {
 		q, ok := inner.blocks[lane]
@@ -101,7 +101,7 @@ func TestPrune_AnchorEpochDropsClosedLane(t *testing.T) {
 		ds := newTestDataState(&data.Config{Registry: registry})
 		sc.SpawnBgNamed("data.Run", func() error { return utils.IgnoreCancel(ds.Run(ctx)) })
 
-		ep0 := registry.LatestEpoch()
+		ep0 := registry.MustEpoch(0)
 		qc0, blocks0 := data.TestCommitQC(rng, ep0, keys, utils.None[*types.CommitQC]())
 		if err := ds.PushQC(ctx, qc0, blocks0); err != nil {
 			return err
@@ -130,6 +130,7 @@ func TestPrune_AnchorEpochDropsClosedLane(t *testing.T) {
 		sub := state.SubscribeLaneProposals(lane0, 0)
 
 		epLeave, err := registry.ActivateEpoch(
+			0,
 			map[types.PublicKey]uint64{b.Public(): 1},
 			time.Time{}, registry.FirstBlock(),
 		)
@@ -148,10 +149,7 @@ func TestPrune_AnchorEpochDropsClosedLane(t *testing.T) {
 		}); err != nil {
 			return err
 		}
-		ep1, ok := registry.EpochByIndex(1)
-		if !ok {
-			return fmt.Errorf("epoch 1 missing")
-		}
+		ep1 := registry.MustEpoch(1)
 		for inner, ctrl := range state.inner.Lock() {
 			inner.anchorEpoch = utils.Some(ep1)
 			ctrl.Updated()
@@ -207,7 +205,7 @@ func TestAnchorResetsState(t *testing.T) {
 	ctx := t.Context()
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
-	epoch := registry.LatestEpoch()
+	epoch := registry.MustEpoch(0)
 	require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
 		t.Logf("data.Run()")
 		ds := newTestDataState(&data.Config{Registry: registry})
@@ -247,7 +245,7 @@ func TestAnchorResetsState(t *testing.T) {
 		s.SpawnBgNamed("avail.Run", func() error { return utils.IgnoreCancel(state.Run(ctx)) })
 
 		t.Logf("push next CommitQC to avail")
-		qc, _ = data.TestCommitQC(rng, registry.LatestEpoch(), keys, utils.Some(qc.QC()))
+		qc, _ = data.TestCommitQC(rng, registry.MustEpoch(0), keys, utils.Some(qc.QC()))
 		if err := state.PushCommitQC(ctx, qc.QC()); err != nil {
 			return err
 		}
@@ -264,7 +262,7 @@ func testState(t *testing.T, rng utils.Rng, stateDir utils.Option[string]) {
 	t.Helper()
 	ctx := t.Context()
 	registry, keys := epoch.GenRegistry(rng, 3)
-	committee := registry.LatestEpoch().Committee()
+	committee := registry.MustEpoch(0).Committee()
 
 	if err := scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
 		ds := newTestDataState(&data.Config{Registry: registry})
@@ -312,11 +310,11 @@ func testState(t *testing.T, rng utils.Rng, stateDir utils.Option[string]) {
 			}
 
 			t.Logf("Push a commit QC.")
-			laneQCs, err := state.WaitForLaneQCs(ctx, registry.LatestEpoch(), prev)
+			laneQCs, err := state.WaitForLaneQCs(ctx, registry.MustEpoch(0), prev)
 			if err != nil {
 				return fmt.Errorf("state.WaitForNewLaneQCs(): %w", err)
 			}
-			qc := types.BuildCommitQC(registry.LatestEpoch(), keys, prev, laneQCs)
+			qc := types.BuildCommitQC(registry.MustEpoch(0), keys, prev, laneQCs)
 			if err := state.PushCommitQC(ctx, qc); err != nil {
 				return fmt.Errorf("state.PushCommitQC(): %w", err)
 			}
@@ -388,7 +386,7 @@ func testState(t *testing.T, rng utils.Rng, stateDir utils.Option[string]) {
 func TestStateRestartFromPersisted(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
-	committee := registry.LatestEpoch().Committee()
+	committee := registry.MustEpoch(0).Committee()
 	dir := t.TempDir()
 
 	// Phase 1: Run state with persistence through 2 iterations.
@@ -438,11 +436,11 @@ func TestStateRestartFromPersisted(t *testing.T) {
 				}
 			}
 
-			laneQCs, err := state.WaitForLaneQCs(ctx, registry.LatestEpoch(), prev)
+			laneQCs, err := state.WaitForLaneQCs(ctx, registry.MustEpoch(0), prev)
 			if err != nil {
 				return fmt.Errorf("WaitForLaneQCs: %w", err)
 			}
-			qc := types.BuildCommitQC(registry.LatestEpoch(), keys, prev, laneQCs)
+			qc := types.BuildCommitQC(registry.MustEpoch(0), keys, prev, laneQCs)
 			if err := state.PushCommitQC(ctx, qc); err != nil {
 				return fmt.Errorf("PushCommitQC: %w", err)
 			}
@@ -502,7 +500,7 @@ func TestPushBlockRejectsBadParentHash(t *testing.T) {
 	ds := newTestDataState(&data.Config{Registry: registry})
 	state := utils.OrPanic1(NewState(keys[0], ds, utils.Some(t.TempDir())))
 
-	committee := registry.LatestEpoch().Committee()
+	committee := registry.MustEpoch(0).Committee()
 	lane := committee.Lane(keys[0].Public()).OrPanic("lane")
 	// Produce a valid first block on our lane.
 	_, err := state.ProduceLocalBlock(lane, state.NextBlock(lane), types.GenPayload(rng))
@@ -526,7 +524,7 @@ func TestPushBlockRejectsWrongSigner(t *testing.T) {
 	ds := newTestDataState(&data.Config{Registry: registry})
 	state := utils.OrPanic1(NewState(keys[0], ds, utils.Some(t.TempDir())))
 
-	lane := registry.LatestEpoch().Committee().Lane(keys[0].Public()).OrPanic("lane")
+	lane := registry.MustEpoch(0).Committee().Lane(keys[0].Public()).OrPanic("lane")
 	// Create a block on keys[0]'s lane but sign it with keys[1].
 	block := types.NewBlock(lane, 0, types.GenBlockHeaderHash(rng), types.GenPayload(rng))
 	prop := types.Sign(keys[1], types.NewLaneProposal(block))
@@ -552,7 +550,7 @@ func TestNewStateWithPersistence(t *testing.T) {
 	t.Run("loads persisted blocks", func(t *testing.T) {
 		dir := t.TempDir()
 		ds := newTestDataState(&data.Config{Registry: registry})
-		lane := registry.LatestEpoch().Committee().Lane(keys[0].Public()).OrPanic("lane")
+		lane := registry.MustEpoch(0).Committee().Lane(keys[0].Public()).OrPanic("lane")
 
 		// Persist blocks using BlockPersister.
 		bp, _, err := persist.NewBlockPersister(utils.Some(dir))
@@ -591,7 +589,7 @@ func TestNewStateWithPersistence(t *testing.T) {
 		qcs := make([]*types.CommitQC, 3)
 		prev := utils.None[*types.CommitQC]()
 		for i := range qcs {
-			qcs[i] = types.BuildCommitQC(registry.LatestEpoch(), keys, prev, nil)
+			qcs[i] = types.BuildCommitQC(registry.MustEpoch(0), keys, prev, nil)
 			prev = utils.Some(qcs[i])
 			require.NoError(t, cp.PruneAndPersist(0, []*types.CommitQC{qcs[i]}))
 		}
@@ -615,7 +613,7 @@ func TestNewStateWithPersistence(t *testing.T) {
 		allQCs := make([]*types.CommitQC, 6)
 		prev := utils.None[*types.CommitQC]()
 		for i := range allQCs {
-			allQCs[i] = types.BuildCommitQC(registry.LatestEpoch(), keys, prev, nil)
+			allQCs[i] = types.BuildCommitQC(registry.MustEpoch(0), keys, prev, nil)
 			prev = utils.Some(allQCs[i])
 		}
 
@@ -661,12 +659,13 @@ func TestHeaders_WaitsForPrevEpochLaneVote(t *testing.T) {
 				return utils.IgnoreCancel(state.runEpochAdvance(ctx))
 			})
 
-			ep0 := registry.LatestEpoch()
+			ep0 := registry.MustEpoch(0)
 			lane := ep0.Committee().Lane(stay.Public()).OrPanic("stay lane")
 			header := types.NewBlock(lane, 0, types.BlockHeaderHash{}, &types.Payload{}).Header()
 			leaverVote := types.Sign(leaver, types.NewLaneVote(header))
 
 			epLeave, err := registry.ActivateEpoch(
+				0,
 				map[types.PublicKey]uint64{stay.Public(): 1, a.Public(): 1, b.Public(): 1},
 				time.Time{}, registry.FirstBlock(),
 			)
@@ -738,8 +737,7 @@ func TestPushCommitQC_MidEpochNoWait(t *testing.T) {
 	require.Error(t, err)
 
 	seekRoads(f.state, epoch.FirstRoad(f.m))
-	epPrev, ok := f.registry.EpochByIndex(f.m - 1)
-	require.True(t, ok)
+	epPrev := f.registry.MustEpoch(f.m - 1)
 	prev := tipLink(epPrev, f.keys[0], epoch.LastRoad(f.m-1))
 	qc := types.BuildCommitQC(f.ep, f.keys, utils.Some(prev), nil)
 	require.Equal(t, epoch.FirstRoad(f.m), qc.Proposal().Index())
@@ -761,8 +759,7 @@ func TestPushCommitQC_FutureEpochParksUntilAdvance(t *testing.T) {
 		setRoadAppQC(f.state, qcLast.Index(), data.TestAppQC(f.keys, types.NewAppProposal(qcLast.Proposal(), types.GenAppHash(rng))))
 
 		f.registry.AdvanceIfNeeded(epoch.LastRoad(f.m))
-		ep2, ok := f.registry.EpochByIndex(f.m + 1)
-		require.True(t, ok)
+		ep2 := f.registry.MustEpoch(f.m + 1)
 		qcNext := types.BuildCommitQC(ep2, f.keys, utils.Some(qcLast), nil)
 		require.Equal(t, epoch.FirstRoad(f.m+1), qcNext.Proposal().Index())
 
@@ -794,8 +791,7 @@ func TestPushCommitQC_StaleAfterAdvanceSoftDrops(t *testing.T) {
 	state, err := NewState(keys[0], ds, utils.None[string]())
 	require.NoError(t, err)
 
-	ep1, ok := registry.EpochByIndex(1)
-	require.True(t, ok)
+	ep1 := registry.MustEpoch(1)
 	require.NoError(t, scope.Run(t.Context(), func(ctx context.Context, sc scope.Scope) error {
 		sc.SpawnBgNamed("runEpochAdvance", func() error {
 			return utils.IgnoreCancel(state.runEpochAdvance(ctx))
@@ -803,8 +799,7 @@ func TestPushCommitQC_StaleAfterAdvanceSoftDrops(t *testing.T) {
 		return DriveAdvance(ctx, state, keys, ep1.EpochIndex())
 	}))
 
-	ep0, ok := registry.EpochByIndex(0)
-	require.True(t, ok)
+	ep0 := registry.MustEpoch(0)
 	before := nextRoad(state)
 	qc0 := types.BuildCommitQC(ep0, keys, utils.None[*types.CommitQC](), nil)
 	require.Equal(t, types.EpochIndex(0), qc0.Proposal().EpochIndex())
@@ -829,8 +824,7 @@ func newSealFixture(t *testing.T) *sealFixture {
 	require.NoError(t, err)
 
 	const m types.EpochIndex = 1
-	ep, ok := registry.EpochByIndex(m)
-	require.True(t, ok, "epoch 1 is present from NewRegistry")
+	ep := registry.MustEpoch(m)
 	_, err = registry.EpochAt(epoch.FirstRoad(m + 1))
 	require.Error(t, err, "epoch 2 must be absent for exec-leash tests")
 
@@ -853,8 +847,7 @@ func TestWaitUntilApplied_ParksUntilEpochAdvance(t *testing.T) {
 		state, err := NewState(keys[0], ds, utils.None[string]())
 		require.NoError(t, err)
 
-		ep1, ok := registry.EpochByIndex(1)
-		require.True(t, ok, "epoch 1 is present from NewRegistry")
+		ep1 := registry.MustEpoch(1)
 
 		require.NoError(t, scope.Run(ctx, func(ctx context.Context, sc scope.Scope) error {
 			sc.SpawnBgNamed("runEpochAdvance", func() error {

--- a/sei-tendermint/internal/autobahn/avail/state_test.go
+++ b/sei-tendermint/internal/autobahn/avail/state_test.go
@@ -931,20 +931,35 @@ func TestRunEpochAdvance_Leashes(t *testing.T) {
 	}
 }
 
-func pruneToLastRoad2(t *testing.T, registry *epoch.Registry, keys []types.SecretKey, state *State) *types.CommitQC {
+// anchorWalk is the Anchor sequence data publishes as it certifies the last
+// road of epochs 0 through 2. Build it before the registry drops those epochs.
+func anchorWalk(t *testing.T, registry *epoch.Registry, keys []types.SecretKey) []data.Anchor {
 	t.Helper()
-	ep2 := registry.MustEpoch(2)
-	qc := types.BuildCommitQC(ep2, keys, utils.Some(tipLink(ep2, keys[0], epoch.LastRoad(2)-1)), nil)
-	require.Equal(t, epoch.LastRoad(2), qc.Index())
-	for inner, ctrl := range state.inner.Lock() {
-		inner.prune(data.Anchor{
+	var anchors []data.Anchor
+	for m := types.EpochIndex(0); m <= 2; m++ {
+		ep := registry.MustEpoch(m)
+		last := epoch.LastRoad(m)
+		qc := types.BuildCommitQC(ep, keys, utils.Some(tipLink(ep, keys[0], last-1)), nil)
+		require.Equal(t, last, qc.Index())
+		anchors = append(anchors, data.Anchor{
 			CommitQC: qc,
 			AppQC:    data.TestAppQC(keys, types.NewAppProposal(qc.Proposal(), types.AppHash{})),
-			Epoch:    ep2,
+			Epoch:    ep,
 		})
-		ctrl.Updated()
 	}
-	return qc
+	return anchors
+}
+
+// pruneToAnchors replays anchors through inner.prune the way runEvict does, and
+// returns the last CommitQC. Epoch advance may be starved for any or all of it.
+func pruneToAnchors(state *State, anchors []data.Anchor) *types.CommitQC {
+	for _, a := range anchors {
+		for inner, ctrl := range state.inner.Lock() {
+			inner.prune(a)
+			ctrl.Updated()
+		}
+	}
+	return anchors[len(anchors)-1].CommitQC
 }
 
 func requireSpec(t *testing.T, state *State, qc *types.CommitQC, idx types.EpochIndex) {
@@ -955,7 +970,7 @@ func requireSpec(t *testing.T, state *State, qc *types.CommitQC, idx types.Epoch
 }
 
 func TestRunEpochAdvance_CatchUpDoesNotKill(t *testing.T) {
-	t.Run("ErrPruned jumps to durable tip next epoch", func(t *testing.T) {
+	t.Run("tip already past applied jumps to the tip's epoch", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
@@ -968,9 +983,8 @@ func TestRunEpochAdvance_CatchUpDoesNotKill(t *testing.T) {
 
 			registry.AdvanceIfNeeded(epoch.LastRoad(1))
 			registry.AdvanceIfNeeded(epoch.LastRoad(2))
-			qc := pruneToLastRoad2(t, registry, keys, state)
+			qc := pruneToAnchors(state, anchorWalk(t, registry, keys))
 			require.Equal(t, types.EpochIndex(0), state.Epoch().Load().EpochIndex())
-			registry.PruneBefore(2)
 
 			var runErr error
 			go func() { runErr = state.runEpochAdvance(ctx) }()
@@ -982,11 +996,10 @@ func TestRunEpochAdvance_CatchUpDoesNotKill(t *testing.T) {
 			cancel()
 			synctest.Wait()
 			require.ErrorIs(t, runErr, context.Canceled)
-			require.False(t, errors.Is(runErr, types.ErrPruned))
 		})
 	})
 
-	t.Run("ErrPruned waits until prune moves a stale tip", func(t *testing.T) {
+	t.Run("unsealed tip parks until the Anchor moves it", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
@@ -998,6 +1011,7 @@ func TestRunEpochAdvance_CatchUpDoesNotKill(t *testing.T) {
 
 			registry.AdvanceIfNeeded(epoch.LastRoad(1))
 			registry.AdvanceIfNeeded(epoch.LastRoad(2))
+			anchors := anchorWalk(t, registry, keys)
 			ep0 := registry.MustEpoch(0)
 			qc0 := types.BuildCommitQC(ep0, keys, utils.None[*types.CommitQC](), nil)
 			require.Equal(t, types.RoadIndex(0), qc0.Index())
@@ -1005,7 +1019,6 @@ func TestRunEpochAdvance_CatchUpDoesNotKill(t *testing.T) {
 				inner.persistedCommitQC.Store(utils.Some(qc0))
 				ctrl.Updated()
 			}
-			registry.PruneBefore(2)
 
 			var runErr error
 			go func() { runErr = state.runEpochAdvance(ctx) }()
@@ -1013,7 +1026,7 @@ func TestRunEpochAdvance_CatchUpDoesNotKill(t *testing.T) {
 			require.Nil(t, runErr)
 			require.Equal(t, types.EpochIndex(0), state.Epoch().Load().EpochIndex())
 
-			qc := pruneToLastRoad2(t, registry, keys, state)
+			qc := pruneToAnchors(state, anchors)
 			synctest.Wait()
 			require.Nil(t, runErr)
 			require.Equal(t, types.EpochIndex(3), state.Epoch().Load().EpochIndex())
@@ -1025,7 +1038,9 @@ func TestRunEpochAdvance_CatchUpDoesNotKill(t *testing.T) {
 		})
 	})
 
-	t.Run("prune unblocks epoch owner during seal wait", func(t *testing.T) {
+	// The registry follows data's Anchor, so it can drop applied+1 before avail
+	// observes the Anchor that moves its own tip past that epoch.
+	t.Run("pruned target retries once the tip names another epoch", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
@@ -1037,12 +1052,18 @@ func TestRunEpochAdvance_CatchUpDoesNotKill(t *testing.T) {
 			state, err := NewState(keys[0], ds, utils.None[string]())
 			require.NoError(t, err)
 
+			anchors := anchorWalk(t, registry, keys)
+			pruneToAnchors(state, anchors[:1])
+			registry.PruneBefore(2)
+
 			var runErr error
 			go func() { runErr = state.runEpochAdvance(ctx) }()
 			synctest.Wait()
-			require.Equal(t, types.EpochIndex(0), state.Epoch().Load().EpochIndex())
+			require.Nil(t, runErr)
+			require.Equal(t, types.EpochIndex(0), state.Epoch().Load().EpochIndex(),
+				"epoch 1 is pruned: park instead of dying")
 
-			qc := pruneToLastRoad2(t, registry, keys, state)
+			qc := pruneToAnchors(state, anchors[1:])
 			synctest.Wait()
 			require.Nil(t, runErr)
 			require.Equal(t, types.EpochIndex(3), state.Epoch().Load().EpochIndex())
@@ -1056,8 +1077,8 @@ func TestRunEpochAdvance_CatchUpDoesNotKill(t *testing.T) {
 }
 
 // A durable-tip catch-up refreshes ConsensusSpec at the persist write site,
-// even while epoch advance is parked on WaitForEpoch.
-func TestMarkCommitQCsPersisted_RefreshesSpecWhileEpochAdvanceWaitsForRegistry(t *testing.T) {
+// even while epoch advance is parked.
+func TestMarkCommitQCsPersisted_RefreshesSpecWhileEpochAdvanceParked(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
@@ -1083,7 +1104,7 @@ func TestMarkCommitQCsPersisted_RefreshesSpecWhileEpochAdvanceWaitsForRegistry(t
 		var advanceErr error
 		go func() { advanceErr = f.state.runEpochAdvance(ctx) }()
 		synctest.Wait()
-		require.Equal(t, f.m, f.state.Epoch().Load().EpochIndex(), "parked on WaitForEpoch(M+1)")
+		require.Equal(t, f.m, f.state.Epoch().Load().EpochIndex(), "parked: the tip does not seal epoch M")
 		got, ok := spec.Load().CommitQC.Get()
 		require.True(t, ok)
 		require.Equal(t, qcA.Index(), got.Index())
@@ -1092,7 +1113,7 @@ func TestMarkCommitQCsPersisted_RefreshesSpecWhileEpochAdvanceWaitsForRegistry(t
 		got, ok = spec.Load().CommitQC.Get()
 		require.True(t, ok)
 		require.Equal(t, qcB.Index(), got.Index())
-		require.Equal(t, f.m, f.state.Epoch().Load().EpochIndex(), "still waiting on registry")
+		require.Equal(t, f.m, f.state.Epoch().Load().EpochIndex(), "still parked: the tip still does not seal epoch M")
 
 		cancel()
 		synctest.Wait()

--- a/sei-tendermint/internal/autobahn/avail/state_test.go
+++ b/sei-tendermint/internal/autobahn/avail/state_test.go
@@ -746,44 +746,6 @@ func TestPushCommitQC_MidEpochNoWait(t *testing.T) {
 	require.Equal(t, epoch.FirstRoad(f.m)+1, nextRoad(f.state))
 }
 
-func TestPushCommitQC_FutureEpochParksUntilAdvance(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		ctx, cancel := context.WithCancel(t.Context())
-		defer cancel()
-		rng := utils.TestRng()
-		f := newSealFixture(t)
-
-		prev := tipLink(f.ep, f.keys[0], epoch.LastRoad(f.m)-1)
-		qcLast := types.BuildCommitQC(f.ep, f.keys, utils.Some(prev), nil)
-		require.NoError(t, f.state.PushCommitQC(ctx, qcLast))
-		setRoadAppQC(f.state, qcLast.Index(), data.TestAppQC(f.keys, types.NewAppProposal(qcLast.Proposal(), types.GenAppHash(rng))))
-
-		f.registry.AdvanceIfNeeded(epoch.LastRoad(f.m))
-		ep2 := f.registry.MustEpoch(f.m + 1)
-		qcNext := types.BuildCommitQC(ep2, f.keys, utils.Some(qcLast), nil)
-		require.Equal(t, epoch.FirstRoad(f.m+1), qcNext.Proposal().Index())
-
-		var pushErr error
-		go func() { pushErr = f.state.PushCommitQC(ctx, qcNext) }()
-		synctest.Wait()
-		require.Equal(t, f.m, f.state.Epoch().Load().EpochIndex())
-		require.Equal(t, epoch.LastRoad(f.m)+1, nextRoad(f.state), "future QC must stay parked")
-
-		var runErr error
-		go func() { runErr = f.state.runEpochAdvance(ctx) }()
-		_, err := f.state.epoch.Wait(t.Context(), func(ep *types.Epoch) bool {
-			return ep.EpochIndex() >= f.m+1
-		})
-		require.NoError(t, err)
-		synctest.Wait()
-		require.NoError(t, pushErr)
-		require.Equal(t, epoch.FirstRoad(f.m+1)+1, nextRoad(f.state))
-		cancel()
-		synctest.Wait()
-		require.ErrorIs(t, runErr, context.Canceled)
-	})
-}
-
 func TestPushCommitQC_StaleAfterAdvanceSoftDrops(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
@@ -880,64 +842,82 @@ func TestWaitUntilApplied_ParksUntilEpochAdvance(t *testing.T) {
 	})
 }
 
-func TestRunEpochAdvance_AdvancesWhenBothLeashesMet(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		ctx, cancel := context.WithCancel(t.Context())
-		defer cancel()
-		rng := utils.TestRng()
-		f := newSealFixture(t)
-		f.registry.AdvanceIfNeeded(epoch.LastRoad(f.m))
+func TestRunEpochAdvance_Leashes(t *testing.T) {
+	type missing int
+	const (
+		none missing = iota
+		registry
+		appQC
+	)
+	for _, tc := range []struct {
+		name       string
+		missing    missing
+		parkNextQC bool
+	}{
+		{name: "both met parks future QC until advance", missing: none, parkNextQC: true},
+		{name: "waits for registry", missing: registry},
+		{name: "waits for AppQC", missing: appQC},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				rng := utils.TestRng()
+				f := newSealFixture(t)
+				if tc.missing != registry {
+					f.registry.AdvanceIfNeeded(epoch.LastRoad(f.m))
+				}
 
-		prev := tipLink(f.ep, f.keys[0], epoch.LastRoad(f.m)-1)
-		qcLast := types.BuildCommitQC(f.ep, f.keys, utils.Some(prev), nil)
-		require.Equal(t, epoch.LastRoad(f.m), qcLast.Proposal().Index())
-		require.NoError(t, f.state.PushCommitQC(ctx, qcLast))
-		setRoadAppQC(f.state, qcLast.Index(), data.TestAppQC(f.keys, types.NewAppProposal(qcLast.Proposal(), types.GenAppHash(rng))))
-		require.Equal(t, f.m, f.state.Epoch().Load().EpochIndex())
+				prev := tipLink(f.ep, f.keys[0], epoch.LastRoad(f.m)-1)
+				qcLast := types.BuildCommitQC(f.ep, f.keys, utils.Some(prev), nil)
+				require.Equal(t, epoch.LastRoad(f.m), qcLast.Proposal().Index())
+				require.NoError(t, f.state.PushCommitQC(ctx, qcLast))
+				if tc.missing != appQC {
+					setRoadAppQC(f.state, qcLast.Index(), data.TestAppQC(f.keys, types.NewAppProposal(qcLast.Proposal(), types.GenAppHash(rng))))
+				}
+				require.Equal(t, f.m, f.state.Epoch().Load().EpochIndex())
 
-		var runErr error
-		go func() { runErr = f.state.runEpochAdvance(ctx) }()
+				var pushErr error
+				if tc.parkNextQC {
+					ep2 := f.registry.MustEpoch(f.m + 1)
+					qcNext := types.BuildCommitQC(ep2, f.keys, utils.Some(qcLast), nil)
+					require.Equal(t, epoch.FirstRoad(f.m+1), qcNext.Proposal().Index())
+					go func() { pushErr = f.state.PushCommitQC(ctx, qcNext) }()
+					synctest.Wait()
+					require.Equal(t, epoch.LastRoad(f.m)+1, nextRoad(f.state), "future QC must stay parked")
+				}
 
-		ep, err := f.state.epoch.Wait(t.Context(), func(ep *types.Epoch) bool {
-			return ep.EpochIndex() >= f.m+1
+				var runErr error
+				go func() { runErr = f.state.runEpochAdvance(ctx) }()
+				if tc.missing != none {
+					synctest.Wait()
+					require.Equal(t, f.m, f.state.Epoch().Load().EpochIndex())
+					switch tc.missing {
+					case registry:
+						f.registry.AdvanceIfNeeded(epoch.LastRoad(f.m))
+					case appQC:
+						setRoadAppQC(f.state, qcLast.Index(), data.TestAppQC(f.keys, types.NewAppProposal(qcLast.Proposal(), types.GenAppHash(rng))))
+					}
+				}
+
+				ep, err := f.state.epoch.Wait(t.Context(), func(ep *types.Epoch) bool {
+					return ep.EpochIndex() >= f.m+1
+				})
+				require.NoError(t, err)
+				require.Equal(t, f.m+1, ep.EpochIndex())
+				require.Equal(t, f.m+1, f.state.Epoch().Load().EpochIndex())
+				if tc.parkNextQC {
+					synctest.Wait()
+					require.NoError(t, pushErr)
+					require.Equal(t, epoch.FirstRoad(f.m+1)+1, nextRoad(f.state))
+				}
+
+				cancel()
+				synctest.Wait()
+				require.ErrorIs(t, runErr, context.Canceled)
+			})
 		})
-		require.NoError(t, err)
-		require.Equal(t, f.m+1, ep.EpochIndex())
-		require.Equal(t, f.m+1, f.state.Epoch().Load().EpochIndex())
-
-		cancel()
-		synctest.Wait()
-		require.ErrorIs(t, runErr, context.Canceled)
-	})
-}
-
-func TestRunEpochAdvance_WaitsForRegistry(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		ctx, cancel := context.WithCancel(t.Context())
-		defer cancel()
-		rng := utils.TestRng()
-		f := newSealFixture(t)
-
-		prev := tipLink(f.ep, f.keys[0], epoch.LastRoad(f.m)-1)
-		qcLast := types.BuildCommitQC(f.ep, f.keys, utils.Some(prev), nil)
-		require.Equal(t, epoch.LastRoad(f.m), qcLast.Proposal().Index())
-		require.NoError(t, f.state.PushCommitQC(ctx, qcLast))
-		setRoadAppQC(f.state, qcLast.Index(), data.TestAppQC(f.keys, types.NewAppProposal(qcLast.Proposal(), types.GenAppHash(rng))))
-
-		var runErr error
-		go func() { runErr = f.state.runEpochAdvance(ctx) }()
-		synctest.Wait()
-		require.Equal(t, f.m, f.state.Epoch().Load().EpochIndex(), "parked on WaitForEpoch(M+1)")
-
-		f.registry.AdvanceIfNeeded(epoch.LastRoad(f.m))
-		_, err := f.state.epoch.Wait(t.Context(), func(ep *types.Epoch) bool {
-			return ep.EpochIndex() >= f.m+1
-		})
-		require.NoError(t, err)
-		cancel()
-		synctest.Wait()
-		require.ErrorIs(t, runErr, context.Canceled)
-	})
+	}
 }
 
 // A durable-tip catch-up refreshes ConsensusSpec at the persist write site,
@@ -982,33 +962,5 @@ func TestMarkCommitQCsPersisted_RefreshesSpecWhileEpochAdvanceWaitsForRegistry(t
 		cancel()
 		synctest.Wait()
 		require.ErrorIs(t, advanceErr, context.Canceled)
-	})
-}
-
-func TestRunEpochAdvance_WaitsForAppQC(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		ctx, cancel := context.WithCancel(t.Context())
-		defer cancel()
-		rng := utils.TestRng()
-		f := newSealFixture(t)
-		f.registry.AdvanceIfNeeded(epoch.LastRoad(f.m))
-
-		prev := tipLink(f.ep, f.keys[0], epoch.LastRoad(f.m)-1)
-		qcLast := types.BuildCommitQC(f.ep, f.keys, utils.Some(prev), nil)
-		require.NoError(t, f.state.PushCommitQC(ctx, qcLast))
-
-		var runErr error
-		go func() { runErr = f.state.runEpochAdvance(ctx) }()
-		synctest.Wait()
-		require.Equal(t, f.m, f.state.Epoch().Load().EpochIndex(), "parked without AppQC covering M")
-
-		setRoadAppQC(f.state, qcLast.Index(), data.TestAppQC(f.keys, types.NewAppProposal(qcLast.Proposal(), types.GenAppHash(rng))))
-		_, err := f.state.epoch.Wait(t.Context(), func(ep *types.Epoch) bool {
-			return ep.EpochIndex() >= f.m+1
-		})
-		require.NoError(t, err)
-		cancel()
-		synctest.Wait()
-		require.ErrorIs(t, runErr, context.Canceled)
 	})
 }

--- a/sei-tendermint/internal/autobahn/avail/state_test.go
+++ b/sei-tendermint/internal/autobahn/avail/state_test.go
@@ -864,12 +864,12 @@ func TestWaitUntilApplied_ParksUntilEpochAdvance(t *testing.T) {
 			var got *types.Epoch
 			var waitErr error
 			sc.Spawn(func() error {
-				got, waitErr = state.waitUntilApplied(ctx, 1)
+				got, waitErr = state.waitUntilAdvanced(ctx, 1)
 				return nil
 			})
 			synctest.Wait()
 			if got != nil {
-				return fmt.Errorf("waitUntilApplied returned before epoch advance")
+				return fmt.Errorf("waitUntilAdvanced returned before epoch advance")
 			}
 
 			if err := DriveAdvance(ctx, state, keys, ep1.EpochIndex()); err != nil {
@@ -880,7 +880,7 @@ func TestWaitUntilApplied_ParksUntilEpochAdvance(t *testing.T) {
 				return waitErr
 			}
 			if got.EpochIndex() != 1 {
-				return fmt.Errorf("waitUntilApplied epoch = %d, want 1", got.EpochIndex())
+				return fmt.Errorf("waitUntilAdvanced epoch = %d, want 1", got.EpochIndex())
 			}
 			return nil
 		}))

--- a/sei-tendermint/internal/autobahn/avail/state_test.go
+++ b/sei-tendermint/internal/autobahn/avail/state_test.go
@@ -802,7 +802,7 @@ func newSealFixture(t *testing.T) *sealFixture {
 	return &sealFixture{registry: registry, keys: keys, state: state, ep: ep, m: m}
 }
 
-func TestWaitUntilApplied_ParksUntilEpochAdvance(t *testing.T) {
+func TestWaitForEpoch_ParksUntilEpochAdvance(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx := t.Context()
 		rng := utils.TestRng()
@@ -821,12 +821,12 @@ func TestWaitUntilApplied_ParksUntilEpochAdvance(t *testing.T) {
 			var got *types.Epoch
 			var waitErr error
 			sc.Spawn(func() error {
-				got, waitErr = state.waitUntilAdvanced(ctx, 1)
+				got, waitErr = state.waitForEpoch(ctx, 1)
 				return nil
 			})
 			synctest.Wait()
 			if got != nil {
-				return fmt.Errorf("waitUntilAdvanced returned before epoch advance")
+				return fmt.Errorf("waitForEpoch returned before epoch advance")
 			}
 
 			if err := DriveAdvance(ctx, state, keys, ep1.EpochIndex()); err != nil {
@@ -837,7 +837,7 @@ func TestWaitUntilApplied_ParksUntilEpochAdvance(t *testing.T) {
 				return waitErr
 			}
 			if got.EpochIndex() != 1 {
-				return fmt.Errorf("waitUntilAdvanced epoch = %d, want 1", got.EpochIndex())
+				return fmt.Errorf("waitForEpoch epoch = %d, want 1", got.EpochIndex())
 			}
 			return nil
 		}))

--- a/sei-tendermint/internal/autobahn/avail/state_test.go
+++ b/sei-tendermint/internal/autobahn/avail/state_test.go
@@ -144,6 +144,7 @@ func TestPrune_AnchorEpochDropsClosedLane(t *testing.T) {
 		// Anchor. Advance the seal cursor without admitting LastRoad tips — runEvict
 		// is not running, and the rest of this test expects empty roads.
 		seekRoads(state, epoch.FirstRoad(1))
+		persistEpochSeal(state, ep0, keys)
 		if _, err := state.Epoch().Wait(ctx, func(ep *types.Epoch) bool {
 			return ep.EpochIndex() >= 1
 		}); err != nil {
@@ -155,6 +156,7 @@ func TestPrune_AnchorEpochDropsClosedLane(t *testing.T) {
 			ctrl.Updated()
 		}
 		seekRoads(state, epoch.FirstRoad(2))
+		persistEpochSeal(state, ep1, keys)
 		if _, err := state.Epoch().Wait(ctx, func(ep *types.Epoch) bool {
 			return ep.EpochIndex() >= epLeave.EpochIndex()
 		}); err != nil {
@@ -678,8 +680,8 @@ func TestHeaders_WaitsForPrevEpochLaneVote(t *testing.T) {
 			}
 
 			for inner := range state.inner.Lock() {
-				if inner.epoch.Load().EpochIndex() != epLeave.EpochIndex() {
-					return fmt.Errorf("applied epoch = %d, want %d", inner.epoch.Load().EpochIndex(), epLeave.EpochIndex())
+				if inner.applied().EpochIndex() != epLeave.EpochIndex() {
+					return fmt.Errorf("applied epoch = %d, want %d", inner.applied().EpochIndex(), epLeave.EpochIndex())
 				}
 				ae, ok := inner.anchorEpoch.Get()
 				if !ok {
@@ -872,6 +874,7 @@ func TestRunEpochAdvance_Leashes(t *testing.T) {
 				qcLast := types.BuildCommitQC(f.ep, f.keys, utils.Some(prev), nil)
 				require.Equal(t, epoch.LastRoad(f.m), qcLast.Proposal().Index())
 				require.NoError(t, f.state.PushCommitQC(ctx, qcLast))
+				f.state.markCommitQCsPersisted(qcLast)
 				if tc.missing != appQC {
 					setRoadAppQC(f.state, qcLast.Index(), data.TestAppQC(f.keys, types.NewAppProposal(qcLast.Proposal(), types.GenAppHash(rng))))
 				}
@@ -900,7 +903,7 @@ func TestRunEpochAdvance_Leashes(t *testing.T) {
 					}
 				}
 
-				ep, err := f.state.epoch.Wait(t.Context(), func(ep *types.Epoch) bool {
+				ep, err := f.state.Epoch().Wait(t.Context(), func(ep *types.Epoch) bool {
 					return ep.EpochIndex() >= f.m+1
 				})
 				require.NoError(t, err)

--- a/sei-tendermint/internal/autobahn/avail/subscriptions.go
+++ b/sei-tendermint/internal/autobahn/avail/subscriptions.go
@@ -48,7 +48,7 @@ func (r *LaneProposalsRecv) Recv(ctx context.Context) (*types.Signed[*types.Lane
 // If exclude is Some, also requires the LaneID to differ (e.g. after the
 // previous identity was closed and a new LaneID allocated).
 func (s *State) WaitForNextLane(ctx context.Context, pk types.PublicKey, exclude utils.Option[types.LaneID]) (types.LaneID, error) {
-	ep, err := s.epoch.Wait(ctx, func(ep *types.Epoch) bool {
+	ep, err := s.Epoch().Wait(ctx, func(ep *types.Epoch) bool {
 		got, ok := ep.Committee().Lane(pk).Get()
 		if !ok {
 			return false

--- a/sei-tendermint/internal/autobahn/avail/subscriptions_test.go
+++ b/sei-tendermint/internal/autobahn/avail/subscriptions_test.go
@@ -7,9 +7,7 @@ import (
 	"testing/synctest"
 	"time"
 
-	"github.com/sei-protocol/sei-chain/sei-db/ledger_db/block/memblock"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/autobahn/types"
-	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/blockstore"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/data"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/epoch"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
@@ -21,9 +19,7 @@ func TestSubscribeLaneProposals_WrongValidatorPanics(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 2)
 	a, b := keys[0], keys[1]
-	db := utils.OrPanic1(blockstore.New(memblock.NewBlockDB()))
-	t.Cleanup(func() { require.NoError(t, db.Close()) })
-	ds := utils.OrPanic1(data.NewState(&data.Config{Registry: registry}, db))
+	ds := newTestDataState(&data.Config{Registry: registry})
 	state := utils.OrPanic1(NewState(a, ds, utils.None[string]()))
 
 	defer func() {
@@ -40,9 +36,7 @@ func TestSubscribeLaneProposals_StayLeaveRejoin(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 2)
 	a, b := keys[0], keys[1]
 	peer := a.Public()
-	db := utils.OrPanic1(blockstore.New(memblock.NewBlockDB()))
-	t.Cleanup(func() { require.NoError(t, db.Close()) })
-	ds := utils.OrPanic1(data.NewState(&data.Config{Registry: registry}, db))
+	ds := newTestDataState(&data.Config{Registry: registry})
 	state := utils.OrPanic1(NewState(a, ds, utils.None[string]()))
 
 	lane0 := state.LocalLane().OrPanic("genesis")
@@ -172,9 +166,7 @@ func TestJoinerCatchup_LaneVotes(t *testing.T) {
 		b := types.GenSecretKey(rng)
 		allKeys := append(keys, b)
 
-		db := utils.OrPanic1(blockstore.New(memblock.NewBlockDB()))
-		t.Cleanup(func() { require.NoError(t, db.Close()) })
-		ds := utils.OrPanic1(data.NewState(&data.Config{Registry: registry}, db))
+		ds := newTestDataState(&data.Config{Registry: registry})
 		stateA := utils.OrPanic1(NewState(a, ds, utils.None[string]()))
 		stateB := utils.OrPanic1(NewState(b, ds, utils.None[string]()))
 		laneA := stateA.LocalLane().OrPanic("genesis")

--- a/sei-tendermint/internal/autobahn/avail/subscriptions_test.go
+++ b/sei-tendermint/internal/autobahn/avail/subscriptions_test.go
@@ -172,7 +172,7 @@ func TestJoinerCatchup_LaneVotes(t *testing.T) {
 		b := types.GenSecretKey(rng)
 		allKeys := append(keys, b)
 
-		db := memblock.NewBlockDB()
+		db := utils.OrPanic1(blockstore.New(memblock.NewBlockDB()))
 		t.Cleanup(func() { require.NoError(t, db.Close()) })
 		ds := utils.OrPanic1(data.NewState(&data.Config{Registry: registry}, db))
 		stateA := utils.OrPanic1(NewState(a, ds, utils.None[string]()))

--- a/sei-tendermint/internal/autobahn/avail/subscriptions_test.go
+++ b/sei-tendermint/internal/autobahn/avail/subscriptions_test.go
@@ -104,7 +104,7 @@ func TestSubscribeLaneProposals_StayLeaveRejoin(t *testing.T) {
 	for inner, ctrl := range state.inner.Lock() {
 		require.Greater(t, inner.roads.next, inner.roads.first)
 		tip := inner.roads.q[inner.roads.next-1].commitQC
-		ep := inner.epoch.Load()
+		ep := inner.applied()
 		require.Equal(t, epLeave.EpochIndex(), ep.EpochIndex())
 		require.True(t, ep.IsClosed(lane0))
 		n := inner.prune(data.Anchor{

--- a/sei-tendermint/internal/autobahn/avail/subscriptions_test.go
+++ b/sei-tendermint/internal/autobahn/avail/subscriptions_test.go
@@ -69,7 +69,7 @@ func TestSubscribeLaneProposals_StayLeaveRejoin(t *testing.T) {
 			got1, err = sub.Recv(ctx)
 			return err
 		})
-		if err := DriveAdvance(ctx, state, keys, 1); err != nil {
+		if err := TestDriveAdvance(ctx, state, keys, 1); err != nil {
 			return err
 		}
 		if cur := state.LocalLane().OrPanic("stay"); cur != lane0 {
@@ -97,7 +97,7 @@ func TestSubscribeLaneProposals_StayLeaveRejoin(t *testing.T) {
 		sc.SpawnBgNamed("runEpochAdvance", func() error {
 			return utils.IgnoreCancel(state.runEpochAdvance(ctx))
 		})
-		return DriveAdvance(ctx, state, keys, epLeave.EpochIndex())
+		return TestDriveAdvance(ctx, state, keys, epLeave.EpochIndex())
 	}))
 	require.False(t, state.LocalLane().IsPresent())
 
@@ -140,7 +140,7 @@ func TestSubscribeLaneProposals_StayLeaveRejoin(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		return DriveAdvance(ctx, state, keys, epJoin.EpochIndex())
+		return TestDriveAdvance(ctx, state, keys, epJoin.EpochIndex())
 	}))
 	lane1 := state.LocalLane().OrPanic("rejoin")
 	require.NotEqual(t, lane0, lane1)
@@ -189,7 +189,7 @@ func TestJoinerCatchup_LaneVotes(t *testing.T) {
 				sc.SpawnBgNamed("runEpochAdvance", func() error {
 					return utils.IgnoreCancel(stateB.runEpochAdvance(ctx))
 				})
-				return DriveAdvance(ctx, stateB, allKeys, want)
+				return TestDriveAdvance(ctx, stateB, allKeys, want)
 			}))
 		}
 		produce := func(n types.BlockNumber) *types.Signed[*types.LaneProposal] {

--- a/sei-tendermint/internal/autobahn/avail/subscriptions_test.go
+++ b/sei-tendermint/internal/autobahn/avail/subscriptions_test.go
@@ -87,6 +87,7 @@ func TestSubscribeLaneProposals_StayLeaveRejoin(t *testing.T) {
 	// Leave: peer drops from committee at epoch 2 (first vacant after genesis seeds).
 	// Anchor-epoch prune drops closed lane maps (same path as runEvict) and ends the subscribe.
 	epLeave, err := registry.ActivateEpoch(
+		0,
 		map[types.PublicKey]uint64{b.Public(): 1},
 		time.Time{}, registry.FirstBlock(),
 	)
@@ -132,6 +133,7 @@ func TestSubscribeLaneProposals_StayLeaveRejoin(t *testing.T) {
 			return nil
 		})
 		epJoin, err := registry.ActivateEpoch(
+			epLeave.EpochIndex(),
 			map[types.PublicKey]uint64{a.Public(): 1, b.Public(): 1},
 			time.Time{}, registry.FirstBlock(),
 		)
@@ -177,8 +179,8 @@ func TestJoinerCatchup_LaneVotes(t *testing.T) {
 		stateB := utils.OrPanic1(NewState(b, ds, utils.None[string]()))
 		laneA := stateA.LocalLane().OrPanic("genesis")
 
-		activate := func(weights map[types.PublicKey]uint64) *types.Epoch {
-			ep, err := registry.ActivateEpoch(weights, time.Time{}, registry.FirstBlock())
+		activate := func(parent types.EpochIndex, weights map[types.PublicKey]uint64) *types.Epoch {
+			ep, err := registry.ActivateEpoch(parent, weights, time.Time{}, registry.FirstBlock())
 			require.NoError(t, err)
 			return ep
 		}
@@ -201,7 +203,7 @@ func TestJoinerCatchup_LaneVotes(t *testing.T) {
 		onlyA := map[types.PublicKey]uint64{a.Public(): 1}
 
 		block0 := produce(0)
-		epJoin := activate(both)
+		epJoin := activate(0, both)
 		advance(epJoin.EpochIndex())
 		require.Equal(t, types.EpochIndex(2), stateB.LocalLane().OrPanic("joiner").Joined)
 
@@ -212,11 +214,11 @@ func TestJoinerCatchup_LaneVotes(t *testing.T) {
 		require.Equal(t, block0.Msg().Block().Header().Hash(), batch[0].Msg().Header().Hash())
 		require.Equal(t, b.Public(), batch[0].Key())
 
-		epLeave := activate(onlyA)
+		epLeave := activate(epJoin.EpochIndex(), onlyA)
 		advance(epLeave.EpochIndex())
 		block1 := produce(1) // while out; skip RecvBatch so the cursor stays behind block1
 
-		epRejoin := activate(both)
+		epRejoin := activate(epLeave.EpochIndex(), both)
 		advance(epRejoin.EpochIndex())
 		require.Equal(t, types.EpochIndex(4), stateB.LocalLane().OrPanic("rejoiner").Joined)
 

--- a/sei-tendermint/internal/autobahn/avail/subscriptions_test.go
+++ b/sei-tendermint/internal/autobahn/avail/subscriptions_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/sei-protocol/sei-chain/sei-db/ledger_db/block/memblock"
@@ -15,39 +16,6 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/require"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/scope"
 )
-
-func TestSubscribeLaneProposals_ErrLaneClosedAfterMapDrop(t *testing.T) {
-	rng := utils.TestRng()
-	registry, keys := epoch.GenRegistry(rng, 2)
-	a, b := keys[0], keys[1]
-	db := utils.OrPanic1(blockstore.New(memblock.NewBlockDB()))
-	t.Cleanup(func() { require.NoError(t, db.Close()) })
-	ds := utils.OrPanic1(data.NewState(&data.Config{Registry: registry}, db))
-	state := utils.OrPanic1(NewState(a, ds, utils.None[string]()))
-
-	lane0 := state.LocalLane().OrPanic("genesis")
-	want, err := state.ProduceLocalBlock(lane0, 0, types.GenPayload(rng))
-	require.NoError(t, err)
-	sub := state.SubscribeLaneProposals(lane0, 0)
-
-	ep, err := registry.ActivateEpoch(
-		map[types.PublicKey]uint64{b.Public(): 1},
-		types.OpenRoadRange(), time.Time{}, registry.FirstBlock(),
-	)
-	require.NoError(t, err)
-	state.ApplyEpoch(ep)
-
-	got, err := sub.Recv(t.Context())
-	require.NoError(t, err)
-	require.Equal(t, want.Msg().Block().Header().Hash(), got.Msg().Block().Header().Hash())
-
-	for inner, ctrl := range state.inner.Lock() {
-		inner.dropLanes([]types.LaneID{lane0})
-		ctrl.Updated()
-	}
-	_, err = sub.Recv(t.Context())
-	require.ErrorIs(t, err, ErrLaneClosed)
-}
 
 func TestSubscribeLaneProposals_WrongValidatorPanics(t *testing.T) {
 	rng := utils.TestRng()
@@ -89,22 +57,21 @@ func TestSubscribeLaneProposals_StayLeaveRejoin(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, want0.Msg().Block().Header().Hash(), got0.Msg().Block().Header().Hash())
 
-	// Stay while Recv waits for the next block: ApplyEpoch must not end the subscribe.
+	// Stay: epoch 1 is already seeded at genesis with the same committee; advance
+	// into it without ActivateEpoch (which must not rewrite existing epochs).
 	var want1, got1 *types.Signed[*types.LaneProposal]
 	require.NoError(t, scope.Run(ctx, func(ctx context.Context, sc scope.Scope) error {
+		sc.SpawnBgNamed("runEpochAdvance", func() error {
+			return utils.IgnoreCancel(state.runEpochAdvance(ctx))
+		})
 		sc.Spawn(func() error {
 			var err error
 			got1, err = sub.Recv(ctx)
 			return err
 		})
-		epStay, err := registry.ActivateEpoch(
-			map[types.PublicKey]uint64{a.Public(): 1, b.Public(): 1},
-			types.OpenRoadRange(), time.Time{}, registry.FirstBlock(),
-		)
-		if err != nil {
+		if err := DriveAdvance(ctx, state, keys, 1); err != nil {
 			return err
 		}
-		state.ApplyEpoch(epStay)
 		if cur := state.LocalLane().OrPanic("stay"); cur != lane0 {
 			return fmt.Errorf("stay LocalLane = %v, want %v", cur, lane0)
 		}
@@ -117,17 +84,34 @@ func TestSubscribeLaneProposals_StayLeaveRejoin(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, lane0, got)
 
-	// Leave: peer drops from committee; map drop ends the subscribe.
+	// Leave: peer drops from committee at epoch 2 (first vacant after genesis seeds).
+	// Anchor-epoch prune drops closed lane maps (same path as runEvict) and ends the subscribe.
 	epLeave, err := registry.ActivateEpoch(
 		map[types.PublicKey]uint64{b.Public(): 1},
-		types.OpenRoadRange(), time.Time{}, registry.FirstBlock(),
+		time.Time{}, registry.FirstBlock(),
 	)
 	require.NoError(t, err)
-	state.ApplyEpoch(epLeave)
+	require.Equal(t, types.EpochIndex(2), epLeave.EpochIndex())
+	require.NoError(t, scope.Run(ctx, func(ctx context.Context, sc scope.Scope) error {
+		sc.SpawnBgNamed("runEpochAdvance", func() error {
+			return utils.IgnoreCancel(state.runEpochAdvance(ctx))
+		})
+		return DriveAdvance(ctx, state, keys, epLeave.EpochIndex())
+	}))
 	require.False(t, state.LocalLane().IsPresent())
 
 	for inner, ctrl := range state.inner.Lock() {
-		inner.dropLanes([]types.LaneID{lane0})
+		require.Greater(t, inner.roads.next, inner.roads.first)
+		tip := inner.roads.q[inner.roads.next-1].commitQC
+		ep := inner.epoch.Load()
+		require.Equal(t, epLeave.EpochIndex(), ep.EpochIndex())
+		require.True(t, ep.IsClosed(lane0))
+		n := inner.prune(data.Anchor{
+			CommitQC: tip,
+			AppQC:    data.TestAppQC([]types.SecretKey{b}, types.NewAppProposal(tip.Proposal(), types.AppHash{})),
+			Epoch:    ep,
+		})
+		require.Equal(t, 1, n)
 		ctrl.Updated()
 	}
 	_, err = sub.Recv(ctx)
@@ -136,6 +120,9 @@ func TestSubscribeLaneProposals_StayLeaveRejoin(t *testing.T) {
 	// Rejoin: WaitForNextLane skips closed lane0 and observes the new LaneID.
 	var gotLane types.LaneID
 	require.NoError(t, scope.Run(ctx, func(ctx context.Context, sc scope.Scope) error {
+		sc.SpawnBgNamed("runEpochAdvance", func() error {
+			return utils.IgnoreCancel(state.runEpochAdvance(ctx))
+		})
 		sc.Spawn(func() error {
 			lane, err := state.WaitForNextLane(ctx, peer, utils.Some(lane0))
 			if err != nil {
@@ -146,13 +133,12 @@ func TestSubscribeLaneProposals_StayLeaveRejoin(t *testing.T) {
 		})
 		epJoin, err := registry.ActivateEpoch(
 			map[types.PublicKey]uint64{a.Public(): 1, b.Public(): 1},
-			types.OpenRoadRange(), time.Time{}, registry.FirstBlock(),
+			time.Time{}, registry.FirstBlock(),
 		)
 		if err != nil {
 			return err
 		}
-		state.ApplyEpoch(epJoin)
-		return nil
+		return DriveAdvance(ctx, state, keys, epJoin.EpochIndex())
 	}))
 	lane1 := state.LocalLane().OrPanic("rejoin")
 	require.NotEqual(t, lane0, lane1)
@@ -170,4 +156,93 @@ func TestSubscribeLaneProposals_StayLeaveRejoin(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, want.Msg().Block().Header().Hash(), gotBlk.Msg().Block().Header().Hash())
 	require.Equal(t, lane1, gotBlk.Msg().Block().Header().Lane())
+}
+
+// Joiner catchup: a first-time joiner votes retained outstanding blocks; after
+// leave/rejoin the cursor stays tip-aligned (no re-vote of already emitted
+// headers; blocks produced while out are still voted once).
+func TestJoinerCatchup_LaneVotes(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+		rng := utils.TestRng()
+		registry, keys := epoch.GenRegistry(rng, 1)
+		a := keys[0]
+		b := types.GenSecretKey(rng)
+		allKeys := append(keys, b)
+
+		db := memblock.NewBlockDB()
+		t.Cleanup(func() { require.NoError(t, db.Close()) })
+		ds := utils.OrPanic1(data.NewState(&data.Config{Registry: registry}, db))
+		stateA := utils.OrPanic1(NewState(a, ds, utils.None[string]()))
+		stateB := utils.OrPanic1(NewState(b, ds, utils.None[string]()))
+		laneA := stateA.LocalLane().OrPanic("genesis")
+
+		activate := func(weights map[types.PublicKey]uint64) *types.Epoch {
+			ep, err := registry.ActivateEpoch(weights, time.Time{}, registry.FirstBlock())
+			require.NoError(t, err)
+			return ep
+		}
+		advance := func(want types.EpochIndex) {
+			require.NoError(t, scope.Run(ctx, func(ctx context.Context, sc scope.Scope) error {
+				sc.SpawnBgNamed("runEpochAdvance", func() error {
+					return utils.IgnoreCancel(stateB.runEpochAdvance(ctx))
+				})
+				return DriveAdvance(ctx, stateB, allKeys, want)
+			}))
+		}
+		produce := func(n types.BlockNumber) *types.Signed[*types.LaneProposal] {
+			prop, err := stateA.ProduceLocalBlock(laneA, n, types.GenPayload(rng))
+			require.NoError(t, err)
+			require.NoError(t, stateB.PushBlock(ctx, prop))
+			stateB.setNextBlockToPersist(laneA, n+1)
+			return prop
+		}
+		both := map[types.PublicKey]uint64{a.Public(): 1, b.Public(): 1}
+		onlyA := map[types.PublicKey]uint64{a.Public(): 1}
+
+		block0 := produce(0)
+		epJoin := activate(both)
+		advance(epJoin.EpochIndex())
+		require.Equal(t, types.EpochIndex(2), stateB.LocalLane().OrPanic("joiner").Joined)
+
+		sub := stateB.SubscribeLaneVotes()
+		batch, err := sub.RecvBatch(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(batch))
+		require.Equal(t, block0.Msg().Block().Header().Hash(), batch[0].Msg().Header().Hash())
+		require.Equal(t, b.Public(), batch[0].Key())
+
+		epLeave := activate(onlyA)
+		advance(epLeave.EpochIndex())
+		block1 := produce(1) // while out; skip RecvBatch so the cursor stays behind block1
+
+		epRejoin := activate(both)
+		advance(epRejoin.EpochIndex())
+		require.Equal(t, types.EpochIndex(4), stateB.LocalLane().OrPanic("rejoiner").Joined)
+
+		batch, err = sub.RecvBatch(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(batch))
+		require.Equal(t, block1.Msg().Block().Header().Hash(), batch[0].Msg().Header().Hash(),
+			"missed-while-out block is voted once; block0 must not be re-emitted")
+
+		ctx2, cancel := context.WithCancel(ctx)
+		defer cancel()
+		done := false
+		go func() {
+			_, _ = sub.RecvBatch(ctx2)
+			done = true
+		}()
+		synctest.Wait()
+		require.False(t, done, "cursor must not rewind onto already-emitted headers")
+		cancel()
+		synctest.Wait()
+		require.True(t, done)
+
+		block2 := produce(2)
+		batch, err = sub.RecvBatch(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(batch))
+		require.Equal(t, block2.Msg().Block().Header().Hash(), batch[0].Msg().Header().Hash())
+	})
 }

--- a/sei-tendermint/internal/autobahn/avail/testonly.go
+++ b/sei-tendermint/internal/autobahn/avail/testonly.go
@@ -102,7 +102,7 @@ func setRoadAppQC(s *State, idx types.RoadIndex, appQC *types.AppQC) {
 
 func tipLink(ep *types.Epoch, key types.SecretKey, idx types.RoadIndex) *types.CommitQC {
 	return types.NewCommitQC([]*types.Signed[*types.CommitVote]{
-		types.Sign(key, types.NewCommitVote(types.ProposalAt(ep, types.View{Index: idx, Number: 0}))),
+		types.Sign(key, types.NewCommitVote(types.ProposalAt(ep, types.View{Index: idx, Number: 0}, ep.FirstBlock()))),
 	})
 }
 

--- a/sei-tendermint/internal/autobahn/avail/testonly.go
+++ b/sei-tendermint/internal/autobahn/avail/testonly.go
@@ -107,7 +107,7 @@ func tipLink(ep *types.Epoch, key types.SecretKey, idx types.RoadIndex) *types.C
 }
 
 // DriveAdvance seals each applied epoch through want-1 and waits for
-// runEpochAdvance to install want. The registry must already contain want;
+// runEpochAdvance to advance to want. The registry must already contain want;
 // runEpochAdvance must be running.
 // Intended for tests only.
 func DriveAdvance(ctx context.Context, state *State, keys []types.SecretKey, want types.EpochIndex) error {

--- a/sei-tendermint/internal/autobahn/avail/testonly.go
+++ b/sei-tendermint/internal/autobahn/avail/testonly.go
@@ -123,16 +123,15 @@ func tipLink(ep *types.Epoch, key types.SecretKey, idx types.RoadIndex) *types.C
 	})
 }
 
-// DriveAdvance seals each applied epoch through want-1 and waits for
+// TestDriveAdvance seals each applied epoch through want-1 and waits for
 // runEpochAdvance to advance to want. The registry must already contain want;
 // runEpochAdvance must be running.
-// Intended for tests only.
-func DriveAdvance(ctx context.Context, state *State, keys []types.SecretKey, want types.EpochIndex) error {
+func TestDriveAdvance(ctx context.Context, state *State, keys []types.SecretKey, want types.EpochIndex) error {
 	for state.Epoch().Load().EpochIndex() < want {
 		cur := state.Epoch().Load()
 		last := cur.RoadRange().Next - 1
 		if cur.RoadRange().Next == utils.Max[types.RoadIndex]() {
-			return fmt.Errorf("DriveAdvance: cannot seal open road range at epoch %d", cur.EpochIndex())
+			return fmt.Errorf("TestDriveAdvance: cannot seal open road range at epoch %d", cur.EpochIndex())
 		}
 		cks := make([]types.SecretKey, 0, len(keys))
 		for _, k := range keys {
@@ -141,7 +140,7 @@ func DriveAdvance(ctx context.Context, state *State, keys []types.SecretKey, wan
 			}
 		}
 		if len(cks) == 0 {
-			return fmt.Errorf("DriveAdvance: no committee keys for epoch %d", cur.EpochIndex())
+			return fmt.Errorf("TestDriveAdvance: no committee keys for epoch %d", cur.EpochIndex())
 		}
 		seekRoads(state, last)
 		var qc *types.CommitQC
@@ -151,7 +150,7 @@ func DriveAdvance(ctx context.Context, state *State, keys []types.SecretKey, wan
 			qc = types.BuildCommitQC(cur, cks, utils.Some(tipLink(cur, cks[0], last-1)), nil)
 		}
 		if qc.Index() != last {
-			return fmt.Errorf("DriveAdvance: qc index %d != last %d", qc.Index(), last)
+			return fmt.Errorf("TestDriveAdvance: qc index %d != last %d", qc.Index(), last)
 		}
 		if err := state.PushCommitQC(ctx, qc); err != nil {
 			return err
@@ -165,7 +164,7 @@ func DriveAdvance(ctx context.Context, state *State, keys []types.SecretKey, wan
 		}
 	}
 	if got := state.Epoch().Load().EpochIndex(); got < want {
-		return fmt.Errorf("DriveAdvance: epoch %d < want %d", got, want)
+		return fmt.Errorf("TestDriveAdvance: epoch %d < want %d", got, want)
 	}
 	return nil
 }

--- a/sei-tendermint/internal/autobahn/avail/testonly.go
+++ b/sei-tendermint/internal/autobahn/avail/testonly.go
@@ -80,6 +80,23 @@ func RunTestNetwork(ctx context.Context, states []*State) error {
 	})
 }
 
+func persistEpochSeal(s *State, ep *types.Epoch, keys []types.SecretKey) {
+	last := ep.RoadRange().Next - 1
+	cks := make([]types.SecretKey, 0, len(keys))
+	for _, k := range keys {
+		if ep.Committee().HasReplica(k.Public()) {
+			cks = append(cks, k)
+		}
+	}
+	var qc *types.CommitQC
+	if last == 0 {
+		qc = types.BuildCommitQC(ep, cks, utils.None[*types.CommitQC](), nil)
+	} else {
+		qc = types.BuildCommitQC(ep, cks, utils.Some(tipLink(ep, cks[0], last-1)), nil)
+	}
+	s.markCommitQCsPersisted(qc)
+}
+
 func seekRoads(s *State, idx types.RoadIndex) {
 	for inner, ctrl := range s.inner.Lock() {
 		inner.roads.first = idx
@@ -139,6 +156,7 @@ func DriveAdvance(ctx context.Context, state *State, keys []types.SecretKey, wan
 		if err := state.PushCommitQC(ctx, qc); err != nil {
 			return err
 		}
+		state.markCommitQCsPersisted(qc)
 		setRoadAppQC(state, qc.Index(), data.TestAppQC(cks, types.NewAppProposal(qc.Proposal(), types.AppHash{})))
 		if _, err := state.Epoch().Wait(ctx, func(ep *types.Epoch) bool {
 			return ep.EpochIndex() > cur.EpochIndex()

--- a/sei-tendermint/internal/autobahn/avail/testonly.go
+++ b/sei-tendermint/internal/autobahn/avail/testonly.go
@@ -3,8 +3,11 @@ package avail
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/sei-protocol/sei-chain/sei-tendermint/autobahn/types"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/data"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/scope"
 )
 
@@ -75,4 +78,76 @@ func RunTestNetwork(ctx context.Context, states []*State) error {
 		}
 		return nil
 	})
+}
+
+func seekRoads(s *State, idx types.RoadIndex) {
+	for inner, ctrl := range s.inner.Lock() {
+		inner.roads.first = idx
+		inner.roads.next = idx
+		ctrl.Updated()
+	}
+}
+
+func setRoadAppQC(s *State, idx types.RoadIndex, appQC *types.AppQC) {
+	for inner, ctrl := range s.inner.Lock() {
+		r := inner.roads.q[idx]
+		r.appQC = utils.Some(appQC)
+		// Tests inject road AppQCs without going through data's persist/Anchor
+		// pipeline; stamp the Anchor watermark to the road's epoch so the prune
+		// leash sees the same coverage production would after one flush.
+		inner.anchorEpoch = utils.Some(r.epoch)
+		ctrl.Updated()
+	}
+}
+
+func tipLink(ep *types.Epoch, key types.SecretKey, idx types.RoadIndex) *types.CommitQC {
+	return types.NewCommitQC([]*types.Signed[*types.CommitVote]{
+		types.Sign(key, types.NewCommitVote(types.ProposalAt(ep, types.View{Index: idx, Number: 0}))),
+	})
+}
+
+// DriveAdvance seals each applied epoch through want-1 and waits for
+// runEpochAdvance to install want. The registry must already contain want;
+// runEpochAdvance must be running.
+// Intended for tests only.
+func DriveAdvance(ctx context.Context, state *State, keys []types.SecretKey, want types.EpochIndex) error {
+	for state.Epoch().Load().EpochIndex() < want {
+		cur := state.Epoch().Load()
+		last := cur.RoadRange().Next - 1
+		if cur.RoadRange().Next == utils.Max[types.RoadIndex]() {
+			return fmt.Errorf("DriveAdvance: cannot seal open road range at epoch %d", cur.EpochIndex())
+		}
+		cks := make([]types.SecretKey, 0, len(keys))
+		for _, k := range keys {
+			if cur.Committee().HasReplica(k.Public()) {
+				cks = append(cks, k)
+			}
+		}
+		if len(cks) == 0 {
+			return fmt.Errorf("DriveAdvance: no committee keys for epoch %d", cur.EpochIndex())
+		}
+		seekRoads(state, last)
+		var qc *types.CommitQC
+		if last == 0 {
+			qc = types.BuildCommitQC(cur, cks, utils.None[*types.CommitQC](), nil)
+		} else {
+			qc = types.BuildCommitQC(cur, cks, utils.Some(tipLink(cur, cks[0], last-1)), nil)
+		}
+		if qc.Index() != last {
+			return fmt.Errorf("DriveAdvance: qc index %d != last %d", qc.Index(), last)
+		}
+		if err := state.PushCommitQC(ctx, qc); err != nil {
+			return err
+		}
+		setRoadAppQC(state, qc.Index(), data.TestAppQC(cks, types.NewAppProposal(qc.Proposal(), types.AppHash{})))
+		if _, err := state.Epoch().Wait(ctx, func(ep *types.Epoch) bool {
+			return ep.EpochIndex() > cur.EpochIndex()
+		}); err != nil {
+			return err
+		}
+	}
+	if got := state.Epoch().Load().EpochIndex(); got < want {
+		return fmt.Errorf("DriveAdvance: epoch %d < want %d", got, want)
+	}
+	return nil
 }

--- a/sei-tendermint/internal/autobahn/consensus/inner.go
+++ b/sei-tendermint/internal/autobahn/consensus/inner.go
@@ -3,10 +3,12 @@
 // # What We Persist
 //
 // All consensus state is persisted atomically in a single A/B file pair (inner_a.pb/inner_b.pb):
-//   - CommitQC: justified entering the current index
+//   - CommitQCIndex: tip road index for ErrAvailBehindConsensus on restore
 //   - TimeoutQC: justified entering the current view number
 //   - PrepareQC: needed for timeoutVote on restart
 //   - PrepareVote, CommitVote, TimeoutVote: this node's votes for the current view
+//
+// Runtime CommitQC + next-view epoch come from avail's ConsensusSpec, not the WAL.
 //
 // # Why We Persist
 //
@@ -55,8 +57,13 @@
 //   - Inconsistent state: Returns error to caller with message indicating which field is corrupt
 //     Examples of inconsistent state:
 //   - Vote from a future view (how could we vote for a view we haven't reached?)
-//   - TimeoutQC at index > 0 without CommitQC (how did we advance past index 0?)
-//   - TimeoutQC at index > CommitQC.Index + 1 (how did we skip intermediate commits?)
+//   - TimeoutQC at index > 0 without CommitQCIndex (how did we advance past index 0?)
+//   - TimeoutQC at index > CommitQCIndex + 1 (how did we skip intermediate commits?)
+//   - WAL tip ahead of ConsensusSpec: ErrAvailBehindConsensus
+//   - Spec ahead of WAL tip: install spec, discard per-view WAL state
+//   - Equal tip: keep WAL votes/QCs if persistedInner.validate(spec) passes
+//     (e.g. reject future-view votes, TimeoutQC index ≠ NextIndexOpt(spec.CommitQC),
+//     bad signatures, CommitVote without PrepareQC)
 //
 // # Write Behavior
 //
@@ -71,9 +78,10 @@
 //   - Votes (prepareVote, commitVote, timeoutVote): YES - rebroadcast via sendUpdates
 //   - TimeoutQC: YES - rebroadcast via myTimeoutQC watch
 //   - CommitQC: NO - used locally for view justification but not rebroadcast;
-//     CommitQCs are served via StreamCommitQCs from the data layer, not from
-//     the persisted viewSpec. TODO: consider rebroadcasting CommitQC on restart
-//     to help peers sync faster after cluster-wide outages.
+//     the runtime tip comes from ConsensusSpec, while the WAL stores only
+//     CommitQCIndex. CommitQCs are served via StreamCommitQCs from the data
+//     layer. TODO: consider rebroadcasting CommitQC on restart to help peers
+//     sync faster after cluster-wide outages.
 package consensus
 
 import (
@@ -93,12 +101,12 @@ const innerFile = "inner"
 
 type inner struct {
 	persistedInner
-	epoch *types.Epoch
+	spec types.ConsensusSpec
 }
 
 // View returns the current view, embedding the epoch's index.
 func (i inner) View() types.View {
-	vs := types.ViewSpec{CommitQC: i.CommitQC, TimeoutQC: i.TimeoutQC, Epoch: i.epoch}
+	vs := types.ViewSpec{CommitQC: i.spec.CommitQC, TimeoutQC: i.TimeoutQC, Epoch: i.spec.Epoch}
 	return vs.View()
 }
 
@@ -111,15 +119,16 @@ func newInner(
 	spec types.ConsensusSpec,
 ) (inner, error) {
 	var persisted persistedInner
+	persistedViewIdx := types.RoadIndex(0)
 	if p, ok := loaded.Get(); ok {
 		decoded, err := innerProtoConv.Decode(p)
 		if err != nil {
 			return inner{}, fmt.Errorf("corrupt persisted state: %w", err)
 		}
 		persisted = *decoded
+		persistedViewIdx = nextIndexOpt(persisted.CommitQCIndex)
 	}
 
-	persistedViewIdx := types.NextIndexOpt(persisted.CommitQC)
 	specViewIdx := types.NextIndexOpt(spec.CommitQC)
 	if persistedViewIdx > specViewIdx {
 		return inner{}, fmt.Errorf("%w: persisted tip %d > ConsensusSpec tip %d",
@@ -127,25 +136,24 @@ func newInner(
 	}
 
 	if specViewIdx == persistedViewIdx {
-		// Same tip: take CommitQC from the spec; keep WAL votes / view QCs.
-		out := persisted
-		out.CommitQC = spec.CommitQC
-		if err := out.validate(spec.Epoch); err != nil {
+		// Same tip: keep WAL votes / view QCs; CommitQC+epoch from the spec.
+		if err := persisted.validate(spec); err != nil {
 			return inner{}, err
 		}
-		logger.Info("restored consensus state", "state", innerProtoConv.Encode(&out))
-		return inner{persistedInner: out, epoch: spec.Epoch}, nil
+		persisted.CommitQCIndex = commitQCIndex(spec)
+		logger.Info("restored consensus state", "state", innerProtoConv.Encode(&persisted))
+		return inner{persistedInner: persisted, spec: spec}, nil
 	}
 
-	out := persistedInner{CommitQC: spec.CommitQC}
+	out := persistedInner{CommitQCIndex: commitQCIndex(spec)}
 	logger.Info("restored consensus state from avail ConsensusSpec", "state", innerProtoConv.Encode(&out))
-	return inner{persistedInner: out, epoch: spec.Epoch}, nil
+	return inner{persistedInner: out, spec: spec}, nil
 }
 
-// pushSpecFromAvail installs avail's ConsensusSpec tip and clears per-view state.
+// pushSpec installs avail's ConsensusSpec tip and clears per-view state.
 // Specs that do not advance the view are ignored, which covers the tipless spec
 // published before the first CommitQC.
-func (s *State) pushSpecFromAvail(spec types.ConsensusSpec) error {
+func (s *State) pushSpec(spec types.ConsensusSpec) error {
 	specViewIdx := types.NextIndexOpt(spec.CommitQC)
 	if specViewIdx <= s.innerRecv.Load().View().Index {
 		return nil
@@ -156,7 +164,10 @@ func (s *State) pushSpecFromAvail(spec types.ConsensusSpec) error {
 			return nil
 		}
 		// CommitQC advances to new index; clear all state for new view.
-		iSend.Store(inner{persistedInner: persistedInner{CommitQC: spec.CommitQC}, epoch: spec.Epoch})
+		iSend.Store(inner{
+			persistedInner: persistedInner{CommitQCIndex: commitQCIndex(spec)},
+			spec:           spec,
+		})
 	}
 	return nil
 }
@@ -174,7 +185,7 @@ func (s *State) pushTimeoutQC(ctx context.Context, qc *types.TimeoutQC) error {
 		return nil
 	}
 	// Verify checks the invariant: TimeoutQC.View().Index == CommitQC.Index + 1
-	if err := qc.Verify(i.epoch, i.CommitQC); err != nil {
+	if err := qc.Verify(i.spec.Epoch, i.spec.CommitQC); err != nil {
 		return fmt.Errorf("qc.Verify(): %w", err)
 	}
 	for isend := range s.inner.Lock() {
@@ -183,7 +194,10 @@ func (s *State) pushTimeoutQC(ctx context.Context, qc *types.TimeoutQC) error {
 			return nil
 		}
 		// TimeoutQC advances view number; clear votes and prepareQC (stale view).
-		isend.Store(inner{persistedInner: persistedInner{CommitQC: i.CommitQC, TimeoutQC: utils.Some(qc)}, epoch: i.epoch})
+		isend.Store(inner{
+			persistedInner: persistedInner{CommitQCIndex: i.CommitQCIndex, TimeoutQC: utils.Some(qc)},
+			spec:           i.spec,
+		})
 	}
 	return nil
 }

--- a/sei-tendermint/internal/autobahn/consensus/inner.go
+++ b/sei-tendermint/internal/autobahn/consensus/inner.go
@@ -3,7 +3,7 @@
 // # What We Persist
 //
 // All consensus state is persisted atomically in a single A/B file pair (inner_a.pb/inner_b.pb):
-//   - CommitQCIndex: tip road index for ErrAvailBehindConsensus on restore
+//   - Index: current view RoadIndex for ErrAvailBehindConsensus on restore
 //   - TimeoutQC: justified entering the current view number
 //   - PrepareQC: needed for timeoutVote on restart
 //   - PrepareVote, CommitVote, TimeoutVote: this node's votes for the current view
@@ -57,12 +57,11 @@
 //   - Inconsistent state: Returns error to caller with message indicating which field is corrupt
 //     Examples of inconsistent state:
 //   - Vote from a future view (how could we vote for a view we haven't reached?)
-//   - TimeoutQC at index > 0 without CommitQCIndex (how did we advance past index 0?)
-//   - TimeoutQC at index > CommitQCIndex + 1 (how did we skip intermediate commits?)
-//   - WAL tip ahead of ConsensusSpec: ErrAvailBehindConsensus
-//   - Spec ahead of WAL tip: advance to spec, discard per-view WAL state
-//   - Equal tip: keep WAL votes/QCs if persistedInner.validate(spec) passes
-//     (e.g. reject future-view votes, TimeoutQC index ≠ NextIndexOpt(spec.CommitQC),
+//   - TimeoutQC.View().Index != Index
+//   - WAL Index ahead of ConsensusSpec: ErrAvailBehindConsensus
+//   - Spec ahead of WAL Index: advance to spec, discard per-view WAL state
+//   - Equal Index: keep WAL votes/QCs if persistedInner.Verify(spec, self) passes
+//     (e.g. reject future-view votes, TimeoutQC index ≠ spec.Index(),
 //     bad signatures, CommitVote without PrepareQC)
 //
 // # Write Behavior
@@ -79,7 +78,7 @@
 //   - TimeoutQC: YES - rebroadcast via myTimeoutQC watch
 //   - CommitQC: NO - used locally for view justification but not rebroadcast;
 //     the runtime tip comes from ConsensusSpec, while the WAL stores only
-//     CommitQCIndex. CommitQCs are served via StreamCommitQCs from the data
+//     Index. CommitQCs are served via StreamCommitQCs from the data
 //     layer. TODO: consider rebroadcasting CommitQC on restart to help peers
 //     sync faster after cluster-wide outages.
 package consensus
@@ -106,17 +105,19 @@ type inner struct {
 
 // View returns the current view, embedding the epoch's index.
 func (i inner) View() types.View {
-	vs := types.ViewSpec{CommitQC: i.spec.CommitQC, TimeoutQC: i.TimeoutQC, Epoch: i.spec.Epoch}
+	vs := types.ViewSpec{ConsensusSpec: i.spec, TimeoutQC: i.TimeoutQC}
 	return vs.View()
 }
 
 // newInner restores consensus state from avail's ConsensusSpec. The tip CommitQC
 // and next-view epoch always come from the spec. The WAL is kept only for
-// same-view votes / TimeoutQC / PrepareQC when its tip matches the spec. Returns
-// ErrAvailBehindConsensus when the WAL tip is ahead of the spec.
+// same-view votes / TimeoutQC / PrepareQC when Index matches spec.Index(); local
+// votes must be signed by self. Returns ErrAvailBehindConsensus when WAL Index
+// is ahead of the spec.
 func newInner(
 	loaded utils.Option[*pb.PersistedInner],
 	spec types.ConsensusSpec,
+	self types.PublicKey,
 ) (inner, error) {
 	var persisted persistedInner
 	persistedViewIdx := types.RoadIndex(0)
@@ -126,26 +127,25 @@ func newInner(
 			return inner{}, fmt.Errorf("corrupt persisted state: %w", err)
 		}
 		persisted = *decoded
-		persistedViewIdx = nextIndexOpt(persisted.CommitQCIndex)
+		persistedViewIdx = persisted.Index
 	}
 
-	specViewIdx := types.NextIndexOpt(spec.CommitQC)
+	specViewIdx := spec.Index()
 	if persistedViewIdx > specViewIdx {
-		return inner{}, fmt.Errorf("%w: persisted tip %d > ConsensusSpec tip %d",
+		return inner{}, fmt.Errorf("%w: persisted view %d > ConsensusSpec view %d",
 			ErrAvailBehindConsensus, persistedViewIdx, specViewIdx)
 	}
 
 	if specViewIdx == persistedViewIdx {
-		// Same tip: keep WAL votes / view QCs; CommitQC+epoch from the spec.
-		if err := persisted.validate(spec); err != nil {
+		// Same view: keep WAL votes / view QCs; CommitQC+epoch from the spec.
+		if err := persisted.Verify(spec, self); err != nil {
 			return inner{}, err
 		}
-		persisted.CommitQCIndex = commitQCIndex(spec)
 		logger.Info("restored consensus state", "state", innerProtoConv.Encode(&persisted))
 		return inner{persistedInner: persisted, spec: spec}, nil
 	}
 
-	out := persistedInner{CommitQCIndex: commitQCIndex(spec)}
+	out := persistedInner{Index: spec.Index()}
 	logger.Info("restored consensus state from avail ConsensusSpec", "state", innerProtoConv.Encode(&out))
 	return inner{persistedInner: out, spec: spec}, nil
 }
@@ -154,7 +154,7 @@ func newInner(
 // state. Specs that do not advance the view are ignored, which covers the
 // tipless spec published before the first CommitQC.
 func (s *State) pushSpec(spec types.ConsensusSpec) error {
-	specViewIdx := types.NextIndexOpt(spec.CommitQC)
+	specViewIdx := spec.Index()
 	if specViewIdx <= s.innerRecv.Load().View().Index {
 		return nil
 	}
@@ -165,7 +165,7 @@ func (s *State) pushSpec(spec types.ConsensusSpec) error {
 		}
 		// CommitQC advances to new index; clear all state for new view.
 		iSend.Store(inner{
-			persistedInner: persistedInner{CommitQCIndex: commitQCIndex(spec)},
+			persistedInner: persistedInner{Index: spec.Index()},
 			spec:           spec,
 		})
 	}
@@ -195,7 +195,7 @@ func (s *State) pushTimeoutQC(ctx context.Context, qc *types.TimeoutQC) error {
 		}
 		// TimeoutQC advances view number; clear votes and prepareQC (stale view).
 		isend.Store(inner{
-			persistedInner: persistedInner{CommitQCIndex: i.CommitQCIndex, TimeoutQC: utils.Some(qc)},
+			persistedInner: persistedInner{Index: i.Index, TimeoutQC: utils.Some(qc)},
 			spec:           i.spec,
 		})
 	}

--- a/sei-tendermint/internal/autobahn/consensus/inner.go
+++ b/sei-tendermint/internal/autobahn/consensus/inner.go
@@ -155,12 +155,12 @@ func newInner(
 // tipless spec published before the first CommitQC.
 func (s *State) pushSpec(spec types.ConsensusSpec) error {
 	specViewIdx := spec.Index()
-	if specViewIdx <= s.innerRecv.Load().View().Index {
+	if specViewIdx <= s.innerRecv.Load().spec.Index() {
 		return nil
 	}
 	for iSend := range s.inner.Lock() {
 		i := iSend.Load()
-		if specViewIdx <= i.View().Index {
+		if specViewIdx <= i.spec.Index() {
 			return nil
 		}
 		// CommitQC advances to new index; clear all state for new view.

--- a/sei-tendermint/internal/autobahn/consensus/inner.go
+++ b/sei-tendermint/internal/autobahn/consensus/inner.go
@@ -60,7 +60,7 @@
 //   - TimeoutQC at index > 0 without CommitQCIndex (how did we advance past index 0?)
 //   - TimeoutQC at index > CommitQCIndex + 1 (how did we skip intermediate commits?)
 //   - WAL tip ahead of ConsensusSpec: ErrAvailBehindConsensus
-//   - Spec ahead of WAL tip: install spec, discard per-view WAL state
+//   - Spec ahead of WAL tip: advance to spec, discard per-view WAL state
 //   - Equal tip: keep WAL votes/QCs if persistedInner.validate(spec) passes
 //     (e.g. reject future-view votes, TimeoutQC index ≠ NextIndexOpt(spec.CommitQC),
 //     bad signatures, CommitVote without PrepareQC)
@@ -150,9 +150,9 @@ func newInner(
 	return inner{persistedInner: out, spec: spec}, nil
 }
 
-// pushSpec installs avail's ConsensusSpec tip and clears per-view state.
-// Specs that do not advance the view are ignored, which covers the tipless spec
-// published before the first CommitQC.
+// pushSpec advances consensus to avail's ConsensusSpec tip and clears per-view
+// state. Specs that do not advance the view are ignored, which covers the
+// tipless spec published before the first CommitQC.
 func (s *State) pushSpec(spec types.ConsensusSpec) error {
 	specViewIdx := types.NextIndexOpt(spec.CommitQC)
 	if specViewIdx <= s.innerRecv.Load().View().Index {

--- a/sei-tendermint/internal/autobahn/consensus/inner.go
+++ b/sei-tendermint/internal/autobahn/consensus/inner.go
@@ -81,7 +81,6 @@ import (
 	"fmt"
 
 	"github.com/sei-protocol/sei-chain/sei-tendermint/autobahn/types"
-	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/epoch"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/pb"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 	"github.com/sei-protocol/seilog"
@@ -105,13 +104,11 @@ func (i inner) View() types.View {
 
 // newInner restores consensus state from avail's ConsensusSpec. The tip CommitQC
 // and next-view epoch always come from the spec. The WAL is kept only for
-// same-view votes / TimeoutQC / PrepareQC when its tip matches the spec.
-// specOpt is None at genesis (no durable tip yet). Returns
+// same-view votes / TimeoutQC / PrepareQC when its tip matches the spec. Returns
 // ErrAvailBehindConsensus when the WAL tip is ahead of the spec.
 func newInner(
 	loaded utils.Option[*pb.PersistedInner],
-	specOpt utils.Option[types.ConsensusSpec],
-	registry *epoch.Registry,
+	spec types.ConsensusSpec,
 ) (inner, error) {
 	var persisted persistedInner
 	if p, ok := loaded.Get(); ok {
@@ -123,32 +120,16 @@ func newInner(
 	}
 
 	persistedViewIdx := types.NextIndexOpt(persisted.CommitQC)
-	spec, hasSpec := specOpt.Get()
-	specViewIdx := types.RoadIndex(0)
-	if hasSpec {
-		specViewIdx = spec.CommitQC.Index() + 1
-	}
+	specViewIdx := types.NextIndexOpt(spec.CommitQC)
 	if persistedViewIdx > specViewIdx {
 		return inner{}, fmt.Errorf("%w: persisted tip %d > ConsensusSpec tip %d",
 			ErrAvailBehindConsensus, persistedViewIdx, specViewIdx)
 	}
 
-	if !hasSpec { // genesis: no ConsensusSpec (and thus no WAL CommitQC)
-		ep, ok := registry.EpochByIndex(0)
-		if !ok {
-			panic("genesis epoch 0 not registered")
-		}
-		if err := persisted.validate(ep); err != nil {
-			return inner{}, err
-		}
-		logger.Info("restored consensus state", "state", innerProtoConv.Encode(&persisted))
-		return inner{persistedInner: persisted, epoch: ep}, nil
-	}
-
 	if specViewIdx == persistedViewIdx {
 		// Same tip: take CommitQC from the spec; keep WAL votes / view QCs.
 		out := persisted
-		out.CommitQC = utils.Some(spec.CommitQC)
+		out.CommitQC = spec.CommitQC
 		if err := out.validate(spec.Epoch); err != nil {
 			return inner{}, err
 		}
@@ -156,24 +137,26 @@ func newInner(
 		return inner{persistedInner: out, epoch: spec.Epoch}, nil
 	}
 
-	out := persistedInner{CommitQC: utils.Some(spec.CommitQC)}
+	out := persistedInner{CommitQC: spec.CommitQC}
 	logger.Info("restored consensus state from avail ConsensusSpec", "state", innerProtoConv.Encode(&out))
 	return inner{persistedInner: out, epoch: spec.Epoch}, nil
 }
 
 // pushSpecFromAvail installs avail's ConsensusSpec tip and clears per-view state.
+// Specs that do not advance the view are ignored, which covers the tipless spec
+// published before the first CommitQC.
 func (s *State) pushSpecFromAvail(spec types.ConsensusSpec) error {
-	qc := spec.CommitQC
-	if qc.Proposal().Index() < s.innerRecv.Load().View().Index {
+	specViewIdx := types.NextIndexOpt(spec.CommitQC)
+	if specViewIdx <= s.innerRecv.Load().View().Index {
 		return nil
 	}
 	for iSend := range s.inner.Lock() {
 		i := iSend.Load()
-		if qc.Proposal().Index() < i.View().Index {
+		if specViewIdx <= i.View().Index {
 			return nil
 		}
 		// CommitQC advances to new index; clear all state for new view.
-		iSend.Store(inner{persistedInner: persistedInner{CommitQC: utils.Some(spec.CommitQC)}, epoch: spec.Epoch})
+		iSend.Store(inner{persistedInner: persistedInner{CommitQC: spec.CommitQC}, epoch: spec.Epoch})
 	}
 	return nil
 }

--- a/sei-tendermint/internal/autobahn/consensus/inner.go
+++ b/sei-tendermint/internal/autobahn/consensus/inner.go
@@ -103,13 +103,18 @@ func (i inner) View() types.View {
 	return vs.View()
 }
 
-// newInner creates the inner state from persisted data loaded by NewPersister.
-// data is None on fresh start (persistence disabled or no prior state).
-// Returns error if persisted state is corrupt (see persistedInner.validate).
-func newInner(data utils.Option[*pb.PersistedInner], registry *epoch.Registry) (inner, error) {
+// newInner restores consensus state from avail's ConsensusSpec. The tip CommitQC
+// and next-view epoch always come from the spec. The WAL is kept only for
+// same-view votes / TimeoutQC / PrepareQC when its tip matches the spec.
+// specOpt is None at genesis (no durable tip yet). Returns
+// ErrAvailBehindConsensus when the WAL tip is ahead of the spec.
+func newInner(
+	loaded utils.Option[*pb.PersistedInner],
+	specOpt utils.Option[types.ConsensusSpec],
+	registry *epoch.Registry,
+) (inner, error) {
 	var persisted persistedInner
-
-	if p, ok := data.Get(); ok {
+	if p, ok := loaded.Get(); ok {
 		decoded, err := innerProtoConv.Decode(p)
 		if err != nil {
 			return inner{}, fmt.Errorf("corrupt persisted state: %w", err)
@@ -117,26 +122,50 @@ func newInner(data utils.Option[*pb.PersistedInner], registry *epoch.Registry) (
 		persisted = *decoded
 	}
 
-	// TODO: when AddEpoch is wired, resolve the epoch from the persisted QC/proposal
-	// rather than assuming LatestEpoch — otherwise a restart after an epoch transition
-	// fails validation with an epoch/road mismatch.
-	ep := registry.LatestEpoch()
-	if err := persisted.validate(ep); err != nil {
-		return inner{}, err
+	persistedViewIdx := types.NextIndexOpt(persisted.CommitQC)
+	spec, hasSpec := specOpt.Get()
+	specViewIdx := types.RoadIndex(0)
+	if hasSpec {
+		specViewIdx = spec.CommitQC.Index() + 1
+	}
+	if persistedViewIdx > specViewIdx {
+		return inner{}, fmt.Errorf("%w: persisted tip %d > ConsensusSpec tip %d",
+			ErrAvailBehindConsensus, persistedViewIdx, specViewIdx)
 	}
 
-	logger.Info("restored consensus state", "state", innerProtoConv.Encode(&persisted))
+	if !hasSpec { // genesis: no ConsensusSpec (and thus no WAL CommitQC)
+		ep, ok := registry.EpochByIndex(0)
+		if !ok {
+			panic("genesis epoch 0 not registered")
+		}
+		if err := persisted.validate(ep); err != nil {
+			return inner{}, err
+		}
+		logger.Info("restored consensus state", "state", innerProtoConv.Encode(&persisted))
+		return inner{persistedInner: persisted, epoch: ep}, nil
+	}
 
-	return inner{persistedInner: persisted, epoch: ep}, nil
+	if specViewIdx == persistedViewIdx {
+		// Same tip: take CommitQC from the spec; keep WAL votes / view QCs.
+		out := persisted
+		out.CommitQC = utils.Some(spec.CommitQC)
+		if err := out.validate(spec.Epoch); err != nil {
+			return inner{}, err
+		}
+		logger.Info("restored consensus state", "state", innerProtoConv.Encode(&out))
+		return inner{persistedInner: out, epoch: spec.Epoch}, nil
+	}
+
+	out := persistedInner{CommitQC: utils.Some(spec.CommitQC)}
+	logger.Info("restored consensus state from avail ConsensusSpec", "state", innerProtoConv.Encode(&out))
+	return inner{persistedInner: out, epoch: spec.Epoch}, nil
 }
 
-func (s *State) pushCommitQC(qc *types.CommitQC) error {
-	i := s.innerRecv.Load()
-	if qc.Proposal().Index() < i.View().Index {
+// pushSpecFromAvail installs avail's ConsensusSpec tip and clears per-view state.
+func (s *State) pushSpecFromAvail(spec types.ConsensusSpec) error {
+	qc := spec.CommitQC
+	if qc.Proposal().Index() < s.innerRecv.Load().View().Index {
 		return nil
-	}
-	if err := qc.Verify(i.epoch); err != nil {
-		return fmt.Errorf("qc.Verify(): %w", err)
 	}
 	for iSend := range s.inner.Lock() {
 		i := iSend.Load()
@@ -144,8 +173,7 @@ func (s *State) pushCommitQC(qc *types.CommitQC) error {
 			return nil
 		}
 		// CommitQC advances to new index; clear all state for new view.
-		// TODO: rotate ep when epoch transitions are wired up.
-		iSend.Store(inner{persistedInner: persistedInner{CommitQC: utils.Some(qc)}, epoch: i.epoch})
+		iSend.Store(inner{persistedInner: persistedInner{CommitQC: utils.Some(spec.CommitQC)}, epoch: spec.Epoch})
 	}
 	return nil
 }

--- a/sei-tendermint/internal/autobahn/consensus/inner_test.go
+++ b/sei-tendermint/internal/autobahn/consensus/inner_test.go
@@ -3,6 +3,7 @@ package consensus
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-db/ledger_db/block/littblock"
 	"github.com/sei-protocol/sei-chain/sei-db/ledger_db/block/memblock"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/autobahn/types"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/avail"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/blockstore"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/consensus/persist"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/data"
@@ -18,6 +20,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/protoutils"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/require"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/scope"
 )
 
 func newTestBlockDB(t *testing.T, dir string) types.BlockStore {
@@ -33,6 +36,15 @@ func newTestDataState(registry *epoch.Registry) *data.State {
 	return utils.OrPanic1(data.NewState(&data.Config{Registry: registry}, store))
 }
 
+func newTestAvail(t *testing.T, registry *epoch.Registry, key types.SecretKey) (*data.State, *avail.State) {
+	t.Helper()
+	ds := newTestDataState(registry)
+	av, err := avail.NewState(key, ds, utils.None[string]())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = av.Close() })
+	return ds, av
+}
+
 // seedPersistedInner is a test helper that persists a persistedInner using the public API.
 func seedPersistedInner(dir string, state *persistedInner) {
 	p, _, err := persist.NewPersister[*pb.PersistedInner](utils.Some(dir), innerFile)
@@ -45,13 +57,66 @@ func seedPersistedInner(dir string, state *persistedInner) {
 }
 
 // loadInner is a test helper that loads persisted data and creates inner.
-// Mirrors what NewState does: NewPersister → newInner.
-func loadInner(dir string, registry *epoch.Registry) (inner, error) {
-	_, data, err := persist.NewPersister[*pb.PersistedInner](utils.Some(dir), innerFile)
+// Mirrors what NewState does: avail first (aligned to the WAL tip via PushCommitQC),
+// then newInner.
+func loadInner(t *testing.T, dir string, registry *epoch.Registry, keys []types.SecretKey) (inner, error) {
+	t.Helper()
+	_, persisted, err := persist.NewPersister[*pb.PersistedInner](utils.Some(dir), innerFile)
 	if err != nil {
 		return inner{}, err
 	}
-	return newInner(data, registry)
+	_, av := newTestAvail(t, registry, keys[0])
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	go func() { _ = utils.IgnoreCancel(av.Run(ctx)) }()
+
+	if p, ok := persisted.Get(); ok {
+		decoded, err := innerProtoConv.Decode(p)
+		if err != nil {
+			return inner{}, err
+		}
+		if cqc, ok := decoded.CommitQC.Get(); ok {
+			if err := alignAvailToTip(ctx, t, av, registry, keys, cqc); err != nil {
+				return inner{}, err
+			}
+		}
+	}
+	return newInner(persisted, av.SubscribeConsensusSpec().Load(), registry)
+}
+
+// alignAvailToTip pushes CommitQCs 0..tip.Index() through avail and waits until
+// the tip index is durable. The QCs are freshly built for the registry — the tip
+// CommitQC used at restore comes from ConsensusSpec, not the WAL bytes.
+// Callers must keep tip.Index() small — EpochLength boundaries are not replayed
+// in unit tests.
+func alignAvailToTip(
+	ctx context.Context,
+	t *testing.T,
+	av *avail.State,
+	registry *epoch.Registry,
+	keys []types.SecretKey,
+	tip *types.CommitQC,
+) error {
+	t.Helper()
+	require.LessOrEqual(t, tip.Index(), types.RoadIndex(64), "alignAvailToTip: tip too high for unit replay")
+
+	var prev utils.Option[*types.CommitQC]
+	for idx := types.RoadIndex(0); idx <= tip.Index(); idx++ {
+		ep, err := registry.EpochAt(idx)
+		if err != nil {
+			return err
+		}
+		qc := types.BuildCommitQC(ep, keys, prev, nil)
+		if err := av.PushCommitQC(ctx, qc); err != nil {
+			return err
+		}
+		prev = utils.Some(qc)
+	}
+	_, err := av.LastCommitQC().Wait(ctx, func(o utils.Option[*types.CommitQC]) bool {
+		c, ok := o.Get()
+		return ok && c.Index() >= tip.Index()
+	})
+	return err
 }
 
 // makePrepareQC creates a PrepareQC with valid signatures from the given keys.
@@ -65,13 +130,149 @@ func makePrepareQC(keys []types.SecretKey, proposal *types.Proposal) *types.Prep
 
 func TestNewInnerEmpty(t *testing.T) {
 	rng := utils.TestRng()
-	registry, _ := epoch.GenRegistry(rng, 1)
-	// No data should return empty inner (persistence disabled / fresh start)
-	i, err := newInner(utils.None[*pb.PersistedInner](), registry)
+	registry, keys := epoch.GenRegistry(rng, 1)
+	_, av := newTestAvail(t, registry, keys[0])
+	i, err := newInner(utils.None[*pb.PersistedInner](), av.SubscribeConsensusSpec().Load(), registry)
 	require.NoError(t, err)
 	require.False(t, i.PrepareVote.IsPresent(), "prepareVote should be None")
 	require.False(t, i.CommitVote.IsPresent(), "commitVote should be None")
 	require.False(t, i.TimeoutVote.IsPresent(), "timeoutVote should be None")
+	require.Equal(t, types.EpochIndex(0), i.epoch.EpochIndex())
+}
+
+// TestNewInner_RejectsWALAheadOfSpec: after avail catch-up, ConsensusSpec must
+// cover the WAL tip. A WAL tip ahead of the spec is a failed catch-up.
+func TestNewInner_RejectsWALAheadOfSpec(t *testing.T) {
+	rng := utils.TestRng()
+	registry, keys := epoch.GenRegistry(rng, 4)
+	registry.AdvanceIfNeeded(epoch.LastRoad(0))
+
+	ep0, ok := registry.EpochByIndex(0)
+	require.True(t, ok)
+	ep1, ok := registry.EpochByIndex(1)
+	require.True(t, ok)
+
+	last := epoch.LastRoad(0)
+	prev := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
+		types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep0, types.View{Index: last - 1, Number: 0}))),
+	})
+	qcLast := types.BuildCommitQC(ep0, keys, utils.Some(prev), nil)
+	require.Equal(t, last, qcLast.Index())
+
+	// Spec still withheld (None): next-view epoch not applied after a floor.
+	view := types.View{Index: last + 1, Number: 0, EpochIndex: 1}
+	proposal := types.GenProposalForEpoch(rng, ep1, view)
+	vote := types.Sign(keys[0], types.NewPrepareVote(proposal))
+	persisted := persistedInner{
+		CommitQC:    utils.Some(qcLast),
+		PrepareVote: utils.Some(vote),
+	}
+
+	_, err := newInner(utils.Some(innerProtoConv.Encode(&persisted)), utils.None[types.ConsensusSpec](), registry)
+	require.ErrorIs(t, err, ErrAvailBehindConsensus)
+}
+
+// TestNewInner_EqualTipKeepsVotes: matching tips take CommitQC from the spec and
+// retain WAL votes for anti-equivocation.
+func TestNewInner_EqualTipKeepsVotes(t *testing.T) {
+	rng := utils.TestRng()
+	registry, keys := epoch.GenRegistry(rng, 4)
+	registry.AdvanceIfNeeded(epoch.LastRoad(0))
+
+	ep0, ok := registry.EpochByIndex(0)
+	require.True(t, ok)
+	ep1, ok := registry.EpochByIndex(1)
+	require.True(t, ok)
+
+	last := epoch.LastRoad(0)
+	prev := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
+		types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep0, types.View{Index: last - 1, Number: 0}))),
+	})
+	qcLast := types.BuildCommitQC(ep0, keys, utils.Some(prev), nil)
+
+	view := types.View{Index: last + 1, Number: 0, EpochIndex: 1}
+	proposal := types.GenProposalForEpoch(rng, ep1, view)
+	vote := types.Sign(keys[0], types.NewPrepareVote(proposal))
+	persisted := persistedInner{
+		CommitQC:    utils.Some(qcLast),
+		PrepareVote: utils.Some(vote),
+	}
+	spec := types.ConsensusSpec{CommitQC: qcLast, Epoch: ep1}
+
+	i, err := newInner(utils.Some(innerProtoConv.Encode(&persisted)), utils.Some(spec), registry)
+	require.NoError(t, err)
+	require.Equal(t, last+1, i.View().Index)
+	require.Equal(t, types.EpochIndex(1), i.epoch.EpochIndex())
+	got, ok := i.PrepareVote.Get()
+	require.True(t, ok)
+	require.Equal(t, view, got.Msg().Proposal().View())
+}
+
+// TestRestore_BoundaryCatchUpSpecCoversWAL is the restart invariant blind-Spec
+// trust depends on. After avail catch-up installs epoch 1 at the LastRoad(0)
+// tip, ConsensusSpec must republish that tip so a WAL at the same tip restores
+// without ErrAvailBehindConsensus and keeps anti-equivocation votes.
+func TestRestore_BoundaryCatchUpSpecCoversWAL(t *testing.T) {
+	rng := utils.TestRng()
+	registry, keys := epoch.GenRegistry(rng, 4)
+	registry.AdvanceIfNeeded(epoch.LastRoad(0))
+
+	ds := newTestDataState(registry)
+	av, err := avail.NewState(keys[0], ds, utils.None[string]())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = av.Close() })
+
+	last := epoch.LastRoad(0)
+	var spec types.ConsensusSpec
+	require.NoError(t, scope.Run(t.Context(), func(ctx context.Context, s scope.Scope) error {
+		s.SpawnBgNamed("data.Run", func() error {
+			return utils.IgnoreCancel(ds.Run(ctx))
+		})
+		s.SpawnBgNamed("avail.Run", func() error {
+			return utils.IgnoreCancel(av.Run(ctx))
+		})
+		if err := avail.DriveAdvance(ctx, av, keys, 1); err != nil {
+			return fmt.Errorf("DriveAdvance: %w", err)
+		}
+		if _, err := av.LastCommitQC().Wait(ctx, func(o utils.Option[*types.CommitQC]) bool {
+			c, ok := o.Get()
+			return ok && c.Index() >= last
+		}); err != nil {
+			return fmt.Errorf("wait durable tip: %w", err)
+		}
+		got, err := av.SubscribeConsensusSpec().Wait(ctx, func(o utils.Option[types.ConsensusSpec]) bool {
+			sp, ok := o.Get()
+			return ok && sp.CommitQC.Index() >= last && sp.Epoch.EpochIndex() >= 1
+		})
+		if err != nil {
+			return fmt.Errorf("wait ConsensusSpec: %w", err)
+		}
+		sp, ok := got.Get()
+		if !ok {
+			return fmt.Errorf("ConsensusSpec missing after catch-up")
+		}
+		spec = sp
+		return nil
+	}))
+
+	require.Equal(t, last, spec.CommitQC.Index(), "catch-up must republish the boundary tip, not withhold")
+	require.Equal(t, types.EpochIndex(1), spec.Epoch.EpochIndex())
+
+	view := types.View{Index: last + 1, Number: 0, EpochIndex: 1}
+	proposal := types.GenProposalForEpoch(rng, spec.Epoch, view)
+	vote := types.Sign(keys[0], types.NewPrepareVote(proposal))
+	persisted := persistedInner{
+		CommitQC:    utils.Some(spec.CommitQC),
+		PrepareVote: utils.Some(vote),
+	}
+
+	i, err := newInner(utils.Some(innerProtoConv.Encode(&persisted)), utils.Some(spec), registry)
+	require.NoError(t, err)
+	require.Equal(t, last+1, i.View().Index)
+	require.Equal(t, types.EpochIndex(1), i.epoch.EpochIndex())
+	got, ok := i.PrepareVote.Get()
+	require.True(t, ok, "equal-tip restore must keep anti-equivocation vote")
+	require.Equal(t, view, got.Msg().Proposal().View())
 }
 
 func TestNewInnerPrepareVote(t *testing.T) {
@@ -89,7 +290,7 @@ func TestNewInnerPrepareVote(t *testing.T) {
 	})
 
 	// Load and verify
-	i, err := loadInner(dir, registry)
+	i, err := loadInner(t, dir, registry, keys)
 	require.NoError(t, err)
 	loaded, ok := i.PrepareVote.Get()
 	require.True(t, ok, "prepareVote should be Some")
@@ -113,7 +314,7 @@ func TestNewInnerCommitVote(t *testing.T) {
 	})
 
 	// Load and verify
-	i, err := loadInner(dir, registry)
+	i, err := loadInner(t, dir, registry, keys)
 	require.NoError(t, err)
 	loaded, ok := i.CommitVote.Get()
 	require.True(t, ok, "commitVote should be Some")
@@ -134,7 +335,7 @@ func TestNewInnerTimeoutVote(t *testing.T) {
 	})
 
 	// Load and verify
-	i, err := loadInner(dir, registry)
+	i, err := loadInner(t, dir, registry, keys)
 	require.NoError(t, err)
 	loaded, ok := i.TimeoutVote.Get()
 	require.True(t, ok, "timeoutVote should be Some")
@@ -162,7 +363,7 @@ func TestNewInnerAllVotes(t *testing.T) {
 	})
 
 	// Load and verify all
-	i, err := loadInner(dir, registry)
+	i, err := loadInner(t, dir, registry, keys)
 	require.NoError(t, err)
 	require.True(t, i.PrepareVote.IsPresent(), "prepareVote should be Some")
 	require.True(t, i.CommitVote.IsPresent(), "commitVote should be Some")
@@ -184,7 +385,7 @@ func TestNewInnerPartialState(t *testing.T) {
 	})
 
 	// Load - only prepareVote should be present
-	i, err := loadInner(dir, registry)
+	i, err := loadInner(t, dir, registry, keys)
 	require.NoError(t, err)
 	require.True(t, i.PrepareVote.IsPresent(), "prepareVote should be Some")
 	require.False(t, i.CommitVote.IsPresent(), "commitVote should be None")
@@ -210,7 +411,7 @@ func TestNewInnerCommitQC(t *testing.T) {
 	})
 
 	// Load and verify
-	i, err := loadInner(dir, registry)
+	i, err := loadInner(t, dir, registry, keys)
 	require.NoError(t, err)
 	require.True(t, i.CommitQC.IsPresent(), "CommitQC should be loaded")
 	loadedQC, ok := i.CommitQC.Get()
@@ -247,7 +448,7 @@ func TestNewInnerTimeoutQC(t *testing.T) {
 	})
 
 	// Load and verify
-	i, err := loadInner(dir, registry)
+	i, err := loadInner(t, dir, registry, keys)
 	require.NoError(t, err)
 	require.True(t, i.TimeoutQC.IsPresent(), "TimeoutQC should be loaded")
 	// View should be (6, 3) since TimeoutQC at (6, 2) advances to (6, 3)
@@ -271,7 +472,7 @@ func TestNewInnerTimeoutQCOnlyGenesis(t *testing.T) {
 	})
 
 	// Load and verify - should work without CommitQC since index is 0
-	i, err := loadInner(dir, registry)
+	i, err := loadInner(t, dir, registry, keys)
 	require.NoError(t, err)
 	require.True(t, i.TimeoutQC.IsPresent(), "TimeoutQC should be loaded")
 	require.Equal(t, types.View{Index: 0, Number: 3}, i.View())
@@ -294,7 +495,7 @@ func TestNewInnerTimeoutQCWithoutCommitQCError(t *testing.T) {
 	})
 
 	// Should return error - TimeoutQC at index 6 requires CommitQC at index 5
-	_, err := loadInner(dir, registry)
+	_, err := loadInner(t, dir, registry, keys)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "corrupt persisted state")
 }
@@ -326,7 +527,7 @@ func TestNewInnerTimeoutQCAheadOfCommitQCError(t *testing.T) {
 	})
 
 	// Should return error - TimeoutQC index must equal CommitQC.Index + 1
-	_, err := loadInner(dir, registry)
+	_, err := loadInner(t, dir, registry, keys)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "corrupt persisted state")
 }
@@ -359,7 +560,7 @@ func TestNewInnerViewSpecStaleTimeoutQC(t *testing.T) {
 	})
 
 	// Load - stale TimeoutQC should be treated as corrupt state
-	_, err := loadInner(dir, registry)
+	_, err := loadInner(t, dir, registry, keys)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "corrupt persisted state")
 }
@@ -391,7 +592,7 @@ func TestNewInnerViewSpecValidBothQCs(t *testing.T) {
 	})
 
 	// Load - both should be present
-	i, err := loadInner(dir, registry)
+	i, err := loadInner(t, dir, registry, keys)
 	require.NoError(t, err)
 	require.True(t, i.CommitQC.IsPresent(), "CommitQC should be loaded")
 	require.True(t, i.TimeoutQC.IsPresent(), "TimeoutQC should be loaded")
@@ -423,7 +624,7 @@ func TestNewInnerStaleVoteError(t *testing.T) {
 		PrepareVote: utils.Some(staleVote),
 	})
 
-	_, err := loadInner(dir, registry)
+	_, err := loadInner(t, dir, registry, keys)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "corrupt persisted state")
 }
@@ -452,7 +653,7 @@ func TestNewInnerFuturePrepareVoteError(t *testing.T) {
 	})
 
 	// Should return error - future votes indicate corrupt state
-	_, err := loadInner(dir, registry)
+	_, err := loadInner(t, dir, registry, keys)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "corrupt persisted state")
 }
@@ -481,7 +682,7 @@ func TestNewInnerFutureCommitVoteError(t *testing.T) {
 	})
 
 	// Should return error
-	_, err := loadInner(dir, registry)
+	_, err := loadInner(t, dir, registry, keys)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "corrupt persisted state")
 }
@@ -509,7 +710,7 @@ func TestNewInnerFutureTimeoutVoteError(t *testing.T) {
 	})
 
 	// Should return error
-	_, err := loadInner(dir, registry)
+	_, err := loadInner(t, dir, registry, keys)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "corrupt persisted state")
 }
@@ -538,37 +739,9 @@ func TestNewInnerCurrentViewVoteOk(t *testing.T) {
 	})
 
 	// Should succeed - current view votes are valid
-	i, err := loadInner(dir, registry)
+	i, err := loadInner(t, dir, registry, keys)
 	require.NoError(t, err)
 	require.True(t, i.PrepareVote.IsPresent(), "current view vote should be loaded")
-}
-
-func TestNewInnerCommitQCInvalidSignatureError(t *testing.T) {
-	rng := utils.TestRng()
-	dir := t.TempDir()
-	registry, _ := epoch.GenRegistry(rng, 3)
-
-	// Create CommitQC signed by keys NOT in committee
-	otherKeys := make([]types.SecretKey, 3)
-	for i := range otherKeys {
-		otherKeys[i] = types.GenSecretKey(rng)
-	}
-	proposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 5, Number: 0})
-	vote := types.NewCommitVote(proposal)
-	var votes []*types.Signed[*types.CommitVote]
-	for _, k := range otherKeys {
-		votes = append(votes, types.Sign(k, vote))
-	}
-	qc := types.NewCommitQC(votes)
-
-	seedPersistedInner(dir, &persistedInner{
-		CommitQC: utils.Some(qc),
-	})
-
-	// Should return error - invalid signatures
-	_, err := loadInner(dir, registry)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "corrupt persisted state")
 }
 
 func TestNewInnerTimeoutQCInvalidSignatureError(t *testing.T) {
@@ -602,7 +775,7 @@ func TestNewInnerTimeoutQCInvalidSignatureError(t *testing.T) {
 	})
 
 	// Should return error - invalid signatures on TimeoutQC
-	_, err := loadInner(dir, registry)
+	_, err := loadInner(t, dir, registry, keys)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "corrupt persisted state")
 }
@@ -632,7 +805,7 @@ func TestNewInnerCurrentViewVoteInvalidSignatureError(t *testing.T) {
 	})
 
 	// Should return error - current view votes must have valid signatures
-	_, err := loadInner(dir, registry)
+	_, err := loadInner(t, dir, registry, keys)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "corrupt persisted state")
 }
@@ -662,7 +835,7 @@ func TestNewInnerStaleVoteInvalidSignatureError(t *testing.T) {
 		PrepareVote: utils.Some(badVote),
 	})
 
-	_, err := loadInner(dir, registry)
+	_, err := loadInner(t, dir, registry, keys)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "corrupt persisted state")
 }
@@ -681,7 +854,7 @@ func TestNewInnerPrepareQC(t *testing.T) {
 	})
 
 	// Load and verify
-	i, err := loadInner(dir, registry)
+	i, err := loadInner(t, dir, registry, keys)
 	require.NoError(t, err)
 	require.True(t, i.PrepareQC.IsPresent(), "prepareQC should be loaded")
 }
@@ -710,7 +883,7 @@ func TestNewInnerStalePrepareQCError(t *testing.T) {
 		PrepareQC: utils.Some(stalePrepareQC),
 	})
 
-	_, err := loadInner(dir, registry)
+	_, err := loadInner(t, dir, registry, keys)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "corrupt persisted state")
 }
@@ -729,7 +902,7 @@ func TestNewInnerCommitVoteWithoutPrepareQCError(t *testing.T) {
 		CommitVote: utils.Some(commitVote),
 	})
 
-	_, err := loadInner(dir, registry)
+	_, err := loadInner(t, dir, registry, keys)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "CommitVote present without PrepareQC")
 }
@@ -758,7 +931,7 @@ func TestNewInnerFuturePrepareQCError(t *testing.T) {
 	})
 
 	// Should return error - future prepareQC indicates corrupt state
-	_, err := loadInner(dir, registry)
+	_, err := loadInner(t, dir, registry, keys)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "corrupt persisted state")
 }
@@ -787,7 +960,7 @@ func TestNewInnerCurrentViewPrepareQCOk(t *testing.T) {
 	})
 
 	// Should succeed - current view prepareQC is valid
-	i, err := loadInner(dir, registry)
+	i, err := loadInner(t, dir, registry, keys)
 	require.NoError(t, err)
 	require.True(t, i.PrepareQC.IsPresent(), "current view prepareQC should be loaded")
 }
@@ -820,7 +993,7 @@ func TestNewInnerCurrentViewPrepareQCInvalidSignatureError(t *testing.T) {
 	})
 
 	// Should return error - current view prepareQC has invalid signatures
-	_, err := loadInner(dir, registry)
+	_, err := loadInner(t, dir, registry, keys)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "corrupt persisted state")
 }
@@ -850,7 +1023,7 @@ func TestNewInnerPrepareQCIncludedInTimeoutVote(t *testing.T) {
 	})
 
 	// Load state
-	i, err := loadInner(dir, registry)
+	i, err := loadInner(t, dir, registry, keys)
 	require.NoError(t, err)
 	require.True(t, i.PrepareQC.IsPresent(), "prepareQC should be loaded")
 
@@ -902,7 +1075,7 @@ func TestPushTimeoutQCClearsStaleState(t *testing.T) {
 	})
 
 	// Load initial state and verify everything is present
-	i, err := loadInner(dir, registry)
+	i, err := loadInner(t, dir, registry, keys)
 	require.NoError(t, err)
 	require.True(t, i.PrepareQC.IsPresent(), "prepareQC should be loaded")
 	require.True(t, i.PrepareVote.IsPresent(), "prepareVote should be loaded")
@@ -962,4 +1135,63 @@ func TestRunOutputsPersistErrorPropagates(t *testing.T) {
 	err = cs.runOutputs(ctx)
 	require.Error(t, err)
 	require.ErrorIs(t, err, wantErr)
+}
+
+func newConsensusState(t *testing.T, registry *epoch.Registry, key types.SecretKey) *State {
+	t.Helper()
+	s, err := NewState(&Config{
+		Key:         key,
+		ViewTimeout: func(types.View) time.Duration { return time.Hour },
+	}, newTestDataState(registry))
+	require.NoError(t, err)
+	return s
+}
+
+func commitQCAtRoad(ep *types.Epoch, keys []types.SecretKey, idx types.RoadIndex) *types.CommitQC {
+	parent := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
+		types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep, types.View{Index: idx - 1, Number: 0}))),
+	})
+	qc := types.BuildCommitQC(ep, keys, utils.Some(parent), nil)
+	if qc.Proposal().Index() != idx {
+		panic("commitQCAtRoad: BuildCommitQC landed on unexpected index")
+	}
+	return qc
+}
+
+func TestPushCommitQC_RotatesEpochAtBoundary(t *testing.T) {
+	rng := utils.TestRng()
+	registry, keys := epoch.GenRegistry(rng, 4)
+	s := newConsensusState(t, registry, keys[0])
+	require.Equal(t, types.EpochIndex(0), s.innerRecv.Load().epoch.EpochIndex())
+
+	ep0, ok := registry.EpochByIndex(0)
+	require.True(t, ok)
+	qc := commitQCAtRoad(ep0, keys, epoch.LastRoad(0))
+	require.Equal(t, epoch.LastRoad(0), qc.Proposal().Index())
+
+	// Avail resolves the next-view epoch; pushSpecFromAvail installs it verbatim.
+	ep1, err := registry.EpochAt(epoch.FirstRoad(1))
+	require.NoError(t, err)
+	require.NoError(t, s.pushSpecFromAvail(types.ConsensusSpec{CommitQC: qc, Epoch: ep1}))
+	got := s.innerRecv.Load()
+	require.Equal(t, types.EpochIndex(1), got.epoch.EpochIndex())
+	require.Equal(t, epoch.FirstRoad(1), got.View().Index)
+}
+
+func TestNewState_ErrAvailBehindConsensus(t *testing.T) {
+	rng := utils.TestRng()
+	registry, keys := epoch.GenRegistry(rng, 4)
+	dir := t.TempDir()
+
+	ep0, ok := registry.EpochByIndex(0)
+	require.True(t, ok)
+	qc := commitQCAtRoad(ep0, keys, 3)
+	seedPersistedInner(dir, &persistedInner{CommitQC: utils.Some(qc)})
+
+	_, err := NewState(&Config{
+		Key:                keys[0],
+		ViewTimeout:        func(types.View) time.Duration { return time.Hour },
+		PersistentStateDir: utils.Some(dir),
+	}, newTestDataState(registry))
+	require.ErrorIs(t, err, ErrAvailBehindConsensus)
 }

--- a/sei-tendermint/internal/autobahn/consensus/inner_test.go
+++ b/sei-tendermint/internal/autobahn/consensus/inner_test.go
@@ -23,12 +23,12 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/scope"
 )
 
-func newTestBlockDB(t *testing.T, dir string) types.BlockStore {
+func newTestBlockStore(t *testing.T, dir string) types.BlockStore {
 	t.Helper()
 	cfg := utils.OrPanic1(littblock.DefaultConfig(dir))
-	db := utils.OrPanic1(blockstore.New(utils.OrPanic1(littblock.NewBlockDB(cfg))))
-	t.Cleanup(func() { _ = db.Close() })
-	return db
+	store := utils.OrPanic1(blockstore.New(utils.OrPanic1(littblock.NewBlockDB(cfg))))
+	t.Cleanup(func() { _ = store.Close() })
+	return store
 }
 
 func newTestDataState(registry *epoch.Registry) *data.State {
@@ -1062,8 +1062,8 @@ func TestRunOutputsPersistErrorPropagates(t *testing.T) {
 	dir := t.TempDir()
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
-	db := newTestBlockDB(t, filepath.Join(dir, "blockdb"))
-	ds, err := data.NewState(&data.Config{Registry: registry}, db)
+	store := newTestBlockStore(t, filepath.Join(dir, "blockdb"))
+	ds, err := data.NewState(&data.Config{Registry: registry}, store)
 	if err != nil {
 		t.Fatalf("data.NewState: %v", err)
 	}

--- a/sei-tendermint/internal/autobahn/consensus/inner_test.go
+++ b/sei-tendermint/internal/autobahn/consensus/inner_test.go
@@ -173,38 +173,6 @@ func TestNewInner_RejectsWALAheadOfSpec(t *testing.T) {
 	require.ErrorIs(t, err, ErrAvailBehindConsensus)
 }
 
-// TestNewInner_EqualTipKeepsVotes: matching tips take CommitQC from the spec and
-// retain WAL votes for anti-equivocation.
-func TestNewInner_EqualTipKeepsVotes(t *testing.T) {
-	rng := utils.TestRng()
-	registry, keys := epoch.GenRegistry(rng, 4)
-	registry.AdvanceIfNeeded(epoch.LastRoad(0))
-
-	ep0 := registry.MustEpoch(0)
-	ep1 := registry.MustEpoch(1)
-
-	last := epoch.LastRoad(0)
-	prev := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
-		types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep0, types.View{Index: last - 1, Number: 0}, ep0.FirstBlock()))),
-	})
-	qcLast := types.BuildCommitQC(ep0, keys, utils.Some(prev), nil)
-
-	view := types.View{Index: last + 1, Number: 0, EpochIndex: 1}
-	proposal := types.GenProposalForEpoch(rng, ep1, view)
-	vote := types.Sign(keys[0], types.NewPrepareVote(proposal))
-	persistedTip := utils.Some(qcLast)
-	persisted := persistedInner{PrepareVote: utils.Some(vote)}
-	spec := types.ConsensusSpec{CommitQC: utils.Some(qcLast), Epoch: ep1}
-
-	i, err := newInner(utils.Some(encodeWal(persistedTip, &persisted)), spec, keys[0].Public())
-	require.NoError(t, err)
-	require.Equal(t, last+1, i.View().Index)
-	require.Equal(t, types.EpochIndex(1), i.spec.Epoch.EpochIndex())
-	got, ok := i.PrepareVote.Get()
-	require.True(t, ok)
-	require.Equal(t, view, got.Msg().Proposal().View())
-}
-
 // TestRestore_BoundaryCatchUpSpecCoversWAL is the restart invariant blind-Spec
 // trust depends on. After avail catch-up advances epoch 1 at the LastRoad(0)
 // tip, ConsensusSpec must republish that tip so a WAL at the same tip restores
@@ -769,44 +737,41 @@ func TestNewInnerCurrentViewVoteInvalidSignatureError(t *testing.T) {
 }
 
 func TestNewInnerVoteFromOtherReplicaError(t *testing.T) {
-	rng := utils.TestRng()
-	dir := t.TempDir()
-	registry, keys := epoch.GenRegistry(rng, 3)
-
-	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
-	qcVote := types.NewCommitVote(qcProposal)
-	var qcVotes []*types.Signed[*types.CommitVote]
-	for _, k := range keys {
-		qcVotes = append(qcVotes, types.Sign(k, qcVote))
+	for _, tc := range []struct {
+		name string
+		wal  func(rng utils.Rng, keys []types.SecretKey, ep *types.Epoch) persistedInner
+	}{
+		{
+			name: "prepare",
+			wal: func(rng utils.Rng, keys []types.SecretKey, ep *types.Epoch) persistedInner {
+				p := types.GenProposalForEpoch(rng, ep, types.View{Index: 6, Number: 0})
+				return persistedInner{PrepareVote: utils.Some(types.Sign(keys[1], types.NewPrepareVote(p)))}
+			},
+		},
+		{
+			name: "timeout",
+			wal: func(_ utils.Rng, keys []types.SecretKey, _ *types.Epoch) persistedInner {
+				return persistedInner{TimeoutVote: utils.Some(types.NewFullTimeoutVote(keys[1], types.View{Index: 6, Number: 0}, utils.None[*types.PrepareQC]()))}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rng := utils.TestRng()
+			dir := t.TempDir()
+			registry, keys := epoch.GenRegistry(rng, 3)
+			ep0 := registry.MustEpoch(0)
+			qcProposal := types.GenProposalForEpoch(rng, ep0, types.View{Index: 5, Number: 0})
+			qcVote := types.NewCommitVote(qcProposal)
+			var qcVotes []*types.Signed[*types.CommitVote]
+			for _, k := range keys {
+				qcVotes = append(qcVotes, types.Sign(k, qcVote))
+			}
+			wal := tc.wal(rng, keys, ep0)
+			seedPersistedInner(dir, utils.Some(types.NewCommitQC(qcVotes)), &wal)
+			_, err := loadInner(t, dir, registry, keys)
+			require.Error(t, err)
+		})
 	}
-	commitQC := types.NewCommitQC(qcVotes)
-
-	currentProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 6, Number: 0})
-	otherReplica := types.Sign(keys[1], types.NewPrepareVote(currentProposal))
-	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareVote: utils.Some(otherReplica)})
-
-	_, err := loadInner(t, dir, registry, keys)
-	require.Error(t, err)
-}
-
-func TestNewInnerTimeoutVoteFromOtherReplicaError(t *testing.T) {
-	rng := utils.TestRng()
-	dir := t.TempDir()
-	registry, keys := epoch.GenRegistry(rng, 3)
-
-	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
-	qcVote := types.NewCommitVote(qcProposal)
-	var qcVotes []*types.Signed[*types.CommitVote]
-	for _, k := range keys {
-		qcVotes = append(qcVotes, types.Sign(k, qcVote))
-	}
-	commitQC := types.NewCommitQC(qcVotes)
-
-	otherReplica := types.NewFullTimeoutVote(keys[1], types.View{Index: 6, Number: 0}, utils.None[*types.PrepareQC]())
-	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{TimeoutVote: utils.Some(otherReplica)})
-
-	_, err := loadInner(t, dir, registry, keys)
-	require.Error(t, err)
 }
 
 func TestNewInnerStaleVoteInvalidSignatureError(t *testing.T) {
@@ -1158,21 +1123,4 @@ func TestPushCommitQC_RotatesEpochAtBoundary(t *testing.T) {
 	got := s.innerRecv.Load()
 	require.Equal(t, types.EpochIndex(1), got.spec.Epoch.EpochIndex())
 	require.Equal(t, epoch.FirstRoad(1), got.View().Index)
-}
-
-func TestNewState_ErrAvailBehindConsensus(t *testing.T) {
-	rng := utils.TestRng()
-	registry, keys := epoch.GenRegistry(rng, 4)
-	dir := t.TempDir()
-
-	ep0 := registry.MustEpoch(0)
-	qc := commitQCAtRoad(ep0, keys, 3)
-	seedPersistedInner(dir, utils.Some(qc), &persistedInner{})
-
-	_, err := NewState(&Config{
-		Key:                keys[0],
-		ViewTimeout:        func(types.View) time.Duration { return time.Hour },
-		PersistentStateDir: utils.Some(dir),
-	}, newTestDataState(registry))
-	require.ErrorIs(t, err, ErrAvailBehindConsensus)
 }

--- a/sei-tendermint/internal/autobahn/consensus/inner_test.go
+++ b/sei-tendermint/internal/autobahn/consensus/inner_test.go
@@ -81,7 +81,7 @@ func loadInner(t *testing.T, dir string, registry *epoch.Registry, keys []types.
 			}
 		}
 	}
-	return newInner(persisted, av.SubscribeConsensusSpec().Load(), registry)
+	return newInner(persisted, av.SubscribeConsensusSpec().Load())
 }
 
 // alignAvailToTip pushes CommitQCs 0..tip.Index() through avail and waits until
@@ -132,7 +132,7 @@ func TestNewInnerEmpty(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 1)
 	_, av := newTestAvail(t, registry, keys[0])
-	i, err := newInner(utils.None[*pb.PersistedInner](), av.SubscribeConsensusSpec().Load(), registry)
+	i, err := newInner(utils.None[*pb.PersistedInner](), av.SubscribeConsensusSpec().Load())
 	require.NoError(t, err)
 	require.False(t, i.PrepareVote.IsPresent(), "prepareVote should be None")
 	require.False(t, i.CommitVote.IsPresent(), "commitVote should be None")
@@ -159,7 +159,7 @@ func TestNewInner_RejectsWALAheadOfSpec(t *testing.T) {
 	qcLast := types.BuildCommitQC(ep0, keys, utils.Some(prev), nil)
 	require.Equal(t, last, qcLast.Index())
 
-	// Spec still withheld (None): next-view epoch not applied after a floor.
+	// Spec tip still None (genesis-shaped stand-in for a withheld tip).
 	view := types.View{Index: last + 1, Number: 0, EpochIndex: 1}
 	proposal := types.GenProposalForEpoch(rng, ep1, view)
 	vote := types.Sign(keys[0], types.NewPrepareVote(proposal))
@@ -168,7 +168,8 @@ func TestNewInner_RejectsWALAheadOfSpec(t *testing.T) {
 		PrepareVote: utils.Some(vote),
 	}
 
-	_, err := newInner(utils.Some(innerProtoConv.Encode(&persisted)), utils.None[types.ConsensusSpec](), registry)
+	genesis := types.ConsensusSpec{CommitQC: utils.None[*types.CommitQC](), Epoch: ep0}
+	_, err := newInner(utils.Some(innerProtoConv.Encode(&persisted)), genesis)
 	require.ErrorIs(t, err, ErrAvailBehindConsensus)
 }
 
@@ -197,9 +198,9 @@ func TestNewInner_EqualTipKeepsVotes(t *testing.T) {
 		CommitQC:    utils.Some(qcLast),
 		PrepareVote: utils.Some(vote),
 	}
-	spec := types.ConsensusSpec{CommitQC: qcLast, Epoch: ep1}
+	spec := types.ConsensusSpec{CommitQC: utils.Some(qcLast), Epoch: ep1}
 
-	i, err := newInner(utils.Some(innerProtoConv.Encode(&persisted)), utils.Some(spec), registry)
+	i, err := newInner(utils.Some(innerProtoConv.Encode(&persisted)), spec)
 	require.NoError(t, err)
 	require.Equal(t, last+1, i.View().Index)
 	require.Equal(t, types.EpochIndex(1), i.epoch.EpochIndex())
@@ -240,33 +241,31 @@ func TestRestore_BoundaryCatchUpSpecCoversWAL(t *testing.T) {
 		}); err != nil {
 			return fmt.Errorf("wait durable tip: %w", err)
 		}
-		got, err := av.SubscribeConsensusSpec().Wait(ctx, func(o utils.Option[types.ConsensusSpec]) bool {
-			sp, ok := o.Get()
-			return ok && sp.CommitQC.Index() >= last && sp.Epoch.EpochIndex() >= 1
+		got, err := av.SubscribeConsensusSpec().Wait(ctx, func(sp types.ConsensusSpec) bool {
+			cqc, ok := sp.CommitQC.Get()
+			return ok && cqc.Index() >= last && sp.Epoch.EpochIndex() >= 1
 		})
 		if err != nil {
 			return fmt.Errorf("wait ConsensusSpec: %w", err)
 		}
-		sp, ok := got.Get()
-		if !ok {
-			return fmt.Errorf("ConsensusSpec missing after catch-up")
-		}
-		spec = sp
+		spec = got
 		return nil
 	}))
 
-	require.Equal(t, last, spec.CommitQC.Index(), "catch-up must republish the boundary tip, not withhold")
+	tip, ok := spec.CommitQC.Get()
+	require.True(t, ok)
+	require.Equal(t, last, tip.Index(), "catch-up must republish the boundary tip, not withhold")
 	require.Equal(t, types.EpochIndex(1), spec.Epoch.EpochIndex())
 
 	view := types.View{Index: last + 1, Number: 0, EpochIndex: 1}
 	proposal := types.GenProposalForEpoch(rng, spec.Epoch, view)
 	vote := types.Sign(keys[0], types.NewPrepareVote(proposal))
 	persisted := persistedInner{
-		CommitQC:    utils.Some(spec.CommitQC),
+		CommitQC:    spec.CommitQC,
 		PrepareVote: utils.Some(vote),
 	}
 
-	i, err := newInner(utils.Some(innerProtoConv.Encode(&persisted)), utils.Some(spec), registry)
+	i, err := newInner(utils.Some(innerProtoConv.Encode(&persisted)), spec)
 	require.NoError(t, err)
 	require.Equal(t, last+1, i.View().Index)
 	require.Equal(t, types.EpochIndex(1), i.epoch.EpochIndex())
@@ -1172,7 +1171,7 @@ func TestPushCommitQC_RotatesEpochAtBoundary(t *testing.T) {
 	// Avail resolves the next-view epoch; pushSpecFromAvail installs it verbatim.
 	ep1, err := registry.EpochAt(epoch.FirstRoad(1))
 	require.NoError(t, err)
-	require.NoError(t, s.pushSpecFromAvail(types.ConsensusSpec{CommitQC: qc, Epoch: ep1}))
+	require.NoError(t, s.pushSpecFromAvail(types.ConsensusSpec{CommitQC: utils.Some(qc), Epoch: ep1}))
 	got := s.innerRecv.Load()
 	require.Equal(t, types.EpochIndex(1), got.epoch.EpochIndex())
 	require.Equal(t, epoch.FirstRoad(1), got.View().Index)

--- a/sei-tendermint/internal/autobahn/consensus/inner_test.go
+++ b/sei-tendermint/internal/autobahn/consensus/inner_test.go
@@ -45,15 +45,26 @@ func newTestAvail(t *testing.T, registry *epoch.Registry, key types.SecretKey) (
 	return ds, av
 }
 
-// seedPersistedInner is a test helper that persists a persistedInner using the public API.
-func seedPersistedInner(dir string, state *persistedInner) {
+// seedPersistedInner persists view-local WAL state. tip is recorded as CommitQCIndex
+// for ErrAvailBehindConsensus comparison on restore; runtime CommitQC comes from avail.
+func seedPersistedInner(dir string, tip utils.Option[*types.CommitQC], state *persistedInner) {
 	p, _, err := persist.NewPersister[*pb.PersistedInner](utils.Some(dir), innerFile)
 	if err != nil {
 		panic(err)
 	}
-	if err := p.Persist(innerProtoConv.Encode(state)); err != nil {
+	if err := p.Persist(encodeWal(tip, state)); err != nil {
 		panic(err)
 	}
+}
+
+func encodeWal(tip utils.Option[*types.CommitQC], state *persistedInner) *pb.PersistedInner {
+	s := *state
+	if cqc, ok := tip.Get(); ok {
+		s.CommitQCIndex = utils.Some(cqc.Index())
+	} else {
+		s.CommitQCIndex = utils.None[types.RoadIndex]()
+	}
+	return innerProtoConv.Encode(&s)
 }
 
 // loadInner is a test helper that loads persisted data and creates inner.
@@ -71,12 +82,8 @@ func loadInner(t *testing.T, dir string, registry *epoch.Registry, keys []types.
 	go func() { _ = utils.IgnoreCancel(av.Run(ctx)) }()
 
 	if p, ok := persisted.Get(); ok {
-		decoded, err := innerProtoConv.Decode(p)
-		if err != nil {
-			return inner{}, err
-		}
-		if cqc, ok := decoded.CommitQC.Get(); ok {
-			if err := alignAvailToTip(ctx, t, av, registry, keys, cqc); err != nil {
+		if tipIdx := walTipIndex(p); tipIdx > 0 {
+			if err := alignAvailToTip(ctx, t, av, registry, keys, tipIdx-1); err != nil {
 				return inner{}, err
 			}
 		}
@@ -84,10 +91,10 @@ func loadInner(t *testing.T, dir string, registry *epoch.Registry, keys []types.
 	return newInner(persisted, av.SubscribeConsensusSpec().Load())
 }
 
-// alignAvailToTip pushes CommitQCs 0..tip.Index() through avail and waits until
-// the tip index is durable. The QCs are freshly built for the registry — the tip
-// CommitQC used at restore comes from ConsensusSpec, not the WAL bytes.
-// Callers must keep tip.Index() small — EpochLength boundaries are not replayed
+// alignAvailToTip pushes CommitQCs 0..tipIndex through avail and waits until
+// that tip is durable. The QCs are freshly built for the registry — the tip
+// CommitQC used at restore comes from ConsensusSpec, not the WAL.
+// Callers must keep tipIndex small — EpochLength boundaries are not replayed
 // in unit tests.
 func alignAvailToTip(
 	ctx context.Context,
@@ -95,13 +102,13 @@ func alignAvailToTip(
 	av *avail.State,
 	registry *epoch.Registry,
 	keys []types.SecretKey,
-	tip *types.CommitQC,
+	tipIndex types.RoadIndex,
 ) error {
 	t.Helper()
-	require.LessOrEqual(t, tip.Index(), types.RoadIndex(64), "alignAvailToTip: tip too high for unit replay")
+	require.LessOrEqual(t, tipIndex, types.RoadIndex(64), "alignAvailToTip: tip too high for unit replay")
 
 	var prev utils.Option[*types.CommitQC]
-	for idx := types.RoadIndex(0); idx <= tip.Index(); idx++ {
+	for idx := types.RoadIndex(0); idx <= tipIndex; idx++ {
 		ep, err := registry.EpochAt(idx)
 		if err != nil {
 			return err
@@ -114,7 +121,7 @@ func alignAvailToTip(
 	}
 	_, err := av.LastCommitQC().Wait(ctx, func(o utils.Option[*types.CommitQC]) bool {
 		c, ok := o.Get()
-		return ok && c.Index() >= tip.Index()
+		return ok && c.Index() >= tipIndex
 	})
 	return err
 }
@@ -137,7 +144,7 @@ func TestNewInnerEmpty(t *testing.T) {
 	require.False(t, i.PrepareVote.IsPresent(), "prepareVote should be None")
 	require.False(t, i.CommitVote.IsPresent(), "commitVote should be None")
 	require.False(t, i.TimeoutVote.IsPresent(), "timeoutVote should be None")
-	require.Equal(t, types.EpochIndex(0), i.epoch.EpochIndex())
+	require.Equal(t, types.EpochIndex(0), i.spec.Epoch.EpochIndex())
 }
 
 // TestNewInner_RejectsWALAheadOfSpec: after avail catch-up, ConsensusSpec must
@@ -163,13 +170,11 @@ func TestNewInner_RejectsWALAheadOfSpec(t *testing.T) {
 	view := types.View{Index: last + 1, Number: 0, EpochIndex: 1}
 	proposal := types.GenProposalForEpoch(rng, ep1, view)
 	vote := types.Sign(keys[0], types.NewPrepareVote(proposal))
-	persisted := persistedInner{
-		CommitQC:    utils.Some(qcLast),
-		PrepareVote: utils.Some(vote),
-	}
+	persistedTip := utils.Some(qcLast)
+	persisted := persistedInner{PrepareVote: utils.Some(vote)}
 
 	genesis := types.ConsensusSpec{CommitQC: utils.None[*types.CommitQC](), Epoch: ep0}
-	_, err := newInner(utils.Some(innerProtoConv.Encode(&persisted)), genesis)
+	_, err := newInner(utils.Some(encodeWal(persistedTip, &persisted)), genesis)
 	require.ErrorIs(t, err, ErrAvailBehindConsensus)
 }
 
@@ -194,16 +199,14 @@ func TestNewInner_EqualTipKeepsVotes(t *testing.T) {
 	view := types.View{Index: last + 1, Number: 0, EpochIndex: 1}
 	proposal := types.GenProposalForEpoch(rng, ep1, view)
 	vote := types.Sign(keys[0], types.NewPrepareVote(proposal))
-	persisted := persistedInner{
-		CommitQC:    utils.Some(qcLast),
-		PrepareVote: utils.Some(vote),
-	}
+	persistedTip := utils.Some(qcLast)
+	persisted := persistedInner{PrepareVote: utils.Some(vote)}
 	spec := types.ConsensusSpec{CommitQC: utils.Some(qcLast), Epoch: ep1}
 
-	i, err := newInner(utils.Some(innerProtoConv.Encode(&persisted)), spec)
+	i, err := newInner(utils.Some(encodeWal(persistedTip, &persisted)), spec)
 	require.NoError(t, err)
 	require.Equal(t, last+1, i.View().Index)
-	require.Equal(t, types.EpochIndex(1), i.epoch.EpochIndex())
+	require.Equal(t, types.EpochIndex(1), i.spec.Epoch.EpochIndex())
 	got, ok := i.PrepareVote.Get()
 	require.True(t, ok)
 	require.Equal(t, view, got.Msg().Proposal().View())
@@ -260,15 +263,13 @@ func TestRestore_BoundaryCatchUpSpecCoversWAL(t *testing.T) {
 	view := types.View{Index: last + 1, Number: 0, EpochIndex: 1}
 	proposal := types.GenProposalForEpoch(rng, spec.Epoch, view)
 	vote := types.Sign(keys[0], types.NewPrepareVote(proposal))
-	persisted := persistedInner{
-		CommitQC:    spec.CommitQC,
-		PrepareVote: utils.Some(vote),
-	}
+	persistedTip := spec.CommitQC
+	persisted := persistedInner{PrepareVote: utils.Some(vote)}
 
-	i, err := newInner(utils.Some(innerProtoConv.Encode(&persisted)), spec)
+	i, err := newInner(utils.Some(encodeWal(persistedTip, &persisted)), spec)
 	require.NoError(t, err)
 	require.Equal(t, last+1, i.View().Index)
-	require.Equal(t, types.EpochIndex(1), i.epoch.EpochIndex())
+	require.Equal(t, types.EpochIndex(1), i.spec.Epoch.EpochIndex())
 	got, ok := i.PrepareVote.Get()
 	require.True(t, ok, "equal-tip restore must keep anti-equivocation vote")
 	require.Equal(t, view, got.Msg().Proposal().View())
@@ -284,7 +285,7 @@ func TestNewInnerPrepareVote(t *testing.T) {
 	genesisProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 0, Number: 0})
 	vote := types.Sign(key, types.NewPrepareVote(genesisProposal))
 
-	seedPersistedInner(dir, &persistedInner{
+	seedPersistedInner(dir, utils.None[*types.CommitQC](), &persistedInner{
 		PrepareVote: utils.Some(vote),
 	})
 
@@ -307,7 +308,7 @@ func TestNewInnerCommitVote(t *testing.T) {
 	prepareQC := makePrepareQC([]types.SecretKey{key}, genesisProposal)
 	vote := types.Sign(key, types.NewCommitVote(genesisProposal))
 
-	seedPersistedInner(dir, &persistedInner{
+	seedPersistedInner(dir, utils.None[*types.CommitQC](), &persistedInner{
 		PrepareQC:  utils.Some(prepareQC),
 		CommitVote: utils.Some(vote),
 	})
@@ -329,7 +330,7 @@ func TestNewInnerTimeoutVote(t *testing.T) {
 	key := keys[0]
 	vote := types.NewFullTimeoutVote(key, types.View{Index: 0, Number: 0}, utils.None[*types.PrepareQC]())
 
-	seedPersistedInner(dir, &persistedInner{
+	seedPersistedInner(dir, utils.None[*types.CommitQC](), &persistedInner{
 		TimeoutVote: utils.Some(vote),
 	})
 
@@ -354,7 +355,7 @@ func TestNewInnerAllVotes(t *testing.T) {
 	commitVote := types.Sign(key, types.NewCommitVote(genesisProposal))
 	timeoutVote := types.NewFullTimeoutVote(key, types.View{Index: 0, Number: 0}, utils.None[*types.PrepareQC]())
 
-	seedPersistedInner(dir, &persistedInner{
+	seedPersistedInner(dir, utils.None[*types.CommitQC](), &persistedInner{
 		PrepareQC:   utils.Some(prepareQC),
 		PrepareVote: utils.Some(prepareVote),
 		CommitVote:  utils.Some(commitVote),
@@ -379,7 +380,7 @@ func TestNewInnerPartialState(t *testing.T) {
 	genesisProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 0, Number: 0})
 	prepareVote := types.Sign(key, types.NewPrepareVote(genesisProposal))
 
-	seedPersistedInner(dir, &persistedInner{
+	seedPersistedInner(dir, utils.None[*types.CommitQC](), &persistedInner{
 		PrepareVote: utils.Some(prepareVote),
 	})
 
@@ -405,15 +406,13 @@ func TestNewInnerCommitQC(t *testing.T) {
 	}
 	qc := types.NewCommitQC(votes)
 
-	seedPersistedInner(dir, &persistedInner{
-		CommitQC: utils.Some(qc),
-	})
+	seedPersistedInner(dir, utils.Some(qc), &persistedInner{})
 
 	// Load and verify
 	i, err := loadInner(t, dir, registry, keys)
 	require.NoError(t, err)
-	require.True(t, i.CommitQC.IsPresent(), "CommitQC should be loaded")
-	loadedQC, ok := i.CommitQC.Get()
+	require.True(t, i.spec.CommitQC.IsPresent(), "CommitQC should be loaded")
+	loadedQC, ok := i.spec.CommitQC.Get()
 	require.True(t, ok)
 	require.Equal(t, types.RoadIndex(5), loadedQC.Proposal().Index())
 	// View should be (6, 0) since CommitQC at index 5 advances to index 6
@@ -441,10 +440,7 @@ func TestNewInnerTimeoutQC(t *testing.T) {
 	}
 	timeoutQC := types.NewTimeoutQC(timeoutVotes)
 
-	seedPersistedInner(dir, &persistedInner{
-		CommitQC:  utils.Some(commitQC),
-		TimeoutQC: utils.Some(timeoutQC),
-	})
+	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{TimeoutQC: utils.Some(timeoutQC)})
 
 	// Load and verify
 	i, err := loadInner(t, dir, registry, keys)
@@ -466,7 +462,7 @@ func TestNewInnerTimeoutQCOnlyGenesis(t *testing.T) {
 	}
 	timeoutQC := types.NewTimeoutQC(timeoutVotes)
 
-	seedPersistedInner(dir, &persistedInner{
+	seedPersistedInner(dir, utils.None[*types.CommitQC](), &persistedInner{
 		TimeoutQC: utils.Some(timeoutQC),
 	})
 
@@ -489,7 +485,7 @@ func TestNewInnerTimeoutQCWithoutCommitQCError(t *testing.T) {
 	}
 	timeoutQC := types.NewTimeoutQC(timeoutVotes)
 
-	seedPersistedInner(dir, &persistedInner{
+	seedPersistedInner(dir, utils.None[*types.CommitQC](), &persistedInner{
 		TimeoutQC: utils.Some(timeoutQC),
 	})
 
@@ -520,10 +516,7 @@ func TestNewInnerTimeoutQCAheadOfCommitQCError(t *testing.T) {
 	}
 	timeoutQC := types.NewTimeoutQC(timeoutVotes)
 
-	seedPersistedInner(dir, &persistedInner{
-		CommitQC:  utils.Some(commitQC),
-		TimeoutQC: utils.Some(timeoutQC),
-	})
+	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{TimeoutQC: utils.Some(timeoutQC)})
 
 	// Should return error - TimeoutQC index must equal CommitQC.Index + 1
 	_, err := loadInner(t, dir, registry, keys)
@@ -553,10 +546,7 @@ func TestNewInnerViewSpecStaleTimeoutQC(t *testing.T) {
 	}
 	timeoutQC := types.NewTimeoutQC(timeoutVotes)
 
-	seedPersistedInner(dir, &persistedInner{
-		CommitQC:  utils.Some(commitQC),
-		TimeoutQC: utils.Some(timeoutQC),
-	})
+	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{TimeoutQC: utils.Some(timeoutQC)})
 
 	// Load - stale TimeoutQC should be treated as corrupt state
 	_, err := loadInner(t, dir, registry, keys)
@@ -585,15 +575,12 @@ func TestNewInnerViewSpecValidBothQCs(t *testing.T) {
 	}
 	timeoutQC := types.NewTimeoutQC(timeoutVotes)
 
-	seedPersistedInner(dir, &persistedInner{
-		CommitQC:  utils.Some(commitQC),
-		TimeoutQC: utils.Some(timeoutQC),
-	})
+	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{TimeoutQC: utils.Some(timeoutQC)})
 
 	// Load - both should be present
 	i, err := loadInner(t, dir, registry, keys)
 	require.NoError(t, err)
-	require.True(t, i.CommitQC.IsPresent(), "CommitQC should be loaded")
+	require.True(t, i.spec.CommitQC.IsPresent(), "CommitQC should be loaded")
 	require.True(t, i.TimeoutQC.IsPresent(), "TimeoutQC should be loaded")
 	// View should be (6, 3) - TimeoutQC at (6, 2) advances to (6, 3)
 	require.Equal(t, types.View{Index: 6, Number: 3}, i.View())
@@ -618,10 +605,7 @@ func TestNewInnerStaleVoteError(t *testing.T) {
 	staleProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 3, Number: 0})
 	staleVote := types.Sign(keys[0], types.NewPrepareVote(staleProposal))
 
-	seedPersistedInner(dir, &persistedInner{
-		CommitQC:    utils.Some(commitQC),
-		PrepareVote: utils.Some(staleVote),
-	})
+	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareVote: utils.Some(staleVote)})
 
 	_, err := loadInner(t, dir, registry, keys)
 	require.Error(t, err)
@@ -646,10 +630,7 @@ func TestNewInnerFuturePrepareVoteError(t *testing.T) {
 	futureProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 10, Number: 0})
 	futureVote := types.Sign(keys[0], types.NewPrepareVote(futureProposal))
 
-	seedPersistedInner(dir, &persistedInner{
-		CommitQC:    utils.Some(commitQC),
-		PrepareVote: utils.Some(futureVote),
-	})
+	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareVote: utils.Some(futureVote)})
 
 	// Should return error - future votes indicate corrupt state
 	_, err := loadInner(t, dir, registry, keys)
@@ -675,10 +656,7 @@ func TestNewInnerFutureCommitVoteError(t *testing.T) {
 	futureProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 10, Number: 0})
 	futureVote := types.Sign(keys[0], types.NewCommitVote(futureProposal))
 
-	seedPersistedInner(dir, &persistedInner{
-		CommitQC:   utils.Some(commitQC),
-		CommitVote: utils.Some(futureVote),
-	})
+	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{CommitVote: utils.Some(futureVote)})
 
 	// Should return error
 	_, err := loadInner(t, dir, registry, keys)
@@ -703,10 +681,7 @@ func TestNewInnerFutureTimeoutVoteError(t *testing.T) {
 	// Create future timeout vote at view (10, 0)
 	futureVote := types.NewFullTimeoutVote(keys[0], types.View{Index: 10, Number: 0}, utils.None[*types.PrepareQC]())
 
-	seedPersistedInner(dir, &persistedInner{
-		CommitQC:    utils.Some(commitQC),
-		TimeoutVote: utils.Some(futureVote),
-	})
+	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{TimeoutVote: utils.Some(futureVote)})
 
 	// Should return error
 	_, err := loadInner(t, dir, registry, keys)
@@ -732,10 +707,7 @@ func TestNewInnerCurrentViewVoteOk(t *testing.T) {
 	currentProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 6, Number: 0})
 	currentVote := types.Sign(keys[0], types.NewPrepareVote(currentProposal))
 
-	seedPersistedInner(dir, &persistedInner{
-		CommitQC:    utils.Some(commitQC),
-		PrepareVote: utils.Some(currentVote),
-	})
+	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareVote: utils.Some(currentVote)})
 
 	// Should succeed - current view votes are valid
 	i, err := loadInner(t, dir, registry, keys)
@@ -768,10 +740,7 @@ func TestNewInnerTimeoutQCInvalidSignatureError(t *testing.T) {
 	}
 	timeoutQC := types.NewTimeoutQC(timeoutVotes)
 
-	seedPersistedInner(dir, &persistedInner{
-		CommitQC:  utils.Some(commitQC),
-		TimeoutQC: utils.Some(timeoutQC),
-	})
+	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{TimeoutQC: utils.Some(timeoutQC)})
 
 	// Should return error - invalid signatures on TimeoutQC
 	_, err := loadInner(t, dir, registry, keys)
@@ -798,10 +767,7 @@ func TestNewInnerCurrentViewVoteInvalidSignatureError(t *testing.T) {
 	currentProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 6, Number: 0})
 	badVote := types.Sign(otherKey, types.NewPrepareVote(currentProposal))
 
-	seedPersistedInner(dir, &persistedInner{
-		CommitQC:    utils.Some(commitQC),
-		PrepareVote: utils.Some(badVote),
-	})
+	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareVote: utils.Some(badVote)})
 
 	// Should return error - current view votes must have valid signatures
 	_, err := loadInner(t, dir, registry, keys)
@@ -829,10 +795,7 @@ func TestNewInnerStaleVoteInvalidSignatureError(t *testing.T) {
 	staleProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 3, Number: 0})
 	badVote := types.Sign(otherKey, types.NewPrepareVote(staleProposal))
 
-	seedPersistedInner(dir, &persistedInner{
-		CommitQC:    utils.Some(commitQC),
-		PrepareVote: utils.Some(badVote),
-	})
+	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareVote: utils.Some(badVote)})
 
 	_, err := loadInner(t, dir, registry, keys)
 	require.Error(t, err)
@@ -848,7 +811,7 @@ func TestNewInnerPrepareQC(t *testing.T) {
 	proposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 0, Number: 0})
 	prepareQC := makePrepareQC(keys, proposal)
 
-	seedPersistedInner(dir, &persistedInner{
+	seedPersistedInner(dir, utils.None[*types.CommitQC](), &persistedInner{
 		PrepareQC: utils.Some(prepareQC),
 	})
 
@@ -877,10 +840,7 @@ func TestNewInnerStalePrepareQCError(t *testing.T) {
 	staleProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 3, Number: 0})
 	stalePrepareQC := makePrepareQC(keys, staleProposal)
 
-	seedPersistedInner(dir, &persistedInner{
-		CommitQC:  utils.Some(commitQC),
-		PrepareQC: utils.Some(stalePrepareQC),
-	})
+	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareQC: utils.Some(stalePrepareQC)})
 
 	_, err := loadInner(t, dir, registry, keys)
 	require.Error(t, err)
@@ -897,7 +857,7 @@ func TestNewInnerCommitVoteWithoutPrepareQCError(t *testing.T) {
 	proposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 0, Number: 0})
 	commitVote := types.Sign(keys[0], types.NewCommitVote(proposal))
 
-	seedPersistedInner(dir, &persistedInner{
+	seedPersistedInner(dir, utils.None[*types.CommitQC](), &persistedInner{
 		CommitVote: utils.Some(commitVote),
 	})
 
@@ -924,10 +884,7 @@ func TestNewInnerFuturePrepareQCError(t *testing.T) {
 	futureProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 10, Number: 0})
 	prepareQC := makePrepareQC(keys, futureProposal)
 
-	seedPersistedInner(dir, &persistedInner{
-		CommitQC:  utils.Some(commitQC),
-		PrepareQC: utils.Some(prepareQC),
-	})
+	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareQC: utils.Some(prepareQC)})
 
 	// Should return error - future prepareQC indicates corrupt state
 	_, err := loadInner(t, dir, registry, keys)
@@ -953,10 +910,7 @@ func TestNewInnerCurrentViewPrepareQCOk(t *testing.T) {
 	currentProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 6, Number: 0})
 	prepareQC := makePrepareQC(keys, currentProposal)
 
-	seedPersistedInner(dir, &persistedInner{
-		CommitQC:  utils.Some(commitQC),
-		PrepareQC: utils.Some(prepareQC),
-	})
+	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareQC: utils.Some(prepareQC)})
 
 	// Should succeed - current view prepareQC is valid
 	i, err := loadInner(t, dir, registry, keys)
@@ -986,10 +940,7 @@ func TestNewInnerCurrentViewPrepareQCInvalidSignatureError(t *testing.T) {
 	currentProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 6, Number: 0})
 	prepareQC := makePrepareQC(otherKeys, currentProposal)
 
-	seedPersistedInner(dir, &persistedInner{
-		CommitQC:  utils.Some(commitQC),
-		PrepareQC: utils.Some(prepareQC),
-	})
+	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareQC: utils.Some(prepareQC)})
 
 	// Should return error - current view prepareQC has invalid signatures
 	_, err := loadInner(t, dir, registry, keys)
@@ -1016,10 +967,7 @@ func TestNewInnerPrepareQCIncludedInTimeoutVote(t *testing.T) {
 	currentProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 6, Number: 0})
 	prepareQC := makePrepareQC(keys, currentProposal)
 
-	seedPersistedInner(dir, &persistedInner{
-		CommitQC:  utils.Some(commitQC),
-		PrepareQC: utils.Some(prepareQC),
-	})
+	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareQC: utils.Some(prepareQC)})
 
 	// Load state
 	i, err := loadInner(t, dir, registry, keys)
@@ -1065,8 +1013,7 @@ func TestPushTimeoutQCClearsStaleState(t *testing.T) {
 	commitVote := types.Sign(keys[0], types.NewCommitVote(currentProposal))
 	timeoutVote := types.NewFullTimeoutVote(keys[0], types.View{Index: 6, Number: 0}, utils.Some(prepareQC))
 
-	seedPersistedInner(dir, &persistedInner{
-		CommitQC:    utils.Some(commitQC),
+	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{
 		PrepareQC:   utils.Some(prepareQC),
 		PrepareVote: utils.Some(prepareVote),
 		CommitVote:  utils.Some(commitVote),
@@ -1090,7 +1037,10 @@ func TestPushTimeoutQCClearsStaleState(t *testing.T) {
 	timeoutQC := types.NewTimeoutQC(timeoutVotes)
 
 	// Simulate pushTimeoutQC's Update callback
-	newInner := inner{persistedInner: persistedInner{CommitQC: i.CommitQC, TimeoutQC: utils.Some(timeoutQC)}, epoch: i.epoch}
+	newInner := inner{
+		persistedInner: persistedInner{CommitQCIndex: i.CommitQCIndex, TimeoutQC: utils.Some(timeoutQC)},
+		spec:           i.spec,
+	}
 
 	// Verify: view advanced to (6, 1)
 	require.Equal(t, types.View{Index: 6, Number: 1}, newInner.View(), "view should advance to (6, 1)")
@@ -1161,19 +1111,19 @@ func TestPushCommitQC_RotatesEpochAtBoundary(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
 	s := newConsensusState(t, registry, keys[0])
-	require.Equal(t, types.EpochIndex(0), s.innerRecv.Load().epoch.EpochIndex())
+	require.Equal(t, types.EpochIndex(0), s.innerRecv.Load().spec.Epoch.EpochIndex())
 
 	ep0, ok := registry.EpochByIndex(0)
 	require.True(t, ok)
 	qc := commitQCAtRoad(ep0, keys, epoch.LastRoad(0))
 	require.Equal(t, epoch.LastRoad(0), qc.Proposal().Index())
 
-	// Avail resolves the next-view epoch; pushSpecFromAvail installs it verbatim.
+	// Avail resolves the next-view epoch; pushSpec installs it verbatim.
 	ep1, err := registry.EpochAt(epoch.FirstRoad(1))
 	require.NoError(t, err)
-	require.NoError(t, s.pushSpecFromAvail(types.ConsensusSpec{CommitQC: utils.Some(qc), Epoch: ep1}))
+	require.NoError(t, s.pushSpec(types.ConsensusSpec{CommitQC: utils.Some(qc), Epoch: ep1}))
 	got := s.innerRecv.Load()
-	require.Equal(t, types.EpochIndex(1), got.epoch.EpochIndex())
+	require.Equal(t, types.EpochIndex(1), got.spec.Epoch.EpochIndex())
 	require.Equal(t, epoch.FirstRoad(1), got.View().Index)
 }
 
@@ -1185,7 +1135,7 @@ func TestNewState_ErrAvailBehindConsensus(t *testing.T) {
 	ep0, ok := registry.EpochByIndex(0)
 	require.True(t, ok)
 	qc := commitQCAtRoad(ep0, keys, 3)
-	seedPersistedInner(dir, &persistedInner{CommitQC: utils.Some(qc)})
+	seedPersistedInner(dir, utils.Some(qc), &persistedInner{})
 
 	_, err := NewState(&Config{
 		Key:                keys[0],

--- a/sei-tendermint/internal/autobahn/consensus/inner_test.go
+++ b/sei-tendermint/internal/autobahn/consensus/inner_test.go
@@ -78,7 +78,7 @@ func loadInner(t *testing.T, dir string, registry *epoch.Registry, keys []types.
 	go func() { _ = utils.IgnoreCancel(av.Run(ctx)) }()
 
 	if p, ok := persisted.Get(); ok {
-		if idx := types.RoadIndex(p.GetCommitQcIndex()); idx > 0 {
+		if idx := types.RoadIndex(p.GetIndex()); idx > 0 {
 			if err := alignAvailToTip(ctx, t, av, registry, keys, idx-1); err != nil {
 				return inner{}, err
 			}

--- a/sei-tendermint/internal/autobahn/consensus/inner_test.go
+++ b/sei-tendermint/internal/autobahn/consensus/inner_test.go
@@ -154,7 +154,7 @@ func TestNewInner_RejectsWALAheadOfSpec(t *testing.T) {
 
 	last := epoch.LastRoad(0)
 	prev := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
-		types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep0, types.View{Index: last - 1, Number: 0}))),
+		types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep0, types.View{Index: last - 1, Number: 0}, ep0.FirstBlock()))),
 	})
 	qcLast := types.BuildCommitQC(ep0, keys, utils.Some(prev), nil)
 	require.Equal(t, last, qcLast.Index())
@@ -186,7 +186,7 @@ func TestNewInner_EqualTipKeepsVotes(t *testing.T) {
 
 	last := epoch.LastRoad(0)
 	prev := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
-		types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep0, types.View{Index: last - 1, Number: 0}))),
+		types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep0, types.View{Index: last - 1, Number: 0}, ep0.FirstBlock()))),
 	})
 	qcLast := types.BuildCommitQC(ep0, keys, utils.Some(prev), nil)
 
@@ -1149,7 +1149,7 @@ func newConsensusState(t *testing.T, registry *epoch.Registry, key types.SecretK
 
 func commitQCAtRoad(ep *types.Epoch, keys []types.SecretKey, idx types.RoadIndex) *types.CommitQC {
 	parent := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
-		types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep, types.View{Index: idx - 1, Number: 0}))),
+		types.Sign(keys[0], types.NewCommitVote(types.ProposalAt(ep, types.View{Index: idx - 1, Number: 0}, ep.FirstBlock()))),
 	})
 	qc := types.BuildCommitQC(ep, keys, utils.Some(parent), nil)
 	if qc.Proposal().Index() != idx {

--- a/sei-tendermint/internal/autobahn/consensus/inner_test.go
+++ b/sei-tendermint/internal/autobahn/consensus/inner_test.go
@@ -154,10 +154,8 @@ func TestNewInner_RejectsWALAheadOfSpec(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 4)
 	registry.AdvanceIfNeeded(epoch.LastRoad(0))
 
-	ep0, ok := registry.EpochByIndex(0)
-	require.True(t, ok)
-	ep1, ok := registry.EpochByIndex(1)
-	require.True(t, ok)
+	ep0 := registry.MustEpoch(0)
+	ep1 := registry.MustEpoch(1)
 
 	last := epoch.LastRoad(0)
 	prev := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
@@ -185,10 +183,8 @@ func TestNewInner_EqualTipKeepsVotes(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 4)
 	registry.AdvanceIfNeeded(epoch.LastRoad(0))
 
-	ep0, ok := registry.EpochByIndex(0)
-	require.True(t, ok)
-	ep1, ok := registry.EpochByIndex(1)
-	require.True(t, ok)
+	ep0 := registry.MustEpoch(0)
+	ep1 := registry.MustEpoch(1)
 
 	last := epoch.LastRoad(0)
 	prev := types.NewCommitQC([]*types.Signed[*types.CommitVote]{
@@ -282,7 +278,7 @@ func TestNewInnerPrepareVote(t *testing.T) {
 	// Create and persist a prepare vote at genesis view (0, 0)
 	registry, keys := epoch.GenRegistry(rng, 1)
 	key := keys[0]
-	genesisProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 0, Number: 0})
+	genesisProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 0, Number: 0})
 	vote := types.Sign(key, types.NewPrepareVote(genesisProposal))
 
 	seedPersistedInner(dir, utils.None[*types.CommitQC](), &persistedInner{
@@ -304,7 +300,7 @@ func TestNewInnerCommitVote(t *testing.T) {
 	// Create and persist a commit vote at genesis view (0, 0)
 	registry, keys := epoch.GenRegistry(rng, 1)
 	key := keys[0]
-	genesisProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 0, Number: 0})
+	genesisProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 0, Number: 0})
 	prepareQC := makePrepareQC([]types.SecretKey{key}, genesisProposal)
 	vote := types.Sign(key, types.NewCommitVote(genesisProposal))
 
@@ -349,7 +345,7 @@ func TestNewInnerAllVotes(t *testing.T) {
 	// Create all vote types at genesis view (0, 0)
 	registry, keys := epoch.GenRegistry(rng, 1)
 	key := keys[0]
-	genesisProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 0, Number: 0})
+	genesisProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 0, Number: 0})
 	prepareQC := makePrepareQC([]types.SecretKey{key}, genesisProposal)
 	prepareVote := types.Sign(key, types.NewPrepareVote(genesisProposal))
 	commitVote := types.Sign(key, types.NewCommitVote(genesisProposal))
@@ -377,7 +373,7 @@ func TestNewInnerPartialState(t *testing.T) {
 	// Only persist prepareVote
 	registry, keys := epoch.GenRegistry(rng, 1)
 	key := keys[0]
-	genesisProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 0, Number: 0})
+	genesisProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 0, Number: 0})
 	prepareVote := types.Sign(key, types.NewPrepareVote(genesisProposal))
 
 	seedPersistedInner(dir, utils.None[*types.CommitQC](), &persistedInner{
@@ -398,7 +394,7 @@ func TestNewInnerCommitQC(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 
 	// Create a CommitQC at index 5
-	proposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 5, Number: 0})
+	proposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
 	vote := types.NewCommitVote(proposal)
 	var votes []*types.Signed[*types.CommitVote]
 	for _, k := range keys {
@@ -425,7 +421,7 @@ func TestNewInnerTimeoutQC(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 
 	// Create a CommitQC at index 5 (required for TimeoutQC at index 6)
-	qcProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 5, Number: 0})
+	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
 	qcVote := types.NewCommitVote(qcProposal)
 	var qcVotes []*types.Signed[*types.CommitVote]
 	for _, k := range keys {
@@ -501,7 +497,7 @@ func TestNewInnerTimeoutQCAheadOfCommitQCError(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 
 	// Create CommitQC at index 5
-	qcProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 5, Number: 0})
+	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
 	qcVote := types.NewCommitVote(qcProposal)
 	var qcVotes []*types.Signed[*types.CommitVote]
 	for _, k := range keys {
@@ -530,7 +526,7 @@ func TestNewInnerViewSpecStaleTimeoutQC(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 
 	// Create CommitQC at index 10
-	qcProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 10, Number: 0})
+	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 10, Number: 0})
 	qcVote := types.NewCommitVote(qcProposal)
 	var qcVotes []*types.Signed[*types.CommitVote]
 	for _, k := range keys {
@@ -560,7 +556,7 @@ func TestNewInnerViewSpecValidBothQCs(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 
 	// Create CommitQC at index 5
-	qcProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 5, Number: 0})
+	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
 	qcVote := types.NewCommitVote(qcProposal)
 	var qcVotes []*types.Signed[*types.CommitVote]
 	for _, k := range keys {
@@ -592,7 +588,7 @@ func TestNewInnerStaleVoteError(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 
 	// Create CommitQC at index 5 -> current view is (6, 0)
-	qcProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 5, Number: 0})
+	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
 	qcVote := types.NewCommitVote(qcProposal)
 	var qcVotes []*types.Signed[*types.CommitVote]
 	for _, k := range keys {
@@ -602,7 +598,7 @@ func TestNewInnerStaleVoteError(t *testing.T) {
 
 	// Create stale vote at view (3, 0) - before current view (6, 0).
 	// Since inner is persisted atomically, a mismatched view is corrupt.
-	staleProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 3, Number: 0})
+	staleProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 3, Number: 0})
 	staleVote := types.Sign(keys[0], types.NewPrepareVote(staleProposal))
 
 	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareVote: utils.Some(staleVote)})
@@ -618,7 +614,7 @@ func TestNewInnerFuturePrepareVoteError(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 
 	// Create CommitQC at index 5 -> current view is (6, 0)
-	qcProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 5, Number: 0})
+	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
 	qcVote := types.NewCommitVote(qcProposal)
 	var qcVotes []*types.Signed[*types.CommitVote]
 	for _, k := range keys {
@@ -627,7 +623,7 @@ func TestNewInnerFuturePrepareVoteError(t *testing.T) {
 	commitQC := types.NewCommitQC(qcVotes)
 
 	// Create future vote at view (10, 0) - ahead of current view (6, 0)
-	futureProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 10, Number: 0})
+	futureProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 10, Number: 0})
 	futureVote := types.Sign(keys[0], types.NewPrepareVote(futureProposal))
 
 	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareVote: utils.Some(futureVote)})
@@ -644,7 +640,7 @@ func TestNewInnerFutureCommitVoteError(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 
 	// Create CommitQC at index 5 -> current view is (6, 0)
-	qcProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 5, Number: 0})
+	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
 	qcVote := types.NewCommitVote(qcProposal)
 	var qcVotes []*types.Signed[*types.CommitVote]
 	for _, k := range keys {
@@ -653,7 +649,7 @@ func TestNewInnerFutureCommitVoteError(t *testing.T) {
 	commitQC := types.NewCommitQC(qcVotes)
 
 	// Create future commit vote at view (10, 0)
-	futureProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 10, Number: 0})
+	futureProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 10, Number: 0})
 	futureVote := types.Sign(keys[0], types.NewCommitVote(futureProposal))
 
 	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{CommitVote: utils.Some(futureVote)})
@@ -670,7 +666,7 @@ func TestNewInnerFutureTimeoutVoteError(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 
 	// Create CommitQC at index 5 -> current view is (6, 0)
-	qcProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 5, Number: 0})
+	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
 	qcVote := types.NewCommitVote(qcProposal)
 	var qcVotes []*types.Signed[*types.CommitVote]
 	for _, k := range keys {
@@ -695,7 +691,7 @@ func TestNewInnerCurrentViewVoteOk(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 
 	// Create CommitQC at index 5 -> current view is (6, 0)
-	qcProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 5, Number: 0})
+	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
 	qcVote := types.NewCommitVote(qcProposal)
 	var qcVotes []*types.Signed[*types.CommitVote]
 	for _, k := range keys {
@@ -704,7 +700,7 @@ func TestNewInnerCurrentViewVoteOk(t *testing.T) {
 	commitQC := types.NewCommitQC(qcVotes)
 
 	// Create vote at exactly current view (6, 0)
-	currentProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 6, Number: 0})
+	currentProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 6, Number: 0})
 	currentVote := types.Sign(keys[0], types.NewPrepareVote(currentProposal))
 
 	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareVote: utils.Some(currentVote)})
@@ -721,7 +717,7 @@ func TestNewInnerTimeoutQCInvalidSignatureError(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 
 	// Create valid CommitQC at index 5
-	qcProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 5, Number: 0})
+	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
 	qcVote := types.NewCommitVote(qcProposal)
 	var qcVotes []*types.Signed[*types.CommitVote]
 	for _, k := range keys {
@@ -754,7 +750,7 @@ func TestNewInnerCurrentViewVoteInvalidSignatureError(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 
 	// Create valid CommitQC at index 5 -> current view is (6, 0)
-	qcProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 5, Number: 0})
+	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
 	qcVote := types.NewCommitVote(qcProposal)
 	var qcVotes []*types.Signed[*types.CommitVote]
 	for _, k := range keys {
@@ -764,7 +760,7 @@ func TestNewInnerCurrentViewVoteInvalidSignatureError(t *testing.T) {
 
 	// Create vote at current view (6, 0) but signed by key NOT in committee
 	otherKey := types.GenSecretKey(rng)
-	currentProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 6, Number: 0})
+	currentProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 6, Number: 0})
 	badVote := types.Sign(otherKey, types.NewPrepareVote(currentProposal))
 
 	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareVote: utils.Some(badVote)})
@@ -781,7 +777,7 @@ func TestNewInnerStaleVoteInvalidSignatureError(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 
 	// Create valid CommitQC at index 5 -> current view is (6, 0)
-	qcProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 5, Number: 0})
+	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
 	qcVote := types.NewCommitVote(qcProposal)
 	var qcVotes []*types.Signed[*types.CommitVote]
 	for _, k := range keys {
@@ -792,7 +788,7 @@ func TestNewInnerStaleVoteInvalidSignatureError(t *testing.T) {
 	// Create stale vote at (3, 0) signed by key NOT in committee.
 	// Since inner is persisted atomically, a mismatched view is corrupt.
 	otherKey := types.GenSecretKey(rng)
-	staleProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 3, Number: 0})
+	staleProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 3, Number: 0})
 	badVote := types.Sign(otherKey, types.NewPrepareVote(staleProposal))
 
 	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareVote: utils.Some(badVote)})
@@ -808,7 +804,7 @@ func TestNewInnerPrepareQC(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 
 	// Create prepareQC at genesis view (0, 0)
-	proposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 0, Number: 0})
+	proposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 0, Number: 0})
 	prepareQC := makePrepareQC(keys, proposal)
 
 	seedPersistedInner(dir, utils.None[*types.CommitQC](), &persistedInner{
@@ -827,7 +823,7 @@ func TestNewInnerStalePrepareQCError(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 
 	// Create CommitQC at index 5 -> current view is (6, 0)
-	qcProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 5, Number: 0})
+	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
 	qcVote := types.NewCommitVote(qcProposal)
 	var qcVotes []*types.Signed[*types.CommitVote]
 	for _, k := range keys {
@@ -837,7 +833,7 @@ func TestNewInnerStalePrepareQCError(t *testing.T) {
 
 	// Create stale prepareQC at view (3, 0) - before current view (6, 0).
 	// Since inner is persisted atomically, a mismatched view is corrupt.
-	staleProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 3, Number: 0})
+	staleProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 3, Number: 0})
 	stalePrepareQC := makePrepareQC(keys, staleProposal)
 
 	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareQC: utils.Some(stalePrepareQC)})
@@ -854,7 +850,7 @@ func TestNewInnerCommitVoteWithoutPrepareQCError(t *testing.T) {
 
 	// Current view is (0, 0) (no CommitQC or TimeoutQC).
 	// CommitVote requires PrepareQC justification.
-	proposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 0, Number: 0})
+	proposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 0, Number: 0})
 	commitVote := types.Sign(keys[0], types.NewCommitVote(proposal))
 
 	seedPersistedInner(dir, utils.None[*types.CommitQC](), &persistedInner{
@@ -872,7 +868,7 @@ func TestNewInnerFuturePrepareQCError(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 
 	// Create CommitQC at index 5 -> current view is (6, 0)
-	qcProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 5, Number: 0})
+	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
 	qcVote := types.NewCommitVote(qcProposal)
 	var qcVotes []*types.Signed[*types.CommitVote]
 	for _, k := range keys {
@@ -881,7 +877,7 @@ func TestNewInnerFuturePrepareQCError(t *testing.T) {
 	commitQC := types.NewCommitQC(qcVotes)
 
 	// Create future prepareQC at index 10 (> current 6)
-	futureProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 10, Number: 0})
+	futureProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 10, Number: 0})
 	prepareQC := makePrepareQC(keys, futureProposal)
 
 	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareQC: utils.Some(prepareQC)})
@@ -898,7 +894,7 @@ func TestNewInnerCurrentViewPrepareQCOk(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 
 	// Create CommitQC at index 5 -> current view is (6, 0)
-	qcProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 5, Number: 0})
+	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
 	qcVote := types.NewCommitVote(qcProposal)
 	var qcVotes []*types.Signed[*types.CommitVote]
 	for _, k := range keys {
@@ -907,7 +903,7 @@ func TestNewInnerCurrentViewPrepareQCOk(t *testing.T) {
 	commitQC := types.NewCommitQC(qcVotes)
 
 	// Create prepareQC at current view (6, 0)
-	currentProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 6, Number: 0})
+	currentProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 6, Number: 0})
 	prepareQC := makePrepareQC(keys, currentProposal)
 
 	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareQC: utils.Some(prepareQC)})
@@ -924,7 +920,7 @@ func TestNewInnerCurrentViewPrepareQCInvalidSignatureError(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 
 	// Create CommitQC at index 5 -> current view is (6, 0)
-	qcProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 5, Number: 0})
+	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
 	qcVote := types.NewCommitVote(qcProposal)
 	var qcVotes []*types.Signed[*types.CommitVote]
 	for _, k := range keys {
@@ -937,7 +933,7 @@ func TestNewInnerCurrentViewPrepareQCInvalidSignatureError(t *testing.T) {
 	for i := range otherKeys {
 		otherKeys[i] = types.GenSecretKey(rng)
 	}
-	currentProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 6, Number: 0})
+	currentProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 6, Number: 0})
 	prepareQC := makePrepareQC(otherKeys, currentProposal)
 
 	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareQC: utils.Some(prepareQC)})
@@ -955,7 +951,7 @@ func TestNewInnerPrepareQCIncludedInTimeoutVote(t *testing.T) {
 	voteKey := keys[0]
 
 	// Create CommitQC at index 5 -> current view is (6, 0)
-	qcProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 5, Number: 0})
+	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
 	qcVote := types.NewCommitVote(qcProposal)
 	var qcVotes []*types.Signed[*types.CommitVote]
 	for _, k := range keys {
@@ -964,7 +960,7 @@ func TestNewInnerPrepareQCIncludedInTimeoutVote(t *testing.T) {
 	commitQC := types.NewCommitQC(qcVotes)
 
 	// Create prepareQC at current view (6, 0)
-	currentProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 6, Number: 0})
+	currentProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 6, Number: 0})
 	prepareQC := makePrepareQC(keys, currentProposal)
 
 	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareQC: utils.Some(prepareQC)})
@@ -979,7 +975,7 @@ func TestNewInnerPrepareQCIncludedInTimeoutVote(t *testing.T) {
 	timeoutVote := types.NewFullTimeoutVote(voteKey, currentView, i.PrepareQC)
 
 	// The timeoutVote should pass verification (which checks prepareQC is correctly included)
-	err = timeoutVote.Verify(registry.LatestEpoch())
+	err = timeoutVote.Verify(registry.MustEpoch(0))
 	require.NoError(t, err, "timeoutVote with loaded prepareQC should verify")
 
 	// Verify the loaded prepareQC matches what we persisted
@@ -996,7 +992,7 @@ func TestPushTimeoutQCClearsStaleState(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 
 	// Setup: Create CommitQC at index 5 -> current view is (6, 0)
-	qcProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 5, Number: 0})
+	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
 	qcVote := types.NewCommitVote(qcProposal)
 	var qcVotes []*types.Signed[*types.CommitVote]
 	for _, k := range keys {
@@ -1005,7 +1001,7 @@ func TestPushTimeoutQCClearsStaleState(t *testing.T) {
 	commitQC := types.NewCommitQC(qcVotes)
 
 	// Setup: Create prepareQC at current view (6, 0)
-	currentProposal := types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 6, Number: 0})
+	currentProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 6, Number: 0})
 	prepareQC := makePrepareQC(keys, currentProposal)
 
 	// Setup: Create votes at current view (6, 0)
@@ -1113,8 +1109,7 @@ func TestPushCommitQC_RotatesEpochAtBoundary(t *testing.T) {
 	s := newConsensusState(t, registry, keys[0])
 	require.Equal(t, types.EpochIndex(0), s.innerRecv.Load().spec.Epoch.EpochIndex())
 
-	ep0, ok := registry.EpochByIndex(0)
-	require.True(t, ok)
+	ep0 := registry.MustEpoch(0)
 	qc := commitQCAtRoad(ep0, keys, epoch.LastRoad(0))
 	require.Equal(t, epoch.LastRoad(0), qc.Proposal().Index())
 
@@ -1132,8 +1127,7 @@ func TestNewState_ErrAvailBehindConsensus(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 4)
 	dir := t.TempDir()
 
-	ep0, ok := registry.EpochByIndex(0)
-	require.True(t, ok)
+	ep0 := registry.MustEpoch(0)
 	qc := commitQCAtRoad(ep0, keys, 3)
 	seedPersistedInner(dir, utils.Some(qc), &persistedInner{})
 

--- a/sei-tendermint/internal/autobahn/consensus/inner_test.go
+++ b/sei-tendermint/internal/autobahn/consensus/inner_test.go
@@ -45,8 +45,8 @@ func newTestAvail(t *testing.T, registry *epoch.Registry, key types.SecretKey) (
 	return ds, av
 }
 
-// seedPersistedInner persists view-local WAL state. tip is recorded as CommitQCIndex
-// for ErrAvailBehindConsensus comparison on restore; runtime CommitQC comes from avail.
+// seedPersistedInner persists view-local WAL state. The WAL records the current
+// view Index (NextIndexOpt of tip) for ErrAvailBehindConsensus on restore.
 func seedPersistedInner(dir string, tip utils.Option[*types.CommitQC], state *persistedInner) {
 	p, _, err := persist.NewPersister[*pb.PersistedInner](utils.Some(dir), innerFile)
 	if err != nil {
@@ -59,11 +59,7 @@ func seedPersistedInner(dir string, tip utils.Option[*types.CommitQC], state *pe
 
 func encodeWal(tip utils.Option[*types.CommitQC], state *persistedInner) *pb.PersistedInner {
 	s := *state
-	if cqc, ok := tip.Get(); ok {
-		s.CommitQCIndex = utils.Some(cqc.Index())
-	} else {
-		s.CommitQCIndex = utils.None[types.RoadIndex]()
-	}
+	s.Index = types.NextIndexOpt(tip)
 	return innerProtoConv.Encode(&s)
 }
 
@@ -82,18 +78,18 @@ func loadInner(t *testing.T, dir string, registry *epoch.Registry, keys []types.
 	go func() { _ = utils.IgnoreCancel(av.Run(ctx)) }()
 
 	if p, ok := persisted.Get(); ok {
-		if tipIdx := walTipIndex(p); tipIdx > 0 {
-			if err := alignAvailToTip(ctx, t, av, registry, keys, tipIdx-1); err != nil {
+		if idx := types.RoadIndex(p.GetCommitQcIndex()); idx > 0 {
+			if err := alignAvailToTip(ctx, t, av, registry, keys, idx-1); err != nil {
 				return inner{}, err
 			}
 		}
 	}
-	return newInner(persisted, av.SubscribeConsensusSpec().Load())
+	return newInner(persisted, av.SubscribeConsensusSpec().Load(), keys[0].Public())
 }
 
 // alignAvailToTip pushes CommitQCs 0..tipIndex through avail and waits until
-// that tip is durable. The QCs are freshly built for the registry — the tip
-// CommitQC used at restore comes from ConsensusSpec, not the WAL.
+// ConsensusSpec covers that tip. The QCs are freshly built for the registry —
+// the tip CommitQC used at restore comes from ConsensusSpec, not the WAL.
 // Callers must keep tipIndex small — EpochLength boundaries are not replayed
 // in unit tests.
 func alignAvailToTip(
@@ -119,9 +115,10 @@ func alignAvailToTip(
 		}
 		prev = utils.Some(qc)
 	}
-	_, err := av.LastCommitQC().Wait(ctx, func(o utils.Option[*types.CommitQC]) bool {
-		c, ok := o.Get()
-		return ok && c.Index() >= tipIndex
+	// Wait on ConsensusSpec, not LastCommitQC: markCommitQCsPersisted stores the
+	// durable tip then refreshes spec, so LastCommitQC can become visible first.
+	_, err := av.SubscribeConsensusSpec().Wait(ctx, func(sp types.ConsensusSpec) bool {
+		return sp.Index() > tipIndex
 	})
 	return err
 }
@@ -139,7 +136,7 @@ func TestNewInnerEmpty(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 1)
 	_, av := newTestAvail(t, registry, keys[0])
-	i, err := newInner(utils.None[*pb.PersistedInner](), av.SubscribeConsensusSpec().Load())
+	i, err := newInner(utils.None[*pb.PersistedInner](), av.SubscribeConsensusSpec().Load(), keys[0].Public())
 	require.NoError(t, err)
 	require.False(t, i.PrepareVote.IsPresent(), "prepareVote should be None")
 	require.False(t, i.CommitVote.IsPresent(), "commitVote should be None")
@@ -148,7 +145,7 @@ func TestNewInnerEmpty(t *testing.T) {
 }
 
 // TestNewInner_RejectsWALAheadOfSpec: after avail catch-up, ConsensusSpec must
-// cover the WAL tip. A WAL tip ahead of the spec is a failed catch-up.
+// cover the WAL. A WAL Index ahead of the spec is a failed catch-up.
 func TestNewInner_RejectsWALAheadOfSpec(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
@@ -172,7 +169,7 @@ func TestNewInner_RejectsWALAheadOfSpec(t *testing.T) {
 	persisted := persistedInner{PrepareVote: utils.Some(vote)}
 
 	genesis := types.ConsensusSpec{CommitQC: utils.None[*types.CommitQC](), Epoch: ep0}
-	_, err := newInner(utils.Some(encodeWal(persistedTip, &persisted)), genesis)
+	_, err := newInner(utils.Some(encodeWal(persistedTip, &persisted)), genesis, keys[0].Public())
 	require.ErrorIs(t, err, ErrAvailBehindConsensus)
 }
 
@@ -199,7 +196,7 @@ func TestNewInner_EqualTipKeepsVotes(t *testing.T) {
 	persisted := persistedInner{PrepareVote: utils.Some(vote)}
 	spec := types.ConsensusSpec{CommitQC: utils.Some(qcLast), Epoch: ep1}
 
-	i, err := newInner(utils.Some(encodeWal(persistedTip, &persisted)), spec)
+	i, err := newInner(utils.Some(encodeWal(persistedTip, &persisted)), spec, keys[0].Public())
 	require.NoError(t, err)
 	require.Equal(t, last+1, i.View().Index)
 	require.Equal(t, types.EpochIndex(1), i.spec.Epoch.EpochIndex())
@@ -262,7 +259,7 @@ func TestRestore_BoundaryCatchUpSpecCoversWAL(t *testing.T) {
 	persistedTip := spec.CommitQC
 	persisted := persistedInner{PrepareVote: utils.Some(vote)}
 
-	i, err := newInner(utils.Some(encodeWal(persistedTip, &persisted)), spec)
+	i, err := newInner(utils.Some(encodeWal(persistedTip, &persisted)), spec, keys[0].Public())
 	require.NoError(t, err)
 	require.Equal(t, last+1, i.View().Index)
 	require.Equal(t, types.EpochIndex(1), i.spec.Epoch.EpochIndex())
@@ -771,6 +768,47 @@ func TestNewInnerCurrentViewVoteInvalidSignatureError(t *testing.T) {
 	require.Contains(t, err.Error(), "corrupt persisted state")
 }
 
+func TestNewInnerVoteFromOtherReplicaError(t *testing.T) {
+	rng := utils.TestRng()
+	dir := t.TempDir()
+	registry, keys := epoch.GenRegistry(rng, 3)
+
+	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
+	qcVote := types.NewCommitVote(qcProposal)
+	var qcVotes []*types.Signed[*types.CommitVote]
+	for _, k := range keys {
+		qcVotes = append(qcVotes, types.Sign(k, qcVote))
+	}
+	commitQC := types.NewCommitQC(qcVotes)
+
+	currentProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 6, Number: 0})
+	otherReplica := types.Sign(keys[1], types.NewPrepareVote(currentProposal))
+	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{PrepareVote: utils.Some(otherReplica)})
+
+	_, err := loadInner(t, dir, registry, keys)
+	require.Error(t, err)
+}
+
+func TestNewInnerTimeoutVoteFromOtherReplicaError(t *testing.T) {
+	rng := utils.TestRng()
+	dir := t.TempDir()
+	registry, keys := epoch.GenRegistry(rng, 3)
+
+	qcProposal := types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 5, Number: 0})
+	qcVote := types.NewCommitVote(qcProposal)
+	var qcVotes []*types.Signed[*types.CommitVote]
+	for _, k := range keys {
+		qcVotes = append(qcVotes, types.Sign(k, qcVote))
+	}
+	commitQC := types.NewCommitQC(qcVotes)
+
+	otherReplica := types.NewFullTimeoutVote(keys[1], types.View{Index: 6, Number: 0}, utils.None[*types.PrepareQC]())
+	seedPersistedInner(dir, utils.Some(commitQC), &persistedInner{TimeoutVote: utils.Some(otherReplica)})
+
+	_, err := loadInner(t, dir, registry, keys)
+	require.Error(t, err)
+}
+
 func TestNewInnerStaleVoteInvalidSignatureError(t *testing.T) {
 	rng := utils.TestRng()
 	dir := t.TempDir()
@@ -1034,7 +1072,7 @@ func TestPushTimeoutQCClearsStaleState(t *testing.T) {
 
 	// Simulate pushTimeoutQC's Update callback
 	newInner := inner{
-		persistedInner: persistedInner{CommitQCIndex: i.CommitQCIndex, TimeoutQC: utils.Some(timeoutQC)},
+		persistedInner: persistedInner{Index: i.Index, TimeoutQC: utils.Some(timeoutQC)},
 		spec:           i.spec,
 	}
 

--- a/sei-tendermint/internal/autobahn/consensus/inner_test.go
+++ b/sei-tendermint/internal/autobahn/consensus/inner_test.go
@@ -213,7 +213,7 @@ func TestNewInner_EqualTipKeepsVotes(t *testing.T) {
 }
 
 // TestRestore_BoundaryCatchUpSpecCoversWAL is the restart invariant blind-Spec
-// trust depends on. After avail catch-up installs epoch 1 at the LastRoad(0)
+// trust depends on. After avail catch-up advances epoch 1 at the LastRoad(0)
 // tip, ConsensusSpec must republish that tip so a WAL at the same tip restores
 // without ErrAvailBehindConsensus and keeps anti-equivocation votes.
 func TestRestore_BoundaryCatchUpSpecCoversWAL(t *testing.T) {
@@ -1118,7 +1118,7 @@ func TestPushCommitQC_RotatesEpochAtBoundary(t *testing.T) {
 	qc := commitQCAtRoad(ep0, keys, epoch.LastRoad(0))
 	require.Equal(t, epoch.LastRoad(0), qc.Proposal().Index())
 
-	// Avail resolves the next-view epoch; pushSpec installs it verbatim.
+	// Avail resolves the next-view epoch; pushSpec advances to it verbatim.
 	ep1, err := registry.EpochAt(epoch.FirstRoad(1))
 	require.NoError(t, err)
 	require.NoError(t, s.pushSpec(types.ConsensusSpec{CommitQC: utils.Some(qc), Epoch: ep1}))

--- a/sei-tendermint/internal/autobahn/consensus/inner_test.go
+++ b/sei-tendermint/internal/autobahn/consensus/inner_test.go
@@ -228,8 +228,8 @@ func TestRestore_BoundaryCatchUpSpecCoversWAL(t *testing.T) {
 		s.SpawnBgNamed("avail.Run", func() error {
 			return utils.IgnoreCancel(av.Run(ctx))
 		})
-		if err := avail.DriveAdvance(ctx, av, keys, 1); err != nil {
-			return fmt.Errorf("DriveAdvance: %w", err)
+		if err := avail.TestDriveAdvance(ctx, av, keys, 1); err != nil {
+			return fmt.Errorf("TestDriveAdvance: %w", err)
 		}
 		if _, err := av.LastCommitQC().Wait(ctx, func(o utils.Option[*types.CommitQC]) bool {
 			c, ok := o.Get()

--- a/sei-tendermint/internal/autobahn/consensus/persist/commitqcs_test.go
+++ b/sei-tendermint/internal/autobahn/consensus/persist/commitqcs_test.go
@@ -62,7 +62,7 @@ func TestNewCommitQCPersisterEmptyDir(t *testing.T) {
 func TestPersistCommitQCAndLoad(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
-	committee := registry.LatestEpoch().Committee()
+	committee := registry.MustEpoch(0).Committee()
 	dir := t.TempDir()
 
 	qcs := makeSequentialCommitQCs(committee, keys, 3)
@@ -89,7 +89,7 @@ func TestPersistCommitQCAndLoad(t *testing.T) {
 func TestCommitQCDeleteBeforeRemovesOldKeepsNew(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
-	committee := registry.LatestEpoch().Committee()
+	committee := registry.MustEpoch(0).Committee()
 	dir := t.TempDir()
 
 	qcs := makeSequentialCommitQCs(committee, keys, 5)
@@ -111,7 +111,7 @@ func TestCommitQCDeleteBeforeRemovesOldKeepsNew(t *testing.T) {
 func TestCommitQCDeleteBeforeZero(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
-	committee := registry.LatestEpoch().Committee()
+	committee := registry.MustEpoch(0).Committee()
 	dir := t.TempDir()
 
 	qcs := makeSequentialCommitQCs(committee, keys, 3)
@@ -136,7 +136,7 @@ func TestCommitQCDeleteBeforeZero(t *testing.T) {
 func TestCommitQCPersistDuplicateIsNoOp(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
-	committee := registry.LatestEpoch().Committee()
+	committee := registry.MustEpoch(0).Committee()
 	dir := t.TempDir()
 
 	qcs := makeSequentialCommitQCs(committee, keys, 3)
@@ -154,7 +154,7 @@ func TestCommitQCPersistDuplicateIsNoOp(t *testing.T) {
 func TestCommitQCPersistGapRejected(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
-	committee := registry.LatestEpoch().Committee()
+	committee := registry.MustEpoch(0).Committee()
 	dir := t.TempDir()
 
 	qcs := makeSequentialCommitQCs(committee, keys, 5)
@@ -176,7 +176,7 @@ func TestCommitQCPersistGapRejected(t *testing.T) {
 func TestLoadAllDropsCommitQCsBehindGap(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
-	committee := registry.LatestEpoch().Committee()
+	committee := registry.MustEpoch(0).Committee()
 	dir := t.TempDir()
 
 	// Build 3 sequential CommitQCs (indices 0, 1, 2).
@@ -201,7 +201,7 @@ func TestLoadAllDropsCommitQCsBehindGap(t *testing.T) {
 func TestNoOpCommitQCPersister(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
-	committee := registry.LatestEpoch().Committee()
+	committee := registry.MustEpoch(0).Committee()
 	qcs := makeSequentialCommitQCs(committee, keys, 11)
 
 	// Fresh no-op persister: persist sequential QCs and track Next.
@@ -222,7 +222,7 @@ func TestNoOpCommitQCPersister(t *testing.T) {
 func TestCommitQCDeleteBeforePastAll(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
-	committee := registry.LatestEpoch().Committee()
+	committee := registry.MustEpoch(0).Committee()
 	dir := t.TempDir()
 
 	qcs := makeSequentialCommitQCs(committee, keys, 12)
@@ -253,7 +253,7 @@ func TestCommitQCDeleteBeforePastAll(t *testing.T) {
 func TestCommitQCDeleteBeforePastAllCrashRecovery(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
-	committee := registry.LatestEpoch().Committee()
+	committee := registry.MustEpoch(0).Committee()
 	dir := t.TempDir()
 
 	qcs := makeSequentialCommitQCs(committee, keys, 12)
@@ -291,7 +291,7 @@ func TestCommitQCDeleteBeforePastAllCrashRecovery(t *testing.T) {
 func TestCommitQCDeleteBeforeWithAnchorRecovers(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
-	committee := registry.LatestEpoch().Committee()
+	committee := registry.MustEpoch(0).Committee()
 	dir := t.TempDir()
 
 	qcs := makeSequentialCommitQCs(committee, keys, 5)
@@ -320,7 +320,7 @@ func TestCommitQCDeleteBeforeWithAnchorRecovers(t *testing.T) {
 func TestCommitQCDeleteBeforeThenPersistMore(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
-	committee := registry.LatestEpoch().Committee()
+	committee := registry.MustEpoch(0).Committee()
 	dir := t.TempDir()
 
 	qcs := makeSequentialCommitQCs(committee, keys, 6)
@@ -345,7 +345,7 @@ func TestCommitQCDeleteBeforeThenPersistMore(t *testing.T) {
 func TestCommitQCDeleteBeforeAlreadyPruned(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
-	committee := registry.LatestEpoch().Committee()
+	committee := registry.MustEpoch(0).Committee()
 	dir := t.TempDir()
 
 	qcs := makeSequentialCommitQCs(committee, keys, 5)
@@ -373,7 +373,7 @@ func TestCommitQCDeleteBeforeAlreadyPruned(t *testing.T) {
 func TestCommitQCProgressiveDeleteBefore(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
-	committee := registry.LatestEpoch().Committee()
+	committee := registry.MustEpoch(0).Committee()
 	dir := t.TempDir()
 
 	qcs := makeSequentialCommitQCs(committee, keys, 8)

--- a/sei-tendermint/internal/autobahn/consensus/persisted_inner.go
+++ b/sei-tendermint/internal/autobahn/consensus/persisted_inner.go
@@ -15,10 +15,12 @@ import (
 // # What We Persist
 //
 // All fields are persisted atomically in a single A/B file pair (inner_a.pb/inner_b.pb):
-//   - CommitQC: justified entering the current index
+//   - CommitQCIndex: tip road index used to validate the WAL against ConsensusSpec
 //   - PrepareQC: needed for timeoutVote on restart
 //   - TimeoutQC: justified entering the current view number
 //   - CommitVote, PrepareVote, TimeoutVote: this node's votes for the current view
+//
+// Runtime CommitQC + next-view epoch live on inner.spec (ConsensusSpec), not here.
 //
 // # Why We Persist
 //
@@ -56,36 +58,54 @@ import (
 //   - Votes (prepareVote, commitVote, timeoutVote): YES — rebroadcast via sendUpdates
 //   - TimeoutQC: YES — rebroadcast via myTimeoutQC watch
 //   - CommitQC: NO — used locally for view justification but not rebroadcast;
-//     CommitQCs are served via StreamCommitQCs from the data layer, not from
-//     the persisted viewSpec. TODO: consider rebroadcasting CommitQC on restart
-//     to help peers sync faster after cluster-wide outages.
+//     the runtime tip comes from ConsensusSpec, while the WAL stores only
+//     CommitQCIndex. CommitQCs are served via StreamCommitQCs from the data
+//     layer. TODO: consider rebroadcasting CommitQC on restart to help peers
+//     sync faster after cluster-wide outages.
 type persistedInner struct {
-	CommitQC  utils.Option[*types.CommitQC]
-	PrepareQC utils.Option[*types.PrepareQC]
-	TimeoutQC utils.Option[*types.TimeoutQC]
+	CommitQCIndex utils.Option[types.RoadIndex]
+	PrepareQC     utils.Option[*types.PrepareQC]
+	TimeoutQC     utils.Option[*types.TimeoutQC]
 
 	CommitVote  utils.Option[*types.Signed[*types.CommitVote]]
 	PrepareVote utils.Option[*types.Signed[*types.PrepareVote]]
 	TimeoutVote utils.Option[*types.FullTimeoutVote]
 }
 
+// commitQCIndex returns the tip road index carried by spec, if any.
+func commitQCIndex(spec types.ConsensusSpec) utils.Option[types.RoadIndex] {
+	if cqc, ok := spec.CommitQC.Get(); ok {
+		return utils.Some(cqc.Index())
+	}
+	return utils.None[types.RoadIndex]()
+}
+
+// nextIndexOpt returns Index+1 of idx, or 0 if absent (same as types.NextIndexOpt for a tip).
+func nextIndexOpt(idx utils.Option[types.RoadIndex]) types.RoadIndex {
+	if i, ok := idx.Get(); ok {
+		return i + 1
+	}
+	return 0
+}
+
 // validate checks internal consistency and cryptographic signatures of persisted state.
-// Returns error on corrupt state.
-func (p *persistedInner) validate(ep *types.Epoch) error {
+// Returns error on corrupt state. CommitQCIndex is checked against spec by newInner first.
+func (p *persistedInner) validate(spec types.ConsensusSpec) error {
+	ep := spec.Epoch
 	// TimeoutQC index must equal NextIndexOpt(CommitQC) (i.e., CommitQC.Index+1, or 0 if missing).
 	// Since we persist the entire inner state atomically, a mismatched index is always corrupt.
 	if tqc, ok := p.TimeoutQC.Get(); ok {
 		tqcIndex := tqc.View().Index
-		expectedIndex := types.NextIndexOpt(p.CommitQC)
+		expectedIndex := types.NextIndexOpt(spec.CommitQC)
 		if tqcIndex != expectedIndex {
 			return fmt.Errorf("corrupt persisted state: TimeoutQC has index %d but expected %d", tqcIndex, expectedIndex)
 		}
-		if err := tqc.Verify(ep, p.CommitQC); err != nil {
+		if err := tqc.Verify(ep, spec.CommitQC); err != nil {
 			return fmt.Errorf("corrupt persisted state: TimeoutQC failed verification: %w", err)
 		}
 	}
 
-	vs := types.ViewSpec{CommitQC: p.CommitQC, TimeoutQC: p.TimeoutQC, Epoch: ep}
+	vs := types.ViewSpec{CommitQC: spec.CommitQC, TimeoutQC: p.TimeoutQC, Epoch: ep}
 	currentView := vs.View()
 	committee := ep.Committee()
 
@@ -134,12 +154,21 @@ func verifyReplicaSig[T types.Msg](c *types.Committee, v *types.Signed[T]) error
 	return v.VerifySig()
 }
 
+// walTipIndex returns NextIndexOpt of the tip recorded in the WAL, if any.
+func walTipIndex(p *pb.PersistedInner) types.RoadIndex {
+	if p == nil || p.CommitQcIndex == nil {
+		return 0
+	}
+	return types.RoadIndex(*p.CommitQcIndex) + 1
+}
+
 // innerProtoConv is a protobuf converter for persistedInner.
 var innerProtoConv = protoutils.Conv[*persistedInner, *pb.PersistedInner]{
 	Encode: func(m *persistedInner) *pb.PersistedInner {
 		p := &pb.PersistedInner{}
-		if v, ok := m.CommitQC.Get(); ok {
-			p.CommitQc = types.CommitQCConv.Encode(v)
+		if idx, ok := m.CommitQCIndex.Get(); ok {
+			v := uint64(idx)
+			p.CommitQcIndex = &v
 		}
 		if v, ok := m.PrepareQC.Get(); ok {
 			p.PrepareQc = types.PrepareQCConv.Encode(v)
@@ -160,12 +189,8 @@ var innerProtoConv = protoutils.Conv[*persistedInner, *pb.PersistedInner]{
 	},
 	Decode: func(p *pb.PersistedInner) (*persistedInner, error) {
 		m := &persistedInner{}
-		if p.CommitQc != nil {
-			v, err := types.CommitQCConv.Decode(p.CommitQc)
-			if err != nil {
-				return nil, fmt.Errorf("commit_qc: %w", err)
-			}
-			m.CommitQC = utils.Some(v)
+		if p.CommitQcIndex != nil {
+			m.CommitQCIndex = utils.Some(types.RoadIndex(*p.CommitQcIndex))
 		}
 		if p.PrepareQc != nil {
 			v, err := types.PrepareQCConv.Decode(p.PrepareQc)

--- a/sei-tendermint/internal/autobahn/consensus/persisted_inner.go
+++ b/sei-tendermint/internal/autobahn/consensus/persisted_inner.go
@@ -72,12 +72,6 @@ type persistedInner struct {
 // validate checks internal consistency and cryptographic signatures of persisted state.
 // Returns error on corrupt state.
 func (p *persistedInner) validate(ep *types.Epoch) error {
-	if cqc, ok := p.CommitQC.Get(); ok {
-		if err := cqc.Verify(ep); err != nil {
-			return fmt.Errorf("corrupt persisted state: CommitQC failed verification: %w", err)
-		}
-	}
-
 	// TimeoutQC index must equal NextIndexOpt(CommitQC) (i.e., CommitQC.Index+1, or 0 if missing).
 	// Since we persist the entire inner state atomically, a mismatched index is always corrupt.
 	if tqc, ok := p.TimeoutQC.Get(); ok {

--- a/sei-tendermint/internal/autobahn/consensus/persisted_inner.go
+++ b/sei-tendermint/internal/autobahn/consensus/persisted_inner.go
@@ -152,7 +152,7 @@ var innerProtoConv = protoutils.Conv[*persistedInner, *pb.PersistedInner]{
 		p := &pb.PersistedInner{}
 		if m.Index != 0 {
 			v := uint64(m.Index)
-			p.CommitQcIndex = &v
+			p.Index = &v
 		}
 		if v, ok := m.PrepareQC.Get(); ok {
 			p.PrepareQc = types.PrepareQCConv.Encode(v)
@@ -173,8 +173,8 @@ var innerProtoConv = protoutils.Conv[*persistedInner, *pb.PersistedInner]{
 	},
 	Decode: func(p *pb.PersistedInner) (*persistedInner, error) {
 		m := &persistedInner{}
-		if p.CommitQcIndex != nil {
-			m.Index = types.RoadIndex(*p.CommitQcIndex)
+		if p.Index != nil {
+			m.Index = types.RoadIndex(*p.Index)
 		}
 		if p.PrepareQc != nil {
 			v, err := types.PrepareQCConv.Decode(p.PrepareQc)

--- a/sei-tendermint/internal/autobahn/consensus/persisted_inner.go
+++ b/sei-tendermint/internal/autobahn/consensus/persisted_inner.go
@@ -110,12 +110,12 @@ func (p *persistedInner) validate(ep *types.Epoch) error {
 		return fmt.Errorf("corrupt persisted state: CommitVote present without PrepareQC")
 	}
 	if v, ok := p.CommitVote.Get(); ok {
-		if err := checkViewAndSig("CommitVote", v.Msg().Proposal().View(), v.VerifySig(committee)); err != nil {
+		if err := checkViewAndSig("CommitVote", v.Msg().Proposal().View(), verifyReplicaSig(committee, v)); err != nil {
 			return err
 		}
 	}
 	if v, ok := p.PrepareVote.Get(); ok {
-		if err := checkViewAndSig("PrepareVote", v.Msg().Proposal().View(), v.VerifySig(committee)); err != nil {
+		if err := checkViewAndSig("PrepareVote", v.Msg().Proposal().View(), verifyReplicaSig(committee, v)); err != nil {
 			return err
 		}
 	}
@@ -125,6 +125,13 @@ func (p *persistedInner) validate(ep *types.Epoch) error {
 		}
 	}
 	return nil
+}
+
+func verifyReplicaSig[T types.Msg](c *types.Committee, v *types.Signed[T]) error {
+	if !c.HasReplica(v.Key()) {
+		return fmt.Errorf("%q is not a replica", v.Key())
+	}
+	return v.VerifySig()
 }
 
 // innerProtoConv is a protobuf converter for persistedInner.

--- a/sei-tendermint/internal/autobahn/consensus/persisted_inner.go
+++ b/sei-tendermint/internal/autobahn/consensus/persisted_inner.go
@@ -15,7 +15,7 @@ import (
 // # What We Persist
 //
 // All fields are persisted atomically in a single A/B file pair (inner_a.pb/inner_b.pb):
-//   - CommitQCIndex: tip road index used to validate the WAL against ConsensusSpec
+//   - Index: current view RoadIndex used to validate the WAL against ConsensusSpec
 //   - PrepareQC: needed for timeoutVote on restart
 //   - TimeoutQC: justified entering the current view number
 //   - CommitVote, PrepareVote, TimeoutVote: this node's votes for the current view
@@ -59,44 +59,30 @@ import (
 //   - TimeoutQC: YES — rebroadcast via myTimeoutQC watch
 //   - CommitQC: NO — used locally for view justification but not rebroadcast;
 //     the runtime tip comes from ConsensusSpec, while the WAL stores only
-//     CommitQCIndex. CommitQCs are served via StreamCommitQCs from the data
+//     Index. CommitQCs are served via StreamCommitQCs from the data
 //     layer. TODO: consider rebroadcasting CommitQC on restart to help peers
 //     sync faster after cluster-wide outages.
 type persistedInner struct {
-	CommitQCIndex utils.Option[types.RoadIndex]
-	PrepareQC     utils.Option[*types.PrepareQC]
-	TimeoutQC     utils.Option[*types.TimeoutQC]
+	Index     types.RoadIndex
+	PrepareQC utils.Option[*types.PrepareQC]
+	TimeoutQC utils.Option[*types.TimeoutQC]
 
 	CommitVote  utils.Option[*types.Signed[*types.CommitVote]]
 	PrepareVote utils.Option[*types.Signed[*types.PrepareVote]]
 	TimeoutVote utils.Option[*types.FullTimeoutVote]
 }
 
-// commitQCIndex returns the tip road index carried by spec, if any.
-func commitQCIndex(spec types.ConsensusSpec) utils.Option[types.RoadIndex] {
-	if cqc, ok := spec.CommitQC.Get(); ok {
-		return utils.Some(cqc.Index())
-	}
-	return utils.None[types.RoadIndex]()
-}
-
-// nextIndexOpt returns Index+1 of idx, or 0 if absent (same as types.NextIndexOpt for a tip).
-func nextIndexOpt(idx utils.Option[types.RoadIndex]) types.RoadIndex {
-	if i, ok := idx.Get(); ok {
-		return i + 1
-	}
-	return 0
-}
-
-// validate checks internal consistency and cryptographic signatures of persisted state.
-// Returns error on corrupt state. CommitQCIndex is checked against spec by newInner first.
-func (p *persistedInner) validate(spec types.ConsensusSpec) error {
+// Verify checks internal consistency and cryptographic signatures of persisted state.
+// Returns error on corrupt state. Index is checked against spec by newInner first.
+// PrepareQC and TimeoutQC may be assembled from any committee replicas; CommitVote,
+// PrepareVote, and TimeoutVote must be this node's.
+func (p *persistedInner) Verify(spec types.ConsensusSpec, self types.PublicKey) error {
 	ep := spec.Epoch
 	// TimeoutQC index must equal NextIndexOpt(CommitQC) (i.e., CommitQC.Index+1, or 0 if missing).
 	// Since we persist the entire inner state atomically, a mismatched index is always corrupt.
 	if tqc, ok := p.TimeoutQC.Get(); ok {
 		tqcIndex := tqc.View().Index
-		expectedIndex := types.NextIndexOpt(spec.CommitQC)
+		expectedIndex := spec.Index()
 		if tqcIndex != expectedIndex {
 			return fmt.Errorf("corrupt persisted state: TimeoutQC has index %d but expected %d", tqcIndex, expectedIndex)
 		}
@@ -105,9 +91,8 @@ func (p *persistedInner) validate(spec types.ConsensusSpec) error {
 		}
 	}
 
-	vs := types.ViewSpec{CommitQC: spec.CommitQC, TimeoutQC: p.TimeoutQC, Epoch: ep}
+	vs := types.ViewSpec{ConsensusSpec: spec, TimeoutQC: p.TimeoutQC}
 	currentView := vs.View()
-	committee := ep.Committee()
 
 	// checkViewAndSig validates that a persisted field has the current view and a valid signature.
 	// Since inner is persisted atomically, any view mismatch indicates corrupt state.
@@ -130,44 +115,43 @@ func (p *persistedInner) validate(spec types.ConsensusSpec) error {
 		return fmt.Errorf("corrupt persisted state: CommitVote present without PrepareQC")
 	}
 	if v, ok := p.CommitVote.Get(); ok {
-		if err := checkViewAndSig("CommitVote", v.Msg().Proposal().View(), verifyReplicaSig(committee, v)); err != nil {
+		if err := checkViewAndSig("CommitVote", v.Msg().Proposal().View(), verifyLocalSig(self, v)); err != nil {
 			return err
 		}
 	}
 	if v, ok := p.PrepareVote.Get(); ok {
-		if err := checkViewAndSig("PrepareVote", v.Msg().Proposal().View(), verifyReplicaSig(committee, v)); err != nil {
+		if err := checkViewAndSig("PrepareVote", v.Msg().Proposal().View(), verifyLocalSig(self, v)); err != nil {
 			return err
 		}
 	}
 	if v, ok := p.TimeoutVote.Get(); ok {
-		if err := checkViewAndSig("TimeoutVote", v.View(), v.Verify(ep)); err != nil {
+		if err := checkViewAndSig("TimeoutVote", v.View(), verifyLocalTimeoutVote(self, v, ep)); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func verifyReplicaSig[T types.Msg](c *types.Committee, v *types.Signed[T]) error {
-	if !c.HasReplica(v.Key()) {
-		return fmt.Errorf("%q is not a replica", v.Key())
+func verifyLocalSig[T types.Msg](self types.PublicKey, v *types.Signed[T]) error {
+	if v.Key() != self {
+		return fmt.Errorf("signed by %q, not this node", v.Key())
 	}
 	return v.VerifySig()
 }
 
-// walTipIndex returns NextIndexOpt of the tip recorded in the WAL, if any.
-func walTipIndex(p *pb.PersistedInner) types.RoadIndex {
-	if p == nil || p.CommitQcIndex == nil {
-		return 0
+func verifyLocalTimeoutVote(self types.PublicKey, v *types.FullTimeoutVote, ep *types.Epoch) error {
+	if v.Vote().Key() != self {
+		return fmt.Errorf("signed by %q, not this node", v.Vote().Key())
 	}
-	return types.RoadIndex(*p.CommitQcIndex) + 1
+	return v.Verify(ep)
 }
 
 // innerProtoConv is a protobuf converter for persistedInner.
 var innerProtoConv = protoutils.Conv[*persistedInner, *pb.PersistedInner]{
 	Encode: func(m *persistedInner) *pb.PersistedInner {
 		p := &pb.PersistedInner{}
-		if idx, ok := m.CommitQCIndex.Get(); ok {
-			v := uint64(idx)
+		if m.Index != 0 {
+			v := uint64(m.Index)
 			p.CommitQcIndex = &v
 		}
 		if v, ok := m.PrepareQC.Get(); ok {
@@ -190,7 +174,7 @@ var innerProtoConv = protoutils.Conv[*persistedInner, *pb.PersistedInner]{
 	Decode: func(p *pb.PersistedInner) (*persistedInner, error) {
 		m := &persistedInner{}
 		if p.CommitQcIndex != nil {
-			m.CommitQCIndex = utils.Some(types.RoadIndex(*p.CommitQcIndex))
+			m.Index = types.RoadIndex(*p.CommitQcIndex)
 		}
 		if p.PrepareQc != nil {
 			v, err := types.PrepareQCConv.Decode(p.PrepareQc)

--- a/sei-tendermint/internal/autobahn/consensus/persisted_inner_test.go
+++ b/sei-tendermint/internal/autobahn/consensus/persisted_inner_test.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/sei-protocol/sei-chain/sei-tendermint/autobahn/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/require"
 )
 
 // genPersistedInner generates a random persistedInner with random optional fields.
 func genPersistedInner(rng utils.Rng) *persistedInner {
 	p := &persistedInner{}
 	if rng.Intn(2) == 1 {
-		p.CommitQC = utils.Some(types.GenCommitQC(rng))
+		p.CommitQCIndex = utils.Some(types.RoadIndex(rng.Uint64()))
 	}
 	if rng.Intn(2) == 1 {
 		p.PrepareQC = utils.Some(types.GenPrepareQC(rng))
@@ -44,4 +45,15 @@ func TestPersistedInnerConv(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+}
+
+func TestInnerProtoConv_WalTipIndex(t *testing.T) {
+	none := innerProtoConv.Encode(&persistedInner{})
+	require.Nil(t, none.CommitQcIndex)
+	require.Equal(t, types.RoadIndex(0), walTipIndex(none))
+
+	withTip := innerProtoConv.Encode(&persistedInner{CommitQCIndex: utils.Some(types.RoadIndex(5))})
+	require.NotNil(t, withTip.CommitQcIndex)
+	require.Equal(t, uint64(5), *withTip.CommitQcIndex)
+	require.Equal(t, types.RoadIndex(6), walTipIndex(withTip))
 }

--- a/sei-tendermint/internal/autobahn/consensus/persisted_inner_test.go
+++ b/sei-tendermint/internal/autobahn/consensus/persisted_inner_test.go
@@ -49,9 +49,9 @@ func TestPersistedInnerConv(t *testing.T) {
 
 func TestInnerProtoConv_Index(t *testing.T) {
 	none := innerProtoConv.Encode(&persistedInner{})
-	require.Nil(t, none.CommitQcIndex)
+	require.Nil(t, none.Index)
 
 	withTip := innerProtoConv.Encode(&persistedInner{Index: 5})
-	require.NotNil(t, withTip.CommitQcIndex)
-	require.Equal(t, uint64(5), *withTip.CommitQcIndex)
+	require.NotNil(t, withTip.Index)
+	require.Equal(t, uint64(5), *withTip.Index)
 }

--- a/sei-tendermint/internal/autobahn/consensus/persisted_inner_test.go
+++ b/sei-tendermint/internal/autobahn/consensus/persisted_inner_test.go
@@ -12,7 +12,7 @@ import (
 func genPersistedInner(rng utils.Rng) *persistedInner {
 	p := &persistedInner{}
 	if rng.Intn(2) == 1 {
-		p.CommitQCIndex = utils.Some(types.RoadIndex(rng.Uint64()))
+		p.Index = types.RoadIndex(rng.Uint64())
 	}
 	if rng.Intn(2) == 1 {
 		p.PrepareQC = utils.Some(types.GenPrepareQC(rng))
@@ -47,13 +47,11 @@ func TestPersistedInnerConv(t *testing.T) {
 	}
 }
 
-func TestInnerProtoConv_WalTipIndex(t *testing.T) {
+func TestInnerProtoConv_Index(t *testing.T) {
 	none := innerProtoConv.Encode(&persistedInner{})
 	require.Nil(t, none.CommitQcIndex)
-	require.Equal(t, types.RoadIndex(0), walTipIndex(none))
 
-	withTip := innerProtoConv.Encode(&persistedInner{CommitQCIndex: utils.Some(types.RoadIndex(5))})
+	withTip := innerProtoConv.Encode(&persistedInner{Index: 5})
 	require.NotNil(t, withTip.CommitQcIndex)
 	require.Equal(t, uint64(5), *withTip.CommitQcIndex)
-	require.Equal(t, types.RoadIndex(6), walTipIndex(withTip))
 }

--- a/sei-tendermint/internal/autobahn/consensus/state.go
+++ b/sei-tendermint/internal/autobahn/consensus/state.go
@@ -185,7 +185,10 @@ func (s *State) PushTimeoutQC(ctx context.Context, qc *types.TimeoutQC) error {
 // PushPrepareVote processes an unverified Prepare vote message.
 func (s *State) PushPrepareVote(vote *types.Signed[*types.PrepareVote]) error {
 	committee := s.myView.Load().Epoch.Committee()
-	if err := vote.VerifySig(committee); err != nil {
+	if !committee.HasReplica(vote.Key()) {
+		return fmt.Errorf("%q is not a replica", vote.Key())
+	}
+	if err := vote.VerifySig(); err != nil {
 		return fmt.Errorf("vote.VerifySig(): %w", err)
 	}
 	for pv := range s.prepareVotes.Lock() {
@@ -197,7 +200,10 @@ func (s *State) PushPrepareVote(vote *types.Signed[*types.PrepareVote]) error {
 // PushCommitVote processes an unverified CommitVote message.
 func (s *State) PushCommitVote(vote *types.Signed[*types.CommitVote]) error {
 	committee := s.myView.Load().Epoch.Committee()
-	if err := vote.VerifySig(committee); err != nil {
+	if !committee.HasReplica(vote.Key()) {
+		return fmt.Errorf("%q is not a replica", vote.Key())
+	}
+	if err := vote.VerifySig(); err != nil {
 		return fmt.Errorf("vote.VerifySig(): %w", err)
 	}
 	for cv := range s.commitVotes.Lock() {

--- a/sei-tendermint/internal/autobahn/consensus/state.go
+++ b/sei-tendermint/internal/autobahn/consensus/state.go
@@ -320,7 +320,7 @@ func (s *State) Run(ctx context.Context) error {
 		scope.SpawnNamed("pushSpec", func() error {
 			// We pull the tip back from "avail" for dissemination. This ensures we
 			// only advance on CommitQCs that avail has verified, logged, and paired
-			// with the epoch of the next view — consensus resolves no epochs itself.
+			// with the epoch of the next RoadIndex — consensus resolves no epochs itself.
 			return s.avail.SubscribeConsensusSpec().Iter(ctx, func(ctx context.Context, spec types.ConsensusSpec) error {
 				return s.pushSpec(spec)
 			})

--- a/sei-tendermint/internal/autobahn/consensus/state.go
+++ b/sei-tendermint/internal/autobahn/consensus/state.go
@@ -2,6 +2,7 @@ package consensus
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -100,14 +101,19 @@ func newState(
 	pers utils.Option[persist.Persister[*pb.PersistedInner]],
 	persistedData utils.Option[*pb.PersistedInner],
 ) (*State, error) {
-	initialInner, err := newInner(persistedData, data.Registry())
-	if err != nil {
-		return nil, fmt.Errorf("newInner: %w", err)
-	}
-
 	availState, err := avail.NewState(cfg.Key, data, cfg.PersistentStateDir)
 	if err != nil {
 		return nil, fmt.Errorf("avail.NewState: %w", err)
+	}
+
+	initialInner, err := newInner(
+		persistedData,
+		availState.SubscribeConsensusSpec().Load(),
+		data.Registry(),
+	)
+	if err != nil {
+		_ = availState.Close()
+		return nil, fmt.Errorf("newInner: %w", err)
 	}
 
 	innerSend := utils.Alloc(utils.NewAtomicSend(initialInner))
@@ -123,7 +129,7 @@ func newState(
 		prepareVotes: utils.NewMutex(newPrepareVotes()),
 		commitVotes:  utils.NewMutex(newCommitVotes()),
 
-		myView:        utils.NewAtomicSend(types.ViewSpec{Epoch: initialInner.epoch}),
+		myView:        utils.NewAtomicSend(types.ViewSpec{CommitQC: initialInner.CommitQC, TimeoutQC: initialInner.TimeoutQC, Epoch: initialInner.epoch}),
 		myProposal:    utils.NewAtomicSend(utils.None[*types.FullProposal]()),
 		myPrepareVote: utils.NewAtomicSend(utils.None[*types.ConsensusReqPrepareVote]()),
 		myCommitVote:  utils.NewAtomicSend(utils.None[*types.ConsensusReqCommitVote]()),
@@ -132,6 +138,9 @@ func newState(
 	}
 	return s, nil
 }
+
+// ErrAvailBehindConsensus means the consensus WAL tip is ahead of ConsensusSpec.
+var ErrAvailBehindConsensus = errors.New("consensus WAL tip ahead of ConsensusSpec")
 
 // Close releases the availability state's WALs, and with them the exclusive lock each holds on its
 // directory.
@@ -306,15 +315,16 @@ func (s *State) Run(ctx context.Context) error {
 				return nil
 			})
 		})
-		scope.SpawnNamed("pushCommitQC", func() error {
-			// We pull the CommitQC back from "avail" for dissemination. This ensures
-			// that we only push CommitQCs that have been successfully "logged" and
-			// sequenced by the availability layer.
-			return s.avail.LastCommitQC().Iter(ctx, func(ctx context.Context, last utils.Option[*types.CommitQC]) error {
-				if qc, ok := last.Get(); ok {
-					return s.pushCommitQC(qc)
+		scope.SpawnNamed("pushSpecFromAvail", func() error {
+			// We pull the tip back from "avail" for dissemination. This ensures we
+			// only advance on CommitQCs that avail has verified, logged, and paired
+			// with the epoch of the next view — consensus resolves no epochs itself.
+			return s.avail.SubscribeConsensusSpec().Iter(ctx, func(ctx context.Context, specOpt utils.Option[types.ConsensusSpec]) error {
+				spec, ok := specOpt.Get()
+				if !ok {
+					return nil
 				}
-				return nil
+				return s.pushSpecFromAvail(spec)
 			})
 		})
 		scope.SpawnNamed("pushPrepareQC", func() error {

--- a/sei-tendermint/internal/autobahn/consensus/state.go
+++ b/sei-tendermint/internal/autobahn/consensus/state.go
@@ -125,7 +125,7 @@ func newState(
 		prepareVotes: utils.NewMutex(newPrepareVotes()),
 		commitVotes:  utils.NewMutex(newCommitVotes()),
 
-		myView:        utils.NewAtomicSend(types.ViewSpec{CommitQC: initialInner.CommitQC, TimeoutQC: initialInner.TimeoutQC, Epoch: initialInner.epoch}),
+		myView:        utils.NewAtomicSend(types.ViewSpec{CommitQC: initialInner.spec.CommitQC, TimeoutQC: initialInner.TimeoutQC, Epoch: initialInner.spec.Epoch}),
 		myProposal:    utils.NewAtomicSend(utils.None[*types.FullProposal]()),
 		myPrepareVote: utils.NewAtomicSend(utils.None[*types.ConsensusReqPrepareVote]()),
 		myCommitVote:  utils.NewAtomicSend(utils.None[*types.ConsensusReqCommitVote]()),
@@ -273,7 +273,7 @@ func updateOutput[T types.ConsensusReq](w *utils.AtomicSend[utils.Option[T]], v 
 // timers, neither of which constitutes a vote.
 func (s *State) runOutputs(ctx context.Context) error {
 	return s.innerRecv.Iter(ctx, func(ctx context.Context, i inner) error {
-		vs := types.ViewSpec{CommitQC: i.CommitQC, TimeoutQC: i.TimeoutQC, Epoch: i.epoch}
+		vs := types.ViewSpec{CommitQC: i.spec.CommitQC, TimeoutQC: i.TimeoutQC, Epoch: i.spec.Epoch}
 		old := s.myView.Load()
 		if old.View().Less(vs.View()) {
 			s.myView.Store(vs)
@@ -317,12 +317,12 @@ func (s *State) Run(ctx context.Context) error {
 				return nil
 			})
 		})
-		scope.SpawnNamed("pushSpecFromAvail", func() error {
+		scope.SpawnNamed("pushSpec", func() error {
 			// We pull the tip back from "avail" for dissemination. This ensures we
 			// only advance on CommitQCs that avail has verified, logged, and paired
 			// with the epoch of the next view — consensus resolves no epochs itself.
 			return s.avail.SubscribeConsensusSpec().Iter(ctx, func(ctx context.Context, spec types.ConsensusSpec) error {
-				return s.pushSpecFromAvail(spec)
+				return s.pushSpec(spec)
 			})
 		})
 		scope.SpawnNamed("pushPrepareQC", func() error {

--- a/sei-tendermint/internal/autobahn/consensus/state.go
+++ b/sei-tendermint/internal/autobahn/consensus/state.go
@@ -106,7 +106,7 @@ func newState(
 		return nil, fmt.Errorf("avail.NewState: %w", err)
 	}
 
-	initialInner, err := newInner(persistedData, availState.SubscribeConsensusSpec().Load())
+	initialInner, err := newInner(persistedData, availState.SubscribeConsensusSpec().Load(), cfg.Key.Public())
 	if err != nil {
 		_ = availState.Close()
 		return nil, fmt.Errorf("newInner: %w", err)
@@ -125,7 +125,7 @@ func newState(
 		prepareVotes: utils.NewMutex(newPrepareVotes()),
 		commitVotes:  utils.NewMutex(newCommitVotes()),
 
-		myView:        utils.NewAtomicSend(types.ViewSpec{CommitQC: initialInner.spec.CommitQC, TimeoutQC: initialInner.TimeoutQC, Epoch: initialInner.spec.Epoch}),
+		myView:        utils.NewAtomicSend(types.ViewSpec{ConsensusSpec: initialInner.spec, TimeoutQC: initialInner.TimeoutQC}),
 		myProposal:    utils.NewAtomicSend(utils.None[*types.FullProposal]()),
 		myPrepareVote: utils.NewAtomicSend(utils.None[*types.ConsensusReqPrepareVote]()),
 		myCommitVote:  utils.NewAtomicSend(utils.None[*types.ConsensusReqCommitVote]()),
@@ -135,8 +135,8 @@ func newState(
 	return s, nil
 }
 
-// ErrAvailBehindConsensus means the consensus WAL tip is ahead of ConsensusSpec.
-var ErrAvailBehindConsensus = errors.New("consensus WAL tip ahead of ConsensusSpec")
+// ErrAvailBehindConsensus means the consensus WAL view is ahead of ConsensusSpec.
+var ErrAvailBehindConsensus = errors.New("consensus WAL view ahead of ConsensusSpec")
 
 // Close releases the availability state's WALs, and with them the exclusive lock each holds on its
 // directory.
@@ -181,6 +181,8 @@ func (s *State) PushTimeoutQC(ctx context.Context, qc *types.TimeoutQC) error {
 
 // TODO: scope prepareVotes, commitVotes, and timeoutVotes to a single epoch
 // so stale votes from a previous epoch are automatically dropped on transition.
+// TODO: PushPrepareVote, PushCommitVote, and PushTimeoutVote should wait for the
+// vote's epoch when it is ahead of myView (ahead-within-epoch ingest is fine).
 
 // PushPrepareVote processes an unverified Prepare vote message.
 func (s *State) PushPrepareVote(vote *types.Signed[*types.PrepareVote]) error {
@@ -273,7 +275,7 @@ func updateOutput[T types.ConsensusReq](w *utils.AtomicSend[utils.Option[T]], v 
 // timers, neither of which constitutes a vote.
 func (s *State) runOutputs(ctx context.Context) error {
 	return s.innerRecv.Iter(ctx, func(ctx context.Context, i inner) error {
-		vs := types.ViewSpec{CommitQC: i.spec.CommitQC, TimeoutQC: i.TimeoutQC, Epoch: i.spec.Epoch}
+		vs := types.ViewSpec{ConsensusSpec: i.spec, TimeoutQC: i.TimeoutQC}
 		old := s.myView.Load()
 		if old.View().Less(vs.View()) {
 			s.myView.Store(vs)
@@ -319,7 +321,7 @@ func (s *State) Run(ctx context.Context) error {
 		})
 		scope.SpawnNamed("pushSpec", func() error {
 			// We pull the tip back from "avail" for dissemination. This ensures we
-			// only advance on CommitQCs that avail has verified, logged, and paired
+			// only advance on CommitQCs that avail has verified, persisted, and paired
 			// with the epoch of the next RoadIndex — consensus resolves no epochs itself.
 			return s.avail.SubscribeConsensusSpec().Iter(ctx, func(ctx context.Context, spec types.ConsensusSpec) error {
 				return s.pushSpec(spec)

--- a/sei-tendermint/internal/autobahn/consensus/state.go
+++ b/sei-tendermint/internal/autobahn/consensus/state.go
@@ -106,11 +106,7 @@ func newState(
 		return nil, fmt.Errorf("avail.NewState: %w", err)
 	}
 
-	initialInner, err := newInner(
-		persistedData,
-		availState.SubscribeConsensusSpec().Load(),
-		data.Registry(),
-	)
+	initialInner, err := newInner(persistedData, availState.SubscribeConsensusSpec().Load())
 	if err != nil {
 		_ = availState.Close()
 		return nil, fmt.Errorf("newInner: %w", err)
@@ -319,11 +315,7 @@ func (s *State) Run(ctx context.Context) error {
 			// We pull the tip back from "avail" for dissemination. This ensures we
 			// only advance on CommitQCs that avail has verified, logged, and paired
 			// with the epoch of the next view — consensus resolves no epochs itself.
-			return s.avail.SubscribeConsensusSpec().Iter(ctx, func(ctx context.Context, specOpt utils.Option[types.ConsensusSpec]) error {
-				spec, ok := specOpt.Get()
-				if !ok {
-					return nil
-				}
+			return s.avail.SubscribeConsensusSpec().Iter(ctx, func(ctx context.Context, spec types.ConsensusSpec) error {
 				return s.pushSpecFromAvail(spec)
 			})
 		})

--- a/sei-tendermint/internal/autobahn/consensus/state_test.go
+++ b/sei-tendermint/internal/autobahn/consensus/state_test.go
@@ -83,7 +83,7 @@ func TestVoteTimeoutPrepareQC_OnlyCurrentView(t *testing.T) {
 	err := scope.Run(t.Context(), func(ctx context.Context, sc scope.Scope) error {
 		sc.SpawnBg(func() error { return utils.IgnoreCancel(s.Run(ctx)) })
 
-		pqc := makePrepareQC(keys, types.GenProposalForEpoch(rng, registry.LatestEpoch(), types.View{Index: 0, Number: 0}))
+		pqc := makePrepareQC(keys, types.GenProposalForEpoch(rng, registry.MustEpoch(0), types.View{Index: 0, Number: 0}))
 		if err := s.pushPrepareQC(ctx, pqc); err != nil {
 			return fmt.Errorf("pushPrepareQC: %w", err)
 		}
@@ -113,7 +113,7 @@ func TestVoteTimeoutPrepareQC_InheritedFromTimeoutQC(t *testing.T) {
 
 		// View (0, 0): push PrepareQC for proposal P.
 		view0 := types.View{Index: 0, Number: 0}
-		pqc0 := makePrepareQC(keys, types.GenProposalForEpoch(rng, registry.LatestEpoch(), view0))
+		pqc0 := makePrepareQC(keys, types.GenProposalForEpoch(rng, registry.MustEpoch(0), view0))
 		if err := s.pushPrepareQC(ctx, pqc0); err != nil {
 			return fmt.Errorf("pushPrepareQC: %w", err)
 		}
@@ -170,7 +170,7 @@ func TestVoteTimeoutPrepareQC_CurrentViewHigherThanInherited(t *testing.T) {
 
 		// View (0, 0): PrepareQC for P.
 		view0 := types.View{Index: 0, Number: 0}
-		pqc0 := makePrepareQC(keys, types.GenProposalForEpoch(rng, registry.LatestEpoch(), view0))
+		pqc0 := makePrepareQC(keys, types.GenProposalForEpoch(rng, registry.MustEpoch(0), view0))
 		if err := s.pushPrepareQC(ctx, pqc0); err != nil {
 			return fmt.Errorf("pushPrepareQC(pqc0): %w", err)
 		}
@@ -183,7 +183,7 @@ func TestVoteTimeoutPrepareQC_CurrentViewHigherThanInherited(t *testing.T) {
 
 		// Reproposal at (0, 1) succeeds — new PrepareQC at view (0, 1).
 		view1 := types.View{Index: 0, Number: 1}
-		pqc1 := makePrepareQC(keys, types.GenProposalForEpoch(rng, registry.LatestEpoch(), view1))
+		pqc1 := makePrepareQC(keys, types.GenProposalForEpoch(rng, registry.MustEpoch(0), view1))
 		if err := s.pushPrepareQC(ctx, pqc1); err != nil {
 			return fmt.Errorf("pushPrepareQC(pqc1): %w", err)
 		}
@@ -227,7 +227,7 @@ func TestVoteTimeoutPrepareQC_CurrentViewPresentInheritedNone(t *testing.T) {
 
 		// Fresh PrepareQC at (0, 1).
 		view1 := types.View{Index: 0, Number: 1}
-		pqc1 := makePrepareQC(keys, types.GenProposalForEpoch(rng, registry.LatestEpoch(), view1))
+		pqc1 := makePrepareQC(keys, types.GenProposalForEpoch(rng, registry.MustEpoch(0), view1))
 		if err := s.pushPrepareQC(ctx, pqc1); err != nil {
 			return fmt.Errorf("pushPrepareQC: %w", err)
 		}
@@ -269,7 +269,7 @@ func TestVoteTimeoutPrepareQC_PersistedRestart(t *testing.T) {
 	makeDataState := func() *data.State { return newTestDataState(registry) }
 
 	view0 := types.View{Index: 0, Number: 0}
-	pqc0 := makePrepareQC(keys, types.GenProposalForEpoch(rng, registry.LatestEpoch(), view0))
+	pqc0 := makePrepareQC(keys, types.GenProposalForEpoch(rng, registry.MustEpoch(0), view0))
 
 	// Session 1: push PrepareQC + TimeoutQC, let runOutputs persist.
 	// Hoisted so session 1's WALs can be released after its goroutines have stopped: they hold an

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -178,13 +178,13 @@ func (i *inner) insertBlock(n types.GlobalBlockNumber, block *types.Block) error
 	// nextAppProposal <= nextBlock, so qcs[n] is always present.
 	qc := i.qcs[n].qc
 	storedGR := qc.QC().GlobalRange()
-	want := qc.Headers()[n-storedGR.First].Hash()
-	got := block.Header().Hash()
-	if want != got {
-		return fmt.Errorf("block %d header hash mismatch: want %v, got %v", n, want, got)
+	want := qc.Headers()[n-storedGR.First]
+	got := block.Header()
+	if *want != *got {
+		return fmt.Errorf("block %d header mismatch: want %v, got %v", n, want.Hash(), got.Hash())
 	}
 	i.blocks[n] = block
-	i.blockHashes[got] = n
+	i.blockHashes[got.Hash()] = n
 	return nil
 }
 

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -158,7 +158,8 @@ func (i *inner) insertAppProposal(appProposal *types.AppProposal) error {
 
 // insertBlock inserts a pre-verified block into the inner state.
 // Requires a QC to already be present for block n. Callers must verify
-// the block signature before calling (unlike insertQC, which verifies).
+// payload integrity before calling; insertBlock matches the header against
+// the stored FullCommitQC (unlike insertQC, which verifies the QC itself).
 //
 // insertBlock does NOT advance nextBlock — callers should call
 // updateNextBlock after inserting one or more blocks. This separation
@@ -288,14 +289,9 @@ func loadFromBlockStore(cfg *Config, blockStore types.BlockStore) (*inner, error
 		}
 	}
 	for _, b := range suffix.Blocks {
-		entry := inner.qcs[b.Number]
-		c := entry.epoch.Committee()
 		prop := types.NewLaneProposal(b.Block)
-		if err := prop.VerifyPayload(); err != nil {
-			return nil, fmt.Errorf("verify block %d payload from BlockStore: %w", b.Number, err)
-		}
-		if err := prop.VerifyCommitteeMembership(c); err != nil {
-			return nil, fmt.Errorf("verify block %d membership from BlockStore: %w", b.Number, err)
+		if err := prop.Verify(); err != nil {
+			return nil, fmt.Errorf("verify block %d from BlockStore: %w", b.Number, err)
 		}
 		if err := inner.insertBlock(b.Number, b.Block); err != nil {
 			return nil, fmt.Errorf("insert block %d from BlockStore: %w", b.Number, err)
@@ -375,15 +371,10 @@ func (s *State) PushQC(ctx context.Context, qc *types.FullCommitQC, blocks []*ty
 		}
 	}
 	byHash := map[types.BlockHeaderHash]*types.Block{}
-	committee := ep.Committee()
 	for _, b := range blocks {
 		byHash[b.Header().Hash()] = b
-		prop := types.NewLaneProposal(b)
-		if err := prop.VerifyPayload(); err != nil {
-			return fmt.Errorf("VerifyPayload(): %w", err)
-		}
-		if err := prop.VerifyCommitteeMembership(committee); err != nil {
-			return fmt.Errorf("VerifyCommitteeMembership(): %w", err)
+		if err := types.NewLaneProposal(b).Verify(); err != nil {
+			return fmt.Errorf("block.Verify(): %w", err)
 		}
 	}
 	// Atomically insert QC and blocks.
@@ -428,7 +419,6 @@ func (s *State) QC(ctx context.Context, n types.GlobalBlockNumber) (*types.FullC
 // the height is already in the contiguous block prefix (n < nextBlock) — in
 // that case the block is dropped silently (already stored or executed/evicted).
 func (s *State) PushBlock(ctx context.Context, n types.GlobalBlockNumber, block *types.Block) error {
-	var ep *types.Epoch
 	for inner, ctrl := range s.inner.Lock() {
 		if err := ctrl.WaitUntil(ctx, func() bool { return n < inner.nextQC }); err != nil {
 			return err
@@ -438,16 +428,11 @@ func (s *State) PushBlock(ctx context.Context, n types.GlobalBlockNumber, block 
 		if n < inner.nextBlock {
 			return nil
 		}
-		// n in [nextBlock, nextQC): QC (and its verify-epoch) is contiguous.
-		ep = inner.qcs[n].epoch
 	}
-	// Verify outside the lock against the epoch stashed with the QC.
-	prop := types.NewLaneProposal(block)
-	if err := prop.VerifyPayload(); err != nil {
-		return fmt.Errorf("VerifyPayload(): %w", err)
-	}
-	if err := prop.VerifyCommitteeMembership(ep.Committee()); err != nil {
-		return fmt.Errorf("VerifyCommitteeMembership(): %w", err)
+	// Payload integrity outside the lock; insertBlock matches the header against
+	// the stored FullCommitQC (membership is implied by that QC).
+	if err := types.NewLaneProposal(block).Verify(); err != nil {
+		return fmt.Errorf("block.Verify(): %w", err)
 	}
 	for inner, ctrl := range s.inner.Lock() {
 		// insertBlock may no-op if n fell into the contiguous prefix (or was

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -31,8 +31,16 @@ type blockEntry struct {
 	block *types.Block
 }
 
+// qcEntry is an admitted FullCommitQC with the epoch used to verify it.
+// The epoch is resolved once at admit (or load); later PushBlock / AppQC
+// paths use this pointer instead of querying the registry again.
+type qcEntry struct {
+	qc    *types.FullCommitQC
+	epoch *types.Epoch
+}
+
 type inner struct {
-	qcs          map[types.GlobalBlockNumber]*types.FullCommitQC   // [first, nextQC)
+	qcs          map[types.GlobalBlockNumber]qcEntry               // [first, nextQC)
 	blocks       map[types.GlobalBlockNumber]*types.Block          // [first, nextBlock) + gap-fills in [nextBlock, nextQC)
 	appProposals map[types.GlobalBlockNumber]*types.AppProposal    // [first, nextAppProposal)
 	appQCs       map[types.GlobalBlockNumber]*types.AppQC          // [first, nextAppQC)
@@ -52,6 +60,9 @@ type inner struct {
 	// Anchor represents the highest fully processed row:
 	// CommitQC, Blocks, AppProposal, AppQC present and persisted.
 	anchor utils.AtomicSend[utils.Option[Anchor]]
+	// commitEpoch is the verify-epoch of the latest admitted CommitQC
+	// (genesis LatestEpoch when none yet). May lead AppQC/Anchor.
+	commitEpoch utils.AtomicSend[*types.Epoch]
 }
 
 // insertQC verifies and inserts a FullCommitQC into the inner state.
@@ -73,13 +84,14 @@ func (i *inner) insertQC(registry *epoch.Registry, qc *types.FullCommitQC) error
 		return fmt.Errorf("qc.Verify(): %w", err)
 	}
 	for i.nextQC < gr.Next {
-		i.qcs[i.nextQC] = qc
+		i.qcs[i.nextQC] = qcEntry{qc: qc, epoch: e}
 		i.nextQC++
 	}
+	i.commitEpoch.Store(e)
 	return nil
 }
 
-func (i *inner) insertAppQC(registry *epoch.Registry, appQC *types.AppQC) error {
+func (i *inner) insertAppQC(appQC *types.AppQC) error {
 	gr := appQC.Proposal().GlobalRange()
 	if gr.Next <= i.nextAppQC {
 		return nil
@@ -90,12 +102,8 @@ func (i *inner) insertAppQC(registry *epoch.Registry, appQC *types.AppQC) error 
 	if gr.First > i.nextAppQC {
 		return fmt.Errorf("AppQC gap: expected first<=%d, got %d", i.nextAppQC, gr.First)
 	}
-	ei := appQC.Proposal().EpochIndex()
-	epoch, ok := registry.EpochByIndex(ei)
-	if !ok {
-		return fmt.Errorf("unknown epoch_index %d", ei)
-	}
-	if err := appQC.Verify(epoch.Committee()); err != nil {
+	ep := i.qcs[i.nextAppQC].epoch
+	if err := appQC.Verify(ep.Committee()); err != nil {
 		return fmt.Errorf("appQC.Verify(): %w", err)
 	}
 	for i.nextAppQC < gr.Next {
@@ -116,7 +124,7 @@ func (i *inner) insertAppProposal(appProposal *types.AppProposal) error {
 	if gr.First > i.nextAppProposal {
 		return fmt.Errorf("AppProposal gap: expected first<=%d, got %d", i.nextAppProposal, gr.First)
 	}
-	if err := appProposal.Verify(i.qcs[i.nextAppProposal].QC()); err != nil {
+	if err := appProposal.Verify(i.qcs[i.nextAppProposal].qc.QC()); err != nil {
 		return fmt.Errorf("appProposal.Verify(): %w", err)
 	}
 	for i.nextAppProposal < gr.Next {
@@ -145,7 +153,7 @@ func (i *inner) insertBlock(n types.GlobalBlockNumber, block *types.Block) error
 	}
 	// n is in [nextBlock, nextQC); QCs are contiguous and first <=
 	// nextAppProposal <= nextBlock, so qcs[n] is always present.
-	qc := i.qcs[n]
+	qc := i.qcs[n].qc
 	storedGR := qc.QC().GlobalRange()
 	want := qc.Headers()[n-storedGR.First].Hash()
 	got := block.Header().Hash()
@@ -212,6 +220,18 @@ func loadFromBlockStore(cfg *Config, blockStore types.BlockStore) (*inner, error
 	if err != nil {
 		return nil, fmt.Errorf("blockStore.ReadSuffix(): %w", err)
 	}
+	var commitSpan utils.Option[types.RoadRange]
+	if qcs := suffix.CommitQCs; len(qcs) > 0 {
+		first := qcs[0].Index()
+		next := qcs[0].Index() + 1
+		for _, qc := range qcs[1:] {
+			idx := qc.Index()
+			first = min(first, idx)
+			next = max(next, idx+1)
+		}
+		commitSpan = utils.Some(types.RoadRange{First: first, Next: next})
+	}
+	cfg.Registry.SetupInitialEpochs(commitSpan)
 	firstBlock := cfg.Registry.FirstBlock()
 	status := suffix.Status.Or(types.SuffixRange{
 		First:           firstBlock,
@@ -221,7 +241,7 @@ func loadFromBlockStore(cfg *Config, blockStore types.BlockStore) (*inner, error
 		NextBlock:       firstBlock,
 	})
 	inner := &inner{
-		qcs:             map[types.GlobalBlockNumber]*types.FullCommitQC{},
+		qcs:             map[types.GlobalBlockNumber]qcEntry{},
 		blocks:          map[types.GlobalBlockNumber]*types.Block{},
 		appQCs:          map[types.GlobalBlockNumber]*types.AppQC{},
 		appProposals:    map[types.GlobalBlockNumber]*types.AppProposal{},
@@ -233,6 +253,7 @@ func loadFromBlockStore(cfg *Config, blockStore types.BlockStore) (*inner, error
 		nextQC:          status.First,
 		persisted:       status,
 		anchor:          utils.NewAtomicSend(utils.None[Anchor]()),
+		commitEpoch:     utils.NewAtomicSend(cfg.Registry.LatestEpoch()),
 	}
 	for _, qc := range suffix.CommitQCs {
 		if err := inner.insertQC(cfg.Registry, qc); err != nil {
@@ -240,13 +261,8 @@ func loadFromBlockStore(cfg *Config, blockStore types.BlockStore) (*inner, error
 		}
 	}
 	for _, b := range suffix.Blocks {
-		qc := inner.qcs[b.Number]
-		ei := qc.QC().Proposal().EpochIndex()
-		e, ok := cfg.Registry.EpochByIndex(ei)
-		if !ok {
-			return nil, fmt.Errorf("unknown epoch_index %d", ei)
-		}
-		if err := b.Block.Verify(e.Committee()); err != nil {
+		entry := inner.qcs[b.Number]
+		if err := b.Block.Verify(entry.epoch.Committee()); err != nil {
 			return nil, fmt.Errorf("verify block %d from BlockStore: %w", b.Number, err)
 		}
 		if err := inner.insertBlock(b.Number, b.Block); err != nil {
@@ -262,7 +278,7 @@ func loadFromBlockStore(cfg *Config, blockStore types.BlockStore) (*inner, error
 		}
 	}
 	for _, appQC := range suffix.AppQCs {
-		if err := inner.insertAppQC(cfg.Registry, appQC); err != nil {
+		if err := inner.insertAppQC(appQC); err != nil {
 			return nil, fmt.Errorf("load AppQC from BlockStore: %w", err)
 		}
 	}
@@ -282,7 +298,7 @@ func (s *State) Registry() *epoch.Registry { return s.cfg.Registry }
 // when the contiguous prefix grows. Caller must hold inner's lock.
 func (s *State) insertBlocksByHash(inner *inner, gr types.GlobalRange, byHash map[types.BlockHeaderHash]*types.Block) error {
 	for n := max(inner.nextBlock, gr.First); n < min(gr.Next, inner.nextQC); n++ {
-		storedQC := inner.qcs[n]
+		storedQC := inner.qcs[n].qc
 		storedGR := storedQC.QC().GlobalRange()
 		if b, ok := byHash[storedQC.Headers()[n-storedGR.First].Hash()]; ok {
 			if err := inner.insertBlock(n, b); err != nil {
@@ -298,7 +314,6 @@ func (s *State) insertBlocksByHash(inner *inner, gr types.GlobalRange, byHash ma
 // Pushing the qc and blocks is atomic, so that no unnecessary GetBlock RPCs are issued.
 // Even if the qc was already pushed earlier, the blocks are pushed anyway.
 func (s *State) PushQC(ctx context.Context, qc *types.FullCommitQC, blocks []*types.Block) error {
-	// Wait until QC is needed.
 	ep, ok := s.cfg.Registry.EpochByIndex(qc.QC().Proposal().EpochIndex())
 	if !ok {
 		return fmt.Errorf("unknown epoch_index %d", qc.QC().Proposal().EpochIndex())
@@ -336,9 +351,10 @@ func (s *State) PushQC(ctx context.Context, qc *types.FullCommitQC, blocks []*ty
 	for inner, ctrl := range s.inner.Lock() {
 		if needQC {
 			for inner.nextQC < gr.Next {
-				inner.qcs[inner.nextQC] = qc
+				inner.qcs[inner.nextQC] = qcEntry{qc: qc, epoch: ep}
 				inner.nextQC += 1
 			}
+			inner.commitEpoch.Store(ep)
 			ctrl.Updated()
 		}
 		if len(byHash) > 0 {
@@ -363,7 +379,7 @@ func (s *State) QC(ctx context.Context, n types.GlobalBlockNumber) (*types.FullC
 		if n < inner.first {
 			break
 		}
-		return inner.qcs[n], nil
+		return inner.qcs[n].qc, nil
 	}
 	return s.qcFromDB(n)
 }
@@ -373,7 +389,7 @@ func (s *State) QC(ctx context.Context, n types.GlobalBlockNumber) (*types.FullC
 // the height is already in the contiguous block prefix (n < nextBlock) — in
 // that case the block is dropped silently (already stored or executed/evicted).
 func (s *State) PushBlock(ctx context.Context, n types.GlobalBlockNumber, block *types.Block) error {
-	var epochIdx types.EpochIndex
+	var ep *types.Epoch
 	for inner, ctrl := range s.inner.Lock() {
 		if err := ctrl.WaitUntil(ctx, func() bool { return n < inner.nextQC }); err != nil {
 			return err
@@ -383,14 +399,10 @@ func (s *State) PushBlock(ctx context.Context, n types.GlobalBlockNumber, block 
 		if n < inner.nextBlock {
 			return nil
 		}
-		// n in [nextBlock, nextQC): QC is contiguous in that range.
-		epochIdx = inner.qcs[n].QC().Proposal().EpochIndex()
+		// n in [nextBlock, nextQC): QC (and its verify-epoch) is contiguous.
+		ep = inner.qcs[n].epoch
 	}
-	ep, ok := s.cfg.Registry.EpochByIndex(epochIdx)
-	if !ok {
-		return fmt.Errorf("unknown epoch_index %d", epochIdx)
-	}
-	// Verify outside the lock against the known epoch.
+	// Verify outside the lock against the epoch stashed with the QC.
 	if err := block.Verify(ep.Committee()); err != nil {
 		return fmt.Errorf("block.Verify(): %w", err)
 	}
@@ -440,7 +452,7 @@ func (s *State) GlobalBlockByHash(hash types.BlockHeaderHash) (utils.Option[*typ
 		// blockHashes stays in lockstep with blocks; a hit means both block and
 		// covering QC are still cached (including n < nextAppProposal when
 		// AppQC eviction has not advanced first past n yet).
-		return utils.Some(assembleGlobalBlock(n, inner.blocks[n], inner.qcs[n])), nil
+		return utils.Some(assembleGlobalBlock(n, inner.blocks[n], inner.qcs[n].qc)), nil
 	}
 	return s.globalBlockByHashFromDB(hash)
 }
@@ -528,7 +540,7 @@ func (s *State) GlobalBlock(ctx context.Context, n types.GlobalBlockNumber) (*ty
 		if n < inner.first {
 			break
 		}
-		return assembleGlobalBlock(n, inner.blocks[n], inner.qcs[n]), nil
+		return assembleGlobalBlock(n, inner.blocks[n], inner.qcs[n].qc), nil
 	}
 	return s.globalBlockFromDB(n)
 }
@@ -601,7 +613,8 @@ func (s *State) globalBlockByHashFromDB(hash types.BlockHeaderHash) (utils.Optio
 	return utils.Some(assembleGlobalBlock(bn.Number, bn.Block, qc)), nil
 }
 
-// PushAppHash marks blocks up to n as executed.
+// PushAppHash marks blocks up to n as executed and advances the epoch
+// registry when n closes a CommitQC at an epoch boundary.
 func (s *State) PushAppHash(ctx context.Context, n types.GlobalBlockNumber, hash types.AppHash) error {
 	for inner, ctrl := range s.inner.Lock() {
 		if err := ctrl.WaitUntil(ctx, func() bool { return n < inner.nextBlock }); err != nil {
@@ -610,7 +623,7 @@ func (s *State) PushAppHash(ctx context.Context, n types.GlobalBlockNumber, hash
 		if n < inner.nextAppProposal {
 			return nil
 		}
-		p := inner.qcs[n].QC().Proposal()
+		p := inner.qcs[n].qc.QC().Proposal()
 		if next, first := inner.nextAppProposal, p.GlobalRange().First; next < first {
 			// We expect the AppHashes to be pushed in order.
 			return fmt.Errorf("received appHash for %v: %w", n, ErrOutOfOrder)
@@ -636,6 +649,11 @@ func (s *State) PushAppHash(ctx context.Context, n types.GlobalBlockNumber, hash
 			inner.nextAppProposal += 1
 		}
 		s.metrics.NextBlock.Execute.Set(utils.Clamp[int64](inner.nextAppProposal))
+		// Seed cursor: at LastRoad(N) register N+1 so runEpochAdvance can install
+		// it once seal and the prune/execution leashes are met. N+2 is not needed —
+		// ConsensusSpec withholds the view after LastRoad(N+1) until this fires
+		// again.
+		s.cfg.Registry.AdvanceIfNeeded(p.Index())
 		ctrl.Updated()
 		// CRITICAL: We need to persist AppHash before we return and start executing the next block,
 		// otherwise we lose the apphash on restart.
@@ -679,7 +697,7 @@ func (s *State) PushAppQC(ctx context.Context, appQC *types.AppQC) error {
 		if gr.First < inner.nextAppQC {
 			return nil
 		}
-		if err := inner.insertAppQC(s.cfg.Registry, appQC); err != nil {
+		if err := inner.insertAppQC(appQC); err != nil {
 			return err
 		}
 		t := time.Now()
@@ -711,6 +729,8 @@ func (s *State) AppQC(ctx context.Context, n types.GlobalBlockNumber) (*types.Ap
 type Anchor struct {
 	CommitQC *types.CommitQC
 	AppQC    *types.AppQC
+	// Epoch is the verify-epoch of CommitQC, stashed at admit.
+	Epoch *types.Epoch
 }
 
 // Anchor represents the AppQC/CommitQC covering inner.first.
@@ -722,12 +742,22 @@ func (s *State) Anchor() utils.AtomicRecv[utils.Option[Anchor]] {
 	panic("unreachable")
 }
 
+// CommitEpoch returns the verify-epoch of the latest admitted CommitQC, or the
+// genesis epoch when none has been admitted. It may lead AppQC/Anchor.
+// Used by giga EVM tx sharding (EvmProxy / EvmShard).
+func (s *State) CommitEpoch() utils.AtomicRecv[*types.Epoch] {
+	for inner := range s.inner.Lock() {
+		return inner.commitEpoch.Subscribe()
+	}
+	panic("unreachable")
+}
+
 func (i *inner) nextToExecute(lane types.LaneID) types.BlockNumber {
 	if i.nextAppProposal < i.nextQC {
-		return i.qcs[i.nextAppProposal].QC().LaneRange(lane).First()
+		return i.qcs[i.nextAppProposal].qc.QC().LaneRange(lane).First()
 	}
 	if i.first < i.nextAppProposal {
-		return i.qcs[i.nextAppProposal-1].QC().LaneRange(lane).Next()
+		return i.qcs[i.nextAppProposal-1].qc.QC().LaneRange(lane).Next()
 	}
 	// Genesis state: i.first == i.nextQC
 	return 0
@@ -794,7 +824,7 @@ func (s *State) runPersist(ctx context.Context) error {
 			}
 			// Collect data to persist.
 			for status.NextQC < inner.nextQC {
-				qc := inner.qcs[status.NextQC]
+				qc := inner.qcs[status.NextQC].qc
 				qcs = append(qcs, qc)
 				status.NextQC = qc.QC().GlobalRange().Next
 			}
@@ -870,9 +900,11 @@ func (s *State) runPersist(ctx context.Context) error {
 
 func (i *inner) setAnchor() {
 	if i.first < i.persisted.NextAppQC {
+		entry := i.qcs[i.first]
 		i.anchor.Store(utils.Some(Anchor{
-			CommitQC: i.qcs[i.first].QC(),
+			CommitQC: entry.qc.QC(),
 			AppQC:    i.appQCs[i.first],
+			Epoch:    entry.epoch,
 		}))
 	}
 }

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -677,7 +677,7 @@ func (s *State) PushAppHash(ctx context.Context, n types.GlobalBlockNumber, hash
 			inner.nextAppProposal += 1
 		}
 		s.metrics.NextBlock.Execute.Set(utils.Clamp[int64](inner.nextAppProposal))
-		// Seed cursor: at LastRoad(N) register N+1 so runEpochAdvance can install
+		// Seed cursor: at LastRoad(N) register N+1 so runEpochAdvance can advance
 		// it once seal and the prune/execution leashes are met. N+2 is not needed —
 		// ConsensusSpec withholds the RoadIndex after LastRoad(N+1) until this fires
 		// again.

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -262,8 +262,13 @@ func loadFromBlockStore(cfg *Config, blockStore types.BlockStore) (*inner, error
 	}
 	for _, b := range suffix.Blocks {
 		entry := inner.qcs[b.Number]
-		if err := b.Block.Verify(entry.epoch.Committee()); err != nil {
-			return nil, fmt.Errorf("verify block %d from BlockStore: %w", b.Number, err)
+		c := entry.epoch.Committee()
+		prop := types.NewLaneProposal(b.Block)
+		if err := prop.VerifyPayload(); err != nil {
+			return nil, fmt.Errorf("verify block %d payload from BlockStore: %w", b.Number, err)
+		}
+		if err := prop.VerifyCommitteeMembership(c); err != nil {
+			return nil, fmt.Errorf("verify block %d membership from BlockStore: %w", b.Number, err)
 		}
 		if err := inner.insertBlock(b.Number, b.Block); err != nil {
 			return nil, fmt.Errorf("insert block %d from BlockStore: %w", b.Number, err)
@@ -343,8 +348,12 @@ func (s *State) PushQC(ctx context.Context, qc *types.FullCommitQC, blocks []*ty
 	committee := ep.Committee()
 	for _, b := range blocks {
 		byHash[b.Header().Hash()] = b
-		if err := b.Verify(committee); err != nil {
-			return fmt.Errorf("b.Verify(): %w", err)
+		prop := types.NewLaneProposal(b)
+		if err := prop.VerifyPayload(); err != nil {
+			return fmt.Errorf("VerifyPayload(): %w", err)
+		}
+		if err := prop.VerifyCommitteeMembership(committee); err != nil {
+			return fmt.Errorf("VerifyCommitteeMembership(): %w", err)
 		}
 	}
 	// Atomically insert QC and blocks.
@@ -403,8 +412,12 @@ func (s *State) PushBlock(ctx context.Context, n types.GlobalBlockNumber, block 
 		ep = inner.qcs[n].epoch
 	}
 	// Verify outside the lock against the epoch stashed with the QC.
-	if err := block.Verify(ep.Committee()); err != nil {
-		return fmt.Errorf("block.Verify(): %w", err)
+	prop := types.NewLaneProposal(block)
+	if err := prop.VerifyPayload(); err != nil {
+		return fmt.Errorf("VerifyPayload(): %w", err)
+	}
+	if err := prop.VerifyCommitteeMembership(ep.Committee()); err != nil {
+		return fmt.Errorf("VerifyCommitteeMembership(): %w", err)
 	}
 	for inner, ctrl := range s.inner.Lock() {
 		// insertBlock may no-op if n fell into the contiguous prefix (or was

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -31,8 +31,8 @@ type blockEntry struct {
 	block *types.Block
 }
 
-// qcEntry is an admitted FullCommitQC with the epoch used to verify it.
-// The epoch is resolved once at admit (or load); later PushBlock / AppQC
+// qcEntry is a FullCommitQC stored in qcs, with the epoch used to verify it.
+// The epoch is resolved once at insertQC (or load); later PushBlock / AppQC
 // paths use this pointer instead of querying the registry again.
 type qcEntry struct {
 	qc    *types.FullCommitQC
@@ -60,14 +60,15 @@ type inner struct {
 	// Anchor represents the highest fully processed row:
 	// CommitQC, Blocks, AppProposal, AppQC present and persisted.
 	anchor utils.AtomicSend[utils.Option[Anchor]]
-	// nextCommitRoad is one past the latest admitted CommitQC. None until one is admitted.
+	// nextCommitRoad is the RoadIndex after the latest CommitQC in qcs.
+	// None before the first CommitQC. Distinct from nextQC (a GlobalBlockNumber).
 	nextCommitRoad utils.Option[types.RoadIndex]
 	// nextCommitEpoch covers nextCommitRoad once that epoch is registered; otherwise
 	// the previous publish stands (genesis epoch 0 before any CommitQC).
 	nextCommitEpoch utils.AtomicSend[*types.Epoch]
 }
 
-func (i *inner) admitCommitRoad(registry *epoch.Registry, road types.RoadIndex) {
+func (i *inner) advanceCommitRoad(registry *epoch.Registry, road types.RoadIndex) {
 	if cur, ok := i.nextCommitRoad.Get(); ok && road < cur {
 		return // a later QC already moved the cursor
 	}
@@ -109,7 +110,7 @@ func (i *inner) insertQC(registry *epoch.Registry, qc *types.FullCommitQC) error
 		i.qcs[i.nextQC] = qcEntry{qc: qc, epoch: e}
 		i.nextQC++
 	}
-	i.admitCommitRoad(registry, qc.QC().Proposal().Index())
+	i.advanceCommitRoad(registry, qc.QC().Proposal().Index())
 	return nil
 }
 
@@ -178,13 +179,13 @@ func (i *inner) insertBlock(n types.GlobalBlockNumber, block *types.Block) error
 	// nextAppProposal <= nextBlock, so qcs[n] is always present.
 	qc := i.qcs[n].qc
 	storedGR := qc.QC().GlobalRange()
-	want := qc.Headers()[n-storedGR.First]
-	got := block.Header()
-	if *want != *got {
-		return fmt.Errorf("block %d header mismatch: want %v, got %v", n, want.Hash(), got.Hash())
+	want := qc.Headers()[n-storedGR.First].Hash()
+	got := block.Header().Hash()
+	if want != got {
+		return fmt.Errorf("block %d header hash mismatch: want %v, got %v", n, want, got)
 	}
 	i.blocks[n] = block
-	i.blockHashes[got.Hash()] = n
+	i.blockHashes[got] = n
 	return nil
 }
 
@@ -245,14 +246,10 @@ func loadFromBlockStore(cfg *Config, blockStore types.BlockStore) (*inner, error
 	}
 	var commitSpan utils.Option[types.RoadRange]
 	if qcs := suffix.CommitQCs; len(qcs) > 0 {
-		first := qcs[0].Index()
-		next := qcs[0].Index() + 1
-		for _, qc := range qcs[1:] {
-			idx := qc.Index()
-			first = min(first, idx)
-			next = max(next, idx+1)
-		}
-		commitSpan = utils.Some(types.RoadRange{First: first, Next: next})
+		commitSpan = utils.Some(types.RoadRange{
+			First: qcs[0].Index(),
+			Next:  qcs[len(qcs)-1].Index() + 1,
+		})
 	}
 	cfg.Registry.SetupInitialEpochs(commitSpan)
 	firstBlock := cfg.Registry.FirstBlock()
@@ -263,7 +260,7 @@ func loadFromBlockStore(cfg *Config, blockStore types.BlockStore) (*inner, error
 		NextAppQC:       firstBlock,
 		NextBlock:       firstBlock,
 	})
-	// Empty-chain default; loaded QCs overwrite via admitCommitRoad.
+	// Empty-chain default; loaded QCs overwrite via advanceCommitRoad.
 	genesis, err := cfg.Registry.EpochByIndex(0)
 	if err != nil {
 		return nil, fmt.Errorf("missing genesis epoch: %w", err)
@@ -344,15 +341,7 @@ func (s *State) insertBlocksByHash(inner *inner, gr types.GlobalRange, byHash ma
 // PushQC pushes FullCommitQC and a subset of blocks that were finalized by it.
 // Pushing the qc and blocks is atomic, so that no unnecessary GetBlock RPCs are issued.
 // Even if the qc was already pushed earlier, the blocks are pushed anyway.
-// A QC whose epoch has been pruned is a no-op.
 func (s *State) PushQC(ctx context.Context, qc *types.FullCommitQC, blocks []*types.Block) error {
-	ep, err := s.cfg.Registry.EpochByIndex(qc.QC().Proposal().EpochIndex())
-	if err != nil {
-		if errors.Is(err, types.ErrPruned) {
-			return nil
-		}
-		return err
-	}
 	gr := qc.QC().GlobalRange()
 	needQC, err := func() (bool, error) {
 		for inner, ctrl := range s.inner.Lock() {
@@ -368,8 +357,12 @@ func (s *State) PushQC(ctx context.Context, qc *types.FullCommitQC, blocks []*ty
 	if err != nil {
 		return err
 	}
-	// Verify data.
+	var ep *types.Epoch
 	if needQC {
+		ep, err = s.cfg.Registry.EpochByIndex(qc.QC().Proposal().EpochIndex())
+		if err != nil {
+			return err
+		}
 		if err := qc.Verify(ep); err != nil {
 			return fmt.Errorf("qc.Verify(): %w", err)
 		}
@@ -388,7 +381,7 @@ func (s *State) PushQC(ctx context.Context, qc *types.FullCommitQC, blocks []*ty
 				inner.qcs[inner.nextQC] = qcEntry{qc: qc, epoch: ep}
 				inner.nextQC += 1
 			}
-			inner.admitCommitRoad(s.cfg.Registry, qc.QC().Proposal().Index())
+			inner.advanceCommitRoad(s.cfg.Registry, qc.QC().Proposal().Index())
 			ctrl.Updated()
 		}
 		if len(byHash) > 0 {
@@ -778,9 +771,9 @@ func (s *State) Anchor() utils.AtomicRecv[utils.Option[Anchor]] {
 	panic("unreachable")
 }
 
-// NextCommitEpoch returns the epoch covering the road after the latest admitted
-// CommitQC, or genesis epoch 0 when none has been admitted. If that epoch is not
-// registered yet, the previous value stands. Used by giga EVM tx sharding.
+// NextCommitEpoch returns the epoch covering the road after the latest CommitQC
+// in qcs, or genesis epoch 0 when qcs is empty. If that epoch is not registered
+// yet, the previous value stands. Used by giga EVM tx sharding.
 func (s *State) NextCommitEpoch() utils.AtomicRecv[*types.Epoch] {
 	for inner := range s.inner.Lock() {
 		return inner.nextCommitEpoch.Subscribe()

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -60,9 +60,31 @@ type inner struct {
 	// Anchor represents the highest fully processed row:
 	// CommitQC, Blocks, AppProposal, AppQC present and persisted.
 	anchor utils.AtomicSend[utils.Option[Anchor]]
-	// commitEpoch is the verify-epoch of the latest admitted CommitQC
-	// (genesis LatestEpoch when none yet). May lead AppQC/Anchor.
-	commitEpoch utils.AtomicSend[*types.Epoch]
+	// nextCommitRoad is one past the latest admitted CommitQC. None until one is admitted.
+	nextCommitRoad utils.Option[types.RoadIndex]
+	// nextCommitEpoch covers nextCommitRoad once that epoch is registered; otherwise
+	// the previous publish stands (genesis epoch 0 before any CommitQC).
+	nextCommitEpoch utils.AtomicSend[*types.Epoch]
+}
+
+func (i *inner) admitCommitRoad(registry *epoch.Registry, road types.RoadIndex) {
+	if cur, ok := i.nextCommitRoad.Get(); ok && road < cur {
+		return // a later QC already moved the cursor
+	}
+	i.nextCommitRoad = utils.Some(road + 1)
+	i.publishNextCommitEpoch(registry)
+}
+
+func (i *inner) publishNextCommitEpoch(registry *epoch.Registry) {
+	road, ok := i.nextCommitRoad.Get()
+	if !ok {
+		return
+	}
+	ep, err := registry.EpochAt(road)
+	if err != nil {
+		return
+	}
+	i.nextCommitEpoch.Store(ep)
 }
 
 // insertQC verifies and inserts a FullCommitQC into the inner state.
@@ -87,7 +109,7 @@ func (i *inner) insertQC(registry *epoch.Registry, qc *types.FullCommitQC) error
 		i.qcs[i.nextQC] = qcEntry{qc: qc, epoch: e}
 		i.nextQC++
 	}
-	i.commitEpoch.Store(e)
+	i.admitCommitRoad(registry, qc.QC().Proposal().Index())
 	return nil
 }
 
@@ -240,6 +262,11 @@ func loadFromBlockStore(cfg *Config, blockStore types.BlockStore) (*inner, error
 		NextAppQC:       firstBlock,
 		NextBlock:       firstBlock,
 	})
+	// Empty-chain default; loaded QCs overwrite via admitCommitRoad.
+	genesis, ok := cfg.Registry.EpochByIndex(0)
+	if !ok {
+		return nil, fmt.Errorf("missing genesis epoch")
+	}
 	inner := &inner{
 		qcs:             map[types.GlobalBlockNumber]qcEntry{},
 		blocks:          map[types.GlobalBlockNumber]*types.Block{},
@@ -253,7 +280,7 @@ func loadFromBlockStore(cfg *Config, blockStore types.BlockStore) (*inner, error
 		nextQC:          status.First,
 		persisted:       status,
 		anchor:          utils.NewAtomicSend(utils.None[Anchor]()),
-		commitEpoch:     utils.NewAtomicSend(cfg.Registry.LatestEpoch()),
+		nextCommitEpoch: utils.NewAtomicSend(genesis),
 	}
 	for _, qc := range suffix.CommitQCs {
 		if err := inner.insertQC(cfg.Registry, qc); err != nil {
@@ -281,6 +308,9 @@ func loadFromBlockStore(cfg *Config, blockStore types.BlockStore) (*inner, error
 		if err := inner.insertAppProposal(appProposal); err != nil {
 			return nil, fmt.Errorf("load AppProposal from BlockStore: %w", err)
 		}
+		// Match PushAppHash: do not rely only on SetupInitialEpochs for NextCommitEpoch.
+		cfg.Registry.AdvanceIfNeeded(appProposal.RoadIndex())
+		inner.publishNextCommitEpoch(cfg.Registry)
 	}
 	for _, appQC := range suffix.AppQCs {
 		if err := inner.insertAppQC(appQC); err != nil {
@@ -363,7 +393,7 @@ func (s *State) PushQC(ctx context.Context, qc *types.FullCommitQC, blocks []*ty
 				inner.qcs[inner.nextQC] = qcEntry{qc: qc, epoch: ep}
 				inner.nextQC += 1
 			}
-			inner.commitEpoch.Store(ep)
+			inner.admitCommitRoad(s.cfg.Registry, qc.QC().Proposal().Index())
 			ctrl.Updated()
 		}
 		if len(byHash) > 0 {
@@ -667,6 +697,8 @@ func (s *State) PushAppHash(ctx context.Context, n types.GlobalBlockNumber, hash
 		// ConsensusSpec withholds the view after LastRoad(N+1) until this fires
 		// again.
 		s.cfg.Registry.AdvanceIfNeeded(p.Index())
+		// Idle boundary: no further CommitQC will republish after registration.
+		inner.publishNextCommitEpoch(s.cfg.Registry)
 		ctrl.Updated()
 		// CRITICAL: We need to persist AppHash before we return and start executing the next block,
 		// otherwise we lose the apphash on restart.
@@ -755,12 +787,12 @@ func (s *State) Anchor() utils.AtomicRecv[utils.Option[Anchor]] {
 	panic("unreachable")
 }
 
-// CommitEpoch returns the verify-epoch of the latest admitted CommitQC, or the
-// genesis epoch when none has been admitted. It may lead AppQC/Anchor.
-// Used by giga EVM tx sharding (EvmProxy / EvmShard).
-func (s *State) CommitEpoch() utils.AtomicRecv[*types.Epoch] {
+// NextCommitEpoch returns the epoch covering the road after the latest admitted
+// CommitQC, or genesis epoch 0 when none has been admitted. If that epoch is not
+// registered yet, the previous value stands. Used by giga EVM tx sharding.
+func (s *State) NextCommitEpoch() utils.AtomicRecv[*types.Epoch] {
 	for inner := range s.inner.Lock() {
-		return inner.commitEpoch.Subscribe()
+		return inner.nextCommitEpoch.Subscribe()
 	}
 	panic("unreachable")
 }

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -679,7 +679,7 @@ func (s *State) PushAppHash(ctx context.Context, n types.GlobalBlockNumber, hash
 		s.metrics.NextBlock.Execute.Set(utils.Clamp[int64](inner.nextAppProposal))
 		// Seed cursor: at LastRoad(N) register N+1 so runEpochAdvance can install
 		// it once seal and the prune/execution leashes are met. N+2 is not needed —
-		// ConsensusSpec withholds the view after LastRoad(N+1) until this fires
+		// ConsensusSpec withholds the RoadIndex after LastRoad(N+1) until this fires
 		// again.
 		s.cfg.Registry.AdvanceIfNeeded(p.Index())
 		// Idle boundary: no further CommitQC will republish after registration.
@@ -759,7 +759,7 @@ func (s *State) AppQC(ctx context.Context, n types.GlobalBlockNumber) (*types.Ap
 type Anchor struct {
 	CommitQC *types.CommitQC
 	AppQC    *types.AppQC
-	// Epoch is the verify-epoch of CommitQC, stashed at admit.
+	// Epoch of CommitQC, stashed at admit.
 	Epoch *types.Epoch
 }
 

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -763,8 +763,10 @@ type Anchor struct {
 	Epoch *types.Epoch
 }
 
-// Anchor represents the AppQC/CommitQC covering inner.first.
-// It is used by avail.State.
+// Anchor is the AppQC/CommitQC covering inner.first.
+//
+// TODO: replace with AvailSpec = Option[Anchor] + nextEpoch (None + first
+// epoch initially) so avail does not consult the registry.
 func (s *State) Anchor() utils.AtomicRecv[utils.Option[Anchor]] {
 	for inner := range s.inner.Lock() {
 		return inner.anchor.Subscribe()

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -98,9 +98,9 @@ func (i *inner) insertQC(registry *epoch.Registry, qc *types.FullCommitQC) error
 	if gr.First > i.nextQC {
 		return fmt.Errorf("QC gap: expected first<=%d, got %d", i.nextQC, gr.First)
 	}
-	e, ok := registry.EpochByIndex(qc.QC().Proposal().EpochIndex())
-	if !ok {
-		return fmt.Errorf("unknown epoch_index %d", qc.QC().Proposal().EpochIndex())
+	e, err := registry.EpochByIndex(qc.QC().Proposal().EpochIndex())
+	if err != nil {
+		return err
 	}
 	if err := qc.Verify(e); err != nil {
 		return fmt.Errorf("qc.Verify(): %w", err)
@@ -264,9 +264,9 @@ func loadFromBlockStore(cfg *Config, blockStore types.BlockStore) (*inner, error
 		NextBlock:       firstBlock,
 	})
 	// Empty-chain default; loaded QCs overwrite via admitCommitRoad.
-	genesis, ok := cfg.Registry.EpochByIndex(0)
-	if !ok {
-		return nil, fmt.Errorf("missing genesis epoch")
+	genesis, err := cfg.Registry.EpochByIndex(0)
+	if err != nil {
+		return nil, fmt.Errorf("missing genesis epoch: %w", err)
 	}
 	inner := &inner{
 		qcs:             map[types.GlobalBlockNumber]qcEntry{},
@@ -344,10 +344,14 @@ func (s *State) insertBlocksByHash(inner *inner, gr types.GlobalRange, byHash ma
 // PushQC pushes FullCommitQC and a subset of blocks that were finalized by it.
 // Pushing the qc and blocks is atomic, so that no unnecessary GetBlock RPCs are issued.
 // Even if the qc was already pushed earlier, the blocks are pushed anyway.
+// A QC whose epoch has been pruned is a no-op.
 func (s *State) PushQC(ctx context.Context, qc *types.FullCommitQC, blocks []*types.Block) error {
-	ep, ok := s.cfg.Registry.EpochByIndex(qc.QC().Proposal().EpochIndex())
-	if !ok {
-		return fmt.Errorf("unknown epoch_index %d", qc.QC().Proposal().EpochIndex())
+	ep, err := s.cfg.Registry.EpochByIndex(qc.QC().Proposal().EpochIndex())
+	if err != nil {
+		if errors.Is(err, types.ErrPruned) {
+			return nil
+		}
+		return err
 	}
 	gr := qc.QC().GlobalRange()
 	needQC, err := func() (bool, error) {
@@ -906,6 +910,7 @@ func (s *State) runPersist(ctx context.Context) error {
 		for inner, ctrl := range s.inner.Lock() {
 			inner.persisted = status
 			t := time.Now()
+			from := inner.first
 			for inner.first < inner.persisted.First {
 				// Divergence detection
 				n := inner.first
@@ -925,6 +930,13 @@ func (s *State) runPersist(ctx context.Context) error {
 			}
 			s.metrics.NextBlock.Evict.Set(utils.Clamp[int64](inner.first))
 			inner.setAnchor()
+			if from < inner.first {
+				a, ok := inner.anchor.Load().Get()
+				if !ok {
+					return fmt.Errorf("evict advanced first but Anchor is None")
+				}
+				s.cfg.Registry.PruneBefore(a.Epoch.EpochIndex())
+			}
 			ctrl.Updated()
 		}
 	}

--- a/sei-tendermint/internal/autobahn/data/state.go
+++ b/sei-tendermint/internal/autobahn/data/state.go
@@ -763,7 +763,7 @@ func (s *State) AppQC(ctx context.Context, n types.GlobalBlockNumber) (*types.Ap
 type Anchor struct {
 	CommitQC *types.CommitQC
 	AppQC    *types.AppQC
-	// Epoch of CommitQC, stashed at admit.
+	// Epoch of CommitQC.
 	Epoch *types.Epoch
 }
 

--- a/sei-tendermint/internal/autobahn/data/state_recovery_test.go
+++ b/sei-tendermint/internal/autobahn/data/state_recovery_test.go
@@ -459,3 +459,20 @@ func TestNewState_SetupInitialEpochsFromCommitQCSpan(t *testing.T) {
 		t.Fatal("epoch 2 should not be seeded from a single epoch-0 CommitQC")
 	}
 }
+
+func TestNewState_NextCommitEpochAtBoundaryTip(t *testing.T) {
+	rng := utils.TestRng()
+	registry, keys := epoch.GenRegistry(rng, 3)
+	ep1, ok := registry.EpochByIndex(1)
+	require.True(t, ok)
+
+	qc, blocks := commitQCAtRoad(ep1, keys, epoch.LastRoad(1), ep1.FirstBlock())
+	db := newTestBlockDB(t, t.TempDir())
+	writeToBlockDB(t, db, []*types.FullCommitQC{qc}, [][]*types.Block{blocks})
+	writeAppDataToBlockDB(t, rng, db, keys, qc)
+
+	state := newTestState(t, &Config{Registry: registry}, db)
+	ep2, err := registry.EpochAt(epoch.FirstRoad(2))
+	require.NoError(t, err)
+	require.Equal(t, ep2, state.NextCommitEpoch().Load())
+}

--- a/sei-tendermint/internal/autobahn/data/state_recovery_test.go
+++ b/sei-tendermint/internal/autobahn/data/state_recovery_test.go
@@ -438,7 +438,7 @@ func TestNewState_SetupInitialEpochsFromCommitQCSpan(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 4)
 	qc, blocks := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 
-	db := memblock.NewBlockDB()
+	db := utils.OrPanic1(blockstore.New(memblock.NewBlockDB()))
 	t.Cleanup(func() { require.NoError(t, db.Close()) })
 	writeToBlockDB(t, db, []*types.FullCommitQC{qc}, [][]*types.Block{blocks})
 

--- a/sei-tendermint/internal/autobahn/data/state_recovery_test.go
+++ b/sei-tendermint/internal/autobahn/data/state_recovery_test.go
@@ -37,7 +37,7 @@ func TestNewStateInMemoryMode(t *testing.T) {
 	ctx := t.Context()
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
-	qc1, blocks1 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 
 	store := utils.OrPanic1(blockstore.New(memblock.NewBlockDB()))
 	state := utils.OrPanic1(NewState(&Config{Registry: registry}, store))
@@ -65,8 +65,8 @@ func TestRecoveryNormal(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 	dir := t.TempDir()
 
-	qc1, blocks1 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
-	qc2, blocks2 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.Some(qc1.QC()))
+	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
+	qc2, blocks2 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.Some(qc1.QC()))
 	gr1 := qc1.QC().GlobalRange()
 	gr2 := qc2.QC().GlobalRange()
 
@@ -103,7 +103,7 @@ func TestRecoveryNormal(t *testing.T) {
 func TestRecoveryStartsAtRegistryFloorWhenBlockDBMissingFirstCommittedBlock(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
-	qc, _ := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+	qc, _ := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 	gr := qc.QC().GlobalRange()
 
 	db := newTestBlockDB(t, t.TempDir())
@@ -118,8 +118,8 @@ func TestRecoveryStartsAtRegistryFloorWhenBlockDBMissingFirstCommittedBlock(t *t
 func TestRecoveryLeavesAppTipBelowPruneFloorUnreadable(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
-	qc1, blocks1 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
-	qc2, blocks2 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.Some(qc1.QC()))
+	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
+	qc2, blocks2 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.Some(qc1.QC()))
 
 	db := newTestBlockDB(t, t.TempDir())
 	writeToBlockDB(t, db,
@@ -142,9 +142,9 @@ func TestPruningDiscards(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
 
-	qc1, blocks1 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
-	qc2, blocks2 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.Some(qc1.QC()))
-	qc3, blocks3 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.Some(qc2.QC()))
+	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
+	qc2, blocks2 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.Some(qc1.QC()))
+	qc3, blocks3 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.Some(qc2.QC()))
 	gr1 := qc1.QC().GlobalRange()
 	gr2 := qc2.QC().GlobalRange()
 	gr3 := qc3.QC().GlobalRange()
@@ -179,9 +179,9 @@ func TestRecoveryAfterPruning(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 	dir := t.TempDir()
 
-	qc1, _ := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
-	qc2, blocks2 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.Some(qc1.QC()))
-	qc3, blocks3 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.Some(qc2.QC()))
+	qc1, _ := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
+	qc2, blocks2 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.Some(qc1.QC()))
+	qc3, blocks3 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.Some(qc2.QC()))
 	gr2 := qc2.QC().GlobalRange()
 	gr3 := qc3.QC().GlobalRange()
 
@@ -226,8 +226,8 @@ func TestRecoveryBlocksBehind(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 	dir := t.TempDir()
 
-	qc1, blocks1 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
-	qc2, blocks2 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.Some(qc1.QC()))
+	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
+	qc2, blocks2 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.Some(qc1.QC()))
 	gr1 := qc1.QC().GlobalRange()
 	gr2 := qc2.QC().GlobalRange()
 
@@ -274,8 +274,8 @@ func TestRecoveryAfterPruneNoGC(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 	dir := t.TempDir()
 
-	qc1, blocks1 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
-	qc2, blocks2 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.Some(qc1.QC()))
+	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
+	qc2, blocks2 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.Some(qc1.QC()))
 	gr1 := qc1.QC().GlobalRange()
 	gr2 := qc2.QC().GlobalRange()
 
@@ -318,7 +318,7 @@ func TestRecoveryQCsNoBlocks(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 	dir := t.TempDir()
 
-	qc1, _ := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+	qc1, _ := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 	gr1 := qc1.QC().GlobalRange()
 
 	db1 := newTestBlockDB(t, dir)
@@ -350,8 +350,8 @@ func TestRunPersistSeedsFromRecoveryFloor(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 	dir := t.TempDir()
 
-	qc1, _ := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
-	qc2, blocks2 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.Some(qc1.QC()))
+	qc1, _ := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
+	qc2, blocks2 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.Some(qc1.QC()))
 	gr2 := qc2.QC().GlobalRange()
 	require.Greater(t, gr2.First, registry.FirstBlock(), "need skipTo past genesis")
 
@@ -400,7 +400,7 @@ func TestRecoveryBlockGap(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 	dir := t.TempDir()
 
-	qc1, blocks1 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 	gr1 := qc1.QC().GlobalRange()
 
 	// TestCommitQC generates 10 global blocks, so the range is always wide
@@ -436,7 +436,7 @@ func TestRecoveryBlockGap(t *testing.T) {
 func TestNewState_SetupInitialEpochsFromCommitQCSpan(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
-	qc, blocks := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+	qc, blocks := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 
 	db := memblock.NewBlockDB()
 	t.Cleanup(func() { require.NoError(t, db.Close()) })
@@ -463,8 +463,7 @@ func TestNewState_SetupInitialEpochsFromCommitQCSpan(t *testing.T) {
 func TestNewState_NextCommitEpochAtBoundaryTip(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
-	ep1, ok := registry.EpochByIndex(1)
-	require.True(t, ok)
+	ep1 := registry.MustEpoch(1)
 
 	qc, blocks := commitQCAtRoad(ep1, keys, epoch.LastRoad(1), ep1.FirstBlock())
 	db := newTestBlockDB(t, t.TempDir())

--- a/sei-tendermint/internal/autobahn/data/state_recovery_test.go
+++ b/sei-tendermint/internal/autobahn/data/state_recovery_test.go
@@ -432,3 +432,30 @@ func TestRecoveryBlockGap(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, mid, state.NextBlock(), "replay must resume at the first unfilled number")
 }
+
+func TestNewState_SetupInitialEpochsFromCommitQCSpan(t *testing.T) {
+	rng := utils.TestRng()
+	registry, keys := epoch.GenRegistry(rng, 4)
+	qc, blocks := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+
+	db := memblock.NewBlockDB()
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	writeToBlockDB(t, db, []*types.FullCommitQC{qc}, [][]*types.Block{blocks})
+
+	_, err := registry.EpochAt(epoch.FirstRoad(1))
+	require.NoError(t, err, "precondition: genesis epochs 0 and 1 are registered")
+	_, err = registry.EpochAt(epoch.FirstRoad(2))
+	require.Error(t, err, "precondition: epoch 2 absent before NewState")
+
+	_, err = NewState(&Config{Registry: registry}, db)
+	require.NoError(t, err)
+
+	for _, idx := range []types.EpochIndex{0, 1} {
+		if _, err := registry.EpochAt(epoch.FirstRoad(idx)); err != nil {
+			t.Fatalf("EpochAt(epoch %d) after NewState: %v", idx, err)
+		}
+	}
+	if _, err := registry.EpochAt(epoch.FirstRoad(2)); err == nil {
+		t.Fatal("epoch 2 should not be seeded from a single epoch-0 CommitQC")
+	}
+}

--- a/sei-tendermint/internal/autobahn/data/state_recovery_test.go
+++ b/sei-tendermint/internal/autobahn/data/state_recovery_test.go
@@ -3,26 +3,22 @@ package data
 import (
 	"context"
 	"testing"
-	"time"
 
-	"github.com/sei-protocol/sei-chain/sei-db/ledger_db/block/littblock"
-	"github.com/sei-protocol/sei-chain/sei-db/ledger_db/block/memblock"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/autobahn/types"
-	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/blockstore"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/epoch"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/require"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/scope"
 )
 
-// TestRecoveryEmpty verifies that NewState is a no-op on a fresh BlockDB.
+// TestRecoveryEmpty verifies that NewState is a no-op on a fresh BlockStore.
 func TestRecoveryEmpty(t *testing.T) {
 	rng := utils.TestRng()
 	registry, _ := epoch.GenRegistry(rng, 3)
 	dir := t.TempDir()
 	fb := registry.FirstBlock()
 
-	db := newTestBlockDB(t, dir)
+	db := newTestBlockStore(t, dir)
 	state := newTestState(t, &Config{Registry: registry}, db)
 	require.Equal(t, fb, state.NextBlock())
 	for inner := range state.inner.Lock() {
@@ -32,14 +28,14 @@ func TestRecoveryEmpty(t *testing.T) {
 }
 
 // TestNewStateInMemoryMode verifies that NewState with an in-memory store followed by Run
-// works end-to-end: QCs and blocks are accessible without a durable BlockDB dir.
+// works end-to-end: QCs and blocks are accessible without a durable store dir.
 func TestNewStateInMemoryMode(t *testing.T) {
 	ctx := t.Context()
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
 	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 
-	store := utils.OrPanic1(blockstore.New(memblock.NewBlockDB()))
+	store := newMemoryBlockStore(t)
 	state := utils.OrPanic1(NewState(&Config{Registry: registry}, store))
 
 	require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
@@ -71,14 +67,14 @@ func TestRecoveryNormal(t *testing.T) {
 	gr2 := qc2.QC().GlobalRange()
 
 	// Session 1: write both QCs and all blocks.
-	db1 := newTestBlockDB(t, dir)
-	writeToBlockDB(t, db1,
+	db1 := newTestBlockStore(t, dir)
+	writeToBlockStore(t, db1,
 		[]*types.FullCommitQC{qc1, qc2},
 		[][]*types.Block{blocks1, blocks2})
 	require.NoError(t, db1.Close())
 
 	// Session 2: NewState should recover blocks and QCs.
-	db2 := newTestBlockDB(t, dir)
+	db2 := newTestBlockStore(t, dir)
 	state2 := newTestState(t, &Config{Registry: registry}, db2)
 
 	require.Equal(t, gr2.Next, state2.NextBlock())
@@ -95,18 +91,18 @@ func TestRecoveryNormal(t *testing.T) {
 	require.NoError(t, db2.Close())
 
 	// Session 3: verify session 2 did not corrupt BlockDB.
-	db3 := newTestBlockDB(t, dir)
+	db3 := newTestBlockStore(t, dir)
 	state3 := newTestState(t, &Config{Registry: registry}, db3)
 	require.Equal(t, gr2.Next, state3.NextBlock())
 }
 
-func TestRecoveryStartsAtRegistryFloorWhenBlockDBMissingFirstCommittedBlock(t *testing.T) {
+func TestRecoveryStartsAtRegistryFloorWhenBlockStoreMissingFirstCommittedBlock(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
 	qc, _ := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 	gr := qc.QC().GlobalRange()
 
-	db := newTestBlockDB(t, t.TempDir())
+	db := newTestBlockStore(t, t.TempDir())
 	require.NoError(t, db.WriteQC(qc))
 	require.NoError(t, db.Flush())
 
@@ -121,11 +117,11 @@ func TestRecoveryLeavesAppTipBelowPruneFloorUnreadable(t *testing.T) {
 	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 	qc2, blocks2 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.Some(qc1.QC()))
 
-	db := newTestBlockDB(t, t.TempDir())
-	writeToBlockDB(t, db,
+	db := newTestBlockStore(t, t.TempDir())
+	writeToBlockStore(t, db,
 		[]*types.FullCommitQC{qc1, qc2},
 		[][]*types.Block{blocks1, blocks2})
-	writeAppDataToBlockDB(t, rng, db, keys, qc1, qc2)
+	writeAppDataToBlockStore(t, rng, db, keys, qc1, qc2)
 	require.NoError(t, db.PruneBefore(qc2.QC().GlobalRange().First))
 
 	state, err := NewState(&Config{Registry: registry}, db)
@@ -149,7 +145,7 @@ func TestPruningDiscards(t *testing.T) {
 	gr2 := qc2.QC().GlobalRange()
 	gr3 := qc3.QC().GlobalRange()
 
-	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
+	state := newTestState(t, &Config{Registry: registry}, newTestBlockStore(t, t.TempDir()))
 	require.NoError(t, state.PushQC(ctx, qc1, blocks1))
 	require.NoError(t, state.PushQC(ctx, qc2, blocks2))
 	require.NoError(t, state.PushQC(ctx, qc3, blocks3))
@@ -186,8 +182,8 @@ func TestRecoveryAfterPruning(t *testing.T) {
 	gr3 := qc3.QC().GlobalRange()
 
 	// Write only qc2 and qc3 — simulating a DB where qc1 was pruned and GC'd.
-	db1 := newTestBlockDB(t, dir)
-	writeToBlockDB(t, db1,
+	db1 := newTestBlockStore(t, dir)
+	writeToBlockStore(t, db1,
 		[]*types.FullCommitQC{qc2, qc3},
 		[][]*types.Block{blocks2, blocks3})
 	require.NoError(t, db1.Close())
@@ -195,7 +191,7 @@ func TestRecoveryAfterPruning(t *testing.T) {
 	// Recovery skipTo(gr2.First); qc1 heights are absent from BlockDB → ErrPruned.
 	// With no AppQC yet, first stays at the recovery floor (not advanced to 0),
 	// so below-floor reads fall through to BlockDB instead of nil maps.
-	db2 := newTestBlockDB(t, dir)
+	db2 := newTestBlockStore(t, dir)
 	state2 := newTestState(t, &Config{Registry: registry}, db2)
 
 	for inner := range state2.inner.Lock() {
@@ -232,7 +228,7 @@ func TestRecoveryBlocksBehind(t *testing.T) {
 	gr2 := qc2.QC().GlobalRange()
 
 	// Write both QCs but only qc1's blocks (simulate crash before qc2 blocks).
-	db1 := newTestBlockDB(t, dir)
+	db1 := newTestBlockStore(t, dir)
 	require.NoError(t, db1.WriteQC(qc1))
 	require.NoError(t, db1.WriteQC(qc2))
 	for i, n := 0, gr1.First; n < gr1.Next; n++ {
@@ -243,7 +239,7 @@ func TestRecoveryBlocksBehind(t *testing.T) {
 	require.NoError(t, db1.Close())
 
 	// Recovery: both QCs loaded, but only qc1's blocks.
-	db2 := newTestBlockDB(t, dir)
+	db2 := newTestBlockStore(t, dir)
 	state2 := newTestState(t, &Config{Registry: registry}, db2)
 
 	for n := gr1.First; n < gr1.Next; n++ {
@@ -279,29 +275,24 @@ func TestRecoveryAfterPruneNoGC(t *testing.T) {
 	gr1 := qc1.QC().GlobalRange()
 	gr2 := qc2.QC().GlobalRange()
 
-	// Write both QCs and all their blocks to the DB.
-	cfg1 := utils.OrPanic1(littblock.DefaultConfig(dir))
-	cfg1.RetentionTime = time.Nanosecond
-	db1 := utils.OrPanic1(blockstore.New(utils.OrPanic1(littblock.NewBlockDB(cfg1))))
-	writeToBlockDB(t, db1, []*types.FullCommitQC{qc1, qc2}, [][]*types.Block{blocks1, blocks2})
+	// Write both QCs and all their blocks to the store.
+	store1 := newTestBlockStore(t, dir)
+	writeToBlockStore(t, store1, []*types.FullCommitQC{qc1, qc2}, [][]*types.Block{blocks1, blocks2})
 
 	// Prune qc1's range. GC is NOT called — pruned entries remain on disk.
-	require.NoError(t, db1.PruneBefore(gr2.First))
-	require.NoError(t, db1.Close())
+	require.NoError(t, store1.PruneBefore(gr2.First))
+	require.NoError(t, store1.Close())
 
 	// Reopen the same dir without ForceGC — pruned entries may still be present.
-	cfg2 := utils.OrPanic1(littblock.DefaultConfig(dir))
-	cfg2.RetentionTime = time.Nanosecond
-	db2 := utils.OrPanic1(blockstore.New(utils.OrPanic1(littblock.NewBlockDB(cfg2))))
-	t.Cleanup(func() { _ = db2.Close() })
+	store2 := newTestBlockStore(t, dir)
 
 	// NewState must succeed — below-watermark blocks never outlive their QCs
 	// because blocks and QCs share the same GC filter in littblock. Without GC,
-	// all entries are still present and recovery treats the DB as unpruned.
+	// all entries are still present and recovery treats the store as unpruned.
 	// This is the PruneBefore-without-GC path: the watermark advanced but
-	// physical reclamation has not happened yet, so the DB looks like a
-	// fresh DB containing all data from qc1 and qc2.
-	state := newTestState(t, &Config{Registry: registry}, db2)
+	// physical reclamation has not happened yet, so the store looks like a
+	// fresh store containing all data from qc1 and qc2.
+	state := newTestState(t, &Config{Registry: registry}, store2)
 
 	// Without GC all data is still present; qc1 and qc2 blocks are accessible.
 	for n := gr1.First; n < gr2.Next; n++ {
@@ -321,12 +312,12 @@ func TestRecoveryQCsNoBlocks(t *testing.T) {
 	qc1, _ := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 	gr1 := qc1.QC().GlobalRange()
 
-	db1 := newTestBlockDB(t, dir)
+	db1 := newTestBlockStore(t, dir)
 	require.NoError(t, db1.WriteQC(qc1))
 	require.NoError(t, db1.Flush())
 	require.NoError(t, db1.Close())
 
-	db2 := newTestBlockDB(t, dir)
+	db2 := newTestBlockStore(t, dir)
 	state2 := newTestState(t, &Config{Registry: registry}, db2)
 
 	require.Equal(t, gr1.First, state2.NextBlock())
@@ -356,12 +347,12 @@ func TestRunPersistSeedsFromRecoveryFloor(t *testing.T) {
 	require.Greater(t, gr2.First, registry.FirstBlock(), "need skipTo past genesis")
 
 	// First WriteQC on an empty DB may start past genesis (crash / partial retain).
-	db1 := newTestBlockDB(t, dir)
+	db1 := newTestBlockStore(t, dir)
 	require.NoError(t, db1.WriteQC(qc2))
 	require.NoError(t, db1.Flush())
 	require.NoError(t, db1.Close())
 
-	db2 := newTestBlockDB(t, dir)
+	db2 := newTestBlockStore(t, dir)
 	tips := db2.Status().OrPanic("non-empty BlockDB status")
 	require.Equal(t, gr2.First, tips.First)
 	require.Equal(t, tips.First, tips.NextBlock)
@@ -407,7 +398,7 @@ func TestRecoveryBlockGap(t *testing.T) {
 	// enough to skip one block in the middle.
 	mid := gr1.First + (gr1.Next-gr1.First)/2
 
-	db1 := newTestBlockDB(t, dir)
+	db1 := newTestBlockStore(t, dir)
 	defer func() { _ = db1.Close() }()
 	require.NoError(t, db1.WriteQC(qc1))
 
@@ -438,16 +429,15 @@ func TestNewState_SetupInitialEpochsFromCommitQCSpan(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 4)
 	qc, blocks := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 
-	db := utils.OrPanic1(blockstore.New(memblock.NewBlockDB()))
-	t.Cleanup(func() { require.NoError(t, db.Close()) })
-	writeToBlockDB(t, db, []*types.FullCommitQC{qc}, [][]*types.Block{blocks})
+	store := newMemoryBlockStore(t)
+	writeToBlockStore(t, store, []*types.FullCommitQC{qc}, [][]*types.Block{blocks})
 
 	_, err := registry.EpochAt(epoch.FirstRoad(1))
 	require.NoError(t, err, "precondition: genesis epochs 0 and 1 are registered")
 	_, err = registry.EpochAt(epoch.FirstRoad(2))
 	require.Error(t, err, "precondition: epoch 2 absent before NewState")
 
-	_, err = NewState(&Config{Registry: registry}, db)
+	_, err = NewState(&Config{Registry: registry}, store)
 	require.NoError(t, err)
 
 	for _, idx := range []types.EpochIndex{0, 1} {
@@ -466,9 +456,9 @@ func TestNewState_NextCommitEpochAtBoundaryTip(t *testing.T) {
 	ep1 := registry.MustEpoch(1)
 
 	qc, blocks := commitQCAtRoad(ep1, keys, epoch.LastRoad(1), ep1.FirstBlock())
-	db := newTestBlockDB(t, t.TempDir())
-	writeToBlockDB(t, db, []*types.FullCommitQC{qc}, [][]*types.Block{blocks})
-	writeAppDataToBlockDB(t, rng, db, keys, qc)
+	db := newTestBlockStore(t, t.TempDir())
+	writeToBlockStore(t, db, []*types.FullCommitQC{qc}, [][]*types.Block{blocks})
+	writeAppDataToBlockStore(t, rng, db, keys, qc)
 
 	state := newTestState(t, &Config{Registry: registry}, db)
 	ep2, err := registry.EpochAt(epoch.FirstRoad(2))

--- a/sei-tendermint/internal/autobahn/data/state_test.go
+++ b/sei-tendermint/internal/autobahn/data/state_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/sei-protocol/sei-chain/sei-db/ledger_db/block/littblock"
+	"github.com/sei-protocol/sei-chain/sei-db/ledger_db/block/memblock"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/autobahn/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/blockstore"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/epoch"
@@ -47,49 +48,56 @@ func snapshot(s *State) Snapshot {
 	panic("unreachable")
 }
 
-// newTestBlockDB opens (or creates) a LittDB-backed BlockDB at dir.
+// newTestBlockStore opens (or creates) a LittDB-backed BlockStore at dir.
 // Retention is set to 1ns so ForceGC reclaims pruned data immediately in tests.
 // Errors panic so the helper is safe to call from non-main test goroutines.
-func newTestBlockDB(t *testing.T, dir string) types.BlockStore {
+func newTestBlockStore(t *testing.T, dir string) types.BlockStore {
 	t.Helper()
 	cfg := utils.OrPanic1(littblock.DefaultConfig(dir))
 	cfg.RetentionTime = time.Nanosecond
-	db := utils.OrPanic1(blockstore.New(utils.OrPanic1(littblock.NewBlockDB(cfg))))
-	t.Cleanup(func() { _ = db.Close() })
-	return db
+	store := utils.OrPanic1(blockstore.New(utils.OrPanic1(littblock.NewBlockDB(cfg))))
+	t.Cleanup(func() { _ = store.Close() })
+	return store
 }
 
-// newTestState constructs a State, replays db, and returns it ready to Run.
-// Errors panic so the helper is safe to call from non-main test goroutines.
-func newTestState(t testing.TB, cfg *Config, db types.BlockStore) *State {
+func newMemoryBlockStore(t testing.TB) types.BlockStore {
 	t.Helper()
-	return utils.OrPanic1(NewState(cfg, db))
+	store := utils.OrPanic1(blockstore.New(memblock.NewBlockDB()))
+	t.Cleanup(func() { _ = store.Close() })
+	return store
 }
 
-// writeToBlockDB writes QC+block pairs sequentially to db and flushes once.
+// newTestState constructs a State, replays store, and returns it ready to Run.
+// Errors panic so the helper is safe to call from non-main test goroutines.
+func newTestState(t testing.TB, cfg *Config, store types.BlockStore) *State {
+	t.Helper()
+	return utils.OrPanic1(NewState(cfg, store))
+}
+
+// writeToBlockStore writes QC+block pairs sequentially to store and flushes once.
 // qcs[i] and blockss[i] must correspond; QCs must be in ascending order.
 // Errors panic so the helper is safe to call from non-main test goroutines.
-func writeToBlockDB(t *testing.T, db types.BlockStore, qcs []*types.FullCommitQC, blockss [][]*types.Block) {
+func writeToBlockStore(t *testing.T, store types.BlockStore, qcs []*types.FullCommitQC, blockss [][]*types.Block) {
 	t.Helper()
 	for i, qc := range qcs {
 		gr := qc.QC().GlobalRange()
-		utils.OrPanic(db.WriteQC(qc))
+		utils.OrPanic(store.WriteQC(qc))
 		for j, n := 0, gr.First; n < gr.Next; n++ {
-			utils.OrPanic(db.WriteBlock(n, blockss[i][j]))
+			utils.OrPanic(store.WriteBlock(n, blockss[i][j]))
 			j++
 		}
 	}
-	utils.OrPanic(db.Flush())
+	utils.OrPanic(store.Flush())
 }
 
-func writeAppDataToBlockDB(t testing.TB, rng utils.Rng, db types.BlockStore, keys []types.SecretKey, qcs ...*types.FullCommitQC) {
+func writeAppDataToBlockStore(t testing.TB, rng utils.Rng, store types.BlockStore, keys []types.SecretKey, qcs ...*types.FullCommitQC) {
 	t.Helper()
 	for _, qc := range qcs {
 		appProposal := types.NewAppProposal(qc.QC().Proposal(), types.GenAppHash(rng))
-		utils.OrPanic(db.WriteAppProposal(appProposal))
-		utils.OrPanic(db.WriteAppQC(TestAppQC(keys, appProposal)))
+		utils.OrPanic(store.WriteAppProposal(appProposal))
+		utils.OrPanic(store.WriteAppQC(TestAppQC(keys, appProposal)))
 	}
-	utils.OrPanic(db.Flush())
+	utils.OrPanic(store.Flush())
 }
 
 // pushAppHashesRunning runs state.Run under scope.Run long enough to accept
@@ -135,7 +143,7 @@ func TestNextCommitEpoch_AdvancesAtIdleEpochBoundary(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
 	ep1 := registry.MustEpoch(1)
-	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
+	state := newTestState(t, &Config{Registry: registry}, newTestBlockStore(t, t.TempDir()))
 
 	qcMid, blocksMid := commitQCAtRoad(ep1, keys, epoch.FirstRoad(1), ep1.FirstBlock())
 	require.NoError(t, state.PushQC(ctx, qcMid, blocksMid))
@@ -162,7 +170,7 @@ func TestState(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
 	if err := scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
-		state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
+		state := newTestState(t, &Config{Registry: registry}, newTestBlockStore(t, t.TempDir()))
 		s.SpawnBgNamed("state.Run()", func() error {
 			return utils.IgnoreCancel(state.Run(ctx))
 		})
@@ -233,7 +241,7 @@ func TestPushConflictingBadCommitQC(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
 	committee := registry.MustEpoch(0).Committee()
-	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
+	state := newTestState(t, &Config{Registry: registry}, newTestBlockStore(t, t.TempDir()))
 
 	// Push a valid QC to advance inner.nextQC.
 	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
@@ -339,7 +347,7 @@ func TestPushQCIgnoresBlocksMatchingUnverifiedHeaders(t *testing.T) {
 	ctx := t.Context()
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
-	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
+	state := newTestState(t, &Config{Registry: registry}, newTestBlockStore(t, t.TempDir()))
 
 	// Push qc1 with NO blocks — only the QC is stored.
 	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
@@ -383,7 +391,7 @@ func TestExecution(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
 	if err := scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
-		state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
+		state := newTestState(t, &Config{Registry: registry}, newTestBlockStore(t, t.TempDir()))
 		s.SpawnBgNamed("state.Run()", func() error {
 			return utils.IgnoreCancel(state.Run(ctx))
 		})
@@ -422,7 +430,7 @@ func TestPushAppHashRejectsJumpOverCommitQCRange(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
 
-	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
+	state := newTestState(t, &Config{Registry: registry}, newTestBlockStore(t, t.TempDir()))
 	require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
 		s.SpawnBgNamed("state.Run()", func() error { return utils.IgnoreCancel(state.Run(ctx)) })
 		epoch := registry.MustEpoch(0)
@@ -473,7 +481,7 @@ func TestPushBlockAcceptsBlockWithQC(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
 
-	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
+	state := newTestState(t, &Config{Registry: registry}, newTestBlockStore(t, t.TempDir()))
 
 	// Push QC without blocks.
 	qc, blocks := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
@@ -492,7 +500,7 @@ func TestGlobalBlockByHash(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
 
-	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
+	state := newTestState(t, &Config{Registry: registry}, newTestBlockStore(t, t.TempDir()))
 
 	qc, blocks := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 	require.NoError(t, state.PushQC(ctx, qc, blocks))
@@ -525,10 +533,10 @@ func TestGlobalBlockByHash(t *testing.T) {
 	require.False(t, ok, "GlobalBlockByHash(random) returned Some")
 }
 
-// TestPushQCBeforeRunPersistsToBlockDB seeds in-memory QCs/blocks before Run
+// TestPushQCBeforeRunPersistsToBlockStore seeds in-memory QCs/blocks before Run
 // (mirroring inbound PushQC after transport start) and asserts runPersist still
 // writes them — Status seeding, not inner.nextQC/nextBlock.
-func TestPushQCBeforeRunPersistsToBlockDB(t *testing.T) {
+func TestPushQCBeforeRunPersistsToBlockStore(t *testing.T) {
 	ctx := t.Context()
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
@@ -537,7 +545,7 @@ func TestPushQCBeforeRunPersistsToBlockDB(t *testing.T) {
 	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 	gr1 := qc1.QC().GlobalRange()
 
-	db := newTestBlockDB(t, dir)
+	db := newTestBlockStore(t, dir)
 	state := newTestState(t, &Config{Registry: registry}, db)
 
 	// Transport-race window: PushQC before data.Run / runPersist starts.
@@ -560,7 +568,7 @@ func TestPushQCBeforeRunPersistsToBlockDB(t *testing.T) {
 	require.Equal(t, gr1.Next, tips.NextQC)
 
 	require.NoError(t, db.Close())
-	db2 := newTestBlockDB(t, dir)
+	db2 := newTestBlockStore(t, dir)
 	state2 := newTestState(t, &Config{Registry: registry}, db2)
 	require.Equal(t, gr1.Next, state2.NextBlock())
 	for n := gr1.First; n < gr1.Next; n++ {
@@ -583,7 +591,7 @@ func TestEvictionWaitsForAppQC(t *testing.T) {
 	qc2, blocks2 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.Some(qc1.QC()))
 	gr2 := qc2.QC().GlobalRange()
 
-	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
+	state := newTestState(t, &Config{Registry: registry}, newTestBlockStore(t, t.TempDir()))
 	require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
 		s.SpawnBgNamed("state.Run", func() error { return utils.IgnoreCancel(state.Run(ctx)) })
 
@@ -672,7 +680,7 @@ func TestEvictionWaitsForPersistedAppQC(t *testing.T) {
 	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 	gr1 := qc1.QC().GlobalRange()
 
-	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
+	state := newTestState(t, &Config{Registry: registry}, newTestBlockStore(t, t.TempDir()))
 	require.NoError(t, state.PushQC(ctx, qc1, blocks1))
 	require.NoError(t, pushAppHashesRunning(ctx, state, rng, gr1.First, gr1.Next))
 	require.NoError(t, pushAppQCForBlock(ctx, state, keys, gr1.First))
@@ -695,7 +703,7 @@ func TestPushAppHashBelowAnchorSucceeds(t *testing.T) {
 	epoch := registry.MustEpoch(0)
 
 	require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
-		state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
+		state := newTestState(t, &Config{Registry: registry}, newTestBlockStore(t, t.TempDir()))
 		s.SpawnBgNamed("state.Run", func() error { return utils.IgnoreCancel(state.Run(ctx)) })
 
 		prev := utils.None[*types.CommitQC]()
@@ -743,7 +751,7 @@ func TestNextToExecuteAfterAppEviction(t *testing.T) {
 	gr1 := qc1.QC().GlobalRange()
 	qc2, blocks2 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.Some(qc1.QC()))
 
-	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
+	state := newTestState(t, &Config{Registry: registry}, newTestBlockStore(t, t.TempDir()))
 	require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
 		s.SpawnBgNamed("state.Run", func() error { return utils.IgnoreCancel(state.Run(ctx)) })
 
@@ -826,7 +834,7 @@ func TestPushAppQCPersistsAndRecovers(t *testing.T) {
 	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 	gr1 := qc1.QC().GlobalRange()
 
-	db1 := newTestBlockDB(t, dir)
+	db1 := newTestBlockStore(t, dir)
 	state1 := newTestState(t, &Config{Registry: registry}, db1)
 	require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
 		s.SpawnBgNamed("state.Run", func() error { return utils.IgnoreCancel(state1.Run(ctx)) })
@@ -861,7 +869,7 @@ func TestPushAppQCPersistsAndRecovers(t *testing.T) {
 	require.True(t, stored.IsPresent(), "PushAppQC must persist the AppQC")
 	require.NoError(t, db1.Close())
 
-	db2 := newTestBlockDB(t, dir)
+	db2 := newTestBlockStore(t, dir)
 	state2 := newTestState(t, &Config{Registry: registry}, db2)
 	for inner := range state2.inner.Lock() {
 		require.Equal(t, gr1.Next, inner.nextAppProposal)
@@ -887,7 +895,7 @@ func TestPruningKeepsLastQCRange(t *testing.T) {
 	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 	gr1 := qc1.QC().GlobalRange()
 
-	state1 := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
+	state1 := newTestState(t, &Config{Registry: registry}, newTestBlockStore(t, t.TempDir()))
 	require.NoError(t, state1.PushQC(ctx, qc1, blocks1))
 	require.NoError(t, pushAppHashesRunning(ctx, state1, rng, gr1.First, gr1.Next))
 
@@ -901,11 +909,11 @@ func TestPruningKeepsLastQCRange(t *testing.T) {
 
 	// Consistent post-GC shape: full QC range of blocks. Restart recovers at QC start.
 	dir := t.TempDir()
-	db := newTestBlockDB(t, dir)
-	writeToBlockDB(t, db, []*types.FullCommitQC{qc1}, [][]*types.Block{blocks1})
+	db := newTestBlockStore(t, dir)
+	writeToBlockStore(t, db, []*types.FullCommitQC{qc1}, [][]*types.Block{blocks1})
 	require.NoError(t, db.Close())
 
-	db2 := newTestBlockDB(t, dir)
+	db2 := newTestBlockStore(t, dir)
 	state2 := newTestState(t, &Config{Registry: registry}, db2)
 	require.Equal(t, gr1.Next, state2.NextBlock())
 	for n := gr1.First; n < gr1.Next; n++ {
@@ -933,7 +941,7 @@ func TestPruningWithPartialQCRange(t *testing.T) {
 	gr1 := qc1.QC().GlobalRange()
 	gr2 := qc2.QC().GlobalRange()
 
-	state1 := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
+	state1 := newTestState(t, &Config{Registry: registry}, newTestBlockStore(t, t.TempDir()))
 	require.NoError(t, state1.PushQC(ctx, qc1, blocks1))
 	require.NoError(t, state1.PushQC(ctx, qc2, blocks2))
 
@@ -995,11 +1003,11 @@ func TestPruningWithPartialQCRange(t *testing.T) {
 
 	// Consistent retained range: full qc2.
 	dir := t.TempDir()
-	db := newTestBlockDB(t, dir)
-	writeToBlockDB(t, db, []*types.FullCommitQC{qc2}, [][]*types.Block{blocks2})
+	db := newTestBlockStore(t, dir)
+	writeToBlockStore(t, db, []*types.FullCommitQC{qc2}, [][]*types.Block{blocks2})
 	require.NoError(t, db.Close())
 
-	db2 := newTestBlockDB(t, dir)
+	db2 := newTestBlockStore(t, dir)
 	state2 := newTestState(t, &Config{Registry: registry}, db2)
 	require.Equal(t, gr2.Next, state2.NextBlock())
 	for n := gr2.First; n < gr2.Next; n++ {
@@ -1015,7 +1023,7 @@ func TestPushBlockWaitsForQC(t *testing.T) {
 		rng := utils.TestRng()
 		registry, keys := epoch.GenRegistry(rng, 3)
 
-		state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
+		state := newTestState(t, &Config{Registry: registry}, newTestBlockStore(t, t.TempDir()))
 
 		// Push first QC covering [0, N).
 		qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
@@ -1071,7 +1079,7 @@ func TestTryBlockHidesGapFills(t *testing.T) {
 	gr2 := qc2.QC().GlobalRange()
 	require.GreaterOrEqual(t, gr2.Len(), 2)
 
-	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
+	state := newTestState(t, &Config{Registry: registry}, newTestBlockStore(t, t.TempDir()))
 	require.NoError(t, state.PushQC(ctx, qc1, blocks1))
 	require.NoError(t, state.PushQC(ctx, qc2, nil))
 	require.Equal(t, gr1.Next, state.NextBlock())

--- a/sei-tendermint/internal/autobahn/data/state_test.go
+++ b/sei-tendermint/internal/autobahn/data/state_test.go
@@ -134,8 +134,7 @@ func TestNextCommitEpoch_TracksNextRoadEpoch(t *testing.T) {
 	ctx := t.Context()
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
-	ep0, ok := registry.EpochByIndex(0)
-	require.True(t, ok)
+	ep0 := registry.MustEpoch(0)
 	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
 	require.Equal(t, ep0, state.NextCommitEpoch().Load())
 
@@ -156,8 +155,7 @@ func TestNextCommitEpoch_AdvancesAtIdleEpochBoundary(t *testing.T) {
 	ctx := t.Context()
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
-	ep1, ok := registry.EpochByIndex(1)
-	require.True(t, ok)
+	ep1 := registry.MustEpoch(1)
 	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
 
 	qcMid, blocksMid := commitQCAtRoad(ep1, keys, epoch.FirstRoad(1), ep1.FirstBlock())
@@ -194,7 +192,7 @@ func TestState(t *testing.T) {
 		prev := utils.None[*types.CommitQC]()
 		for i := range 3 {
 			t.Logf("iteration %v", i)
-			qc, blocks := TestCommitQC(rng, registry.LatestEpoch(), keys, prev)
+			qc, blocks := TestCommitQC(rng, registry.MustEpoch(0), keys, prev)
 			prev = utils.Some(qc.QC())
 			if err := state.PushQC(ctx, qc, blocks); err != nil {
 				return fmt.Errorf("state.PushQC(): %w", err)
@@ -255,11 +253,11 @@ func TestPushConflictingBadCommitQC(t *testing.T) {
 	ctx := t.Context()
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
-	committee := registry.LatestEpoch().Committee()
+	committee := registry.MustEpoch(0).Committee()
 	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
 
 	// Push a valid QC to advance inner.nextQC.
-	qc1, blocks1 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 	require.NoError(t, state.PushQC(ctx, qc1, blocks1))
 	gr1 := qc1.QC().GlobalRange()
 
@@ -299,7 +297,7 @@ func TestPushConflictingBadCommitQC(t *testing.T) {
 			malBlocks = append(malBlocks, b)
 		}
 	}
-	viewSpec := types.ViewSpec{CommitQC: utils.None[*types.CommitQC](), Epoch: registry.LatestEpoch()}
+	viewSpec := types.ViewSpec{CommitQC: utils.None[*types.CommitQC](), Epoch: registry.MustEpoch(0)}
 	leader := committee.Leader(viewSpec.View())
 	var leaderKey types.SecretKey
 	for _, k := range keys {
@@ -348,7 +346,7 @@ func TestPushConflictingBadCommitQC(t *testing.T) {
 	}
 
 	// Verify state is still functional: the next valid QC is accepted and visible.
-	qc2, blocks2 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.Some(qc1.QC()))
+	qc2, blocks2 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.Some(qc1.QC()))
 	require.NoError(t, state.PushQC(ctx, qc2, blocks2))
 	gr2 := qc2.QC().GlobalRange()
 	for n := gr2.First; n < gr2.Next; n++ {
@@ -365,7 +363,7 @@ func TestPushQCIgnoresBlocksMatchingUnverifiedHeaders(t *testing.T) {
 	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
 
 	// Push qc1 with NO blocks — only the QC is stored.
-	qc1, blocks1 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 	require.NoError(t, state.PushQC(ctx, qc1, nil))
 	gr := qc1.QC().GlobalRange()
 
@@ -414,7 +412,7 @@ func TestExecution(t *testing.T) {
 		prev := utils.None[*types.CommitQC]()
 		for i := range 3 {
 			t.Logf("iteration %v", i)
-			qc, blocks := TestCommitQC(rng, registry.LatestEpoch(), keys, prev)
+			qc, blocks := TestCommitQC(rng, registry.MustEpoch(0), keys, prev)
 			if err := state.PushQC(ctx, qc, blocks); err != nil {
 				return fmt.Errorf("state.PushQC(): %w", err)
 			}
@@ -448,7 +446,7 @@ func TestPushAppHashRejectsJumpOverCommitQCRange(t *testing.T) {
 	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
 	require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
 		s.SpawnBgNamed("state.Run()", func() error { return utils.IgnoreCancel(state.Run(ctx)) })
-		epoch := registry.LatestEpoch()
+		epoch := registry.MustEpoch(0)
 		var qcs []*types.CommitQC
 		for range 3 {
 			var prev utils.Option[*types.CommitQC]
@@ -500,7 +498,7 @@ func TestPushAppHash_AdvancesRegistryAtEpochBoundary(t *testing.T) {
 		state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
 		require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
 			s.SpawnBgNamed("state.Run()", func() error { return utils.IgnoreCancel(state.Run(ctx)) })
-			qc, blocks := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+			qc, blocks := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 			if err := state.PushQC(ctx, qc, blocks); err != nil {
 				return err
 			}
@@ -517,7 +515,7 @@ func TestPushAppHash_AdvancesRegistryAtEpochBoundary(t *testing.T) {
 	t.Run("LastRoad does not seed epoch 2", func(t *testing.T) {
 		registry, keys := epoch.GenRegistry(rng, 3)
 		state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
-		ep := registry.LatestEpoch()
+		ep := registry.MustEpoch(0)
 		require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
 			s.SpawnBgNamed("state.Run()", func() error { return utils.IgnoreCancel(state.Run(ctx)) })
 			qc, blocks := commitQCAtRoad(ep, keys, epoch.LastRoad(0), ep.FirstBlock())
@@ -546,7 +544,7 @@ func TestPushBlockAcceptsBlockWithQC(t *testing.T) {
 	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
 
 	// Push QC without blocks.
-	qc, blocks := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+	qc, blocks := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 	require.NoError(t, state.PushQC(ctx, qc, nil))
 	gr := qc.QC().GlobalRange()
 
@@ -564,7 +562,7 @@ func TestGlobalBlockByHash(t *testing.T) {
 
 	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
 
-	qc, blocks := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+	qc, blocks := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 	require.NoError(t, state.PushQC(ctx, qc, blocks))
 	gr := qc.QC().GlobalRange()
 	n := gr.First
@@ -604,7 +602,7 @@ func TestPushQCBeforeRunPersistsToBlockDB(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 	dir := t.TempDir()
 
-	qc1, blocks1 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 	gr1 := qc1.QC().GlobalRange()
 
 	db := newTestBlockDB(t, dir)
@@ -648,9 +646,9 @@ func TestEvictionWaitsForAppQC(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
 
-	qc1, blocks1 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 	gr1 := qc1.QC().GlobalRange()
-	qc2, blocks2 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.Some(qc1.QC()))
+	qc2, blocks2 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.Some(qc1.QC()))
 	gr2 := qc2.QC().GlobalRange()
 
 	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
@@ -739,7 +737,7 @@ func TestEvictionWaitsForPersistedAppQC(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
 
-	qc1, blocks1 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 	gr1 := qc1.QC().GlobalRange()
 
 	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
@@ -762,7 +760,7 @@ func TestPushAppHashBelowAnchorSucceeds(t *testing.T) {
 	ctx := t.Context()
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
-	epoch := registry.LatestEpoch()
+	epoch := registry.MustEpoch(0)
 
 	require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
 		state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
@@ -809,9 +807,9 @@ func TestNextToExecuteAfterAppEviction(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
 
-	qc1, blocks1 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 	gr1 := qc1.QC().GlobalRange()
-	qc2, blocks2 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.Some(qc1.QC()))
+	qc2, blocks2 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.Some(qc1.QC()))
 
 	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
 	require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
@@ -893,7 +891,7 @@ func TestPushAppQCPersistsAndRecovers(t *testing.T) {
 	registry, keys := epoch.GenRegistry(rng, 3)
 	dir := t.TempDir()
 
-	qc1, blocks1 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 	gr1 := qc1.QC().GlobalRange()
 
 	db1 := newTestBlockDB(t, dir)
@@ -954,7 +952,7 @@ func TestPruningKeepsLastQCRange(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
 
-	qc1, blocks1 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 	gr1 := qc1.QC().GlobalRange()
 
 	state1 := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
@@ -998,8 +996,8 @@ func TestPruningWithPartialQCRange(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
 
-	qc1, blocks1 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
-	qc2, blocks2 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.Some(qc1.QC()))
+	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
+	qc2, blocks2 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.Some(qc1.QC()))
 	gr1 := qc1.QC().GlobalRange()
 	gr2 := qc2.QC().GlobalRange()
 
@@ -1088,11 +1086,11 @@ func TestPushBlockWaitsForQC(t *testing.T) {
 		state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
 
 		// Push first QC covering [0, N).
-		qc1, blocks1 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+		qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
 		require.NoError(t, state.PushQC(ctx, qc1, blocks1))
 
 		// Prepare second QC covering [N, M) but don't push it yet.
-		qc2, blocks2 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.Some(qc1.QC()))
+		qc2, blocks2 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.Some(qc1.QC()))
 		gr2 := qc2.QC().GlobalRange()
 
 		// Block gr2.First should not be in state yet.
@@ -1135,8 +1133,8 @@ func TestTryBlockHidesGapFills(t *testing.T) {
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
 
-	qc1, blocks1 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
-	qc2, blocks2 := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.Some(qc1.QC()))
+	qc1, blocks1 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
+	qc2, blocks2 := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.Some(qc1.QC()))
 	gr1 := qc1.QC().GlobalRange()
 	gr2 := qc2.QC().GlobalRange()
 	require.GreaterOrEqual(t, gr2.Len(), 2)

--- a/sei-tendermint/internal/autobahn/data/state_test.go
+++ b/sei-tendermint/internal/autobahn/data/state_test.go
@@ -115,24 +115,69 @@ func pushAppQCForBlock(ctx context.Context, state *State, keys []types.SecretKey
 	return state.PushAppQC(ctx, TestAppQC(keys, vote.Proposal()))
 }
 
-func TestCommitEpoch_TracksLatestCommitQC(t *testing.T) {
+func commitQCAtRoad(
+	ep *types.Epoch,
+	keys []types.SecretKey,
+	road types.RoadIndex,
+	globalFirst types.GlobalBlockNumber,
+) (*types.FullCommitQC, []*types.Block) {
+	proposal := types.ProposalAt(ep, types.View{Index: road, Number: 0}, globalFirst)
+	block := types.NewBlock(ep.Committee().Lanes().At(0), 0, types.BlockHeaderHash{}, &types.Payload{})
+	votes := make([]*types.Signed[*types.CommitVote], 0, len(keys))
+	for _, k := range keys {
+		votes = append(votes, types.Sign(k, types.NewCommitVote(proposal)))
+	}
+	return types.NewFullCommitQC(types.NewCommitQC(votes), []*types.BlockHeader{block.Header()}), []*types.Block{block}
+}
+
+func TestNextCommitEpoch_TracksNextRoadEpoch(t *testing.T) {
 	ctx := t.Context()
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 3)
+	ep0, ok := registry.EpochByIndex(0)
+	require.True(t, ok)
 	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
-	require.Equal(t, registry.LatestEpoch(), state.CommitEpoch().Load())
+	require.Equal(t, ep0, state.NextCommitEpoch().Load())
 
 	require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
 		s.SpawnBgNamed("state.Run()", func() error {
 			return utils.IgnoreCancel(state.Run(ctx))
 		})
-		qc, blocks := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+		qc, blocks := TestCommitQC(rng, ep0, keys, utils.None[*types.CommitQC]())
 		if err := state.PushQC(ctx, qc, blocks); err != nil {
 			return err
 		}
-		require.Equal(t, registry.LatestEpoch(), state.CommitEpoch().Load())
+		require.Equal(t, ep0, state.NextCommitEpoch().Load())
 		return nil
 	}))
+}
+
+func TestNextCommitEpoch_AdvancesAtIdleEpochBoundary(t *testing.T) {
+	ctx := t.Context()
+	rng := utils.TestRng()
+	registry, keys := epoch.GenRegistry(rng, 3)
+	ep1, ok := registry.EpochByIndex(1)
+	require.True(t, ok)
+	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
+
+	qcMid, blocksMid := commitQCAtRoad(ep1, keys, epoch.FirstRoad(1), ep1.FirstBlock())
+	require.NoError(t, state.PushQC(ctx, qcMid, blocksMid))
+	require.Equal(t, ep1, state.NextCommitEpoch().Load(), "mid-epoch next road is still in epoch 1")
+	grMid := qcMid.QC().GlobalRange()
+	require.NoError(t, pushAppHashesRunning(ctx, state, rng, grMid.First, grMid.Next))
+	require.Equal(t, ep1, state.NextCommitEpoch().Load(), "mid-epoch AppHash must not seed epoch 2")
+
+	qcLast, blocksLast := commitQCAtRoad(ep1, keys, epoch.LastRoad(1), grMid.Next)
+	require.NoError(t, state.PushQC(ctx, qcLast, blocksLast))
+	_, err := registry.EpochAt(epoch.FirstRoad(2))
+	require.Error(t, err, "epoch 2 must stay unregistered until the boundary AppProposal lands")
+	require.Equal(t, ep1, state.NextCommitEpoch().Load(), "unregistered next epoch: previous publish stands")
+
+	grLast := qcLast.QC().GlobalRange()
+	require.NoError(t, pushAppHashesRunning(ctx, state, rng, grLast.First, grLast.Next))
+	ep2, err := registry.EpochAt(epoch.FirstRoad(2))
+	require.NoError(t, err)
+	require.Equal(t, ep2, state.NextCommitEpoch().Load())
 }
 
 func TestState(t *testing.T) {
@@ -475,21 +520,11 @@ func TestPushAppHash_AdvancesRegistryAtEpochBoundary(t *testing.T) {
 		ep := registry.LatestEpoch()
 		require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
 			s.SpawnBgNamed("state.Run()", func() error { return utils.IgnoreCancel(state.Run(ctx)) })
-			// A valid QC stamped at the epoch boundary: ProposalAt finalizes one block on
-			// lane 0 starting at ep.FirstBlock(), which a fresh state admits since PushQC
-			// requires global-block contiguity, not road contiguity. block must stay
-			// identical to the one ProposalAt builds, or the header hashes disagree.
-			proposal := types.ProposalAt(ep, types.View{Index: epoch.LastRoad(0), Number: 0})
-			block := types.NewBlock(ep.Committee().Lanes().At(0), 0, types.BlockHeaderHash{}, &types.Payload{})
-			votes := make([]*types.Signed[*types.CommitVote], 0, len(keys))
-			for _, k := range keys {
-				votes = append(votes, types.Sign(k, types.NewCommitVote(proposal)))
-			}
-			qc := types.NewFullCommitQC(types.NewCommitQC(votes), []*types.BlockHeader{block.Header()})
+			qc, blocks := commitQCAtRoad(ep, keys, epoch.LastRoad(0), ep.FirstBlock())
 			if qc.QC().Proposal().Index() != epoch.LastRoad(0) {
 				return fmt.Errorf("road = %d, want %d", qc.QC().Proposal().Index(), epoch.LastRoad(0))
 			}
-			if err := state.PushQC(ctx, qc, []*types.Block{block}); err != nil {
+			if err := state.PushQC(ctx, qc, blocks); err != nil {
 				return err
 			}
 			if err := state.PushAppHash(ctx, qc.QC().GlobalRange().Next-1, types.GenAppHash(rng)); err != nil {

--- a/sei-tendermint/internal/autobahn/data/state_test.go
+++ b/sei-tendermint/internal/autobahn/data/state_test.go
@@ -276,7 +276,7 @@ func TestPushConflictingBadCommitQC(t *testing.T) {
 			malBlocks = append(malBlocks, b)
 		}
 	}
-	viewSpec := types.ViewSpec{CommitQC: utils.None[*types.CommitQC](), Epoch: registry.MustEpoch(0)}
+	viewSpec := types.ViewSpec{ConsensusSpec: types.ConsensusSpec{CommitQC: utils.None[*types.CommitQC](), Epoch: registry.MustEpoch(0)}}
 	leader := committee.Leader(viewSpec.View())
 	var leaderKey types.SecretKey
 	for _, k := range keys {

--- a/sei-tendermint/internal/autobahn/data/state_test.go
+++ b/sei-tendermint/internal/autobahn/data/state_test.go
@@ -34,11 +34,14 @@ func newSnapshot() Snapshot {
 
 func snapshot(s *State) Snapshot {
 	for inner := range s.inner.Lock() {
-		aps := maps.Clone(inner.appProposals)
+		qcs := make(map[types.GlobalBlockNumber]*types.FullCommitQC, len(inner.qcs))
+		for n, e := range inner.qcs {
+			qcs[n] = e.qc
+		}
 		return Snapshot{
-			QCs:          maps.Clone(inner.qcs),
+			QCs:          qcs,
 			Blocks:       maps.Clone(inner.blocks),
-			AppProposals: aps,
+			AppProposals: maps.Clone(inner.appProposals),
 		}
 	}
 	panic("unreachable")
@@ -110,6 +113,26 @@ func pushAppQCForBlock(ctx context.Context, state *State, keys []types.SecretKey
 		return err
 	}
 	return state.PushAppQC(ctx, TestAppQC(keys, vote.Proposal()))
+}
+
+func TestCommitEpoch_TracksLatestCommitQC(t *testing.T) {
+	ctx := t.Context()
+	rng := utils.TestRng()
+	registry, keys := epoch.GenRegistry(rng, 3)
+	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
+	require.Equal(t, registry.LatestEpoch(), state.CommitEpoch().Load())
+
+	require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
+		s.SpawnBgNamed("state.Run()", func() error {
+			return utils.IgnoreCancel(state.Run(ctx))
+		})
+		qc, blocks := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+		if err := state.PushQC(ctx, qc, blocks); err != nil {
+			return err
+		}
+		require.Equal(t, registry.LatestEpoch(), state.CommitEpoch().Load())
+		return nil
+	}))
 }
 
 func TestState(t *testing.T) {
@@ -423,6 +446,63 @@ func TestPushAppHashRejectsJumpOverCommitQCRange(t *testing.T) {
 	}))
 }
 
+func TestPushAppHash_AdvancesRegistryAtEpochBoundary(t *testing.T) {
+	ctx := t.Context()
+	rng := utils.TestRng()
+
+	t.Run("mid-epoch road does not seed epoch 2", func(t *testing.T) {
+		registry, keys := epoch.GenRegistry(rng, 3)
+		state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
+		require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
+			s.SpawnBgNamed("state.Run()", func() error { return utils.IgnoreCancel(state.Run(ctx)) })
+			qc, blocks := TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*types.CommitQC]())
+			if err := state.PushQC(ctx, qc, blocks); err != nil {
+				return err
+			}
+			if err := state.PushAppHash(ctx, qc.QC().GlobalRange().Next-1, types.GenAppHash(rng)); err != nil {
+				return err
+			}
+			if _, err := registry.EpochAt(epoch.FirstRoad(2)); err == nil {
+				return fmt.Errorf("epoch 2 must stay absent for road %d", qc.QC().Proposal().Index())
+			}
+			return nil
+		}))
+	})
+
+	t.Run("LastRoad does not seed epoch 2", func(t *testing.T) {
+		registry, keys := epoch.GenRegistry(rng, 3)
+		state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
+		ep := registry.LatestEpoch()
+		require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
+			s.SpawnBgNamed("state.Run()", func() error { return utils.IgnoreCancel(state.Run(ctx)) })
+			// A valid QC stamped at the epoch boundary: ProposalAt finalizes one block on
+			// lane 0 starting at ep.FirstBlock(), which a fresh state admits since PushQC
+			// requires global-block contiguity, not road contiguity. block must stay
+			// identical to the one ProposalAt builds, or the header hashes disagree.
+			proposal := types.ProposalAt(ep, types.View{Index: epoch.LastRoad(0), Number: 0})
+			block := types.NewBlock(ep.Committee().Lanes().At(0), 0, types.BlockHeaderHash{}, &types.Payload{})
+			votes := make([]*types.Signed[*types.CommitVote], 0, len(keys))
+			for _, k := range keys {
+				votes = append(votes, types.Sign(k, types.NewCommitVote(proposal)))
+			}
+			qc := types.NewFullCommitQC(types.NewCommitQC(votes), []*types.BlockHeader{block.Header()})
+			if qc.QC().Proposal().Index() != epoch.LastRoad(0) {
+				return fmt.Errorf("road = %d, want %d", qc.QC().Proposal().Index(), epoch.LastRoad(0))
+			}
+			if err := state.PushQC(ctx, qc, []*types.Block{block}); err != nil {
+				return err
+			}
+			if err := state.PushAppHash(ctx, qc.QC().GlobalRange().Next-1, types.GenAppHash(rng)); err != nil {
+				return err
+			}
+			if _, err := registry.EpochAt(epoch.FirstRoad(2)); err == nil {
+				return fmt.Errorf("PushAppHash at LastRoad(0) must not seed epoch 2")
+			}
+			return nil
+		}))
+	})
+}
+
 func TestPushBlockAcceptsBlockWithQC(t *testing.T) {
 	ctx := t.Context()
 	rng := utils.TestRng()
@@ -590,7 +670,7 @@ func TestEvictionWaitsForAppQC(t *testing.T) {
 			if inner.first != evictionBound {
 				return fmt.Errorf("after catching up, first = %d, want eviction bound %d", inner.first, evictionBound)
 			}
-			if anchor, ok := inner.anchor.Load().Get(); !ok || anchor.AppQC != inner.appQCs[inner.first] || anchor.CommitQC != inner.qcs[inner.first].QC() {
+			if anchor, ok := inner.anchor.Load().Get(); !ok || anchor.AppQC != inner.appQCs[inner.first] || anchor.CommitQC != inner.qcs[inner.first].qc.QC() {
 				return fmt.Errorf("anchor must cover inner.first %d", inner.first)
 			}
 			for n := gr1.First; n < inner.first; n++ {
@@ -744,7 +824,7 @@ func TestNextToExecuteAfterAppEviction(t *testing.T) {
 			if inner.nextAppProposal >= inner.nextQC {
 				return fmt.Errorf("nextAppProposal = %d, want < nextQC %d", inner.nextAppProposal, inner.nextQC)
 			}
-			fqc := inner.qcs[inner.nextAppProposal]
+			fqc := inner.qcs[inner.nextAppProposal].qc
 			if fqc == nil {
 				return fmt.Errorf("QC %d missing", inner.nextAppProposal)
 			}

--- a/sei-tendermint/internal/autobahn/data/state_test.go
+++ b/sei-tendermint/internal/autobahn/data/state_test.go
@@ -130,27 +130,6 @@ func commitQCAtRoad(
 	return types.NewFullCommitQC(types.NewCommitQC(votes), []*types.BlockHeader{block.Header()}), []*types.Block{block}
 }
 
-func TestNextCommitEpoch_TracksNextRoadEpoch(t *testing.T) {
-	ctx := t.Context()
-	rng := utils.TestRng()
-	registry, keys := epoch.GenRegistry(rng, 3)
-	ep0 := registry.MustEpoch(0)
-	state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
-	require.Equal(t, ep0, state.NextCommitEpoch().Load())
-
-	require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
-		s.SpawnBgNamed("state.Run()", func() error {
-			return utils.IgnoreCancel(state.Run(ctx))
-		})
-		qc, blocks := TestCommitQC(rng, ep0, keys, utils.None[*types.CommitQC]())
-		if err := state.PushQC(ctx, qc, blocks); err != nil {
-			return err
-		}
-		require.Equal(t, ep0, state.NextCommitEpoch().Load())
-		return nil
-	}))
-}
-
 func TestNextCommitEpoch_AdvancesAtIdleEpochBoundary(t *testing.T) {
 	ctx := t.Context()
 	rng := utils.TestRng()
@@ -487,53 +466,6 @@ func TestPushAppHashRejectsJumpOverCommitQCRange(t *testing.T) {
 		}
 		return nil
 	}))
-}
-
-func TestPushAppHash_AdvancesRegistryAtEpochBoundary(t *testing.T) {
-	ctx := t.Context()
-	rng := utils.TestRng()
-
-	t.Run("mid-epoch road does not seed epoch 2", func(t *testing.T) {
-		registry, keys := epoch.GenRegistry(rng, 3)
-		state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
-		require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
-			s.SpawnBgNamed("state.Run()", func() error { return utils.IgnoreCancel(state.Run(ctx)) })
-			qc, blocks := TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*types.CommitQC]())
-			if err := state.PushQC(ctx, qc, blocks); err != nil {
-				return err
-			}
-			if err := state.PushAppHash(ctx, qc.QC().GlobalRange().Next-1, types.GenAppHash(rng)); err != nil {
-				return err
-			}
-			if _, err := registry.EpochAt(epoch.FirstRoad(2)); err == nil {
-				return fmt.Errorf("epoch 2 must stay absent for road %d", qc.QC().Proposal().Index())
-			}
-			return nil
-		}))
-	})
-
-	t.Run("LastRoad does not seed epoch 2", func(t *testing.T) {
-		registry, keys := epoch.GenRegistry(rng, 3)
-		state := newTestState(t, &Config{Registry: registry}, newTestBlockDB(t, t.TempDir()))
-		ep := registry.MustEpoch(0)
-		require.NoError(t, scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
-			s.SpawnBgNamed("state.Run()", func() error { return utils.IgnoreCancel(state.Run(ctx)) })
-			qc, blocks := commitQCAtRoad(ep, keys, epoch.LastRoad(0), ep.FirstBlock())
-			if qc.QC().Proposal().Index() != epoch.LastRoad(0) {
-				return fmt.Errorf("road = %d, want %d", qc.QC().Proposal().Index(), epoch.LastRoad(0))
-			}
-			if err := state.PushQC(ctx, qc, blocks); err != nil {
-				return err
-			}
-			if err := state.PushAppHash(ctx, qc.QC().GlobalRange().Next-1, types.GenAppHash(rng)); err != nil {
-				return err
-			}
-			if _, err := registry.EpochAt(epoch.FirstRoad(2)); err == nil {
-				return fmt.Errorf("PushAppHash at LastRoad(0) must not seed epoch 2")
-			}
-			return nil
-		}))
-	})
 }
 
 func TestPushBlockAcceptsBlockWithQC(t *testing.T) {

--- a/sei-tendermint/internal/autobahn/epoch/registry.go
+++ b/sei-tendermint/internal/autobahn/epoch/registry.go
@@ -10,6 +10,7 @@ import (
 )
 
 // EpochLength is the number of road indices per epoch.
+// TODO: move on-chain when epoch length becomes configurable.
 const EpochLength types.RoadIndex = 108_000
 
 // IndexForRoad returns the epoch index containing road.
@@ -137,7 +138,7 @@ func (r *Registry) ActivateEpoch(
 			}
 			next++
 		}
-		prev := s.m[next-1]
+		prev := s.m[s.latest]
 		committee, err := prev.Committee().DeriveNext(weights, next)
 		if err != nil {
 			return nil, err

--- a/sei-tendermint/internal/autobahn/epoch/registry.go
+++ b/sei-tendermint/internal/autobahn/epoch/registry.go
@@ -30,9 +30,14 @@ func LastRoad(idx types.EpochIndex) types.RoadIndex {
 
 type registryState struct {
 	m map[types.EpochIndex]*types.Epoch
-	// prunedTo is the exclusive floor of dropped indices. Epochs in (0, prunedTo)
-	// are gone; 0 is always retained for genesis metadata and placeholders.
-	prunedTo types.EpochIndex
+	// live is the supported non-zero epoch indices [First, Next). Epoch 0 is
+	// always kept for genesis metadata and is not represented here.
+	live types.EpochRange
+}
+
+// dropped reports whether idx is below live.First. Epoch 0 is never dropped.
+func (s *registryState) dropped(idx types.EpochIndex) bool {
+	return idx != 0 && idx < s.live.First
 }
 
 // Registry stores activated epochs and placeholders.
@@ -50,7 +55,8 @@ func NewRegistry(
 	ep1 := types.NewEpoch(1, types.RoadRange{First: FirstRoad(1), Next: FirstRoad(2)}, genesisTimestamp, committee, firstBlock)
 	return &Registry{
 		state: utils.NewWatch(&registryState{
-			m: map[types.EpochIndex]*types.Epoch{0: ep0, 1: ep1},
+			m:    map[types.EpochIndex]*types.Epoch{0: ep0, 1: ep1},
+			live: types.EpochRange{First: 1, Next: 2},
 		}),
 	}, nil
 }
@@ -97,7 +103,7 @@ func (r *Registry) GenesisTimestamp() time.Time {
 // It returns ErrPruned if idx has been dropped by PruneBefore.
 func (r *Registry) EpochByIndex(idx types.EpochIndex) (*types.Epoch, error) {
 	for s := range r.state.Lock() {
-		if r.pruned(s, idx) {
+		if s.dropped(idx) {
 			return nil, fmt.Errorf("epoch %d: %w", idx, types.ErrPruned)
 		}
 		ep, ok := s.m[idx]
@@ -113,7 +119,7 @@ func (r *Registry) EpochByIndex(idx types.EpochIndex) (*types.Epoch, error) {
 func (r *Registry) EpochAt(roadIndex types.RoadIndex) (*types.Epoch, error) {
 	epochIdx := IndexForRoad(roadIndex)
 	for s := range r.state.Lock() {
-		if r.pruned(s, epochIdx) {
+		if s.dropped(epochIdx) {
 			return nil, fmt.Errorf("epoch %d (road %d): %w", epochIdx, roadIndex, types.ErrPruned)
 		}
 		if ep, ok := s.m[epochIdx]; ok {
@@ -134,7 +140,7 @@ func (r *Registry) ActivateEpoch(
 	firstBlock types.GlobalBlockNumber,
 ) (*types.Epoch, error) {
 	for s, ctrl := range r.state.Lock() {
-		if r.pruned(s, parent) {
+		if s.dropped(parent) {
 			return nil, fmt.Errorf("epoch %d: %w", parent, types.ErrPruned)
 		}
 		prev, ok := s.m[parent]
@@ -143,7 +149,7 @@ func (r *Registry) ActivateEpoch(
 		}
 		next := parent + 1
 		for {
-			if r.pruned(s, next) {
+			if s.dropped(next) {
 				next++
 				continue
 			}
@@ -159,6 +165,7 @@ func (r *Registry) ActivateEpoch(
 		roads := types.RoadRange{First: FirstRoad(next), Next: FirstRoad(next + 1)}
 		ep := types.NewEpoch(next, roads, firstTimestamp, committee, firstBlock)
 		s.m[next] = ep
+		r.extendLive(s, next)
 		ctrl.Updated()
 		return ep, nil
 	}
@@ -178,13 +185,20 @@ func (r *Registry) makeEpoch(s *registryState, epochIdx types.EpochIndex) *types
 		ep0.FirstBlock(),
 	)
 	s.m[epochIdx] = epoch
+	r.extendLive(s, epochIdx)
 	return epoch
+}
+
+func (r *Registry) extendLive(s *registryState, idx types.EpochIndex) {
+	if idx >= s.live.Next {
+		s.live.Next = idx + 1
+	}
 }
 
 // ensureLocked registers a genesis-committee placeholder for idx if missing.
 // Caller must hold r.state. Pruned indices are not recreated.
 func (r *Registry) ensureLocked(s *registryState, idx types.EpochIndex) {
-	if r.pruned(s, idx) {
+	if s.dropped(idx) {
 		return
 	}
 	if _, ok := s.m[idx]; !ok {
@@ -217,21 +231,20 @@ func (r *Registry) AdvanceIfNeeded(roadIndex types.RoadIndex) {
 	}
 }
 
-func (r *Registry) pruned(s *registryState, idx types.EpochIndex) bool {
-	return idx > 0 && idx < s.prunedTo
-}
-
-// PruneBefore drops registered epochs in (0, keep). Epoch 0 is kept for
-// genesis metadata. keep is an exclusive floor and only moves forward.
+// PruneBefore drops supported epochs in [live.First, keep). Epoch 0 is kept
+// for genesis metadata. keep is exclusive and only moves live.First forward.
 func (r *Registry) PruneBefore(keep types.EpochIndex) {
 	for s, ctrl := range r.state.Lock() {
-		if keep <= s.prunedTo {
+		if keep <= s.live.First {
 			return
 		}
-		for idx := max(s.prunedTo, 1); idx < keep; idx++ {
+		for idx := s.live.First; idx < keep; idx++ {
 			delete(s.m, idx)
 		}
-		s.prunedTo = keep
+		s.live.First = keep
+		if s.live.First > s.live.Next {
+			s.live.Next = s.live.First
+		}
 		ctrl.Updated()
 	}
 }
@@ -240,7 +253,7 @@ func (r *Registry) PruneBefore(keep types.EpochIndex) {
 func (r *Registry) WaitForEpoch(ctx context.Context, i types.EpochIndex) (*types.Epoch, error) {
 	for inner, ctrl := range r.state.Lock() {
 		for {
-			if r.pruned(inner, i) {
+			if inner.dropped(i) {
 				return nil, fmt.Errorf("epoch %d: %w", i, types.ErrPruned)
 			}
 			if ep, ok := inner.m[i]; ok {

--- a/sei-tendermint/internal/autobahn/epoch/registry.go
+++ b/sei-tendermint/internal/autobahn/epoch/registry.go
@@ -190,7 +190,7 @@ func (r *Registry) ensureAround(s *registryState, road types.RoadIndex) {
 
 // AdvanceIfNeeded registers epoch M+1 when roadIndex is LastRoad(M).
 // M+2 is not seeded: tip may race to LastRoad(M+1) before AppQC, but
-// ConsensusSpec withholds that next view until M+1's AppQC boundary fires
+// ConsensusSpec withholds that next RoadIndex until M+1's AppQC boundary fires
 // AdvanceIfNeeded again.
 func (r *Registry) AdvanceIfNeeded(roadIndex types.RoadIndex) {
 	tipEpoch := IndexForRoad(roadIndex)

--- a/sei-tendermint/internal/autobahn/epoch/registry.go
+++ b/sei-tendermint/internal/autobahn/epoch/registry.go
@@ -1,104 +1,218 @@
 package epoch
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"github.com/sei-protocol/sei-chain/sei-tendermint/autobahn/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
 )
 
+// EpochLength is the number of road indices per epoch.
+const EpochLength types.RoadIndex = 108_000
+
+// IndexForRoad returns the epoch index containing road.
+func IndexForRoad(road types.RoadIndex) types.EpochIndex {
+	return types.EpochIndex(road / EpochLength)
+}
+
+// FirstRoad returns the first road index of epoch idx.
+func FirstRoad(idx types.EpochIndex) types.RoadIndex {
+	return types.RoadIndex(idx) * EpochLength
+}
+
+// LastRoad returns the last road index of epoch idx.
+func LastRoad(idx types.EpochIndex) types.RoadIndex {
+	return FirstRoad(idx+1) - 1
+}
+
 type registryState struct {
 	m      map[types.EpochIndex]*types.Epoch
 	latest types.EpochIndex
 }
 
-// Registry is the authoritative source of epoch and committee information.
-// All layers (consensus, data, avail) read from it.
+// Registry stores activated epochs and placeholders.
 type Registry struct {
-	state utils.RWMutex[*registryState]
+	state utils.Watch[*registryState]
 }
 
-// NewRegistry creates a Registry with the genesis committee.
+// NewRegistry creates a Registry with genesis epochs 0 and 1 (genesis committee).
 func NewRegistry(
 	committee *types.Committee,
 	firstBlock types.GlobalBlockNumber,
 	genesisTimestamp time.Time,
 ) (*Registry, error) {
-	ep := types.NewEpoch(0, types.OpenRoadRange(), genesisTimestamp, committee, firstBlock)
+	ep0 := types.NewEpoch(0, types.RoadRange{First: 0, Next: FirstRoad(1)}, genesisTimestamp, committee, firstBlock)
+	ep1 := types.NewEpoch(1, types.RoadRange{First: FirstRoad(1), Next: FirstRoad(2)}, genesisTimestamp, committee, firstBlock)
 	return &Registry{
-		state: utils.NewRWMutex(&registryState{
-			m:      map[types.EpochIndex]*types.Epoch{0: ep},
+		state: utils.NewWatch(&registryState{
+			m:      map[types.EpochIndex]*types.Epoch{0: ep0, 1: ep1},
 			latest: 0,
 		}),
 	}, nil
 }
 
-// FirstBlock returns the first global block number of the genesis epoch.
-// Used as the cold-start default (no WAL, no snapshot); WAL overrides this on restart.
+// SetupInitialEpochs registers placeholders covering commitQCs and the next epoch.
+// With no CommitQCs this is a no-op (epochs 0 and 1 are already present).
+func (r *Registry) SetupInitialEpochs(commitQCs utils.Option[types.RoadRange]) {
+	span, ok := commitQCs.Get()
+	if !ok {
+		return
+	}
+	for s, ctrl := range r.state.Lock() {
+		windowFirst := IndexForRoad(span.First)
+		windowLast := IndexForRoad(span.Next - 1)
+		r.ensureAround(s, span.First)
+		for idx := windowFirst; idx <= windowLast; idx++ {
+			r.ensureLocked(s, idx)
+		}
+		r.ensureAround(s, span.Next)
+		// TODO: replace placeholders with execution-derived committee,
+		// FirstTimestamp, and FirstBlock (genesis copies feed ViewSpec).
+		r.ensureLocked(s, windowLast+1)
+		ctrl.Updated()
+	}
+}
+
+// FirstBlock returns the genesis epoch's first global block number.
 func (r *Registry) FirstBlock() types.GlobalBlockNumber {
-	for s := range r.state.RLock() {
+	for s := range r.state.Lock() {
 		return s.m[0].FirstBlock()
 	}
 	panic("unreachable")
 }
 
-// GenesisTimestamp returns the timestamp of the genesis epoch.
+// GenesisTimestamp returns the genesis epoch timestamp.
 func (r *Registry) GenesisTimestamp() time.Time {
-	for s := range r.state.RLock() {
+	for s := range r.state.Lock() {
 		return s.m[0].FirstTimestamp()
 	}
 	panic("unreachable")
 }
 
-// EpochByIndex returns the epoch with the given index, if it exists.
+// EpochByIndex returns the registered epoch at idx, if any.
 func (r *Registry) EpochByIndex(idx types.EpochIndex) (*types.Epoch, bool) {
-	for s := range r.state.RLock() {
+	for s := range r.state.Lock() {
 		ep, ok := s.m[idx]
 		return ep, ok
 	}
 	panic("unreachable")
 }
 
-// LatestEpoch returns the most recently activated epoch.
+// EpochAt returns the registered epoch containing roadIndex.
+func (r *Registry) EpochAt(roadIndex types.RoadIndex) (*types.Epoch, error) {
+	epochIdx := IndexForRoad(roadIndex)
+	for s := range r.state.Lock() {
+		if ep, ok := s.m[epochIdx]; ok {
+			return ep, nil
+		}
+		return nil, fmt.Errorf("epoch %d (road %d) not registered", epochIdx, roadIndex)
+	}
+	panic("unreachable")
+}
+
+// LatestEpoch returns the ActivateEpoch tip.
 func (r *Registry) LatestEpoch() *types.Epoch {
-	for s := range r.state.RLock() {
+	for s := range r.state.Lock() {
 		return s.m[s.latest]
 	}
 	panic("unreachable")
 }
 
+// ActivateEpoch registers the next vacant epoch after LatestEpoch with the given
+// committee weights. Already-registered epochs are never modified. The first
+// activation lands at index ≥ 2 (epochs 0 and 1 are always present). The new
+// epoch's road range is FirstRoad(index)..FirstRoad(index+1).
 func (r *Registry) ActivateEpoch(
 	weights map[types.PublicKey]uint64,
-	roads types.RoadRange,
 	firstTimestamp time.Time,
 	firstBlock types.GlobalBlockNumber,
 ) (*types.Epoch, error) {
-	for s := range r.state.Lock() {
-		prev := s.m[s.latest]
+	for s, ctrl := range r.state.Lock() {
 		next := s.latest + 1
+		for {
+			if _, ok := s.m[next]; !ok {
+				break
+			}
+			next++
+		}
+		prev := s.m[next-1]
 		committee, err := prev.Committee().DeriveNext(weights, next)
 		if err != nil {
 			return nil, err
 		}
+		roads := types.RoadRange{First: FirstRoad(next), Next: FirstRoad(next + 1)}
 		ep := types.NewEpoch(next, roads, firstTimestamp, committee, firstBlock)
 		s.m[next] = ep
 		s.latest = next
+		ctrl.Updated()
 		return ep, nil
 	}
 	panic("unreachable")
 }
 
-// VerifyInWindow calls fn against the latest epoch's committee and returns it if accepted.
-// Returns a slice of all matching epochs so callers can skip re-verification for any
-// epoch already checked here.
-// TODO(#3736): expand to neighbor epochs (previous and next) once multi-epoch transitions are wired up.
-func (r *Registry) VerifyInWindow(fn func(*types.Committee) error) ([]*types.Epoch, error) {
-	for s := range r.state.RLock() {
-		ep := s.m[s.latest]
-		if err := fn(ep.Committee()); err != nil {
-			return nil, err
+// makeEpoch inserts a genesis-committee placeholder at epochIdx.
+// Caller must hold r.state. Epochs 0 and 1 are always present (seeded at
+// construction with the genesis committee); further epochs copy from epoch 0.
+func (r *Registry) makeEpoch(s *registryState, epochIdx types.EpochIndex) *types.Epoch {
+	ep0 := s.m[0]
+	firstRoad := FirstRoad(epochIdx)
+	epoch := types.NewEpoch(
+		epochIdx,
+		types.RoadRange{First: firstRoad, Next: FirstRoad(epochIdx + 1)},
+		ep0.FirstTimestamp(),
+		ep0.Committee(),
+		ep0.FirstBlock(),
+	)
+	s.m[epochIdx] = epoch
+	return epoch
+}
+
+// ensureLocked registers a genesis-committee placeholder for idx if missing.
+// Caller must hold r.state.
+func (r *Registry) ensureLocked(s *registryState, idx types.EpochIndex) {
+	if _, ok := s.m[idx]; !ok {
+		r.makeEpoch(s, idx)
+	}
+}
+
+// ensureAround registers the epoch containing road and its predecessor.
+// Caller must hold r.state.
+func (r *Registry) ensureAround(s *registryState, road types.RoadIndex) {
+	center := IndexForRoad(road)
+	if center > 0 {
+		r.ensureLocked(s, center-1)
+	}
+	r.ensureLocked(s, center)
+}
+
+// AdvanceIfNeeded registers epoch M+1 when roadIndex is LastRoad(M).
+// M+2 is not seeded: tip may race to LastRoad(M+1) before AppQC, but
+// ConsensusSpec withholds that next view until M+1's AppQC boundary fires
+// AdvanceIfNeeded again.
+func (r *Registry) AdvanceIfNeeded(roadIndex types.RoadIndex) {
+	tipEpoch := IndexForRoad(roadIndex)
+	if roadIndex != LastRoad(tipEpoch) {
+		return
+	}
+	for s, ctrl := range r.state.Lock() {
+		r.ensureLocked(s, tipEpoch+1)
+		ctrl.Updated()
+	}
+}
+
+// WaitForEpoch blocks until epoch i is registered.
+func (r *Registry) WaitForEpoch(ctx context.Context, i types.EpochIndex) (*types.Epoch, error) {
+	for inner, ctrl := range r.state.Lock() {
+		for {
+			if ep, ok := inner.m[i]; ok {
+				return ep, nil
+			}
+			if err := ctrl.Wait(ctx); err != nil {
+				return nil, err
+			}
 		}
-		return []*types.Epoch{ep}, nil
 	}
 	panic("unreachable")
 }

--- a/sei-tendermint/internal/autobahn/epoch/registry.go
+++ b/sei-tendermint/internal/autobahn/epoch/registry.go
@@ -249,6 +249,14 @@ func (r *Registry) PruneBefore(keep types.EpochIndex) {
 	}
 }
 
+// Live returns the supported non-zero epoch window [First, Next).
+func (r *Registry) Live() types.EpochRange {
+	for s := range r.state.Lock() {
+		return s.live
+	}
+	panic("unreachable")
+}
+
 // WaitForEpoch blocks until epoch i is registered.
 func (r *Registry) WaitForEpoch(ctx context.Context, i types.EpochIndex) (*types.Epoch, error) {
 	for inner, ctrl := range r.state.Lock() {

--- a/sei-tendermint/internal/autobahn/epoch/registry.go
+++ b/sei-tendermint/internal/autobahn/epoch/registry.go
@@ -29,8 +29,10 @@ func LastRoad(idx types.EpochIndex) types.RoadIndex {
 }
 
 type registryState struct {
-	m      map[types.EpochIndex]*types.Epoch
-	latest types.EpochIndex
+	m map[types.EpochIndex]*types.Epoch
+	// prunedTo is the exclusive floor of dropped indices. Epochs in (0, prunedTo)
+	// are gone; 0 is always retained for genesis metadata and placeholders.
+	prunedTo types.EpochIndex
 }
 
 // Registry stores activated epochs and placeholders.
@@ -48,8 +50,7 @@ func NewRegistry(
 	ep1 := types.NewEpoch(1, types.RoadRange{First: FirstRoad(1), Next: FirstRoad(2)}, genesisTimestamp, committee, firstBlock)
 	return &Registry{
 		state: utils.NewWatch(&registryState{
-			m:      map[types.EpochIndex]*types.Epoch{0: ep0, 1: ep1},
-			latest: 0,
+			m: map[types.EpochIndex]*types.Epoch{0: ep0, 1: ep1},
 		}),
 	}, nil
 }
@@ -92,11 +93,18 @@ func (r *Registry) GenesisTimestamp() time.Time {
 	panic("unreachable")
 }
 
-// EpochByIndex returns the registered epoch at idx, if any.
-func (r *Registry) EpochByIndex(idx types.EpochIndex) (*types.Epoch, bool) {
+// EpochByIndex returns the registered epoch at idx.
+// It returns ErrPruned if idx has been dropped by PruneBefore.
+func (r *Registry) EpochByIndex(idx types.EpochIndex) (*types.Epoch, error) {
 	for s := range r.state.Lock() {
+		if r.pruned(s, idx) {
+			return nil, fmt.Errorf("epoch %d: %w", idx, types.ErrPruned)
+		}
 		ep, ok := s.m[idx]
-		return ep, ok
+		if !ok {
+			return nil, fmt.Errorf("epoch %d not registered", idx)
+		}
+		return ep, nil
 	}
 	panic("unreachable")
 }
@@ -105,6 +113,9 @@ func (r *Registry) EpochByIndex(idx types.EpochIndex) (*types.Epoch, bool) {
 func (r *Registry) EpochAt(roadIndex types.RoadIndex) (*types.Epoch, error) {
 	epochIdx := IndexForRoad(roadIndex)
 	for s := range r.state.Lock() {
+		if r.pruned(s, epochIdx) {
+			return nil, fmt.Errorf("epoch %d (road %d): %w", epochIdx, roadIndex, types.ErrPruned)
+		}
 		if ep, ok := s.m[epochIdx]; ok {
 			return ep, nil
 		}
@@ -113,32 +124,34 @@ func (r *Registry) EpochAt(roadIndex types.RoadIndex) (*types.Epoch, error) {
 	panic("unreachable")
 }
 
-// LatestEpoch returns the ActivateEpoch tip.
-func (r *Registry) LatestEpoch() *types.Epoch {
-	for s := range r.state.Lock() {
-		return s.m[s.latest]
-	}
-	panic("unreachable")
-}
-
-// ActivateEpoch registers the next vacant epoch after LatestEpoch with the given
-// committee weights. Already-registered epochs are never modified. The first
-// activation lands at index ≥ 2 (epochs 0 and 1 are always present). The new
-// epoch's road range is FirstRoad(index)..FirstRoad(index+1).
+// ActivateEpoch registers the next vacant epoch after parent. parent is the
+// epoch at the execution tip; the new committee is derived from it. Already-
+// registered epochs are never modified. Pruned indices are skipped.
 func (r *Registry) ActivateEpoch(
+	parent types.EpochIndex,
 	weights map[types.PublicKey]uint64,
 	firstTimestamp time.Time,
 	firstBlock types.GlobalBlockNumber,
 ) (*types.Epoch, error) {
 	for s, ctrl := range r.state.Lock() {
-		next := s.latest + 1
+		if r.pruned(s, parent) {
+			return nil, fmt.Errorf("epoch %d: %w", parent, types.ErrPruned)
+		}
+		prev, ok := s.m[parent]
+		if !ok {
+			return nil, fmt.Errorf("epoch %d not registered", parent)
+		}
+		next := parent + 1
 		for {
+			if r.pruned(s, next) {
+				next++
+				continue
+			}
 			if _, ok := s.m[next]; !ok {
 				break
 			}
 			next++
 		}
-		prev := s.m[s.latest]
 		committee, err := prev.Committee().DeriveNext(weights, next)
 		if err != nil {
 			return nil, err
@@ -146,7 +159,6 @@ func (r *Registry) ActivateEpoch(
 		roads := types.RoadRange{First: FirstRoad(next), Next: FirstRoad(next + 1)}
 		ep := types.NewEpoch(next, roads, firstTimestamp, committee, firstBlock)
 		s.m[next] = ep
-		s.latest = next
 		ctrl.Updated()
 		return ep, nil
 	}
@@ -154,8 +166,7 @@ func (r *Registry) ActivateEpoch(
 }
 
 // makeEpoch inserts a genesis-committee placeholder at epochIdx.
-// Caller must hold r.state. Epochs 0 and 1 are always present (seeded at
-// construction with the genesis committee); further epochs copy from epoch 0.
+// Caller must hold r.state. Epoch 0 is always present; further epochs copy from it.
 func (r *Registry) makeEpoch(s *registryState, epochIdx types.EpochIndex) *types.Epoch {
 	ep0 := s.m[0]
 	firstRoad := FirstRoad(epochIdx)
@@ -171,8 +182,11 @@ func (r *Registry) makeEpoch(s *registryState, epochIdx types.EpochIndex) *types
 }
 
 // ensureLocked registers a genesis-committee placeholder for idx if missing.
-// Caller must hold r.state.
+// Caller must hold r.state. Pruned indices are not recreated.
 func (r *Registry) ensureLocked(s *registryState, idx types.EpochIndex) {
+	if r.pruned(s, idx) {
+		return
+	}
 	if _, ok := s.m[idx]; !ok {
 		r.makeEpoch(s, idx)
 	}
@@ -203,10 +217,32 @@ func (r *Registry) AdvanceIfNeeded(roadIndex types.RoadIndex) {
 	}
 }
 
+func (r *Registry) pruned(s *registryState, idx types.EpochIndex) bool {
+	return idx > 0 && idx < s.prunedTo
+}
+
+// PruneBefore drops registered epochs in (0, keep). Epoch 0 is kept for
+// genesis metadata. keep is an exclusive floor and only moves forward.
+func (r *Registry) PruneBefore(keep types.EpochIndex) {
+	for s, ctrl := range r.state.Lock() {
+		if keep <= s.prunedTo {
+			return
+		}
+		for idx := max(s.prunedTo, 1); idx < keep; idx++ {
+			delete(s.m, idx)
+		}
+		s.prunedTo = keep
+		ctrl.Updated()
+	}
+}
+
 // WaitForEpoch blocks until epoch i is registered.
 func (r *Registry) WaitForEpoch(ctx context.Context, i types.EpochIndex) (*types.Epoch, error) {
 	for inner, ctrl := range r.state.Lock() {
 		for {
+			if r.pruned(inner, i) {
+				return nil, fmt.Errorf("epoch %d: %w", i, types.ErrPruned)
+			}
 			if ep, ok := inner.m[i]; ok {
 				return ep, nil
 			}

--- a/sei-tendermint/internal/autobahn/epoch/registry_test.go
+++ b/sei-tendermint/internal/autobahn/epoch/registry_test.go
@@ -1,6 +1,7 @@
 package epoch
 
 import (
+	"errors"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -28,16 +29,20 @@ func midRoad(idx types.EpochIndex) types.RoadIndex {
 
 func TestRegistry_EpochByIndex_UnknownReturnsNotFound(t *testing.T) {
 	r, _ := makeRegistry(t)
-	if _, ok := r.EpochByIndex(99); ok {
-		t.Fatal("EpochByIndex(99) returned ok, want not found")
+	_, err := r.EpochByIndex(99)
+	if err == nil {
+		t.Fatal("EpochByIndex(99) succeeded, want not found")
+	}
+	if errors.Is(err, types.ErrPruned) {
+		t.Fatal("EpochByIndex(99) returned ErrPruned, want not registered")
 	}
 }
 
 func TestRegistry_EpochByIndex_GenesisFound(t *testing.T) {
 	r, _ := makeRegistry(t)
-	ep, ok := r.EpochByIndex(0)
-	if !ok {
-		t.Fatal("EpochByIndex(0) not found")
+	ep, err := r.EpochByIndex(0)
+	if err != nil {
+		t.Fatal(err)
 	}
 	if ep.EpochIndex() != 0 {
 		t.Fatalf("EpochIndex() = %d, want 0", ep.EpochIndex())
@@ -168,26 +173,23 @@ func TestSetupInitialEpochs_CommitSpanFromFirst(t *testing.T) {
 func TestActivateEpoch_SkipsExistingSeeds(t *testing.T) {
 	r, committee := makeRegistry(t)
 	r.SetupInitialEpochs(utils.None[types.RoadRange]())
-	require.Equal(t, types.EpochIndex(0), r.LatestEpoch().EpochIndex())
-	seeded, ok := r.EpochByIndex(1)
-	require.True(t, ok)
+	seeded := r.MustEpoch(1)
 	seededCommittee := seeded.Committee()
 
 	pk := committee.Lanes().At(0).Validator
 	ep, err := r.ActivateEpoch(
+		0,
 		map[types.PublicKey]uint64{pk: 1},
 		time.Time{},
 		r.FirstBlock(),
 	)
 	require.NoError(t, err)
 	require.Equal(t, types.EpochIndex(2), ep.EpochIndex())
-	require.Equal(t, types.EpochIndex(2), r.LatestEpoch().EpochIndex())
 	require.Equal(t, FirstRoad(2), ep.RoadRange().First)
 	require.Equal(t, FirstRoad(3), ep.RoadRange().Next)
-	got, ok := r.EpochByIndex(1)
-	require.True(t, ok)
+	got := r.MustEpoch(1)
 	require.Equal(t, seededCommittee, got.Committee())
-	_, ok = ep.Committee().Lane(pk).Get()
+	_, ok := ep.Committee().Lane(pk).Get()
 	require.True(t, ok)
 	require.Equal(t, 1, ep.Committee().Lanes().Len())
 }
@@ -203,6 +205,7 @@ func TestActivateEpoch_RejoinJoinedFromLatestNotPlaceholder(t *testing.T) {
 	r.SetupInitialEpochs(utils.None[types.RoadRange]())
 
 	epLeave, err := r.ActivateEpoch(
+		0,
 		map[types.PublicKey]uint64{b.Public(): 1},
 		time.Time{}, r.FirstBlock(),
 	)
@@ -210,14 +213,14 @@ func TestActivateEpoch_RejoinJoinedFromLatestNotPlaceholder(t *testing.T) {
 	require.Equal(t, types.EpochIndex(2), epLeave.EpochIndex())
 	require.False(t, epLeave.Committee().HasReplica(a.Public()))
 
-	// Seed a genesis-committee placeholder ahead of latest. Deriving from that
+	// Seed a genesis-committee placeholder ahead of the activated epoch. Deriving from that
 	// slot would treat A as still present and keep Joined=0.
 	r.AdvanceIfNeeded(LastRoad(2))
-	seeded, ok := r.EpochByIndex(3)
-	require.True(t, ok)
+	seeded := r.MustEpoch(3)
 	require.True(t, seeded.Committee().HasReplica(a.Public()))
 
 	epJoin, err := r.ActivateEpoch(
+		epLeave.EpochIndex(),
 		map[types.PublicKey]uint64{a.Public(): 1, b.Public(): 1},
 		time.Time{}, r.FirstBlock(),
 	)
@@ -254,4 +257,39 @@ func TestWaitForEpoch_FastPathAndWait(t *testing.T) {
 		require.NoError(t, waitErr)
 		require.Equal(t, types.EpochIndex(2), got.EpochIndex())
 	})
+}
+
+func TestPruneBefore_DropsIntermediateKeepsGenesis(t *testing.T) {
+	r, _ := makeRegistry(t)
+	r.AdvanceIfNeeded(LastRoad(0))
+	r.AdvanceIfNeeded(LastRoad(1))
+	_ = r.MustEpoch(1)
+	_ = r.MustEpoch(2)
+
+	r.PruneBefore(2)
+	_ = r.MustEpoch(0)
+	_, err := r.EpochByIndex(1)
+	require.ErrorIs(t, err, types.ErrPruned)
+	_ = r.MustEpoch(2)
+	require.Equal(t, types.GlobalBlockNumber(0), r.FirstBlock())
+
+	_, err = r.EpochAt(FirstRoad(1))
+	require.ErrorIs(t, err, types.ErrPruned)
+	_, err = r.WaitForEpoch(t.Context(), 1)
+	require.ErrorIs(t, err, types.ErrPruned)
+
+	r.PruneBefore(1) // no rewind
+	_ = r.MustEpoch(2)
+
+	pk := r.MustEpoch(0).Committee().Lanes().At(0).Validator
+	ep, err := r.ActivateEpoch(
+		0,
+		map[types.PublicKey]uint64{pk: 1},
+		time.Time{},
+		r.FirstBlock(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, types.EpochIndex(3), ep.EpochIndex())
+	_, err = r.EpochByIndex(1)
+	require.ErrorIs(t, err, types.ErrPruned)
 }

--- a/sei-tendermint/internal/autobahn/epoch/registry_test.go
+++ b/sei-tendermint/internal/autobahn/epoch/registry_test.go
@@ -234,6 +234,7 @@ func TestPruneBefore_DropsIntermediateKeepsGenesis(t *testing.T) {
 	_ = r.MustEpoch(2)
 
 	r.PruneBefore(2)
+	require.Equal(t, types.EpochRange{First: 2, Next: 3}, r.Live())
 	_ = r.MustEpoch(0)
 	_, err := r.EpochByIndex(1)
 	require.ErrorIs(t, err, types.ErrPruned)

--- a/sei-tendermint/internal/autobahn/epoch/registry_test.go
+++ b/sei-tendermint/internal/autobahn/epoch/registry_test.go
@@ -2,10 +2,12 @@ package epoch
 
 import (
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/sei-protocol/sei-chain/sei-tendermint/autobahn/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/require"
 )
 
 func makeRegistry(t *testing.T) (*Registry, *types.Committee) {
@@ -18,6 +20,10 @@ func makeRegistry(t *testing.T) (*Registry, *types.Committee) {
 	}))
 	r := utils.OrPanic1(NewRegistry(committee, 0, time.Time{}))
 	return r, committee
+}
+
+func midRoad(idx types.EpochIndex) types.RoadIndex {
+	return FirstRoad(idx) + EpochLength/2
 }
 
 func TestRegistry_EpochByIndex_UnknownReturnsNotFound(t *testing.T) {
@@ -36,4 +42,181 @@ func TestRegistry_EpochByIndex_GenesisFound(t *testing.T) {
 	if ep.EpochIndex() != 0 {
 		t.Fatalf("EpochIndex() = %d, want 0", ep.EpochIndex())
 	}
+}
+
+func TestNewRegistry_GenesisEpochBoundedRange(t *testing.T) {
+	r, _ := makeRegistry(t)
+	ep0, err := r.EpochAt(0)
+	if err != nil {
+		t.Fatalf("EpochAt(0): %v", err)
+	}
+	rng0 := ep0.RoadRange()
+	if rng0.First != 0 || rng0.Next != FirstRoad(1) {
+		t.Fatalf("epoch 0 RoadRange = {%d, %d}, want {0, %d}", rng0.First, rng0.Next, FirstRoad(1))
+	}
+	ep1, err := r.EpochAt(FirstRoad(1))
+	if err != nil {
+		t.Fatalf("EpochAt(FirstRoad(1)): %v", err)
+	}
+	rng1 := ep1.RoadRange()
+	if rng1.First != FirstRoad(1) || rng1.Next != FirstRoad(2) {
+		t.Fatalf("epoch 1 RoadRange = {%d, %d}, want {%d, %d}", rng1.First, rng1.Next, FirstRoad(1), FirstRoad(2))
+	}
+	if ep1.Committee() != ep0.Committee() {
+		t.Fatal("epoch 1 must use the genesis committee")
+	}
+}
+
+func TestEpochAt_WithinGenesisEpoch(t *testing.T) {
+	r, _ := makeRegistry(t)
+	ep, err := r.EpochAt(LastRoad(0))
+	if err != nil {
+		t.Fatalf("EpochAt(LastRoad(0)) error: %v", err)
+	}
+	if ep.EpochIndex() != 0 {
+		t.Fatalf("EpochAt(LastRoad(0)).EpochIndex() = %d, want 0", ep.EpochIndex())
+	}
+}
+
+func TestEpochAt_ErrorIfNotRegistered(t *testing.T) {
+	r, _ := makeRegistry(t)
+	_, err := r.EpochAt(FirstRoad(2))
+	if err == nil {
+		t.Fatal("EpochAt(FirstRoad(2)) expected error for unregistered epoch, got nil")
+	}
+}
+
+func TestEpochAt_FoundAfterAdvanceIfNeeded(t *testing.T) {
+	r, _ := makeRegistry(t)
+	if _, err := r.EpochAt(FirstRoad(1)); err != nil {
+		t.Fatalf("epoch 1 must be present from NewRegistry: %v", err)
+	}
+	r.AdvanceIfNeeded(0)
+	if _, err := r.EpochAt(FirstRoad(2)); err == nil {
+		t.Fatal("AdvanceIfNeeded(0) must not seed epoch 2")
+	}
+	r.AdvanceIfNeeded(LastRoad(0))
+	ep, err := r.EpochAt(FirstRoad(1))
+	if err != nil {
+		t.Fatalf("EpochAt(FirstRoad(1)) after last road of epoch 0: %v", err)
+	}
+	if ep.EpochIndex() != 1 {
+		t.Fatalf("EpochAt(FirstRoad(1)).EpochIndex() = %d, want 1", ep.EpochIndex())
+	}
+	if _, err := r.EpochAt(FirstRoad(2)); err == nil {
+		t.Fatal("AdvanceIfNeeded must not seed epoch 2")
+	}
+}
+
+func TestSetupInitialEpochs_EmptyNoneIsNoOp(t *testing.T) {
+	r, _ := makeRegistry(t)
+	r.SetupInitialEpochs(utils.None[types.RoadRange]())
+	for _, idx := range []types.EpochIndex{0, 1} {
+		if _, err := r.EpochAt(FirstRoad(idx)); err != nil {
+			t.Fatalf("EpochAt(epoch %d) after empty None: %v", idx, err)
+		}
+	}
+	if _, err := r.EpochAt(FirstRoad(2)); err == nil {
+		t.Fatal("EpochAt(epoch 2) should not be present from empty None")
+	}
+}
+
+func TestSetupInitialEpochs_CommitQCMidSeedsPlaceholderNext(t *testing.T) {
+	r, _ := makeRegistry(t)
+	tip := midRoad(5)
+	r.SetupInitialEpochs(utils.Some(types.RoadRange{First: tip, Next: tip + 1}))
+	for _, idx := range []types.EpochIndex{4, 5, 6} {
+		if _, err := r.EpochAt(FirstRoad(idx)); err != nil {
+			t.Fatalf("EpochAt(epoch %d) after CommitQC seeding: %v", idx, err)
+		}
+	}
+	if _, err := r.EpochAt(FirstRoad(7)); err == nil {
+		t.Fatal("EpochAt(epoch 7) should not be present from mid-epoch CommitQC")
+	}
+}
+
+func TestSetupInitialEpochs_CommitQCClosingSeedsNext(t *testing.T) {
+	r, _ := makeRegistry(t)
+	tip := LastRoad(5)
+	r.SetupInitialEpochs(utils.Some(types.RoadRange{First: tip, Next: tip + 1}))
+	for _, idx := range []types.EpochIndex{4, 5, 6} {
+		if _, err := r.EpochAt(FirstRoad(idx)); err != nil {
+			t.Fatalf("EpochAt(epoch %d) after closing CommitQC: %v", idx, err)
+		}
+	}
+	if _, err := r.EpochAt(FirstRoad(7)); err == nil {
+		t.Fatal("EpochAt(epoch 7) should not be present past windowLast+1")
+	}
+}
+
+func TestSetupInitialEpochs_CommitSpanFromFirst(t *testing.T) {
+	r, _ := makeRegistry(t)
+	r.SetupInitialEpochs(utils.Some(types.RoadRange{
+		First: midRoad(2),
+		Next:  midRoad(5) + 1,
+	}))
+	for _, idx := range []types.EpochIndex{1, 2, 3, 4, 5, 6} {
+		if _, err := r.EpochAt(FirstRoad(idx)); err != nil {
+			t.Fatalf("EpochAt(epoch %d) after commit span seeding: %v", idx, err)
+		}
+	}
+	if _, err := r.EpochAt(FirstRoad(7)); err == nil {
+		t.Fatal("EpochAt(epoch 7) should not be present past placeholder windowLast+1")
+	}
+}
+
+func TestActivateEpoch_SkipsExistingSeeds(t *testing.T) {
+	r, committee := makeRegistry(t)
+	r.SetupInitialEpochs(utils.None[types.RoadRange]())
+	require.Equal(t, types.EpochIndex(0), r.LatestEpoch().EpochIndex())
+	seeded, ok := r.EpochByIndex(1)
+	require.True(t, ok)
+	seededCommittee := seeded.Committee()
+
+	pk := committee.Lanes().At(0).Validator
+	ep, err := r.ActivateEpoch(
+		map[types.PublicKey]uint64{pk: 1},
+		time.Time{},
+		r.FirstBlock(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, types.EpochIndex(2), ep.EpochIndex())
+	require.Equal(t, types.EpochIndex(2), r.LatestEpoch().EpochIndex())
+	require.Equal(t, FirstRoad(2), ep.RoadRange().First)
+	require.Equal(t, FirstRoad(3), ep.RoadRange().Next)
+	got, ok := r.EpochByIndex(1)
+	require.True(t, ok)
+	require.Equal(t, seededCommittee, got.Committee())
+	_, ok = ep.Committee().Lane(pk).Get()
+	require.True(t, ok)
+	require.Equal(t, 1, ep.Committee().Lanes().Len())
+}
+
+func TestWaitForEpoch_FastPathAndWait(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		r, _ := makeRegistry(t)
+		ep, err := r.WaitForEpoch(t.Context(), 0)
+		require.NoError(t, err)
+		require.Equal(t, types.EpochIndex(0), ep.EpochIndex())
+
+		ep, err = r.WaitForEpoch(t.Context(), 1)
+		require.NoError(t, err)
+		require.Equal(t, types.EpochIndex(1), ep.EpochIndex())
+
+		_, err = r.EpochAt(FirstRoad(2))
+		require.Error(t, err)
+
+		var got *types.Epoch
+		var waitErr error
+		go func() {
+			got, waitErr = r.WaitForEpoch(t.Context(), 2)
+		}()
+		synctest.Wait()
+		require.Nil(t, got, "WaitForEpoch returned before AdvanceIfNeeded")
+
+		r.AdvanceIfNeeded(LastRoad(1))
+		synctest.Wait()
+		require.NoError(t, waitErr)
+		require.Equal(t, types.EpochIndex(2), got.EpochIndex())
+	})
 }

--- a/sei-tendermint/internal/autobahn/epoch/registry_test.go
+++ b/sei-tendermint/internal/autobahn/epoch/registry_test.go
@@ -192,6 +192,41 @@ func TestActivateEpoch_SkipsExistingSeeds(t *testing.T) {
 	require.Equal(t, 1, ep.Committee().Lanes().Len())
 }
 
+func TestActivateEpoch_RejoinJoinedFromLatestNotPlaceholder(t *testing.T) {
+	rng := utils.TestRng()
+	a := types.GenSecretKey(rng)
+	b := types.GenSecretKey(rng)
+	committee := utils.OrPanic1(types.NewCommittee(map[types.PublicKey]uint64{
+		a.Public(): 1, b.Public(): 1,
+	}))
+	r := utils.OrPanic1(NewRegistry(committee, 0, time.Time{}))
+	r.SetupInitialEpochs(utils.None[types.RoadRange]())
+
+	epLeave, err := r.ActivateEpoch(
+		map[types.PublicKey]uint64{b.Public(): 1},
+		time.Time{}, r.FirstBlock(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, types.EpochIndex(2), epLeave.EpochIndex())
+	require.False(t, epLeave.Committee().HasReplica(a.Public()))
+
+	// Seed a genesis-committee placeholder ahead of latest. Deriving from that
+	// slot would treat A as still present and keep Joined=0.
+	r.AdvanceIfNeeded(LastRoad(2))
+	seeded, ok := r.EpochByIndex(3)
+	require.True(t, ok)
+	require.True(t, seeded.Committee().HasReplica(a.Public()))
+
+	epJoin, err := r.ActivateEpoch(
+		map[types.PublicKey]uint64{a.Public(): 1, b.Public(): 1},
+		time.Time{}, r.FirstBlock(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, types.EpochIndex(4), epJoin.EpochIndex())
+	lane := epJoin.Committee().Lane(a.Public()).OrPanic("rejoin")
+	require.Equal(t, types.EpochIndex(4), lane.Joined)
+}
+
 func TestWaitForEpoch_FastPathAndWait(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		r, _ := makeRegistry(t)

--- a/sei-tendermint/internal/autobahn/epoch/registry_test.go
+++ b/sei-tendermint/internal/autobahn/epoch/registry_test.go
@@ -61,12 +61,7 @@ func TestNewRegistry_Genesis(t *testing.T) {
 	if ep1.Committee() != ep0.Committee() {
 		t.Fatal("epoch 1 must use the genesis committee")
 	}
-}
-
-func TestEpochAt_ErrorIfNotRegistered(t *testing.T) {
-	r, _ := makeRegistry(t)
-	_, err := r.EpochAt(FirstRoad(2))
-	if err == nil {
+	if _, err := r.EpochAt(FirstRoad(2)); err == nil {
 		t.Fatal("EpochAt(FirstRoad(2)) expected error for unregistered epoch, got nil")
 	}
 }

--- a/sei-tendermint/internal/autobahn/epoch/registry_test.go
+++ b/sei-tendermint/internal/autobahn/epoch/registry_test.go
@@ -38,48 +38,28 @@ func TestRegistry_EpochByIndex_UnknownReturnsNotFound(t *testing.T) {
 	}
 }
 
-func TestRegistry_EpochByIndex_GenesisFound(t *testing.T) {
+func TestNewRegistry_Genesis(t *testing.T) {
 	r, _ := makeRegistry(t)
-	ep, err := r.EpochByIndex(0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ep.EpochIndex() != 0 {
-		t.Fatalf("EpochIndex() = %d, want 0", ep.EpochIndex())
-	}
-}
+	ep0, err := r.EpochByIndex(0)
+	require.NoError(t, err)
+	require.Equal(t, types.EpochIndex(0), ep0.EpochIndex())
 
-func TestNewRegistry_GenesisEpochBoundedRange(t *testing.T) {
-	r, _ := makeRegistry(t)
-	ep0, err := r.EpochAt(0)
-	if err != nil {
-		t.Fatalf("EpochAt(0): %v", err)
-	}
-	rng0 := ep0.RoadRange()
+	epAt, err := r.EpochAt(LastRoad(0))
+	require.NoError(t, err)
+	require.Equal(t, types.EpochIndex(0), epAt.EpochIndex())
+	rng0 := epAt.RoadRange()
 	if rng0.First != 0 || rng0.Next != FirstRoad(1) {
 		t.Fatalf("epoch 0 RoadRange = {%d, %d}, want {0, %d}", rng0.First, rng0.Next, FirstRoad(1))
 	}
+
 	ep1, err := r.EpochAt(FirstRoad(1))
-	if err != nil {
-		t.Fatalf("EpochAt(FirstRoad(1)): %v", err)
-	}
+	require.NoError(t, err)
 	rng1 := ep1.RoadRange()
 	if rng1.First != FirstRoad(1) || rng1.Next != FirstRoad(2) {
 		t.Fatalf("epoch 1 RoadRange = {%d, %d}, want {%d, %d}", rng1.First, rng1.Next, FirstRoad(1), FirstRoad(2))
 	}
 	if ep1.Committee() != ep0.Committee() {
 		t.Fatal("epoch 1 must use the genesis committee")
-	}
-}
-
-func TestEpochAt_WithinGenesisEpoch(t *testing.T) {
-	r, _ := makeRegistry(t)
-	ep, err := r.EpochAt(LastRoad(0))
-	if err != nil {
-		t.Fatalf("EpochAt(LastRoad(0)) error: %v", err)
-	}
-	if ep.EpochIndex() != 0 {
-		t.Fatalf("EpochAt(LastRoad(0)).EpochIndex() = %d, want 0", ep.EpochIndex())
 	}
 }
 
@@ -113,60 +93,47 @@ func TestEpochAt_FoundAfterAdvanceIfNeeded(t *testing.T) {
 	}
 }
 
-func TestSetupInitialEpochs_EmptyNoneIsNoOp(t *testing.T) {
-	r, _ := makeRegistry(t)
-	r.SetupInitialEpochs(utils.None[types.RoadRange]())
-	for _, idx := range []types.EpochIndex{0, 1} {
-		if _, err := r.EpochAt(FirstRoad(idx)); err != nil {
-			t.Fatalf("EpochAt(epoch %d) after empty None: %v", idx, err)
-		}
-	}
-	if _, err := r.EpochAt(FirstRoad(2)); err == nil {
-		t.Fatal("EpochAt(epoch 2) should not be present from empty None")
-	}
-}
-
-func TestSetupInitialEpochs_CommitQCMidSeedsPlaceholderNext(t *testing.T) {
-	r, _ := makeRegistry(t)
-	tip := midRoad(5)
-	r.SetupInitialEpochs(utils.Some(types.RoadRange{First: tip, Next: tip + 1}))
-	for _, idx := range []types.EpochIndex{4, 5, 6} {
-		if _, err := r.EpochAt(FirstRoad(idx)); err != nil {
-			t.Fatalf("EpochAt(epoch %d) after CommitQC seeding: %v", idx, err)
-		}
-	}
-	if _, err := r.EpochAt(FirstRoad(7)); err == nil {
-		t.Fatal("EpochAt(epoch 7) should not be present from mid-epoch CommitQC")
-	}
-}
-
-func TestSetupInitialEpochs_CommitQCClosingSeedsNext(t *testing.T) {
-	r, _ := makeRegistry(t)
-	tip := LastRoad(5)
-	r.SetupInitialEpochs(utils.Some(types.RoadRange{First: tip, Next: tip + 1}))
-	for _, idx := range []types.EpochIndex{4, 5, 6} {
-		if _, err := r.EpochAt(FirstRoad(idx)); err != nil {
-			t.Fatalf("EpochAt(epoch %d) after closing CommitQC: %v", idx, err)
-		}
-	}
-	if _, err := r.EpochAt(FirstRoad(7)); err == nil {
-		t.Fatal("EpochAt(epoch 7) should not be present past windowLast+1")
-	}
-}
-
-func TestSetupInitialEpochs_CommitSpanFromFirst(t *testing.T) {
-	r, _ := makeRegistry(t)
-	r.SetupInitialEpochs(utils.Some(types.RoadRange{
-		First: midRoad(2),
-		Next:  midRoad(5) + 1,
-	}))
-	for _, idx := range []types.EpochIndex{1, 2, 3, 4, 5, 6} {
-		if _, err := r.EpochAt(FirstRoad(idx)); err != nil {
-			t.Fatalf("EpochAt(epoch %d) after commit span seeding: %v", idx, err)
-		}
-	}
-	if _, err := r.EpochAt(FirstRoad(7)); err == nil {
-		t.Fatal("EpochAt(epoch 7) should not be present past placeholder windowLast+1")
+func TestSetupInitialEpochs(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		span   utils.Option[types.RoadRange]
+		want   []types.EpochIndex
+		absent types.EpochIndex
+	}{
+		{
+			name:   "empty None is no-op",
+			span:   utils.None[types.RoadRange](),
+			want:   []types.EpochIndex{0, 1},
+			absent: 2,
+		},
+		{
+			name:   "mid CommitQC seeds placeholder next",
+			span:   utils.Some(types.RoadRange{First: midRoad(5), Next: midRoad(5) + 1}),
+			want:   []types.EpochIndex{4, 5, 6},
+			absent: 7,
+		},
+		{
+			name: "commit span from first",
+			span: utils.Some(types.RoadRange{
+				First: midRoad(2),
+				Next:  midRoad(5) + 1,
+			}),
+			want:   []types.EpochIndex{1, 2, 3, 4, 5, 6},
+			absent: 7,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, _ := makeRegistry(t)
+			r.SetupInitialEpochs(tc.span)
+			for _, idx := range tc.want {
+				if _, err := r.EpochAt(FirstRoad(idx)); err != nil {
+					t.Fatalf("EpochAt(epoch %d): %v", idx, err)
+				}
+			}
+			if _, err := r.EpochAt(FirstRoad(tc.absent)); err == nil {
+				t.Fatalf("EpochAt(epoch %d) should not be present", tc.absent)
+			}
+		})
 	}
 }
 

--- a/sei-tendermint/internal/autobahn/epoch/testonly.go
+++ b/sei-tendermint/internal/autobahn/epoch/testonly.go
@@ -21,3 +21,12 @@ func GenRegistry(rng utils.Rng, size int) (*Registry, []types.SecretKey) {
 	registry := utils.OrPanic1(NewRegistry(committee, firstBlock, time.Now()))
 	return registry, sks
 }
+
+// MustEpoch returns the registered epoch at i. Panics if it is missing.
+func (r *Registry) MustEpoch(i types.EpochIndex) *types.Epoch {
+	ep, err := r.EpochByIndex(i)
+	if err != nil {
+		panic(err)
+	}
+	return ep
+}

--- a/sei-tendermint/internal/autobahn/pb/autobahn.pb.go
+++ b/sei-tendermint/internal/autobahn/pb/autobahn.pb.go
@@ -1358,7 +1358,7 @@ func (x *FullTimeoutVote) GetLatestPrepareQc() *PrepareQC {
 type PersistedInner struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Index is the current view RoadIndex (ConsensusSpec.Index; 0 at genesis).
-	CommitQcIndex *uint64          `protobuf:"varint,9,opt,name=commit_qc_index,json=commitQcIndex,proto3,oneof" json:"commit_qc_index,omitempty"`
+	Index         *uint64          `protobuf:"varint,9,opt,name=index,proto3,oneof" json:"index,omitempty"`
 	PrepareQc     *PrepareQC       `protobuf:"bytes,2,opt,name=prepare_qc,json=prepareQc,proto3,oneof" json:"prepare_qc,omitempty"`
 	TimeoutQc     *TimeoutQC       `protobuf:"bytes,3,opt,name=timeout_qc,json=timeoutQc,proto3,oneof" json:"timeout_qc,omitempty"`
 	CommitVoteV2  *SignedProposal  `protobuf:"bytes,7,opt,name=commit_vote_v2,json=commitVoteV2,proto3,oneof" json:"commit_vote_v2,omitempty"`
@@ -1398,9 +1398,9 @@ func (*PersistedInner) Descriptor() ([]byte, []int) {
 	return file_autobahn_autobahn_proto_rawDescGZIP(), []int{23}
 }
 
-func (x *PersistedInner) GetCommitQcIndex() uint64 {
-	if x != nil && x.CommitQcIndex != nil {
-		return *x.CommitQcIndex
+func (x *PersistedInner) GetIndex() uint64 {
+	if x != nil && x.Index != nil {
+		return *x.Index
 	}
 	return 0
 }
@@ -2386,17 +2386,17 @@ const file_autobahn_autobahn_proto_rawDesc = "" +
 	"\x0fFullTimeoutVote\x124\n" +
 	"\avote_v2\x18\x03 \x01(\v2\x1b.autobahn.SignedTimeoutVoteR\x06voteV2\x12D\n" +
 	"\x11latest_prepare_qc\x18\x02 \x01(\v2\x13.autobahn.PrepareQCH\x00R\x0flatestPrepareQc\x88\x01\x01:\x06\xe8\x88\xe2\xab\f\x01B\x14\n" +
-	"\x12_latest_prepare_qcJ\x04\b\x01\x10\x02R\x04vote\"\xa0\x04\n" +
-	"\x0ePersistedInner\x12+\n" +
-	"\x0fcommit_qc_index\x18\t \x01(\x04H\x00R\rcommitQcIndex\x88\x01\x01\x127\n" +
+	"\x12_latest_prepare_qcJ\x04\b\x01\x10\x02R\x04vote\"\x84\x04\n" +
+	"\x0ePersistedInner\x12\x19\n" +
+	"\x05index\x18\t \x01(\x04H\x00R\x05index\x88\x01\x01\x127\n" +
 	"\n" +
 	"prepare_qc\x18\x02 \x01(\v2\x13.autobahn.PrepareQCH\x01R\tprepareQc\x88\x01\x01\x127\n" +
 	"\n" +
 	"timeout_qc\x18\x03 \x01(\v2\x13.autobahn.TimeoutQCH\x02R\ttimeoutQc\x88\x01\x01\x12C\n" +
 	"\x0ecommit_vote_v2\x18\a \x01(\v2\x18.autobahn.SignedProposalH\x03R\fcommitVoteV2\x88\x01\x01\x12E\n" +
 	"\x0fprepare_vote_v2\x18\b \x01(\v2\x18.autobahn.SignedProposalH\x04R\rprepareVoteV2\x88\x01\x01\x12A\n" +
-	"\ftimeout_vote\x18\x06 \x01(\v2\x19.autobahn.FullTimeoutVoteH\x05R\vtimeoutVote\x88\x01\x01B\x12\n" +
-	"\x10_commit_qc_indexB\r\n" +
+	"\ftimeout_vote\x18\x06 \x01(\v2\x19.autobahn.FullTimeoutVoteH\x05R\vtimeoutVote\x88\x01\x01B\b\n" +
+	"\x06_indexB\r\n" +
 	"\v_prepare_qcB\r\n" +
 	"\v_timeout_qcB\x11\n" +
 	"\x0f_commit_vote_v2B\x12\n" +

--- a/sei-tendermint/internal/autobahn/pb/autobahn.pb.go
+++ b/sei-tendermint/internal/autobahn/pb/autobahn.pb.go
@@ -1356,13 +1356,15 @@ func (x *FullTimeoutVote) GetLatestPrepareQc() *PrepareQC {
 // Do NOT persist internal derived fields (e.g., cached computations, runtime state).
 // Derived fields are implementation-dependent and should be recomputed on load.
 type PersistedInner struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	CommitQc      *CommitQC              `protobuf:"bytes,1,opt,name=commit_qc,json=commitQc,proto3,oneof" json:"commit_qc,omitempty"`
-	PrepareQc     *PrepareQC             `protobuf:"bytes,2,opt,name=prepare_qc,json=prepareQc,proto3,oneof" json:"prepare_qc,omitempty"`
-	TimeoutQc     *TimeoutQC             `protobuf:"bytes,3,opt,name=timeout_qc,json=timeoutQc,proto3,oneof" json:"timeout_qc,omitempty"`
-	CommitVoteV2  *SignedProposal        `protobuf:"bytes,7,opt,name=commit_vote_v2,json=commitVoteV2,proto3,oneof" json:"commit_vote_v2,omitempty"`
-	PrepareVoteV2 *SignedProposal        `protobuf:"bytes,8,opt,name=prepare_vote_v2,json=prepareVoteV2,proto3,oneof" json:"prepare_vote_v2,omitempty"`
-	TimeoutVote   *FullTimeoutVote       `protobuf:"bytes,6,opt,name=timeout_vote,json=timeoutVote,proto3,oneof" json:"timeout_vote,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Tip CommitQC road index for ErrAvailBehindConsensus on restore.
+	// Absent means no tip yet (genesis view 0). Runtime tip comes from ConsensusSpec.
+	CommitQcIndex *uint64          `protobuf:"varint,9,opt,name=commit_qc_index,json=commitQcIndex,proto3,oneof" json:"commit_qc_index,omitempty"`
+	PrepareQc     *PrepareQC       `protobuf:"bytes,2,opt,name=prepare_qc,json=prepareQc,proto3,oneof" json:"prepare_qc,omitempty"`
+	TimeoutQc     *TimeoutQC       `protobuf:"bytes,3,opt,name=timeout_qc,json=timeoutQc,proto3,oneof" json:"timeout_qc,omitempty"`
+	CommitVoteV2  *SignedProposal  `protobuf:"bytes,7,opt,name=commit_vote_v2,json=commitVoteV2,proto3,oneof" json:"commit_vote_v2,omitempty"`
+	PrepareVoteV2 *SignedProposal  `protobuf:"bytes,8,opt,name=prepare_vote_v2,json=prepareVoteV2,proto3,oneof" json:"prepare_vote_v2,omitempty"`
+	TimeoutVote   *FullTimeoutVote `protobuf:"bytes,6,opt,name=timeout_vote,json=timeoutVote,proto3,oneof" json:"timeout_vote,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1397,11 +1399,11 @@ func (*PersistedInner) Descriptor() ([]byte, []int) {
 	return file_autobahn_autobahn_proto_rawDescGZIP(), []int{23}
 }
 
-func (x *PersistedInner) GetCommitQc() *CommitQC {
-	if x != nil {
-		return x.CommitQc
+func (x *PersistedInner) GetCommitQcIndex() uint64 {
+	if x != nil && x.CommitQcIndex != nil {
+		return *x.CommitQcIndex
 	}
-	return nil
+	return 0
 }
 
 func (x *PersistedInner) GetPrepareQc() *PrepareQC {
@@ -2385,23 +2387,22 @@ const file_autobahn_autobahn_proto_rawDesc = "" +
 	"\x0fFullTimeoutVote\x124\n" +
 	"\avote_v2\x18\x03 \x01(\v2\x1b.autobahn.SignedTimeoutVoteR\x06voteV2\x12D\n" +
 	"\x11latest_prepare_qc\x18\x02 \x01(\v2\x13.autobahn.PrepareQCH\x00R\x0flatestPrepareQc\x88\x01\x01:\x06\xe8\x88\xe2\xab\f\x01B\x14\n" +
-	"\x12_latest_prepare_qcJ\x04\b\x01\x10\x02R\x04vote\"\x92\x04\n" +
-	"\x0ePersistedInner\x124\n" +
-	"\tcommit_qc\x18\x01 \x01(\v2\x12.autobahn.CommitQCH\x00R\bcommitQc\x88\x01\x01\x127\n" +
+	"\x12_latest_prepare_qcJ\x04\b\x01\x10\x02R\x04vote\"\xa0\x04\n" +
+	"\x0ePersistedInner\x12+\n" +
+	"\x0fcommit_qc_index\x18\t \x01(\x04H\x00R\rcommitQcIndex\x88\x01\x01\x127\n" +
 	"\n" +
 	"prepare_qc\x18\x02 \x01(\v2\x13.autobahn.PrepareQCH\x01R\tprepareQc\x88\x01\x01\x127\n" +
 	"\n" +
 	"timeout_qc\x18\x03 \x01(\v2\x13.autobahn.TimeoutQCH\x02R\ttimeoutQc\x88\x01\x01\x12C\n" +
 	"\x0ecommit_vote_v2\x18\a \x01(\v2\x18.autobahn.SignedProposalH\x03R\fcommitVoteV2\x88\x01\x01\x12E\n" +
 	"\x0fprepare_vote_v2\x18\b \x01(\v2\x18.autobahn.SignedProposalH\x04R\rprepareVoteV2\x88\x01\x01\x12A\n" +
-	"\ftimeout_vote\x18\x06 \x01(\v2\x19.autobahn.FullTimeoutVoteH\x05R\vtimeoutVote\x88\x01\x01B\f\n" +
-	"\n" +
-	"_commit_qcB\r\n" +
+	"\ftimeout_vote\x18\x06 \x01(\v2\x19.autobahn.FullTimeoutVoteH\x05R\vtimeoutVote\x88\x01\x01B\x12\n" +
+	"\x10_commit_qc_indexB\r\n" +
 	"\v_prepare_qcB\r\n" +
 	"\v_timeout_qcB\x11\n" +
 	"\x0f_commit_vote_v2B\x12\n" +
 	"\x10_prepare_vote_v2B\x0f\n" +
-	"\r_timeout_voteJ\x04\b\x04\x10\x05J\x04\b\x05\x10\x06R\vcommit_voteR\fprepare_vote\"\x97\x01\n" +
+	"\r_timeout_voteJ\x04\b\x04\x10\x05J\x04\b\x05\x10\x06J\x04\b\x01\x10\x02R\vcommit_voteR\fprepare_voteR\tcommit_qc\"\x97\x01\n" +
 	"\x19PersistedAvailPruneAnchor\x12+\n" +
 	"\x06app_qc\x18\x01 \x01(\v2\x0f.autobahn.AppQCH\x00R\x05appQc\x88\x01\x01\x124\n" +
 	"\tcommit_qc\x18\x02 \x01(\v2\x12.autobahn.CommitQCH\x01R\bcommitQc\x88\x01\x01B\t\n" +
@@ -2545,45 +2546,44 @@ var file_autobahn_autobahn_proto_depIdxs = []int32{
 	17, // 28: autobahn.TimeoutQC.latest_prepare_qc:type_name -> autobahn.PrepareQC
 	29, // 29: autobahn.FullTimeoutVote.vote_v2:type_name -> autobahn.SignedTimeoutVote
 	17, // 30: autobahn.FullTimeoutVote.latest_prepare_qc:type_name -> autobahn.PrepareQC
-	18, // 31: autobahn.PersistedInner.commit_qc:type_name -> autobahn.CommitQC
-	17, // 32: autobahn.PersistedInner.prepare_qc:type_name -> autobahn.PrepareQC
-	21, // 33: autobahn.PersistedInner.timeout_qc:type_name -> autobahn.TimeoutQC
-	28, // 34: autobahn.PersistedInner.commit_vote_v2:type_name -> autobahn.SignedProposal
-	28, // 35: autobahn.PersistedInner.prepare_vote_v2:type_name -> autobahn.SignedProposal
-	22, // 36: autobahn.PersistedInner.timeout_vote:type_name -> autobahn.FullTimeoutVote
-	25, // 37: autobahn.PersistedAvailPruneAnchor.app_qc:type_name -> autobahn.AppQC
-	18, // 38: autobahn.PersistedAvailPruneAnchor.commit_qc:type_name -> autobahn.CommitQC
-	26, // 39: autobahn.AppQC.vote:type_name -> autobahn.AppProposal
-	8,  // 40: autobahn.AppQC.sigs:type_name -> autobahn.Signature
-	11, // 41: autobahn.Msg.lane_proposal:type_name -> autobahn.Block
-	9,  // 42: autobahn.Msg.lane_vote:type_name -> autobahn.BlockHeader
-	15, // 43: autobahn.Msg.proposal:type_name -> autobahn.Proposal
-	15, // 44: autobahn.Msg.prepare_vote:type_name -> autobahn.Proposal
-	15, // 45: autobahn.Msg.commit_vote:type_name -> autobahn.Proposal
-	20, // 46: autobahn.Msg.timeout_vote:type_name -> autobahn.TimeoutVote
-	26, // 47: autobahn.Msg.app_vote:type_name -> autobahn.AppProposal
-	15, // 48: autobahn.SignedProposal.msg:type_name -> autobahn.Proposal
-	8,  // 49: autobahn.SignedProposal.sig:type_name -> autobahn.Signature
-	20, // 50: autobahn.SignedTimeoutVote.msg:type_name -> autobahn.TimeoutVote
-	8,  // 51: autobahn.SignedTimeoutVote.sig:type_name -> autobahn.Signature
-	26, // 52: autobahn.SignedAppVote.msg:type_name -> autobahn.AppProposal
-	8,  // 53: autobahn.SignedAppVote.sig:type_name -> autobahn.Signature
-	11, // 54: autobahn.SignedBlock.msg:type_name -> autobahn.Block
-	8,  // 55: autobahn.SignedBlock.sig:type_name -> autobahn.Signature
-	9,  // 56: autobahn.SignedBlockHeader.msg:type_name -> autobahn.BlockHeader
-	8,  // 57: autobahn.SignedBlockHeader.sig:type_name -> autobahn.Signature
-	26, // 58: autobahn.SignedAppProposal.msg:type_name -> autobahn.AppProposal
-	8,  // 59: autobahn.SignedAppProposal.sig:type_name -> autobahn.Signature
-	16, // 60: autobahn.ConsensusReq.proposal:type_name -> autobahn.FullProposal
-	28, // 61: autobahn.ConsensusReq.prepare_vote_v2:type_name -> autobahn.SignedProposal
-	28, // 62: autobahn.ConsensusReq.commit_vote_v2:type_name -> autobahn.SignedProposal
-	22, // 63: autobahn.ConsensusReq.timeout_vote:type_name -> autobahn.FullTimeoutVote
-	21, // 64: autobahn.ConsensusReq.timeout_qc:type_name -> autobahn.TimeoutQC
-	65, // [65:65] is the sub-list for method output_type
-	65, // [65:65] is the sub-list for method input_type
-	65, // [65:65] is the sub-list for extension type_name
-	65, // [65:65] is the sub-list for extension extendee
-	0,  // [0:65] is the sub-list for field type_name
+	17, // 31: autobahn.PersistedInner.prepare_qc:type_name -> autobahn.PrepareQC
+	21, // 32: autobahn.PersistedInner.timeout_qc:type_name -> autobahn.TimeoutQC
+	28, // 33: autobahn.PersistedInner.commit_vote_v2:type_name -> autobahn.SignedProposal
+	28, // 34: autobahn.PersistedInner.prepare_vote_v2:type_name -> autobahn.SignedProposal
+	22, // 35: autobahn.PersistedInner.timeout_vote:type_name -> autobahn.FullTimeoutVote
+	25, // 36: autobahn.PersistedAvailPruneAnchor.app_qc:type_name -> autobahn.AppQC
+	18, // 37: autobahn.PersistedAvailPruneAnchor.commit_qc:type_name -> autobahn.CommitQC
+	26, // 38: autobahn.AppQC.vote:type_name -> autobahn.AppProposal
+	8,  // 39: autobahn.AppQC.sigs:type_name -> autobahn.Signature
+	11, // 40: autobahn.Msg.lane_proposal:type_name -> autobahn.Block
+	9,  // 41: autobahn.Msg.lane_vote:type_name -> autobahn.BlockHeader
+	15, // 42: autobahn.Msg.proposal:type_name -> autobahn.Proposal
+	15, // 43: autobahn.Msg.prepare_vote:type_name -> autobahn.Proposal
+	15, // 44: autobahn.Msg.commit_vote:type_name -> autobahn.Proposal
+	20, // 45: autobahn.Msg.timeout_vote:type_name -> autobahn.TimeoutVote
+	26, // 46: autobahn.Msg.app_vote:type_name -> autobahn.AppProposal
+	15, // 47: autobahn.SignedProposal.msg:type_name -> autobahn.Proposal
+	8,  // 48: autobahn.SignedProposal.sig:type_name -> autobahn.Signature
+	20, // 49: autobahn.SignedTimeoutVote.msg:type_name -> autobahn.TimeoutVote
+	8,  // 50: autobahn.SignedTimeoutVote.sig:type_name -> autobahn.Signature
+	26, // 51: autobahn.SignedAppVote.msg:type_name -> autobahn.AppProposal
+	8,  // 52: autobahn.SignedAppVote.sig:type_name -> autobahn.Signature
+	11, // 53: autobahn.SignedBlock.msg:type_name -> autobahn.Block
+	8,  // 54: autobahn.SignedBlock.sig:type_name -> autobahn.Signature
+	9,  // 55: autobahn.SignedBlockHeader.msg:type_name -> autobahn.BlockHeader
+	8,  // 56: autobahn.SignedBlockHeader.sig:type_name -> autobahn.Signature
+	26, // 57: autobahn.SignedAppProposal.msg:type_name -> autobahn.AppProposal
+	8,  // 58: autobahn.SignedAppProposal.sig:type_name -> autobahn.Signature
+	16, // 59: autobahn.ConsensusReq.proposal:type_name -> autobahn.FullProposal
+	28, // 60: autobahn.ConsensusReq.prepare_vote_v2:type_name -> autobahn.SignedProposal
+	28, // 61: autobahn.ConsensusReq.commit_vote_v2:type_name -> autobahn.SignedProposal
+	22, // 62: autobahn.ConsensusReq.timeout_vote:type_name -> autobahn.FullTimeoutVote
+	21, // 63: autobahn.ConsensusReq.timeout_qc:type_name -> autobahn.TimeoutQC
+	64, // [64:64] is the sub-list for method output_type
+	64, // [64:64] is the sub-list for method input_type
+	64, // [64:64] is the sub-list for extension type_name
+	64, // [64:64] is the sub-list for extension extendee
+	0,  // [0:64] is the sub-list for field type_name
 }
 
 func init() { file_autobahn_autobahn_proto_init() }

--- a/sei-tendermint/internal/autobahn/pb/autobahn.pb.go
+++ b/sei-tendermint/internal/autobahn/pb/autobahn.pb.go
@@ -1357,8 +1357,7 @@ func (x *FullTimeoutVote) GetLatestPrepareQc() *PrepareQC {
 // Derived fields are implementation-dependent and should be recomputed on load.
 type PersistedInner struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Tip CommitQC road index for ErrAvailBehindConsensus on restore.
-	// Absent means no tip yet (genesis view 0). Runtime tip comes from ConsensusSpec.
+	// Current view RoadIndex (0 at genesis). Compared to ConsensusSpec.Index on restore.
 	CommitQcIndex *uint64          `protobuf:"varint,9,opt,name=commit_qc_index,json=commitQcIndex,proto3,oneof" json:"commit_qc_index,omitempty"`
 	PrepareQc     *PrepareQC       `protobuf:"bytes,2,opt,name=prepare_qc,json=prepareQc,proto3,oneof" json:"prepare_qc,omitempty"`
 	TimeoutQc     *TimeoutQC       `protobuf:"bytes,3,opt,name=timeout_qc,json=timeoutQc,proto3,oneof" json:"timeout_qc,omitempty"`

--- a/sei-tendermint/internal/autobahn/pb/autobahn.pb.go
+++ b/sei-tendermint/internal/autobahn/pb/autobahn.pb.go
@@ -1357,7 +1357,7 @@ func (x *FullTimeoutVote) GetLatestPrepareQc() *PrepareQC {
 // Derived fields are implementation-dependent and should be recomputed on load.
 type PersistedInner struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Current view RoadIndex (0 at genesis). Compared to ConsensusSpec.Index on restore.
+	// Index is the current view RoadIndex (ConsensusSpec.Index; 0 at genesis).
 	CommitQcIndex *uint64          `protobuf:"varint,9,opt,name=commit_qc_index,json=commitQcIndex,proto3,oneof" json:"commit_qc_index,omitempty"`
 	PrepareQc     *PrepareQC       `protobuf:"bytes,2,opt,name=prepare_qc,json=prepareQc,proto3,oneof" json:"prepare_qc,omitempty"`
 	TimeoutQc     *TimeoutQC       `protobuf:"bytes,3,opt,name=timeout_qc,json=timeoutQc,proto3,oneof" json:"timeout_qc,omitempty"`

--- a/sei-tendermint/internal/autobahn/pb/autobahn.wireguard.go
+++ b/sei-tendermint/internal/autobahn/pb/autobahn.wireguard.go
@@ -275,7 +275,7 @@ func init() {
 
 	// Register the wireguard.Schema generated for autobahn.PersistedInner.
 	runtime.MustRegister[*PersistedInner](runtime.Schema{
-		1: {MaxCount: 1, Nested: utils.Some(reflect.TypeFor[*CommitQC]())},
+		9: {MaxCount: 1},
 		2: {MaxCount: 1, Nested: utils.Some(reflect.TypeFor[*PrepareQC]())},
 		3: {MaxCount: 1, Nested: utils.Some(reflect.TypeFor[*TimeoutQC]())},
 		7: {MaxCount: 1, Nested: utils.Some(reflect.TypeFor[*SignedProposal]())},

--- a/sei-tendermint/internal/autobahn/producer/mempool_test.go
+++ b/sei-tendermint/internal/autobahn/producer/mempool_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-db/ledger_db/block/memblock"
 	abci "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/autobahn/types"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/avail"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/blockstore"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/consensus"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/data"
@@ -577,12 +578,14 @@ func TestProducer_LeaveCancelsAndRejoinStartsNewLane(t *testing.T) {
 
 		epLeave, err := registry.ActivateEpoch(
 			map[types.PublicKey]uint64{b.Public(): 1},
-			types.OpenRoadRange(), time.Time{}, registry.FirstBlock(),
+			time.Time{}, registry.FirstBlock(),
 		)
 		if err != nil {
 			return err
 		}
-		availState.ApplyEpoch(epLeave)
+		if err := avail.DriveAdvance(ctx, availState, keys, epLeave.EpochIndex()); err != nil {
+			return err
+		}
 		if err := availState.WaitUntilClosed(ctx, lane0); err != nil {
 			return err
 		}
@@ -603,12 +606,14 @@ func TestProducer_LeaveCancelsAndRejoinStartsNewLane(t *testing.T) {
 
 		epJoin, err := registry.ActivateEpoch(
 			map[types.PublicKey]uint64{a.Public(): 1, b.Public(): 1},
-			types.OpenRoadRange(), time.Time{}, registry.FirstBlock(),
+			time.Time{}, registry.FirstBlock(),
 		)
 		if err != nil {
 			return err
 		}
-		availState.ApplyEpoch(epJoin)
+		if err := avail.DriveAdvance(ctx, availState, keys, epJoin.EpochIndex()); err != nil {
+			return err
+		}
 		got, err := availState.WaitForNextLane(ctx, a.Public(), utils.Some(lane0))
 		if err != nil {
 			return err
@@ -646,10 +651,15 @@ func TestInsertTx_WaitUnblocksOnLeave(t *testing.T) {
 
 	epLeave, err := registry.ActivateEpoch(
 		map[types.PublicKey]uint64{b.Public(): 1},
-		types.OpenRoadRange(), time.Time{}, registry.FirstBlock(),
+		time.Time{}, registry.FirstBlock(),
 	)
 	require.NoError(t, err)
-	availState.ApplyEpoch(epLeave)
+	require.NoError(t, scope.Run(ctx, func(ctx context.Context, sc scope.Scope) error {
+		sc.SpawnBgNamed("avail", func() error {
+			return utils.IgnoreCancel(availState.Run(ctx))
+		})
+		return avail.DriveAdvance(ctx, availState, keys, epLeave.EpochIndex())
+	}))
 	env.state.clearMempool()
 
 	select {

--- a/sei-tendermint/internal/autobahn/producer/mempool_test.go
+++ b/sei-tendermint/internal/autobahn/producer/mempool_test.go
@@ -577,6 +577,7 @@ func TestProducer_LeaveCancelsAndRejoinStartsNewLane(t *testing.T) {
 		}
 
 		epLeave, err := registry.ActivateEpoch(
+			0,
 			map[types.PublicKey]uint64{b.Public(): 1},
 			time.Time{}, registry.FirstBlock(),
 		)
@@ -605,6 +606,7 @@ func TestProducer_LeaveCancelsAndRejoinStartsNewLane(t *testing.T) {
 		}
 
 		epJoin, err := registry.ActivateEpoch(
+			epLeave.EpochIndex(),
 			map[types.PublicKey]uint64{a.Public(): 1, b.Public(): 1},
 			time.Time{}, registry.FirstBlock(),
 		)
@@ -650,6 +652,7 @@ func TestInsertTx_WaitUnblocksOnLeave(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 
 	epLeave, err := registry.ActivateEpoch(
+		0,
 		map[types.PublicKey]uint64{b.Public(): 1},
 		time.Time{}, registry.FirstBlock(),
 	)

--- a/sei-tendermint/internal/autobahn/producer/mempool_test.go
+++ b/sei-tendermint/internal/autobahn/producer/mempool_test.go
@@ -584,7 +584,7 @@ func TestProducer_LeaveCancelsAndRejoinStartsNewLane(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if err := avail.DriveAdvance(ctx, availState, keys, epLeave.EpochIndex()); err != nil {
+		if err := avail.TestDriveAdvance(ctx, availState, keys, epLeave.EpochIndex()); err != nil {
 			return err
 		}
 		if err := availState.WaitUntilClosed(ctx, lane0); err != nil {
@@ -613,7 +613,7 @@ func TestProducer_LeaveCancelsAndRejoinStartsNewLane(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if err := avail.DriveAdvance(ctx, availState, keys, epJoin.EpochIndex()); err != nil {
+		if err := avail.TestDriveAdvance(ctx, availState, keys, epJoin.EpochIndex()); err != nil {
 			return err
 		}
 		got, err := availState.WaitForNextLane(ctx, a.Public(), utils.Some(lane0))
@@ -661,7 +661,7 @@ func TestInsertTx_WaitUnblocksOnLeave(t *testing.T) {
 		sc.SpawnBgNamed("avail", func() error {
 			return utils.IgnoreCancel(availState.Run(ctx))
 		})
-		return avail.DriveAdvance(ctx, availState, keys, epLeave.EpochIndex())
+		return avail.TestDriveAdvance(ctx, availState, keys, epLeave.EpochIndex())
 	}))
 	env.state.clearMempool()
 

--- a/sei-tendermint/internal/p2p/giga/avail.go
+++ b/sei-tendermint/internal/p2p/giga/avail.go
@@ -114,15 +114,22 @@ func (x *validatorService) serverStreamCommitQCs(ctx context.Context, server rpc
 
 func (x *validatorService) clientStreamLaneProposals(ctx context.Context, c rpc.Client[API], peer types.PublicKey) error {
 	a := x.state.Avail()
+	var closed utils.Option[types.LaneID]
 	for ctx.Err() == nil {
 		// Wait on the peer's current committee LaneID: returns immediately for a
-		// stay/transient redial, blocks across leave until rejoin.
-		lane, err := a.WaitForNextLane(ctx, peer, utils.None[types.LaneID]())
+		// stay/transient redial, blocks across leave until rejoin (exclude closed).
+		lane, err := a.WaitForNextLane(ctx, peer, closed)
 		if err != nil {
 			return err
 		}
 		if err := x.streamLaneProposalsOnce(ctx, c, lane, a.NextBlock(lane)); err != nil {
 			return err
+		}
+		cur, ok := a.Lane(peer).Get()
+		if !ok || cur != lane {
+			closed = utils.Some(lane)
+		} else {
+			closed = utils.None[types.LaneID]()
 		}
 	}
 	return ctx.Err()

--- a/sei-tendermint/internal/p2p/giga/avail_test.go
+++ b/sei-tendermint/internal/p2p/giga/avail_test.go
@@ -19,7 +19,7 @@ func TestAvailClientServer(t *testing.T) {
 	ctx := t.Context()
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 4)
-	committee := registry.LatestEpoch().Committee()
+	committee := registry.MustEpoch(0).Committee()
 	env := newTestEnv(registry)
 	var nodes []*testNode
 	activeKeys := keys[:3] // keys are sorted by weight, so that's ok.

--- a/sei-tendermint/internal/p2p/giga/consensus_test.go
+++ b/sei-tendermint/internal/p2p/giga/consensus_test.go
@@ -15,7 +15,7 @@ func TestConsensusClientServer(t *testing.T) {
 	ctx := t.Context()
 	rng := utils.TestRng()
 	registry, keys := epoch.GenRegistry(rng, 7)
-	committee := registry.LatestEpoch().Committee()
+	committee := registry.MustEpoch(0).Committee()
 	env := newTestEnv(registry)
 	// Run only a subset of replicas, to enforce timeouts.
 	var nodes []*testNode

--- a/sei-tendermint/internal/p2p/giga/data_test.go
+++ b/sei-tendermint/internal/p2p/giga/data_test.go
@@ -63,7 +63,7 @@ type testEnv struct {
 }
 
 func newTestEnv(registry *epoch.Registry) *testEnv {
-	return &testEnv{registry, registry.LatestEpoch().Committee(), map[types.PublicKey]*testNode{}}
+	return &testEnv{registry, registry.MustEpoch(0).Committee(), map[types.PublicKey]*testNode{}}
 }
 
 // Call AddNode BEFORE Run.
@@ -114,7 +114,7 @@ func TestDataClientServer(t *testing.T) {
 		prev := utils.None[*types.CommitQC]()
 		for i := range 3 {
 			t.Logf("iteration %v", i)
-			qc, blocks := data.TestCommitQC(rng, server.data.Registry().LatestEpoch(), keys, prev)
+			qc, blocks := data.TestCommitQC(rng, server.data.Registry().MustEpoch(0), keys, prev)
 			if err := server.data.PushQC(ctx, qc, blocks); err != nil {
 				return fmt.Errorf("serverState.PushQC(): %w", err)
 			}

--- a/sei-tendermint/internal/p2p/giga_router_common.go
+++ b/sei-tendermint/internal/p2p/giga_router_common.go
@@ -41,6 +41,10 @@ type gigaRouterCommon struct {
 	poolOut *giga.Pool[NodePublicKey, rpc.Client[giga.API]]
 	proxies utils.RWMutex[map[atypes.PublicKey]*ethrpc.Client]
 	app     *proxy.Proxy
+	// commitEpoch is data.CommitEpoch() cached at construction so EvmProxy
+	// can Load() without taking the data lock on every call. Used for EVM
+	// tx sharding (Committee.EvmShard).
+	commitEpoch utils.AtomicRecv[*atypes.Epoch]
 
 	// inboundFullnodeCount tracks live non-committee inbound block-sync
 	// connections. Optimistic Add(1) + compare against cap; over-rejects

--- a/sei-tendermint/internal/p2p/giga_router_common.go
+++ b/sei-tendermint/internal/p2p/giga_router_common.go
@@ -41,10 +41,9 @@ type gigaRouterCommon struct {
 	poolOut *giga.Pool[NodePublicKey, rpc.Client[giga.API]]
 	proxies utils.RWMutex[map[atypes.PublicKey]*ethrpc.Client]
 	app     *proxy.Proxy
-	// commitEpoch is data.CommitEpoch() cached at construction so EvmProxy
-	// can Load() without taking the data lock on every call. Used for EVM
-	// tx sharding (Committee.EvmShard).
-	commitEpoch utils.AtomicRecv[*atypes.Epoch]
+	// nextCommitEpoch is data.NextCommitEpoch() cached at construction so
+	// EvmProxy can Load() without taking the data lock on every call.
+	nextCommitEpoch utils.AtomicRecv[*atypes.Epoch]
 
 	// inboundFullnodeCount tracks live non-committee inbound block-sync
 	// connections. Optimistic Add(1) + compare against cap; over-rejects

--- a/sei-tendermint/internal/p2p/giga_router_common_test.go
+++ b/sei-tendermint/internal/p2p/giga_router_common_test.go
@@ -120,7 +120,7 @@ func TestBuildDataStateStartsRecoveryAtAppTip(t *testing.T) {
 	require.NoError(t, err)
 	registry, err := epoch.NewRegistry(committee, atypes.GlobalBlockNumber(genDoc.InitialHeight), genDoc.GenesisTime)
 	require.NoError(t, err)
-	qc, blocks := data.TestCommitQC(rng, registry.LatestEpoch(), keys, utils.None[*atypes.CommitQC]())
+	qc, blocks := data.TestCommitQC(rng, registry.MustEpoch(0), keys, utils.None[*atypes.CommitQC]())
 	gr := qc.QC().GlobalRange()
 	require.Greater(t, gr.Len(), 2)
 	last := gr.First + atypes.GlobalBlockNumber(gr.Len()/2)

--- a/sei-tendermint/internal/p2p/giga_router_fullnode.go
+++ b/sei-tendermint/internal/p2p/giga_router_fullnode.go
@@ -30,7 +30,7 @@ func NewGigaFullnodeRouter(cfg *GigaRouterCommonConfig, key NodeSecretKey, dataS
 			cfg:                cfg,
 			key:                key,
 			data:               dataState,
-			commitEpoch:        dataState.CommitEpoch(),
+			nextCommitEpoch:    dataState.NextCommitEpoch(),
 			service:            giga.NewFullNodeService(dataState),
 			poolIn:             giga.NewPool[NodePublicKey, rpc.Server[giga.API]](),
 			poolOut:            giga.NewPool[NodePublicKey, rpc.Client[giga.API]](),
@@ -66,7 +66,7 @@ func (r *gigaFullnodeRouter) Run(ctx context.Context) error {
 // EvmProxy on the fullnode always returns the shard owner's EVM RPC client.
 // EnableEvmProxy is a no-op here because fullnodes do not have a local mempool.
 func (r *gigaFullnodeRouter) EvmProxy(sender common.Address) utils.Option[*ethrpc.Client] {
-	return r.evmProxy(r.commitEpoch.Load().Committee().EvmShard(sender))
+	return r.evmProxy(r.nextCommitEpoch.Load().Committee().EvmShard(sender))
 }
 
 // runFullnodeSubscriber: pick a committee member, dial + block-sync,

--- a/sei-tendermint/internal/p2p/giga_router_fullnode.go
+++ b/sei-tendermint/internal/p2p/giga_router_fullnode.go
@@ -30,6 +30,7 @@ func NewGigaFullnodeRouter(cfg *GigaRouterCommonConfig, key NodeSecretKey, dataS
 			cfg:                cfg,
 			key:                key,
 			data:               dataState,
+			commitEpoch:        dataState.CommitEpoch(),
 			service:            giga.NewFullNodeService(dataState),
 			poolIn:             giga.NewPool[NodePublicKey, rpc.Server[giga.API]](),
 			poolOut:            giga.NewPool[NodePublicKey, rpc.Client[giga.API]](),
@@ -65,7 +66,7 @@ func (r *gigaFullnodeRouter) Run(ctx context.Context) error {
 // EvmProxy on the fullnode always returns the shard owner's EVM RPC client.
 // EnableEvmProxy is a no-op here because fullnodes do not have a local mempool.
 func (r *gigaFullnodeRouter) EvmProxy(sender common.Address) utils.Option[*ethrpc.Client] {
-	return r.evmProxy(r.data.Registry().LatestEpoch().Committee().EvmShard(sender))
+	return r.evmProxy(r.commitEpoch.Load().Committee().EvmShard(sender))
 }
 
 // runFullnodeSubscriber: pick a committee member, dial + block-sync,

--- a/sei-tendermint/internal/p2p/giga_router_fullnode_test.go
+++ b/sei-tendermint/internal/p2p/giga_router_fullnode_test.go
@@ -104,7 +104,7 @@ func TestGigaRouter_Fullnode(t *testing.T) {
 	returnedRemoteClients := map[*ethrpc.Client]struct{}{}
 	for range 200 {
 		sender := common.BytesToAddress(utils.GenBytes(rng, common.AddressLength))
-		shardValidator := router.data.CommitEpoch().Load().Committee().EvmShard(sender)
+		shardValidator := router.data.NextCommitEpoch().Load().Committee().EvmShard(sender)
 		expectedClient := clientByValidator[shardValidator]
 		proxyClient, ok := router.EvmProxy(sender).Get()
 		require.True(t, ok)

--- a/sei-tendermint/internal/p2p/giga_router_fullnode_test.go
+++ b/sei-tendermint/internal/p2p/giga_router_fullnode_test.go
@@ -104,7 +104,7 @@ func TestGigaRouter_Fullnode(t *testing.T) {
 	returnedRemoteClients := map[*ethrpc.Client]struct{}{}
 	for range 200 {
 		sender := common.BytesToAddress(utils.GenBytes(rng, common.AddressLength))
-		shardValidator := router.data.Registry().LatestEpoch().Committee().EvmShard(sender)
+		shardValidator := router.data.CommitEpoch().Load().Committee().EvmShard(sender)
 		expectedClient := clientByValidator[shardValidator]
 		proxyClient, ok := router.EvmProxy(sender).Get()
 		require.True(t, ok)

--- a/sei-tendermint/internal/p2p/giga_router_validator.go
+++ b/sei-tendermint/internal/p2p/giga_router_validator.go
@@ -45,7 +45,7 @@ func NewGigaValidatorRouter(cfg *GigaValidatorConfig, key NodeSecretKey, dataSta
 			cfg:                &cfg.GigaRouterCommonConfig,
 			key:                key,
 			data:               dataState,
-			commitEpoch:        dataState.CommitEpoch(),
+			nextCommitEpoch:    dataState.NextCommitEpoch(),
 			service:            giga.NewService(consensusState),
 			poolIn:             giga.NewPool[NodePublicKey, rpc.Server[giga.API]](),
 			poolOut:            giga.NewPool[NodePublicKey, rpc.Client[giga.API]](),
@@ -106,7 +106,7 @@ func (r *gigaValidatorRouter) EvmProxy(sender common.Address) utils.Option[*ethr
 	if !r.cfg.EnableEvmProxy {
 		return utils.None[*ethrpc.Client]()
 	}
-	validator := r.commitEpoch.Load().Committee().EvmShard(sender)
+	validator := r.nextCommitEpoch.Load().Committee().EvmShard(sender)
 	if r.validatorKey == validator {
 		return utils.None[*ethrpc.Client]()
 	}

--- a/sei-tendermint/internal/p2p/giga_router_validator.go
+++ b/sei-tendermint/internal/p2p/giga_router_validator.go
@@ -45,6 +45,7 @@ func NewGigaValidatorRouter(cfg *GigaValidatorConfig, key NodeSecretKey, dataSta
 			cfg:                &cfg.GigaRouterCommonConfig,
 			key:                key,
 			data:               dataState,
+			commitEpoch:        dataState.CommitEpoch(),
 			service:            giga.NewService(consensusState),
 			poolIn:             giga.NewPool[NodePublicKey, rpc.Server[giga.API]](),
 			poolOut:            giga.NewPool[NodePublicKey, rpc.Client[giga.API]](),
@@ -105,7 +106,7 @@ func (r *gigaValidatorRouter) EvmProxy(sender common.Address) utils.Option[*ethr
 	if !r.cfg.EnableEvmProxy {
 		return utils.None[*ethrpc.Client]()
 	}
-	validator := r.data.Registry().LatestEpoch().Committee().EvmShard(sender)
+	validator := r.commitEpoch.Load().Committee().EvmShard(sender)
 	if r.validatorKey == validator {
 		return utils.None[*ethrpc.Client]()
 	}

--- a/sei-tendermint/internal/p2p/giga_router_validator_test.go
+++ b/sei-tendermint/internal/p2p/giga_router_validator_test.go
@@ -314,7 +314,7 @@ func TestGigaRouter_EvmProxy(t *testing.T) {
 		seenDisconnected := false
 		for range 400 {
 			sender := common.BytesToAddress(utils.GenBytes(rng, common.AddressLength))
-			shardValidator := router.data.Registry().LatestEpoch().Committee().EvmShard(sender)
+			shardValidator := router.data.CommitEpoch().Load().Committee().EvmShard(sender)
 
 			proxyClient, ok := router.EvmProxy(sender).Get()
 

--- a/sei-tendermint/internal/p2p/giga_router_validator_test.go
+++ b/sei-tendermint/internal/p2p/giga_router_validator_test.go
@@ -314,7 +314,7 @@ func TestGigaRouter_EvmProxy(t *testing.T) {
 		seenDisconnected := false
 		for range 400 {
 			sender := common.BytesToAddress(utils.GenBytes(rng, common.AddressLength))
-			shardValidator := router.data.CommitEpoch().Load().Committee().EvmShard(sender)
+			shardValidator := router.data.NextCommitEpoch().Load().Committee().EvmShard(sender)
 
 			proxyClient, ok := router.EvmProxy(sender).Get()
 

--- a/sei-tendermint/libs/utils/readonly.go
+++ b/sei-tendermint/libs/utils/readonly.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"reflect"
+)
+
+// ReadOnly marks a struct so TestEqual compares its private fields.
+type ReadOnly struct{}
+
+// isReadOnly reports whether t embeds ReadOnly.
+func isReadOnly(t reflect.Type) bool {
+	want := reflect.TypeFor[ReadOnly]()
+	if t.Kind() != reflect.Struct {
+		return false
+	}
+	for i := range t.NumField() {
+		if f := t.Field(i); f.Anonymous || f.Type == want {
+			return true
+		}
+	}
+	return false
+}

--- a/sei-tendermint/libs/utils/testonly.go
+++ b/sei-tendermint/libs/utils/testonly.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
-	"reflect"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -14,24 +13,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/testing/protocmp"
 )
-
-// ReadOnly - if a struct embeds ReadOnly,
-// its private fields will be compared by TestEqual.
-type ReadOnly struct{}
-
-// isReadOnly returns true if t embeds ReadOnly.
-func isReadOnly(t reflect.Type) bool {
-	want := reflect.TypeFor[ReadOnly]()
-	if t.Kind() != reflect.Struct {
-		return false
-	}
-	for i := range t.NumField() {
-		if f := t.Field(i); f.Anonymous || f.Type == want {
-			return true
-		}
-	}
-	return false
-}
 
 func cmpComparer[T any, PT interface {
 	Cmp(b *T) int


### PR DESCRIPTION
## Summary

Completes multi-epoch ownership for Autobahn (CON-358): each layer owns one epoch step and publishes what the next layer consumes.

- **Registry** — road-bounded epochs; `NewRegistry` seeds **0 and 1** (genesis committee). Live window is `[First, Next)` (`EpochRange`); epoch 0 is always kept. `SetupInitialEpochs` fills placeholders over retained CommitQC history; `AdvanceIfNeeded` seeds only **M+1** at `LastRoad(M)`; `PruneBefore` drops supported epochs below the data Anchor; `ActivateEpoch` never overwrites an already-registered index.
- **data** — admits CommitQCs under their verify-epoch (`nextQC` is a block cursor; `nextCommitRoad` is the road after the latest CommitQC). Publishes **`NextCommitEpoch`** (road after that tip, or the previous value until the epoch is registered). `PushAppHash` drives `AdvanceIfNeeded` at `LastRoad`. `PushQC` waits `gr.First <= nextQC` before epoch lookup.
- **avail** — live writer of the **applied** epoch (`runEpochAdvance`), one epoch per wake behind seal + Anchor (prune) leashes and registry presence. Construction (`restorePlan` / `nextViewEpoch`) may hop to the next-view epoch of the persisted tip. Catch-up: `prune` installs `anchor.Epoch` when it is ahead of applied; `WaitForEpoch` `ErrPruned` jumps to `Live().First`; if prune already passed `next` during the seal wait, advance continues instead of killing `Run`. Recounts lane votes under applied; publishes **`ConsensusSpec`**.
- **consensus** — one-shot `Load()` of Spec at `newInner` (durable CommitQC tip + epoch of the **following** road). WAL `Index` is the current view (`NextIndexOpt` of the tip; proto field 9 still `commit_qc_index`). Same-view votes/QCs are kept when tips match; local votes must be signed by this node. WAL view ahead of Spec → **`ErrAvailBehindConsensus`**.
- **p2p** — validator/fullnode `EvmProxy` shards from `data.NextCommitEpoch` (recv handle cached at construction).

### ConsensusSpec withhold (restart safety)

At an epoch boundary the durable tip sits on `LastRoad(E)` while applied is still `E`. Spec is **withheld** (previous Spec stands) until the next-view epoch is applied — never publishes a predecessor tip. Walking tip back would roll consensus view backward and discard that view's votes.

`persistedCommitQC` can still sit on `LastRoad(E)` while Spec withholds; `markCommitQCsPersisted` refreshes the spec tip while `runEpochAdvance` is parked. Mid-epoch persist and epoch advance stay separate loops.

### Three epoch concepts

| Concept | Owner | Meaning |
|---|---|---|
| Registry placeholders / ActivateEpoch tip | `epoch.Registry` | Which roads resolve; placeholders copy genesis committee |
| NextCommitEpoch | `data.State` | Epoch covering the road after the latest CommitQC (EVM sharding) |
| Applied epoch | `avail.State` | Lane QC weight, CommitQC ingress, producer membership |
| ConsensusSpec.Epoch | avail → consensus | Epoch of the view **after** the durable CommitQC tip |

`ViewSpec` embeds `ConsensusSpec` plus `TimeoutQC`.

## Test plan

- [x] `go test -race -count=1 ./sei-tendermint/autobahn/types/ ./sei-tendermint/internal/autobahn/... ./sei-tendermint/internal/p2p/ -timeout 20m`
- [ ] Spot-check boundary restart: node with WAL tip on `LastRoad(0)` after avail catch-up installs epoch 1 and republishes Spec
- [ ] Spot-check leave/rejoin: `ActivateEpoch` into epoch 2+ (epoch 1 is genesis-seeded and must not be overwritten)
- [ ] Spot-check data catch-up: Anchor jumps several epochs while avail is stale — `Run` stays up, applied jumps to the live floor

## Known follow-ups

- `ActivateEpoch` has no production caller yet — real committee weights still land via tests / future wiring; placeholders remain genesis copies (`registry.go` TODO)
- Future-epoch joiner votes still silently dropped (`avail/state.go` TODO)
- Lockstep persist + epoch advance at `LastRoad` (so `persistedCommitQC` and Spec tip never diverge) is not in this PR