### PR TITLE
metrics: refine block gas histogram buckets (PLT-1002)

### DIFF
--- a/app/metrics.go
+++ b/app/metrics.go
@@ -25,18 +25,17 @@ var (
 		0.000025, 0.000050, 0.0001, 0.0005, 0.001, 0.0025, 0.005, 0.010, 0.020, 0.050, 0.075, 0.1, 0.25, 0.5, 1, 10,
 	)
 
-	// blockGasWantedBuckets covers the 0–50 M gas range (current MaxGasWanted cap) with
-	// 1 M steps up to 10 M and 5 M steps thereafter so both lightly- and heavily-loaded
-	// blocks get useful quantiles.
+	// blockGasWantedBuckets covers the 0–50 M gas range (current MaxGasWanted cap)
 	blockGasWantedBuckets = metric.WithExplicitBucketBoundaries(
-		1e6, 2e6, 3e6, 4e6, 5e6, 6e6, 7e6, 8e6, 9e6, 10e6,
-		15e6, 20e6, 25e6, 30e6, 35e6, 40e6, 45e6, 50e6,
+		10e3, 25e3, 50e3, 100e3, 250e3, 500e3,
+		1e6, 2.5e6, 5e6, 10e6, 12.5e6, 25e6, 50e6,
 	)
 
 	// blockGasWantedRatioBuckets covers the 0.0–1.0 utilisation range so we can see
 	// how close blocks are to the MaxGasWanted cap.
 	blockGasWantedRatioBuckets = metric.WithExplicitBucketBoundaries(
-		0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 1.0,
+		0.0002, 0.0005, 0.001, 0.002, 0.005, 0.01, 0.02,
+		0.05, 0.1, 0.2, 0.25, 0.5, 0.9, 0.95, 1.0,
 	)
 
 	appMetrics = struct {


### PR DESCRIPTION
## Summary

Retune the OpenTelemetry histogram bucket boundaries for per-block gas utilisation metrics so lightly loaded blocks are visible in quantiles.

- **`blockGasWanted`** — add sub-1M resolution (10k–500k) and widen upper-range steps (1M → 50M) instead of uniform 1M/5M steps.
- **`blockGasWantedRatio`** — add fine-grained buckets below 10% utilisation (down to 0.02%) so low-fill blocks are distinguishable; keep coarse steps near the cap (0.9, 0.95, 1.0).

## Why

The previous boundaries put everything below 1M gas wanted into a single bucket and started the utilisation ratio at 0.1, which collapsed most production blocks into undifferentiated tails and made p50/p95 unusable for capacity planning.

