### PR TITLE
Fix intermittent failures in buf breaking change check

### DIFF
--- a/.github/workflows/buf-check.yml
+++ b/.github/workflows/buf-check.yml
@@ -16,8 +16,20 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-        # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+      # See: https://github.com/actions/checkout/releases/tag/v7.0.0
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          path: head
+        # Check the comparison base out locally so `buf breaking` never clones
+        # over the network: the buf CLI caps every command at 120s, and its
+        # anonymous HTTPS fetch of this repository does not reliably finish in
+        # that budget, which made the breaking step fail intermittently.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          path: base
+          ref: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
       - uses: bufbuild/buf-action@v1
         with:
           version: 1.58.0
+          input: head
+          breaking_against: base


### PR DESCRIPTION
Check the comparison base out locally so `buf breaking` never clones
over the network: the buf CLI caps every command at 120s, and its
anonymous HTTPS fetch of this repository does not reliably finish in
that budget, which made the breaking step fail intermittently.
