### PR TITLE
fix(gov): harden deposit refund handling

### DIFF
--- a/sei-cosmos/x/bank/keeper/keeper.go
+++ b/sei-cosmos/x/bank/keeper/keeper.go
@@ -270,6 +270,9 @@ func (k BaseKeeper) UndelegateCoins(ctx sdk.Context, moduleAccAddr, delegatorAdd
 	if !amt.IsValid() {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, amt.String())
 	}
+	if !k.CanSendTo(ctx, delegatorAddr) {
+		return sdkerrors.ErrInvalidRecipient
+	}
 
 	err := k.SubUnlockedCoins(ctx, moduleAccAddr, amt, true)
 	if err != nil {

--- a/sei-cosmos/x/bank/keeper/keeper_test.go
+++ b/sei-cosmos/x/bank/keeper/keeper_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/baseapp"
 	tmtime "github.com/sei-protocol/sei-chain/sei-cosmos/std"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/types/query"
 	authkeeper "github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/keeper"
 	authtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/types"
@@ -1539,6 +1540,27 @@ func (suite *IntegrationTestSuite) TestUndelegateCoins_Invalid() {
 	app.AccountKeeper.SetAccount(ctx, acc)
 
 	suite.Require().Error(app.BankKeeper.UndelegateCoins(ctx, addrModule, addr1, delCoins))
+}
+
+func (suite *IntegrationTestSuite) TestUndelegateCoins_InvalidRecipientIsAtomic() {
+	app, ctx := suite.app, suite.ctx
+	moduleAddr := sdk.AccAddress([]byte("moduleAcc___________"))
+	delegatorAddr := sdk.AccAddress([]byte("delegator___________"))
+	amount := sdk.NewCoins(sdk.NewInt64Coin("usei", 50))
+
+	app.AccountKeeper.SetAccount(ctx, app.AccountKeeper.NewAccountWithAddress(ctx, moduleAddr))
+	app.AccountKeeper.SetAccount(ctx, app.AccountKeeper.NewAccountWithAddress(ctx, delegatorAddr))
+	suite.Require().NoError(apptesting.FundAccount(app.BankKeeper, ctx, moduleAddr, amount))
+	app.BankKeeper.RegisterRecipientChecker(func(_ sdk.Context, recipient sdk.AccAddress) bool {
+		return !recipient.Equals(delegatorAddr)
+	})
+
+	moduleBalanceBefore := app.BankKeeper.GetAllBalances(ctx, moduleAddr)
+	delegatorBalanceBefore := app.BankKeeper.GetAllBalances(ctx, delegatorAddr)
+	err := app.BankKeeper.UndelegateCoins(ctx, moduleAddr, delegatorAddr, amount)
+	suite.Require().ErrorIs(err, sdkerrors.ErrInvalidRecipient)
+	suite.Require().Equal(moduleBalanceBefore, app.BankKeeper.GetAllBalances(ctx, moduleAddr))
+	suite.Require().Equal(delegatorBalanceBefore, app.BankKeeper.GetAllBalances(ctx, delegatorAddr))
 }
 
 func (suite *IntegrationTestSuite) TestSetDenomMetaData() {

--- a/sei-cosmos/x/gov/keeper/deposit.go
+++ b/sei-cosmos/x/gov/keeper/deposit.go
@@ -167,6 +167,11 @@ func (keeper Keeper) RefundDeposits(ctx sdk.Context, proposalID uint64) {
 
 	keeper.IterateDeposits(ctx, proposalID, func(deposit types.Deposit) bool {
 		depositor := sdk.MustAccAddressFromBech32(deposit.Depositor)
+		if !keeper.bankKeeper.CanSendTo(ctx, depositor) {
+			// Keep the deposit and its backing funds together until the recipient can
+			// receive them; attempting the send would debit the module before failing.
+			return false
+		}
 
 		err := keeper.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, depositor, deposit.Amount)
 		if err != nil {

--- a/sei-cosmos/x/gov/keeper/deposit.go
+++ b/sei-cosmos/x/gov/keeper/deposit.go
@@ -161,15 +161,18 @@ func (keeper Keeper) AddDeposit(ctx sdk.Context, proposalID uint64, depositorAdd
 	return activatedVotingPeriod, nil
 }
 
-// RefundDeposits refunds and deletes all the deposits on a specific proposal
+// RefundDeposits refunds deposits whose recipients can receive funds and deletes
+// their records. Deposits for unpayable recipients remain recorded and backed by
+// the governance module balance.
 func (keeper Keeper) RefundDeposits(ctx sdk.Context, proposalID uint64) {
 	store := ctx.KVStore(keeper.storeKey)
 
 	keeper.IterateDeposits(ctx, proposalID, func(deposit types.Deposit) bool {
 		depositor := sdk.MustAccAddressFromBech32(deposit.Depositor)
-		if !keeper.bankKeeper.CanSendTo(ctx, depositor) {
-			// Keep the deposit and its backing funds together until the recipient can
-			// receive them; attempting the send would debit the module before failing.
+		if keeper.bankKeeper.BlockedAddr(depositor) || !keeper.bankKeeper.CanSendTo(ctx, depositor) {
+			// Retain the deposit so its record continues to account for the backing
+			// module balance. Recovering a permanently unreceivable deposit requires
+			// a migration.
 			return false
 		}
 

--- a/sei-cosmos/x/gov/keeper/deposit_test.go
+++ b/sei-cosmos/x/gov/keeper/deposit_test.go
@@ -13,6 +13,7 @@ import (
 
 	seiapp "github.com/sei-protocol/sei-chain/app"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	bankkeeper "github.com/sei-protocol/sei-chain/sei-cosmos/x/bank/keeper"
 )
 
 func TestDeposits(t *testing.T) {
@@ -166,4 +167,36 @@ func TestRefundDepositsLeavesInvalidRecipientPending(t *testing.T) {
 	require.False(t, found)
 	require.Equal(t, sdk.NewInt(100), app.BankKeeper.GetBalance(ctx, validDepositor, sdk.DefaultBondDenom).Amount)
 	require.Equal(t, castDeposit, app.BankKeeper.GetAllBalances(ctx, app.AccountKeeper.GetModuleAddress(types.ModuleName)))
+}
+
+func TestRefundDepositsLeavesBlockedRecipientPending(t *testing.T) {
+	app := seiapp.Setup(t, false, false, false)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+
+	proposal, err := app.GovKeeper.SubmitProposal(ctx, TestProposal)
+	require.NoError(t, err)
+
+	blockedDepositor := sdk.AccAddress(append(append([]byte{}, bankkeeper.CoinbaseAddressPrefix...), make([]byte, 8)...))
+	require.True(t, app.BankKeeper.CanSendTo(ctx, blockedDepositor))
+	require.True(t, app.BankKeeper.BlockedAddr(blockedDepositor))
+
+	initialBalance := sdk.NewInt(100)
+	depositAmount := sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 40))
+	require.NoError(t, app.BankKeeper.AddCoins(
+		ctx,
+		blockedDepositor,
+		sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, initialBalance)),
+		true,
+	))
+	_, err = app.GovKeeper.AddDeposit(ctx, proposal.ProposalId, blockedDepositor, depositAmount)
+	require.NoError(t, err)
+
+	app.GovKeeper.RefundDeposits(ctx, proposal.ProposalId)
+
+	deposit, found := app.GovKeeper.GetDeposit(ctx, proposal.ProposalId, blockedDepositor)
+	require.True(t, found)
+	require.Equal(t, depositAmount, deposit.Amount)
+	expectedBalance := initialBalance.Sub(depositAmount.AmountOf(sdk.DefaultBondDenom))
+	require.Equal(t, expectedBalance, app.BankKeeper.GetBalance(ctx, blockedDepositor, sdk.DefaultBondDenom).Amount)
+	require.Equal(t, depositAmount, app.BankKeeper.GetAllBalances(ctx, app.AccountKeeper.GetModuleAddress(types.ModuleName)))
 }

--- a/sei-cosmos/x/gov/keeper/deposit_test.go
+++ b/sei-cosmos/x/gov/keeper/deposit_test.go
@@ -1,9 +1,11 @@
 package keeper_test
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/x/gov/types"
 
 	tmproto "github.com/sei-protocol/sei-chain/sei-tendermint/proto/tendermint/types"
@@ -130,4 +132,38 @@ func TestDeposits(t *testing.T) {
 		deposits = app.GovKeeper.GetDeposits(ctx, proposalID)
 		require.Len(t, deposits, 0)
 	}
+}
+
+func TestRefundDepositsLeavesInvalidRecipientPending(t *testing.T) {
+	app := seiapp.Setup(t, false, false, false)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+	validDepositor := seiapp.AddTestAddrsIncremental(app, ctx, 1, sdk.NewInt(100))[0]
+
+	proposal, err := app.GovKeeper.SubmitProposal(ctx, TestProposal)
+	require.NoError(t, err)
+
+	evmAddr := common.HexToAddress("0x0000000000000000000000000000000000000001")
+	castDepositor := sdk.AccAddress(evmAddr[:])
+	app.EvmKeeper.SetAddressMapping(ctx, castDepositor, evmAddr)
+	require.NoError(t, app.BankKeeper.AddCoins(ctx, castDepositor, sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100)), true))
+
+	castDeposit := sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 40))
+	validDeposit := sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 30))
+	_, err = app.GovKeeper.AddDeposit(ctx, proposal.ProposalId, castDepositor, castDeposit)
+	require.NoError(t, err)
+	_, err = app.GovKeeper.AddDeposit(ctx, proposal.ProposalId, validDepositor, validDeposit)
+	require.NoError(t, err)
+
+	app.EvmKeeper.SetAddressMapping(ctx, sdk.AccAddress(bytes.Repeat([]byte{2}, common.AddressLength)), evmAddr)
+	require.False(t, app.BankKeeper.CanSendTo(ctx, castDepositor))
+
+	app.GovKeeper.RefundDeposits(ctx, proposal.ProposalId)
+
+	deposit, found := app.GovKeeper.GetDeposit(ctx, proposal.ProposalId, castDepositor)
+	require.True(t, found)
+	require.Equal(t, castDeposit, deposit.Amount)
+	_, found = app.GovKeeper.GetDeposit(ctx, proposal.ProposalId, validDepositor)
+	require.False(t, found)
+	require.Equal(t, sdk.NewInt(100), app.BankKeeper.GetBalance(ctx, validDepositor, sdk.DefaultBondDenom).Amount)
+	require.Equal(t, castDeposit, app.BankKeeper.GetAllBalances(ctx, app.AccountKeeper.GetModuleAddress(types.ModuleName)))
 }

--- a/sei-cosmos/x/gov/types/expected_keepers.go
+++ b/sei-cosmos/x/gov/types/expected_keepers.go
@@ -45,6 +45,7 @@ type BankKeeper interface {
 	LockedCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
 	SpendableCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
 	CanSendTo(ctx sdk.Context, recipient sdk.AccAddress) bool
+	BlockedAddr(addr sdk.AccAddress) bool
 
 	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error

--- a/sei-cosmos/x/gov/types/expected_keepers.go
+++ b/sei-cosmos/x/gov/types/expected_keepers.go
@@ -44,6 +44,7 @@ type BankKeeper interface {
 	GetBalance(ctx sdk.Context, addr sdk.AccAddress, denom string) sdk.Coin
 	LockedCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
 	SpendableCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
+	CanSendTo(ctx sdk.Context, recipient sdk.AccAddress) bool
 
 	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error

--- a/sei-cosmos/x/staking/keeper/delegation_test.go
+++ b/sei-cosmos/x/staking/keeper/delegation_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -275,6 +276,53 @@ func TestUnbondingDelegation(t *testing.T) {
 
 	resUnbonds = app.StakingKeeper.GetAllUnbondingDelegations(ctx, delAddrs[0])
 	require.Equal(t, 0, len(resUnbonds))
+}
+
+func TestEndBlockRetainsUnbondingForInvalidRecipient(t *testing.T) {
+	_, app, ctx := createTestInput(t)
+	maturity := time.Unix(1, 0).UTC()
+	ctx = ctx.WithBlockTime(maturity)
+	evmAddr := common.HexToAddress("0x3333333333333333333333333333333333333333")
+	delegator := sdk.AccAddress(evmAddr[:])
+	app.EvmKeeper.SetAddressMapping(ctx, delegator, evmAddr)
+	app.EvmKeeper.SetAddressMapping(
+		ctx,
+		sdk.AccAddress(common.HexToAddress("0x4444444444444444444444444444444444444444").Bytes()),
+		evmAddr,
+	)
+	validator := sdk.ValAddress(seiapp.AddTestAddrsIncremental(app, ctx, 1, sdk.NewInt(10000))[0])
+	amount := sdk.NewInt(40)
+	bondDenom := app.StakingKeeper.BondDenom(ctx)
+	notBondedPool := app.StakingKeeper.GetNotBondedPool(ctx)
+	coins := sdk.NewCoins(sdk.NewCoin(bondDenom, amount))
+
+	require.NoError(t, apptesting.FundModuleAccount(
+		app.BankKeeper,
+		ctx,
+		notBondedPool.GetName(),
+		coins,
+	))
+
+	unbonding := types.NewUnbondingDelegation(delegator, validator, 0, maturity, amount)
+	app.StakingKeeper.SetUnbondingDelegation(ctx, unbonding)
+	app.StakingKeeper.InsertUBDQueue(ctx, unbonding, maturity)
+	require.False(t, app.BankKeeper.CanSendTo(ctx, delegator))
+
+	poolBalanceBefore := app.BankKeeper.GetBalance(ctx, notBondedPool.GetAddress(), bondDenom)
+	require.NotPanics(t, func() {
+		staking.EndBlocker(ctx, app.StakingKeeper)
+	})
+
+	poolBalanceAfter := app.BankKeeper.GetBalance(ctx, notBondedPool.GetAddress(), bondDenom)
+	require.Equal(t, poolBalanceBefore, poolBalanceAfter)
+	require.True(t, app.BankKeeper.GetBalance(ctx, delegator, bondDenom).IsZero())
+	retained, found := app.StakingKeeper.GetUnbondingDelegation(ctx, delegator, validator)
+	require.True(t, found)
+	require.Equal(t, unbonding, retained)
+
+	iterator := app.StakingKeeper.UBDQueueIterator(ctx, maturity)
+	require.False(t, iterator.Valid())
+	require.NoError(t, iterator.Close())
 }
 
 func TestUnbondDelegation(t *testing.T) {


### PR DESCRIPTION
## Summary

- align governance refund handling with bank-layer recipient eligibility rules
- preserve deposit records and their backing module balance when a payout cannot be completed
- continue processing eligible refunds independently
- expand regression coverage for recipient-policy edge cases

## Behavior

Refund processing now validates recipient eligibility before initiating each account transfer. If a recipient is unavailable, its deposit remains recorded and backed by the governance module balance for migration-based recovery. Other eligible deposits are refunded and removed normally.

## Validation

- `go test ./sei-cosmos/x/gov/...`
- `go vet ./sei-cosmos/x/gov/...`
- `gofmt` and `goimports` on all changed Go files
- `git diff --check`