### PR TITLE
Remove legacy sei_rpc_* dual-emit after evmrpc dashboard migration (PLT-326)

### DIFF
--- a/evmrpc/utils.go
+++ b/evmrpc/utils.go
@@ -277,9 +277,6 @@ func recordMetricsWithError(ctx context.Context, apiMethod string, connectionTyp
 	}
 
 	recordRPCLatency(ctx, apiMethod, string(connectionType), success, err, panicValue != nil, startTime)
-	// TODO(PLT-326): remove legacy dual-emit once dashboards are migrated to evmrpc_* OTEL metrics. Use metrics.requestLatencySeconds histogram instead.
-	utilmetrics.IncrementRpcRequestCounter(apiMethod, string(connectionType), success)
-	utilmetrics.MeasureRpcRequestLatency(apiMethod, string(connectionType), startTime)
 	stats.RecordAPIInvocation(apiMethod, string(connectionType), startTime, success)
 
 	if panicValue != nil {

--- a/evmrpc/websockets.go
+++ b/evmrpc/websockets.go
@@ -2,8 +2,6 @@ package evmrpc
 
 import (
 	"net/http"
-
-	utilmetrics "github.com/sei-protocol/sei-chain/utils/metrics"
 )
 
 type wsConnectionHandler struct {
@@ -12,8 +10,6 @@ type wsConnectionHandler struct {
 
 func (h *wsConnectionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	recordWebsocketConnect(r.Context())
-	// TODO(PLT-326): remove legacy dual-emit once dashboards are migrated to evmrpc_* OTEL metrics. Use metrics.wsConnectionCount instead.
-	utilmetrics.IncWebsocketConnects()
 	h.underlying.ServeHTTP(w, r)
 }
 

--- a/evmrpc/worker_pool_metrics.go
+++ b/evmrpc/worker_pool_metrics.go
@@ -9,7 +9,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -555,8 +554,6 @@ func (m *WorkerPoolMetrics) RecordSubscriptionEnd() {
 func (m *WorkerPoolMetrics) RecordSubscriptionError() {
 	m.SubscriptionErrors.Add(1)
 	otelMetrics.subscriptionErrorsTotal.Add(context.Background(), 1)
-	// TODO(PLT-326): remove once evmrpc_subscriptions_errors_total verified
-	telemetry.IncrCounter(1, "sei", "evm", "subscriptions", "errors")
 }
 
 // GetTPS calculates the current TPS based on time window

--- a/utils/metrics/metrics_util.go
+++ b/utils/metrics/metrics_util.go
@@ -329,48 +329,6 @@ func IncrementOptimisticProcessingCounter(enabled bool) {
 	)
 }
 
-// TODO(PLT-326): remove once dashboards are migrated to evmrpc_* OTEL metrics.
-// Measures number of new websocket connects
-// Metric Name:
-//
-//	sei_websocket_connect
-func IncWebsocketConnects() {
-	SafeTelemetryIncrCounterWithLabels([]string{"sei", "websocket", "connect"}, 1, nil)
-}
-
-// TODO(PLT-326): remove once dashboards are migrated to evmrpc_* OTEL metrics.
-// Measures RPC endpoint request throughput
-// Metric Name:
-//
-//	sei_rpc_request_counter
-func IncrementRpcRequestCounter(endpoint string, connectionType string, success bool) {
-	SafeTelemetryIncrCounterWithLabels(
-		[]string{"sei", "rpc", "request", "counter"},
-		float32(1),
-		[]metrics.Label{
-			telemetry.NewLabel("endpoint", endpoint),
-			telemetry.NewLabel("connection", connectionType),
-			telemetry.NewLabel("success", strconv.FormatBool(success)),
-		},
-	)
-}
-
-// TODO(PLT-326): remove once dashboards are migrated to evmrpc_* OTEL metrics.
-// Measures the RPC request latency in milliseconds
-// Metric Name:
-//
-//	sei_rpc_request_latency_ms
-func MeasureRpcRequestLatency(endpoint string, connectionType string, startTime time.Time) {
-	metrics.MeasureSinceWithLabels(
-		[]string{"sei", "rpc", "request", "latency_ms"},
-		startTime.UTC(),
-		[]metrics.Label{
-			telemetry.NewLabel("endpoint", endpoint),
-			telemetry.NewLabel("connection", connectionType),
-		},
-	)
-}
-
 func IncrementErrorMetrics(scenario string, err error) {
 	if err == nil {
 		return


### PR DESCRIPTION
## Describe your changes and provide context

Follow-up to [platform#1575](https://github.com/sei-protocol/platform/pull/1575), which migrated `sei-node-monitoring` and `launch-warroom` panels off legacy telemetry metrics. With dashboards now on `sei_chain_evmrpc_*` OTEL series, this removes the dual-emit paths that were kept during the migration.

**Removed legacy emission:**
- `sei_rpc_request_counter` / `sei_rpc_request_latency_ms` from `recordMetricsWithError`
- `sei_websocket_connect` from the websocket connection handler
- `sei_evm_subscriptions_errors` telemetry counter from subscription error recording

**Deleted helpers in `utils/metrics`:**
- `IncWebsocketConnects`
- `IncrementRpcRequestCounter`
- `MeasureRpcRequestLatency`

OTEL metrics (`evmrpc_request_latency_seconds_*`, `evmrpc_ws_connection_count`, `evmrpc_subscriptions_errors_total`) and existing stats recording are unchanged.

Linear: [PLT-326](https://linear.app/seilabs/issue/PLT-326/remove-legacy-sei-rpc-dual-emit-after-evmrpc-dashboard-migration)

## Testing performed to validate your change

- [x] `go test ./evmrpc/... ./utils/metrics/...`