### PR TITLE
fix(sei-tendermint): bound P2P and consensus Prometheus label cardinality (PLT-1070, PLT-1071)

### DIFF
--- a/sei-tendermint/internal/consensus/metrics.gen.go
+++ b/sei-tendermint/internal/consensus/metrics.gen.go
@@ -179,8 +179,8 @@ func NewMetrics() *Metrics {
 			Namespace: MetricsNamespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "block_parts",
-			Help:      "Number of block parts transmitted by each peer.",
-		}, []string{"peer_id"}),
+			Help:      "Number of block parts received from peers.",
+		}, nil),
 		StepDuration: tmprometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: MetricsNamespace,
 			Subsystem: MetricsSubsystem,
@@ -267,7 +267,7 @@ func NewMetrics() *Metrics {
 			Subsystem: MetricsSubsystem,
 			Name:      "late_votes",
 			Help:      "Number of votes received by the node since process start that correspond to earlier heights and rounds than this node is currently in.",
-		}, []string{"validator_address"}),
+		}, nil),
 		FinalRound: tmprometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: MetricsNamespace,
 			Subsystem: MetricsSubsystem,
@@ -401,8 +401,8 @@ func (m *Metrics) StateSyncingAt() *tmprometheus.GaugeInt {
 	return m.StateSyncing.WithLabelValues()
 }
 
-func (m *Metrics) BlockPartsAt(peer_id string) *tmprometheus.CounterInt {
-	return m.BlockParts.WithLabelValues(peer_id)
+func (m *Metrics) BlockPartsAt() *tmprometheus.CounterInt {
+	return m.BlockParts.WithLabelValues()
 }
 
 func (m *Metrics) StepDurationAt(step string) *tmprometheus.Histogram {
@@ -457,8 +457,8 @@ func (m *Metrics) RoundVotingPowerPercentAt(vote_type string) prometheus.Gauge {
 	return m.RoundVotingPowerPercent.WithLabelValues(vote_type)
 }
 
-func (m *Metrics) LateVotesAt(validator_address string) *tmprometheus.CounterInt {
-	return m.LateVotes.WithLabelValues(validator_address)
+func (m *Metrics) LateVotesAt() *tmprometheus.CounterInt {
+	return m.LateVotes.WithLabelValues()
 }
 
 func (m *Metrics) FinalRoundAt(proposer_address string) *tmprometheus.Histogram {

--- a/sei-tendermint/internal/consensus/metrics.gen.go
+++ b/sei-tendermint/internal/consensus/metrics.gen.go
@@ -266,8 +266,8 @@ func NewMetrics() *Metrics {
 			Namespace: MetricsNamespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "late_votes",
-			Help:      "Number of votes received by the node since process start that correspond to earlier heights and rounds than this node is currently in.",
-		}, nil),
+			Help:      "Number of late votes received by the node, labeled by validator address for the current validator set or other.",
+		}, []string{"validator_address"}),
 		FinalRound: tmprometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: MetricsNamespace,
 			Subsystem: MetricsSubsystem,
@@ -457,8 +457,8 @@ func (m *Metrics) RoundVotingPowerPercentAt(vote_type string) prometheus.Gauge {
 	return m.RoundVotingPowerPercent.WithLabelValues(vote_type)
 }
 
-func (m *Metrics) LateVotesAt() *tmprometheus.CounterInt {
-	return m.LateVotes.WithLabelValues()
+func (m *Metrics) LateVotesAt(validator_address string) *tmprometheus.CounterInt {
+	return m.LateVotes.WithLabelValues(validator_address)
 }
 
 func (m *Metrics) FinalRoundAt(proposer_address string) *tmprometheus.Histogram {

--- a/sei-tendermint/internal/consensus/metrics.go
+++ b/sei-tendermint/internal/consensus/metrics.go
@@ -145,9 +145,9 @@ type Metrics struct {
 
 	// LateVotes stores the number of votes that were received by this node that
 	// correspond to earlier heights and rounds than this node is currently
-	// in.
-	//metrics:Number of votes received by the node since process start that correspond to earlier heights and rounds than this node is currently in.
-	LateVotes tmprometheus.CounterIntVec
+	// in, labeled by validator address for the current validator set.
+	//metrics:Number of late votes received by the node, labeled by validator address for the current validator set or other.
+	LateVotes tmprometheus.CounterIntVec `metrics_labels:"validator_address"`
 
 	// FinalRound stores the final round id the proposal block reach consensus in.
 	//metrics:The final round number for where the proposal block reach consensus in, starting at 0.
@@ -227,8 +227,14 @@ func (m *Metrics) MarkRound(r int32, st time.Time) {
 	m.RoundVotingPowerPercentAt(pcn).Set(0)
 }
 
-func (m *Metrics) MarkLateVote() {
-	m.LateVotesAt().Add(1)
+const lateVoteOtherLabel = "other"
+
+func (m *Metrics) MarkLateVote(addr types.Address, validators *types.ValidatorSet) {
+	label := lateVoteOtherLabel
+	if validators != nil && validators.HasAddress(addr) {
+		label = addr.String()
+	}
+	m.LateVotesAt(label).Add(1)
 }
 
 func (m *Metrics) MarkFinalRound(round int32, proposer string) {

--- a/sei-tendermint/internal/consensus/metrics.go
+++ b/sei-tendermint/internal/consensus/metrics.go
@@ -75,8 +75,8 @@ type Metrics struct {
 	// Whether or not a node is state syncing. 1 if yes, 0 if no.
 	StateSyncing tmprometheus.GaugeIntVec
 
-	// Number of block parts transmitted by each peer.
-	BlockParts tmprometheus.CounterIntVec `metrics_labels:"peer_id"`
+	// Number of block parts received from peers.
+	BlockParts tmprometheus.CounterIntVec
 
 	// Histogram of durations for each step in the consensus protocol.
 	StepDuration tmprometheus.HistogramVec `metrics_labels:"step" metrics_buckets:"exprange(0.1, 100, 8)"`
@@ -147,7 +147,7 @@ type Metrics struct {
 	// correspond to earlier heights and rounds than this node is currently
 	// in.
 	//metrics:Number of votes received by the node since process start that correspond to earlier heights and rounds than this node is currently in.
-	LateVotes tmprometheus.CounterIntVec `metrics_labels:"validator_address"`
+	LateVotes tmprometheus.CounterIntVec
 
 	// FinalRound stores the final round id the proposal block reach consensus in.
 	//metrics:The final round number for where the proposal block reach consensus in, starting at 0.
@@ -227,9 +227,8 @@ func (m *Metrics) MarkRound(r int32, st time.Time) {
 	m.RoundVotingPowerPercentAt(pcn).Set(0)
 }
 
-func (m *Metrics) MarkLateVote(vote *types.Vote) {
-	validator := vote.ValidatorAddress.String()
-	m.LateVotesAt(validator).Add(1)
+func (m *Metrics) MarkLateVote() {
+	m.LateVotesAt().Add(1)
 }
 
 func (m *Metrics) MarkFinalRound(round int32, proposer string) {

--- a/sei-tendermint/internal/consensus/reactor.go
+++ b/sei-tendermint/internal/consensus/reactor.go
@@ -761,7 +761,7 @@ func (r *Reactor) handleDataMessage(ctx context.Context, m p2p.RecvMsg[*tmcons.M
 		return nil
 	case *BlockPartMessage:
 		ps.SetHasProposalBlockPart(msg.Height, msg.Round, int(msg.Part.Index))
-		Global.BlockPartsAt(string(m.From)).Add(1)
+		Global.BlockPartsAt().Add(1)
 		return utils.Send(ctx, r.state.peerMsgQueue, msgInfo{msg, m.From, tmtime.Now()})
 	default:
 		return fmt.Errorf("received unknown message on DataChannel: %T", msg)

--- a/sei-tendermint/internal/consensus/state.go
+++ b/sei-tendermint/internal/consensus/state.go
@@ -2456,7 +2456,7 @@ func (cs *State) addVote(
 		"cs_height", cs.roundState.Height(),
 	)
 	if vote.Height < cs.roundState.Height() || (vote.Height == cs.roundState.Height() && vote.Round < cs.roundState.Round()) {
-		Global.MarkLateVote(vote)
+		Global.MarkLateVote()
 	}
 
 	// A precommit for the previous height?

--- a/sei-tendermint/internal/consensus/state.go
+++ b/sei-tendermint/internal/consensus/state.go
@@ -2456,7 +2456,7 @@ func (cs *State) addVote(
 		"cs_height", cs.roundState.Height(),
 	)
 	if vote.Height < cs.roundState.Height() || (vote.Height == cs.roundState.Height() && vote.Round < cs.roundState.Round()) {
-		Global.MarkLateVote()
+		Global.MarkLateVote(vote.ValidatorAddress, cs.roundState.Validators())
 	}
 
 	// A precommit for the previous height?

--- a/sei-tendermint/internal/p2p/metrics.gen.go
+++ b/sei-tendermint/internal/p2p/metrics.gen.go
@@ -34,8 +34,8 @@ func NewMetrics() *Metrics {
 			Namespace: MetricsNamespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "peer_receive_bytes_total",
-			Help:      "Number of bytes per channel received from a given peer.",
-		}, []string{"peer_id", "chID", "message_type"}),
+			Help:      "Number of bytes per channel received.",
+		}, []string{"chID", "message_type"}),
 		newConnections: tmprometheus.NewCounterIntVec(prometheus.CounterOpts{
 			Namespace: MetricsNamespace,
 			Subsystem: MetricsSubsystem,
@@ -80,8 +80,8 @@ func (m *Metrics) peersAt() *tmprometheus.GaugeInt {
 	return m.peers.WithLabelValues()
 }
 
-func (m *Metrics) peerReceiveBytesTotalAt(peer_id string, chID string, message_type string) *tmprometheus.CounterInt {
-	return m.peerReceiveBytesTotal.WithLabelValues(peer_id, chID, message_type)
+func (m *Metrics) peerReceiveBytesTotalAt(chID string, message_type string) *tmprometheus.CounterInt {
+	return m.peerReceiveBytesTotal.WithLabelValues(chID, message_type)
 }
 
 func (m *Metrics) newConnectionsAt(direction string, success string) *tmprometheus.CounterInt {

--- a/sei-tendermint/internal/p2p/metrics.go
+++ b/sei-tendermint/internal/p2p/metrics.go
@@ -30,8 +30,8 @@ var (
 type Metrics struct {
 	// Number of peers.
 	peers prometheus.GaugeIntVec
-	// Number of bytes per channel received from a given peer.
-	peerReceiveBytesTotal prometheus.CounterIntVec `metrics_labels:"peer_id, chID, message_type"`
+	// Number of bytes per channel received.
+	peerReceiveBytesTotal prometheus.CounterIntVec `metrics_labels:"chID, message_type"`
 	// Number of newly established connections.
 	newConnections prometheus.CounterIntVec `metrics_labels:"direction, success"`
 

--- a/sei-tendermint/internal/p2p/transport.go
+++ b/sei-tendermint/internal/p2p/transport.go
@@ -95,7 +95,6 @@ func (r *Router) connRecvRoutine(ctx context.Context, conn *ConnV2) error {
 				Global.queueDroppedMsgsAt(fmt.Sprint(chID), "in").Add(1)
 			}
 			Global.peerReceiveBytesTotalAt(
-				string(conn.ID),
 				fmt.Sprint(chID),
 				r.lc.ValueToMetricLabel(msg),
 			).Add(int64(gogoproto.Size(msg)))


### PR DESCRIPTION
## Summary

- Remove `peer_id` from `tendermint_consensus_block_parts` and `tendermint_p2p_peer_receive_bytes_total`
- Gate `tendermint_consensus_late_votes` to the **current validator set**: label active-set senders by `validator_address`, roll all others into `other`
- Keep remaining labels bounded (`chID`, `message_type` on receive-bytes)

## Context

`peer_id` labels on P2P-fed counters grow without bound as peers churn over a node's lifetime. Those metrics are aggregated at the node level (or by channel/message type where labels are fixed).

`late_votes` previously labeled every distinct sender address forever, which also inflated cardinality as the validator set churned. Full label removal would have broken the **Top-10 validators by late-votes rate** panel on the Sei L1 Block Time SLO dashboard (`sei-l1-block-time-slo`). Active-set gating caps series at ~|validator set| + 1 per node while preserving per-validator attribution for live validators.

## Platform impact

- No alert or recording-rule changes required
- SLO dashboard panel 21 (`tendermint_consensus_late_votes`) continues to work for current-set validators; an `other` overflow series may appear during catch-up or after set churn
- `block_parts` and `peer_receive_bytes_total` are not referenced in Platform dashboards or alerts

Closes PLT-1070 and PLT-1071.