### PR TITLE
Split the musl cgo link path by architecture

### DIFF
--- a/.github/workflows/cross-arch-build.yml
+++ b/.github/workflows/cross-arch-build.yml
@@ -68,7 +68,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          PATTERN='^(scripts/(build-static|boot-smoke|check-libwasmvm-static)\.sh|Makefile|third_party/alpine-gcc10-libgcc/|\.goreleaser\.yaml|\.github/workflows/cross-arch-build\.yml)'
+          PATTERN='^(scripts/(build-static|boot-smoke|check-libwasmvm-static|goreleaser-shim)\.sh|Makefile|third_party/alpine-gcc10-libgcc/|sei-wasmvm/internal/api/link_|sei-wasmd/x/wasm/artifacts/v[0-9]+/api/link_|link_(constraints|directives)_test\.go|\.goreleaser\.yaml|\.github/workflows/cross-arch-build\.yml)'
           FILES=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate -q '.[].filename')
           if echo "$FILES" | grep -qE "$PATTERN"; then
             echo "changed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cross-arch-build.yml
+++ b/.github/workflows/cross-arch-build.yml
@@ -54,6 +54,50 @@ jobs:
 
       - name: Verify build binary
         run: ./build/seid version --long
+
+  linux-arm64:
+    name: "Linux ARM64"
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout code
+        # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25.6'
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential
+
+      - name: Verify Go installation
+        run: |
+          go version
+          echo "GOARCH: $(go env GOARCH)"
+          echo "GOOS: $(go env GOOS)"
+
+      - name: Download Go dependencies
+        run: go mod download
+
+      - name: Run make install
+        run: make install
+
+      - name: Verify install binary
+        run: seid version --long
+
+      - name: Run make build
+        run: make build
+
+      - name: Verify build binary
+        run: ./build/seid version --long
+
+      # The link-directive tests are per-platform: the arm64 expectations only
+      # compile into the test binary on an arm64 host, so amd64 jobs cannot run them.
+      - name: Verify cgo link directives for this architecture
+        run: go test -count=1 -v -run 'TestLinkConstraints|TestLinkDirectivesResolve|TestArtifactsHaveNoOrphans' .
   # Detect PRs that change the static-build inputs so they run the full static
   # job below even when targeting main; otherwise a change to the static build
   # only gets exercised once it reaches a release branch.

--- a/link_constraints_darwin_test.go
+++ b/link_constraints_darwin_test.go
@@ -1,0 +1,12 @@
+package sei_test
+
+import "testing"
+
+func TestLinkConstraints(t *testing.T) {
+	for _, dir := range linkDirs {
+		t.Run(dir, func(t *testing.T) {
+			assertSelects(t, dir, nil, "link_mac.go", false)
+			assertSelects(t, dir, []string{"muslc"}, "link_mac.go", false)
+		})
+	}
+}

--- a/link_constraints_linux_amd64_test.go
+++ b/link_constraints_linux_amd64_test.go
@@ -1,0 +1,13 @@
+package sei_test
+
+import "testing"
+
+func TestLinkConstraints(t *testing.T) {
+	for _, dir := range linkDirs {
+		t.Run(dir, func(t *testing.T) {
+			assertSelects(t, dir, []string{"muslc"}, "link_muslc.go", false)
+			assertSelects(t, dir, nil, "link_glibclinux_x86_64.go", false)
+			assertSelects(t, dir, []string{"muslc", "sys_wasmvm"}, "link_system.go", false)
+		})
+	}
+}

--- a/link_constraints_linux_arm64_test.go
+++ b/link_constraints_linux_arm64_test.go
@@ -1,0 +1,13 @@
+package sei_test
+
+import "testing"
+
+func TestLinkConstraints(t *testing.T) {
+	for _, dir := range linkDirs {
+		t.Run(dir, func(t *testing.T) {
+			assertSelects(t, dir, []string{"muslc"}, "link_muslc_aarch64.go", true)
+			assertSelects(t, dir, nil, "link_glibclinux_aarch64.go", true)
+			assertSelects(t, dir, []string{"muslc", "sys_wasmvm"}, "link_system.go", false)
+		})
+	}
+}

--- a/link_constraints_test.go
+++ b/link_constraints_test.go
@@ -1,0 +1,149 @@
+package sei_test
+
+import (
+	"go/build"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// linkPkgDirs are the vendored libwasmvm api packages whose link_*.go files carry the
+// cgo directive naming a prebuilt archive.
+var linkPkgDirs = []string{
+	"sei-wasmd/x/wasm/artifacts/v152/api",
+	"sei-wasmd/x/wasm/artifacts/v155/api",
+	"sei-wasmvm/internal/api",
+}
+
+// linkPlatform is a build configuration and the link directive it must resolve to.
+type linkPlatform struct {
+	goos, goarch string
+	tags         []string
+	// wantCount is how many link_*.go files the toolchain selects. 1 is the only
+	// healthy value: 0 leaves the linker with no archive and undefined references,
+	// 2 puts two -l directives on one line and the archives collide.
+	wantCount int
+	// wantFile, when set, is the file that must be selected. It catches a swap that
+	// leaves wantCount at 1.
+	wantFile string
+	why      string
+}
+
+// linkPlatforms enumerates the build configurations this repo produces, plus the
+// linux/arm64 muslc cell the static arm64 binary depends on.
+var linkPlatforms = []linkPlatform{
+	{"linux", "amd64", []string{"muslc"}, 1, "link_muslc.go", "static musl release build, amd64"},
+	{"linux", "arm64", []string{"muslc"}, 1, "link_muslc_aarch64.go", "static musl release build, arm64"},
+	{"linux", "amd64", nil, 1, "link_glibclinux_x86_64.go", "ordinary dynamic build, amd64"},
+	{"linux", "arm64", nil, 1, "link_glibclinux_aarch64.go", "ordinary dynamic build, arm64 (the Docker image)"},
+	{"linux", "amd64", []string{"muslc", "sys_wasmvm"}, 1, "link_system.go", "system-libs escape hatch"},
+	{"linux", "arm64", []string{"muslc", "sys_wasmvm"}, 1, "link_system.go", "system-libs escape hatch, arm64"},
+	{"darwin", "arm64", nil, 1, "link_mac.go", "local development on Apple Silicon"},
+	{"darwin", "amd64", nil, 1, "link_mac.go", "local development on Intel Mac"},
+	{"windows", "amd64", nil, 1, "link_windows.go", "windows"},
+
+	// No archive of either flavour is vendored for the remaining linux architectures,
+	// so selecting nothing is correct and matches the glibc path. seid cannot build
+	// for them regardless: giga/executor/lib rejects them at compile time.
+	{"linux", "riscv64", []string{"muslc"}, 0, "", "unsupported arch, must select nothing"},
+}
+
+// TestLinkConstraintsSelectOneFile asserts that every build configuration selects exactly
+// one cgo link directive per api package, and that the archive it names matches the target
+// architecture.
+func TestLinkConstraintsSelectOneFile(t *testing.T) {
+	for _, p := range linkPlatforms {
+		p := p
+		name := p.goos + "_" + p.goarch
+		for _, tag := range p.tags {
+			name += "_" + tag
+		}
+		t.Run(name, func(t *testing.T) {
+			for _, dir := range linkPkgDirs {
+				dir := dir
+				t.Run(dir, func(t *testing.T) {
+					selected := selectedLinkFiles(t, dir, p)
+					require.Lenf(t, selected, p.wantCount,
+						"%s/%s tags=%v (%s): expected %d link file(s), got %d: %v\n"+
+							"  0 means nothing links (undefined references at link time)\n"+
+							"  2 means two -l directives on one link line (incompatible archives)",
+						p.goos, p.goarch, p.tags, p.why, p.wantCount, len(selected), selected)
+
+					if p.wantFile != "" {
+						require.Equalf(t, p.wantFile, selected[0],
+							"%s/%s tags=%v (%s): wrong link directive selected",
+							p.goos, p.goarch, p.tags, p.why)
+					}
+
+					// Naming an archive that exists is already covered by
+					// TestLinkDirectivesResolve, and that holds even if two directives are
+					// swapped. Pin the architecture of the archive as well.
+					if p.goos == "linux" && !hasTag(p.tags, "sys_wasmvm") && len(selected) == 1 {
+						lib := ldflagLibrary(t, filepath.Join(dir, selected[0]))
+						require.Equalf(t, p.goarch == "arm64", strings.Contains(lib, "aarch64"),
+							"%s/%s tags=%v: %s links -l%s; an aarch64 archive must be used "+
+								"exactly when building for arm64",
+							p.goos, p.goarch, p.tags, selected[0], lib)
+					}
+				})
+			}
+		})
+	}
+}
+
+// selectedLinkFiles returns the link_*.go files in dir that the Go toolchain compiles for
+// the given platform.
+func selectedLinkFiles(t *testing.T, dir string, p linkPlatform) []string {
+	t.Helper()
+
+	ctx := build.Default
+	ctx.GOOS = p.goos
+	ctx.GOARCH = p.goarch
+	ctx.BuildTags = p.tags
+	// The link files are pure `import "C"`; with cgo off the toolchain excludes them all.
+	ctx.CgoEnabled = true
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err, "read %s", dir)
+
+	var selected []string
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, "link_") || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		ok, err := ctx.MatchFile(dir, name)
+		require.NoErrorf(t, err, "match %s", filepath.Join(dir, name))
+		if ok {
+			selected = append(selected, name)
+		}
+	}
+	return selected
+}
+
+// hasTag reports whether tag is present in tags.
+func hasTag(tags []string, tag string) bool {
+	for _, t := range tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// ldflagLibrary returns the -l<name> argument from the cgo LDFLAGS directive in the file
+// at path, for example "wasmvm155_muslc.aarch64".
+func ldflagLibrary(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "read %s", path)
+	m := reLDFlag.FindStringSubmatch(string(data))
+	require.NotEmptyf(t, m, "no `#cgo LDFLAGS: ... -l<name>` directive in %s", path)
+	return m[1]
+}

--- a/link_constraints_test.go
+++ b/link_constraints_test.go
@@ -4,68 +4,52 @@ import (
 	"go/build"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-// linkPkgDirs are the vendored libwasmvm api packages whose link_*.go files carry the
-// cgo directive naming a prebuilt archive.
-var linkPkgDirs = []string{
-	"sei-wasmd/x/wasm/artifacts/v152/api",
-	"sei-wasmd/x/wasm/artifacts/v155/api",
-	"sei-wasmvm/internal/api",
-}
-
-// linkPlatform is a build configuration and the link directive it must resolve to.
-type linkPlatform struct {
-	goos, goarch string
-	tags         []string
-	// wantCount is how many link_*.go files the toolchain selects. 1 is the only
-	// healthy value: 0 leaves the linker with no archive and undefined references,
-	// 2 puts two -l directives on one line and the archives collide.
-	wantCount int
-	// wantFile, when set, is the file that must be selected. It catches a swap that
-	// leaves wantCount at 1.
-	wantFile string
-	why      string
-}
-
-// linkPlatforms enumerates the build configurations this repo produces, plus the
-// linux/arm64 muslc cell the static arm64 binary depends on.
-var linkPlatforms = []linkPlatform{
-	{"linux", "amd64", []string{"muslc"}, 1, "link_muslc.go", "static musl release build, amd64"},
-	{"linux", "arm64", []string{"muslc"}, 1, "link_muslc_aarch64.go", "static musl release build, arm64"},
-	{"linux", "amd64", nil, 1, "link_glibclinux_x86_64.go", "ordinary dynamic build, amd64"},
-	{"linux", "arm64", nil, 1, "link_glibclinux_aarch64.go", "ordinary dynamic build, arm64 (the Docker image)"},
-	{"linux", "amd64", []string{"muslc", "sys_wasmvm"}, 1, "link_system.go", "system-libs escape hatch"},
-	{"linux", "arm64", []string{"muslc", "sys_wasmvm"}, 1, "link_system.go", "system-libs escape hatch, arm64"},
-	{"darwin", "arm64", nil, 1, "link_mac.go", "local development on Apple Silicon"},
-	{"darwin", "amd64", nil, 1, "link_mac.go", "local development on Intel Mac"},
-	{"windows", "amd64", nil, 1, "link_windows.go", "windows"},
-
-	// No archive of either flavour is vendored for the remaining linux architectures,
-	// so selecting nothing is correct and matches the glibc path. seid cannot build
-	// for them regardless: giga/executor/lib rejects them at compile time.
-	{"linux", "riscv64", []string{"muslc"}, 0, "", "unsupported arch, must select nothing"},
-}
-
 // TestLinkConstraintsSelectOneFile asserts that every build configuration selects exactly
-// one cgo link directive per api package, and that the archive it names matches the target
-// architecture.
+// one cgo link directive in each of linkDirs, and that the archive it names matches the
+// target architecture.
 func TestLinkConstraintsSelectOneFile(t *testing.T) {
-	for _, p := range linkPlatforms {
-		p := p
+	// wantCount is how many link_*.go files the toolchain selects: 0 leaves the linker
+	// with no archive and undefined references, 2 puts two -l directives on one line and
+	// the archives collide. wantFile pins which file, catching a swap that keeps the
+	// count at 1.
+	for _, p := range []struct {
+		goos, goarch string
+		tags         []string
+		wantCount    int
+		wantFile     string
+		why          string
+	}{
+		{"linux", "amd64", []string{"muslc"}, 1, "link_muslc.go", "static musl release build, amd64"},
+		{"linux", "arm64", []string{"muslc"}, 1, "link_muslc_aarch64.go", "static musl release build, arm64"},
+		{"linux", "amd64", nil, 1, "link_glibclinux_x86_64.go", "ordinary dynamic build, amd64"},
+		{"linux", "arm64", nil, 1, "link_glibclinux_aarch64.go", "ordinary dynamic build, arm64 (the Docker image)"},
+		{"linux", "amd64", []string{"muslc", "sys_wasmvm"}, 1, "link_system.go", "system-libs escape hatch"},
+		{"linux", "arm64", []string{"muslc", "sys_wasmvm"}, 1, "link_system.go", "system-libs escape hatch, arm64"},
+		{"darwin", "arm64", nil, 1, "link_mac.go", "local development on Apple Silicon"},
+		{"darwin", "amd64", nil, 1, "link_mac.go", "local development on Intel Mac"},
+		{"windows", "amd64", nil, 1, "link_windows.go", "windows"},
+
+		// No archive of either flavour is vendored for the remaining linux
+		// architectures, so selecting nothing is correct and matches the glibc path.
+		// seid cannot build for them regardless: giga/executor/lib rejects them at
+		// compile time.
+		{"linux", "riscv64", []string{"muslc"}, 0, "", "unsupported arch, must select nothing"},
+	} {
 		name := p.goos + "_" + p.goarch
 		for _, tag := range p.tags {
 			name += "_" + tag
 		}
 		t.Run(name, func(t *testing.T) {
-			for _, dir := range linkPkgDirs {
-				dir := dir
+			for _, dir := range linkDirs {
 				t.Run(dir, func(t *testing.T) {
-					selected := selectedLinkFiles(t, dir, p)
+					selected := selectedLinkFiles(t, dir, p.goos, p.goarch, p.tags)
 					require.Lenf(t, selected, p.wantCount,
 						"%s/%s tags=%v (%s): expected %d link file(s), got %d: %v\n"+
 							"  0 means nothing links (undefined references at link time)\n"+
@@ -79,9 +63,9 @@ func TestLinkConstraintsSelectOneFile(t *testing.T) {
 					}
 
 					// Naming an archive that exists is already covered by
-					// TestLinkDirectivesResolve, and that holds even if two directives are
-					// swapped. Pin the architecture of the archive as well.
-					if p.goos == "linux" && !hasTag(p.tags, "sys_wasmvm") && len(selected) == 1 {
+					// TestLinkDirectivesResolve, and that holds even if two directives
+					// are swapped. Pin the architecture of the archive as well.
+					if p.goos == "linux" && !slices.Contains(p.tags, "sys_wasmvm") && len(selected) == 1 {
 						lib := ldflagLibrary(t, filepath.Join(dir, selected[0]))
 						require.Equalf(t, p.goarch == "arm64", strings.Contains(lib, "aarch64"),
 							"%s/%s tags=%v: %s links -l%s; an aarch64 archive must be used "+
@@ -96,15 +80,13 @@ func TestLinkConstraintsSelectOneFile(t *testing.T) {
 
 // selectedLinkFiles returns the link_*.go files in dir that the Go toolchain compiles for
 // the given platform.
-func selectedLinkFiles(t *testing.T, dir string, p linkPlatform) []string {
+func selectedLinkFiles(t *testing.T, dir, goos, goarch string, tags []string) []string {
 	t.Helper()
 
 	ctx := build.Default
-	ctx.GOOS = p.goos
-	ctx.GOARCH = p.goarch
-	ctx.BuildTags = p.tags
-	// The link files are pure `import "C"`; with cgo off the toolchain excludes them all.
-	ctx.CgoEnabled = true
+	ctx.GOOS = goos
+	ctx.GOARCH = goarch
+	ctx.BuildTags = tags
 
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err, "read %s", dir)
@@ -127,20 +109,11 @@ func selectedLinkFiles(t *testing.T, dir string, p linkPlatform) []string {
 	return selected
 }
 
-// hasTag reports whether tag is present in tags.
-func hasTag(tags []string, tag string) bool {
-	for _, t := range tags {
-		if t == tag {
-			return true
-		}
-	}
-	return false
-}
-
 // ldflagLibrary returns the -l<name> argument from the cgo LDFLAGS directive in the file
 // at path, for example "wasmvm155_muslc.aarch64".
 func ldflagLibrary(t *testing.T, path string) string {
 	t.Helper()
+
 	data, err := os.ReadFile(path)
 	require.NoError(t, err, "read %s", path)
 	m := reLDFlag.FindStringSubmatch(string(data))

--- a/link_constraints_test.go
+++ b/link_constraints_test.go
@@ -4,88 +4,37 @@ import (
 	"go/build"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-// TestLinkConstraintsSelectOneFile asserts that every build configuration selects exactly
-// one cgo link directive in each of linkDirs, and that the archive it names matches the
-// target architecture.
-func TestLinkConstraintsSelectOneFile(t *testing.T) {
-	// wantCount is how many link_*.go files the toolchain selects: 0 leaves the linker
-	// with no archive and undefined references, 2 puts two -l directives on one line and
-	// the archives collide. wantFile pins which file, catching a swap that keeps the
-	// count at 1.
-	for _, p := range []struct {
-		goos, goarch string
-		tags         []string
-		wantCount    int
-		wantFile     string
-		why          string
-	}{
-		{"linux", "amd64", []string{"muslc"}, 1, "link_muslc.go", "static musl release build, amd64"},
-		{"linux", "arm64", []string{"muslc"}, 1, "link_muslc_aarch64.go", "static musl release build, arm64"},
-		{"linux", "amd64", nil, 1, "link_glibclinux_x86_64.go", "ordinary dynamic build, amd64"},
-		{"linux", "arm64", nil, 1, "link_glibclinux_aarch64.go", "ordinary dynamic build, arm64 (the Docker image)"},
-		{"linux", "amd64", []string{"muslc", "sys_wasmvm"}, 1, "link_system.go", "system-libs escape hatch"},
-		{"linux", "arm64", []string{"muslc", "sys_wasmvm"}, 1, "link_system.go", "system-libs escape hatch, arm64"},
-		{"darwin", "arm64", nil, 1, "link_mac.go", "local development on Apple Silicon"},
-		{"darwin", "amd64", nil, 1, "link_mac.go", "local development on Intel Mac"},
-		{"windows", "amd64", nil, 1, "link_windows.go", "windows"},
+// assertSelects asserts that dir selects exactly wantFile for the given build tags on the
+// platform this test binary was built for, and that the archive it names is aarch64 only
+// when wantAarch64 is set.
+func assertSelects(t *testing.T, dir string, tags []string, wantFile string, wantAarch64 bool) {
+	t.Helper()
 
-		// No archive of either flavour is vendored for the remaining linux
-		// architectures, so selecting nothing is correct and matches the glibc path.
-		// seid cannot build for them regardless: giga/executor/lib rejects them at
-		// compile time.
-		{"linux", "riscv64", []string{"muslc"}, 0, "", "unsupported arch, must select nothing"},
-	} {
-		name := p.goos + "_" + p.goarch
-		for _, tag := range p.tags {
-			name += "_" + tag
-		}
-		t.Run(name, func(t *testing.T) {
-			for _, dir := range linkDirs {
-				t.Run(dir, func(t *testing.T) {
-					selected := selectedLinkFiles(t, dir, p.goos, p.goarch, p.tags)
-					require.Lenf(t, selected, p.wantCount,
-						"%s/%s tags=%v (%s): expected %d link file(s), got %d: %v\n"+
-							"  0 means nothing links (undefined references at link time)\n"+
-							"  2 means two -l directives on one link line (incompatible archives)",
-						p.goos, p.goarch, p.tags, p.why, p.wantCount, len(selected), selected)
+	selected := selectedLinkFiles(t, dir, tags)
+	require.Lenf(t, selected, 1,
+		"%s tags=%v: expected exactly one link file, got %v\n"+
+			"  0 means nothing links (undefined references at link time)\n"+
+			"  2 means two -l directives on one link line (incompatible archives)",
+		dir, tags, selected)
+	require.Equalf(t, wantFile, selected[0], "%s tags=%v: wrong link directive", dir, tags)
 
-					if p.wantFile != "" {
-						require.Equalf(t, p.wantFile, selected[0],
-							"%s/%s tags=%v (%s): wrong link directive selected",
-							p.goos, p.goarch, p.tags, p.why)
-					}
-
-					// Naming an archive that exists is already covered by
-					// TestLinkDirectivesResolve, and that holds even if two directives
-					// are swapped. Pin the architecture of the archive as well.
-					if p.goos == "linux" && !slices.Contains(p.tags, "sys_wasmvm") && len(selected) == 1 {
-						lib := ldflagLibrary(t, filepath.Join(dir, selected[0]))
-						require.Equalf(t, p.goarch == "arm64", strings.Contains(lib, "aarch64"),
-							"%s/%s tags=%v: %s links -l%s; an aarch64 archive must be used "+
-								"exactly when building for arm64",
-							p.goos, p.goarch, p.tags, selected[0], lib)
-					}
-				})
-			}
-		})
-	}
+	lib := ldflagLibrary(t, filepath.Join(dir, selected[0]))
+	require.Equalf(t, wantAarch64, strings.Contains(lib, "aarch64"),
+		"%s links -l%s", selected[0], lib)
 }
 
 // selectedLinkFiles returns the link_*.go files in dir that the Go toolchain compiles for
-// the given platform.
-func selectedLinkFiles(t *testing.T, dir, goos, goarch string, tags []string) []string {
+// the platform this test binary was built for.
+func selectedLinkFiles(t *testing.T, dir string, tags []string) []string {
 	t.Helper()
 
 	ctx := build.Default
-	ctx.GOOS = goos
-	ctx.GOARCH = goarch
 	ctx.BuildTags = tags
 
 	entries, err := os.ReadDir(dir)

--- a/link_constraints_windows_test.go
+++ b/link_constraints_windows_test.go
@@ -1,0 +1,11 @@
+package sei_test
+
+import "testing"
+
+func TestLinkConstraints(t *testing.T) {
+	for _, dir := range linkDirs {
+		t.Run(dir, func(t *testing.T) {
+			assertSelects(t, dir, nil, "link_windows.go", false)
+		})
+	}
+}

--- a/sei-wasmd/x/wasm/artifacts/v152/api/link_muslc.go
+++ b/sei-wasmd/x/wasm/artifacts/v152/api/link_muslc.go
@@ -1,4 +1,4 @@
-//go:build linux && muslc && !sys_wasmvm
+//go:build linux && muslc && amd64 && !sys_wasmvm
 
 package api
 

--- a/sei-wasmd/x/wasm/artifacts/v152/api/link_muslc_aarch64.go
+++ b/sei-wasmd/x/wasm/artifacts/v152/api/link_muslc_aarch64.go
@@ -1,0 +1,6 @@
+//go:build linux && muslc && arm64 && !sys_wasmvm
+
+package api
+
+// #cgo LDFLAGS: -Wl,-rpath,${SRCDIR} -L${SRCDIR} -lwasmvm152_muslc.aarch64
+import "C"

--- a/sei-wasmd/x/wasm/artifacts/v155/api/link_muslc.go
+++ b/sei-wasmd/x/wasm/artifacts/v155/api/link_muslc.go
@@ -1,4 +1,4 @@
-//go:build linux && muslc && !sys_wasmvm
+//go:build linux && muslc && amd64 && !sys_wasmvm
 
 package api
 

--- a/sei-wasmd/x/wasm/artifacts/v155/api/link_muslc_aarch64.go
+++ b/sei-wasmd/x/wasm/artifacts/v155/api/link_muslc_aarch64.go
@@ -1,0 +1,6 @@
+//go:build linux && muslc && arm64 && !sys_wasmvm
+
+package api
+
+// #cgo LDFLAGS: -Wl,-rpath,${SRCDIR} -L${SRCDIR} -lwasmvm155_muslc.aarch64
+import "C"

--- a/sei-wasmvm/internal/api/link_muslc.go
+++ b/sei-wasmvm/internal/api/link_muslc.go
@@ -1,4 +1,4 @@
-//go:build linux && muslc && !sys_wasmvm
+//go:build linux && muslc && amd64 && !sys_wasmvm
 
 package api
 

--- a/sei-wasmvm/internal/api/link_muslc_aarch64.go
+++ b/sei-wasmvm/internal/api/link_muslc_aarch64.go
@@ -1,0 +1,6 @@
+//go:build linux && muslc && arm64 && !sys_wasmvm
+
+package api
+
+// #cgo LDFLAGS: -Wl,-rpath,${SRCDIR} -L${SRCDIR} -lwasmvm_muslc.aarch64
+import "C"

--- a/sei-wasmvm/internal/api/static_archive_checksums_test.go
+++ b/sei-wasmvm/internal/api/static_archive_checksums_test.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStaticArchiveChecksums asserts that the static libwasmvm archives checked into
+// this package match their expected SHA256 sums.
+//
+// These are the archives the cgo linker resolves the link_*.go directives against.
+// Pinning the hashes rejects a replacement archive built for the wrong architecture,
+// which otherwise surfaces only as a link failure on whichever platform stops
+// matching. Update the values here after a deliberate rebuild, once the provenance
+// of the new archives is confirmed.
+func TestStaticArchiveChecksums(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want string
+	}{
+		{
+			name: "libwasmvm_muslc.a",
+			want: "2c2d90423e5bebba911b0be7963b09062adb555ecd6149f7cc759a494bb2eda6",
+		},
+		{
+			name: "libwasmvm_muslc.aarch64.a",
+			want: "409cd9da695d4f1989271230094563c38aa2d867b26908b2ca2082a0d71e3b8e",
+		},
+		{
+			name: "libwasmvmstatic_darwin.a",
+			want: "713d221d712bee043794fc600e093b62e9e878b312f044f548a8852b670451c8",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, archiveSHA256(t, tc.name))
+		})
+	}
+}
+
+// archiveSHA256 returns the hex-encoded SHA256 of the file at path.
+func archiveSHA256(t *testing.T, path string) string {
+	t.Helper()
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, f.Close()) }()
+
+	h := sha256.New()
+	_, err = io.Copy(h, f)
+	require.NoError(t, err)
+	return hex.EncodeToString(h.Sum(nil))
+}


### PR DESCRIPTION
Prerequisite for shipping a static `linux/arm64` seid binary. It changes three words, adds three five-line files, and adds a test.

## The bug

The glibc link path is arch-split (`link_glibclinux_aarch64.go` and `link_glibclinux_x86_64.go`), but the musl path never was. `link_muslc.go` carried `linux && muslc && !sys_wasmvm` with no arch term, so a `linux/arm64` muslc build selected it, emitted `-lwasmvm_muslc`, resolved the **x86_64** archive, and died at link time with incompatible-archive errors.

The `libwasmvm*_muslc.aarch64.a` archives have been checked in for months, referenced by nothing.

## The change

Constrain the three existing files to `amd64`, and add three aarch64 siblings pointing at the archives already in the tree. The new files are byte-identical to CosmWasm/wasmvm v2.1.0's equivalents, since the vendored tree here predates that upstream fix.

## Validation

Each of the six changes was tested in isolation rather than as one bundle:

| Mutation | `linux/arm64 muslc` selection | Effect |
|---|---|---|
| (correct) | 1 | links |
| remove any one new file | **0** | undefined references |
| drop `amd64` from any one file | **2** | both archives on one link line |

Real links in the pinned release image (Alpine 3.23.3, gcc 15.2.0, native arm64) confirm the model predicts linker behaviour rather than just build-tag arithmetic. The baseline fails with 3x `incompatible`, the "new files but no constraints" variant fails with 6x (double, one per extra archive), "constraints but no new files" fails with `undefined reference to version_str`, and the full change produces `ELF 64-bit LSB executable, ARM aarch64, statically linked`.

**amd64 is provably untouched.** For `GOARCH=amd64` the selected files and the resulting cgo `LDFLAGS` are byte-identical before and after, across all three packages. An actual amd64 static build via unmodified `scripts/build-static.sh` succeeds with the change applied.

**No consensus impact observed.** A mixed fleet of three binaries built from this branch (arm64 static musl, amd64 static musl, arm64 dynamic glibc) on one chain agreed on every app hash compared, including the blocks carrying a wasm store/instantiate/execute cycle. Separately, the seven consensus-relevant packages that swap amd64 assembly for portable Go on arm64 all pass their upstream vector suites on both architectures.

## Reviewer notes

- **This lands inert.** Nothing in CI, goreleaser or the Dockerfile builds `linux/arm64` with the muslc tag yet. It unblocks that work, it does not ship an arm64 binary.
- **Behaviour change for exotic architectures.** 386, riscv64, s390x and ppc64le previously matched the amd64 muslc directive and failed with an incompatible-archive error. They now match no link file and fail with undefined references instead. That matches what the glibc path has always done, and seid cannot build on those architectures anyway, since `giga/executor/lib` rejects them at compile time with a clearer message.
- **The third commit touches a workflow file**, so the backport bot cannot carry it and it needs a manual cherry-pick for release branches. Happy to split it out if you'd prefer, the first two commits stand alone.

## Why the test

`link_directives_test.go` checks each `-l<name>` resolves to a file on disk but never parses `//go:build`, so it passed even while this bug was present. Nothing else covers it either, because no job anywhere builds arm64 muslc. Without the new test, reverting this change is a green build.

It asserts each platform selects exactly one link directive, which file it is, and that an aarch64 archive is used exactly when `GOARCH=arm64`. Selection is evaluated with `go/build`'s own `MatchFile`, so the answer is the toolchain's rather than a reimplementation.

Confirmed to fail rather than merely to pass. All seven ways of breaking this change turn it red, including swapping the `-l` names between two files, which is a case the existing tests still pass.
