### PR TITLE
fix(sei-tendermint): address mac/linux test node divergence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ release/
 .idea/
 .vscode/
 .cursor/
+**/.codex/
+**/.claude/
+**/.mcp.json
 .DS_Store
 build/
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,6 @@ release/
 .idea/
 .vscode/
 .cursor/
-**/.codex/
-**/.claude/
-**/.mcp.json
 .DS_Store
 build/
 dist/

--- a/sei-tendermint/node/node_test.go
+++ b/sei-tendermint/node/node_test.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -256,7 +255,8 @@ func TestPrivValidatorListenAddrNoProtocol(t *testing.T) {
 }
 
 func TestNodeSetPrivValIPC(t *testing.T) {
-	tmpfile := filepath.Join(t.TempDir(), "kms.sock")
+	tmpfile := "/tmp/kms." + tmrand.Str(6) + ".sock"
+	defer os.Remove(tmpfile) // clean up
 
 	ctx := t.Context()
 

--- a/sei-tendermint/node/node_test.go
+++ b/sei-tendermint/node/node_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -34,7 +35,6 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/service"
 	tmtime "github.com/sei-protocol/sei-chain/sei-tendermint/libs/time"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
-	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/tcp"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/privval"
 	tmproto "github.com/sei-protocol/sei-chain/sei-tendermint/proto/tendermint/types"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
@@ -57,7 +57,7 @@ func newLocalNodeService(ctx context.Context, cfg *config.Config) (service.Servi
 func TestNodeStartStop(t *testing.T) {
 	cfg, err := config.ResetTestRoot(t.TempDir(), "node_node_test")
 	require.NoError(t, err)
-	cfg.RPC.ListenAddress = fmt.Sprintf("tcp://%s", tcp.TestReserveAddr())
+	cfg.RPC.ListenAddress = fmt.Sprintf("tcp://%s", freeLoopbackAddr(t))
 
 	ctx := t.Context()
 
@@ -102,7 +102,7 @@ func TestNodeRestartEventAllowsRecreate(t *testing.T) {
 	cfg, err := config.ResetTestRoot(t.TempDir(), "node_restart_event_test")
 	require.NoError(t, err)
 	cfg.Mode = config.ModeFull
-	cfg.RPC.ListenAddress = fmt.Sprintf("tcp://%s", tcp.TestReserveAddr())
+	cfg.RPC.ListenAddress = fmt.Sprintf("tcp://%s", freeLoopbackAddr(t))
 
 	ctx := t.Context()
 
@@ -133,6 +133,7 @@ func TestNodeRestartEventAllowsRecreate(t *testing.T) {
 
 func getTestNode(ctx context.Context, t *testing.T, conf *config.Config) *nodeImpl {
 	t.Helper()
+	conf.RPC.ListenAddress = fmt.Sprintf("tcp://%s", freeLoopbackAddr(t))
 
 	ns, err := newLocalNodeService(ctx, conf)
 	require.NoError(t, err)
@@ -197,7 +198,7 @@ func TestNodeSetAppVersion(t *testing.T) {
 }
 
 func TestNodeSetPrivValTCP(t *testing.T) {
-	addr := fmt.Sprintf("tcp://%s", tcp.TestReserveAddr())
+	addr := fmt.Sprintf("tcp://%s", freeLoopbackAddr(t))
 
 	t.Cleanup(leaktest.Check(t))
 	ctx := t.Context()
@@ -236,7 +237,7 @@ func TestNodeSetPrivValTCP(t *testing.T) {
 func TestPrivValidatorListenAddrNoProtocol(t *testing.T) {
 	ctx := t.Context()
 
-	addrNoPrefix := tcp.TestReserveAddr().String()
+	addrNoPrefix := "127.0.0.1:1234"
 
 	cfg, err := config.ResetTestRoot(t.TempDir(), "node_priv_val_tcp_test")
 	require.NoError(t, err)
@@ -255,8 +256,7 @@ func TestPrivValidatorListenAddrNoProtocol(t *testing.T) {
 }
 
 func TestNodeSetPrivValIPC(t *testing.T) {
-	tmpfile := "/tmp/kms." + tmrand.Str(6) + ".sock"
-	defer os.Remove(tmpfile) // clean up
+	tmpfile := filepath.Join(t.TempDir(), "kms.sock")
 
 	ctx := t.Context()
 

--- a/sei-tendermint/node/node_test.go
+++ b/sei-tendermint/node/node_test.go
@@ -236,7 +236,7 @@ func TestNodeSetPrivValTCP(t *testing.T) {
 func TestPrivValidatorListenAddrNoProtocol(t *testing.T) {
 	ctx := t.Context()
 
-	addrNoPrefix := "127.0.0.1:1234"
+	addrNoPrefix := freeLoopbackAddr(t)
 
 	cfg, err := config.ResetTestRoot(t.TempDir(), "node_priv_val_tcp_test")
 	require.NoError(t, err)


### PR DESCRIPTION
Two low level mac/linux test fix. First, SO_REUSEADDR permits listen() reuse on Linux but not on mac. Second, allocate temp files via the go testing framework.

## Summary

- Use released ephemeral loopback addresses for node tests whose servers bind through net.Listen.
- Ensure helper-created nodes receive unique RPC listener addresses.
- Use a test-local directory for the private-validator Unix socket.
- Avoid tcp.TestReserveAddr, whose reserved socket can conflict with net.Listen on macOS.

## Testing

- Verified the sei-tendermint/node test suite passes.