### PR TITLE
test(sei-db): wait for the flush before releasing the snapshot

### DIFF
--- a/sei-db/db_engine/snapshot/snapshot_flush_test.go
+++ b/sei-db/db_engine/snapshot/snapshot_flush_test.go
@@ -35,14 +35,12 @@ func TestFlushLatestValueWinsAcrossVersions(t *testing.T) {
 	require.NoError(t, engine.Set([]byte("k"), []byte("v1")))
 	snap1, err := engine.Commit()
 	require.NoError(t, err)
-	hashAndRelease(t, snap1)
-	awaitFlushed(t, snap1, time.Second)
+	hashAwaitFlushAndRelease(t, snap1)
 
 	require.NoError(t, engine.Set([]byte("k"), []byte("v2")))
 	snap2, err := engine.Commit()
 	require.NoError(t, err)
-	hashAndRelease(t, snap2)
-	awaitFlushed(t, snap2, time.Second)
+	hashAwaitFlushAndRelease(t, snap2)
 
 	kv, ok := db.get("k")
 	require.True(t, ok)

--- a/sei-db/db_engine/snapshot/test_helpers_test.go
+++ b/sei-db/db_engine/snapshot/test_helpers_test.go
@@ -319,6 +319,18 @@ func hashAndRelease(t *testing.T, snap Snapshot) {
 	require.NoError(t, snap.Release())
 }
 
+// hashAwaitFlushAndRelease waits for the flush before releasing. A released
+// version is retired out of the version map as soon as it flushes, and a wait
+// that arrives after that retirement fails, which
+// TestAwaitFlushAfterRetirementFails pins. Releasing first therefore makes the
+// wait a race against the lifecycle goroutine.
+func hashAwaitFlushAndRelease(t *testing.T, snap Snapshot) {
+	t.Helper()
+	require.NoError(t, snap.SetHash(testHash))
+	awaitFlushed(t, snap, time.Second)
+	require.NoError(t, snap.Release())
+}
+
 func commitAndHashRelease(t *testing.T, engine SnapshotEngine) {
 	t.Helper()
 	snap, err := engine.Commit()


### PR DESCRIPTION
TestFlushLatestValueWinsAcrossVersions released each version and then waited for its flush. A released version is retired out of the version map as soon as it flushes, so the wait raced the lifecycle goroutine and failed with "snapshot version (2) is no longer tracked" whenever retirement won. Waiting after release is invalid use, which TestAwaitFlushAfterRetirementFails already pins, so the test now waits first and releases after.

## Describe your changes and provide context

## Testing performed to validate your change

