### PR TITLE
Deprecate IBC and transfer query handlers

### DIFF
--- a/sei-ibc-go/modules/apps/transfer/keeper/grpc_query.go
+++ b/sei-ibc-go/modules/apps/transfer/keeper/grpc_query.go
@@ -2,122 +2,33 @@ package keeper
 
 import (
 	"context"
-	"fmt"
-	"strings"
-
-	"github.com/sei-protocol/sei-chain/sei-cosmos/store/prefix"
-	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
-	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
-	"github.com/sei-protocol/sei-chain/sei-cosmos/types/query"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/sei-protocol/sei-chain/sei-ibc-go/modules/apps/transfer/types"
 )
 
 var _ types.QueryServer = Keeper{}
 
-// DenomTrace implements the Query/DenomTrace gRPC method
-func (q Keeper) DenomTrace(c context.Context, req *types.QueryDenomTraceRequest) (*types.QueryDenomTraceResponse, error) {
-	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
-	}
-
-	hash, err := types.ParseHexHash(strings.TrimPrefix(req.Hash, "ibc/"))
-	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("invalid denom trace hash: %s, error: %s", hash.String(), err))
-	}
-
-	ctx := sdk.UnwrapSDKContext(c)
-	denomTrace, found := q.GetDenomTrace(ctx, hash)
-	if !found {
-		return nil, status.Error(
-			codes.NotFound,
-			sdkerrors.Wrap(types.ErrTraceNotFound, req.Hash).Error(),
-		)
-	}
-
-	return &types.QueryDenomTraceResponse{
-		DenomTrace: &denomTrace,
-	}, nil
+// DenomTrace implements the Query/DenomTrace gRPC method.
+func (Keeper) DenomTrace(context.Context, *types.QueryDenomTraceRequest) (*types.QueryDenomTraceResponse, error) {
+	return nil, types.ErrTransferDeprecated
 }
 
-// DenomTraces implements the Query/DenomTraces gRPC method
-func (q Keeper) DenomTraces(c context.Context, req *types.QueryDenomTracesRequest) (*types.QueryDenomTracesResponse, error) {
-	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
-	}
-
-	ctx := sdk.UnwrapSDKContext(c)
-
-	traces := types.Traces{}
-	store := prefix.NewStore(ctx.KVStore(q.storeKey), types.DenomTraceKey)
-
-	pageRes, err := query.Paginate(store, req.Pagination, func(_, value []byte) error {
-		result, err := q.UnmarshalDenomTrace(value)
-		if err != nil {
-			return err
-		}
-
-		traces = append(traces, result)
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return &types.QueryDenomTracesResponse{
-		DenomTraces: traces.Sort(),
-		Pagination:  pageRes,
-	}, nil
+// DenomTraces implements the Query/DenomTraces gRPC method.
+func (Keeper) DenomTraces(context.Context, *types.QueryDenomTracesRequest) (*types.QueryDenomTracesResponse, error) {
+	return nil, types.ErrTransferDeprecated
 }
 
-// Params implements the Query/Params gRPC method
-func (q Keeper) Params(c context.Context, _ *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
-	ctx := sdk.UnwrapSDKContext(c)
-	params := q.GetParams(ctx)
-
-	return &types.QueryParamsResponse{
-		Params: &params,
-	}, nil
+// Params implements the Query/Params gRPC method.
+func (Keeper) Params(context.Context, *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
+	return nil, types.ErrTransferDeprecated
 }
 
-// DenomHash implements the Query/DenomHash gRPC method
-func (q Keeper) DenomHash(c context.Context, req *types.QueryDenomHashRequest) (*types.QueryDenomHashResponse, error) {
-	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
-	}
-
-	// Convert given request trace path to DenomTrace struct to confirm the path in a valid denom trace format
-	denomTrace := types.ParseDenomTrace(req.Trace)
-	if err := denomTrace.Validate(); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
-	}
-
-	ctx := sdk.UnwrapSDKContext(c)
-	denomHash := denomTrace.Hash()
-	found := q.HasDenomTrace(ctx, denomHash)
-	if !found {
-		return nil, status.Error(
-			codes.NotFound,
-			sdkerrors.Wrap(types.ErrTraceNotFound, req.Trace).Error(),
-		)
-	}
-
-	return &types.QueryDenomHashResponse{
-		Hash: denomHash.String(),
-	}, nil
+// DenomHash implements the Query/DenomHash gRPC method.
+func (Keeper) DenomHash(context.Context, *types.QueryDenomHashRequest) (*types.QueryDenomHashResponse, error) {
+	return nil, types.ErrTransferDeprecated
 }
 
-// EscrowAddress implements the EscrowAddress gRPC method
-func (q Keeper) EscrowAddress(c context.Context, req *types.QueryEscrowAddressRequest) (*types.QueryEscrowAddressResponse, error) {
-	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
-	}
-
-	addr := types.GetEscrowAddress(req.PortId, req.ChannelId)
-
-	return &types.QueryEscrowAddressResponse{
-		EscrowAddress: addr.String(),
-	}, nil
+// EscrowAddress implements the EscrowAddress gRPC method.
+func (Keeper) EscrowAddress(context.Context, *types.QueryEscrowAddressRequest) (*types.QueryEscrowAddressResponse, error) {
+	return nil, types.ErrTransferDeprecated
 }

--- a/sei-ibc-go/modules/apps/transfer/keeper/grpc_query_test.go
+++ b/sei-ibc-go/modules/apps/transfer/keeper/grpc_query_test.go
@@ -1,0 +1,30 @@
+package keeper
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sei-protocol/sei-chain/sei-ibc-go/modules/apps/transfer/types"
+)
+
+func TestDeprecatedQueries(t *testing.T) {
+	var queryServer types.QueryServer = Keeper{}
+	server := reflect.ValueOf(queryServer)
+	queryServerType := reflect.TypeOf((*types.QueryServer)(nil)).Elem()
+
+	for i := 0; i < queryServerType.NumMethod(); i++ {
+		method := queryServerType.Method(i)
+		t.Run(method.Name, func(t *testing.T) {
+			results := server.MethodByName(method.Name).Call([]reflect.Value{
+				reflect.ValueOf(context.Background()),
+				reflect.Zero(method.Type.In(1)),
+			})
+
+			require.Nil(t, results[0].Interface())
+			require.ErrorIs(t, results[1].Interface().(error), types.ErrTransferDeprecated)
+		})
+	}
+}

--- a/sei-ibc-go/modules/apps/transfer/types/errors.go
+++ b/sei-ibc-go/modules/apps/transfer/types/errors.go
@@ -15,4 +15,6 @@ var (
 	ErrReceiveDisabled         = sdkerrors.Register(ModuleName, 8, "fungible token transfers to this chain are disabled")
 	ErrMaxTransferChannels     = sdkerrors.Register(ModuleName, 9, "max transfer channels")
 	ErrInvalidMemo             = sdkerrors.Register(ModuleName, 10, "invalid memo")
+	// ErrTransferDeprecated is returned by every transfer query handler.
+	ErrTransferDeprecated = sdkerrors.Register(ModuleName, 11, "transfer module is deprecated")
 )

--- a/sei-ibc-go/modules/core/keeper/grpc_query.go
+++ b/sei-ibc-go/modules/core/keeper/grpc_query.go
@@ -6,134 +6,140 @@ import (
 	clienttypes "github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core/02-client/types"
 	connectiontypes "github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core/03-connection/types"
 	channeltypes "github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core/04-channel/types"
+	"github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core/types"
 )
 
-// ClientState implements the IBC QueryServer interface
-func (q Keeper) ClientState(c context.Context, req *clienttypes.QueryClientStateRequest) (*clienttypes.QueryClientStateResponse, error) {
-	return q.ClientKeeper.ClientState(c, req)
+// ClientState implements the IBC QueryServer interface.
+func (Keeper) ClientState(context.Context, *clienttypes.QueryClientStateRequest) (*clienttypes.QueryClientStateResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// ClientStates implements the IBC QueryServer interface
-func (q Keeper) ClientStates(c context.Context, req *clienttypes.QueryClientStatesRequest) (*clienttypes.QueryClientStatesResponse, error) {
-	return q.ClientKeeper.ClientStates(c, req)
+// ClientStates implements the IBC QueryServer interface.
+func (Keeper) ClientStates(context.Context, *clienttypes.QueryClientStatesRequest) (*clienttypes.QueryClientStatesResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// ConsensusState implements the IBC QueryServer interface
-func (q Keeper) ConsensusState(c context.Context, req *clienttypes.QueryConsensusStateRequest) (*clienttypes.QueryConsensusStateResponse, error) {
-	return q.ClientKeeper.ConsensusState(c, req)
+// ConsensusState implements the IBC QueryServer interface.
+func (Keeper) ConsensusState(context.Context, *clienttypes.QueryConsensusStateRequest) (*clienttypes.QueryConsensusStateResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// ConsensusStates implements the IBC QueryServer interface
-func (q Keeper) ConsensusStates(c context.Context, req *clienttypes.QueryConsensusStatesRequest) (*clienttypes.QueryConsensusStatesResponse, error) {
-	return q.ClientKeeper.ConsensusStates(c, req)
+// ConsensusStates implements the IBC QueryServer interface.
+func (Keeper) ConsensusStates(context.Context, *clienttypes.QueryConsensusStatesRequest) (*clienttypes.QueryConsensusStatesResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// ConsensusStateHeights implements the IBC QueryServer interface
-func (q Keeper) ConsensusStateHeights(c context.Context, req *clienttypes.QueryConsensusStateHeightsRequest) (*clienttypes.QueryConsensusStateHeightsResponse, error) {
-	return q.ClientKeeper.ConsensusStateHeights(c, req)
+// ConsensusStateHeights implements the IBC QueryServer interface.
+func (Keeper) ConsensusStateHeights(context.Context, *clienttypes.QueryConsensusStateHeightsRequest) (*clienttypes.QueryConsensusStateHeightsResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// ClientStatus implements the IBC QueryServer interface
-func (q Keeper) ClientStatus(c context.Context, req *clienttypes.QueryClientStatusRequest) (*clienttypes.QueryClientStatusResponse, error) {
-	return q.ClientKeeper.ClientStatus(c, req)
+// ClientStatus implements the IBC QueryServer interface.
+func (Keeper) ClientStatus(context.Context, *clienttypes.QueryClientStatusRequest) (*clienttypes.QueryClientStatusResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// ClientParams implements the IBC QueryServer interface
-func (q Keeper) ClientParams(c context.Context, req *clienttypes.QueryClientParamsRequest) (*clienttypes.QueryClientParamsResponse, error) {
-	return q.ClientKeeper.ClientParams(c, req)
+// ClientParams implements the IBC QueryServer interface.
+func (Keeper) ClientParams(context.Context, *clienttypes.QueryClientParamsRequest) (*clienttypes.QueryClientParamsResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// UpgradedClientState implements the IBC QueryServer interface
-func (q Keeper) UpgradedClientState(c context.Context, req *clienttypes.QueryUpgradedClientStateRequest) (*clienttypes.QueryUpgradedClientStateResponse, error) {
-	return q.ClientKeeper.UpgradedClientState(c, req)
+// UpgradedClientState implements the IBC QueryServer interface.
+func (Keeper) UpgradedClientState(context.Context, *clienttypes.QueryUpgradedClientStateRequest) (*clienttypes.QueryUpgradedClientStateResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// Connection implements the IBC QueryServer interface
-func (q Keeper) Connection(c context.Context, req *connectiontypes.QueryConnectionRequest) (*connectiontypes.QueryConnectionResponse, error) {
-	return q.ConnectionKeeper.Connection(c, req)
+// UpgradedConsensusState implements the IBC QueryServer interface.
+func (Keeper) UpgradedConsensusState(context.Context, *clienttypes.QueryUpgradedConsensusStateRequest) (*clienttypes.QueryUpgradedConsensusStateResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// Connections implements the IBC QueryServer interface
-func (q Keeper) Connections(c context.Context, req *connectiontypes.QueryConnectionsRequest) (*connectiontypes.QueryConnectionsResponse, error) {
-	return q.ConnectionKeeper.Connections(c, req)
+// Connection implements the IBC QueryServer interface.
+func (Keeper) Connection(context.Context, *connectiontypes.QueryConnectionRequest) (*connectiontypes.QueryConnectionResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// ClientConnections implements the IBC QueryServer interface
-func (q Keeper) ClientConnections(c context.Context, req *connectiontypes.QueryClientConnectionsRequest) (*connectiontypes.QueryClientConnectionsResponse, error) {
-	return q.ConnectionKeeper.ClientConnections(c, req)
+// Connections implements the IBC QueryServer interface.
+func (Keeper) Connections(context.Context, *connectiontypes.QueryConnectionsRequest) (*connectiontypes.QueryConnectionsResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// ConnectionClientState implements the IBC QueryServer interface
-func (q Keeper) ConnectionClientState(c context.Context, req *connectiontypes.QueryConnectionClientStateRequest) (*connectiontypes.QueryConnectionClientStateResponse, error) {
-	return q.ConnectionKeeper.ConnectionClientState(c, req)
+// ClientConnections implements the IBC QueryServer interface.
+func (Keeper) ClientConnections(context.Context, *connectiontypes.QueryClientConnectionsRequest) (*connectiontypes.QueryClientConnectionsResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// ConnectionConsensusState implements the IBC QueryServer interface
-func (q Keeper) ConnectionConsensusState(c context.Context, req *connectiontypes.QueryConnectionConsensusStateRequest) (*connectiontypes.QueryConnectionConsensusStateResponse, error) {
-	return q.ConnectionKeeper.ConnectionConsensusState(c, req)
+// ConnectionClientState implements the IBC QueryServer interface.
+func (Keeper) ConnectionClientState(context.Context, *connectiontypes.QueryConnectionClientStateRequest) (*connectiontypes.QueryConnectionClientStateResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// Channel implements the IBC QueryServer interface
-func (q Keeper) Channel(c context.Context, req *channeltypes.QueryChannelRequest) (*channeltypes.QueryChannelResponse, error) {
-	return q.ChannelKeeper.Channel(c, req)
+// ConnectionConsensusState implements the IBC QueryServer interface.
+func (Keeper) ConnectionConsensusState(context.Context, *connectiontypes.QueryConnectionConsensusStateRequest) (*connectiontypes.QueryConnectionConsensusStateResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// Channels implements the IBC QueryServer interface
-func (q Keeper) Channels(c context.Context, req *channeltypes.QueryChannelsRequest) (*channeltypes.QueryChannelsResponse, error) {
-	return q.ChannelKeeper.Channels(c, req)
+// Channel implements the IBC QueryServer interface.
+func (Keeper) Channel(context.Context, *channeltypes.QueryChannelRequest) (*channeltypes.QueryChannelResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// ConnectionChannels implements the IBC QueryServer interface
-func (q Keeper) ConnectionChannels(c context.Context, req *channeltypes.QueryConnectionChannelsRequest) (*channeltypes.QueryConnectionChannelsResponse, error) {
-	return q.ChannelKeeper.ConnectionChannels(c, req)
+// Channels implements the IBC QueryServer interface.
+func (Keeper) Channels(context.Context, *channeltypes.QueryChannelsRequest) (*channeltypes.QueryChannelsResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// ChannelClientState implements the IBC QueryServer interface
-func (q Keeper) ChannelClientState(c context.Context, req *channeltypes.QueryChannelClientStateRequest) (*channeltypes.QueryChannelClientStateResponse, error) {
-	return q.ChannelKeeper.ChannelClientState(c, req)
+// ConnectionChannels implements the IBC QueryServer interface.
+func (Keeper) ConnectionChannels(context.Context, *channeltypes.QueryConnectionChannelsRequest) (*channeltypes.QueryConnectionChannelsResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// ChannelConsensusState implements the IBC QueryServer interface
-func (q Keeper) ChannelConsensusState(c context.Context, req *channeltypes.QueryChannelConsensusStateRequest) (*channeltypes.QueryChannelConsensusStateResponse, error) {
-	return q.ChannelKeeper.ChannelConsensusState(c, req)
+// ChannelClientState implements the IBC QueryServer interface.
+func (Keeper) ChannelClientState(context.Context, *channeltypes.QueryChannelClientStateRequest) (*channeltypes.QueryChannelClientStateResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// PacketCommitment implements the IBC QueryServer interface
-func (q Keeper) PacketCommitment(c context.Context, req *channeltypes.QueryPacketCommitmentRequest) (*channeltypes.QueryPacketCommitmentResponse, error) {
-	return q.ChannelKeeper.PacketCommitment(c, req)
+// ChannelConsensusState implements the IBC QueryServer interface.
+func (Keeper) ChannelConsensusState(context.Context, *channeltypes.QueryChannelConsensusStateRequest) (*channeltypes.QueryChannelConsensusStateResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// PacketCommitments implements the IBC QueryServer interface
-func (q Keeper) PacketCommitments(c context.Context, req *channeltypes.QueryPacketCommitmentsRequest) (*channeltypes.QueryPacketCommitmentsResponse, error) {
-	return q.ChannelKeeper.PacketCommitments(c, req)
+// PacketCommitment implements the IBC QueryServer interface.
+func (Keeper) PacketCommitment(context.Context, *channeltypes.QueryPacketCommitmentRequest) (*channeltypes.QueryPacketCommitmentResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// PacketReceipt implements the IBC QueryServer interface
-func (q Keeper) PacketReceipt(c context.Context, req *channeltypes.QueryPacketReceiptRequest) (*channeltypes.QueryPacketReceiptResponse, error) {
-	return q.ChannelKeeper.PacketReceipt(c, req)
+// PacketCommitments implements the IBC QueryServer interface.
+func (Keeper) PacketCommitments(context.Context, *channeltypes.QueryPacketCommitmentsRequest) (*channeltypes.QueryPacketCommitmentsResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// PacketAcknowledgement implements the IBC QueryServer interface
-func (q Keeper) PacketAcknowledgement(c context.Context, req *channeltypes.QueryPacketAcknowledgementRequest) (*channeltypes.QueryPacketAcknowledgementResponse, error) {
-	return q.ChannelKeeper.PacketAcknowledgement(c, req)
+// PacketReceipt implements the IBC QueryServer interface.
+func (Keeper) PacketReceipt(context.Context, *channeltypes.QueryPacketReceiptRequest) (*channeltypes.QueryPacketReceiptResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// PacketAcknowledgements implements the IBC QueryServer interface
-func (q Keeper) PacketAcknowledgements(c context.Context, req *channeltypes.QueryPacketAcknowledgementsRequest) (*channeltypes.QueryPacketAcknowledgementsResponse, error) {
-	return q.ChannelKeeper.PacketAcknowledgements(c, req)
+// PacketAcknowledgement implements the IBC QueryServer interface.
+func (Keeper) PacketAcknowledgement(context.Context, *channeltypes.QueryPacketAcknowledgementRequest) (*channeltypes.QueryPacketAcknowledgementResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// UnreceivedPackets implements the IBC QueryServer interface
-func (q Keeper) UnreceivedPackets(c context.Context, req *channeltypes.QueryUnreceivedPacketsRequest) (*channeltypes.QueryUnreceivedPacketsResponse, error) {
-	return q.ChannelKeeper.UnreceivedPackets(c, req)
+// PacketAcknowledgements implements the IBC QueryServer interface.
+func (Keeper) PacketAcknowledgements(context.Context, *channeltypes.QueryPacketAcknowledgementsRequest) (*channeltypes.QueryPacketAcknowledgementsResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// UnreceivedAcks implements the IBC QueryServer interface
-func (q Keeper) UnreceivedAcks(c context.Context, req *channeltypes.QueryUnreceivedAcksRequest) (*channeltypes.QueryUnreceivedAcksResponse, error) {
-	return q.ChannelKeeper.UnreceivedAcks(c, req)
+// UnreceivedPackets implements the IBC QueryServer interface.
+func (Keeper) UnreceivedPackets(context.Context, *channeltypes.QueryUnreceivedPacketsRequest) (*channeltypes.QueryUnreceivedPacketsResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }
 
-// NextSequenceReceive implements the IBC QueryServer interface
-func (q Keeper) NextSequenceReceive(c context.Context, req *channeltypes.QueryNextSequenceReceiveRequest) (*channeltypes.QueryNextSequenceReceiveResponse, error) {
-	return q.ChannelKeeper.NextSequenceReceive(c, req)
+// UnreceivedAcks implements the IBC QueryServer interface.
+func (Keeper) UnreceivedAcks(context.Context, *channeltypes.QueryUnreceivedAcksRequest) (*channeltypes.QueryUnreceivedAcksResponse, error) {
+	return nil, types.ErrIBCDeprecated
+}
+
+// NextSequenceReceive implements the IBC QueryServer interface.
+func (Keeper) NextSequenceReceive(context.Context, *channeltypes.QueryNextSequenceReceiveRequest) (*channeltypes.QueryNextSequenceReceiveResponse, error) {
+	return nil, types.ErrIBCDeprecated
 }

--- a/sei-ibc-go/modules/core/keeper/grpc_query_test.go
+++ b/sei-ibc-go/modules/core/keeper/grpc_query_test.go
@@ -1,0 +1,30 @@
+package keeper
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core/types"
+)
+
+func TestDeprecatedQueries(t *testing.T) {
+	var queryServer types.QueryServer = Keeper{}
+	server := reflect.ValueOf(queryServer)
+	queryServerType := reflect.TypeOf((*types.QueryServer)(nil)).Elem()
+
+	for i := 0; i < queryServerType.NumMethod(); i++ {
+		method := queryServerType.Method(i)
+		t.Run(method.Name, func(t *testing.T) {
+			results := server.MethodByName(method.Name).Call([]reflect.Value{
+				reflect.ValueOf(context.Background()),
+				reflect.Zero(method.Type.In(1)),
+			})
+
+			require.Nil(t, results[0].Interface())
+			require.ErrorIs(t, results[1].Interface().(error), types.ErrIBCDeprecated)
+		})
+	}
+}

--- a/sei-ibc-go/modules/core/types/errors.go
+++ b/sei-ibc-go/modules/core/types/errors.go
@@ -8,4 +8,6 @@ var (
 	// ErrInboundDisabled / ErrOutboundDisabled
 	ErrInboundDisabled  = sdkerrors.Register("ibc", 101, "ibc inbound disabled")
 	ErrOutboundDisabled = sdkerrors.Register("ibc", 102, "ibc outbound disabled")
+	// ErrIBCDeprecated is returned by every IBC query handler.
+	ErrIBCDeprecated = sdkerrors.Register("ibc", 103, "ibc module is deprecated")
 )


### PR DESCRIPTION
Now that IBC in/outbound is disabled as part of SIP-3:
- return explicit deprecation errors from every IBC core and transfer gRPC query handler
- add coverage ensuring all registered query methods reject requests
- preserve capability unchanged because it exposes no query service
