### PR TITLE
feat(sei-db): roll back state store from snapshot and WAL

### DIFF
--- a/sei-cosmos/storev2/rootmulti/flatkv_recovery_test.go
+++ b/sei-cosmos/storev2/rootmulti/flatkv_recovery_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/sei-protocol/sei-chain/sei-db/common/keys"
+	seidbconfig "github.com/sei-protocol/sei-chain/sei-db/config"
+	seidbtypes "github.com/sei-protocol/sei-chain/sei-db/db_engine/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,6 +40,92 @@ func TestFlatKVRollbackWithLatticeHash(t *testing.T) {
 		require.NotNil(t, findStoreInfo(rec.infos, "evm_lattice"))
 	}
 
+	require.NoError(t, store.Close())
+}
+
+func TestRollbackToVersionRollsBackStateStore(t *testing.T) {
+	dir := t.TempDir()
+	scCfg := dualWriteConfig()
+	ssCfg := seidbconfig.DefaultStateStoreConfig()
+	ssCfg.Enable = true
+	ssCfg.SnapshotEnable = true
+	ssCfg.AsyncWriteBuffer = 100
+	ssCfg.KeepRecent = 100000
+
+	store, storeKeys := newTestRootMultiWithSS(t, dir, scCfg, ssCfg)
+	evmData := newEVMTestData(0x19)
+	for block := 1; block <= 5; block++ {
+		simulateBlock(t, store, storeKeys, block, evmData)
+	}
+
+	require.NoError(t, store.RollbackToVersion(3))
+	require.Equal(t, int64(3), store.LastCommitID().Version)
+	require.NotNil(t, store.ssStore)
+	require.Equal(t, int64(3), store.ssStore.GetLatestVersion())
+
+	value, err := store.ssStore.Get("bank", 100, []byte("supply"))
+	require.NoError(t, err)
+	require.Equal(t, []byte{3, 3}, value)
+	require.NoError(t, store.Close())
+}
+
+// The default node configuration keeps state store snapshots off, so the state
+// store has nothing to restore from. The command still has to rewind the commit
+// store, which is all it did before the state store could roll back at all.
+func TestRollbackToVersionWithoutStateStoreSnapshots(t *testing.T) {
+	dir := t.TempDir()
+	scCfg := dualWriteConfig()
+	ssCfg := seidbconfig.DefaultStateStoreConfig()
+	ssCfg.Enable = true
+	ssCfg.AsyncWriteBuffer = 100
+	ssCfg.KeepRecent = 100000
+	require.False(t, ssCfg.SnapshotEnable, "the default configuration takes no state store snapshots")
+
+	store, storeKeys := newTestRootMultiWithSS(t, dir, scCfg, ssCfg)
+	evmData := newEVMTestData(0x1b)
+	for block := 1; block <= 5; block++ {
+		simulateBlock(t, store, storeKeys, block, evmData)
+	}
+
+	require.NoError(t, store.RollbackToVersion(3))
+	require.Equal(t, int64(3), store.LastCommitID().Version)
+	require.Equal(t, int64(5), store.ssStore.GetLatestVersion(),
+		"the state store stays ahead, which the command warns about")
+	require.NoError(t, store.Close())
+}
+
+// nonRollbackableStateStore is a state store with no rollback capability: the
+// embedded interface carries the read and write methods but not Rollback.
+type nonRollbackableStateStore struct {
+	seidbtypes.StateStore
+}
+
+// A state store that cannot roll back must not disable the command. Rollback is
+// the recovery path for a node that cannot make progress, and it rewound the
+// commit store alone before the state store could follow at all.
+func TestRollbackToVersionProceedsWhenStateStoreCannotFollow(t *testing.T) {
+	dir := t.TempDir()
+	scCfg := dualWriteConfig()
+	ssCfg := seidbconfig.DefaultStateStoreConfig()
+	ssCfg.Enable = true
+	ssCfg.AsyncWriteBuffer = 100
+	ssCfg.KeepRecent = 100000
+
+	store, storeKeys := newTestRootMultiWithSS(t, dir, scCfg, ssCfg)
+	evmData := newEVMTestData(0x1a)
+	for block := 1; block <= 5; block++ {
+		simulateBlock(t, store, storeKeys, block, evmData)
+	}
+	rollbackable := store.ssStore
+	store.ssStore = nonRollbackableStateStore{rollbackable}
+
+	require.NoError(t, store.RollbackToVersion(3))
+	require.Equal(t, int64(3), store.LastCommitID().Version,
+		"the commit store must still roll back when the state store cannot follow")
+	require.Equal(t, int64(5), store.ssStore.GetLatestVersion(),
+		"the state store stays where it was")
+
+	store.ssStore = rollbackable
 	require.NoError(t, store.Close())
 }
 

--- a/sei-cosmos/storev2/rootmulti/store.go
+++ b/sei-cosmos/storev2/rootmulti/store.go
@@ -850,9 +850,47 @@ func (rs *Store) RollbackToVersion(target int64) error {
 	if target > math.MaxUint32 {
 		return fmt.Errorf("rollback height target %d exceeds max uint32", target)
 	}
+	// Whether the state store can follow is settled before the commit store
+	// moves. A state store that can follow and then fails mid-rollback is an
+	// error, but one that cannot follow at all must not disable the command:
+	// rollback is what an operator reaches for when the node cannot make
+	// progress, and it rewound SC and Tendermint alone before SS could follow
+	// at all. That outcome is now announced instead of silent.
+	var ssRollback seidbtypes.Rollbackable
+	if rs.ssStore != nil {
+		var reason error
+		capable, ok := rs.ssStore.(seidbtypes.Rollbackable)
+		switch {
+		case !ok:
+			reason = fmt.Errorf("state store %T does not support rollback", rs.ssStore)
+		default:
+			ssRollback = capable
+			if validator, ok := rs.ssStore.(seidbtypes.RollbackValidator); ok {
+				reason = validator.ValidateRollback(target)
+			}
+		}
+		if reason != nil {
+			ssRollback = nil
+			warnStateStoreStaysAhead(target, rs.ssStore.GetLatestVersion(), reason)
+		}
+	}
 	err := rs.scStore.Rollback(target)
 	if err != nil {
 		return err
+	}
+	if ssRollback != nil {
+		// The commit store is already at the target here, and the caller rewinds
+		// Tendermint only after this returns, so a failure leaves three layers on
+		// two heights. It is recoverable rather than terminal: re-running the
+		// command takes the app-behind-Tendermint path and rewinds Tendermint,
+		// and the state store converges on its own if the failure landed after
+		// the directory swap, because the marker drives the next open. The
+		// pre-flight is what keeps this to an I/O failure rather than a plan the
+		// state store was never going to accept.
+		if err := ssRollback.Rollback(target); err != nil {
+			return fmt.Errorf("rollback state store to version %d: %w", target, err)
+		}
+		fmt.Printf("Rolled back SS to version %d\n", rs.ssStore.GetLatestVersion())
 	}
 	// We need to update the lastCommitInfo after rollback
 	if rs.scStore.Version() != 0 {
@@ -861,6 +899,17 @@ func (rs *Store) RollbackToVersion(target int64) error {
 		rs.lastCommitInfo = amendCommitInfo(rs.lastCommitInfo, rs.storesParams)
 	}
 	return nil
+}
+
+// warnStateStoreStaysAhead tells the operator that only part of the node moved.
+// Re-execution rewrites the keys the replayed blocks write, so the state store
+// heals when the chain replays the same blocks; the keys written only by the
+// discarded ones keep their old values and do not.
+func warnStateStoreStaysAhead(target, ssVersion int64, reason error) {
+	fmt.Printf("WARNING: state store rollback skipped: %v\n", reason)
+	fmt.Printf("WARNING: the commit store and Tendermint roll back to version %d while the state store stays at version %d\n",
+		target, ssVersion)
+	fmt.Printf("WARNING: rebuild the state store from state sync unless the chain replays the same blocks above version %d\n", target)
 }
 
 // getStoreByName performs a lookup of a StoreKey given a store name typically

--- a/sei-db/common/utils/clone.go
+++ b/sei-db/common/utils/clone.go
@@ -1,0 +1,89 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ClonePebbleDir copies one PebbleDB directory. Immutable .sst files are
+// hard-linked; everything else is byte-copied. The LOCK file is skipped, as the
+// destination takes its own.
+//
+// A subdirectory is refused rather than skipped: the default layout has none,
+// and a configured WAL directory inside the database would otherwise make the
+// clone silently incomplete.
+func ClonePebbleDir(src, dst string) error {
+	if err := os.MkdirAll(dst, 0o750); err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() {
+			return fmt.Errorf("clone %q: unexpected subdirectory %q in PebbleDB directory", src, name)
+		}
+		if name == "LOCK" {
+			continue
+		}
+
+		srcPath := filepath.Join(src, name)
+		dstPath := filepath.Join(dst, name)
+		if strings.HasSuffix(name, ".sst") {
+			if linkErr := os.Link(srcPath, dstPath); linkErr == nil {
+				continue
+			}
+			// Fall back to a copy if hardlinks are not available.
+		}
+
+		if err := copyFile(srcPath, dstPath); err != nil {
+			return fmt.Errorf("copy %s: %w", name, err)
+		}
+	}
+	return SyncDir(dst)
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src) //nolint:gosec // paths come from internal DB layout
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.Create(dst) //nolint:gosec // paths come from internal DB layout
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Sync()
+}
+
+// SyncDir persists a directory's own entries, which an fsync of the files in it
+// does not cover.
+func SyncDir(path string) error {
+	dir, err := os.Open(path) //nolint:gosec // paths come from internal DB layout
+	if err != nil {
+		return fmt.Errorf("open directory %q for sync: %w", path, err)
+	}
+	syncErr := dir.Sync()
+	closeErr := dir.Close()
+	if syncErr != nil {
+		syncErr = fmt.Errorf("sync directory %q: %w", path, syncErr)
+	}
+	if closeErr != nil {
+		closeErr = fmt.Errorf("close directory %q after sync: %w", path, closeErr)
+	}
+	return errors.Join(syncErr, closeErr)
+}

--- a/sei-db/common/utils/path.go
+++ b/sei-db/common/utils/path.go
@@ -47,11 +47,19 @@ func GetFlatKVPath(homePath string) string {
 // New nodes use data/state_store/cosmos/{backend}; existing nodes with
 // data/{backend} continue using the legacy path for backward compatibility.
 func GetStateStorePath(homePath string, backend string) string {
-	legacyPath := filepath.Join(homePath, "data", backend)
+	legacyPath := LegacyStateStorePath(homePath, backend)
 	if DirExists(legacyPath) {
 		return legacyPath
 	}
 	return filepath.Join(homePath, "data", "state_store", "cosmos", backend)
+}
+
+// LegacyStateStorePath is where a node created before the state_store layout
+// keeps its Cosmos state store. GetStateStorePath answers by asking whether this
+// directory exists, so a caller that moves it has to name it to find its way
+// back.
+func LegacyStateStorePath(homePath string, backend string) string {
+	return filepath.Join(homePath, "data", backend)
 }
 
 // GetEVMStateStorePath returns the path for the EVM state store.

--- a/sei-db/config/ss_config.go
+++ b/sei-db/config/ss_config.go
@@ -82,7 +82,17 @@ type StateStoreConfig struct {
 	// snapshot — significant on a multi-TB state store. Managed snapshots are
 	// rollback restore points, not an archive format. They have no lease in this
 	// release, so node-external tools must not resolve a snapshot path and open it
-	// later without first adding a hold mechanism. Attempts, skips, outcomes,
+	// later without first adding a hold mechanism.
+	//
+	// The changelog grows with them. A rollback replays it forward from a
+	// snapshot, so retention holds every entry above the oldest retained one:
+	// roughly SnapshotInterval entries per retained snapshot, against a floor of
+	// 1000 entries when snapshots are off. Size disk for the count-based ceiling
+	// rather than that steady state — 40,000 entries at the shipped cadence. Every
+	// snapshot-enabled node pays it whether or not it ever rolls back, and the
+	// snapshot-anchored prune that brings the log back below it is best-effort
+	// and only runs when a retention pass drops a snapshot, so a node can sit at
+	// the ceiling indefinitely with nothing else degraded. Attempts, skips, outcomes,
 	// duration, in-flight state, per-store height, retained count, apparent bytes,
 	// and newest common height are exported as ss_snapshot_* metrics.
 	// defaults to false

--- a/sei-db/db_engine/pebbledb/mvcc/db.go
+++ b/sei-db/db_engine/pebbledb/mvcc/db.go
@@ -227,9 +227,17 @@ func OpenDB(dataDir string, config config.StateStoreConfig) (types.StateStore, e
 		_ = db.Close()
 		return nil, errors.New("KeepRecent must be non-negative")
 	}
-	walKeepRecent := math.Max(MinWALEntriesToKeep, float64(config.AsyncWriteBuffer+1))
+	walKeepRecent := changelogKeepRecent(config)
+	// Snapshot rollback replays the changelog forward from the oldest retained
+	// snapshot, so count-based pruning must not cut inside that span. The
+	// snapshot manager prunes this changelog by snapshot version after every
+	// retention pass and is what actually holds it down; the count below is the
+	// ceiling for the states that pass does not cover — external snapshot
+	// pruning, and the stretch before enough snapshots exist to prune. Raising
+	// the ceiling is what a rollback window costs on disk: roughly one snapshot
+	// interval of changelog per retained snapshot.
 	streamHandler, err := wal.NewChangelogWAL(utils.GetChangelogPath(dataDir), wal.Config{
-		KeepRecent:    uint64(walKeepRecent),
+		KeepRecent:    walKeepRecent,
 		PruneInterval: time.Duration(config.PruneIntervalSeconds) * time.Second,
 	})
 	if err != nil {
@@ -245,6 +253,118 @@ func OpenDB(dataDir string, config config.StateStoreConfig) (types.StateStore, e
 	go database.collectMetricsInBackground(metricsCtx)
 
 	return database, nil
+}
+
+func changelogKeepRecent(cfg config.StateStoreConfig) uint64 {
+	keepRecent := uint64(math.Max(MinWALEntriesToKeep, float64(cfg.AsyncWriteBuffer+1)))
+	return max(keepRecent, snapshotWALKeepRecent(cfg.SnapshotInterval, cfg.SnapshotKeepRecent))
+}
+
+// snapshotWALKeepRecent is the widest changelog span a rollback can ask for:
+// the oldest retained snapshot sits keepRecent+1 intervals below the newest,
+// the newest sits up to one interval below the head, and one interval more
+// covers the window before a retention pass runs. It is 0 when snapshots are
+// off, which leaves the caller's own floor in place.
+func snapshotWALKeepRecent(interval int64, keepRecent int) uint64 {
+	if interval <= 0 {
+		return 0
+	}
+	intervals := uint64(3)
+	if keepRecent > 0 {
+		intervals += uint64(keepRecent)
+	}
+	span := uint64(interval)
+	if span > math.MaxUint64/intervals {
+		return math.MaxUint64
+	}
+	return span * intervals
+}
+
+// PruneWALBeforeVersion drops changelog entries older than the first entry that
+// would be needed to replay forward from version. It is intentionally
+// best-effort at the caller: snapshots are still valid without this, but the WAL
+// would retain more history than rollback can use.
+func (db *Database) PruneWALBeforeVersion(version int64) error {
+	if db.streamHandler == nil || version <= 0 {
+		return nil
+	}
+	firstOffset, err := db.streamHandler.FirstOffset()
+	if err != nil {
+		return fmt.Errorf("read WAL first offset: %w", err)
+	}
+	if firstOffset == 0 {
+		return nil
+	}
+	lastOffset, err := db.streamHandler.LastOffset()
+	if err != nil {
+		return fmt.Errorf("read WAL last offset: %w", err)
+	}
+	if lastOffset == 0 || firstOffset > lastOffset {
+		return nil
+	}
+	// The last entry at or below the snapshot is kept rather than cut. A rollback
+	// replays from the entry after the snapshot, so that entry is not needed to
+	// replay — it is needed to read the log: a first entry above the snapshot
+	// version can be a block that wrote nothing or a prefix that was pruned, and
+	// only a retained entry below it tells a reader which.
+	keepOffset, ok, err := wal.FindLastOffsetAtOrBeforeVersion(db.streamHandler, firstOffset, lastOffset, version)
+	if err != nil {
+		return fmt.Errorf("find WAL prune offset for version %d: %w", version, err)
+	}
+	if !ok || keepOffset <= firstOffset {
+		return nil
+	}
+	// Snapshot anchoring can only widen the recovery log. Count-based retention
+	// also protects Pebble writes that were not durable at a power loss, so a
+	// short snapshot cadence must not cut the changelog below that floor.
+	keepRecent := changelogKeepRecent(db.config)
+	retained := lastOffset - keepOffset + 1
+	if retained < keepRecent {
+		if available := lastOffset - firstOffset + 1; available <= keepRecent {
+			return nil
+		}
+		keepOffset = lastOffset - keepRecent + 1
+	}
+	return db.streamHandler.TruncateBefore(keepOffset)
+}
+
+// WALVersionsAfter reads the changelog through the handle this database already
+// holds. Reads are serialized against the truncations the pruner sends down the
+// same handle, which a second handle over the directory would not be.
+func (db *Database) WALVersionsAfter(version int64) (oldest int64, next int64, err error) {
+	if db.streamHandler == nil {
+		return 0, 0, nil
+	}
+	firstOffset, err := db.streamHandler.FirstOffset()
+	if err != nil {
+		return 0, 0, fmt.Errorf("read WAL first offset: %w", err)
+	}
+	if firstOffset == 0 {
+		return 0, 0, nil
+	}
+	lastOffset, err := db.streamHandler.LastOffset()
+	if err != nil {
+		return 0, 0, fmt.Errorf("read WAL last offset: %w", err)
+	}
+	if lastOffset == 0 || firstOffset > lastOffset {
+		return 0, 0, nil
+	}
+	oldestEntry, err := db.streamHandler.ReadAt(firstOffset)
+	if err != nil {
+		return 0, 0, fmt.Errorf("read WAL at offset %d: %w", firstOffset, err)
+	}
+	nextOffset, err := wal.FindFirstOffsetAfterVersion(db.streamHandler, firstOffset, lastOffset, version)
+	if err != nil {
+		return 0, 0, fmt.Errorf("find WAL entry after version %d: %w", version, err)
+	}
+	if nextOffset > lastOffset {
+		return oldestEntry.Version, 0, nil
+	}
+	nextEntry, err := db.streamHandler.ReadAt(nextOffset)
+	if err != nil {
+		return 0, 0, fmt.Errorf("read WAL at offset %d: %w", nextOffset, err)
+	}
+	return oldestEntry.Version, nextEntry.Version, nil
 }
 
 func (db *Database) Close() error {

--- a/sei-db/db_engine/pebbledb/mvcc/wal_prune_test.go
+++ b/sei-db/db_engine/pebbledb/mvcc/wal_prune_test.go
@@ -1,0 +1,54 @@
+package mvcc
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sei-protocol/sei-chain/sei-db/config"
+	"github.com/sei-protocol/sei-chain/sei-db/proto"
+)
+
+func TestPruneWALBeforeVersionKeepsRecoveryFloor(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		snapshot     int64
+		firstVersion int64
+	}{
+		{
+			name:         "snapshot anchor keeps more history",
+			snapshot:     100,
+			firstVersion: 100,
+		},
+		{
+			name:         "recovery floor keeps more history",
+			snapshot:     1499,
+			firstVersion: 501,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.DefaultStateStoreConfig()
+			cfg.Backend = config.PebbleDBBackend
+			cfg.SnapshotInterval = 100
+			cfg.SnapshotKeepRecent = 1
+			cfg.PruneIntervalSeconds = 3600
+
+			store, err := OpenDB(filepath.Join(t.TempDir(), "state"), cfg)
+			require.NoError(t, err)
+			db := store.(*Database)
+			t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+			for version := int64(1); version <= 1500; version++ {
+				require.NoError(t, db.streamHandler.Write(proto.ChangelogEntry{Version: version}))
+			}
+
+			require.NoError(t, db.PruneWALBeforeVersion(tc.snapshot))
+			firstOffset, err := db.streamHandler.FirstOffset()
+			require.NoError(t, err)
+			first, err := db.streamHandler.ReadAt(firstOffset)
+			require.NoError(t, err)
+			require.Equal(t, tc.firstVersion, first.Version)
+		})
+	}
+}

--- a/sei-db/db_engine/types/types.go
+++ b/sei-db/db_engine/types/types.go
@@ -146,6 +146,38 @@ type PendingWriteWaiter interface {
 	WaitForPendingWrites()
 }
 
+// SnapshotWALPruner is an optional capability for engines that keep a changelog
+// WAL beside snapshotable state. It lets snapshot retention keep the WAL anchored
+// to the oldest retained snapshot instead of to a fixed count of recent entries.
+type SnapshotWALPruner interface {
+	PruneWALBeforeVersion(version int64) error
+}
+
+// SnapshotWALReader is the read side of SnapshotWALPruner. It answers what the
+// changelog still covers through the handle the engine already holds, so a
+// caller planning a replay does not open a second one over a live WAL
+// directory: a second open repairs a corrupt tail rather than reading past it,
+// and it races the pruner truncating the same segments.
+type SnapshotWALReader interface {
+	// WALVersionsAfter reports the oldest version the changelog still holds and
+	// the oldest one above version. Either is 0 when the changelog holds no such
+	// entry.
+	WALVersionsAfter(version int64) (oldest int64, next int64, err error)
+}
+
+// Rollbackable is an optional offline capability for stores that can discard
+// versions above target and reopen at that target. Callers must quiesce the
+// store before invoking it.
+type Rollbackable interface {
+	Rollback(target int64) error
+}
+
+// RollbackValidator is an optional companion to Rollbackable. It checks whether
+// a rollback can be performed without changing store state.
+type RollbackValidator interface {
+	ValidateRollback(target int64) error
+}
+
 // The interfaces above are engine capabilities. Deciding when a checkpoint runs,
 // and what version it is labeled with, is coordination rather than engine
 // behavior and lives in sei-db/management: CheckpointScheduler,

--- a/sei-db/state_db/ss/composite/recovery_test.go
+++ b/sei-db/state_db/ss/composite/recovery_test.go
@@ -23,11 +23,11 @@ func newCompositeStateStoreWithStores(
 	evmStore types.StateStore,
 	ssConfig config.StateStoreConfig,
 ) *CompositeStateStore {
-	return &CompositeStateStore{
+	return &CompositeStateStore{compositeState: compositeState{
 		cosmosStore: cosmosStore,
 		evmStore:    evmStore,
 		config:      ssConfig,
-	}
+	}}
 }
 
 // TestEVMSSDirectoryCheck: populated Cosmos SS + missing/empty EVM SS dir must abort startup.
@@ -321,6 +321,50 @@ func TestSyncEVMStoreBehind(t *testing.T) {
 	val, err := compositeStore.evmStore.Get("evm", 10, evmKey)
 	require.NoError(t, err)
 	require.Equal(t, []byte{10}, val)
+}
+
+func TestSplitRecoveryAdvancesEVMVersionWithoutEVMData(t *testing.T) {
+	dir, err := os.MkdirTemp("", "composite_split_gap_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	ssConfig := config.DefaultStateStoreConfig()
+	ssConfig.Backend = config.PebbleDBBackend
+	dbHome := utils.GetStateStorePath(dir, ssConfig.Backend)
+	mvccDB, err := backend.ResolveBackend(ssConfig.Backend)(dbHome, ssConfig)
+	require.NoError(t, err)
+	cosmosStore := cosmos.NewCosmosStateStore(mvccDB)
+
+	changelogDir := filepath.Join(dir, "changelog")
+	walLog, err := wal.NewChangelogWAL(changelogDir, wal.Config{})
+	require.NoError(t, err)
+	for version := int64(1); version <= 3; version++ {
+		err := walLog.Write(proto.ChangelogEntry{
+			Version: version,
+			Changesets: []*proto.NamedChangeSet{{
+				Name: "bank",
+				Changeset: proto.ChangeSet{Pairs: []*proto.KVPair{{
+					Key: []byte("supply"), Value: []byte{byte(version)},
+				}}},
+			}},
+		})
+		require.NoError(t, err)
+	}
+	require.NoError(t, walLog.Close())
+
+	ssConfig.EVMSplit = true
+	ssConfig.EVMDBDirectory = filepath.Join(dir, "evm_ss")
+	evmStore, err := evm.NewEVMStateStore(ssConfig.EVMDBDirectory, ssConfig)
+	require.NoError(t, err)
+	compositeStore := newCompositeStateStoreWithStores(cosmosStore, evmStore, ssConfig)
+	defer compositeStore.Close()
+
+	require.NoError(t, RecoverCompositeStateStore(changelogDir, compositeStore))
+	require.Equal(t, int64(3), compositeStore.evmStore.GetLatestVersion())
+
+	has, err := compositeStore.evmStore.Has(evm.EVMStoreKey, 3, evmStorageKey())
+	require.NoError(t, err)
+	require.False(t, has)
 }
 
 func TestExtractEVMChanges(t *testing.T) {

--- a/sei-db/state_db/ss/composite/rollback.go
+++ b/sei-db/state_db/ss/composite/rollback.go
@@ -132,6 +132,13 @@ func rollbackBaseVersion(root string, changelog types.SnapshotWALReader, target 
 		return 0, fmt.Errorf("cannot roll back state store to version %d: nearest snapshot is %d and the changelog is empty", target, base)
 	}
 	if next == 0 {
+		// A retained prefix proves that a gap between two retained entries came
+		// from empty blocks, because retention only removes a prefix. It does
+		// not prove that a missing suffix was empty: rollback truncates the WAL
+		// tail, and opening the WAL can repair a corrupt tail. If the live
+		// database is still above that cut, restoring base and advancing only
+		// its watermark to target would silently lose the missing writes.
+		// base == target is different and returns above: no suffix is needed.
 		return 0, fmt.Errorf("cannot roll back state store to version %d: nearest snapshot is %d and the changelog has no newer entries", target, base)
 	}
 	// A first entry above base+1 means the versions in between either wrote

--- a/sei-db/state_db/ss/composite/rollback.go
+++ b/sei-db/state_db/ss/composite/rollback.go
@@ -1,0 +1,489 @@
+package composite
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/sei-protocol/sei-chain/sei-db/common/utils"
+	"github.com/sei-protocol/sei-chain/sei-db/config"
+	"github.com/sei-protocol/sei-chain/sei-db/db_engine/types"
+	sssnapshot "github.com/sei-protocol/sei-chain/sei-db/state_db/ss/snapshot"
+	"github.com/sei-protocol/sei-chain/sei-db/wal"
+)
+
+const rollbackTargetFile = ".ss-rollback-target"
+
+type ssRollbackPlan struct {
+	root        string
+	changelog   string
+	baseVersion int64
+	snapshotDir string
+}
+
+func (s *CompositeStateStore) ValidateRollback(target int64) error {
+	_, err := s.planRollback(target)
+	return err
+}
+
+func (s *CompositeStateStore) Rollback(target int64) error {
+	plan, err := s.planRollback(target)
+	if err != nil {
+		return err
+	}
+
+	if err := s.Close(); err != nil {
+		return fmt.Errorf("close state store before rollback: %w", err)
+	}
+	if err := runRollbackSteps(plan, s.dbHome, target); err != nil {
+		return fmt.Errorf("roll back state store to version %d from snapshot %d: %w", target, plan.baseVersion, err)
+	}
+
+	reopened, err := NewCompositeStateStore(s.config, s.homeDir)
+	if err != nil {
+		return fmt.Errorf("reopen state store after rollback: %w", err)
+	}
+	// The reopen is the same path a crashed rollback takes: it advances the
+	// watermark to the target through the marker, including the case where the
+	// target height wrote no changelog entry of its own, and clears the marker.
+	if got := reopened.GetLatestVersion(); got != target {
+		_ = reopened.Close()
+		return fmt.Errorf("state store rollback failed: wanted version %d but reached %d", target, got)
+	}
+	s.adopt(reopened)
+	logger.Info("state store rollback complete", "target", target, "snapshot", plan.baseVersion)
+	return nil
+}
+
+func (s *CompositeStateStore) planRollback(target int64) (ssRollbackPlan, error) {
+	if target <= 0 {
+		return ssRollbackPlan{}, fmt.Errorf("invalid state store rollback target: %d", target)
+	}
+	if s.evmStore != nil || s.config.EVMSplit {
+		return ssRollbackPlan{}, fmt.Errorf("state store rollback does not support evm-ss-split yet; rebuild SS from state sync or set evm-ss-split=false")
+	}
+	if s.config.Backend != config.PebbleDBBackend {
+		return ssRollbackPlan{}, fmt.Errorf("state store rollback requires pebbledb backend, got %q", s.config.Backend)
+	}
+	if s.homeDir == "" || s.dbHome == "" {
+		return ssRollbackPlan{}, fmt.Errorf("state store rollback missing home or database directory")
+	}
+	if latest := s.GetLatestVersion(); target > latest {
+		return ssRollbackPlan{}, fmt.Errorf("cannot roll back state store to version %d: the store is at version %d", target, latest)
+	}
+
+	// Planning reads the changelog through the live store's own handle. The
+	// store is still open here — ValidateRollback never closes it — and a second
+	// handle over the same directory would repair a corrupt tail instead of
+	// reporting it, and would read segments the pruner can truncate underneath.
+	changelog, ok := s.cosmosStore.(types.SnapshotWALReader)
+	if !ok {
+		return ssRollbackPlan{}, fmt.Errorf("state store %T cannot report what its changelog covers", s.cosmosStore)
+	}
+	root := cosmosSnapshotRoot(s.homeDir, s.dbHome, s.config)
+	baseVersion, err := rollbackBaseVersion(root, changelog, target)
+	if err != nil {
+		return ssRollbackPlan{}, err
+	}
+	return ssRollbackPlan{
+		root:        root,
+		changelog:   utils.GetChangelogPath(s.dbHome),
+		baseVersion: baseVersion,
+		snapshotDir: filepath.Join(root, SnapshotDirName(baseVersion)),
+	}, nil
+}
+
+func cosmosSnapshotRoot(homeDir, dbHome string, cfg config.StateStoreConfig) string {
+	if cfg.DBDirectory != "" {
+		return utils.GetStateStoreSnapshotsSiblingPath(dbHome)
+	}
+	return utils.GetStateStoreSnapshotsPath(homeDir)
+}
+
+func rollbackBaseVersion(root string, changelog types.SnapshotWALReader, target int64) (int64, error) {
+	versions, err := sssnapshot.ListSnapshotVersions(root)
+	if err != nil {
+		return 0, fmt.Errorf("list state store snapshots for rollback: %w", err)
+	}
+	var base int64
+	for _, version := range versions {
+		if version <= target {
+			base = version
+		}
+	}
+	if base == 0 {
+		return 0, fmt.Errorf("cannot roll back state store to version %d: no snapshot at or below target", target)
+	}
+	if base == target {
+		// The snapshot is the target height, so nothing has to be replayed onto
+		// it. The changelog is not consulted: every entry it still holds is
+		// above the target and is dropped by the rollback either way.
+		return base, nil
+	}
+
+	oldest, next, err := changelog.WALVersionsAfter(base)
+	if err != nil {
+		return 0, fmt.Errorf("read changelog coverage above snapshot %d: %w", base, err)
+	}
+	if oldest == 0 {
+		return 0, fmt.Errorf("cannot roll back state store to version %d: nearest snapshot is %d and the changelog is empty", target, base)
+	}
+	if next == 0 {
+		return 0, fmt.Errorf("cannot roll back state store to version %d: nearest snapshot is %d and the changelog has no newer entries", target, base)
+	}
+	// A first entry above base+1 means the versions in between either wrote
+	// nothing, which a block with no changesets does, or were pruned away.
+	// Retention prunes a prefix only, so a retained entry below the first one to
+	// replay proves the gap was never pruned and is empty blocks. A changelog
+	// that starts at the gap proves nothing and is refused.
+	if next == oldest && next != base+1 {
+		return 0, fmt.Errorf("cannot roll back state store to version %d: the changelog starts at version %d, above snapshot %d, so the versions in between may have been pruned", target, next, base)
+	}
+	return base, nil
+}
+
+type rollbackStep struct {
+	name string
+	run  func() error
+}
+
+// rollbackSteps lists, in order, every change a rollback makes on disk. One list
+// is the whole story: a step kept outside it is a step no crash test reaches and
+// no recovery path redoes.
+//
+// The order is what makes a crash survivable. Two rules set it.
+//
+// The changelog holds every version the snapshot does not and is the only copy,
+// so it stays inside the live directory until that directory has been moved
+// aside whole, and it is moved into the published directory before the
+// moved-aside one is deleted. Between any two steps the changelog is inside
+// exactly one of dbHome and the backup directory, and recoverRollbackDirSwap
+// empties both into dbHome before it deletes either.
+//
+// The snapshots above the target go first, before anything is published. They
+// describe the fork this rollback discards, and only the changelog cut and the
+// version watermark are redone from the marker on the next open — so a snapshot
+// above the target that outlives the swap outlives the rollback, and a later
+// rollback would take it as its base and restore the discarded fork's writes.
+// Losing them to an abandoned rollback only narrows a future rollback window.
+func rollbackSteps(plan ssRollbackPlan, dbHome string, target int64) []rollbackStep {
+	tmpDir := rollbackTmpDir(dbHome)
+	backupDir := rollbackBackupDir(dbHome)
+	return []rollbackStep{
+		{"remove stale rollback dirs", func() error {
+			if err := os.RemoveAll(tmpDir); err != nil {
+				return err
+			}
+			return os.RemoveAll(backupDir)
+		}},
+		{"discard snapshots above target", func() error {
+			return removeSnapshotsAbove(plan.root, target)
+		}},
+		{"clone snapshot", func() error {
+			return utils.ClonePebbleDir(plan.snapshotDir, tmpDir)
+		}},
+		{"mark rollback target", func() error {
+			return writeRollbackTarget(tmpDir, target)
+		}},
+		{"move live database aside", func() error {
+			if err := os.Rename(dbHome, backupDir); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+			return nil
+		}},
+		{"publish restored database", func() error {
+			return os.Rename(tmpDir, dbHome)
+		}},
+		{"move changelog into restored database", func() error {
+			return moveChangelog(backupDir, dbHome)
+		}},
+		{"persist directory swap", func() error {
+			return utils.SyncDir(filepath.Dir(dbHome))
+		}},
+		{"remove old database backup", func() error {
+			return os.RemoveAll(backupDir)
+		}},
+		{"cut changelog to target", func() error {
+			return truncateChangelogAfterVersion(plan.changelog, target)
+		}},
+	}
+}
+
+// rollbackStepNames returns the step names in order, for a caller that needs the
+// sequence without a database to run it against.
+func rollbackStepNames() []string {
+	steps := rollbackSteps(ssRollbackPlan{}, "", 0)
+	names := make([]string, len(steps))
+	for i, step := range steps {
+		names[i] = step.name
+	}
+	return names
+}
+
+func runRollbackSteps(plan ssRollbackPlan, dbHome string, target int64) error {
+	for _, step := range rollbackSteps(plan, dbHome, target) {
+		if err := step.run(); err != nil {
+			return fmt.Errorf("%s: %w", step.name, err)
+		}
+	}
+	return nil
+}
+
+// stateStoreHome resolves the live database directory, including the window a
+// rollback opens in it. GetStateStorePath answers by asking whether the legacy
+// directory exists, and the swap renames that directory away between two of its
+// steps; a node that crashes there would otherwise come back on the new layout,
+// open an empty database, and orphan the real one — changelog included — beside
+// the path it no longer looks at.
+func stateStoreHome(homeDir, backend string) string {
+	resolved := utils.GetStateStorePath(homeDir, backend)
+	legacy := utils.LegacyStateStorePath(homeDir, backend)
+	if resolved == legacy {
+		return resolved
+	}
+	if dirExists(rollbackTmpDir(legacy)) || dirExists(rollbackBackupDir(legacy)) {
+		return legacy
+	}
+	return resolved
+}
+
+// recoverRollbackDirSwap finishes or abandons the directory swap of a rollback
+// that died partway. It runs before the state store opens.
+//
+// It takes the changelog out of a directory before it deletes that directory:
+// without the changelog the versions above the retained snapshots are gone for
+// good, and no later rollback can replay forward.
+func recoverRollbackDirSwap(dbHome string) error {
+	tmpDir := rollbackTmpDir(dbHome)
+	backupDir := rollbackBackupDir(dbHome)
+
+	_, err := os.Stat(dbHome)
+	switch {
+	case err == nil:
+	case os.IsNotExist(err):
+		// The crash landed between moving the live database aside and
+		// publishing the restored one. Publish the restored database when it is
+		// staged, otherwise put the live one back and leave the rollback undone.
+		switch {
+		case dirExists(tmpDir):
+			if err := os.Rename(tmpDir, dbHome); err != nil {
+				return fmt.Errorf("publish restored rollback tmp dir: %w", err)
+			}
+		case dirExists(backupDir):
+			if err := os.Rename(backupDir, dbHome); err != nil {
+				return fmt.Errorf("restore live database from rollback backup: %w", err)
+			}
+		default:
+			return nil
+		}
+	default:
+		return err
+	}
+
+	for _, dir := range []string{backupDir, tmpDir} {
+		if err := moveChangelog(dir, dbHome); err != nil {
+			return err
+		}
+		if err := os.RemoveAll(dir); err != nil {
+			return fmt.Errorf("remove rollback dir %q: %w", dir, err)
+		}
+	}
+	return nil
+}
+
+// moveChangelog moves srcDir's changelog into dstDir when dstDir has none. It
+// makes the new destination entry durable before returning, because the caller
+// deletes srcDir next and that directory holds the only other copy.
+func moveChangelog(srcDir, dstDir string) error {
+	src := utils.GetChangelogPath(srcDir)
+	if !dirExists(src) {
+		return nil
+	}
+	dst := utils.GetChangelogPath(dstDir)
+	if dirExists(dst) {
+		// Only one of the two directories ever holds a changelog, so this is a
+		// leftover of an older attempt and the live one is already in place.
+		return nil
+	}
+	if err := os.Rename(src, dst); err != nil {
+		return fmt.Errorf("move changelog %q to %q: %w", src, dst, err)
+	}
+	return utils.SyncDir(dstDir)
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func completePendingRollback(changelogPath, dbHome string) (target int64, ok bool, err error) {
+	target, ok, err = readRollbackTarget(dbHome)
+	if err != nil || !ok {
+		return target, ok, err
+	}
+	if err := truncateChangelogAfterVersion(changelogPath, target); err != nil {
+		return 0, false, err
+	}
+	return target, true, nil
+}
+
+func rollbackTmpDir(dbHome string) string {
+	return dbHome + "-rollback-tmp"
+}
+
+func rollbackBackupDir(dbHome string) string {
+	return dbHome + "-rollback-old"
+}
+
+func rollbackTargetPath(dbHome string) string {
+	return filepath.Join(dbHome, rollbackTargetFile)
+}
+
+// writeRollbackTarget persists the marker before the directory swap publishes
+// the snapshot it belongs to. A marker that is lost to a crash after that swap
+// is worse than no rollback at all: the next open finds a restored database, no
+// pending target, and replays the whole uncut changelog forward, so the store
+// silently returns to the height the rollback was undoing.
+func writeRollbackTarget(dbHome string, target int64) error {
+	path := rollbackTargetPath(dbHome)
+	tmp := path + ".tmp"
+	if err := writeFileSynced(tmp, []byte(strconv.FormatInt(target, 10)+"\n")); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("publish rollback target marker: %w", err)
+	}
+	return utils.SyncDir(dbHome)
+}
+
+func writeFileSynced(path string, contents []byte) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec // internal marker path
+	if err != nil {
+		return fmt.Errorf("create %q: %w", path, err)
+	}
+	if _, err := f.Write(contents); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("write %q: %w", path, err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("sync %q: %w", path, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close %q: %w", path, err)
+	}
+	return nil
+}
+
+func readRollbackTarget(dbHome string) (int64, bool, error) {
+	bz, err := os.ReadFile(rollbackTargetPath(dbHome)) //nolint:gosec // internal marker path
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	target, err := strconv.ParseInt(strings.TrimSpace(string(bz)), 10, 64)
+	if err != nil {
+		return 0, false, fmt.Errorf("parse rollback target marker: %w", err)
+	}
+	return target, true, nil
+}
+
+// clearRollbackTarget persists the removal too. A marker that comes back after a
+// crash sends the next open through the cut again, against a changelog that has
+// grown blocks since the rollback finished, and those blocks would be discarded.
+func clearRollbackTarget(dbHome string) error {
+	if err := os.Remove(rollbackTargetPath(dbHome)); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	return utils.SyncDir(dbHome)
+}
+
+// truncateChangelogAfterVersion drops every changelog entry above target. It is
+// safe to run again on a changelog it has already cut, which is how a rollback
+// that died after this step finishes on the next open.
+//
+// A changelog whose retained entries are all above the target is deleted rather
+// than emptied in place. The WAL only empties a log that was opened with
+// AllowEmpty, and a log emptied that way is then refused by every open that
+// does not set it, which is every opener of this changelog. The entries are the
+// ones the rollback discards regardless, so a log recreated empty on the next
+// open holds the same history.
+func truncateChangelogAfterVersion(changelogPath string, target int64) error {
+	reset, err := cutChangelogAfterVersion(changelogPath, target)
+	if err != nil {
+		return err
+	}
+	if !reset {
+		// TruncateAfter rewrites a segment and replaces it through a rename.
+		// The WAL handle fsyncs the rewritten file; this sync makes its directory
+		// entry durable before the marker that would redo the cut is cleared.
+		return utils.SyncDir(changelogPath)
+	}
+	if err := os.RemoveAll(changelogPath); err != nil {
+		return fmt.Errorf("reset changelog %q: %w", changelogPath, err)
+	}
+	return utils.SyncDir(filepath.Dir(changelogPath))
+}
+
+// cutChangelogAfterVersion truncates the changelog in place and reports whether
+// it has to be reset instead, which is the case when it holds no entry at or
+// below target.
+func cutChangelogAfterVersion(changelogPath string, target int64) (reset bool, err error) {
+	stream, err := wal.NewChangelogWAL(changelogPath, wal.Config{FsyncEnabled: true})
+	if err != nil {
+		return false, fmt.Errorf("open state store changelog: %w", err)
+	}
+	defer func() {
+		if closeErr := stream.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close state store changelog: %w", closeErr)
+		}
+	}()
+	firstOffset, err := stream.FirstOffset()
+	if err != nil {
+		return false, err
+	}
+	if firstOffset == 0 {
+		return false, nil
+	}
+	lastOffset, err := stream.LastOffset()
+	if err != nil {
+		return false, err
+	}
+	keepOffset, ok, err := wal.FindLastOffsetAtOrBeforeVersion(stream, firstOffset, lastOffset, target)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return true, nil
+	}
+	return false, stream.TruncateAfter(keepOffset)
+}
+
+func removeSnapshotsAbove(root string, target int64) error {
+	versions, err := sssnapshot.ListSnapshotVersions(root)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, version := range versions {
+		if version <= target {
+			continue
+		}
+		dir := filepath.Join(root, SnapshotDirName(version))
+		if err := os.RemoveAll(dir); err != nil {
+			errs = append(errs, fmt.Errorf("remove snapshot %q: %w", dir, err))
+		}
+	}
+	if err := utils.SyncDir(root); err != nil {
+		errs = append(errs, fmt.Errorf("persist state store snapshot removals: %w", err))
+	}
+	return errors.Join(errs...)
+}

--- a/sei-db/state_db/ss/composite/rollback_test.go
+++ b/sei-db/state_db/ss/composite/rollback_test.go
@@ -435,7 +435,7 @@ func TestRollbackRejectsUnreachableTargets(t *testing.T) {
 		require.ErrorContains(t, err, "no snapshot at or below target")
 	})
 
-	t.Run("changelog cut below target", func(t *testing.T) {
+	t.Run("changelog tail cut below target", func(t *testing.T) {
 		store, home := setupRollbackStore(t, 5, 1)
 		for version := int64(1); version <= 8; version++ {
 			writeRollbackBlock(t, store, version)
@@ -451,6 +451,9 @@ func TestRollbackRejectsUnreachableTargets(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = reopened.Close() })
 
+		// Versions 6-8 wrote data, but the artificial tail cut leaves only
+		// entries at or below snapshot 5. Treating versions 6-7 as empty would
+		// restore snapshot 5, label it version 7, and silently lose their writes.
 		require.ErrorContains(t, reopened.Rollback(7), "changelog has no newer entries")
 	})
 

--- a/sei-db/state_db/ss/composite/rollback_test.go
+++ b/sei-db/state_db/ss/composite/rollback_test.go
@@ -1,0 +1,560 @@
+package composite
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sei-protocol/sei-chain/sei-db/common/utils"
+	"github.com/sei-protocol/sei-chain/sei-db/config"
+	"github.com/sei-protocol/sei-chain/sei-db/proto"
+	sssnapshot "github.com/sei-protocol/sei-chain/sei-db/state_db/ss/snapshot"
+	"github.com/sei-protocol/sei-chain/sei-db/wal"
+	"github.com/stretchr/testify/require"
+)
+
+func setupRollbackStore(t *testing.T, interval int64, keepRecent int) (*CompositeStateStore, string) {
+	t.Helper()
+	return setupRollbackStoreAt(t, t.TempDir(), interval, keepRecent)
+}
+
+// legacyLayoutHome is a home directory that already holds the pre-state_store
+// database directory, which is what makes GetStateStorePath resolve to it.
+func legacyLayoutHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(utils.LegacyStateStorePath(home, config.PebbleDBBackend), 0o750))
+	return home
+}
+
+func setupRollbackStoreAt(t *testing.T, home string, interval int64, keepRecent int) (*CompositeStateStore, string) {
+	t.Helper()
+	store, err := NewCompositeStateStore(config.StateStoreConfig{
+		Backend:            config.PebbleDBBackend,
+		AsyncWriteBuffer:   100,
+		KeepRecent:         100000,
+		SnapshotEnable:     true,
+		SnapshotInterval:   interval,
+		SnapshotKeepRecent: keepRecent,
+	}, home)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	require.NotNil(t, store.snapshotMgr)
+	return store, home
+}
+
+func rollbackChangeset(version int64) []*proto.NamedChangeSet {
+	return []*proto.NamedChangeSet{{
+		Name: "bank",
+		Changeset: proto.ChangeSet{Pairs: []*proto.KVPair{
+			{Key: []byte("balance"), Value: []byte(fmt.Sprintf("v%d", version))},
+			{Key: []byte(fmt.Sprintf("block-%d", version)), Value: []byte("present")},
+		}},
+	}}
+}
+
+func writeRollbackBlock(t *testing.T, store *CompositeStateStore, version int64) {
+	t.Helper()
+	commitBlock(t, store, version, rollbackChangeset(version))
+}
+
+// writeEmptyRollbackBlock commits a block with no changesets the way rootmulti
+// does: the state store apply is skipped, so the block writes no changelog
+// entry and only the version watermark moves.
+func writeEmptyRollbackBlock(t *testing.T, store *CompositeStateStore, version int64) {
+	t.Helper()
+	require.NoError(t, store.SetLatestVersion(version))
+	store.ScheduleSnapshot(version)
+}
+
+func TestRollbackRestoresSnapshotAndReplaysWALToTarget(t *testing.T) {
+	store, _ := setupRollbackStore(t, 5, 1)
+	for version := int64(1); version <= 8; version++ {
+		writeRollbackBlock(t, store, version)
+	}
+	settle(t, store)
+	require.Equal(t, int64(8), store.GetLatestVersion())
+
+	require.NoError(t, store.Rollback(7))
+	require.Equal(t, int64(7), store.GetLatestVersion())
+
+	value, err := store.Get("bank", 100, []byte("balance"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("v7"), value)
+
+	has, err := store.Has("bank", 100, []byte("block-7"))
+	require.NoError(t, err)
+	require.True(t, has)
+	has, err = store.Has("bank", 100, []byte("block-8"))
+	require.NoError(t, err)
+	require.False(t, has)
+}
+
+// TestRollbackToOldestRetainedSnapshot covers the target that retention leaves
+// with nothing to replay: the snapshot is the target height, so every entry the
+// WAL holds above the oldest snapshot's own is dropped by the rollback.
+func TestRollbackToOldestRetainedSnapshot(t *testing.T) {
+	store, home := setupRollbackStore(t, 2, 1)
+	for version := int64(1); version <= 6; version++ {
+		writeRollbackBlock(t, store, version)
+		settle(t, store)
+	}
+	require.Equal(t, []int64{4, 6}, snapshotVersions(t, store))
+	cfg := store.config
+	require.NoError(t, store.Close())
+	// This short log stays above the count-based recovery floor. Snapshot
+	// retention can widen history, but it must not narrow that floor.
+	require.Equal(t, int64(1), firstChangelogVersion(t, home))
+
+	store, err := NewCompositeStateStore(cfg, home)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	require.NoError(t, store.ValidateRollback(4))
+	require.NoError(t, store.Rollback(4))
+	require.Equal(t, int64(4), store.GetLatestVersion())
+	require.Equal(t, []int64{4}, snapshotVersions(t, store))
+
+	value, err := store.Get("bank", 100, []byte("balance"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("v4"), value)
+	has, err := store.Has("bank", 100, []byte("block-5"))
+	require.NoError(t, err)
+	require.False(t, has)
+
+	// The store stays writable, which is what a changelog left empty in place
+	// would break: the WAL refuses such a log on the next open.
+	writeRollbackBlock(t, store, 5)
+	settle(t, store)
+	require.Equal(t, int64(5), store.GetLatestVersion())
+	require.NoError(t, store.Close())
+
+	reopened, err := NewCompositeStateStore(cfg, home)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reopened.Close() })
+	require.Equal(t, int64(5), reopened.GetLatestVersion())
+}
+
+// TestRollbackReplaysAcrossAnEmptyBlock covers a changelog gap that is not a
+// pruned prefix: version 4 wrote nothing, so replay onto snapshot 3 resumes at
+// version 5 and is still complete.
+func TestRollbackReplaysAcrossAnEmptyBlock(t *testing.T) {
+	store, _ := setupRollbackStore(t, 3, 1)
+	for version := int64(1); version <= 6; version++ {
+		if version == 4 {
+			writeEmptyRollbackBlock(t, store, version)
+		} else {
+			writeRollbackBlock(t, store, version)
+		}
+		settle(t, store)
+	}
+	require.Equal(t, []int64{3, 6}, snapshotVersions(t, store))
+	require.Equal(t, int64(6), store.GetLatestVersion())
+
+	require.NoError(t, store.ValidateRollback(5))
+	require.NoError(t, store.Rollback(5))
+	require.Equal(t, int64(5), store.GetLatestVersion())
+
+	value, err := store.Get("bank", 100, []byte("balance"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("v5"), value)
+	has, err := store.Has("bank", 100, []byte("block-6"))
+	require.NoError(t, err)
+	require.False(t, has)
+}
+
+func snapshotVersions(t *testing.T, store *CompositeStateStore) []int64 {
+	t.Helper()
+	versions, err := sssnapshot.ListSnapshotVersions(
+		cosmosSnapshotRoot(store.homeDir, store.dbHome, store.config))
+	require.NoError(t, err)
+	return versions
+}
+
+// pruneChangelogBeforeVersion drops the changelog prefix below version, the way
+// snapshot-anchored retention does. The store must be closed.
+func pruneChangelogBeforeVersion(t *testing.T, changelogPath string, version int64) {
+	t.Helper()
+	stream, err := wal.NewChangelogWAL(changelogPath, wal.Config{})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, stream.Close()) }()
+	first, err := stream.FirstOffset()
+	require.NoError(t, err)
+	last, err := stream.LastOffset()
+	require.NoError(t, err)
+	keep, err := wal.FindFirstOffsetAfterVersion(stream, first, last, version-1)
+	require.NoError(t, err)
+	require.NoError(t, stream.TruncateBefore(keep))
+}
+
+// firstChangelogVersion reports the version of the oldest retained changelog
+// entry. The store must be closed: it opens a second handle on the same log.
+func firstChangelogVersion(t *testing.T, home string) int64 {
+	t.Helper()
+	changelogPath := utils.GetChangelogPath(utils.GetStateStorePath(home, config.PebbleDBBackend))
+	stream, err := wal.NewChangelogWAL(changelogPath, wal.Config{})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, stream.Close()) }()
+	first, err := stream.FirstOffset()
+	require.NoError(t, err)
+	entry, err := stream.ReadAt(first)
+	require.NoError(t, err)
+	return entry.Version
+}
+
+// TestValidateRollbackAgreesWithRollback holds the pre-flight to its promise: a
+// target it approves must not fail once the database has been swapped, and a
+// target it refuses must be refused for the same reason.
+func TestValidateRollbackAgreesWithRollback(t *testing.T) {
+	for _, target := range []int64{1, 3, 4, 5, 6, 9} {
+		t.Run(fmt.Sprintf("target %d", target), func(t *testing.T) {
+			store, _ := setupRollbackStore(t, 2, 1)
+			for version := int64(1); version <= 6; version++ {
+				writeRollbackBlock(t, store, version)
+				settle(t, store)
+			}
+
+			validateErr := store.ValidateRollback(target)
+			rollbackErr := store.Rollback(target)
+			if validateErr == nil {
+				require.NoError(t, rollbackErr)
+				require.Equal(t, target, store.GetLatestVersion())
+				return
+			}
+			require.EqualError(t, rollbackErr, validateErr.Error())
+		})
+	}
+}
+
+// TestValidateRollbackLeavesTheChangelogAlone pins that planning reads the
+// changelog through the handle the live store already holds. A second handle
+// over the same directory truncates a corrupt tail as it opens, which is a
+// repair, and RollbackValidator promises not to change store state.
+func TestValidateRollbackLeavesTheChangelogAlone(t *testing.T) {
+	store, home := setupRollbackStore(t, 2, 1)
+	for version := int64(1); version <= 6; version++ {
+		writeRollbackBlock(t, store, version)
+		settle(t, store)
+	}
+
+	changelogPath := utils.GetChangelogPath(utils.GetStateStorePath(home, config.PebbleDBBackend))
+	segment := lastChangelogSegment(t, changelogPath)
+	corrupted := append(readFileBytes(t, segment), []byte("corrupt tail")...)
+	require.NoError(t, os.WriteFile(segment, corrupted, 0o600))
+
+	require.NoError(t, store.ValidateRollback(5))
+
+	require.Equal(t, corrupted, readFileBytes(t, segment),
+		"validation rewrote the changelog segment")
+}
+
+func lastChangelogSegment(t *testing.T, changelogPath string) string {
+	t.Helper()
+	entries, err := os.ReadDir(changelogPath)
+	require.NoError(t, err)
+	var last string
+	for _, entry := range entries {
+		// Segments are 20-digit offsets, the same shape the WAL itself scans for.
+		if entry.IsDir() || len(entry.Name()) < 20 {
+			continue
+		}
+		last = entry.Name()
+	}
+	require.NotEmpty(t, last, "changelog %q holds no segment", changelogPath)
+	return filepath.Join(changelogPath, last)
+}
+
+func readFileBytes(t *testing.T, path string) []byte {
+	t.Helper()
+	bz, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return bz
+}
+
+// TestRollbackCrashRecoveryAtEveryStep stops the rollback after each of its
+// steps and reopens. Whichever way recovery resolves it, the changelog has to
+// survive — it is the only copy of the versions above the snapshots, so losing
+// it costs the node every later rollback as well as this one — and a store that
+// comes back on the target must not keep a snapshot of the fork it discarded.
+//
+// Both directory layouts are covered: the swap renames the live directory away,
+// and on the legacy layout that rename is what GetStateStorePath reads to decide
+// where the database lives, so a reopen in that window has to resolve back to
+// the directory the rollback moved rather than to an empty one.
+func TestRollbackCrashRecoveryAtEveryStep(t *testing.T) {
+	for _, layout := range []struct {
+		name string
+		home func(*testing.T) string
+	}{
+		{"state_store layout", func(t *testing.T) string { return t.TempDir() }},
+		{"legacy layout", legacyLayoutHome},
+	} {
+		t.Run(layout.name, func(t *testing.T) {
+			runRollbackCrashRecoveryAtEveryStep(t, layout.home)
+		})
+	}
+}
+
+func runRollbackCrashRecoveryAtEveryStep(t *testing.T, newHome func(*testing.T) string) {
+	const target = int64(7)
+	names := rollbackStepNames()
+	// Recovery rolls forward from the step that moves the live database aside,
+	// because from there on the restored database is the one on disk.
+	rollsForwardFrom := rollbackStepIndex(t, "move live database aside")
+
+	for stop := range names {
+		t.Run(fmt.Sprintf("after %s", names[stop]), func(t *testing.T) {
+			cfg, home, dbHome := stageRollback(t, newHome(t), target, stop+1)
+
+			reopened, err := NewCompositeStateStore(cfg, home)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = reopened.Close() })
+			require.Equal(t, dbHome, reopened.dbHome,
+				"the reopened store must resolve to the database the rollback moved")
+			require.NoDirExists(t, rollbackTmpDir(dbHome))
+			require.NoDirExists(t, rollbackBackupDir(dbHome))
+			require.NoFileExists(t, rollbackTargetPath(dbHome))
+
+			if stop >= rollsForwardFrom {
+				require.Equal(t, target, reopened.GetLatestVersion())
+				// v7 is only readable if the changelog survived the crash: the
+				// restored snapshot is version 6, and 7 is replayed.
+				value, err := reopened.Get("bank", 100, []byte("balance"))
+				require.NoError(t, err)
+				require.Equal(t, []byte("v7"), value)
+				has, err := reopened.Has("bank", 100, []byte("block-8"))
+				require.NoError(t, err)
+				require.False(t, has)
+				// A snapshot above the target describes the discarded fork. One
+				// left behind here would outlive the rollback, and the next one
+				// would take it as its base.
+				require.Equal(t, []int64{2, 4, 6}, snapshotVersions(t, reopened))
+				return
+			}
+
+			// The rollback was abandoned, so the pre-crash database is back and
+			// the changelog is intact enough to roll back for real.
+			require.Equal(t, int64(8), reopened.GetLatestVersion())
+			require.NoError(t, reopened.Rollback(target))
+			require.Equal(t, target, reopened.GetLatestVersion())
+			require.Equal(t, []int64{2, 4, 6}, snapshotVersions(t, reopened))
+		})
+	}
+}
+
+// TestRollbackTargetMarkerIsPublishedAtomically pins the shape of the write: the
+// marker is staged under a temporary name and renamed into place, so a reader
+// sees all of it or none of it, and no staging file is left for the next open to
+// trip over. The fsyncs that make this survive a power loss cannot be observed
+// from a test; the atomic publish they protect can.
+func TestRollbackTargetMarkerIsPublishedAtomically(t *testing.T) {
+	dbHome := t.TempDir()
+
+	require.NoError(t, writeRollbackTarget(dbHome, 42))
+	require.NoFileExists(t, rollbackTargetPath(dbHome)+".tmp")
+	target, ok, err := readRollbackTarget(dbHome)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, int64(42), target)
+
+	require.NoError(t, clearRollbackTarget(dbHome))
+	_, ok, err = readRollbackTarget(dbHome)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.NoError(t, clearRollbackTarget(dbHome), "clearing a cleared marker is not an error")
+}
+
+func rollbackStepIndex(t *testing.T, name string) int {
+	t.Helper()
+	for i, stepName := range rollbackStepNames() {
+		if stepName == name {
+			return i
+		}
+	}
+	t.Fatalf("rollback step %q not found", name)
+	return 0
+}
+
+// stageRollback runs the first stop steps of a rollback and returns the
+// config, home, and database directory of the store it left behind.
+//
+// The fixture takes a snapshot every other block, and keeps them all, so a
+// rollback to version 7 has both a snapshot below the target to restore from
+// and a snapshot above it to discard.
+func stageRollback(t *testing.T, home string, target int64, stop int) (config.StateStoreConfig, string, string) {
+	t.Helper()
+	store, home := setupRollbackStoreAt(t, home, 2, 3)
+	for version := int64(1); version <= 8; version++ {
+		writeRollbackBlock(t, store, version)
+		settle(t, store)
+	}
+	require.Equal(t, []int64{2, 4, 6, 8}, snapshotVersions(t, store))
+	plan, err := store.planRollback(target)
+	require.NoError(t, err)
+	cfg, dbHome := store.config, store.dbHome
+	require.NoError(t, store.Close())
+
+	for _, step := range rollbackSteps(plan, dbHome, target)[:stop] {
+		require.NoError(t, step.run(), step.name)
+	}
+	return cfg, home, dbHome
+}
+
+func TestRollbackCrashRecoveryCompletesPendingRestore(t *testing.T) {
+	t.Run("after restore before WAL cut", func(t *testing.T) {
+		cfg, home, _ := stageRollback(t, t.TempDir(), 7, rollbackStepIndex(t, "cut changelog to target"))
+
+		reopened, err := NewCompositeStateStore(cfg, home)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = reopened.Close() })
+		require.Equal(t, int64(7), reopened.GetLatestVersion())
+		require.NoFileExists(t, rollbackTargetPath(reopened.dbHome))
+	})
+
+	t.Run("after WAL cut before reopen", func(t *testing.T) {
+		cfg, home, _ := stageRollback(t, t.TempDir(), 7, len(rollbackStepNames()))
+
+		reopened, err := NewCompositeStateStore(cfg, home)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = reopened.Close() })
+		require.Equal(t, int64(7), reopened.GetLatestVersion())
+		require.NoFileExists(t, rollbackTargetPath(reopened.dbHome))
+	})
+}
+
+func TestRollbackRejectsUnreachableTargets(t *testing.T) {
+	t.Run("below first snapshot", func(t *testing.T) {
+		store, _ := setupRollbackStore(t, 5, 1)
+		for version := int64(1); version <= 5; version++ {
+			writeRollbackBlock(t, store, version)
+		}
+		settle(t, store)
+
+		err := store.Rollback(4)
+		require.ErrorContains(t, err, "no snapshot at or below target")
+	})
+
+	t.Run("changelog cut below target", func(t *testing.T) {
+		store, home := setupRollbackStore(t, 5, 1)
+		for version := int64(1); version <= 8; version++ {
+			writeRollbackBlock(t, store, version)
+		}
+		settle(t, store)
+		cfg := store.config
+		require.NoError(t, store.Close())
+
+		changelogPath := utils.GetChangelogPath(utils.GetStateStorePath(home, config.PebbleDBBackend))
+		require.NoError(t, truncateChangelogAfterVersion(changelogPath, 5))
+
+		reopened, err := NewCompositeStateStore(cfg, home)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = reopened.Close() })
+
+		require.ErrorContains(t, reopened.Rollback(7), "changelog has no newer entries")
+	})
+
+	t.Run("changelog pruned past target", func(t *testing.T) {
+		store, home := setupRollbackStore(t, 5, 1)
+		for version := int64(1); version <= 8; version++ {
+			writeRollbackBlock(t, store, version)
+		}
+		settle(t, store)
+		cfg := store.config
+		require.NoError(t, store.Close())
+
+		// A changelog whose prefix was pruned away cannot bridge the gap between
+		// the snapshot and the target.
+		changelogPath := utils.GetChangelogPath(utils.GetStateStorePath(home, config.PebbleDBBackend))
+		pruneChangelogBeforeVersion(t, changelogPath, 7)
+
+		reopened, err := NewCompositeStateStore(cfg, home)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = reopened.Close() })
+
+		require.ErrorContains(t, reopened.Rollback(8), "the changelog starts at version 7, above snapshot 5")
+	})
+
+	t.Run("target above the store version", func(t *testing.T) {
+		store, _ := setupRollbackStore(t, 5, 1)
+		for version := int64(1); version <= 8; version++ {
+			writeRollbackBlock(t, store, version)
+		}
+		settle(t, store)
+
+		require.ErrorContains(t, store.Rollback(9), "the store is at version 8")
+	})
+
+	t.Run("zero target", func(t *testing.T) {
+		store, _ := setupRollbackStore(t, 5, 1)
+		require.ErrorContains(t, store.Rollback(0), "invalid state store rollback target")
+	})
+}
+
+func TestRollbackRefusesEVMSplit(t *testing.T) {
+	home := t.TempDir()
+	store, err := NewCompositeStateStore(config.StateStoreConfig{
+		Backend:          config.PebbleDBBackend,
+		AsyncWriteBuffer: 100,
+		KeepRecent:       100000,
+		EVMSplit:         true,
+		EVMDBDirectory:   filepath.Join(home, "evm_ss"),
+		SnapshotEnable:   true,
+		SnapshotInterval: 5,
+	}, home)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	require.ErrorContains(t, store.Rollback(5), "evm-ss-split")
+}
+
+// TestSnapshotRetentionKeepsWALRecoveryFloor pins that snapshot retention only
+// widens changelog history. This log is shorter than the count-based floor, so
+// dropping a snapshot must not prune any entry.
+func TestSnapshotRetentionKeepsWALRecoveryFloor(t *testing.T) {
+	store, home := setupRollbackStore(t, 2, 1)
+	for version := int64(1); version <= 6; version++ {
+		writeRollbackBlock(t, store, version)
+		if version%2 == 0 {
+			settle(t, store)
+		}
+	}
+	settle(t, store)
+	require.Equal(t, []int64{4, 6}, snapshotVersions(t, store))
+	require.NoError(t, store.Close())
+
+	require.Equal(t, int64(1), firstChangelogVersion(t, home))
+}
+
+// TestRollbackAcrossAnEmptyBlockAfterTheOldestSnapshot is the case the retained
+// entry buys: the block right after the oldest retained snapshot wrote nothing,
+// so the first entry above that snapshot is two versions up. Without an entry at
+// or below the snapshot, that gap is indistinguishable from a pruned prefix and
+// the rollback would be refused.
+func TestRollbackAcrossAnEmptyBlockAfterTheOldestSnapshot(t *testing.T) {
+	store, home := setupRollbackStore(t, 3, 1)
+	for version := int64(1); version <= 9; version++ {
+		if version == 7 {
+			writeEmptyRollbackBlock(t, store, version)
+		} else {
+			writeRollbackBlock(t, store, version)
+		}
+		settle(t, store)
+	}
+	// Retention drops snapshot 3 but keeps this short changelog above its
+	// recovery floor. Version 7 wrote nothing, so the first entry after it is 8;
+	// a retained entry at or below snapshot 6 proves the gap was not pruned.
+	require.Equal(t, []int64{6, 9}, snapshotVersions(t, store))
+	require.Equal(t, int64(1), firstChangelogVersion(t, home))
+
+	require.NoError(t, store.ValidateRollback(8))
+	require.NoError(t, store.Rollback(8))
+	require.Equal(t, int64(8), store.GetLatestVersion())
+
+	value, err := store.Get("bank", 100, []byte("balance"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("v8"), value)
+	has, err := store.Has("bank", 100, []byte("block-9"))
+	require.NoError(t, err)
+	require.False(t, has)
+}

--- a/sei-db/state_db/ss/composite/store.go
+++ b/sei-db/state_db/ss/composite/store.go
@@ -34,13 +34,31 @@ var _ types.ContextIteratorStore = (*CompositeStateStore)(nil)
 // CompositeStateStore routes operations between Cosmos_SS and EVM_SS.
 // Both are db_engine.StateStore; the composite itself also implements db_engine.StateStore.
 type CompositeStateStore struct {
+	compositeState
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// compositeState holds everything a reopened store hands to the store the
+// caller already holds. Rollback closes the members, rebuilds them, and adopts
+// the result in one assignment, so state added here travels with it. Anything
+// added to CompositeStateStore itself does not.
+type compositeState struct {
 	cosmosStore    types.StateStore // CosmosStateStore wrapping MVCC DB
 	evmStore       types.StateStore // EVMStateStore wrapping sub MVCC DBs (nil if disabled)
 	pruningManager *pruning.Manager
 	snapshotMgr    *snapshotCoordinator
 	config         config.StateStoreConfig
-	closeOnce      sync.Once
-	closeErr       error
+	homeDir        string
+	dbHome         string
+}
+
+// adopt takes over the members of other, which must be a freshly opened store
+// for the same home, and arms Close again for them.
+func (s *CompositeStateStore) adopt(other *CompositeStateStore) {
+	s.compositeState = other.compositeState
+	s.closeOnce = sync.Once{}
+	s.closeErr = nil
 }
 
 // NewCompositeStateStore creates a new composite state store.
@@ -49,9 +67,20 @@ func NewCompositeStateStore(
 	ssConfig config.StateStoreConfig,
 	homeDir string,
 ) (*CompositeStateStore, error) {
-	dbHome := utils.GetStateStorePath(homeDir, ssConfig.Backend)
+	dbHome := stateStoreHome(homeDir, ssConfig.Backend)
 	if ssConfig.DBDirectory != "" {
 		dbHome = ssConfig.DBDirectory
+	}
+	if err := recoverRollbackDirSwap(dbHome); err != nil {
+		return nil, fmt.Errorf("recover state store rollback directory swap: %w", err)
+	}
+	changelogPath := utils.GetChangelogPath(dbHome)
+	// Ahead of the backend, which opens its own handle on this changelog: the
+	// cut rewrites the directory, and a second handle over it would keep writing
+	// to files the cut has replaced.
+	pendingRollbackTarget, hasPendingRollback, err := completePendingRollback(changelogPath, dbHome)
+	if err != nil {
+		return nil, fmt.Errorf("complete pending state store rollback: %w", err)
 	}
 
 	mvccDB, err := backend.ResolveBackend(ssConfig.Backend)(dbHome, ssConfig)
@@ -61,10 +90,12 @@ func NewCompositeStateStore(
 	cosmosStore := cosmos.NewCosmosStateStore(mvccDB)
 	cosmosStore.SetExternalPruning(ssConfig.ExternalPruning)
 
-	cs := &CompositeStateStore{
+	cs := &CompositeStateStore{compositeState: compositeState{
 		cosmosStore: cosmosStore,
 		config:      ssConfig,
-	}
+		homeDir:     homeDir,
+		dbHome:      dbHome,
+	}}
 
 	if ssConfig.EVMSplit {
 		evmDir := ssConfig.EVMDBDirectory
@@ -96,22 +127,36 @@ func NewCompositeStateStore(
 		}
 	}
 
-	changelogPath := utils.GetChangelogPath(dbHome)
 	if err := RecoverCompositeStateStore(changelogPath, cs); err != nil {
 		_ = cs.Close()
 		return nil, fmt.Errorf("failed to recover state store: %w", err)
+	}
+	if hasPendingRollback {
+		// The watermark can sit below the target with every entry replayed: a
+		// block with no changesets writes no changelog entry, so the last entry
+		// at or below the target may name an earlier height.
+		if cs.GetLatestVersion() < pendingRollbackTarget {
+			if err := cs.SetLatestVersion(pendingRollbackTarget); err != nil {
+				_ = cs.Close()
+				return nil, fmt.Errorf("advance state store version marker to pending rollback target %d: %w",
+					pendingRollbackTarget, err)
+			}
+		}
+		if err := clearRollbackTarget(dbHome); err != nil {
+			_ = cs.Close()
+			return nil, fmt.Errorf("clear pending state store rollback marker: %w", err)
+		}
 	}
 
 	cs.validateEVMSSPostRecovery()
 
 	if ssConfig.SnapshotInterval > 0 {
-		cosmosSnapshotRoot := utils.GetStateStoreSnapshotsPath(homeDir)
-		if ssConfig.DBDirectory != "" {
-			cosmosSnapshotRoot = utils.GetStateStoreSnapshotsSiblingPath(dbHome)
-		}
+		// Shared with the rollback, which has to resolve the same root to find
+		// the snapshots this manager writes.
+		cosmosRoot := cosmosSnapshotRoot(homeDir, dbHome, ssConfig)
 		evmStore, hasEVM := cs.evmStore.(*evm.EVMStateStore)
 		var evmSnapshotRoot string
-		roots := []string{cosmosSnapshotRoot}
+		roots := []string{cosmosRoot}
 		if hasEVM {
 			evmSnapshotRoot = utils.GetStateStoreSnapshotsSiblingPath(evmStore.Dir())
 			roots = append(roots, evmSnapshotRoot)
@@ -121,7 +166,7 @@ func NewCompositeStateStore(
 		floor := sssnapshot.NewFloor(sssnapshot.NewestCommonVersion(roots))
 
 		members := make([]snapshotMember, 0, len(roots))
-		if err := cosmosStore.StartSnapshots(cosmosSnapshotRoot, []string{dbHome}, ssConfig, floor); err != nil {
+		if err := cosmosStore.StartSnapshots(cosmosRoot, []string{dbHome}, ssConfig, floor); err != nil {
 			_ = cs.Close()
 			return nil, fmt.Errorf("start Cosmos state store snapshot manager: %w", err)
 		}
@@ -712,7 +757,7 @@ func ReplayWAL(
 		return nil
 	}
 
-	startOffset, err := findReplayStartOffset(streamHandler, firstOffset, lastOffset, fromVersion)
+	startOffset, err := wal.FindFirstOffsetAfterVersion(streamHandler, firstOffset, lastOffset, fromVersion)
 	if err != nil {
 		return fmt.Errorf("failed to find replay start offset: %w", err)
 	}
@@ -734,27 +779,4 @@ func ReplayWAL(
 		}
 		return handler(entry)
 	})
-}
-
-func findReplayStartOffset(streamHandler wal.ChangelogWAL, firstOffset, lastOffset uint64, targetVersion int64) (uint64, error) {
-	lo, hi := firstOffset, lastOffset
-	result := lastOffset + 1
-
-	for lo <= hi {
-		mid := lo + (hi-lo)/2
-		entry, err := streamHandler.ReadAt(mid)
-		if err != nil {
-			return 0, fmt.Errorf("failed to read WAL at offset %d: %w", mid, err)
-		}
-		if entry.Version > targetVersion {
-			result = mid
-			if mid == firstOffset {
-				break
-			}
-			hi = mid - 1
-		} else {
-			lo = mid + 1
-		}
-	}
-	return result, nil
 }

--- a/sei-db/state_db/ss/composite/store_test.go
+++ b/sei-db/state_db/ss/composite/store_test.go
@@ -1348,7 +1348,7 @@ func TestImport_NonEvmModulesUnaffected(t *testing.T) {
 
 func TestImport_ReturnsEVMErrorWithoutBlocking(t *testing.T) {
 	expectedErr := errors.New("evm import failed")
-	store := &CompositeStateStore{
+	store := &CompositeStateStore{compositeState: compositeState{
 		cosmosStore: &mockImportStateStore{
 			importFn: func(version int64, ch <-chan types.SnapshotNode) error {
 				for range ch {
@@ -1367,7 +1367,7 @@ func TestImport_ReturnsEVMErrorWithoutBlocking(t *testing.T) {
 		config: config.StateStoreConfig{
 			EVMSplit: true,
 		},
-	}
+	}}
 
 	const nodeCount = 256
 	ch := make(chan types.SnapshotNode, nodeCount)

--- a/sei-db/state_db/ss/cosmos/store.go
+++ b/sei-db/state_db/ss/cosmos/store.go
@@ -2,6 +2,7 @@ package cosmos
 
 import (
 	"context"
+	"fmt"
 
 	dbm "github.com/tendermint/tm-db"
 
@@ -145,4 +146,22 @@ func (s *CosmosStateStore) WaitForPendingWrites() {
 	if w, ok := s.db.(types.PendingWriteWaiter); ok {
 		w.WaitForPendingWrites()
 	}
+}
+
+func (s *CosmosStateStore) PruneWALBeforeVersion(version int64) error {
+	if p, ok := s.db.(types.SnapshotWALPruner); ok {
+		return p.PruneWALBeforeVersion(version)
+	}
+	return nil
+}
+
+// WALVersionsAfter fails rather than reporting an empty changelog when the
+// engine keeps none: a caller asking what the changelog covers cannot act on
+// "nothing" and "no such thing" as the same answer.
+func (s *CosmosStateStore) WALVersionsAfter(version int64) (oldest int64, next int64, err error) {
+	r, ok := s.db.(types.SnapshotWALReader)
+	if !ok {
+		return 0, 0, fmt.Errorf("%T does not keep a changelog WAL", s.db)
+	}
+	return r.WALVersionsAfter(version)
 }

--- a/sei-db/state_db/ss/snapshot/manager.go
+++ b/sei-db/state_db/ss/snapshot/manager.go
@@ -123,6 +123,10 @@ type Manager struct {
 	lastPublished int64
 }
 
+type snapshotWALPruner interface {
+	PruneWALBeforeVersion(version int64) error
+}
+
 // Staged names a checkpoint that has been written to a staging directory but
 // has not yet been published.
 type Staged struct {
@@ -386,7 +390,11 @@ func (m *Manager) PruneSnapshots(cutLine int64) error {
 			candidates = append(candidates, v)
 		}
 	}
-	return m.removeSnapshots(candidates)
+	if err := m.removeSnapshots(candidates); err != nil {
+		return err
+	}
+	m.pruneWALToOldestSnapshot()
+	return nil
 }
 
 // removeSnapshots deletes each candidate except the current snapshot and the shared floor. Every
@@ -470,6 +478,29 @@ func (m *Manager) prune() {
 	}
 	if err := m.removeSnapshots(versions[:len(versions)-keep]); err != nil {
 		logger.Error("failed to prune state store snapshots", "store", m.name, "error", err)
+		return
+	}
+	m.pruneWALToOldestSnapshot()
+}
+
+func (m *Manager) pruneWALToOldestSnapshot() {
+	pruner, ok := m.scheduler.(snapshotWALPruner)
+	if !ok {
+		return
+	}
+	versions, err := m.Versions()
+	if err != nil {
+		logger.Error("failed to list state store snapshots for WAL pruning",
+			"store", m.name, "error", err)
+		return
+	}
+	if len(versions) == 0 {
+		return
+	}
+	oldest := versions[0]
+	if err := pruner.PruneWALBeforeVersion(oldest); err != nil {
+		logger.Error("failed to prune state store changelog WAL",
+			"store", m.name, "version", oldest, "error", err)
 	}
 }
 

--- a/sei-db/wal/changelog.go
+++ b/sei-db/wal/changelog.go
@@ -2,6 +2,7 @@ package wal
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/sei-protocol/sei-chain/sei-db/proto"
 )
@@ -23,4 +24,56 @@ func NewChangelogWAL(dir string, config Config) (ChangelogWAL, error) {
 		dir,
 		config,
 	)
+}
+
+// FindFirstOffsetAfterVersion returns the first WAL offset whose entry version is
+// strictly greater than targetVersion. If no such entry exists, it returns
+// lastOffset+1. Changelog versions are monotonic, but empty blocks can advance
+// the state-store version without writing an entry, so callers must search the
+// entry versions rather than assuming offset == version.
+func FindFirstOffsetAfterVersion(
+	stream ChangelogWAL,
+	firstOffset uint64,
+	lastOffset uint64,
+	targetVersion int64,
+) (uint64, error) {
+	lo, hi := firstOffset, lastOffset
+	result := lastOffset + 1
+
+	for lo <= hi {
+		mid := lo + (hi-lo)/2
+		entry, err := stream.ReadAt(mid)
+		if err != nil {
+			return 0, fmt.Errorf("read WAL at offset %d: %w", mid, err)
+		}
+		if entry.Version > targetVersion {
+			result = mid
+			if mid == firstOffset {
+				break
+			}
+			hi = mid - 1
+		} else {
+			lo = mid + 1
+		}
+	}
+	return result, nil
+}
+
+// FindLastOffsetAtOrBeforeVersion returns the last WAL offset whose entry
+// version is less than or equal to targetVersion. If every entry is above the
+// target, ok is false.
+func FindLastOffsetAtOrBeforeVersion(
+	stream ChangelogWAL,
+	firstOffset uint64,
+	lastOffset uint64,
+	targetVersion int64,
+) (offset uint64, ok bool, err error) {
+	firstAfter, err := FindFirstOffsetAfterVersion(stream, firstOffset, lastOffset, targetVersion)
+	if err != nil {
+		return 0, false, err
+	}
+	if firstAfter == firstOffset {
+		return 0, false, nil
+	}
+	return firstAfter - 1, true, nil
 }


### PR DESCRIPTION
## Summary

Make `seid rollback` rewind the state store with Tendermint and state-commit. The state store restores the newest retained snapshot at or below the target and replays its changelog to the exact target height. If the configured state store cannot follow, the command logs a warning and keeps the previous behavior of rolling back Tendermint and state-commit.

- `sei-db/state_db/ss/composite`: adds validation, snapshot selection, WAL replay, and a crash-resumable rollback sequence. Durable markers, directory synchronization, and restart recovery keep the snapshot, changelog, and version watermark consistent after a process crash or power loss. Rollback rejects unsupported EVM-split and non-Pebble state stores.
- `sei-cosmos/storev2/rootmulti`: validates state-store rollback before moving state-commit, then coordinates both stores through the existing rollback command.
- `sei-db/db_engine/pebbledb/mvcc` and `sei-db/state_db/ss/snapshot`: anchor changelog retention to the oldest retained snapshot while preserving the count-based recovery floor. Empty-block version gaps remain replayable.
- `sei-db/wal` and `sei-db/common/utils`: add version-aware WAL searches and durable Pebble directory cloning.
- `sei-db/db_engine/types`: defines optional rollback, rollback-validation, WAL-read, and WAL-pruning capabilities.

## Test plan

- `go build ./...`
- `go vet ./sei-db/state_db/ss/composite/... ./sei-db/db_engine/pebbledb/mvcc/... ./sei-cosmos/storev2/rootmulti/...`
- `golangci-lint run ./sei-db/state_db/ss/composite/... ./sei-db/db_engine/pebbledb/mvcc/... ./sei-cosmos/storev2/rootmulti/...`
- `go test -race -count=1 ./sei-db/state_db/ss/composite/... ./sei-db/db_engine/pebbledb/mvcc/... ./sei-cosmos/storev2/rootmulti/...`
- Covers exact-snapshot rollback, WAL replay, empty blocks, unavailable rollback support, legacy layouts, every crash-recovery step, durable marker and changelog handling, discarded-fork snapshot cleanup, and WAL retention bounds.
