### PR TITLE
Test gas gating in weighted vote

### DIFF
--- a/precompiles/common/decode_cost_test.go
+++ b/precompiles/common/decode_cost_test.go
@@ -114,6 +114,56 @@ func TestDecodeStringCopyBytes_Aliased(t *testing.T) {
 	}
 }
 
+func TestDecodeStringCopyBytes_AliasedVoteWeighted(t *testing.T) {
+	const (
+		k = uint64(18432)
+		s = uint64(602592)
+	)
+	args := abi.Arguments{
+		{Type: mustABIType(t, "uint64", nil)},
+		{Type: mustABIType(t, "tuple[]", []abi.ArgumentMarshaling{
+			{Name: "option", Type: "int32"},
+			{Name: "weight", Type: "string"},
+		})},
+	}
+	data := newAliasedVoteWeightedArgs(k, s)
+
+	n, ok := decodeStringCopyBytes(args, data)
+	require.True(t, ok)
+	require.Equal(t, k*s, n)
+
+	// DecodeGasCost must price the amplified copy volume, not just len(input).
+	input := append([]byte{0x59, 0x63, 0x4a, 0x88}, data...)
+	gas, ok := DecodeGasCost(args, input)
+	require.True(t, ok)
+	base := DefaultGasCost(input, false)
+	require.Equal(t, satAdd(base, satMul(storetypes.KVGasConfig().ReadCostPerByte, k*s)), gas)
+	require.Greater(t, gas, uint64(12_500_000))
+	require.Less(t, uint64(len(input)), uint64(2<<20)) // compact calldata, ~1.2MiB
+}
+
+// newAliasedVoteWeightedArgs builds non-canonical voteWeighted argument
+// bytes: k dynamic-tuple offsets all point at one shared (option, weight) body
+// whose weight string has length s. Calldata stays O(k+s); decoded copy volume
+// is O(k*s).
+func newAliasedVoteWeightedArgs(k, s uint64) []byte {
+	tupleRel := 32 * k // offset within the array payload (after the length word)
+	arrayPayload := make([]byte, 0, int(32*k+64+s))
+	for range k {
+		arrayPayload = append(arrayPayload, abiWord(tupleRel)...)
+	}
+	// Shared dynamic tuple: word0 = s (option / string length via offset 0),
+	// word1 = 0 (string offset), then s payload bytes starting at tuple+32.
+	arrayPayload = append(arrayPayload, abiWord(s)...)
+	arrayPayload = append(arrayPayload, abiWord(0)...)
+	arrayPayload = append(arrayPayload, make([]byte, s)...)
+
+	data := append(abiWord(1), abiWord(64)...) // proposalID, options offset
+	data = append(data, abiWord(k)...)
+	data = append(data, arrayPayload...)
+	return data
+}
+
 func TestDecodeStringCopyBytes_Malformed(t *testing.T) {
 	// A string[] header claiming an offset past the end of the buffer must not
 	// be scanned as if valid.

--- a/precompiles/gov/gov_test.go
+++ b/precompiles/gov/gov_test.go
@@ -2,6 +2,7 @@ package gov_test
 
 import (
 	"embed"
+	"encoding/binary"
 	"encoding/hex"
 	"math/big"
 	"testing"
@@ -1214,4 +1215,74 @@ func TestGovQueryPrecompile(t *testing.T) {
 		})
 		require.NotNil(t, err)
 	})
+}
+
+func TestVoteWeightedAliasedOptionsRejectedBeforeUnpack(t *testing.T) {
+	testApp := testkeeper.EVMTestApp
+	ctx := testApp.NewContext(false, tmtypes.Header{}).WithBlockHeight(2)
+	k := &testApp.EvmKeeper
+
+	seiAddr, evmAddr := testkeeper.MockAddressPair()
+	k.SetAddressMapping(ctx, seiAddr, evmAddr)
+
+	p, err := gov.NewPrecompile(testApp.GetPrecompileKeepers())
+	require.NoError(t, err)
+	method := p.ABI.Methods[gov.VoteWeightedMethod]
+
+	// Dimensions chosen so calldata stays small (~40KiB) while decoded copy
+	// volume (options*weightBytes) prices above the 12.5M gas cap used in the
+	// original reproduction. If Unpack ran, allocation would be only ~8MiB —
+	// CI-safe — and the error would be the post-decode max-options message
+	// instead.
+	const (
+		options     = uint64(1024)
+		weightBytes = uint64(8192)
+		suppliedGas = uint64(12_500_000)
+	)
+	args := craftAliasedVoteWeightedArgs(options, weightBytes)
+	input := append(append([]byte{}, method.ID...), args...)
+
+	decodeGas, ok := pcommon.DecodeGasCost(method.Inputs, input)
+	require.True(t, ok)
+	require.Greater(t, decodeGas, suppliedGas)
+
+	statedb := state.NewDBImpl(ctx, k, true)
+	evm := vm.EVM{StateDB: statedb}
+	ret, remaining, runErr := p.RunAndCalculateGas(&evm, evmAddr, evmAddr, input, suppliedGas, big.NewInt(0), nil, false, false)
+	require.Nil(t, ret)
+	require.Equal(t, uint64(0), remaining)
+	require.ErrorIs(t, runErr, vm.ErrExecutionReverted)
+
+	precompileErr := statedb.GetPrecompileError()
+	require.NotNil(t, precompileErr)
+	require.NotContains(t, precompileErr.Error(), "too many vote options",
+		"decode must fail before the post-Unpack max-options check; got %v", precompileErr)
+	// chargeDecodeGas recovers sdk.ErrorOutOfGas as fmt.Errorf("%v", r), which
+	// stringifies to "{<descriptor>}"; the descriptor names the decode charge.
+	require.Contains(t, precompileErr.Error(), "gov precompile calldata decode")
+
+	_, found := testApp.GovKeeper.GetVote(statedb.Ctx(), 1, seiAddr)
+	require.False(t, found)
+}
+
+func craftAliasedVoteWeightedArgs(k, s uint64) []byte {
+	tupleRel := 32 * k
+	arrayPayload := make([]byte, 0, int(32*k+64+s))
+	for range k {
+		arrayPayload = append(arrayPayload, abiWord(tupleRel)...)
+	}
+	arrayPayload = append(arrayPayload, abiWord(s)...)
+	arrayPayload = append(arrayPayload, abiWord(0)...)
+	arrayPayload = append(arrayPayload, make([]byte, s)...)
+
+	data := append(abiWord(1), abiWord(64)...)
+	data = append(data, abiWord(k)...)
+	data = append(data, arrayPayload...)
+	return data
+}
+
+func abiWord(v uint64) []byte {
+	b := make([]byte, 32)
+	binary.BigEndian.PutUint64(b[24:], v)
+	return b
 }


### PR DESCRIPTION
Add regression coverage for the gov voteWeighted amplification shape.

The estimator test pins DecodeGasCost to the reported k*s volume, and the gov end-to-end test checks a call under the 12.5M gas cap reverts in chargeDecodeGas before Inputs.Unpack and the post-decode max-options check.

Fixes CON-404
