### PR TITLE
Fix memiavl snapshot race condition

### DIFF
--- a/sei-db/state_db/sc/memiavl/snapshot.go
+++ b/sei-db/state_db/sc/memiavl/snapshot.go
@@ -501,21 +501,23 @@ func (t *Tree) WriteSnapshot(ctx context.Context, snapshotDir string) error {
 // WriteSnapshotWithRateLimit writes snapshot with optional rate limiting.
 // limiter is a shared rate limiter. nil means unlimited.
 func (t *Tree) WriteSnapshotWithRateLimit(ctx context.Context, snapshotDir string, limiter *rate.Limiter) error {
+	root, version := t.snapshotSource()
+
 	// Estimate tree size: root.Size() returns leaf count, total = leaves + branches ≈ 2x
 	treeSize := int64(0)
-	if t.root != nil {
-		treeSize = t.root.Size() * 2 // Total nodes (leaves + branches)
+	if root != nil {
+		treeSize = root.Size() * 2 // Total nodes (leaves + branches)
 	}
 
 	// Use 128MB buffer for all trees (large buffer for better performance)
 	bufSize := bufIOSize
 
-	err := writeSnapshotWithBuffer(ctx, snapshotDir, t.version, bufSize, treeSize, limiter, func(w *snapshotWriter) (uint32, error) {
-		if t.root == nil {
+	err := writeSnapshotWithBuffer(ctx, snapshotDir, version, bufSize, treeSize, limiter, func(w *snapshotWriter) (uint32, error) {
+		if root == nil {
 			return 0, nil
 		}
 
-		if err := w.writePostOrder(t.root); err != nil {
+		if err := w.writePostOrder(root); err != nil {
 			return 0, err
 		}
 		return w.leafCounter, nil
@@ -526,6 +528,15 @@ func (t *Tree) WriteSnapshotWithRateLimit(ctx context.Context, snapshotDir strin
 	}
 
 	return nil
+}
+
+// snapshotSource returns the root to serialize together with the version to
+// record for it. Reading them as a pair keeps the metadata from naming a
+// version the serialized nodes do not correspond to.
+func (t *Tree) snapshotSource() (Node, uint32) {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
+	return t.root, t.version
 }
 
 // writeSnapshotWithBuffer writes snapshot with specified buffer size and optional rate limiting.

--- a/sei-db/state_db/sc/memiavl/snapshot.go
+++ b/sei-db/state_db/sc/memiavl/snapshot.go
@@ -531,8 +531,13 @@ func (t *Tree) WriteSnapshotWithRateLimit(ctx context.Context, snapshotDir strin
 }
 
 // snapshotSource returns the root to serialize together with the version to
-// record for it. Reading them as a pair keeps the metadata from naming a
-// version the serialized nodes do not correspond to.
+// record for it, read as a pair so a concurrent SaveVersion cannot land between
+// them and pair a root with the wrong version.
+//
+// The version returned is the last saved one. It describes the root only when
+// the tree has no unsaved writes, which holds for every snapshot writer today
+// because DB.Commit copies after SaveVersion. A snapshot written from a
+// mid-version copy would record a version its nodes are one ahead of.
 func (t *Tree) snapshotSource() (Node, uint32) {
 	t.mtx.RLock()
 	defer t.mtx.RUnlock()

--- a/sei-db/state_db/sc/memiavl/tree.go
+++ b/sei-db/state_db/sc/memiavl/tree.go
@@ -30,18 +30,20 @@ type Tree struct {
 	// when true, the get and iterator methods could return a slice pointing to mmaped blob files.
 	zeroCopy bool
 
+	// unsavedWrites reports whether Set or Remove has stamped nodes at
+	// version+1 since the last SaveVersion, so maxNodeVersion knows whether the
+	// tree currently holds nodes above version.
+	unsavedWrites bool
+
 	// mtx guards concurrent access to this tree's mutable state (root, version,
 	// cowVersion, snapshot) AND the lazily-populated MemNode.hash caches reachable
 	// from root. Operations that fill those caches in place — RootHash and the
 	// proof builders (GetProof/GetMembership/GetNonMembership) — take the write
 	// lock; pure reads (Get/Has/Iterator) take the read lock. This serialization
 	// only protects a single tree instance: a tree produced by Copy() gets its
-	// own mtx and shares the underlying nodes copy-on-write. Cross-copy hash
-	// consistency therefore relies on (a) the shared nodes already being fully
-	// hashed before the copy is used for hashing/proofs (Copy is taken between
-	// commits, and the commit path hashes via SaveVersion(true)/RootHash), and
-	// (b) cowVersion cloning any shared MemNode before it is structurally mutated,
-	// so a live-tree write never mutates a node another copy is still reading.
+	// own mtx and shares the underlying nodes copy-on-write. Copy is what makes
+	// that safe across instances, by freezing the shared nodes before handing
+	// them over; see its doc comment.
 	mtx *sync.RWMutex
 
 	pendingChanges chan proto.ChangeSet
@@ -108,22 +110,60 @@ func (t *Tree) SetInitialVersion(initialVersion int64) error {
 	return nil
 }
 
-// Copy returns a concurrent-safe snapshot. Acquires the underlying *Snapshot
-// so background rewrites can't unmap it while the copy is live; callers must
-// call Close on the returned tree to release the ref.
+// Copy returns a concurrent-safe snapshot of the tree. Acquires the underlying
+// *Snapshot so background rewrites can't unmap it while the copy is live;
+// callers must call Close on the returned tree to release the ref.
+//
+// The copy shares its nodes with the live tree, so it is only safe to read
+// concurrently if those nodes are frozen: every reachable MemNode is already
+// hashed, and sits at or below cowVersion so a live write clones it rather than
+// mutating it in place. Copy establishes both under the write lock.
 func (t *Tree) Copy() *Tree {
-	t.mtx.RLock()
-	defer t.mtx.RUnlock()
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+	return t.copyNoLock()
+}
+
+// copyNoLock is Copy without acquiring t.mtx; the caller must already hold the
+// write lock.
+func (t *Tree) copyNoLock() *Tree {
+	// Hash every reachable node now, while we hold the write lock. Otherwise the
+	// copy's reader fills MemNode.hash in place on nodes the live tree also
+	// holds, and the two trees have separate mutexes to serialize with.
+	_ = t.rootHashNoLock()
+
 	if _, ok := t.root.(*MemNode); ok {
-		// protect the existing `MemNode`s from get modified in-place
-		t.cowVersion = t.version
+		// Freeze the shared MemNodes against in-place mutation. The floor is the
+		// highest version present in the tree, not t.version: Set and Remove
+		// stamp nodes at t.version+1, so between a changeset and SaveVersion the
+		// tree holds nodes a t.version floor would leave mutable.
+		t.cowVersion = t.maxNodeVersion()
 	}
+
 	newTree := *t
 	newTree.mtx = &sync.RWMutex{}
+	// The copy is read-only and must not share the live tree's background-write
+	// plumbing: Close would otherwise close the live tree's pendingChanges.
+	newTree.pendingChanges = nil
+	newTree.pendingWg = &sync.WaitGroup{}
 	if newTree.snapshot != nil {
 		newTree.snapshot.Acquire()
 	}
 	return &newTree
+}
+
+// writeVersion returns the version Set and Remove stamp onto the nodes they
+// create or mutate, which is one ahead of the last saved version.
+func (t *Tree) writeVersion() uint32 {
+	return t.version + 1
+}
+
+// maxNodeVersion returns the highest version carried by any node in the tree.
+func (t *Tree) maxNodeVersion() uint32 {
+	if t.unsavedWrites {
+		return t.writeVersion()
+	}
+	return t.version
 }
 
 // ApplyChangeSet apply the change set of a whole version, and update hashes.
@@ -172,27 +212,37 @@ func (t *Tree) Set(key, value []byte) {
 		// the value could be nil when replaying changes from write-ahead-log because of protobuf decoding
 		value = []byte{}
 	}
-	t.root, _ = setRecursive(t.root, key, value, t.version+1, t.cowVersion)
+	t.root, _ = setRecursive(t.root, key, value, t.writeVersion(), t.cowVersion)
+	t.unsavedWrites = true
 }
 
 func (t *Tree) Remove(key []byte) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
-	_, t.root, _ = removeRecursive(t.root, key, t.version+1, t.cowVersion)
+	_, t.root, _ = removeRecursive(t.root, key, t.writeVersion(), t.cowVersion)
+	t.unsavedWrites = true
 }
 
-// SaveVersion increases the version number and optionally updates the hashes
+// SaveVersion increases the version number and optionally updates the hashes.
+//
+// It holds the write lock across both, so a concurrent Copy cannot observe the
+// bumped version before the nodes stamped at the old write version are hashed,
+// which would let it derive a cowVersion that leaves them mutable.
 func (t *Tree) SaveVersion(updateHash bool) ([]byte, int64, error) {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+
 	if t.version >= uint32(math.MaxUint32) {
 		return nil, 0, errors.New("version overflows uint32")
 	}
 
 	var hash []byte
 	if updateHash {
-		hash = t.RootHash()
+		hash = t.rootHashNoLock()
 	}
 
 	t.version = nextVersionU32(t.version, t.initialVersion)
+	t.unsavedWrites = false
 	return hash, int64(t.version), nil
 }
 
@@ -376,6 +426,7 @@ func (t *Tree) ReplaceWith(other *Tree) error {
 	t.initialVersion = other.initialVersion
 	t.cowVersion = other.cowVersion
 	t.zeroCopy = other.zeroCopy
+	t.unsavedWrites = other.unsavedWrites
 
 	if snapshot != nil {
 		return snapshot.Close()

--- a/sei-db/state_db/sc/memiavl/tree_copy_test.go
+++ b/sei-db/state_db/sc/memiavl/tree_copy_test.go
@@ -1,19 +1,21 @@
 package memiavl
 
 import (
+	"context"
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/sei-protocol/sei-chain/sei-db/proto"
 	"github.com/stretchr/testify/require"
 )
 
-// Copy hands a tree to readers that run concurrently with the live tree — the
-// background snapshot rewrite is the one that matters, since it serializes every
-// reachable node while consensus keeps committing. For that to be safe the copy
-// must be frozen: every MemNode it can reach is already hashed, and sits at or
-// below cowVersion so a live write clones it instead of mutating it in place.
-// The tests below pin both halves of that invariant.
+// Copy hands a tree to readers that run concurrently with the live tree: the
+// background snapshot rewrite, which serializes every reachable node, and the
+// DB.Copy consumers that read a copy while consensus keeps committing. For that
+// to be safe the copy must be frozen: every MemNode it can reach is already
+// hashed, and sits at or below cowVersion so a live write clones it instead of
+// mutating it in place. The tests below pin both halves of that invariant.
 
 const copyTestSeedKeys = 3000
 
@@ -128,6 +130,40 @@ func TestCopyIsStableWhileLiveTreeAdvances(t *testing.T) {
 
 	require.Equal(t, wantVersion, frozen.Version(), "copy's version moved with the live tree")
 	require.Equal(t, want, frozen.RootHash(), "live-tree commits mutated nodes the copy still references")
+}
+
+// TestSnapshotFromCopyIgnoresLaterCommits carries the freeze invariant through
+// the snapshot writer to what lands on disk: serializing a copy must reproduce
+// the tree as it stood when copied, however far the live tree has moved on.
+//
+// This is the deterministic form of the corruption. The concurrent version needs
+// -race to be caught reliably, because at test scale the writer finishes before
+// the live tree does much damage; here the commits land before the writer runs
+// at all, so an unfrozen copy drifts every time.
+func TestSnapshotFromCopyIgnoresLaterCommits(t *testing.T) {
+	tree := seedTree(t, copyTestSeedKeys)
+	tree.ApplyChangeSet(changeSet(0, 500, "mid"))
+
+	frozen := tree.Copy()
+	want := frozen.RootHash()
+
+	_, _, err := tree.SaveVersion(true)
+	require.NoError(t, err)
+	for round := 0; round < 20; round++ {
+		tree.ApplyChangeSet(changeSet(round*100, 500, fmt.Sprintf("adv%02d", round)))
+		_, _, err := tree.SaveVersion(true)
+		require.NoError(t, err)
+	}
+
+	snapshotDir := filepath.Join(t.TempDir(), "snapshot")
+	require.NoError(t, frozen.WriteSnapshot(context.Background(), snapshotDir))
+
+	snapshot, err := OpenSnapshot(snapshotDir, Options{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, snapshot.Close()) })
+
+	require.Equal(t, want, snapshot.RootHash(),
+		"snapshot of the copy picked up commits made after Copy returned")
 }
 
 // TestCopyDoesNotInheritBackgroundWriteChannel covers the other way a copy

--- a/sei-db/state_db/sc/memiavl/tree_copy_test.go
+++ b/sei-db/state_db/sc/memiavl/tree_copy_test.go
@@ -1,0 +1,147 @@
+package memiavl
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sei-protocol/sei-chain/sei-db/proto"
+	"github.com/stretchr/testify/require"
+)
+
+// Copy hands a tree to readers that run concurrently with the live tree — the
+// background snapshot rewrite is the one that matters, since it serializes every
+// reachable node while consensus keeps committing. For that to be safe the copy
+// must be frozen: every MemNode it can reach is already hashed, and sits at or
+// below cowVersion so a live write clones it instead of mutating it in place.
+// The tests below pin both halves of that invariant.
+
+const copyTestSeedKeys = 3000
+
+// seedTree returns a tree holding keys 0..keys-1, saved and fully hashed.
+func seedTree(t *testing.T, keys int) *Tree {
+	t.Helper()
+	tree := NewEmptyTree(0, 0)
+	tree.ApplyChangeSet(changeSet(0, keys, "seed"))
+	_, _, err := tree.SaveVersion(true)
+	require.NoError(t, err)
+	return tree
+}
+
+// changeSet writes count values over keys offset..offset+count-1, tagged so
+// repeated rounds over the same keys produce distinct values.
+func changeSet(offset, count int, tag string) proto.ChangeSet {
+	cs := proto.ChangeSet{Pairs: make([]*proto.KVPair, 0, count)}
+	for i := offset; i < offset+count; i++ {
+		cs.Pairs = append(cs.Pairs, &proto.KVPair{
+			Key:   []byte(fmt.Sprintf("key%08d", i)),
+			Value: []byte(fmt.Sprintf("%s%08d", tag, i)),
+		})
+	}
+	return cs
+}
+
+// frozenViolations counts the MemNodes reachable from tree's root that break the
+// freeze invariant: unhashed, so a reader fills MemNode.hash in place on a node
+// the live tree also holds; or above cowVersion, so a live write mutates the node
+// rather than cloning it. Either lets a live commit change a node out from under
+// the snapshot writer mid-traversal.
+func frozenViolations(tree *Tree) (unhashed, mutable int) {
+	var walk func(node Node)
+	walk = func(node Node) {
+		// PersistedNode is backed by a read-only mmap and is never mutated.
+		mem, ok := node.(*MemNode)
+		if !ok {
+			return
+		}
+		if mem.hash == nil {
+			unhashed++
+		}
+		if mem.version > tree.cowVersion {
+			mutable++
+		}
+		if !mem.IsLeaf() {
+			walk(mem.left)
+			walk(mem.right)
+		}
+	}
+	if tree.root != nil {
+		walk(tree.root)
+	}
+	return unhashed, mutable
+}
+
+// TestCopyFreezesNodesWrittenThisVersion pins the copy-on-write floor. Set and
+// Remove stamp new nodes at version+1, so between a changeset and SaveVersion the
+// tree holds nodes above t.version. Deriving the floor from t.version alone
+// leaves exactly those nodes mutable in the copy.
+func TestCopyFreezesNodesWrittenThisVersion(t *testing.T) {
+	tree := seedTree(t, copyTestSeedKeys)
+
+	// Mid-version: the changeset is applied but not yet saved.
+	tree.ApplyChangeSet(changeSet(0, 500, "mid"))
+
+	frozen := tree.Copy()
+
+	unhashed, mutable := frozenViolations(frozen)
+	require.Zerof(t, mutable,
+		"copy shares %d MemNode(s) above cowVersion %d; a live write will mutate them in place", mutable, frozen.cowVersion)
+	require.Zerof(t, unhashed,
+		"copy shares %d unhashed MemNode(s); a reader will fill MemNode.hash in place on nodes the live tree also holds", unhashed)
+}
+
+// TestCopyFreezesAfterSaveVersion is the same invariant at the other point a copy
+// is taken, immediately after a commit. This one holds even without the fix, so
+// it guards against a fix that only moves the window rather than closing it.
+func TestCopyFreezesAfterSaveVersion(t *testing.T) {
+	tree := seedTree(t, copyTestSeedKeys)
+	tree.ApplyChangeSet(changeSet(0, 500, "committed"))
+	_, _, err := tree.SaveVersion(true)
+	require.NoError(t, err)
+
+	frozen := tree.Copy()
+
+	unhashed, mutable := frozenViolations(frozen)
+	require.Zero(t, mutable, "copy shares %d MemNode(s) above cowVersion %d", mutable, frozen.cowVersion)
+	require.Zero(t, unhashed, "copy shares %d unhashed MemNode(s)", unhashed)
+}
+
+// TestCopyIsStableWhileLiveTreeAdvances is the behavioural form of the invariant:
+// the tree handed to the snapshot writer must serialize identically no matter how
+// far the live tree advances underneath it. A copy taken mid-version fails this
+// when the live commits mutate its nodes in place.
+func TestCopyIsStableWhileLiveTreeAdvances(t *testing.T) {
+	tree := seedTree(t, copyTestSeedKeys)
+	tree.ApplyChangeSet(changeSet(0, 500, "mid"))
+
+	frozen := tree.Copy()
+	want := frozen.RootHash()
+	wantVersion := frozen.Version()
+
+	// Finish the in-flight version, then keep committing.
+	_, _, err := tree.SaveVersion(true)
+	require.NoError(t, err)
+	for round := 0; round < 20; round++ {
+		tree.ApplyChangeSet(changeSet(round*100, 500, fmt.Sprintf("adv%02d", round)))
+		_, _, err := tree.SaveVersion(true)
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, wantVersion, frozen.Version(), "copy's version moved with the live tree")
+	require.Equal(t, want, frozen.RootHash(), "live-tree commits mutated nodes the copy still references")
+}
+
+// TestCopyDoesNotInheritBackgroundWriteChannel covers the other way a copy
+// reaches back into the live tree. Close closes pendingChanges, so a copy that
+// inherited the channel closes the live tree's background writer: the next
+// ApplyChangeSetAsync sends on a closed channel and panics, and
+// WaitToCompleteAsyncWrite closes it a second time.
+func TestCopyDoesNotInheritBackgroundWriteChannel(t *testing.T) {
+	tree := seedTree(t, 100)
+	tree.StartBackgroundWrite()
+	defer tree.WaitToCompleteAsyncWrite()
+
+	frozen := tree.Copy()
+
+	require.Nil(t, frozen.pendingChanges, "copy shares the live tree's background-write channel")
+	require.NotSame(t, tree.pendingWg, frozen.pendingWg, "copy shares the live tree's background-write WaitGroup")
+}

--- a/sei-db/state_db/sc/memiavl/tree_race_test.go
+++ b/sei-db/state_db/sc/memiavl/tree_race_test.go
@@ -1,7 +1,10 @@
 package memiavl
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -98,5 +101,79 @@ func TestTreeConcurrentRootHash(t *testing.T) {
 
 	for i := 1; i < workers; i++ {
 		require.Equal(t, hashes[0], hashes[i], "concurrent RootHash produced divergent hashes")
+	}
+}
+
+// TestSnapshotWriteRaceWithLiveCommits reproduces the corrupted-snapshot failure
+// that surfaces at startup as "leaves file size N is not a multiple of 48". The
+// background rewrite serializes a Copy of the tree while consensus keeps
+// committing, and the copy is taken mid-version, which is where DB.Commit takes
+// it. If the copy is not frozen, those commits mutate nodes the writer is
+// traversing: Mutate clears MemNode.hash under the writer, and writeLeafDirect
+// emits the 16-byte header and the hash as two writes, so a torn read of the
+// cleared slice header writes a leaf record with no hash and leaves the file 32
+// bytes short. Under -race the unsynchronized MemNode access is the signal; the
+// file-size assertions cover the on-disk symptom.
+func TestSnapshotWriteRaceWithLiveCommits(t *testing.T) {
+	const (
+		rounds           = 6
+		blocksPerRound   = 30
+		keysPerChangeSet = 400
+	)
+
+	dir := t.TempDir()
+	tree := seedTree(t, copyTestSeedKeys)
+
+	var (
+		wg       sync.WaitGroup
+		errMtx   sync.Mutex
+		writeErr []error
+	)
+
+	for round := 0; round < rounds; round++ {
+		// Copy mid-version, before SaveVersion, matching DB.Commit's ordering.
+		tree.ApplyChangeSet(changeSet(round*137, keysPerChangeSet, fmt.Sprintf("pre%02d", round)))
+		frozen := tree.Copy()
+
+		snapshotDir := filepath.Join(dir, fmt.Sprintf("snapshot-%d", round))
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := frozen.WriteSnapshot(context.Background(), snapshotDir); err != nil {
+				errMtx.Lock()
+				writeErr = append(writeErr, err)
+				errMtx.Unlock()
+			}
+		}()
+
+		_, _, err := tree.SaveVersion(true)
+		require.NoError(t, err)
+		for block := 0; block < blocksPerRound; block++ {
+			tree.ApplyChangeSet(changeSet(block*29, keysPerChangeSet, fmt.Sprintf("r%02db%02d", round, block)))
+			_, _, err := tree.SaveVersion(true)
+			require.NoError(t, err)
+		}
+	}
+	wg.Wait()
+	require.Empty(t, writeErr, "snapshot writer failed while the live tree committed")
+
+	for round := 0; round < rounds; round++ {
+		snapshotDir := filepath.Join(dir, fmt.Sprintf("snapshot-%d", round))
+
+		info, err := os.Stat(filepath.Join(snapshotDir, FileNameLeaves))
+		require.NoError(t, err)
+		require.Zerof(t, info.Size()%int64(SizeLeaf),
+			"round %d: leaves file size %d is not a multiple of %d", round, info.Size(), SizeLeaf)
+
+		info, err = os.Stat(filepath.Join(snapshotDir, FileNameNodes))
+		require.NoError(t, err)
+		require.Zerof(t, info.Size()%int64(SizeNode),
+			"round %d: nodes file size %d is not a multiple of %d", round, info.Size(), SizeNode)
+
+		// The published snapshot must reopen, which is the check that panics the
+		// node on restart when a rewrite raced a commit.
+		snapshot, err := OpenSnapshot(snapshotDir, Options{})
+		require.NoErrorf(t, err, "round %d: snapshot written during live commits does not reopen", round)
+		require.NoError(t, snapshot.Close())
 	}
 }

--- a/sei-db/state_db/sc/memiavl/tree_race_test.go
+++ b/sei-db/state_db/sc/memiavl/tree_race_test.go
@@ -104,16 +104,77 @@ func TestTreeConcurrentRootHash(t *testing.T) {
 	}
 }
 
+// TestCopyReadRaceWithLiveCommits covers the cross-copy hole that the per-tree
+// write lock does not close. RootHash and the proof builders take the write lock
+// because MemNode.Hash fills the hash cache in place (Immunefi 83246), but Copy
+// gives each tree its own mutex, so a copy and the tree it came from serialize
+// against nothing. Reading a copy whose nodes the live tree is still free to
+// mutate is the same unsynchronized access, one lock away from the fix for it.
+//
+// This is the trace-snapshot path: SnapshotSCStore hands EndBlock a DB.Copy, and
+// ApplyChangeSets has already released db.mtx by then, so the copy can share
+// nodes stamped at version+1 that the old cowVersion = t.version floor left
+// mutable. Its consequence is a wrong trace or proof rather than a bad snapshot
+// file, which is why it is separate from the writer test below.
+func TestCopyReadRaceWithLiveCommits(t *testing.T) {
+	const (
+		rounds           = 4
+		blocksPerRound   = 20
+		keysPerChangeSet = 200
+	)
+
+	tree := seedTree(t, copyTestSeedKeys)
+
+	for round := 0; round < rounds; round++ {
+		// Copy mid-version, where DB.Copy lands between ApplyChangeSets and Commit.
+		tree.ApplyChangeSet(changeSet(round*53, keysPerChangeSet, fmt.Sprintf("pre%02d", round)))
+		leased := tree.Copy()
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < blocksPerRound; i++ {
+				_ = leased.RootHash()
+				_ = leased.Get([]byte(fmt.Sprintf("key%08d", i)))
+				_ = leased.GetProof([]byte(fmt.Sprintf("key%08d", i)))
+			}
+		}()
+
+		_, _, err := tree.SaveVersion(true)
+		require.NoError(t, err)
+		for block := 0; block < blocksPerRound; block++ {
+			tree.ApplyChangeSet(changeSet(block*17, keysPerChangeSet, fmt.Sprintf("r%02db%02d", round, block)))
+			_, _, err := tree.SaveVersion(true)
+			require.NoError(t, err)
+		}
+		wg.Wait()
+	}
+}
+
 // TestSnapshotWriteRaceWithLiveCommits reproduces the corrupted-snapshot failure
 // that surfaces at startup as "leaves file size N is not a multiple of 48". The
 // background rewrite serializes a Copy of the tree while consensus keeps
-// committing, and the copy is taken mid-version, which is where DB.Commit takes
-// it. If the copy is not frozen, those commits mutate nodes the writer is
+// committing. If the copy is not frozen, those commits mutate nodes the writer is
 // traversing: Mutate clears MemNode.hash under the writer, and writeLeafDirect
 // emits the 16-byte header and the hash as two writes, so a torn read of the
 // cleared slice header writes a leaf record with no hash and leaves the file 32
-// bytes short. Under -race the unsynchronized MemNode access is the signal; the
-// file-size assertions cover the on-disk symptom.
+// bytes short.
+//
+// The copy is taken mid-version, between a changeset and SaveVersion, which is
+// what DB.Copy and CommitStore.Copy produce: ApplyChangeSets releases db.mtx on
+// return, so a copy taken before the following Commit sees nodes stamped at
+// version+1. That is the state the old cowVersion = t.version floor left
+// mutable. The background rewrite, by contrast, copies inside Commit after
+// SaveVersion, where that floor already covered every node.
+//
+// Driving the snapshot writer over such a copy composes the two: the mid-version
+// copy is the state a real caller produces, and the writer is the reader that
+// touches every reachable node, which makes it the strongest probe of the freeze.
+//
+// Under -race the unsynchronized MemNode access is the signal. The assertions
+// then cover the on-disk result: well-formedness, and that each snapshot holds
+// the tree as it stood when copied rather than some blend of it and later blocks.
 func TestSnapshotWriteRaceWithLiveCommits(t *testing.T) {
 	const (
 		rounds           = 6
@@ -123,6 +184,9 @@ func TestSnapshotWriteRaceWithLiveCommits(t *testing.T) {
 
 	dir := t.TempDir()
 	tree := seedTree(t, copyTestSeedKeys)
+	roundDir := func(round int) string {
+		return filepath.Join(dir, fmt.Sprintf("snapshot-%d", round))
+	}
 
 	var (
 		wg       sync.WaitGroup
@@ -130,12 +194,15 @@ func TestSnapshotWriteRaceWithLiveCommits(t *testing.T) {
 		writeErr []error
 	)
 
+	// Root hash of each copy at the moment it was handed to the writer.
+	wantHash := make([][]byte, rounds)
+
 	for round := 0; round < rounds; round++ {
-		// Copy mid-version, before SaveVersion, matching DB.Commit's ordering.
 		tree.ApplyChangeSet(changeSet(round*137, keysPerChangeSet, fmt.Sprintf("pre%02d", round)))
 		frozen := tree.Copy()
+		wantHash[round] = frozen.RootHash()
 
-		snapshotDir := filepath.Join(dir, fmt.Sprintf("snapshot-%d", round))
+		snapshotDir := roundDir(round)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -158,7 +225,7 @@ func TestSnapshotWriteRaceWithLiveCommits(t *testing.T) {
 	require.Empty(t, writeErr, "snapshot writer failed while the live tree committed")
 
 	for round := 0; round < rounds; round++ {
-		snapshotDir := filepath.Join(dir, fmt.Sprintf("snapshot-%d", round))
+		snapshotDir := roundDir(round)
 
 		info, err := os.Stat(filepath.Join(snapshotDir, FileNameLeaves))
 		require.NoError(t, err)
@@ -174,6 +241,12 @@ func TestSnapshotWriteRaceWithLiveCommits(t *testing.T) {
 		// node on restart when a rewrite raced a commit.
 		snapshot, err := OpenSnapshot(snapshotDir, Options{})
 		require.NoErrorf(t, err, "round %d: snapshot written during live commits does not reopen", round)
+
+		// A well-formed snapshot holding the wrong nodes reopens fine, so compare
+		// contents: the serialized tree must be the one that was copied.
+		require.Equalf(t, wantHash[round], snapshot.RootHash(),
+			"round %d: snapshot contents drifted from the copy the writer was given", round)
+
 		require.NoError(t, snapshot.Close())
 	}
 }


### PR DESCRIPTION
## Summary

`Tree.Copy()` shares nodes with the live tree but did not freeze them. A reader of the copy and a writer on the live tree therefore share `MemNode` memory with no lock in common, and a torn read of `MemNode.hash` is enough to produce a leaves file that is 32 bytes short of a whole number of records. This PR makes `Copy()` establish the freeze before handing the tree over.

The production crash that motivated the work is:

```
corrupted snapshot, leaves file size 63201088 is not a multiple of 48
```

The byte pattern matches that torn-hash write. **This PR does not claim to have found the production trigger, and should not be treated as a confirmed fix for that incident.** On the affected node's config, every concrete path we could enumerate is closed; see "Scope" below.

## The problem

Snapshots are written in the background so they don't block the chain. To do that safely, `Tree.Copy()` hands the writer its own view of the tree. The two views share the same underlying nodes in memory, and the deal is: the copy is *frozen*, so the live chain will never touch a node the writer is still reading.

`Copy()` was not keeping that deal. Three separate reasons:

- **The freeze line was off by one version.** Writes stamp new nodes at `version + 1`, but `Copy()` set its protection floor at `version`, leaving any node written during the current block unprotected. `DB.Copy` / `CommitStore.Copy` reach this state: `ApplyChangeSets` releases `db.mtx` on return, so a copy taken before the following `Commit` is mid-version.
- **`SaveVersion()` updated the version with no lock held**, so a concurrent copy could read the new version and compute a floor that protected nothing.
- **Nodes weren't guaranteed to be hashed before being handed over**, so a reader would compute and cache hashes in place on nodes the live tree also held.

Each leaf is written as a 16-byte header followed by its 32-byte hash. `writeLeaf` sizes that copy with `len(hash)`. A torn read of the slice header — pointer set, length still zero — yields a zero-length hash, so the writer emits the header and nothing else. That is a leaves file with remainder 16, which is the observed `63201088 % 48 == 16`.

### Why one mutex per copy is the underlying hole

`RootHash` and the proof builders take the *write* lock because `MemNode.Hash` fills the hash cache in place — that was the fix for Immunefi 83246. But `Copy()` gives each tree its **own** mutex, so that lock only serializes hash fills within a single tree instance. Two trees sharing nodes serialize against nothing, which puts the same unsynchronized mutation right back. Freezing the nodes before handing them over is what actually closes it.


## Changes

- `Copy()` now takes the write lock, hashes everything reachable before handing the tree over, and sets the protection floor to the highest version actually present in the tree instead of the last saved version.
- `SaveVersion()` is now a single locked section, so the version bump and the hashing can't be observed apart.
- The snapshot writer reads the root and the version together, so a snapshot's metadata can't claim a version its contents don't match.
- **Separate bug, also fixed:** a copy inherited the live tree's background-write channel, so calling `Close()` on *any* copy shut down the live tree's background writer and made the next async write panic on a closed channel. Copies now get their own.

There is no behavior change outside the race — no existing test needed editing.


## Notes for reviewers

- **Performance:** the added hashing in `Copy()` is free on the rewrite path, since the commit already hashed everything and the call short-circuits. Only a mid-block copy does real work, and that's work the next `SaveVersion` would have done moments later anyway. The tighter freeze line avoids extra node copies rather than adding them.
- **Relationship to #4036:** complementary, not redundant. That PR catches a corrupt snapshot before publishing it; this one stops the known API-reachable way of producing one. Worth having both: the validator is the backstop if another path to this kind of mutation turns up, and it is the only thing that would have turned this incident into a failed rewrite instead of a published-and-unbootable snapshot.
- **Still open:** the production trigger. The mechanism (torn `node.hash` at the write site → remainder 16) is exact. A production path that writes `node.hash` on a node the rewrite is traversing has not been found on this node's config.
