### PR TITLE
[ConfigManager] Install resolved configuration into the boot source

### DIFF
--- a/config/appopts/appopts.go
+++ b/config/appopts/appopts.go
@@ -49,6 +49,9 @@ func Install(target *viper.Viper, resolved registry.Resolved) (Report, error) {
 	// Enumerated once and handed to both the refusal and the report, so the two cannot disagree about
 	// what the source carries.
 	enumerated := enumerate(target)
+	if err := refuseNotLowerCase(resolved); err != nil {
+		return Report{}, err
+	}
 	if err := refuseUnwritable(target, resolved, enumerated); err != nil {
 		return Report{}, err
 	}
@@ -73,6 +76,33 @@ func enumerate(target *viper.Viper) map[string]bool {
 		out[key] = true
 	}
 	return out
+}
+
+// refuseNotLowerCase rejects a declared key the source would store under a different name.
+//
+// A source lower-cases a key on the way in, so a key that is not already lower case is written and read
+// under a name that is not the one declared. Two consequences, and the first is the reason this runs
+// before anything else here: a comparison against another key or against what the source enumerates
+// misses a match that the source itself would make, so the refusal below cannot see the collision and
+// both values land on one path. The second is that the report counts one key twice, once as installed
+// under the declared spelling and once as untouched under the stored one.
+//
+// Refused rather than folded, because folding accepts a key the registry refuses at both of its own
+// doors and then quietly writes a different one.
+func refuseNotLowerCase(resolved registry.Resolved) error {
+	var wrong []string
+	for key := range resolved.Values {
+		if key != strings.ToLower(key) {
+			wrong = append(wrong, key)
+		}
+	}
+	if len(wrong) == 0 {
+		return nil
+	}
+	sort.Strings(wrong)
+	return fmt.Errorf("these declared keys are not lower case, and a configuration source stores a key "+
+		"lower-cased, so each would be written and read under a name nothing declares: %s",
+		strings.Join(wrong, ", "))
 }
 
 // dottedPrefixes returns every path a key nests under, outermost first.

--- a/config/appopts/appopts.go
+++ b/config/appopts/appopts.go
@@ -49,10 +49,7 @@ func Install(target *viper.Viper, resolved registry.Resolved) (Report, error) {
 	// Enumerated once and handed to both the refusal and the report, so the two cannot disagree about
 	// what the source carries.
 	enumerated := enumerate(target)
-	if err := refuseColliding(resolved); err != nil {
-		return Report{}, err
-	}
-	if err := refuseShadowing(target, resolved, enumerated); err != nil {
+	if err := refuseUnwritable(target, resolved, enumerated); err != nil {
 		return Report{}, err
 	}
 
@@ -94,65 +91,49 @@ func dottedPrefixes(key string) []string {
 	return out
 }
 
-// refuseColliding rejects two declared keys where one names a path the other nests under.
+// refuseUnwritable rejects a key that cannot be written without making another key unreadable.
 //
-// A source holds a value at a path, so writing a.b turns a into a table and destroys whatever a held,
-// and writing a afterwards destroys the table. Neither order keeps both, and which one survives is
-// decided by map iteration order.
-func refuseColliding(resolved registry.Resolved) error {
-	var collisions []string
-	for key := range resolved.Values {
-		for _, under := range dottedPrefixes(key) {
-			if _, declared := resolved.Values[under]; declared {
-				collisions = append(collisions, under+" and "+key)
-			}
-		}
-	}
-	if len(collisions) == 0 {
-		return nil
-	}
-	sort.Strings(collisions)
-	return fmt.Errorf("these declared key pairs cannot both be installed, because one names a path the "+
-		"other nests under and whichever is written second destroys the first: %s",
-		strings.Join(collisions, ", "))
-}
-
-// refuseShadowing rejects a declared key that cannot be written without making another key unreadable.
+// The source holds one value per path, so two keys cannot both occupy one. Writing a.b turns a into a
+// table and destroys whatever a held; writing a afterwards destroys the table. Neither order keeps both,
+// and which one survives is decided by map iteration order.
 //
-// The source holds one value per path, so a declared key and a key nobody declared cannot both occupy
-// one. Installing anyway costs the undeclared value silently: the shorter path answers with a table
-// instead of what an operator wrote, or the longer one answers with nothing, and a reader of either gets
-// a zero rather than an error. That is the value this package exists to leave alone.
-//
-// Refused rather than skipped. Skipping the declared key leaves a section half migrated and a key whose
-// answer depends on which of two readers a caller asked, where refusing names the two keys and stops.
-func refuseShadowing(target *viper.Viper, resolved registry.Resolved, enumerated map[string]bool) error {
+// The cost falls on whichever key is not declared: the shorter path answers with a table instead of what
+// an operator wrote, or the longer one answers with nothing, and a reader of either gets a zero rather
+// than an error. That is the value this package exists to leave alone, so this refuses rather than
+// choosing. Skipping the declared key instead would leave a section half migrated and a key whose answer
+// depends on which of two readers a caller asked.
+func refuseUnwritable(target *viper.Viper, resolved registry.Resolved, enumerated map[string]bool) error {
 	var lost []string
-	note := func(declared, undeclared string) {
-		lost = append(lost, fmt.Sprintf("%q is declared and %q is not", declared, undeclared))
+	// Each pair says which of the two nobody declared, because that decides the remedy: an operator can
+	// rename their own key, and only a release can change what a section declares.
+	note := func(outer, inner string, bothDeclared bool) {
+		if bothDeclared {
+			lost = append(lost, fmt.Sprintf("%q and %q, both declared", outer, inner))
+			return
+		}
+		lost = append(lost, fmt.Sprintf("%q declared and %q not", outer, inner))
 	}
 
-	// A declared key under a path the source already answers with a value of its own. Writing it puts a
-	// table where that value was.
+	// A declared key nesting under a path something already occupies, whether that is another declared
+	// key or a value the source answers with.
 	for key := range resolved.Values {
 		for _, under := range dottedPrefixes(key) {
 			if _, declared := resolved.Values[under]; declared {
-				continue // refuseColliding names this pair
-			}
-			if holdsAValue(target, under) {
-				note(key, under)
+				note(under, key, true)
+			} else if holdsAValue(target, under) {
+				note(key, under, false)
 			}
 		}
 	}
-	// A key the source enumerates that nests under a declared key. The declared value shadows it, and a
-	// read of it stops before the source consults the layer it came from.
+	// A key the source enumerates nesting under a declared key. The declared value shadows it, and a read
+	// of it stops before the source consults the layer it came from.
 	for key := range enumerated {
 		if _, declared := resolved.Values[key]; declared {
 			continue
 		}
 		for _, under := range dottedPrefixes(key) {
 			if _, declared := resolved.Values[under]; declared {
-				note(under, key)
+				note(under, key, false)
 			}
 		}
 	}
@@ -160,10 +141,9 @@ func refuseShadowing(target *viper.Viper, resolved registry.Resolved, enumerated
 		return nil
 	}
 	sort.Strings(lost)
-	return fmt.Errorf("this configuration cannot be installed without losing a value nobody declared, "+
-		"and no order of writes keeps both: %s. A source holds one value per path, so the two keys "+
-		"cannot both occupy theirs. Either rename the undeclared key, or run a release whose sections "+
-		"do not declare over it", strings.Join(lost, "; "))
+	return fmt.Errorf("these key pairs cannot both be installed, because one names a path the other "+
+		"nests under and the source holds one value per path: %s. An undeclared key is an operator's to "+
+		"rename; a declared one changes only in a release", strings.Join(lost, ", "))
 }
 
 // holdsAValue reports whether target answers for key with something other than a table.

--- a/config/appopts/appopts.go
+++ b/config/appopts/appopts.go
@@ -46,61 +46,145 @@ func Install(target *viper.Viper, resolved registry.Resolved) (Report, error) {
 	if target == nil {
 		return Report{}, fmt.Errorf("no configuration source to install into")
 	}
+	// Enumerated once and handed to both the refusal and the report, so the two cannot disagree about
+	// what the source carries.
+	enumerated := enumerate(target)
 	if err := refuseColliding(resolved); err != nil {
+		return Report{}, err
+	}
+	if err := refuseShadowing(target, resolved, enumerated); err != nil {
 		return Report{}, err
 	}
 
 	// Described before anything is written, because installing makes every declared key enumerable and
 	// Added is the set that was not. Taken afterwards it is always empty.
-	report := describe(target, resolved)
+	report := describe(resolved, enumerated)
 	for key, value := range resolved.Values {
 		target.Set(key, value)
 	}
 	return report, nil
 }
 
-// refuseColliding rejects two declared keys where one names a prefix of the other.
+// enumerate returns the keys the source lists.
 //
-// A source holds a key's value at a path, so writing a.b turns a into a table and destroys whatever a
-// held, and writing a afterwards destroys the table. Either order loses a value, so there is no order
-// this can be installed in. Refused here rather than at registration because it is a property of how
-// this source stores a key, not of whether the key space is coherent.
-func refuseColliding(resolved registry.Resolved) error {
-	keys := make([]string, 0, len(resolved.Values))
-	for key := range resolved.Values {
-		keys = append(keys, key)
+// A source lower-cases a key on the way in, so what it enumerates is already lower case and a declared
+// key is too. The two compare directly.
+func enumerate(target *viper.Viper) map[string]bool {
+	keys := target.AllKeys()
+	out := make(map[string]bool, len(keys))
+	for _, key := range keys {
+		out[key] = true
 	}
-	sort.Strings(keys)
+	return out
+}
 
-	var collisions []string
-	for i, key := range keys {
-		// Sorted, so any key with this one as a prefix follows it directly and the scan stops at the
-		// first that does not.
-		for j := i + 1; j < len(keys); j++ {
-			if !strings.HasPrefix(keys[j], key+".") {
-				break
-			}
-			collisions = append(collisions, key+" and "+keys[j])
+// dottedPrefixes returns every path a key nests under, outermost first.
+//
+// Derived from the key rather than found among its neighbours. A sorted scan looking for the keys under
+// one of them has to assume they follow it directly, and they do not: a hyphen sorts before a dot, so a
+// hyphenated sibling sits between a key and its children. This key space separates words with hyphens,
+// and grpc-web.address already sits between grpc and grpc.enable.
+func dottedPrefixes(key string) []string {
+	var out []string
+	for i := range key {
+		if key[i] == '.' {
+			out = append(out, key[:i])
 		}
 	}
-	if len(collisions) > 0 {
-		return fmt.Errorf("these declared key pairs cannot both be installed, because one is a prefix "+
-			"of the other and whichever is written second destroys the first: %s",
-			strings.Join(collisions, ", "))
+	return out
+}
+
+// refuseColliding rejects two declared keys where one names a path the other nests under.
+//
+// A source holds a value at a path, so writing a.b turns a into a table and destroys whatever a held,
+// and writing a afterwards destroys the table. Neither order keeps both, and which one survives is
+// decided by map iteration order.
+func refuseColliding(resolved registry.Resolved) error {
+	var collisions []string
+	for key := range resolved.Values {
+		for _, under := range dottedPrefixes(key) {
+			if _, declared := resolved.Values[under]; declared {
+				collisions = append(collisions, under+" and "+key)
+			}
+		}
 	}
-	return nil
+	if len(collisions) == 0 {
+		return nil
+	}
+	sort.Strings(collisions)
+	return fmt.Errorf("these declared key pairs cannot both be installed, because one names a path the "+
+		"other nests under and whichever is written second destroys the first: %s",
+		strings.Join(collisions, ", "))
+}
+
+// refuseShadowing rejects a declared key that cannot be written without making another key unreadable.
+//
+// The source holds one value per path, so a declared key and a key nobody declared cannot both occupy
+// one. Installing anyway costs the undeclared value silently: the shorter path answers with a table
+// instead of what an operator wrote, or the longer one answers with nothing, and a reader of either gets
+// a zero rather than an error. That is the value this package exists to leave alone.
+//
+// Refused rather than skipped. Skipping the declared key leaves a section half migrated and a key whose
+// answer depends on which of two readers a caller asked, where refusing names the two keys and stops.
+func refuseShadowing(target *viper.Viper, resolved registry.Resolved, enumerated map[string]bool) error {
+	var lost []string
+	note := func(declared, undeclared string) {
+		lost = append(lost, fmt.Sprintf("%q is declared and %q is not", declared, undeclared))
+	}
+
+	// A declared key under a path the source already answers with a value of its own. Writing it puts a
+	// table where that value was.
+	for key := range resolved.Values {
+		for _, under := range dottedPrefixes(key) {
+			if _, declared := resolved.Values[under]; declared {
+				continue // refuseColliding names this pair
+			}
+			if holdsAValue(target, under) {
+				note(key, under)
+			}
+		}
+	}
+	// A key the source enumerates that nests under a declared key. The declared value shadows it, and a
+	// read of it stops before the source consults the layer it came from.
+	for key := range enumerated {
+		if _, declared := resolved.Values[key]; declared {
+			continue
+		}
+		for _, under := range dottedPrefixes(key) {
+			if _, declared := resolved.Values[under]; declared {
+				note(under, key)
+			}
+		}
+	}
+	if len(lost) == 0 {
+		return nil
+	}
+	sort.Strings(lost)
+	return fmt.Errorf("this configuration cannot be installed without losing a value nobody declared, "+
+		"and no order of writes keeps both: %s. A source holds one value per path, so the two keys "+
+		"cannot both occupy theirs. Either rename the undeclared key, or run a release whose sections "+
+		"do not declare over it", strings.Join(lost, "; "))
+}
+
+// holdsAValue reports whether target answers for key with something other than a table.
+//
+// Asked of the source rather than of what it enumerates, because a value delivered through the
+// environment is answerable and unlistable. IsSet rather than a nil check on Get, because a bound flag
+// nobody set still answers with its default and refusing over one would be a false alarm.
+func holdsAValue(target *viper.Viper, key string) bool {
+	if !target.IsSet(key) {
+		return false
+	}
+	switch target.Get(key).(type) {
+	case map[string]any, map[any]any:
+		return false
+	default:
+		return true
+	}
 }
 
 // describe sorts the keys of target and resolved into the three populations a Report names.
-func describe(target *viper.Viper, resolved registry.Resolved) Report {
-	// A source lower-cases a key on the way in, so what it enumerates is already lower case and a declared
-	// key is too. The two compare directly.
-	keys := target.AllKeys()
-	enumerated := make(map[string]bool, len(keys))
-	for _, key := range keys {
-		enumerated[key] = true
-	}
-
+func describe(resolved registry.Resolved, enumerated map[string]bool) Report {
 	var report Report
 	for key := range resolved.Values {
 		report.Installed = append(report.Installed, key)

--- a/config/appopts/appopts.go
+++ b/config/appopts/appopts.go
@@ -1,0 +1,121 @@
+// Package appopts installs resolved configuration into the source a booting node reads.
+//
+// It layers rather than replaces. A key a section declares is written at override precedence, so the
+// registry's answer wins over the file, the environment and any flag, and no resolution runs when the
+// node reads it. Every other key is left exactly as it was, answered by the machinery that answers it
+// today.
+//
+// Layering is what makes the migration possible at all. A key's value can only be resolved ahead of the
+// read if its name is known, and a name is known only once a section declares it: an environment cannot
+// be enumerated for a prefix, so a value delivered that way under a key nothing declares is readable and
+// unlistable at the same time. Building a fresh source from an enumeration would drop exactly those
+// values and replace an operator's setting with a code default. Leaving them alone cannot, because the
+// code that answers them is unchanged.
+//
+// The two halves partition the problem rather than overlapping. Declared keys are resolvable because
+// their names are known; undeclared keys are delegated because theirs are not. The delegated half shrinks
+// as sections are declared, and when the last one lands the source carries a resolved value for every
+// key.
+package appopts
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/viper"
+
+	"github.com/sei-protocol/sei-chain/config/registry"
+)
+
+// Report says where each key in the resulting configuration comes from.
+type Report struct {
+	// Installed are the declared keys written at override precedence, sorted. The registry answers for
+	// these.
+	Installed []string
+	// Passthrough are keys the source enumerates that no section declares, sorted. These still read as
+	// they always have, and they are the migration that remains.
+	Passthrough []string
+	// Added are declared keys the source did not enumerate, sorted. A node reads these for the first
+	// time from the registry.
+	Added []string
+}
+
+// Install writes every resolved value into target at override precedence and reports what it found.
+func Install(target *viper.Viper, resolved registry.Resolved) (Report, error) {
+	if target == nil {
+		return Report{}, fmt.Errorf("no configuration source to install into")
+	}
+	if err := refuseColliding(resolved); err != nil {
+		return Report{}, err
+	}
+
+	// Described before anything is written, because installing makes every declared key enumerable and
+	// Added is the set that was not. Taken afterwards it is always empty.
+	report := describe(target, resolved)
+	for key, value := range resolved.Values {
+		target.Set(key, value)
+	}
+	return report, nil
+}
+
+// refuseColliding rejects two declared keys where one names a prefix of the other.
+//
+// A source holds a key's value at a path, so writing a.b turns a into a table and destroys whatever a
+// held, and writing a afterwards destroys the table. Either order loses a value, so there is no order
+// this can be installed in. Refused here rather than at registration because it is a property of how
+// this source stores a key, not of whether the key space is coherent.
+func refuseColliding(resolved registry.Resolved) error {
+	keys := make([]string, 0, len(resolved.Values))
+	for key := range resolved.Values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var collisions []string
+	for i, key := range keys {
+		// Sorted, so any key with this one as a prefix follows it directly and the scan stops at the
+		// first that does not.
+		for j := i + 1; j < len(keys); j++ {
+			if !strings.HasPrefix(keys[j], key+".") {
+				break
+			}
+			collisions = append(collisions, key+" and "+keys[j])
+		}
+	}
+	if len(collisions) > 0 {
+		return fmt.Errorf("these declared key pairs cannot both be installed, because one is a prefix "+
+			"of the other and whichever is written second destroys the first: %s",
+			strings.Join(collisions, ", "))
+	}
+	return nil
+}
+
+// describe sorts the keys of target and resolved into the three populations a Report names.
+func describe(target *viper.Viper, resolved registry.Resolved) Report {
+	// A source lower-cases a key on the way in, so what it enumerates is already lower case and a declared
+	// key is too. The two compare directly.
+	keys := target.AllKeys()
+	enumerated := make(map[string]bool, len(keys))
+	for _, key := range keys {
+		enumerated[key] = true
+	}
+
+	var report Report
+	for key := range resolved.Values {
+		report.Installed = append(report.Installed, key)
+		if !enumerated[key] {
+			report.Added = append(report.Added, key)
+		}
+	}
+	for key := range enumerated {
+		if _, declared := resolved.Values[key]; !declared {
+			report.Passthrough = append(report.Passthrough, key)
+		}
+	}
+
+	sort.Strings(report.Installed)
+	sort.Strings(report.Passthrough)
+	sort.Strings(report.Added)
+	return report
+}

--- a/config/appopts/appopts_test.go
+++ b/config/appopts/appopts_test.go
@@ -261,6 +261,17 @@ func TestACollidingDeclaredPairIsRefused(t *testing.T) {
 			t.Errorf("the refusal does not name %q: %v", want, err)
 		}
 	}
+	// Two levels up, not one. Every path a key nests under has to be asked about, not only its parent:
+	// a.b.c nests under a as well as under a.b.
+	registry.Reset()
+	distant := registry.Resolved{Values: map[string]any{"a": 1, "a.b.c": 2}}
+	err = nil
+	if _, err = appopts.Install(bootLike(t, "TESTBOOT", nil), distant); err == nil {
+		t.Error("a and a.b.c were installed together, and a is two segments above a.b.c rather than one")
+	} else if !strings.Contains(err.Error(), `"a"`) {
+		t.Errorf("the refusal reads %q and does not name the outer key", err)
+	}
+
 	// Sharing a leading string is not a collision, or ordinary key spaces would fail.
 	fine := registry.Resolved{Values: map[string]any{"a.b": 1, "a.bc": 2, "a.b_c": 3}}
 	if _, err := appopts.Install(bootLike(t, "TESTBOOT", nil), fine); err != nil {

--- a/config/appopts/appopts_test.go
+++ b/config/appopts/appopts_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"github.com/sei-protocol/sei-chain/config/appopts"
@@ -322,3 +323,135 @@ func TestTheResultIsStillWhatAppNewTakes(t *testing.T) {
 // reflect.DeepEqual rather than a comparison written here, for the same reason: == panics on a slice
 // instead of returning false, so enumerating slice types by hand is wrong as soon as one is missed.
 func sameRead(a, b any) bool { return reflect.DeepEqual(a, b) }
+
+// TestAHyphenatedSiblingDoesNotHideACollision covers the shape a sorted scan misses.
+//
+// A collision was found by walking a sorted key list and stopping at the first key that was not a child.
+// A hyphen sorts before a dot, so a hyphenated sibling sits between a key and its children and ends the
+// walk early. This key space separates words with hyphens, and grpc-web.address already sits between grpc
+// and grpc.enable, so the shape is not hypothetical.
+func TestAHyphenatedSiblingDoesNotHideACollision(t *testing.T) {
+	// Every separator that sorts before a dot ends a sorted walk early; the ones after it do not, which is
+	// why a scan looked correct. The rule is stated by the class rather than by one member.
+	for _, sep := range []string{"-", "!", "+", "$", "_", "0", "/"} {
+		t.Run("sibling separated by "+sep, func(t *testing.T) {
+			registry.Reset()
+			colliding := registry.Resolved{Values: map[string]any{
+				"foo.bar": 1, "foo.bar" + sep + "x": 2, "foo.bar.baz": 3,
+			}}
+			_, err := appopts.Install(bootLike(t, "TESTBOOT", nil), colliding)
+			if err == nil {
+				t.Fatalf("foo.bar and foo.bar.baz were installed with a %q sibling between them. One of "+
+					"the two values is gone and which one depends on iteration order", sep)
+			}
+			for _, want := range []string{"foo.bar", "foo.bar.baz"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("the refusal reads %q and does not name %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+// TestADeclaredKeyIsRefusedRatherThanShadowingAnUndeclaredOne is the property the package exists for.
+//
+// A source holds one value per path. So a declared key and an undeclared key cannot both occupy one, and
+// installing anyway costs the undeclared value with nothing reported: the shorter path answers with a
+// table instead of what an operator wrote, or the longer one answers with nothing. Either way a reader
+// gets a zero and no error.
+func TestADeclaredKeyIsRefusedRatherThanShadowingAnUndeclaredOne(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		file     map[string]any
+		declared map[string]any
+		read     string
+	}{
+		{
+			"a declared key nests under an undeclared value",
+			map[string]any{"giga_executor": "on"},
+			map[string]any{"giga_executor.enabled": true},
+			"giga_executor",
+		},
+		{
+			"an undeclared key nests under a declared value",
+			map[string]any{"giga_executor.enabled": true},
+			map[string]any{"giga_executor": "on"},
+			"giga_executor.enabled",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			registry.Reset()
+			target := bootLike(t, "TESTBOOT", tc.file)
+			before := target.Get(tc.read)
+
+			_, err := appopts.Install(target, registry.Resolved{Values: tc.declared})
+			if err == nil {
+				t.Fatalf("the install was accepted and %s now reads %#v where it read %#v. Nothing "+
+					"reports the loss and a reader gets a zero", tc.read, target.Get(tc.read), before)
+			}
+			if got := target.Get(tc.read); !sameRead(got, before) {
+				t.Errorf("%s reads %#v after a refused install, want the %#v it read before",
+					tc.read, got, before)
+			}
+			if !strings.Contains(err.Error(), tc.read) {
+				t.Errorf("the refusal reads %q and does not name the key that would be lost, %q",
+					err, tc.read)
+			}
+		})
+	}
+}
+
+// TestAValueDeliveredOnlyByTheEnvironmentIsStillSeen covers the layer a key list cannot reach.
+//
+// A source answers for an environment value without listing it, so a check written against what the
+// source enumerates misses an undeclared value delivered that way. Asking the source itself does not.
+func TestAValueDeliveredOnlyByTheEnvironmentIsStillSeen(t *testing.T) {
+	registry.Reset()
+	t.Setenv("TESTBOOT_GIGA_EXECUTOR", "on")
+	target := bootLike(t, "TESTBOOT", nil)
+	if !target.IsSet("giga_executor") {
+		t.Skip("this source does not answer for the environment value, so there is nothing to shadow")
+	}
+
+	_, err := appopts.Install(target, registry.Resolved{Values: map[string]any{"giga_executor.enabled": true}})
+	if err == nil {
+		t.Fatal("a declared key was installed over a value the environment supplied. The source answers " +
+			"for it and does not list it, so nothing downstream reports the loss")
+	}
+}
+
+// TestATableAtAnAncestorIsNotACollision keeps the refusal from rejecting every nested section.
+//
+// A declared key nests under the table its own section makes. That is the ordinary shape of every section
+// in the tree, so a check that treated an ancestor holding a table as a conflict would refuse all of them.
+func TestATableAtAnAncestorIsNotACollision(t *testing.T) {
+	registry.Reset()
+	target := bootLike(t, "TESTBOOT", map[string]any{"state-commit.buffer": 100})
+
+	declared := registry.Resolved{Values: map[string]any{"state-commit.flatkv.enable": true}}
+	if _, err := appopts.Install(target, declared); err != nil {
+		t.Fatalf("a declared key under a section that already holds other keys was refused: %v", err)
+	}
+	if got := target.Get("state-commit.buffer"); !sameRead(got, 100) {
+		t.Errorf("state-commit.buffer reads %#v, want the 100 it read before", got)
+	}
+}
+
+// TestAnUnsetBoundFlagAtAnAncestorIsNotACollision keeps a default from reading as an operator's value.
+//
+// A bound flag nobody set still answers with its default, so a nil check on the read would treat every
+// such flag as a value to protect and refuse a boot over one.
+func TestAnUnsetBoundFlagAtAnAncestorIsNotACollision(t *testing.T) {
+	registry.Reset()
+	target := bootLike(t, "TESTBOOT", nil)
+	flags := pflag.NewFlagSet("probe", pflag.ContinueOnError)
+	flags.String("state-commit", "a default nobody set", "")
+	if err := target.BindPFlag("state-commit", flags.Lookup("state-commit")); err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+
+	declared := registry.Resolved{Values: map[string]any{"state-commit.buffer": 100}}
+	if _, err := appopts.Install(target, declared); err != nil {
+		t.Fatalf("a declared key was refused over a flag default nobody set: %v", err)
+	}
+}

--- a/config/appopts/appopts_test.go
+++ b/config/appopts/appopts_test.go
@@ -421,7 +421,7 @@ func TestAValueDeliveredOnlyByTheEnvironmentIsStillSeen(t *testing.T) {
 	t.Setenv("TESTBOOT_GIGA_EXECUTOR", "on")
 	target := bootLike(t, "TESTBOOT", nil)
 	if !target.IsSet("giga_executor") {
-		t.Skip("this source does not answer for the environment value, so there is nothing to shadow")
+		t.Fatal("the source does not answer for the environment value, so this test measures nothing")
 	}
 
 	_, err := appopts.Install(target, registry.Resolved{Values: map[string]any{"giga_executor.enabled": true}})
@@ -464,5 +464,35 @@ func TestAnUnsetBoundFlagAtAnAncestorIsNotACollision(t *testing.T) {
 	declared := registry.Resolved{Values: map[string]any{"state-commit.buffer": 100}}
 	if _, err := appopts.Install(target, declared); err != nil {
 		t.Fatalf("a declared key was refused over a flag default nobody set: %v", err)
+	}
+}
+
+// TestADeclaredKeyThatIsNotLowerCaseIsRefused covers the one input assumption taken on faith.
+//
+// A source stores a key lower-cased, so a declared key that is not already lower case is written and read
+// under a name nothing declares. That defeats the refusal below it rather than merely being untidy: a
+// comparison against another declared key or against what the source enumerates misses a match the source
+// itself would make, so both values land on one path and the survivor is whichever was written second.
+func TestADeclaredKeyThatIsNotLowerCaseIsRefused(t *testing.T) {
+	registry.Reset()
+
+	// The pair the collision refusal cannot see, because the two spellings differ only in case.
+	target := bootLike(t, "TESTBOOT", nil)
+	_, err := appopts.Install(target, registry.Resolved{Values: map[string]any{"A": 1, "a.b": 2}})
+	if err == nil {
+		t.Fatalf("A and a.b were installed together. The source stores both under a, so a reads %#v "+
+			"and the 1 is gone", target.Get("a"))
+	}
+	if !strings.Contains(err.Error(), "not lower case") {
+		t.Errorf("the refusal reads %q and does not say what is wrong with the key", err)
+	}
+
+	// And the report counted one key twice, once under each spelling.
+	registry.Reset()
+	_, err = appopts.Install(bootLike(t, "TESTBOOT", map[string]any{"probe.workers": 1}),
+		registry.Resolved{Values: map[string]any{"Probe.Workers": 4}})
+	if err == nil {
+		t.Error("a key differing from an enumerated one only in case was installed, so the report names " +
+			"it as installed and as untouched at the same time")
 	}
 }

--- a/config/appopts/appopts_test.go
+++ b/config/appopts/appopts_test.go
@@ -1,0 +1,324 @@
+package appopts_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/sei-protocol/sei-chain/config/appopts"
+	"github.com/sei-protocol/sei-chain/config/registry"
+	servertypes "github.com/sei-protocol/sei-chain/sei-cosmos/server/types"
+)
+
+// probe is a section whose defaults vary by mode.
+type probe struct {
+	Workers int  `mapstructure:"workers"`
+	Enabled bool `mapstructure:"enabled"`
+}
+
+// registerProbe registers that section.
+func registerProbe(t *testing.T) {
+	t.Helper()
+	registry.Reset()
+	registry.RegisterSection("probe", &probe{}, func(m registry.Mode) any {
+		return probe{Workers: 4, Enabled: m != registry.ModeArchive}
+	})
+	for _, d := range registry.Defects() {
+		t.Fatalf("registering probe produced a defect: %v", d.Err)
+	}
+}
+
+// resolve returns every declared key's value for a mode, with no source but the defaults.
+func resolve(t *testing.T, mode registry.Mode) registry.Resolved {
+	t.Helper()
+	got, err := registry.Resolve(mode, registry.Sources{})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	return got
+}
+
+// bootLike returns a source shaped like the one a node boots with.
+//
+// A file's worth of values, plus the environment consultation the real one performs. That second part
+// is what matters: it answers for a key on Get without listing it in AllKeys, which is the behaviour
+// every assertion about delegation here depends on.
+func bootLike(t *testing.T, prefix string, fileValues map[string]any) *viper.Viper {
+	t.Helper()
+	v := viper.New()
+	v.SetEnvPrefix(prefix)
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
+	v.AutomaticEnv()
+	for key, value := range fileValues {
+		// SetDefault rather than Set, so these sit below the override layer exactly as a file's values
+		// do and an installed value has something real to beat.
+		v.SetDefault(key, value)
+	}
+	return v
+}
+
+// TestAnEnvironmentValueUnderAnUndeclaredKeySurvives is the property this package exists for.
+//
+// A boot source answers for a key on Get whether or not it lists it, so a value an operator delivered
+// through the environment is readable and unlistable at the same time. Building a fresh source from an
+// enumeration drops exactly those values and replaces an operator's setting with a code default,
+// silently. Leaving the key alone cannot, because the code that answers it is unchanged.
+func TestAnEnvironmentValueUnderAnUndeclaredKeySurvives(t *testing.T) {
+	registerProbe(t)
+	t.Setenv("TESTBOOT_ONLY_IN_THE_ENVIRONMENT", "4242")
+	target := bootLike(t, "TESTBOOT", map[string]any{"in.the.file": 1})
+
+	// The premise: readable, and absent from the enumeration.
+	if got := target.Get("only.in.the.environment"); got != "4242" {
+		t.Fatalf("the fixture does not deliver the value through the environment (got %#v), so this "+
+			"test measures nothing", got)
+	}
+	for _, key := range target.AllKeys() {
+		if strings.EqualFold(key, "only.in.the.environment") {
+			t.Fatal("the fixture enumerates the environment-delivered key, so the case this test " +
+				"exists for is not being exercised")
+		}
+	}
+
+	if _, err := appopts.Install(target, resolve(t, registry.ModeValidator)); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	if got := target.Get("only.in.the.environment"); got != "4242" {
+		t.Errorf("after installing, the environment-delivered key reads %#v and the operator set 4242. "+
+			"A key nothing declares has to keep being answered by whatever answered it before, because "+
+			"nothing can enumerate it to carry it across", got)
+	}
+	if got := target.Get("in.the.file"); got != 1 {
+		t.Errorf("a key from the file reads %#v after installing, want 1", got)
+	}
+}
+
+// TestADeclaredKeyReadsTheRegistryOverEverythingElse is what makes declaring a section a real change.
+//
+// Override precedence is the whole mechanism: viper checks it before the file, the environment and any
+// bound flag. If either of those still won, a section could be declared and the node would carry on
+// reading what it always read.
+func TestADeclaredKeyReadsTheRegistryOverEverythingElse(t *testing.T) {
+	registerProbe(t)
+	// Both channels say something other than the default of 4.
+	t.Setenv("TESTBOOT_PROBE_WORKERS", "999")
+	target := bootLike(t, "TESTBOOT", map[string]any{"probe.workers": 64})
+
+	if got := target.Get("probe.workers"); got == 4 {
+		t.Fatal("the fixture already reads the default, so this test would pass without installing")
+	}
+
+	report, err := appopts.Install(target, resolve(t, registry.ModeValidator))
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	if got := target.Get("probe.workers"); got != 4 {
+		t.Errorf("probe.workers reads %#v with a file value of 64 and an environment value of 999, want "+
+			"the resolved 4. A declared key still answered by either of those makes declaring the "+
+			"section a change with no effect", got)
+	}
+	if len(report.Installed) != 2 {
+		t.Errorf("the report says %v was installed, want both of the section's keys", report.Installed)
+	}
+}
+
+// TestNothingUndeclaredIsDisturbed holds the other half of the partition.
+//
+// The keys a node reads today keep reading the same values, or migrating one section breaks readers
+// that had nothing to do with it.
+func TestNothingUndeclaredIsDisturbed(t *testing.T) {
+	registerProbe(t)
+	file := map[string]any{
+		"probe.workers":     64, // declared, so this one is expected to change
+		"storage.keep":      100,
+		"rpc.addr":          "tcp://0.0.0.0:26657",
+		"a.list":            []string{"x", "y"},
+		"nested.thing.here": true,
+	}
+	target := bootLike(t, "TESTBOOT", file)
+
+	before := map[string]any{}
+	for key := range file {
+		before[key] = target.Get(key)
+	}
+
+	if _, err := appopts.Install(target, resolve(t, registry.ModeValidator)); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	for key, was := range before {
+		if key == "probe.workers" {
+			continue
+		}
+		if got := target.Get(key); !sameRead(got, was) {
+			t.Errorf("%s read %#v before installing and %#v after. Migrating one section must not "+
+				"change what any other key answers", key, was, got)
+		}
+	}
+}
+
+// TestTheKeySpaceOnlyGrows keeps enumeration from losing anything.
+//
+// The sweep that reports unrecognized experimental keys walks AllKeys, so a key space that shrank here
+// would quietly narrow what that sweep can see.
+func TestTheKeySpaceOnlyGrows(t *testing.T) {
+	registerProbe(t)
+	target := bootLike(t, "TESTBOOT", map[string]any{"storage.keep": 1, "rpc.addr": "x"})
+
+	before := map[string]bool{}
+	for _, key := range target.AllKeys() {
+		before[strings.ToLower(key)] = true
+	}
+
+	if _, err := appopts.Install(target, resolve(t, registry.ModeValidator)); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	after := map[string]bool{}
+	for _, key := range target.AllKeys() {
+		after[strings.ToLower(key)] = true
+	}
+	for key := range before {
+		if !after[key] {
+			t.Errorf("%q was enumerable before installing and is not after. Anything walking AllKeys, "+
+				"including the experimental sweep, would stop seeing it", key)
+		}
+	}
+	for _, declared := range []string{"probe.workers", "probe.enabled"} {
+		if !after[declared] {
+			t.Errorf("%q is declared and installed but not enumerable, so a report over AllKeys would "+
+				"not know the node reads it", declared)
+		}
+	}
+}
+
+// TestTheReportNamesWhatIsLeftToMigrate is what makes the remaining work a number rather than a guess.
+func TestTheReportNamesWhatIsLeftToMigrate(t *testing.T) {
+	registerProbe(t)
+	target := bootLike(t, "TESTBOOT", map[string]any{"probe.workers": 64, "storage.keep": 1, "rpc.addr": "x"})
+
+	report, err := appopts.Install(target, resolve(t, registry.ModeValidator))
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	if strings.Join(report.Passthrough, ",") != "rpc.addr,storage.keep" {
+		t.Errorf("the backlog is %v, want the two keys no section declares", report.Passthrough)
+	}
+	// probe.enabled is declared and the file never had it, so a node reads it from the registry for the
+	// first time. Reported apart from the backlog, since it is not work that remains.
+	if len(report.Added) != 1 || report.Added[0] != "probe.enabled" {
+		t.Errorf("the report says %v was added, want probe.enabled", report.Added)
+	}
+}
+
+// TestTheReportIsTakenBeforeAnythingIsInstalled is why the order inside Install matters.
+//
+// Installing a declared key the source never enumerated makes it enumerable. A report built afterwards
+// could not tell such a key from one the source always had, so the backlog and the added set would both
+// be wrong in the same direction.
+func TestTheReportIsTakenBeforeAnythingIsInstalled(t *testing.T) {
+	registerProbe(t)
+	target := bootLike(t, "TESTBOOT", nil) // nothing enumerated at all
+
+	report, err := appopts.Install(target, resolve(t, registry.ModeValidator))
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	if len(report.Added) != 2 {
+		t.Errorf("the report says %v was added, want both declared keys: the source enumerated nothing, "+
+			"so a node reads both from the registry for the first time", report.Added)
+	}
+	if len(report.Passthrough) != 0 {
+		t.Errorf("the report claims %v reads as it always has, and the source enumerated nothing. A "+
+			"report taken after installing counts the keys it just installed", report.Passthrough)
+	}
+}
+
+// TestACollidingDeclaredPairIsRefused holds the one shape the override layer cannot carry.
+//
+// Two keys where one extends the other cannot both live there: whichever is written second turns the
+// other into a map or leaves it unreadable, and which survives depends only on iteration order. A
+// single section cannot produce such a pair, since keys derive from struct leaves, so this is for a pair
+// arriving from two sections at once.
+func TestACollidingDeclaredPairIsRefused(t *testing.T) {
+	registry.Reset()
+	colliding := registry.Resolved{Values: map[string]any{"a.b": 1, "a.b.c": 2}}
+
+	_, err := appopts.Install(bootLike(t, "TESTBOOT", nil), colliding)
+	if err == nil {
+		t.Fatal("a declared pair where one key extends the other was installed. One of the two values " +
+			"is gone and which one depends on iteration order")
+	}
+	for _, want := range []string{"a.b", "a.b.c"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal does not name %q: %v", want, err)
+		}
+	}
+	// Sharing a leading string is not a collision, or ordinary key spaces would fail.
+	fine := registry.Resolved{Values: map[string]any{"a.b": 1, "a.bc": 2, "a.b_c": 3}}
+	if _, err := appopts.Install(bootLike(t, "TESTBOOT", nil), fine); err != nil {
+		t.Errorf("keys sharing a leading string but no dotted prefix were refused: %v", err)
+	}
+}
+
+// TestARefusedInstallChangesNothing keeps a rejected key space from leaving half its values behind.
+func TestARefusedInstallChangesNothing(t *testing.T) {
+	registry.Reset()
+	target := bootLike(t, "TESTBOOT", map[string]any{"untouched": "before"})
+	colliding := registry.Resolved{Values: map[string]any{"a.b": 1, "a.b.c": 2}}
+
+	if _, err := appopts.Install(target, colliding); err == nil {
+		t.Fatal("the colliding pair was accepted")
+	}
+
+	if got := target.Get("untouched"); got != "before" {
+		t.Errorf("a refused install changed the source: untouched reads %#v", got)
+	}
+	if got := target.Get("a.b"); got != nil {
+		t.Errorf("a refused install wrote a.b = %#v, so the source now holds part of a key space that "+
+			"was rejected", got)
+	}
+}
+
+// TestInstallRefusesWithNoSourceToInstallInto keeps a missing source from reading as success.
+func TestInstallRefusesWithNoSourceToInstallInto(t *testing.T) {
+	registerProbe(t)
+
+	if _, err := appopts.Install(nil, resolve(t, registry.ModeValidator)); err == nil {
+		t.Error("Install accepted no source, which would report every key resolved while nothing was " +
+			"written anywhere")
+	}
+}
+
+// TestTheResultIsStillWhatAppNewTakes is what keeps every read site unchanged.
+//
+// The boot hands its own source to the application, so installing into that source is what lets a
+// resolved value reach a reader without any appOpts.Get call site moving.
+func TestTheResultIsStillWhatAppNewTakes(t *testing.T) {
+	registerProbe(t)
+	target := bootLike(t, "TESTBOOT", map[string]any{"legacy.key": 1})
+
+	if _, err := appopts.Install(target, resolve(t, registry.ModeValidator)); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	var opts servertypes.AppOptions = target
+	if opts.Get("probe.workers") != 4 {
+		t.Errorf("read through the interface a node uses, probe.workers is %#v", opts.Get("probe.workers"))
+	}
+	if opts.Get("legacy.key") != 1 {
+		t.Errorf("read through the interface a node uses, legacy.key is %#v", opts.Get("legacy.key"))
+	}
+}
+
+// sameRead reports whether a value read from the source is unchanged.
+//
+// reflect.DeepEqual rather than a comparison written here, for the same reason: == panics on a slice
+// instead of returning false, so enumerating slice types by hand is wrong as soon as one is missed.
+func sameRead(a, b any) bool { return reflect.DeepEqual(a, b) }


### PR DESCRIPTION
A node's configuration is answered today by viper, reading a file, the environment and flags. The registry declares keys and resolves a value for each. This is the piece that puts one into the other: `Install` writes every declared key into the source a booting node reads, at override precedence, and leaves every other key alone.

**Start with `config/appopts/appopts.go`** — the package doc explains why it layers rather than replaces, which is the decision the rest follows from.

### Properties

- **A declared key reads the registry over everything else.** It is written at override precedence, so no resolution runs when the node reads it.
- **Nothing undeclared is disturbed.** A value can only be resolved ahead of the read if its name is known, and a name is known only once a section declares it. An environment cannot be enumerated for a prefix, so a value delivered that way under an undeclared key is readable and unlistable at the same time: building a fresh source from an enumeration would drop exactly those values and replace an operator's setting with a code default. Leaving them alone cannot, because the code that answers them is unchanged.
- **The key space only grows.** Installing adds declared keys and removes none, so a key a node read before it reads after.
- **Two declared keys where one names a prefix of the other are refused.** A source holds a value at a path, so writing `a.b` turns `a` into a table and destroys what `a` held, and writing `a` afterwards destroys the table. No order installs both. This is a property of how the source stores a key rather than of whether the key space is coherent, which is why it is checked here and not at registration.
- **A refused install changes nothing.** The refusal happens before the first write.
- **The report is taken before anything is written.** Installing makes every declared key enumerable, and the report names the set that was not, so taken afterwards it is always empty.

`Report` names the three populations: the declared keys written, the keys that still read as they always have, and the declared keys the source did not carry. The second is the migration that remains, and it shrinks as sections are declared.

### Scope

This is the package alone. Nothing here calls it: the boot path that installs on startup is a separate change.

Three things it does not carry, each for want of a caller today. A one-line summary of the report, and the mapping from a node mode to the mode Tendermint runs, both belong with the command that prints them. Reconciling the mode `sei.toml` records against the one `config.toml` runs is a diagnostic, and it arrives with the diagnostic that asks for it.

### Verified

`build`, `vet`, `gofmt -s`, `goimports`, `golangci-lint` clean. 10 cases under `-race`, 100% of statements.

Clobbering an undeclared key fails three tests, taking the report after installing fails two, and dropping the collision refusal fails two. A fold to lower case on what the source enumerates was removed rather than tested: a source lower-cases a key on the way in, so the fold could not fire.
