### PR TITLE
Upgrade to AI review to the latest UCI v0.0.18

### DIFF
--- a/.github/workflows/ai-assist.yml
+++ b/.github/workflows/ai-assist.yml
@@ -8,8 +8,8 @@ on:
     types: [ submitted ]
 jobs:
   assistant:
-    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.17
-    uses: sei-protocol/uci/.github/workflows/ai-assistant.yml@1d50ef2bd27c695493f254c3037eb6b78f9bb85f
+    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.18
+    uses: sei-protocol/uci/.github/workflows/ai-assistant.yml@be869659dad9a0ca5b5f2da126c0b5e7fa842535
     permissions:
       contents: read
       pull-requests: write
@@ -17,6 +17,6 @@ jobs:
       id-token: write
     secrets: inherit
     with:
-      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.17
-      uci-ref: 1d50ef2bd27c695493f254c3037eb6b78f9bb85f
+      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.18
+      uci-ref: be869659dad9a0ca5b5f2da126c0b5e7fa842535
       allowed-team: 'sei-protocol/sei-core'

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -11,8 +11,8 @@ on:
 jobs:
   ai-review:
     if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
-    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.17
-    uses: sei-protocol/uci/.github/workflows/ai-review.yml@1d50ef2bd27c695493f254c3037eb6b78f9bb85f
+    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.18
+    uses: sei-protocol/uci/.github/workflows/ai-review.yml@be869659dad9a0ca5b5f2da126c0b5e7fa842535
     permissions:
       contents: read
       pull-requests: write
@@ -20,7 +20,7 @@ jobs:
       id-token: write
     secrets: inherit
     with:
-      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.17
-      uci-ref: 1d50ef2bd27c695493f254c3037eb6b78f9bb85f
+      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.18
+      uci-ref: be869659dad9a0ca5b5f2da126c0b5e7fa842535
       allowed-team: 'sei-protocol/sei-core'
       enable-cursor: false # Disabled for now since there is a dedicated Bugbot flow built into Cursor currently enabled on repo.


### PR DESCRIPTION
Most notably:
* skips `nit` comments by default unless `ai: nitpick` label is set
* reacts with emoji when explicit AI review is asked for
