### PR TITLE
fix(types): return false for coin denomination mismatches

### DIFF
--- a/giga/deps/xbank/types/msgs.go
+++ b/giga/deps/xbank/types/msgs.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"maps"
+
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
 )
@@ -83,23 +85,10 @@ func ValidateInputsOutputs(inputs []Input, outputs []Output) error {
 		addCoins(outCoinsMap, out.Coins)
 	}
 
-	totalIn := coinsFromTotals(inCoinsMap)
-	totalOut := coinsFromTotals(outCoinsMap)
-
-	// Preserve Coins.IsEqual's panic for equal-length sets with different denominations.
-	if !totalIn.IsEqual(totalOut) {
+	if !maps.EqualFunc(inCoinsMap, outCoinsMap, sdk.Int.Equal) {
 		return ErrInputOutputMismatch
 	}
 	return nil
-}
-
-// coinsFromTotals returns a sorted coin set containing the aggregated totals.
-func coinsFromTotals(coinsMap map[string]sdk.Int) sdk.Coins {
-	result := make(sdk.Coins, 0, len(coinsMap))
-	for denom, amount := range coinsMap {
-		result = append(result, sdk.NewCoin(denom, amount))
-	}
-	return result.Sort()
 }
 
 // addCoins aggregates coins by denomination.

--- a/giga/deps/xbank/types/msgs_test.go
+++ b/giga/deps/xbank/types/msgs_test.go
@@ -1,7 +1,6 @@
 package types_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -38,7 +37,7 @@ func TestValidateInputsOutputs(t *testing.T) {
 	})
 }
 
-func TestValidateInputsOutputsMismatchedDenominationsPanics(t *testing.T) {
+func TestValidateInputsOutputsRejectsMismatchedDenominations(t *testing.T) {
 	inputAddr := sdk.AccAddress([]byte("_______alice________"))
 	outputAddr := sdk.AccAddress([]byte("________bob_________"))
 
@@ -58,11 +57,7 @@ func TestValidateInputsOutputsMismatchedDenominationsPanics(t *testing.T) {
 				bank.NewOutput(outputAddr, sdk.NewCoins(sdk.NewInt64Coin(tc.outputDenom, 1))),
 			}
 
-			require.PanicsWithValue(
-				t,
-				fmt.Sprintf("invalid coin denominations; %s, %s", tc.inputDenom, tc.outputDenom),
-				func() { _ = bank.ValidateInputsOutputs(inputs, outputs) },
-			)
+			require.ErrorIs(t, bank.ValidateInputsOutputs(inputs, outputs), bank.ErrInputOutputMismatch)
 		})
 	}
 }

--- a/sei-cosmos/types/coin.go
+++ b/sei-cosmos/types/coin.go
@@ -82,13 +82,9 @@ func (coin Coin) IsLT(other Coin) bool {
 	return coin.Amount.LT(other.Amount)
 }
 
-// IsEqual returns true if the two sets of Coins have the same value
+// IsEqual returns true if both coins have the same denomination and amount.
 func (coin Coin) IsEqual(other Coin) bool {
-	if coin.Denom != other.Denom {
-		panic(fmt.Sprintf("invalid coin denominations; %s, %s", coin.Denom, other.Denom))
-	}
-
-	return coin.Amount.Equal(other.Amount)
+	return coin.Equal(other)
 }
 
 // Add adds amounts of two coins with same denom. If the coins differ in denom then
@@ -442,34 +438,34 @@ func (coins Coins) PartitionSigned() (positives Coins, negatives Coins) {
 // {2A, 3B}.Max({1B, 4C}) == {2A, 3B, 4C}
 // {1A, 2B}.Max({}) == {1A, 2B}
 func (coins Coins) Max(coinsB Coins) Coins {
-	max := make([]Coin, 0)
+	maxCoins := make([]Coin, 0)
 	indexA, indexB := 0, 0
 	for indexA < len(coins) && indexB < len(coinsB) {
 		coinA, coinB := coins[indexA], coinsB[indexB]
 		switch strings.Compare(coinA.Denom, coinB.Denom) {
 		case -1: // denom missing from coinsB
-			max = append(max, coinA)
+			maxCoins = append(maxCoins, coinA)
 			indexA++
 		case 0: // same denom in both
 			maxCoin := coinA
 			if coinB.Amount.GT(maxCoin.Amount) {
 				maxCoin = coinB
 			}
-			max = append(max, maxCoin)
+			maxCoins = append(maxCoins, maxCoin)
 			indexA++
 			indexB++
 		case 1: // denom missing from coinsA
-			max = append(max, coinB)
+			maxCoins = append(maxCoins, coinB)
 			indexB++
 		}
 	}
 	for ; indexA < len(coins); indexA++ {
-		max = append(max, coins[indexA])
+		maxCoins = append(maxCoins, coins[indexA])
 	}
 	for ; indexB < len(coinsB); indexB++ {
-		max = append(max, coinsB[indexB])
+		maxCoins = append(maxCoins, coinsB[indexB])
 	}
-	return NewCoins(max...)
+	return NewCoins(maxCoins...)
 }
 
 // Min takes two valid Coins inputs and returns a valid Coins result
@@ -490,7 +486,7 @@ func (coins Coins) Max(coinsB Coins) Coins {
 //
 // See also DecCoins.Intersect().
 func (coins Coins) Min(coinsB Coins) Coins {
-	min := make([]Coin, 0)
+	minCoins := make([]Coin, 0)
 	for indexA, indexB := 0, 0; indexA < len(coins) && indexB < len(coinsB); {
 		coinA, coinB := coins[indexA], coinsB[indexB]
 		switch strings.Compare(coinA.Denom, coinB.Denom) {
@@ -502,7 +498,7 @@ func (coins Coins) Min(coinsB Coins) Coins {
 				minCoin = coinB
 			}
 			if !minCoin.IsZero() {
-				min = append(min, minCoin)
+				minCoins = append(minCoins, minCoin)
 			}
 			indexA++
 			indexB++
@@ -510,7 +506,7 @@ func (coins Coins) Min(coinsB Coins) Coins {
 			indexB++
 		}
 	}
-	return NewCoins(min...)
+	return NewCoins(minCoins...)
 }
 
 // IsAllGT returns true if for every denom in coinsB,

--- a/sei-cosmos/types/coin.go
+++ b/sei-cosmos/types/coin.go
@@ -84,7 +84,7 @@ func (coin Coin) IsLT(other Coin) bool {
 
 // IsEqual returns true if both coins have the same denomination and amount.
 func (coin Coin) IsEqual(other Coin) bool {
-	return coin.Equal(other)
+	return coin.Denom == other.Denom && coin.Amount.Equal(other.Amount)
 }
 
 // Add adds amounts of two coins with same denom. If the coins differ in denom then
@@ -438,34 +438,34 @@ func (coins Coins) PartitionSigned() (positives Coins, negatives Coins) {
 // {2A, 3B}.Max({1B, 4C}) == {2A, 3B, 4C}
 // {1A, 2B}.Max({}) == {1A, 2B}
 func (coins Coins) Max(coinsB Coins) Coins {
-	maxCoins := make([]Coin, 0)
+	max := make([]Coin, 0)
 	indexA, indexB := 0, 0
 	for indexA < len(coins) && indexB < len(coinsB) {
 		coinA, coinB := coins[indexA], coinsB[indexB]
 		switch strings.Compare(coinA.Denom, coinB.Denom) {
 		case -1: // denom missing from coinsB
-			maxCoins = append(maxCoins, coinA)
+			max = append(max, coinA)
 			indexA++
 		case 0: // same denom in both
 			maxCoin := coinA
 			if coinB.Amount.GT(maxCoin.Amount) {
 				maxCoin = coinB
 			}
-			maxCoins = append(maxCoins, maxCoin)
+			max = append(max, maxCoin)
 			indexA++
 			indexB++
 		case 1: // denom missing from coinsA
-			maxCoins = append(maxCoins, coinB)
+			max = append(max, coinB)
 			indexB++
 		}
 	}
 	for ; indexA < len(coins); indexA++ {
-		maxCoins = append(maxCoins, coins[indexA])
+		max = append(max, coins[indexA])
 	}
 	for ; indexB < len(coinsB); indexB++ {
-		maxCoins = append(maxCoins, coinsB[indexB])
+		max = append(max, coinsB[indexB])
 	}
-	return NewCoins(maxCoins...)
+	return NewCoins(max...)
 }
 
 // Min takes two valid Coins inputs and returns a valid Coins result
@@ -486,7 +486,7 @@ func (coins Coins) Max(coinsB Coins) Coins {
 //
 // See also DecCoins.Intersect().
 func (coins Coins) Min(coinsB Coins) Coins {
-	minCoins := make([]Coin, 0)
+	min := make([]Coin, 0)
 	for indexA, indexB := 0, 0; indexA < len(coins) && indexB < len(coinsB); {
 		coinA, coinB := coins[indexA], coinsB[indexB]
 		switch strings.Compare(coinA.Denom, coinB.Denom) {
@@ -498,7 +498,7 @@ func (coins Coins) Min(coinsB Coins) Coins {
 				minCoin = coinB
 			}
 			if !minCoin.IsZero() {
-				minCoins = append(minCoins, minCoin)
+				min = append(min, minCoin)
 			}
 			indexA++
 			indexB++
@@ -506,7 +506,7 @@ func (coins Coins) Min(coinsB Coins) Coins {
 			indexB++
 		}
 	}
-	return NewCoins(minCoins...)
+	return NewCoins(min...)
 }
 
 // IsAllGT returns true if for every denom in coinsB,

--- a/sei-cosmos/types/coin_test.go
+++ b/sei-cosmos/types/coin_test.go
@@ -57,21 +57,17 @@ func (s *coinTestSuite) TestIsEqualCoin() {
 		inputOne sdk.Coin
 		inputTwo sdk.Coin
 		expected bool
-		panics   bool
 	}{
-		{sdk.NewInt64Coin(testDenom1, 1), sdk.NewInt64Coin(testDenom1, 1), true, false},
-		{sdk.NewInt64Coin(testDenom1, 1), sdk.NewInt64Coin(testDenom2, 1), false, true},
-		{sdk.NewInt64Coin("usei", 1), sdk.NewInt64Coin("usei", 10), false, false},
+		{sdk.NewInt64Coin(testDenom1, 1), sdk.NewInt64Coin(testDenom1, 1), true},
+		{sdk.NewInt64Coin(testDenom1, 1), sdk.NewInt64Coin(testDenom2, 1), false},
+		{sdk.NewInt64Coin(testDenom2, 1), sdk.NewInt64Coin(testDenom1, 1), false},
+		{sdk.NewInt64Coin("usei", 1), sdk.NewInt64Coin("usei", 10), false},
 	}
 
 	for tcIndex, tc := range cases {
-		tc := tc
-		if tc.panics {
-			s.Require().Panics(func() { tc.inputOne.IsEqual(tc.inputTwo) })
-		} else {
-			res := tc.inputOne.IsEqual(tc.inputTwo)
-			s.Require().Equal(tc.expected, res, "coin equality relation is incorrect, tc #%d", tcIndex)
-		}
+		var res bool
+		s.Require().NotPanics(func() { res = tc.inputOne.IsEqual(tc.inputTwo) }, "coin equality relation panicked, tc #%d", tcIndex)
+		s.Require().Equal(tc.expected, res, "coin equality relation is incorrect, tc #%d", tcIndex)
 	}
 }
 
@@ -407,25 +403,22 @@ func (s *coinTestSuite) TestEqualCoins() {
 		inputOne sdk.Coins
 		inputTwo sdk.Coins
 		expected bool
-		panics   bool
 	}{
-		{sdk.Coins{}, sdk.Coins{}, true, false},
-		{sdk.Coins{sdk.NewInt64Coin(testDenom1, 0)}, sdk.Coins{sdk.NewInt64Coin(testDenom1, 0)}, true, false},
-		{sdk.Coins{sdk.NewInt64Coin(testDenom1, 0), sdk.NewInt64Coin(testDenom2, 1)}, sdk.Coins{sdk.NewInt64Coin(testDenom1, 0), sdk.NewInt64Coin(testDenom2, 1)}, true, false},
-		{sdk.Coins{sdk.NewInt64Coin(testDenom1, 0)}, sdk.Coins{sdk.NewInt64Coin(testDenom2, 0)}, false, true},
-		{sdk.Coins{sdk.NewInt64Coin(testDenom1, 0)}, sdk.Coins{sdk.NewInt64Coin(testDenom1, 1)}, false, false},
-		{sdk.Coins{sdk.NewInt64Coin(testDenom1, 0)}, sdk.Coins{sdk.NewInt64Coin(testDenom1, 0), sdk.NewInt64Coin(testDenom2, 1)}, false, false},
-		{sdk.Coins{sdk.NewInt64Coin(testDenom1, 0), sdk.NewInt64Coin(testDenom2, 1)}, sdk.Coins{sdk.NewInt64Coin(testDenom1, 0), sdk.NewInt64Coin(testDenom2, 1)}, true, false},
+		{sdk.Coins{}, sdk.Coins{}, true},
+		{sdk.Coins{sdk.NewInt64Coin(testDenom1, 0)}, sdk.Coins{sdk.NewInt64Coin(testDenom1, 0)}, true},
+		{sdk.Coins{sdk.NewInt64Coin(testDenom1, 0), sdk.NewInt64Coin(testDenom2, 1)}, sdk.Coins{sdk.NewInt64Coin(testDenom1, 0), sdk.NewInt64Coin(testDenom2, 1)}, true},
+		{sdk.Coins{sdk.NewInt64Coin(testDenom1, 0)}, sdk.Coins{sdk.NewInt64Coin(testDenom2, 0)}, false},
+		{sdk.Coins{sdk.NewInt64Coin(testDenom2, 0)}, sdk.Coins{sdk.NewInt64Coin(testDenom1, 0)}, false},
+		{sdk.Coins{sdk.NewInt64Coin(testDenom1, 0), sdk.NewInt64Coin(testDenom2, 1)}, sdk.Coins{sdk.NewInt64Coin(testDenom1, 0), sdk.NewInt64Coin(testDenom3, 1)}, false},
+		{sdk.Coins{sdk.NewInt64Coin(testDenom1, 0)}, sdk.Coins{sdk.NewInt64Coin(testDenom1, 1)}, false},
+		{sdk.Coins{sdk.NewInt64Coin(testDenom1, 0)}, sdk.Coins{sdk.NewInt64Coin(testDenom1, 0), sdk.NewInt64Coin(testDenom2, 1)}, false},
+		{sdk.Coins{sdk.NewInt64Coin(testDenom1, 0), sdk.NewInt64Coin(testDenom2, 1)}, sdk.Coins{sdk.NewInt64Coin(testDenom1, 0), sdk.NewInt64Coin(testDenom2, 1)}, true},
 	}
 
 	for tcnum, tc := range cases {
-		tc := tc
-		if tc.panics {
-			s.Require().Panics(func() { tc.inputOne.IsEqual(tc.inputTwo) })
-		} else {
-			res := tc.inputOne.IsEqual(tc.inputTwo)
-			s.Require().Equal(tc.expected, res, "Equality is differed from exported. tc #%d, expected %b, actual %b.", tcnum, tc.expected, res)
-		}
+		var res bool
+		s.Require().NotPanics(func() { res = tc.inputOne.IsEqual(tc.inputTwo) }, "coin set equality relation panicked, tc #%d", tcnum)
+		s.Require().Equal(tc.expected, res, "Equality is differed from exported. tc #%d, expected %b, actual %b.", tcnum, tc.expected, res)
 	}
 }
 
@@ -677,10 +670,10 @@ func (s *coinTestSuite) TestMinMax() {
 	}
 
 	for _, tc := range cases {
-		min := tc.input1.Min(tc.input2)
-		max := tc.input1.Max(tc.input2)
-		s.Require().True(min.IsEqual(tc.min), tc.name)
-		s.Require().True(max.IsEqual(tc.max), tc.name)
+		tcMin := tc.input1.Min(tc.input2)
+		tcMax := tc.input1.Max(tc.input2)
+		s.Require().True(tcMin.IsEqual(tc.min), tc.name)
+		s.Require().True(tcMax.IsEqual(tc.max), tc.name)
 	}
 }
 

--- a/sei-cosmos/types/dec_coin.go
+++ b/sei-cosmos/types/dec_coin.go
@@ -78,13 +78,9 @@ func (coin DecCoin) IsLT(other DecCoin) bool {
 	return coin.Amount.LT(other.Amount)
 }
 
-// IsEqual returns true if the two sets of Coins have the same value.
+// IsEqual returns true if both decimal coins have the same denomination and amount.
 func (coin DecCoin) IsEqual(other DecCoin) bool {
-	if coin.Denom != other.Denom {
-		panic(fmt.Sprintf("invalid coin denominations; %s, %s", coin.Denom, other.Denom))
-	}
-
-	return coin.Amount.Equal(other.Amount)
+	return coin.Equal(other)
 }
 
 // Add adds amounts of two decimal coins with same denom.

--- a/sei-cosmos/types/dec_coin.go
+++ b/sei-cosmos/types/dec_coin.go
@@ -80,7 +80,7 @@ func (coin DecCoin) IsLT(other DecCoin) bool {
 
 // IsEqual returns true if both decimal coins have the same denomination and amount.
 func (coin DecCoin) IsEqual(other DecCoin) bool {
-	return coin.Equal(other)
+	return coin.Denom == other.Denom && coin.Amount.Equal(other.Amount)
 }
 
 // Add adds amounts of two decimal coins with same denom.

--- a/sei-cosmos/types/dec_coin_test.go
+++ b/sei-cosmos/types/dec_coin_test.go
@@ -82,6 +82,48 @@ func (s *decCoinTestSuite) TestDecCoinIsPositive() {
 	s.Require().False(dc.IsPositive())
 }
 
+func (s *decCoinTestSuite) TestDecCoinIsEqual() {
+	testCases := []struct {
+		inputOne sdk.DecCoin
+		inputTwo sdk.DecCoin
+		expected bool
+	}{
+		{sdk.NewInt64DecCoin(testDenom1, 1), sdk.NewInt64DecCoin(testDenom1, 1), true},
+		{sdk.NewInt64DecCoin(testDenom1, 1), sdk.NewInt64DecCoin(testDenom2, 1), false},
+		{sdk.NewInt64DecCoin(testDenom2, 1), sdk.NewInt64DecCoin(testDenom1, 1), false},
+		{sdk.NewInt64DecCoin(testDenom1, 1), sdk.NewInt64DecCoin(testDenom1, 2), false},
+	}
+
+	for i, tc := range testCases {
+		var equal bool
+		s.Require().NotPanics(func() { equal = tc.inputOne.IsEqual(tc.inputTwo) }, "decimal coin equality panicked, tc #%d", i)
+		s.Require().Equal(tc.expected, equal, "decimal coin equality is incorrect, tc #%d", i)
+	}
+}
+
+func (s *decCoinTestSuite) TestDecCoinsIsEqual() {
+	testCases := []struct {
+		inputOne sdk.DecCoins
+		inputTwo sdk.DecCoins
+		expected bool
+	}{
+		{sdk.DecCoins{}, sdk.DecCoins{}, true},
+		{sdk.DecCoins{sdk.NewInt64DecCoin(testDenom1, 1)}, sdk.DecCoins{sdk.NewInt64DecCoin(testDenom2, 1)}, false},
+		{sdk.DecCoins{sdk.NewInt64DecCoin(testDenom2, 1)}, sdk.DecCoins{sdk.NewInt64DecCoin(testDenom1, 1)}, false},
+		{
+			sdk.DecCoins{sdk.NewInt64DecCoin(testDenom1, 1), sdk.NewInt64DecCoin(testDenom2, 1)},
+			sdk.DecCoins{sdk.NewInt64DecCoin(testDenom1, 1), sdk.NewInt64DecCoin(testDenom3, 1)},
+			false,
+		},
+	}
+
+	for i, tc := range testCases {
+		var equal bool
+		s.Require().NotPanics(func() { equal = tc.inputOne.IsEqual(tc.inputTwo) }, "decimal coin set equality panicked, tc #%d", i)
+		s.Require().Equal(tc.expected, equal, "decimal coin set equality is incorrect, tc #%d", i)
+	}
+}
+
 func (s *decCoinTestSuite) TestAddDecCoin() {
 	decCoinA1 := sdk.NewDecCoinFromDec(testDenom1, sdk.NewDecWithPrec(11, 1))
 	decCoinA2 := sdk.NewDecCoinFromDec(testDenom1, sdk.NewDecWithPrec(22, 1))

--- a/sei-cosmos/x/bank/types/msgs.go
+++ b/sei-cosmos/x/bank/types/msgs.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"maps"
+
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
 )
@@ -183,23 +185,10 @@ func ValidateInputsOutputs(inputs []Input, outputs []Output) error {
 		addCoins(outCoinsMap, out.Coins)
 	}
 
-	totalIn := coinsFromTotals(inCoinsMap)
-	totalOut := coinsFromTotals(outCoinsMap)
-
-	// Preserve Coins.IsEqual's panic for equal-length sets with different denominations.
-	if !totalIn.IsEqual(totalOut) {
+	if !maps.EqualFunc(inCoinsMap, outCoinsMap, sdk.Int.Equal) {
 		return ErrInputOutputMismatch
 	}
 	return nil
-}
-
-// coinsFromTotals returns a sorted coin set containing the aggregated totals.
-func coinsFromTotals(coinsMap map[string]sdk.Int) sdk.Coins {
-	result := make(sdk.Coins, 0, len(coinsMap))
-	for denom, amount := range coinsMap {
-		result = append(result, sdk.NewCoin(denom, amount))
-	}
-	return result.Sort()
 }
 
 // addCoins aggregates coins by denomination.

--- a/sei-cosmos/x/bank/types/msgs_test.go
+++ b/sei-cosmos/x/bank/types/msgs_test.go
@@ -274,7 +274,7 @@ func TestValidateInputsOutputsUniqueDenominations(t *testing.T) {
 	})
 }
 
-func TestValidateInputsOutputsMismatchedDenominationsPanics(t *testing.T) {
+func TestValidateInputsOutputsRejectsMismatchedDenominations(t *testing.T) {
 	inputAddr := sdk.AccAddress([]byte("_______alice________"))
 	outputAddr := sdk.AccAddress([]byte("________bob_________"))
 
@@ -290,11 +290,7 @@ func TestValidateInputsOutputsMismatchedDenominationsPanics(t *testing.T) {
 			inputs := []Input{NewInput(inputAddr, sdk.NewCoins(sdk.NewInt64Coin(tc.inputDenom, 1)))}
 			outputs := []Output{NewOutput(outputAddr, sdk.NewCoins(sdk.NewInt64Coin(tc.outputDenom, 1)))}
 
-			require.PanicsWithValue(
-				t,
-				fmt.Sprintf("invalid coin denominations; %s, %s", tc.inputDenom, tc.outputDenom),
-				func() { _ = ValidateInputsOutputs(inputs, outputs) },
-			)
+			require.ErrorIs(t, ValidateInputsOutputs(inputs, outputs), ErrInputOutputMismatch)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Coin.IsEqual currently panics when the denominations differ. That panic flows through Coins.IsEqual and can cause bank multisend validation to panic instead of returning ErrInputOutputMismatch.

This change makes Coin.IsEqual return false for different denominations. Coins.IsEqual continues to delegate to Coin.IsEqual, so the corrected behavior flows through all callers.

Coin.IsLT and Coin.IsGTE are unchanged.

This is intentionally app-hash-breaking and must be coordinated with a network upgrade.

Stacked on #3955 and intended to be rebased onto main after that PR merges.

This reverses the low end speed regression of 5% to a 1-10% speedup.

## Testing

go test -race ./sei-cosmos/types ./sei-cosmos/x/bank/types ./giga/deps/xbank/types