### PR TITLE
Remove legacy commit hash validation fallback

### DIFF
--- a/sei-tendermint/types/block.go
+++ b/sei-tendermint/types/block.go
@@ -89,12 +89,9 @@ func (b *Block) ValidateBasic(policy ConsensusPolicy) error {
 	}
 
 	if w, g := b.LastCommit.Hash(), b.LastCommitHash; !bytes.Equal(w, g) {
-		// Fall back to legacy hash calculation pre-6.4.
-		if wLegacy := b.LastCommit.legacyHash(); !bytes.Equal(wLegacy, g) {
-			if err := policy.HandleError(fmt.Errorf(
-				"wrong Header.LastCommitHash: expected %X, got %X: %w", w, g, ErrLastCommitHash)); err != nil {
-				return err
-			}
+		if err := policy.HandleError(fmt.Errorf(
+			"wrong Header.LastCommitHash: expected %X, got %X: %w", w, g, ErrLastCommitHash)); err != nil {
+			return err
 		}
 	}
 
@@ -1069,25 +1066,6 @@ func (ec *Commit) GetByIndex(valIdx int32) (*Vote, bool) {
 // Implements VoteSetReader.
 func (ec *Commit) IsCommit() bool {
 	return len(ec.Signatures) != 0
-}
-
-// legacyHash computes the commit hash using the pre-v6.4 algorithm, which
-// only includes signatures (not Height, Round, or BlockID). This is needed
-// to validate blocks that were created before the CommitHash change.
-func (commit *Commit) legacyHash() tmbytes.HexBytes {
-	if commit == nil {
-		return nil
-	}
-	bs := make([][]byte, len(commit.Signatures))
-	for i, commitSig := range commit.Signatures {
-		pbcs := commitSig.ToProto()
-		bz, err := pbcs.Marshal()
-		if err != nil {
-			panic(err)
-		}
-		bs[i] = bz
-	}
-	return merkle.HashFromByteSlices(bs)
 }
 
 //-------------------------------------


### PR DESCRIPTION
Remove the pre-v6.4 commit hash calculation and fallback validation path.

Release 6.5 no longer needs to replay blocks across the v6.3-to-v6.4commit hash transition, so LastCommitHash is now validated exclusively with the current algorithm.

Fixes CON-218
