### PR TITLE
Retire remaining CosmWasm IBC execution

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -116,7 +116,6 @@ import (
 	"github.com/sei-protocol/sei-chain/precompiles"
 	putils "github.com/sei-protocol/sei-chain/precompiles/utils"
 	ibc "github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core"
-	ibcporttypes "github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core/05-port/types"
 	ibchost "github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core/24-host"
 	ibckeeper "github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core/keeper"
 	ibccoretypes "github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core/types"
@@ -391,7 +390,7 @@ type App struct {
 	GovKeeper      govkeeper.Keeper
 	UpgradeKeeper  upgradekeeper.Keeper
 	ParamsKeeper   paramskeeper.Keeper
-	IBCKeeper      *ibckeeper.Keeper // IBC Keeper must be a pointer in the app, so we can SetRouter on it correctly
+	IBCKeeper      *ibckeeper.Keeper
 	EvidenceKeeper evidencekeeper.Keeper
 	WasmKeeper     wasm.Keeper
 	OracleKeeper   oraclekeeper.Keeper
@@ -657,7 +656,6 @@ func New(
 			&app.TokenFactoryKeeper,
 			&app.AccountKeeper,
 			app.MsgServiceRouter(),
-			app.IBCKeeper.ChannelKeeper,
 			app.BankKeeper,
 			appCodec,
 			&app.EvmKeeper,
@@ -831,12 +829,6 @@ func New(
 	)
 
 	// this line is used by starport scaffolding # stargate/app/keeperDefinition
-
-	// Create the static IBC router, then set and seal it.
-	ibcRouter := ibcporttypes.NewRouter()
-	ibcRouter.AddRoute(wasm.ModuleName, wasm.NewIBCHandler(app.WasmKeeper, app.IBCKeeper.ChannelKeeper))
-	// this line is used by starport scaffolding # ibc/app/router
-	app.IBCKeeper.SetRouter(ibcRouter)
 
 	if enableCustomEVMPrecompiles {
 		customPrecompiles := precompiles.GetCustomPrecompiles(LatestUpgrade, app.GetPrecompileKeepers())

--- a/sei-wasmd/app/app.go
+++ b/sei-wasmd/app/app.go
@@ -66,7 +66,6 @@ import (
 	upgradetypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/upgrade/types"
 	ibc "github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core"
 	ibcclient "github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core/02-client"
-	porttypes "github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core/05-port/types"
 	ibchost "github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core/24-host"
 	ibckeeper "github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core/keeper"
 	tmcfg "github.com/sei-protocol/sei-chain/sei-tendermint/config"
@@ -222,7 +221,7 @@ type WasmApp struct {
 	upgradeKeeper  upgradekeeper.Keeper
 	paramsKeeper   paramskeeper.Keeper
 	evidenceKeeper evidencekeeper.Keeper
-	ibcKeeper      *ibckeeper.Keeper // IBC Keeper must be a pointer in the app, so we can SetRouter on it correctly
+	ibcKeeper      *ibckeeper.Keeper
 	authzKeeper    authzkeeper.Keeper
 	wasmKeeper     wasm.Keeper
 
@@ -403,15 +402,10 @@ func NewWasmApp(
 		wasmOpts...,
 	)
 
-	// Create static IBC router, add app routes, then set and seal it
-	ibcRouter := porttypes.NewRouter()
-
 	// The gov proposal types can be individually enabled
 	if len(enabledProposals) != 0 {
 		govRouter.AddRoute(wasm.RouterKey, wasm.NewWasmProposalHandler(app.wasmKeeper, enabledProposals))
 	}
-	ibcRouter.AddRoute(wasm.ModuleName, wasm.NewIBCHandler(app.wasmKeeper, app.ibcKeeper.ChannelKeeper))
-	app.ibcKeeper.SetRouter(ibcRouter)
 
 	app.govKeeper = govkeeper.NewKeeper(
 		appCodec,

--- a/sei-wasmd/x/wasm/keeper/handler_plugin.go
+++ b/sei-wasmd/x/wasm/keeper/handler_plugin.go
@@ -8,7 +8,7 @@ import (
 	codectypes "github.com/sei-protocol/sei-chain/sei-cosmos/codec/types"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
-	channeltypes "github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core/04-channel/types"
+	ibccoretypes "github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core/types"
 	wasmvmtypes "github.com/sei-protocol/sei-chain/sei-wasmvm/types"
 
 	"github.com/sei-protocol/sei-chain/sei-wasmd/x/wasm/types"
@@ -33,7 +33,6 @@ type SDKMessageHandler struct {
 
 func NewDefaultMessageHandler(
 	router MessageRouter,
-	channelKeeper types.ChannelKeeper,
 	bankKeeper types.Burner,
 	unpacker codectypes.AnyUnpacker,
 	customEncoders ...*MessageEncoders,
@@ -44,7 +43,7 @@ func NewDefaultMessageHandler(
 	}
 	return NewMessageHandlerChain(
 		NewSDKMessageHandler(router, encoders),
-		NewIBCRawPacketHandler(channelKeeper),
+		NewIBCRawPacketHandler(),
 		NewBurnCoinMessageHandler(bankKeeper),
 	)
 }
@@ -137,50 +136,19 @@ func (m MessageHandlerChain) DispatchMsg(ctx sdk.Context, contractAddr sdk.AccAd
 	return nil, nil, sdkerrors.Wrap(types.ErrUnknownMsg, "no handler found")
 }
 
-// IBCRawPacketHandler handels IBC.SendPacket messages which are published to an IBC channel.
-type IBCRawPacketHandler struct {
-	channelKeeper types.ChannelKeeper
+// IBCRawPacketHandler handles retired IBC.SendPacket messages.
+type IBCRawPacketHandler struct{}
+
+func NewIBCRawPacketHandler() IBCRawPacketHandler {
+	return IBCRawPacketHandler{}
 }
 
-func NewIBCRawPacketHandler(chk types.ChannelKeeper) IBCRawPacketHandler {
-	return IBCRawPacketHandler{channelKeeper: chk}
-}
-
-// DispatchMsg publishes a raw IBC packet onto the channel.
-func (h IBCRawPacketHandler) DispatchMsg(ctx sdk.Context, _ sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg, _ wasmvmtypes.MessageInfo, _ types.CodeInfo) (events []sdk.Event, data [][]byte, err error) {
+// DispatchMsg rejects raw IBC packets with the module retirement error.
+func (h IBCRawPacketHandler) DispatchMsg(_ sdk.Context, _ sdk.AccAddress, _ string, msg wasmvmtypes.CosmosMsg, _ wasmvmtypes.MessageInfo, _ types.CodeInfo) (events []sdk.Event, data [][]byte, err error) {
 	if msg.IBC == nil || msg.IBC.SendPacket == nil {
 		return nil, nil, types.ErrUnknownMsg
 	}
-	if contractIBCPortID == "" {
-		return nil, nil, sdkerrors.Wrapf(types.ErrUnsupportedForContract, "ibc not supported")
-	}
-	contractIBCChannelID := msg.IBC.SendPacket.ChannelID
-	if contractIBCChannelID == "" {
-		return nil, nil, sdkerrors.Wrapf(types.ErrEmpty, "ibc channel")
-	}
-
-	sequence, found := h.channelKeeper.GetNextSequenceSend(ctx, contractIBCPortID, contractIBCChannelID)
-	if !found {
-		return nil, nil, sdkerrors.Wrapf(channeltypes.ErrSequenceSendNotFound,
-			"source port: %s, source channel: %s", contractIBCPortID, contractIBCChannelID,
-		)
-	}
-
-	channelInfo, ok := h.channelKeeper.GetChannel(ctx, contractIBCPortID, contractIBCChannelID)
-	if !ok {
-		return nil, nil, sdkerrors.Wrap(channeltypes.ErrInvalidChannel, "not found")
-	}
-	packet := channeltypes.NewPacket(
-		msg.IBC.SendPacket.Data,
-		sequence,
-		contractIBCPortID,
-		contractIBCChannelID,
-		channelInfo.Counterparty.PortId,
-		channelInfo.Counterparty.ChannelId,
-		ConvertWasmIBCTimeoutHeightToCosmosHeight(msg.IBC.SendPacket.Timeout.Block),
-		msg.IBC.SendPacket.Timeout.Timestamp,
-	)
-	return nil, nil, h.channelKeeper.SendPacket(ctx, packet)
+	return nil, nil, ibccoretypes.ErrIBCDeprecated
 }
 
 var _ Messenger = MessageHandlerFunc(nil)

--- a/sei-wasmd/x/wasm/keeper/handler_plugin_test.go
+++ b/sei-wasmd/x/wasm/keeper/handler_plugin_test.go
@@ -8,9 +8,7 @@ import (
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
 	banktypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/bank/types"
-	clienttypes "github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core/02-client/types"
-	channeltypes "github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core/04-channel/types"
-	ibcexported "github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core/exported"
+	ibccoretypes "github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core/types"
 	wasmvm "github.com/sei-protocol/sei-chain/sei-wasmvm"
 	wasmvmtypes "github.com/sei-protocol/sei-chain/sei-wasmvm/types"
 	"github.com/stretchr/testify/assert"
@@ -221,80 +219,36 @@ func TestSDKMessageHandlerDispatch(t *testing.T) {
 }
 
 func TestIBCRawPacketHandler(t *testing.T) {
-	ibcPort := "contractsIBCPort"
-	var ctx sdk.Context
-
-	var capturedPacket ibcexported.PacketI
-
-	chanKeeper := &wasmtesting.MockChannelKeeper{
-		GetNextSequenceSendFn: func(ctx sdk.Context, portID, channelID string) (uint64, bool) {
-			return 1, true
-		},
-		GetChannelFn: func(ctx sdk.Context, srcPort, srcChan string) (channeltypes.Channel, bool) {
-			return channeltypes.Channel{
-				Counterparty: channeltypes.NewCounterparty(
-					"other-port",
-					"other-channel-1",
-				),
-			}, true
-		},
-		SendPacketFn: func(ctx sdk.Context, packet ibcexported.PacketI) error {
-			capturedPacket = packet
-			return nil
-		},
-	}
-
 	specs := map[string]struct {
-		srcMsg        wasmvmtypes.SendPacketMsg
-		chanKeeper    types.ChannelKeeper
-		expPacketSent channeltypes.Packet
-		expErr        *sdkerrors.Error
+		portID    string
+		channelID string
 	}{
-		"all good": {
-			srcMsg: wasmvmtypes.SendPacketMsg{
-				ChannelID: "channel-1",
-				Data:      []byte("myData"),
-				Timeout:   wasmvmtypes.IBCTimeout{Block: &wasmvmtypes.IBCTimeoutBlock{Revision: 1, Height: 2}},
-			},
-			chanKeeper: chanKeeper,
-			expPacketSent: channeltypes.Packet{
-				Sequence:           1,
-				SourcePort:         ibcPort,
-				SourceChannel:      "channel-1",
-				DestinationPort:    "other-port",
-				DestinationChannel: "other-channel-1",
-				Data:               []byte("myData"),
-				TimeoutHeight:      clienttypes.Height{RevisionNumber: 1, RevisionHeight: 2},
-			},
+		"valid packet": {
+			portID:    "contractsIBCPort",
+			channelID: "channel-1",
 		},
-		"sequence not found returns error": {
-			srcMsg: wasmvmtypes.SendPacketMsg{
-				ChannelID: "channel-1",
-				Data:      []byte("myData"),
-				Timeout:   wasmvmtypes.IBCTimeout{Block: &wasmvmtypes.IBCTimeoutBlock{Revision: 1, Height: 2}},
-			},
-			chanKeeper: &wasmtesting.MockChannelKeeper{
-				GetNextSequenceSendFn: func(ctx sdk.Context, portID, channelID string) (uint64, bool) {
-					return 0, false
-				},
-			},
-			expErr: channeltypes.ErrSequenceSendNotFound,
+		"empty contract port": {
+			channelID: "channel-1",
+		},
+		"empty channel": {
+			portID: "contractsIBCPort",
 		},
 	}
 	for name, spec := range specs {
 		t.Run(name, func(t *testing.T) {
-			capturedPacket = nil
-			// when
-			h := NewIBCRawPacketHandler(spec.chanKeeper)
-			data, evts, gotErr := h.DispatchMsg(ctx, RandomAccountAddress(t), ibcPort, wasmvmtypes.CosmosMsg{IBC: &wasmvmtypes.IBCMsg{SendPacket: &spec.srcMsg}}, wasmvmtypes.MessageInfo{}, types.CodeInfo{})
-			// then
-			require.True(t, spec.expErr.Is(gotErr), "exp %v but got %#+v", spec.expErr, gotErr)
-			if spec.expErr != nil {
-				return
-			}
-			assert.Nil(t, data)
+			h := NewIBCRawPacketHandler()
+			msg := wasmvmtypes.CosmosMsg{IBC: &wasmvmtypes.IBCMsg{SendPacket: &wasmvmtypes.SendPacketMsg{
+				ChannelID: spec.channelID,
+				Data:      []byte("myData"),
+				Timeout:   wasmvmtypes.IBCTimeout{Block: &wasmvmtypes.IBCTimeoutBlock{Revision: 1, Height: 2}},
+			}}}
+
+			evts, data, gotErr := h.DispatchMsg(sdk.Context{}, RandomAccountAddress(t), spec.portID, msg, wasmvmtypes.MessageInfo{}, types.CodeInfo{})
+
+			require.ErrorIs(t, gotErr, ibccoretypes.ErrIBCDeprecated)
+			require.EqualError(t, gotErr, "ibc module is deprecated")
 			assert.Nil(t, evts)
-			assert.Equal(t, spec.expPacketSent, capturedPacket)
+			assert.Nil(t, data)
 		})
 	}
 }

--- a/sei-wasmd/x/wasm/keeper/keeper.go
+++ b/sei-wasmd/x/wasm/keeper/keeper.go
@@ -151,7 +151,7 @@ func NewKeeper(
 		accountKeeper:     accountKeeper,
 		bank:              NewBankCoinTransferrer(bankKeeper),
 		upgradeKeeper:     upgradeKeeper,
-		messenger:         NewDefaultMessageHandler(router, channelKeeper, bankKeeper, cdc),
+		messenger:         NewDefaultMessageHandler(router, bankKeeper, cdc),
 		queryGasLimit:     wasmConfig.SmartQueryGasLimit,
 		paramSpace:        paramSpace,
 		gasRegister:       NewDefaultWasmGasRegister(),

--- a/wasmbinding/message_plugin.go
+++ b/wasmbinding/message_plugin.go
@@ -34,7 +34,6 @@ func (r *CustomRouter) Handler(msg sdk.Msg) baseapp.MsgServiceHandler {
 // forked from wasm
 func CustomMessageHandler(
 	router wasmkeeper.MessageRouter,
-	channelKeeper wasmtypes.ChannelKeeper,
 	bankKeeper wasmtypes.Burner,
 	evmKeeper *evmkeeper.Keeper,
 	unpacker codectypes.AnyUnpacker,
@@ -46,7 +45,7 @@ func CustomMessageHandler(
 		})
 	return wasmkeeper.NewMessageHandlerChain(
 		wasmkeeper.NewSDKMessageHandler(&CustomRouter{MessageRouter: router, evmKeeper: evmKeeper}, encoders),
-		wasmkeeper.NewIBCRawPacketHandler(channelKeeper),
+		wasmkeeper.NewIBCRawPacketHandler(),
 		wasmkeeper.NewBurnCoinMessageHandler(bankKeeper),
 	)
 }

--- a/wasmbinding/message_plugin_test.go
+++ b/wasmbinding/message_plugin_test.go
@@ -1,0 +1,33 @@
+package wasmbinding
+
+import (
+	"testing"
+
+	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	ibccoretypes "github.com/sei-protocol/sei-chain/sei-ibc-go/modules/core/types"
+	wasmtypes "github.com/sei-protocol/sei-chain/sei-wasmd/x/wasm/types"
+	wasmvmtypes "github.com/sei-protocol/sei-chain/sei-wasmvm/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomMessageHandlerRejectsIBCRawPacket(t *testing.T) {
+	handler := CustomMessageHandler(nil, nil, nil, nil)
+	msg := wasmvmtypes.CosmosMsg{IBC: &wasmvmtypes.IBCMsg{SendPacket: &wasmvmtypes.SendPacketMsg{
+		ChannelID: "channel-1",
+		Data:      []byte("data"),
+	}}}
+
+	events, data, err := handler.DispatchMsg(
+		sdk.Context{},
+		sdk.AccAddress("contract"),
+		"contract-port",
+		msg,
+		wasmvmtypes.MessageInfo{},
+		wasmtypes.CodeInfo{},
+	)
+
+	require.ErrorIs(t, err, ibccoretypes.ErrIBCDeprecated)
+	require.EqualError(t, err, "ibc module is deprecated")
+	require.Nil(t, events)
+	require.Nil(t, data)
+}

--- a/wasmbinding/wasm.go
+++ b/wasmbinding/wasm.go
@@ -23,7 +23,6 @@ func RegisterCustomPlugins(
 	tokenfactory *tokenfactorykeeper.Keeper,
 	_ *authkeeper.AccountKeeper,
 	router wasmkeeper.MessageRouter,
-	channelKeeper wasmtypes.ChannelKeeper,
 	bankKeeper wasmtypes.Burner,
 	unpacker codectypes.AnyUnpacker,
 	evmKeeper *evmkeeper.Keeper,
@@ -39,7 +38,7 @@ func RegisterCustomPlugins(
 		Custom: CustomQuerier(wasmQueryPlugin),
 	})
 	messengerHandlerOpt := wasmkeeper.WithMessageHandler(
-		CustomMessageHandler(router, channelKeeper, bankKeeper, evmKeeper, unpacker),
+		CustomMessageHandler(router, bankKeeper, evmKeeper, unpacker),
 	)
 
 	return []wasm.Option{


### PR DESCRIPTION
Reject raw CosmWasm IBC packet sends with the IBC retirement error and
remove the unreachable IBC callback router wiring.

Drop channel keeper dependencies from wasm message handling while
retaining channel access for existing wasm queries and keeping all
retired stores mounted.
