### PR TITLE
Disable provider caching for instant-mined receipts

### DIFF
--- a/integration_test/rpc_tests/package.json
+++ b/integration_test/rpc_tests/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "compile": "hardhat compile",
-    "rpc:geth": "geth --dev --http --http.addr 127.0.0.1 --http.port 9547 --http.api eth,net,web3,debug,txpool --dev.period 0",
+    "rpc:geth": "geth --dev --http --http.addr 127.0.0.1 --http.port 9547 --http.api eth,net,web3,debug,txpool --dev.period 1",
     "rpc:fork": "hardhat --config hardhat/hardhat.config.ts node --port 9546",
     "rpc:bootstrap": "mocha --config .mocharc.bootstrap.json",
     "rpc:run": "mocha --config .mocharc.run.json",

--- a/integration_test/rpc_tests/utils/chainUtils.ts
+++ b/integration_test/rpc_tests/utils/chainUtils.ts
@@ -11,6 +11,9 @@ const makeProvider = (url: string): ethers.JsonRpcProvider =>
         batchMaxCount: 1,
         staticNetwork: true,
         pollingInterval: POLLING_INTERVAL_MS,
+        // geth --dev mines before ethers starts waiting for the receipt and does not
+        // produce another block to correct a cached pre-transaction block number.
+        cacheTimeout: -1,
     });
 
 let seiProvider: ethers.JsonRpcProvider | undefined;


### PR DESCRIPTION
Ethers could use a cached pre-transaction block height after geth
instant-mined a transaction. With no subsequent blocks, receipt waits
then stalled indefinitely. Disable provider request caching so waits
compare receipts against the current chain head.


Flaked in [unrelated changes](https://github.com/sei-protocol/sei-chain/actions/runs/32969984141/job/98183006404).
