### PR TITLE
Stop AI workflows from running on submitted reviews

### DIFF
--- a/.github/workflows/ai-assist.yml
+++ b/.github/workflows/ai-assist.yml
@@ -4,8 +4,6 @@ on:
     types: [ created ]
   pull_request_review_comment:
     types: [ created ]
-  pull_request_review:
-    types: [ submitted ]
 jobs:
   assistant:
     # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.19

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -6,8 +6,6 @@ on:
     types: [ created ]
   pull_request_review_comment:
     types: [ created ]
-  pull_request_review:
-    types: [ submitted ]
 jobs:
   ai-review:
     if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null


### PR DESCRIPTION
Remove pull_request_review triggers from the AI review and assistant
workflows. Approvals and ordinary submitted reviews cannot invoke either
bot, but were creating skipped AI jobs and redundant notifications.

Top-level PR comments and inline review comments remain supported for
explicit @seidroid commands.
