### PR TITLE
Split the musl cgo link path by architecture

### DIFF
--- a/.github/workflows/cross-arch-build.yml
+++ b/.github/workflows/cross-arch-build.yml
@@ -68,7 +68,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          PATTERN='^(scripts/(build-static|boot-smoke|check-libwasmvm-static)\.sh|Makefile|third_party/alpine-gcc10-libgcc/|\.goreleaser\.yaml|\.github/workflows/cross-arch-build\.yml)'
+          PATTERN='^(scripts/(build-static|boot-smoke|check-libwasmvm-static|goreleaser-shim)\.sh|Makefile|third_party/alpine-gcc10-libgcc/|sei-wasmvm/internal/api/link_|sei-wasmd/x/wasm/artifacts/v[0-9]+/api/link_|link_(constraints|directives)_test\.go|\.goreleaser\.yaml|\.github/workflows/cross-arch-build\.yml)'
           FILES=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate -q '.[].filename')
           if echo "$FILES" | grep -qE "$PATTERN"; then
             echo "changed=true" >> "$GITHUB_OUTPUT"

--- a/link_constraints_test.go
+++ b/link_constraints_test.go
@@ -1,0 +1,149 @@
+package sei_test
+
+import (
+	"go/build"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// linkPkgDirs are the vendored libwasmvm api packages whose link_*.go files carry the
+// cgo directive naming a prebuilt archive.
+var linkPkgDirs = []string{
+	"sei-wasmd/x/wasm/artifacts/v152/api",
+	"sei-wasmd/x/wasm/artifacts/v155/api",
+	"sei-wasmvm/internal/api",
+}
+
+// linkPlatform is a build configuration and the link directive it must resolve to.
+type linkPlatform struct {
+	goos, goarch string
+	tags         []string
+	// wantCount is how many link_*.go files the toolchain selects. 1 is the only
+	// healthy value: 0 leaves the linker with no archive and undefined references,
+	// 2 puts two -l directives on one line and the archives collide.
+	wantCount int
+	// wantFile, when set, is the file that must be selected. It catches a swap that
+	// leaves wantCount at 1.
+	wantFile string
+	why      string
+}
+
+// linkPlatforms enumerates the build configurations this repo produces, plus the
+// linux/arm64 muslc cell the static arm64 binary depends on.
+var linkPlatforms = []linkPlatform{
+	{"linux", "amd64", []string{"muslc"}, 1, "link_muslc.go", "static musl release build, amd64"},
+	{"linux", "arm64", []string{"muslc"}, 1, "link_muslc_aarch64.go", "static musl release build, arm64"},
+	{"linux", "amd64", nil, 1, "link_glibclinux_x86_64.go", "ordinary dynamic build, amd64"},
+	{"linux", "arm64", nil, 1, "link_glibclinux_aarch64.go", "ordinary dynamic build, arm64 (the Docker image)"},
+	{"linux", "amd64", []string{"muslc", "sys_wasmvm"}, 1, "link_system.go", "system-libs escape hatch"},
+	{"linux", "arm64", []string{"muslc", "sys_wasmvm"}, 1, "link_system.go", "system-libs escape hatch, arm64"},
+	{"darwin", "arm64", nil, 1, "link_mac.go", "local development on Apple Silicon"},
+	{"darwin", "amd64", nil, 1, "link_mac.go", "local development on Intel Mac"},
+	{"windows", "amd64", nil, 1, "link_windows.go", "windows"},
+
+	// No archive of either flavour is vendored for the remaining linux architectures,
+	// so selecting nothing is correct and matches the glibc path. seid cannot build
+	// for them regardless: giga/executor/lib rejects them at compile time.
+	{"linux", "riscv64", []string{"muslc"}, 0, "", "unsupported arch, must select nothing"},
+}
+
+// TestLinkConstraintsSelectOneFile asserts that every build configuration selects exactly
+// one cgo link directive per api package, and that the archive it names matches the target
+// architecture.
+func TestLinkConstraintsSelectOneFile(t *testing.T) {
+	for _, p := range linkPlatforms {
+		p := p
+		name := p.goos + "_" + p.goarch
+		for _, tag := range p.tags {
+			name += "_" + tag
+		}
+		t.Run(name, func(t *testing.T) {
+			for _, dir := range linkPkgDirs {
+				dir := dir
+				t.Run(dir, func(t *testing.T) {
+					selected := selectedLinkFiles(t, dir, p)
+					require.Lenf(t, selected, p.wantCount,
+						"%s/%s tags=%v (%s): expected %d link file(s), got %d: %v\n"+
+							"  0 means nothing links (undefined references at link time)\n"+
+							"  2 means two -l directives on one link line (incompatible archives)",
+						p.goos, p.goarch, p.tags, p.why, p.wantCount, len(selected), selected)
+
+					if p.wantFile != "" {
+						require.Equalf(t, p.wantFile, selected[0],
+							"%s/%s tags=%v (%s): wrong link directive selected",
+							p.goos, p.goarch, p.tags, p.why)
+					}
+
+					// Naming an archive that exists is already covered by
+					// TestLinkDirectivesResolve, and that holds even if two directives are
+					// swapped. Pin the architecture of the archive as well.
+					if p.goos == "linux" && !hasTag(p.tags, "sys_wasmvm") && len(selected) == 1 {
+						lib := ldflagLibrary(t, filepath.Join(dir, selected[0]))
+						require.Equalf(t, p.goarch == "arm64", strings.Contains(lib, "aarch64"),
+							"%s/%s tags=%v: %s links -l%s; an aarch64 archive must be used "+
+								"exactly when building for arm64",
+							p.goos, p.goarch, p.tags, selected[0], lib)
+					}
+				})
+			}
+		})
+	}
+}
+
+// selectedLinkFiles returns the link_*.go files in dir that the Go toolchain compiles for
+// the given platform.
+func selectedLinkFiles(t *testing.T, dir string, p linkPlatform) []string {
+	t.Helper()
+
+	ctx := build.Default
+	ctx.GOOS = p.goos
+	ctx.GOARCH = p.goarch
+	ctx.BuildTags = p.tags
+	// The link files are pure `import "C"`; with cgo off the toolchain excludes them all.
+	ctx.CgoEnabled = true
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err, "read %s", dir)
+
+	var selected []string
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, "link_") || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		ok, err := ctx.MatchFile(dir, name)
+		require.NoErrorf(t, err, "match %s", filepath.Join(dir, name))
+		if ok {
+			selected = append(selected, name)
+		}
+	}
+	return selected
+}
+
+// hasTag reports whether tag is present in tags.
+func hasTag(tags []string, tag string) bool {
+	for _, t := range tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// ldflagLibrary returns the -l<name> argument from the cgo LDFLAGS directive in the file
+// at path, for example "wasmvm155_muslc.aarch64".
+func ldflagLibrary(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "read %s", path)
+	m := reLDFlag.FindStringSubmatch(string(data))
+	require.NotEmptyf(t, m, "no `#cgo LDFLAGS: ... -l<name>` directive in %s", path)
+	return m[1]
+}

--- a/sei-wasmd/x/wasm/artifacts/v152/api/link_muslc.go
+++ b/sei-wasmd/x/wasm/artifacts/v152/api/link_muslc.go
@@ -1,4 +1,4 @@
-//go:build linux && muslc && !sys_wasmvm
+//go:build linux && muslc && amd64 && !sys_wasmvm
 
 package api
 

--- a/sei-wasmd/x/wasm/artifacts/v152/api/link_muslc_aarch64.go
+++ b/sei-wasmd/x/wasm/artifacts/v152/api/link_muslc_aarch64.go
@@ -1,0 +1,6 @@
+//go:build linux && muslc && arm64 && !sys_wasmvm
+
+package api
+
+// #cgo LDFLAGS: -Wl,-rpath,${SRCDIR} -L${SRCDIR} -lwasmvm152_muslc.aarch64
+import "C"

--- a/sei-wasmd/x/wasm/artifacts/v155/api/link_muslc.go
+++ b/sei-wasmd/x/wasm/artifacts/v155/api/link_muslc.go
@@ -1,4 +1,4 @@
-//go:build linux && muslc && !sys_wasmvm
+//go:build linux && muslc && amd64 && !sys_wasmvm
 
 package api
 

--- a/sei-wasmd/x/wasm/artifacts/v155/api/link_muslc_aarch64.go
+++ b/sei-wasmd/x/wasm/artifacts/v155/api/link_muslc_aarch64.go
@@ -1,0 +1,6 @@
+//go:build linux && muslc && arm64 && !sys_wasmvm
+
+package api
+
+// #cgo LDFLAGS: -Wl,-rpath,${SRCDIR} -L${SRCDIR} -lwasmvm155_muslc.aarch64
+import "C"

--- a/sei-wasmvm/internal/api/link_muslc.go
+++ b/sei-wasmvm/internal/api/link_muslc.go
@@ -1,4 +1,4 @@
-//go:build linux && muslc && !sys_wasmvm
+//go:build linux && muslc && amd64 && !sys_wasmvm
 
 package api
 

--- a/sei-wasmvm/internal/api/link_muslc_aarch64.go
+++ b/sei-wasmvm/internal/api/link_muslc_aarch64.go
@@ -1,0 +1,6 @@
+//go:build linux && muslc && arm64 && !sys_wasmvm
+
+package api
+
+// #cgo LDFLAGS: -Wl,-rpath,${SRCDIR} -L${SRCDIR} -lwasmvm_muslc.aarch64
+import "C"


### PR DESCRIPTION
Prerequisite for shipping a static `linux/arm64` seid binary. It changes three words, adds three five-line files, and adds a test.

## The bug

The glibc link path is arch-split (`link_glibclinux_aarch64.go` and `link_glibclinux_x86_64.go`), but the musl path never was. `link_muslc.go` carried `linux && muslc && !sys_wasmvm` with no arch term, so a `linux/arm64` muslc build selected it, emitted `-lwasmvm_muslc`, resolved the **x86_64** archive, and died at link time with incompatible-archive errors.

The `libwasmvm*_muslc.aarch64.a` archives have been checked in for months, referenced by nothing.

## The change

Constrain the three existing files to `amd64`, and add three aarch64 siblings pointing at the archives already in the tree. The new files are byte-identical to CosmWasm/wasmvm v2.1.0's equivalents, since the vendored tree here predates that upstream fix.

## Validation

Each of the six changes was tested in isolation rather than as one bundle:

| Mutation | `linux/arm64 muslc` selection | Effect |
|---|---|---|
| (correct) | 1 | links |
| remove any one new file | **0** | undefined references |
| drop `amd64` from any one file | **2** | both archives on one link line |

Real links in the pinned release image (Alpine 3.23.3, gcc 15.2.0, native arm64) confirm the model predicts linker behaviour rather than just build-tag arithmetic. The baseline fails with 3x `incompatible`, the "new files but no constraints" variant fails with 6x (double, one per extra archive), "constraints but no new files" fails with `undefined reference to version_str`, and the full change produces `ELF 64-bit LSB executable, ARM aarch64, statically linked`.

**amd64 is provably untouched.** For `GOARCH=amd64` the selected files and the resulting cgo `LDFLAGS` are byte-identical before and after, across all three packages. An actual amd64 static build via unmodified `scripts/build-static.sh` succeeds with the change applied.

**No consensus impact observed.** A mixed fleet of three binaries built from this branch (arm64 static musl, amd64 static musl, arm64 dynamic glibc) on one chain agreed on every app hash compared, including the blocks carrying a wasm store/instantiate/execute cycle. Separately, the seven consensus-relevant packages that swap amd64 assembly for portable Go on arm64 all pass their upstream vector suites on both architectures.

## Reviewer notes

- **This lands inert.** Nothing in CI, goreleaser or the Dockerfile builds `linux/arm64` with the muslc tag yet. It unblocks that work, it does not ship an arm64 binary.
- **Behaviour change for exotic architectures.** 386, riscv64, s390x and ppc64le previously matched the amd64 muslc directive and failed with an incompatible-archive error. They now match no link file and fail with undefined references instead. That matches what the glibc path has always done, and seid cannot build on those architectures anyway, since `giga/executor/lib` rejects them at compile time with a clearer message.
- **The third commit touches a workflow file**, so the backport bot cannot carry it and it needs a manual cherry-pick for release branches. Happy to split it out if you'd prefer, the first two commits stand alone.

## Why the test

`link_directives_test.go` checks each `-l<name>` resolves to a file on disk but never parses `//go:build`, so it passed even while this bug was present. Nothing else covers it either, because no job anywhere builds arm64 muslc. Without the new test, reverting this change is a green build.

It asserts each platform selects exactly one link directive, which file it is, and that an aarch64 archive is used exactly when `GOARCH=arm64`. Selection is evaluated with `go/build`'s own `MatchFile`, so the answer is the toolchain's rather than a reimplementation.

Confirmed to fail rather than merely to pass. All seven ways of breaking this change turn it red, including swapping the `-l` names between two files, which is a case the existing tests still pass.
