### PR TITLE
[ConfigManager] Check a Node's sei.toml

### DIFF
--- a/cmd/seid/cmd/check_through_root_test.go
+++ b/cmd/seid/cmd/check_through_root_test.go
@@ -1,0 +1,144 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sei-protocol/sei-chain/sei-cosmos/client"
+	"github.com/sei-protocol/sei-chain/sei-cosmos/client/flags"
+	"github.com/sei-protocol/sei-chain/sei-cosmos/server"
+	tmcli "github.com/sei-protocol/sei-chain/sei-tendermint/libs/cli"
+	"github.com/sei-protocol/sei-chain/testutil/configtest"
+)
+
+// runCheckThroughRoot runs `sei-config check --home <dir>` the way an operator and a runbook run it.
+//
+// Through the real root command, because that is what makes the difference. A command executed on its own
+// has no parent, so nothing the root does before it happens: no hook runs, no flag is marked changed by
+// anything but the caller, and no file is generated. Every one of those is a thing this command has to be
+// right about, and a test that builds the command directly cannot see any of them.
+func runCheckThroughRoot(t *testing.T, home string, extraArgs ...string) (string, error) {
+	t.Helper()
+
+	root, _ := NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SilenceUsage = true
+	root.SilenceErrors = true
+
+	// The same wiring the binary uses. --home is registered by PrepareBaseCmd rather than by the root
+	// command itself, so a root built without it is not the command an operator runs.
+	srvCtx := server.NewDefaultContext()
+	ctx := context.WithValue(context.Background(), client.ClientContextKey, &client.Context{})
+	ctx = context.WithValue(ctx, server.ServerContextKey, srvCtx)
+	root.PersistentFlags().String(flags.FlagLogLevel, "", "")
+	root.PersistentFlags().String(flags.FlagLogFormat, "", "")
+	executor := tmcli.PrepareBaseCmd(root, "", home)
+
+	root.SetArgs(append([]string{"sei-config", "check", "--home", home}, extraArgs...))
+	err := executor.ExecuteContext(ctx)
+	return out.String(), err
+}
+
+// writeSeiToml puts a sei.toml in a home that holds nothing else.
+func writeSeiToml(t *testing.T, body string) string {
+	t.Helper()
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "config"), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config", "sei.toml"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write sei.toml: %v", err)
+	}
+	return home
+}
+
+// TestTheCheckPassesACorrectFileWhenRunAsAnOperatorRunsIt is the answer the command exists to give.
+//
+// The one flag every real invocation carries is --home, and it names no setting: the node is told where its
+// files are, not what to put in them. It arrives in the resolution beside the file's own keys, and counted
+// with them it is a key nothing declares, so the command failed on a correct file and named a key the file
+// does not contain. A pre-flight that fails every time carries nothing, and it is the whole compensating
+// control for a boot that may not refuse a file.
+func TestTheCheckPassesACorrectFileWhenRunAsAnOperatorRunsIt(t *testing.T) {
+	configtest.Isolate(t)
+	home := writeSeiToml(t, "schema_version = 1\nnode_mode = \"validator\"\n\n[mempool]\nsize = 4321\n")
+
+	out, err := runCheckThroughRoot(t, home)
+	if err != nil {
+		t.Errorf("a correct file was refused when the command was run with --home: %v\n%s", err, out)
+	}
+	for _, flag := range []string{"home", "trace", "chain-id"} {
+		if strings.Contains(out, flag+": sei.toml writes this") {
+			t.Errorf("the report names --%s as something sei.toml wrote. The file does not contain it, "+
+				"and an operator told this on every run stops reading the one signal they have", flag)
+		}
+	}
+}
+
+// TestTheCheckDoesNotGenerateTheFilesItIsAskedAbout holds the command to answering rather than acting.
+//
+// The root command's hook runs the configuration handler, which writes config.toml and app.toml when they
+// are absent. A command that reports on one file would then create two others as a side effect, on a node
+// an operator was only asking a question about.
+func TestTheCheckDoesNotGenerateTheFilesItIsAskedAbout(t *testing.T) {
+	configtest.Isolate(t)
+	home := writeSeiToml(t, "schema_version = 1\nnode_mode = \"validator\"\n\n[mempool]\nsize = 4321\n")
+
+	// The verdict is not what this measures, and asserting it first would stop the measurement whenever
+	// something else about the check is wrong.
+	if out, err := runCheckThroughRoot(t, home); err != nil {
+		t.Logf("the check reported a problem, which is not what this test is about: %v\n%s", err, out)
+	}
+	for _, name := range []string{"config.toml", "app.toml"} {
+		if _, err := os.Stat(filepath.Join(home, "config", name)); err == nil {
+			t.Errorf("%s was created by a command that answers a question about a different file", name)
+		}
+	}
+}
+
+// TestTheCheckStillFailsAFileWithSomethingWrongInIt keeps the fixes above from making it answer nothing.
+//
+// Passing a correct file and generating no files are both satisfied by a command that does nothing at all,
+// so the failure has to be shown to still happen through the same path.
+func TestTheCheckStillFailsAFileWithSomethingWrongInIt(t *testing.T) {
+	configtest.Isolate(t)
+	for _, tc := range []struct {
+		name string
+		body string
+		says string
+	}{
+		{
+			name: "a key no section declares",
+			body: "schema_version = 1\nnode_mode = \"validator\"\n\n[mempool]\nsizze = 4321\n",
+			says: "no section declares it",
+		},
+		{
+			name: "a length of time as a plain number",
+			body: "schema_version = 1\nnode_mode = \"validator\"\n\n[mempool]\nttl-duration = 60\n",
+			says: "nanoseconds",
+		},
+		{
+			name: "a number larger than the setting holds",
+			body: "schema_version = 1\nnode_mode = \"validator\"\n\n[p2p]\nmax-connections = 1e20\n",
+			says: "larger than this setting can hold",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := runCheckThroughRoot(t, writeSeiToml(t, tc.body))
+			if err == nil {
+				t.Fatalf("the file was accepted, so a boot would apply what it could and the operator "+
+					"would find out afterwards\n%s", out)
+			}
+			if !strings.Contains(out, tc.says) {
+				t.Errorf("the report does not say %q, so it does not tell an operator what to change:\n%s",
+					tc.says, out)
+			}
+		})
+	}
+}

--- a/cmd/seid/cmd/check_through_root_test.go
+++ b/cmd/seid/cmd/check_through_root_test.go
@@ -147,3 +147,22 @@ func TestTheCheckStillFailsAFileWithSomethingWrongInIt(t *testing.T) {
 		})
 	}
 }
+
+// TestTheCheckRefusesWhatTheDeliveryWouldRefuse holds the two paths to the same answer.
+//
+// A value can decode cleanly and still be one the node's own rules reject, and the delivery refuses a
+// section on exactly that. A check that rehearses only the decode passes a file the boot drops, which is
+// the divergence this command exists to prevent rather than produce.
+func TestTheCheckRefusesWhatTheDeliveryWouldRefuse(t *testing.T) {
+	configtest.Isolate(t)
+	home := writeNodeHome(t,
+		"schema_version = 1\nnode_mode = \"validator\"\n\n[mempool]\nmax-tx-bytes = -1\n")
+
+	out, err := runCheckThroughRoot(t, home)
+	if err == nil {
+		t.Fatalf("a negative transaction-size ceiling passed the check, and a boot refuses it:\n%s", out)
+	}
+	if !strings.Contains(out, "max-tx-bytes") {
+		t.Errorf("the report does not name the value the node's rules reject:\n%s", out)
+	}
+}

--- a/cmd/seid/cmd/check_through_root_test.go
+++ b/cmd/seid/cmd/check_through_root_test.go
@@ -2,16 +2,12 @@ package cmd
 
 import (
 	"bytes"
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/sei-protocol/sei-chain/sei-cosmos/client"
-	"github.com/sei-protocol/sei-chain/sei-cosmos/client/flags"
-	"github.com/sei-protocol/sei-chain/sei-cosmos/server"
-	tmcli "github.com/sei-protocol/sei-chain/sei-tendermint/libs/cli"
+	svrcmd "github.com/sei-protocol/sei-chain/sei-cosmos/server/cmd"
 	"github.com/sei-protocol/sei-chain/testutil/configtest"
 )
 
@@ -30,19 +26,28 @@ func runCheckThroughRoot(t *testing.T, home string, extraArgs ...string) (string
 	root.SetErr(&out)
 	root.SilenceUsage = true
 	root.SilenceErrors = true
-
-	// The same wiring the binary uses. --home is registered by PrepareBaseCmd rather than by the root
-	// command itself, so a root built without it is not the command an operator runs.
-	srvCtx := server.NewDefaultContext()
-	ctx := context.WithValue(context.Background(), client.ClientContextKey, &client.Context{})
-	ctx = context.WithValue(ctx, server.ServerContextKey, srvCtx)
-	root.PersistentFlags().String(flags.FlagLogLevel, "", "")
-	root.PersistentFlags().String(flags.FlagLogFormat, "", "")
-	executor := tmcli.PrepareBaseCmd(root, "", home)
-
 	root.SetArgs(append([]string{"sei-config", "check", "--home", home}, extraArgs...))
-	err := executor.ExecuteContext(ctx)
+
+	// The binary's own entry point rather than a copy of it. It registers the two logging flags, seeds the
+	// client and server contexts, and runs PrepareBaseCmd, which is what registers --home. Re-implementing
+	// that here would drift the moment any of it changes, and the claim this helper rests on is that the
+	// command runs the way an operator runs it.
+	err := svrcmd.Execute(root, home)
 	return out.String(), err
+}
+
+// writeNodeHome puts a sei.toml in a home that also records what kind of node this is.
+//
+// A real node has a configuration file of its own. Without one, every case here would also carry a
+// disagreement about what kind of node it is, which is a different test's subject.
+func writeNodeHome(t *testing.T, body string) string {
+	t.Helper()
+	home := writeSeiToml(t, body)
+	if err := os.WriteFile(filepath.Join(home, "config", "config.toml"),
+		[]byte("mode = \"validator\"\n"), 0o600); err != nil {
+		t.Fatalf("write config.toml: %v", err)
+	}
+	return home
 }
 
 // writeSeiToml puts a sei.toml in a home that holds nothing else.
@@ -67,7 +72,7 @@ func writeSeiToml(t *testing.T, body string) string {
 // control for a boot that may not refuse a file.
 func TestTheCheckPassesACorrectFileWhenRunAsAnOperatorRunsIt(t *testing.T) {
 	configtest.Isolate(t)
-	home := writeSeiToml(t, "schema_version = 1\nnode_mode = \"validator\"\n\n[mempool]\nsize = 4321\n")
+	home := writeNodeHome(t, "schema_version = 1\nnode_mode = \"validator\"\n\n[mempool]\nsize = 4321\n")
 
 	out, err := runCheckThroughRoot(t, home)
 	if err != nil {
@@ -130,7 +135,7 @@ func TestTheCheckStillFailsAFileWithSomethingWrongInIt(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			out, err := runCheckThroughRoot(t, writeSeiToml(t, tc.body))
+			out, err := runCheckThroughRoot(t, writeNodeHome(t, tc.body))
 			if err == nil {
 				t.Fatalf("the file was accepted, so a boot would apply what it could and the operator "+
 					"would find out afterwards\n%s", out)

--- a/cmd/seid/cmd/check_through_root_test.go
+++ b/cmd/seid/cmd/check_through_root_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sei-protocol/sei-chain/testutil/configtest"
 )
 
-// runCheckThroughRoot runs `sei-config check --home <dir>` the way an operator and a runbook run it.
+// runCheckThroughRoot runs `config check --home <dir>` the way an operator and a runbook run it.
 //
 // Through the real root command, because that is what makes the difference. A command executed on its own
 // has no parent, so nothing the root does before it happens: no hook runs, no flag is marked changed by
@@ -26,7 +26,7 @@ func runCheckThroughRoot(t *testing.T, home string, extraArgs ...string) (string
 	root.SetErr(&out)
 	root.SilenceUsage = true
 	root.SilenceErrors = true
-	root.SetArgs(append([]string{"sei-config", "check", "--home", home}, extraArgs...))
+	root.SetArgs(append([]string{"config", "check", "--home", home}, extraArgs...))
 
 	// The binary's own entry point rather than a copy of it. It registers the two logging flags, seeds the
 	// client and server contexts, and runs PrepareBaseCmd, which is what registers --home. Re-implementing

--- a/cmd/seid/cmd/configmanager/check.go
+++ b/cmd/seid/cmd/configmanager/check.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -141,6 +142,16 @@ func checkSeiToml(cmd *cobra.Command) (problems, notes []string, found bool, err
 	if err != nil {
 		return nil, nil, false, fmt.Errorf("resolve the home directory: %w", err)
 	}
+	// An empty home leaves every path below relative, so the reads land in ./config under whatever
+	// directory this command was run from. That answers for some other node's files, and answering for
+	// the wrong node is worse than not answering: an operator runs this to decide whether to restart.
+	//
+	// The boot declines the same case. Refused rather than reported, because the exit status is this
+	// command's answer and there is nothing here to have an opinion about.
+	if home == "" {
+		return nil, nil, false, fmt.Errorf("no home directory is set, so there is no sei.toml to check. "+
+			"Pass --home, or set %s", theVariableThatSetsTheHome())
+	}
 	file, err := readSeiTomlAt(home)
 	switch {
 	case errors.Is(err, fs.ErrNotExist):
@@ -200,6 +211,18 @@ func checkSeiToml(cmd *cobra.Command) (problems, notes []string, found bool, err
 	problems = append(problems, whatADecodeWouldRefuse(resolved, own)...)
 	notes = append(notes, whatTheFileLeavesToTheDeclaration(resolved, written, mode))
 	return problems, notes, true, nil
+}
+
+// theVariableThatSetsTheHome names the environment variable the home resolves from.
+//
+// Derived from the running binary the same way the resolver derives it, so a message naming it cannot
+// drift from the name that actually works.
+func theVariableThatSetsTheHome() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return "the home variable for this binary"
+	}
+	return strings.ToUpper(path.Base(exe)) + "_HOME"
 }
 
 // theNodesOwnConfiguration reads the node's own configuration file into the struct a boot decodes it into.

--- a/cmd/seid/cmd/configmanager/check.go
+++ b/cmd/seid/cmd/configmanager/check.go
@@ -285,26 +285,27 @@ func whatTheResolutionAlreadyKnows(resolved registry.Resolved) []string {
 
 // whatADecodeWouldRefuse rehearses each decoded section the way the boot's delivery does.
 //
-// Rehearsed against the node's own configuration, which is the target the delivery uses. Every declared key
-// of a section is delivered, so the values under test are the same either way today; sharing the target is
-// what keeps the two answers together as the declared set changes.
-//
-// One difference remains. The delivery applies a section whose rules fail when the node's configuration
-// already fails its own, and this has no such allowance, so on a node in that state this reports a section
-// the boot applies.
+// Rehearsed against the node's own configuration, which is the target the delivery decodes into. Every
+// declared key of a section is delivered, so both rehearse the same values, and sharing the target keeps
+// the two answers together as the declared set changes.
 func whatADecodeWouldRefuse(resolved registry.Resolved, own *tmcfg.Config) []string {
 	bySection, _ := registry.ResolvedAndOwnedByDecodedSections(resolved)
+	base := own
+	if base == nil {
+		base = tmcfg.DefaultConfig()
+	}
+	// The type the node's configuration holds for each declared key, which is what a written value is
+	// weighed against below.
+	fields := keyFieldTypes(reflect.TypeOf(*base), "")
+
 	var problems []string
 	for _, name := range sortedKeys(bySection) {
 		values := bySection[name]
-		base := own
-		if base == nil {
-			base = tmcfg.DefaultConfig()
-		}
+		keys := sortedKeys(values)
 
-		// Each message says what is wrong with the value it names, and there is more than one thing that
-		// can be. Stating one of them here would describe the others wrongly.
-		fields := keyFieldTypes(reflect.TypeOf(*base), "")
+		// Asked before the decode, because a plain number where a length of time belongs decodes cleanly
+		// and means nanoseconds. Each message says what is wrong with the value it names, and there is
+		// more than one thing that can be, so stating one of them here would describe the others wrongly.
 		if bad := whatDecodesToSomethingElse(fields, values); len(bad) > 0 {
 			problems = append(problems, fmt.Sprintf("[%s]: %s", name,
 				strings.Join(problemsInOrder(bad), "; ")))
@@ -322,15 +323,16 @@ func whatADecodeWouldRefuse(resolved registry.Resolved, own *tmcfg.Config) []str
 		}
 		if err := source.Unmarshal(candidate); err != nil {
 			problems = append(problems, fmt.Sprintf("[%s]: %v, so none of this section would apply "+
-				"(keys: %s)", name, err, strings.Join(sortedKeys(values), ",")))
+				"(keys: %s)", name, err, strings.Join(keys, ",")))
 			continue
 		}
 
-		// The node's own rules, the same step the delivery takes after a clean decode. Without it this
-		// command passes a file the boot drops, which is the divergence it exists to prevent.
-		if err := candidate.ValidateBasic(); err != nil {
+		// The node's own rules, through the same function the delivery asks after a clean decode. The
+		// whole configuration's rules stop at the first failing section, so a failure standing anywhere in
+		// config.toml would read here as this section's values being refused.
+		if err := whatTheSectionsOwnRulesSay(candidate, keys); err != nil {
 			problems = append(problems, fmt.Sprintf("[%s]: %v, so none of this section would apply "+
-				"(keys: %s)", name, err, strings.Join(sortedKeys(values), ",")))
+				"(keys: %s)", name, err, strings.Join(keys, ",")))
 		}
 	}
 	sort.Strings(problems)

--- a/cmd/seid/cmd/configmanager/check.go
+++ b/cmd/seid/cmd/configmanager/check.go
@@ -154,6 +154,11 @@ func checkSeiToml(cmd *cobra.Command) (problems []string, found bool, err error)
 		return []string{fmt.Sprintf("this node's configuration cannot be resolved: %v", err)}, true, nil
 	}
 
+	// First, because a refused registration is what makes the report below name the wrong file: the
+	// section's keys are absent from the declared set, so an operator's valid key for one of them reads as
+	// a key nothing declares. Whoever reads this output in order has to meet the cause first.
+	problems = append(problems, whatTheResolutionAlreadyKnows(resolved)...)
+
 	// Only the file's own keys. A flag matching no declared key arrives in the same resolution and is not
 	// a mistake: every command carries flags that name no setting, so reporting those would fail this
 	// check on every invocation that types one, including a correct file.
@@ -171,7 +176,6 @@ func checkSeiToml(cmd *cobra.Command) (problems []string, found bool, err error)
 			"configuration file says %s. Every value resolved here is the answer for the first and the "+
 			"node would run as the second", mode, running))
 	}
-	problems = append(problems, whatTheResolutionAlreadyKnows(resolved)...)
 	problems = append(problems, whatADecodeWouldRefuse(resolved)...)
 	return problems, true, nil
 }

--- a/cmd/seid/cmd/configmanager/check.go
+++ b/cmd/seid/cmd/configmanager/check.go
@@ -1,0 +1,152 @@
+package configmanager
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/sei-protocol/sei-chain/config/registry"
+	tmcfg "github.com/sei-protocol/sei-chain/sei-tendermint/config"
+)
+
+// CheckCmd answers, without starting a node, whether this binary can use a sei.toml.
+//
+// A boot may not refuse a file. A node that stopped because one line was mistyped is worse than a node
+// running the value it ran yesterday, so every failure at boot is a report and the node keeps going. That
+// makes the report the only signal, and a fleet rolling a configuration change forward reads it after the
+// change is already on every node.
+//
+// The same questions have exact answers before then. The file, the binary and the environment are all the
+// input, so a refusal is deterministic: the same file against the same binary gives the same answer here as
+// it will at boot. This asks them where an answer costs a failed check rather than a restart.
+func CheckCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "check",
+		Short: "Report whether this binary can use the node's sei.toml",
+		Long: "Resolves the node's sei.toml the way a boot resolves it and reports every value this " +
+			"binary would refuse, without starting anything. Exits non-zero if there is one.\n\n" +
+			"A boot cannot refuse a file, so it applies what it can and reports the rest. Running this " +
+			"first is how a mistyped value costs a failed check rather than a restart.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			problems, found, err := checkSeiToml(cmd)
+			if err != nil {
+				return err
+			}
+			if !found {
+				report(cmd.OutOrStdout(), "this node has no sei.toml, so every key reads as it always "+
+					"has and there is nothing here to be wrong")
+				return nil
+			}
+			out := cmd.OutOrStdout()
+			for _, line := range problems {
+				report(out, line)
+			}
+			if len(problems) > 0 {
+				return fmt.Errorf("%d problem(s); a boot would apply what it could and report the rest",
+					len(problems))
+			}
+			report(out, "every value this file supplies is one this binary can use")
+			return nil
+		},
+	}
+	return cmd
+}
+
+// report writes one line of the answer.
+//
+// A failed write is dropped rather than returned. Where this runs the answer is the exit status, and a
+// caller that cannot read the report still gets that.
+func report(out io.Writer, line string) { _, _ = fmt.Fprintln(out, line) }
+
+// checkSeiToml resolves the node's file and returns what a boot would refuse, in the order it would.
+//
+// The absence of a file is not a problem to report: a node without one reads exactly as it always has, so
+// there is nothing here that could be wrong. A file that exists and will not read is the opposite, and is
+// reported as a problem of a file that was found.
+func checkSeiToml(cmd *cobra.Command) (problems []string, found bool, err error) {
+	home, err := resolveHomeDir(cmd)
+	if err != nil {
+		return nil, false, fmt.Errorf("resolve the home directory: %w", err)
+	}
+	file, err := readSeiTomlAt(home)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		// The absence of a file is the one case with nothing to report.
+		return nil, false, nil
+	case err != nil:
+		// A file that exists and will not read is the case this command exists for. Reported as a problem
+		// of a file that was found, so the command exits non-zero: an operator running this before a
+		// restart is asking whether their file is right, and answering that they have no file is both
+		// wrong and the answer least likely to make them look.
+		return []string{fmt.Sprintf("sei.toml cannot be read: %v", err)}, true, nil
+	}
+	mode, err := file.Mode()
+	if err != nil {
+		return []string{fmt.Sprintf("sei.toml records no usable node mode: %v", err)}, true, nil
+	}
+	written, err := file.Values()
+	if err != nil {
+		return []string{fmt.Sprintf("sei.toml cannot be read: %v", err)}, true, nil
+	}
+
+	resolved, err := registry.Resolve(registry.Mode(mode), registry.Sources{
+		File:      written,
+		LookupEnv: os.LookupEnv,
+		Flags:     flagValues(TypedFlags(cmd)),
+	})
+	if err != nil {
+		return []string{fmt.Sprintf("this node's configuration cannot be resolved: %v", err)}, true, nil
+	}
+
+	for _, key := range resolved.Unknown {
+		problems = append(problems, fmt.Sprintf("%s: sei.toml writes this and no section declares it, "+
+			"so it has no effect", key))
+	}
+	problems = append(problems, whatADecodeWouldRefuse(resolved)...)
+	return problems, true, nil
+}
+
+// whatADecodeWouldRefuse rehearses each decoded section the way the boot's delivery does.
+//
+// Rehearsed against a fresh configuration rather than a running node's, because there is no node here. That
+// is a weaker target than the delivery uses, and the difference is the point: a value this accepts may still
+// be refused at boot if the field it lands on holds something this cannot see. It is why this reports what
+// it can answer and the boot still reports what it finds.
+func whatADecodeWouldRefuse(resolved registry.Resolved) []string {
+	bySection := registry.SuppliedByDecodedSection(resolved)
+	var problems []string
+	for _, name := range sortedSectionNames(bySection) {
+		values := bySection[name]
+		base := tmcfg.DefaultConfig()
+
+		if bad := refuseWhatDecodesToSomethingElse(base, values); len(bad) > 0 {
+			problems = append(problems, fmt.Sprintf("[%s]: %s is a length of time written as a plain "+
+				"number, which reads as nanoseconds", name, strings.Join(bad, "; ")))
+			continue
+		}
+
+		source := viper.New()
+		for key, value := range values {
+			source.Set(key, value)
+		}
+		candidate, err := copyNodeConfig(base)
+		if err != nil {
+			problems = append(problems, fmt.Sprintf("[%s]: cannot be rehearsed: %v", name, err))
+			continue
+		}
+		if err := source.Unmarshal(candidate); err != nil {
+			problems = append(problems, fmt.Sprintf("[%s]: %v, so none of this section would apply "+
+				"(keys: %s)", name, err, strings.Join(sortedKeys(values), ",")))
+		}
+	}
+	sort.Strings(problems)
+	return problems
+}

--- a/cmd/seid/cmd/configmanager/check.go
+++ b/cmd/seid/cmd/configmanager/check.go
@@ -45,6 +45,10 @@ func CheckCmd() *cobra.Command {
 			"A boot cannot refuse a file, so it applies what it can and reports the rest. Running this " +
 			"first is how a mistyped value costs a failed check rather than a restart.",
 		Args: cobra.NoArgs,
+		// A mistyped value is not a usage error, and nothing in the production wiring silences usage, so
+		// cobra would follow this command's error with the whole usage block into the same stdout the
+		// report was just written to.
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			out := cmd.OutOrStdout()
 
@@ -157,11 +161,17 @@ func checkSeiToml(cmd *cobra.Command) (problems []string, found bool, err error)
 		problems = append(problems, fmt.Sprintf("%s: sei.toml writes this and no section declares it, "+
 			"so it has no effect", key))
 	}
-	if running := theModeTheNodesOwnFileRecords(home); modesDisagree(mode, running) {
+	running, err := theModeTheNodesOwnFileRecords(home)
+	switch {
+	case err != nil:
+		problems = append(problems, fmt.Sprintf("the node's own configuration file cannot be read, so a "+
+			"boot would not start: %v", err))
+	case modesDisagree(mode, running):
 		problems = append(problems, fmt.Sprintf("sei.toml says this is a %s and the node's own "+
 			"configuration file says %s. Every value resolved here is the answer for the first and the "+
 			"node would run as the second", mode, running))
 	}
+	problems = append(problems, whatTheResolutionAlreadyKnows(resolved)...)
 	problems = append(problems, whatADecodeWouldRefuse(resolved)...)
 	return problems, true, nil
 }
@@ -175,16 +185,44 @@ func checkSeiToml(cmd *cobra.Command) (problems []string, found bool, err error)
 // never empty on that path. Answering empty here would pass a node whose sei.toml names a different kind,
 // and then that node reports the disagreement at its loudest level on the next start: a pass in exactly
 // the case with the largest consequence.
-func theModeTheNodesOwnFileRecords(home string) string {
+func theModeTheNodesOwnFileRecords(home string) (string, error) {
 	v := viper.New()
 	v.SetConfigFile(filepath.Join(home, "config", "config.toml"))
-	if err := v.ReadInConfig(); err != nil {
-		return tmcfg.DefaultConfig().Mode
+	switch err := v.ReadInConfig(); {
+	case errors.Is(err, fs.ErrNotExist):
+		// The only case that is an absence. Every other failure is a file somebody wrote that this
+		// binary cannot read, and a boot does not start at all on one of those, so answering with a
+		// default would pass a node that cannot boot.
+	case err != nil:
+		return "", err
 	}
 	if mode := v.GetString("mode"); mode != "" {
-		return mode
+		return mode, nil
 	}
-	return tmcfg.DefaultConfig().Mode
+	return tmcfg.DefaultConfig().Mode, nil
+}
+
+// whatTheResolutionAlreadyKnows returns the problems a resolution reports without any rehearsal.
+//
+// Two of them, and the boot reports both. A refused registration leaves its section's keys out of the
+// declared set, so an operator's valid key lands among the undeclared ones and this command would tell them
+// their file is wrong about a key it was right about. Reported first for that reason, so whoever reads the
+// output in order meets the cause before the symptom.
+//
+// The other is a variable set for a key the environment cannot carry. The boot warns about it and this
+// command was silent, so an operator was not told that the channel they reached for did nothing.
+func whatTheResolutionAlreadyKnows(resolved registry.Resolved) []string {
+	problems := make([]string, 0, len(resolved.Refused)+len(resolved.Ignored))
+	for _, d := range resolved.Refused {
+		problems = append(problems, fmt.Sprintf("this binary's own registration of [%s] carries a defect, "+
+			"so some declared keys do not reach the node as declared: %v", d.Section, d.Err))
+	}
+	for _, key := range sortedKeys(resolved.Ignored) {
+		problems = append(problems, fmt.Sprintf("%s: an environment variable is set for this and the "+
+			"environment cannot supply it, so it has no effect and the file's value applies (%s)",
+			key, resolved.Ignored[key]))
+	}
+	return problems
 }
 
 // whatADecodeWouldRefuse rehearses each decoded section the way the boot's delivery does.

--- a/cmd/seid/cmd/configmanager/check.go
+++ b/cmd/seid/cmd/configmanager/check.go
@@ -200,8 +200,11 @@ func theModeTheNodesOwnFileRecords(home string) (string, error) {
 	case err != nil:
 		return "", err
 	}
-	if mode := v.GetString("mode"); mode != "" {
-		return mode, nil
+	// A key that is present answers with what it holds, empty included. A boot unmarshals that empty
+	// string over the default, so the running kind really is empty and the comparison beside this reports
+	// it. Substituting the default here would pass a node the boot goes on to report.
+	if v.IsSet("mode") {
+		return v.GetString("mode"), nil
 	}
 	return tmcfg.DefaultConfig().Mode, nil
 }
@@ -236,7 +239,7 @@ func whatTheResolutionAlreadyKnows(resolved registry.Resolved) []string {
 // be refused at boot if the field it lands on holds something this cannot see. It is why this reports what
 // it can answer and the boot still reports what it finds.
 func whatADecodeWouldRefuse(resolved registry.Resolved) []string {
-	bySection := registry.SuppliedByDecodedSection(resolved)
+	bySection, _ := registry.SuppliedAndOwnedByDecodedSections(resolved)
 	var problems []string
 	for _, name := range sortedKeys(bySection) {
 		values := bySection[name]

--- a/cmd/seid/cmd/configmanager/check.go
+++ b/cmd/seid/cmd/configmanager/check.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -24,8 +25,17 @@ import (
 // change is already on every node.
 //
 // The same questions have exact answers before then. The file, the binary and the environment are all the
-// input, so a refusal is deterministic: the same file against the same binary gives the same answer here as
-// it will at boot. This asks them where an answer costs a failed check rather than a restart.
+// input, so the same file against the same binary gives the same answer here as it will at boot, for the
+// same environment. That last part is a real condition and not a formality: this reads the environment of
+// whoever runs it, and a node started by an init system or a container runtime has a different one. A
+// variable that answers a declared key is a variable this cannot see unless it is set here too.
+//
+// What it does not rehearse is the install into the source a node builds, because that source does not
+// exist until a boot builds it. A key can be refused there for a reason nothing here can see, and the whole
+// install is dropped when it is. That is worth adding when the surface it covers is more than a handful of
+// keys on a live node.
+//
+// This asks what it can answer where an answer costs a failed check rather than a restart.
 func CheckCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "check",
@@ -46,6 +56,7 @@ func CheckCmd() *cobra.Command {
 				return nil
 			}
 			out := cmd.OutOrStdout()
+			reportWhetherABootWouldReadThisFile(out, os.Getenv)
 			for _, line := range problems {
 				report(out, line)
 			}
@@ -58,6 +69,25 @@ func CheckCmd() *cobra.Command {
 		},
 	}
 	return cmd
+}
+
+// reportWhetherABootWouldReadThisFile says whether this node is set up to use the file at all.
+//
+// Without it, a passing check reads as "this file is in use and correct" on a node where a boot ignores it
+// completely, which is the state every node is in until an operator switches the gate. That is the wrong
+// conclusion in the more dangerous direction: it invites somebody to trust a file nothing reads.
+//
+// Answered from the environment this command runs in, which is the same limitation the resolution has.
+func reportWhetherABootWouldReadThisFile(out io.Writer, getenv func(string) string) {
+	if _, err := Select(getenv); err != nil {
+		report(out, fmt.Sprintf("%s is set to something this binary does not accept, so a boot would "+
+			"refuse before reaching this file: %v", EnvVar, err))
+		return
+	}
+	if getenv(EnvVar) != "v2" {
+		report(out, fmt.Sprintf("%s is not set to v2 for this command, so a boot in the same environment "+
+			"reads none of this file. What follows is what it would reach if it were", EnvVar))
+	}
 }
 
 // report writes one line of the answer.
@@ -106,12 +136,34 @@ func checkSeiToml(cmd *cobra.Command) (problems []string, found bool, err error)
 		return []string{fmt.Sprintf("this node's configuration cannot be resolved: %v", err)}, true, nil
 	}
 
-	for _, key := range resolved.Unknown {
+	// Only the file's own keys. A flag matching no declared key arrives in the same resolution and is not
+	// a mistake: every command carries flags that name no setting, so reporting those would fail this
+	// check on every invocation that types one, including a correct file.
+	for _, key := range resolved.UnknownInFile {
 		problems = append(problems, fmt.Sprintf("%s: sei.toml writes this and no section declares it, "+
 			"so it has no effect", key))
 	}
+	if running := theModeTheNodesOwnFileRecords(home); modesDisagree(mode, running) {
+		problems = append(problems, fmt.Sprintf("sei.toml says this is a %s and the node's own "+
+			"configuration file says %s. Every value resolved here is the answer for the first and the "+
+			"node would run as the second", mode, running))
+	}
 	problems = append(problems, whatADecodeWouldRefuse(resolved)...)
 	return problems, true, nil
+}
+
+// theModeTheNodesOwnFileRecords reads what kind of node the node's own configuration file says this is.
+//
+// Read from the file here rather than taken from a running node, because nothing is running. An absent file
+// or an absent key answers empty, which is not a disagreement: a node that was never initialised has
+// nothing to disagree with.
+func theModeTheNodesOwnFileRecords(home string) string {
+	v := viper.New()
+	v.SetConfigFile(filepath.Join(home, "config", "config.toml"))
+	if err := v.ReadInConfig(); err != nil {
+		return ""
+	}
+	return v.GetString("mode")
 }
 
 // whatADecodeWouldRefuse rehearses each decoded section the way the boot's delivery does.
@@ -123,13 +175,14 @@ func checkSeiToml(cmd *cobra.Command) (problems []string, found bool, err error)
 func whatADecodeWouldRefuse(resolved registry.Resolved) []string {
 	bySection := registry.SuppliedByDecodedSection(resolved)
 	var problems []string
-	for _, name := range sortedSectionNames(bySection) {
+	for _, name := range sortedKeys(bySection) {
 		values := bySection[name]
 		base := tmcfg.DefaultConfig()
 
-		if bad := refuseWhatDecodesToSomethingElse(base, values); len(bad) > 0 {
-			problems = append(problems, fmt.Sprintf("[%s]: %s is a length of time written as a plain "+
-				"number, which reads as nanoseconds", name, strings.Join(bad, "; ")))
+		// Each message says what is wrong with the value it names, and there is more than one thing that
+		// can be. Stating one of them here would describe the others wrongly.
+		if bad := whatDecodesToSomethingElse(base, values); len(bad) > 0 {
+			problems = append(problems, fmt.Sprintf("[%s]: %s", name, strings.Join(bad, "; ")))
 			continue
 		}
 

--- a/cmd/seid/cmd/configmanager/check.go
+++ b/cmd/seid/cmd/configmanager/check.go
@@ -46,48 +46,62 @@ func CheckCmd() *cobra.Command {
 			"first is how a mistyped value costs a failed check rather than a restart.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			problems, found, err := checkSeiToml(cmd)
+			out := cmd.OutOrStdout()
+
+			// The gate is answered first and whether or not there is a file, because a value this binary
+			// refuses stops the node before it reaches one. Reported as a problem for the same reason: the
+			// exit status is this command's answer, and a node that cannot start is not a pass.
+			problems, notes := whatTheGateSays(os.Getenv)
+
+			inTheFile, found, err := checkSeiToml(cmd)
 			if err != nil {
 				return err
 			}
-			if !found {
-				report(cmd.OutOrStdout(), "this node has no sei.toml, so every key reads as it always "+
-					"has and there is nothing here to be wrong")
-				return nil
+			problems = append(problems, inTheFile...)
+
+			switch {
+			case !found:
+				notes = append(notes, "this node has no sei.toml, so every key reads as it always has "+
+					"and there is nothing in it to be wrong")
+			case len(problems) == 0:
+				notes = append(notes, "every value this file supplies is one this binary can use")
 			}
-			out := cmd.OutOrStdout()
-			reportWhetherABootWouldReadThisFile(out, os.Getenv)
-			for _, line := range problems {
+
+			for _, line := range append(notes, problems...) {
 				report(out, line)
 			}
 			if len(problems) > 0 {
 				return fmt.Errorf("%d problem(s); a boot would apply what it could and report the rest",
 					len(problems))
 			}
-			report(out, "every value this file supplies is one this binary can use")
 			return nil
 		},
 	}
 	return cmd
 }
 
-// reportWhetherABootWouldReadThisFile says whether this node is set up to use the file at all.
+// whatTheGateSays answers what the gate means for this node, split into problems and notes.
 //
-// Without it, a passing check reads as "this file is in use and correct" on a node where a boot ignores it
-// completely, which is the state every node is in until an operator switches the gate. That is the wrong
-// conclusion in the more dangerous direction: it invites somebody to trust a file nothing reads.
+// A value this binary does not accept is a problem rather than a note. A boot refuses on it before reaching
+// any file, so the node will not start, and this command's answer is its exit status: reporting that as a
+// passing run tells a runbook the node is fine when it cannot boot.
+//
+// A gate that is simply off is a note. Without it a passing check reads as "this file is in use and
+// correct" on a node where a boot ignores the file completely, which is every node until an operator
+// switches it. That is the wrong conclusion in the more dangerous direction, because it invites somebody to
+// trust a file nothing reads.
 //
 // Answered from the environment this command runs in, which is the same limitation the resolution has.
-func reportWhetherABootWouldReadThisFile(out io.Writer, getenv func(string) string) {
+func whatTheGateSays(getenv func(string) string) (problems, notes []string) {
 	if _, err := Select(getenv); err != nil {
-		report(out, fmt.Sprintf("%s is set to something this binary does not accept, so a boot would "+
-			"refuse before reaching this file: %v", EnvVar, err))
-		return
+		return []string{fmt.Sprintf("%s is set to something this binary does not accept, so a boot "+
+			"would refuse before reaching this file: %v", EnvVar, err)}, nil
 	}
 	if getenv(EnvVar) != "v2" {
-		report(out, fmt.Sprintf("%s is not set to v2 for this command, so a boot in the same environment "+
-			"reads none of this file. What follows is what it would reach if it were", EnvVar))
+		return nil, []string{fmt.Sprintf("%s is not set to v2 for this command, so a boot in the same "+
+			"environment reads none of this file. What follows is what it would reach if it were", EnvVar)}
 	}
+	return nil, nil
 }
 
 // report writes one line of the answer.
@@ -154,16 +168,23 @@ func checkSeiToml(cmd *cobra.Command) (problems []string, found bool, err error)
 
 // theModeTheNodesOwnFileRecords reads what kind of node the node's own configuration file says this is.
 //
-// Read from the file here rather than taken from a running node, because nothing is running. An absent file
-// or an absent key answers empty, which is not a disagreement: a node that was never initialised has
-// nothing to disagree with.
+// Read from the file here rather than taken from a running node, because nothing is running.
+//
+// An absent file, or one with no mode in it, answers what a boot would compute rather than empty. A boot
+// starts from this binary's defaults and writes the file itself when it is missing, so the running mode is
+// never empty on that path. Answering empty here would pass a node whose sei.toml names a different kind,
+// and then that node reports the disagreement at its loudest level on the next start: a pass in exactly
+// the case with the largest consequence.
 func theModeTheNodesOwnFileRecords(home string) string {
 	v := viper.New()
 	v.SetConfigFile(filepath.Join(home, "config", "config.toml"))
 	if err := v.ReadInConfig(); err != nil {
-		return ""
+		return tmcfg.DefaultConfig().Mode
 	}
-	return v.GetString("mode")
+	if mode := v.GetString("mode"); mode != "" {
+		return mode
+	}
+	return tmcfg.DefaultConfig().Mode
 }
 
 // whatADecodeWouldRefuse rehearses each decoded section the way the boot's delivery does.

--- a/cmd/seid/cmd/configmanager/check.go
+++ b/cmd/seid/cmd/configmanager/check.go
@@ -49,6 +49,17 @@ func CheckCmd() *cobra.Command {
 		// cobra would follow this command's error with the whole usage block into the same stdout the
 		// report was just written to.
 		SilenceUsage: true,
+		// A hook of its own, which stops the root one from running. Cobra runs the closest hook it finds,
+		// so this covers only this command. Two things follow, and both are required.
+		//
+		// The root hook writes files. It runs the configuration handler, which generates config.toml and
+		// app.toml when they are absent, so a command that answers a question about a file would create
+		// two others as a side effect.
+		//
+		// It also copies configuration values into flags and marks them changed. That is the state which
+		// makes a flag indistinguishable from a key an operator's app.toml holds. This command reports on
+		// what was typed, so it has to read the flags before that happens.
+		PersistentPreRunE: func(*cobra.Command, []string) error { return nil },
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			out := cmd.OutOrStdout()
 

--- a/cmd/seid/cmd/configmanager/check.go
+++ b/cmd/seid/cmd/configmanager/check.go
@@ -57,11 +57,12 @@ func CheckCmd() *cobra.Command {
 			// exit status is this command's answer, and a node that cannot start is not a pass.
 			problems, notes := whatTheGateSays(os.Getenv)
 
-			inTheFile, found, err := checkSeiToml(cmd)
+			inTheFile, fromTheFile, found, err := checkSeiToml(cmd)
 			if err != nil {
 				return err
 			}
 			problems = append(problems, inTheFile...)
+			notes = append(notes, fromTheFile...)
 
 			switch {
 			case !found:
@@ -119,30 +120,30 @@ func report(out io.Writer, line string) { _, _ = fmt.Fprintln(out, line) }
 // The absence of a file is not a problem to report: a node without one reads exactly as it always has, so
 // there is nothing here that could be wrong. A file that exists and will not read is the opposite, and is
 // reported as a problem of a file that was found.
-func checkSeiToml(cmd *cobra.Command) (problems []string, found bool, err error) {
+func checkSeiToml(cmd *cobra.Command) (problems, notes []string, found bool, err error) {
 	home, err := resolveHomeDir(cmd)
 	if err != nil {
-		return nil, false, fmt.Errorf("resolve the home directory: %w", err)
+		return nil, nil, false, fmt.Errorf("resolve the home directory: %w", err)
 	}
 	file, err := readSeiTomlAt(home)
 	switch {
 	case errors.Is(err, fs.ErrNotExist):
 		// The absence of a file is the one case with nothing to report.
-		return nil, false, nil
+		return nil, nil, false, nil
 	case err != nil:
 		// A file that exists and will not read is the case this command exists for. Reported as a problem
 		// of a file that was found, so the command exits non-zero: an operator running this before a
 		// restart is asking whether their file is right, and answering that they have no file is both
 		// wrong and the answer least likely to make them look.
-		return []string{fmt.Sprintf("sei.toml cannot be read: %v", err)}, true, nil
+		return []string{fmt.Sprintf("sei.toml cannot be read: %v", err)}, nil, true, nil
 	}
 	mode, err := file.Mode()
 	if err != nil {
-		return []string{fmt.Sprintf("sei.toml records no usable node mode: %v", err)}, true, nil
+		return []string{fmt.Sprintf("sei.toml records no usable node mode: %v", err)}, nil, true, nil
 	}
 	written, err := file.Values()
 	if err != nil {
-		return []string{fmt.Sprintf("sei.toml cannot be read: %v", err)}, true, nil
+		return []string{fmt.Sprintf("sei.toml cannot be read: %v", err)}, nil, true, nil
 	}
 
 	resolved, err := registry.Resolve(registry.Mode(mode), registry.Sources{
@@ -151,7 +152,7 @@ func checkSeiToml(cmd *cobra.Command) (problems []string, found bool, err error)
 		Flags:     flagValues(TypedFlags(cmd)),
 	})
 	if err != nil {
-		return []string{fmt.Sprintf("this node's configuration cannot be resolved: %v", err)}, true, nil
+		return []string{fmt.Sprintf("this node's configuration cannot be resolved: %v", err)}, nil, true, nil
 	}
 
 	// First, because a refused registration is what makes the report below name the wrong file: the
@@ -177,7 +178,8 @@ func checkSeiToml(cmd *cobra.Command) (problems []string, found bool, err error)
 			"node would run as the second", mode, running))
 	}
 	problems = append(problems, whatADecodeWouldRefuse(resolved)...)
-	return problems, true, nil
+	notes = append(notes, whatTheFileLeavesToTheDeclaration(resolved, written, mode))
+	return problems, notes, true, nil
 }
 
 // theModeTheNodesOwnFileRecords reads what kind of node the node's own configuration file says this is.
@@ -207,6 +209,31 @@ func theModeTheNodesOwnFileRecords(home string) (string, error) {
 		return v.GetString("mode"), nil
 	}
 	return tmcfg.DefaultConfig().Mode, nil
+}
+
+// whatTheFileLeavesToTheDeclaration says how much of this node's configuration the file does not state.
+//
+// Every declared key the file leaves out takes the value this binary declares for the kind of node this is,
+// so a sparse file is not a small change to a node that has been running: it is most of its configuration.
+// An operator running this before a restart is owed the count, because it is the difference between moving
+// one setting and replacing everything around it.
+//
+// A note rather than a problem. It is the design working, and there is no file for which it is absent.
+func whatTheFileLeavesToTheDeclaration(resolved registry.Resolved, written map[string]any,
+	mode string) string {
+	inTheFile := make(map[string]bool, len(written))
+	for key := range written {
+		inTheFile[strings.ToLower(key)] = true
+	}
+	left := 0
+	for key := range resolved.Values {
+		if !inTheFile[strings.ToLower(key)] {
+			left++
+		}
+	}
+	return fmt.Sprintf("this file states %d of %d declared keys; the other %d take the value this binary "+
+		"declares for a %s, whatever app.toml and config.toml currently say",
+		len(resolved.Values)-left, len(resolved.Values), left, mode)
 }
 
 // whatTheResolutionAlreadyKnows returns the problems a resolution reports without any rehearsal.
@@ -239,7 +266,7 @@ func whatTheResolutionAlreadyKnows(resolved registry.Resolved) []string {
 // be refused at boot if the field it lands on holds something this cannot see. It is why this reports what
 // it can answer and the boot still reports what it finds.
 func whatADecodeWouldRefuse(resolved registry.Resolved) []string {
-	bySection, _ := registry.SuppliedAndOwnedByDecodedSections(resolved)
+	bySection, _ := registry.ResolvedAndOwnedByDecodedSections(resolved)
 	var problems []string
 	for _, name := range sortedKeys(bySection) {
 		values := bySection[name]

--- a/cmd/seid/cmd/configmanager/check.go
+++ b/cmd/seid/cmd/configmanager/check.go
@@ -219,6 +219,14 @@ func whatADecodeWouldRefuse(resolved registry.Resolved) []string {
 		if err := source.Unmarshal(candidate); err != nil {
 			problems = append(problems, fmt.Sprintf("[%s]: %v, so none of this section would apply "+
 				"(keys: %s)", name, err, strings.Join(sortedKeys(values), ",")))
+			continue
+		}
+
+		// The node's own rules, the same step the delivery takes after a clean decode. Without it this
+		// command passes a file the boot drops, which is the divergence it exists to prevent.
+		if err := candidate.ValidateBasic(); err != nil {
+			problems = append(problems, fmt.Sprintf("[%s]: %v, so none of this section would apply "+
+				"(keys: %s)", name, err, strings.Join(sortedKeys(values), ",")))
 		}
 	}
 	sort.Strings(problems)

--- a/cmd/seid/cmd/configmanager/check.go
+++ b/cmd/seid/cmd/configmanager/check.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -109,11 +110,15 @@ func CheckCmd() *cobra.Command {
 //
 // Answered from the environment this command runs in, which is the same limitation the resolution has.
 func whatTheGateSays(getenv func(string) string) (problems, notes []string) {
-	if _, err := Select(getenv); err != nil {
+	mgr, err := Select(getenv)
+	if err != nil {
 		return []string{fmt.Sprintf("%s is set to something this binary does not accept, so a boot "+
 			"would refuse before reaching this file: %v", EnvVar, err)}, nil
 	}
-	if getenv(EnvVar) != "v2" {
+	// Asked of the manager Select returned rather than of the value itself. Select owns which gate values
+	// read this file, and a value added there later would otherwise make this note say a boot reads none
+	// of the file on a node where it does.
+	if _, reads := mgr.(SeiConfigManager); !reads {
 		return nil, []string{fmt.Sprintf("%s is not set to v2 for this command, so a boot in the same "+
 			"environment reads none of this file. What follows is what it would reach if it were", EnvVar)}
 	}
@@ -178,7 +183,11 @@ func checkSeiToml(cmd *cobra.Command) (problems, notes []string, found bool, err
 		problems = append(problems, fmt.Sprintf("%s: sei.toml writes this and no section declares it, "+
 			"so it has no effect", key))
 	}
-	running, err := theModeTheNodesOwnFileRecords(home)
+	own, err := theNodesOwnConfiguration(home)
+	running := ""
+	if own != nil {
+		running = own.Mode
+	}
 	switch {
 	case err != nil:
 		problems = append(problems, fmt.Sprintf("the node's own configuration file cannot be read, so a "+
@@ -188,38 +197,33 @@ func checkSeiToml(cmd *cobra.Command) (problems, notes []string, found bool, err
 			"configuration file says %s. Every value resolved here is the answer for the first and the "+
 			"node would run as the second", mode, running))
 	}
-	problems = append(problems, whatADecodeWouldRefuse(resolved)...)
+	problems = append(problems, whatADecodeWouldRefuse(resolved, own)...)
 	notes = append(notes, whatTheFileLeavesToTheDeclaration(resolved, written, mode))
 	return problems, notes, true, nil
 }
 
-// theModeTheNodesOwnFileRecords reads what kind of node the node's own configuration file says this is.
+// theNodesOwnConfiguration reads the node's own configuration file into the struct a boot decodes it into.
 //
-// Read from the file here rather than taken from a running node, because nothing is running.
+// Decoded rather than read key by key, so the mode and the rehearsal base below come from one read and both
+// answer for the same file. A boot unmarshals this file over the same defaults, so a key stated with nothing
+// after it arrives empty and an absent key keeps the default, which is what a boot runs with.
 //
-// An absent file, or one with no mode in it, answers what a boot would compute rather than empty. A boot
-// starts from this binary's defaults and writes the file itself when it is missing, so the running mode is
-// never empty on that path. Answering empty here would pass a node whose sei.toml names a different kind,
-// and then that node reports the disagreement at its loudest level on the next start: a pass in exactly
-// the case with the largest consequence.
-func theModeTheNodesOwnFileRecords(home string) (string, error) {
+// A file that is not there is the only absence. Every other failure is a file somebody wrote that a boot
+// does not start on, so answering with defaults would pass a node that cannot boot.
+func theNodesOwnConfiguration(home string) (*tmcfg.Config, error) {
+	cfg := tmcfg.DefaultConfig()
 	v := viper.New()
 	v.SetConfigFile(filepath.Join(home, "config", "config.toml"))
 	switch err := v.ReadInConfig(); {
 	case errors.Is(err, fs.ErrNotExist):
-		// The only case that is an absence. Every other failure is a file somebody wrote that this
-		// binary cannot read, and a boot does not start at all on one of those, so answering with a
-		// default would pass a node that cannot boot.
+		return cfg, nil
 	case err != nil:
-		return "", err
+		return nil, err
 	}
-	// A key that is present answers with what it holds, empty included. A boot unmarshals that empty
-	// string over the default, so the running kind really is empty and the comparison beside this reports
-	// it. Substituting the default here would pass a node the boot goes on to report.
-	if v.IsSet("mode") {
-		return v.GetString("mode"), nil
+	if err := v.Unmarshal(cfg); err != nil {
+		return nil, err
 	}
-	return tmcfg.DefaultConfig().Mode, nil
+	return cfg, nil
 }
 
 // whatTheFileLeavesToTheDeclaration says how much of this node's configuration the file does not state.
@@ -236,15 +240,24 @@ func whatTheFileLeavesToTheDeclaration(resolved registry.Resolved, written map[s
 	for key := range written {
 		inTheFile[strings.ToLower(key)] = true
 	}
-	left := 0
+	stated := 0
 	for key := range resolved.Values {
-		if !inTheFile[strings.ToLower(key)] {
-			left++
+		if inTheFile[strings.ToLower(key)] {
+			stated++
 		}
 	}
-	return fmt.Sprintf("this file states %d of %d declared keys; the other %d take the value this binary "+
-		"declares for a %s, whatever app.toml and config.toml currently say",
-		len(resolved.Values)-left, len(resolved.Values), left, mode)
+	// Overrides holds every key a source answered, the file included, so the remainder is the set that
+	// took a declared value. Counting the keys absent from the file instead would put a key answered by a
+	// variable or a flag in that remainder, and tell an operator a default applies where it does not.
+	declared := len(resolved.Values) - len(resolved.Overrides)
+	elsewhere := len(resolved.Overrides) - stated
+
+	line := fmt.Sprintf("this file states %d of %d declared keys", stated, len(resolved.Values))
+	if elsewhere > 0 {
+		line += fmt.Sprintf("; %d more are answered by an environment variable or a flag", elsewhere)
+	}
+	return line + fmt.Sprintf("; the other %d take the value this binary declares for a %s, whatever "+
+		"app.toml and config.toml currently say", declared, mode)
 }
 
 // whatTheResolutionAlreadyKnows returns the problems a resolution reports without any rehearsal.
@@ -272,21 +285,29 @@ func whatTheResolutionAlreadyKnows(resolved registry.Resolved) []string {
 
 // whatADecodeWouldRefuse rehearses each decoded section the way the boot's delivery does.
 //
-// Rehearsed against a fresh configuration rather than a running node's, because there is no node here. That
-// is a weaker target than the delivery uses, and the difference is the point: a value this accepts may still
-// be refused at boot if the field it lands on holds something this cannot see. It is why this reports what
-// it can answer and the boot still reports what it finds.
-func whatADecodeWouldRefuse(resolved registry.Resolved) []string {
+// Rehearsed against the node's own configuration, which is the target the delivery uses. Every declared key
+// of a section is delivered, so the values under test are the same either way today; sharing the target is
+// what keeps the two answers together as the declared set changes.
+//
+// One difference remains. The delivery applies a section whose rules fail when the node's configuration
+// already fails its own, and this has no such allowance, so on a node in that state this reports a section
+// the boot applies.
+func whatADecodeWouldRefuse(resolved registry.Resolved, own *tmcfg.Config) []string {
 	bySection, _ := registry.ResolvedAndOwnedByDecodedSections(resolved)
 	var problems []string
 	for _, name := range sortedKeys(bySection) {
 		values := bySection[name]
-		base := tmcfg.DefaultConfig()
+		base := own
+		if base == nil {
+			base = tmcfg.DefaultConfig()
+		}
 
 		// Each message says what is wrong with the value it names, and there is more than one thing that
 		// can be. Stating one of them here would describe the others wrongly.
-		if bad := whatDecodesToSomethingElse(base, values); len(bad) > 0 {
-			problems = append(problems, fmt.Sprintf("[%s]: %s", name, strings.Join(bad, "; ")))
+		fields := keyFieldTypes(reflect.TypeOf(*base), "")
+		if bad := whatDecodesToSomethingElse(fields, values); len(bad) > 0 {
+			problems = append(problems, fmt.Sprintf("[%s]: %s", name,
+				strings.Join(problemsInOrder(bad), "; ")))
 			continue
 		}
 

--- a/cmd/seid/cmd/configmanager/check_test.go
+++ b/cmd/seid/cmd/configmanager/check_test.go
@@ -3,12 +3,14 @@ package configmanager
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/sei-protocol/sei-chain/config/registry"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/client/flags"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/server"
 	serverconfig "github.com/sei-protocol/sei-chain/sei-cosmos/server/config"
@@ -345,12 +347,55 @@ func TestTheCheckFindsADisagreementAboutWhatKindOfNodeThisIs(t *testing.T) {
 		}
 	})
 
+	t.Run("a configuration file it cannot read is a problem, not an absence", func(t *testing.T) {
+		// A boot does not start on one of these at all, so answering with a default would pass a node
+		// that cannot boot. It is the same rule this command already applies to sei.toml.
+		out, err := runCheckWithNodeFile(t, seiToml, "mode = \"validator\"\n[[[ not toml\n")
+		if err == nil {
+			t.Errorf("an unparseable configuration file passed the check, and a boot would not start:\n%s",
+				out)
+		}
+		if !strings.Contains(out, "cannot be read") {
+			t.Errorf("the report does not say the node's own file cannot be read:\n%s", out)
+		}
+	})
+
 	t.Run("no configuration file of its own and a matching kind passes", func(t *testing.T) {
 		matching := "schema_version = 1\nnode_mode = \"" + tmcfg.DefaultConfig().Mode +
 			"\"\n\n[mempool]\nsize = 4321\n"
 		out, err := runCheckWithNodeFile(t, matching, "")
 		if err != nil {
 			t.Errorf("sei.toml names the kind a boot would compute and the check failed: %v\n%s", err, out)
+		}
+	})
+}
+
+// TestTheCheckReportsWhatTheResolutionAlreadyKnows covers the two problems that need no rehearsal.
+//
+// A refused registration is the one that matters most, because of what it does to the report beside it: the
+// section's keys are absent from the declared set, so an operator's valid key for one of them lands among
+// the keys nothing declares. Reported without the cause, this command tells them their file is wrong about
+// a key it was right about. The boot reports the cause first for exactly this reason.
+func TestTheCheckReportsWhatTheResolutionAlreadyKnows(t *testing.T) {
+	t.Run("a refused registration is named, before anything else", func(t *testing.T) {
+		got := whatTheResolutionAlreadyKnows(registry.Resolved{
+			Refused: []registry.Defect{{Section: "mempool", Err: errors.New("two keys share a spelling")}},
+			Ignored: map[string]string{"telemetry.global-labels": "a variable holds one string"},
+		})
+		if len(got) != 2 {
+			t.Fatalf("got %d problems, want the refusal and the ignored variable: %v", len(got), got)
+		}
+		if !strings.Contains(got[0], "mempool") || !strings.Contains(got[0], "carries a defect") {
+			t.Errorf("the first problem does not name the refused registration: %q", got[0])
+		}
+		if !strings.Contains(got[1], "telemetry.global-labels") {
+			t.Errorf("the second problem does not name the ignored variable: %q", got[1])
+		}
+	})
+
+	t.Run("a clean resolution reports nothing", func(t *testing.T) {
+		if got := whatTheResolutionAlreadyKnows(registry.Resolved{}); len(got) != 0 {
+			t.Errorf("a resolution with no defect and no ignored variable reports %v", got)
 		}
 	})
 }

--- a/cmd/seid/cmd/configmanager/check_test.go
+++ b/cmd/seid/cmd/configmanager/check_test.go
@@ -209,3 +209,111 @@ func TestCheckReportsAFileItCannotRead(t *testing.T) {
 		})
 	}
 }
+
+// TestTheCheckSaysWhetherABootWouldReadTheFileAtAll covers the conclusion an operator would otherwise draw.
+//
+// Until the gate is switched, a boot reads none of this file. A check that answers only about the file's
+// contents reads as "in use and correct" on every one of those nodes, which invites somebody to trust a
+// file nothing reads. That is the wrong conclusion in the dangerous direction.
+func TestTheCheckSaysWhetherABootWouldReadTheFileAtAll(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value string
+		says  bool
+	}{
+		{"unset", "", true},
+		{"legacy", "legacy", true},
+		{"v2", "v2", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			reportWhetherABootWouldReadThisFile(&out, func(string) string { return tc.value })
+			said := strings.Contains(out.String(), "reads none of this file")
+			if said != tc.says {
+				t.Errorf("with %s=%q the command says a boot reads none of the file: %v, want %v.\n%s",
+					EnvVar, tc.value, said, tc.says, out.String())
+			}
+		})
+	}
+}
+
+// TestTheCheckSaysWhenTheGateItselfIsWrong covers a value a boot refuses outright.
+//
+// The gate is matched exactly and never falls back, so a misspelling stops the node before it reaches any
+// file. A check that reported only on the file would pass, and the node would not start.
+func TestTheCheckSaysWhenTheGateItselfIsWrong(t *testing.T) {
+	var out bytes.Buffer
+	reportWhetherABootWouldReadThisFile(&out, func(string) string { return "V2" })
+	if !strings.Contains(out.String(), "does not accept") {
+		t.Errorf("a gate value this binary refuses is not reported, so the check passes for a node that "+
+			"would not start:\n%s", out.String())
+	}
+}
+
+// runCheckWithNodeFile runs the command against a home holding both files.
+func runCheckWithNodeFile(t *testing.T, seiToml, configToml string) (string, error) {
+	t.Helper()
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "config"), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config", seiTomlName), []byte(seiToml), 0o600); err != nil {
+		t.Fatalf("write sei.toml: %v", err)
+	}
+	if configToml != "" {
+		path := filepath.Join(home, "config", "config.toml")
+		if err := os.WriteFile(path, []byte(configToml), 0o600); err != nil {
+			t.Fatalf("write config.toml: %v", err)
+		}
+	}
+
+	cmd := CheckCmd()
+	cmd.Flags().String(flags.FlagHome, home, "")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+// TestTheCheckFindsADisagreementAboutWhatKindOfNodeThisIs covers the question with the largest consequence.
+//
+// Two files record what kind of node this is, under different names, and nothing keeps them in step. A node
+// whose sei.toml says validator while its own file says full resolves a validator's answers and runs as a
+// full node, serving queries. Every report about it reads correctly, which is what makes it worth catching
+// before a restart rather than after.
+//
+// The boot reports this at its loudest level. A pre-flight that does not ask is silent on the one thing an
+// operator most needs to know before they restart.
+func TestTheCheckFindsADisagreementAboutWhatKindOfNodeThisIs(t *testing.T) {
+	const seiToml = "schema_version = 1\nnode_mode = \"validator\"\n\n[mempool]\nsize = 4321\n"
+
+	t.Run("a disagreement is reported", func(t *testing.T) {
+		out, err := runCheckWithNodeFile(t, seiToml, "mode = \"full\"\n")
+		if err == nil {
+			t.Errorf("sei.toml says validator and the node's own file says full, and the check passed:\n%s",
+				out)
+		}
+		if !strings.Contains(out, "node's own") {
+			t.Errorf("the report does not name the disagreement:\n%s", out)
+		}
+	})
+
+	t.Run("agreement is not a problem", func(t *testing.T) {
+		out, err := runCheckWithNodeFile(t, seiToml, "mode = \"validator\"\n")
+		if err != nil {
+			t.Errorf("both files say validator and the check failed: %v\n%s", err, out)
+		}
+	})
+
+	t.Run("a node with no configuration file of its own has nothing to disagree with", func(t *testing.T) {
+		// Every node is in this state before it is initialised, and answering that it disagrees with a file
+		// it does not have would fail the check on a correct sei.toml.
+		out, err := runCheckWithNodeFile(t, seiToml, "")
+		if err != nil {
+			t.Errorf("a node with no configuration file of its own failed the check: %v\n%s", err, out)
+		}
+	})
+}

--- a/cmd/seid/cmd/configmanager/check_test.go
+++ b/cmd/seid/cmd/configmanager/check_test.go
@@ -676,3 +676,42 @@ func TestTheCheckRefusesWhatTheDeliveryRefuses(t *testing.T) {
 		})
 	}
 }
+
+// TestNoHomeIsRefusedRatherThanAnsweredFromTheWorkingDirectory covers the one case where answering is
+// worse than declining.
+//
+// Every path here joins the home with config/sei.toml. An empty home leaves that relative, so the read
+// lands wherever the command was run from and reports on a file belonging to some other node. An operator
+// runs this to decide whether to restart, so a confident answer about the wrong node is the worst outcome
+// available.
+//
+// The variable this names is read from the running binary, which under a test binary is not the one a node
+// uses, so the message is checked for naming a variable rather than for naming seid's.
+func TestNoHomeIsRefusedRatherThanAnsweredFromTheWorkingDirectory(t *testing.T) {
+	configtest.Isolate(t)
+
+	elsewhere := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(elsewhere, "config"), 0o750); err != nil {
+		t.Fatalf("make a directory holding another node's file: %v", err)
+	}
+	// A complete, valid file for a different node. Nothing about it is wrong; it is simply not ours.
+	if err := os.WriteFile(filepath.Join(elsewhere, "config", seiTomlName),
+		[]byte("schema_version = 1\nnode_mode = \"validator\"\n"), 0o600); err != nil {
+		t.Fatalf("write another node's sei.toml: %v", err)
+	}
+	t.Chdir(elsewhere)
+
+	// No --home flag and nothing in the environment, which is what an exec into a container gives when
+	// the variable that is set is not the one the resolver reads.
+	cmd := &cobra.Command{Use: "check"}
+	cmd.SetContext(context.Background())
+
+	problems, notes, found, err := checkSeiToml(cmd)
+	if err == nil {
+		t.Fatalf("with no home set the check answered from the working directory: found=%v problems=%v "+
+			"notes=%v. It reported on a file belonging to another node", found, problems, notes)
+	}
+	if !strings.Contains(err.Error(), "--home") || !strings.Contains(err.Error(), "_HOME") {
+		t.Errorf("declining is right, but the reason does not name what to set: %v", err)
+	}
+}

--- a/cmd/seid/cmd/configmanager/check_test.go
+++ b/cmd/seid/cmd/configmanager/check_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -438,5 +439,62 @@ func TestTheCauseIsReportedBeforeTheSymptom(t *testing.T) {
 	if cause > symptom {
 		t.Errorf("the registration defect is printed after the key it explains, so an operator reading "+
 			"in order treats a valid key as their own typo:\n%s", out.String())
+	}
+}
+
+// TestTheCountsAddUpAndNameTheRightSource holds the arithmetic an operator reads before a restart.
+//
+// The line decides whether somebody expects a restart to move one setting or to replace everything around
+// it, and an off-by-one in it is invisible: the sentence reads correctly whatever the numbers are. The
+// source matters as much as the count. A key an environment variable or a flag answered is absent from the
+// file and does not take a declared value, so counting the file's absences would name a default where one
+// does not apply.
+func TestTheCountsAddUpAndNameTheRightSource(t *testing.T) {
+	configtest.Isolate(t)
+	written := map[string]any{"mempool.size": 4321}
+	resolved, err := registry.Resolve(registry.ModeFull, registry.Sources{
+		File:      written,
+		LookupEnv: func(name string) (string, bool) { return "", false },
+		Flags:     map[string]any{"rpc.max-open-connections": "99"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	total := len(resolved.Values)
+	if total == 0 || len(resolved.Overrides) < 2 {
+		t.Fatalf("the resolution answered %d keys with %d overrides, so this measures nothing",
+			total, len(resolved.Overrides))
+	}
+
+	line := whatTheFileLeavesToTheDeclaration(resolved, written, "full")
+
+	// Every declared key falls in exactly one of the three, so the three have to sum to the total.
+	var stated, elsewhere, declared int
+	if _, err := fmt.Sscanf(line, "this file states %d of %d declared keys", &stated, &total); err != nil {
+		t.Fatalf("the line does not state the file's count: %q", line)
+	}
+	if !strings.Contains(line, "answered by an environment variable or a flag") {
+		t.Fatalf("a flag answered a declared key and the line does not say so, so its value reads as a "+
+			"binary default: %q", line)
+	}
+	for _, part := range strings.Split(line, "; ") {
+		switch {
+		case strings.HasPrefix(part, "the other "):
+			_, _ = fmt.Sscanf(part, "the other %d", &declared)
+		case strings.Contains(part, "more are answered"):
+			_, _ = fmt.Sscanf(part, "%d more are answered", &elsewhere)
+		}
+	}
+	if stated+elsewhere+declared != total {
+		t.Errorf("%d stated + %d answered elsewhere + %d declared = %d, and the resolution answered %d. "+
+			"A key is counted twice or not at all:\n%s",
+			stated, elsewhere, declared, stated+elsewhere+declared, total, line)
+	}
+	if stated != 1 {
+		t.Errorf("the file states one key and the line says %d", stated)
+	}
+	if elsewhere != 1 {
+		t.Errorf("one flag answered a declared key and the line says %d", elsewhere)
 	}
 }

--- a/cmd/seid/cmd/configmanager/check_test.go
+++ b/cmd/seid/cmd/configmanager/check_test.go
@@ -1,0 +1,211 @@
+package configmanager
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sei-protocol/sei-chain/sei-cosmos/client/flags"
+	"github.com/sei-protocol/sei-chain/sei-cosmos/server"
+	serverconfig "github.com/sei-protocol/sei-chain/sei-cosmos/server/config"
+	"github.com/sei-protocol/sei-chain/testutil/configtest"
+	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+// runCheck runs the command against a home holding the given sei.toml, and returns what it printed and
+// whether it failed.
+func runCheck(t *testing.T, body string) (string, error) {
+	t.Helper()
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "config"), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if body != "" {
+		if err := os.WriteFile(filepath.Join(home, "config", seiTomlName), []byte(body), 0o600); err != nil {
+			t.Fatalf("write sei.toml: %v", err)
+		}
+	}
+
+	cmd := CheckCmd()
+	cmd.Flags().String(flags.FlagHome, home, "")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+// TestTheCheckFailsOnWhatABootWouldRefuse is the point of the command.
+//
+// A boot may not refuse a file, so every value it cannot use is a report on a node that has already
+// restarted. The same questions have exact answers beforehand, and this is where an answer costs a failed
+// check instead.
+func TestTheCheckFailsOnWhatABootWouldRefuse(t *testing.T) {
+	const header = "schema_version = 1\nnode_mode = \"validator\"\n"
+
+	t.Run("a file this binary can use passes", func(t *testing.T) {
+		out, err := runCheck(t, header+"\n[mempool]\nttl-duration = \"60s\"\nsize = 4321\n")
+		if err != nil {
+			t.Errorf("a usable file was refused: %v\n%s", err, out)
+		}
+	})
+
+	t.Run("no file at all is not a problem", func(t *testing.T) {
+		out, err := runCheck(t, "")
+		if err != nil {
+			t.Errorf("a node with no sei.toml was refused: %v", err)
+		}
+		if !strings.Contains(out, "no sei.toml") {
+			t.Errorf("the report does not say the file is absent, so a missing file reads as a clean "+
+				"one:\n%s", out)
+		}
+	})
+
+	t.Run("a length of time written as a plain number fails", func(t *testing.T) {
+		out, err := runCheck(t, header+"\n[mempool]\nttl-duration = 60\n")
+		if err == nil {
+			t.Errorf("a plain number in a length of time passed:\n%s", out)
+		}
+		if !strings.Contains(out, "nanoseconds") {
+			t.Errorf("the report does not say what is wrong with it:\n%s", out)
+		}
+	})
+
+	t.Run("a value the decode refuses fails", func(t *testing.T) {
+		out, err := runCheck(t, header+"\n[instrumentation]\nmax-open-connections = \"not a number\"\n")
+		if err == nil {
+			t.Errorf("a value no decode accepts passed:\n%s", out)
+		}
+	})
+
+	t.Run("a key no section declares is reported", func(t *testing.T) {
+		out, err := runCheck(t, header+"\n[mempool]\nnot-a-key = 1\n")
+		if err == nil {
+			t.Errorf("a key nothing declares passed:\n%s", out)
+		}
+		if !strings.Contains(out, "no effect") {
+			t.Errorf("the report does not say the key has no effect:\n%s", out)
+		}
+	})
+
+	t.Run("a mode this binary does not know fails", func(t *testing.T) {
+		out, err := runCheck(t, "schema_version = 1\nnode_mode = \"sentry\"\n")
+		if err == nil {
+			t.Errorf("a mode nothing declares passed:\n%s", out)
+		}
+	})
+}
+
+// TestADisagreementAboutTheKindOfNodeIsFound covers a fact two files state under different names.
+//
+// sei.toml records the kind of node at its top and every value resolved through this manager is the answer
+// for that kind. The node's own configuration file states it again in a key of its own, and that one is what
+// the node runs as. Nothing here declares the second on purpose, so the two can be written to disagree, and
+// a node that resolves a validator's values while running as a full node reads correctly in every report
+// about it.
+func TestADisagreementAboutTheKindOfNodeIsFound(t *testing.T) {
+	for _, tc := range []struct {
+		recorded, running string
+		disagree          bool
+		why               string
+	}{
+		{"validator", "validator", false, "the same kind is not a disagreement"},
+		{"validator", "full", true, "a validator that runs as a query-serving node serves queries"},
+		{"full", "validator", true, "a node resolved for queries that runs as a validator holds a key"},
+		{"seed", "full", true, "a seed exists to serve peers and would be serving queries"},
+		{"archive", "full", false, "the kind that keeps every version has no name of its own in that " +
+			"file, so the command that writes it writes this one"},
+		{"archive", "validator", true, "an archive that runs as a validator is a disagreement"},
+	} {
+		if got := modesDisagree(tc.recorded, tc.running); got != tc.disagree {
+			t.Errorf("sei.toml %q against a node running %q reports disagree=%v, want %v: %s",
+				tc.recorded, tc.running, got, tc.disagree, tc.why)
+		}
+	}
+}
+
+// TestApplyReportsADisagreementAboutTheKindOfNode drives the real Apply, so the wiring is what is asserted.
+//
+// The test beside this one holds the decision, which a comparison never reached would still pass. This one
+// gives the two files different kinds of node and looks for the report, so removing the call fails here.
+func TestApplyReportsADisagreementAboutTheKindOfNode(t *testing.T) {
+	configtest.Isolate(t)
+	root := writeMinimalHome(t, "mode = \"full\"\n", "")
+	if err := os.WriteFile(filepath.Join(root, "config", seiTomlName),
+		[]byte("schema_version = 1\nnode_mode = \"validator\"\n"), 0o600); err != nil {
+		t.Fatalf("write sei.toml: %v", err)
+	}
+
+	cmd := server.StartCmd(nil, "/foobar", []trace.TracerProviderOption{})
+	if err := cmd.Flags().Set(flags.FlagHome, root); err != nil {
+		t.Fatalf("set --home: %v", err)
+	}
+	serverCtx := &server.Context{}
+	cmd.SetContext(context.WithValue(context.Background(), server.ServerContextKey, serverCtx))
+
+	capture := &capturingHandler{}
+	mgr := SeiConfigManager{logger: slog.New(capture)}
+	if err := mgr.Apply(cmd, serverconfig.DefaultConfigTemplate, serverconfig.DefaultConfig()); err != nil {
+		t.Fatalf("the fixture is meant to boot, so this is the fixture: %v", err)
+	}
+
+	var found bool
+	for _, r := range capture.records {
+		if strings.Contains(r.Message, "one kind of node") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("sei.toml said validator, the node's own file said full, and nothing reported it. A " +
+			"node resolving a validator's values while running as a query-serving node reads correctly " +
+			"in every other report about it")
+	}
+}
+
+// TestCheckReportsAFileItCannotRead holds the difference the command exists to tell an operator.
+//
+// Running this before a restart asks whether the file is right. A file that will not parse, or records a
+// schema this binary does not know, or names no node kind, is the case where the answer matters most, and
+// answering that the node has no file is both wrong and the answer least likely to make anyone look.
+func TestCheckReportsAFileItCannotRead(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"unparseable", "[evm\n"},
+		{"unknown schema", "schema_version = 99\nnode_mode = \"validator\"\n"},
+		{"no node mode", "schema_version = 1\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(home, "config"), 0o750); err != nil {
+				t.Fatalf("make a home: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(home, "config", seiTomlName),
+				[]byte(tc.body), 0o600); err != nil {
+				t.Fatalf("write the file: %v", err)
+			}
+
+			cmd := &cobra.Command{}
+			cmd.Flags().String(flags.FlagHome, home, "")
+			problems, found, err := checkSeiToml(cmd)
+			if err != nil {
+				t.Fatalf("checkSeiToml: %v", err)
+			}
+			if !found {
+				t.Errorf("a %s sei.toml is reported as no file at all, so the command exits zero on it",
+					tc.name)
+			}
+			if len(problems) == 0 {
+				t.Errorf("a %s sei.toml produced no problem to report", tc.name)
+			}
+		})
+	}
+}

--- a/cmd/seid/cmd/configmanager/check_test.go
+++ b/cmd/seid/cmd/configmanager/check_test.go
@@ -347,6 +347,19 @@ func TestTheCheckFindsADisagreementAboutWhatKindOfNodeThisIs(t *testing.T) {
 		}
 	})
 
+	t.Run("a present but empty kind is what a boot gets, not the default", func(t *testing.T) {
+		// sei.toml names the kind this binary defaults to, which is the case that separates the two
+		// answers: substituting the default makes the two sides agree and the check pass, while a boot
+		// unmarshals the empty string over its default, runs with no kind at all, and reports it.
+		naming := "schema_version = 1\nnode_mode = \"" + tmcfg.DefaultConfig().Mode +
+			"\"\n\n[mempool]\nsize = 4321\n"
+		out, err := runCheckWithNodeFile(t, naming, "mode = \"\"\n")
+		if err == nil {
+			t.Errorf("the node's own file records no kind at all and the check passed, so it answered "+
+				"with a default the boot does not use:\n%s", out)
+		}
+	})
+
 	t.Run("a configuration file it cannot read is a problem, not an absence", func(t *testing.T) {
 		// A boot does not start on one of these at all, so answering with a default would pass a node
 		// that cannot boot. It is the same rule this command already applies to sei.toml.

--- a/cmd/seid/cmd/configmanager/check_test.go
+++ b/cmd/seid/cmd/configmanager/check_test.go
@@ -399,3 +399,31 @@ func TestTheCheckReportsWhatTheResolutionAlreadyKnows(t *testing.T) {
 		}
 	})
 }
+
+// TestTheCauseIsReportedBeforeTheSymptom holds the order the two reports are read in.
+//
+// A refused registration leaves its section's keys out of the declared set, so an operator's valid key for
+// one of them reads as a key nothing declares. Printed after that line, the registration defect explains
+// something the reader has already concluded was their own typo. The boot reports the cause first for the
+// same reason.
+func TestTheCauseIsReportedBeforeTheSymptom(t *testing.T) {
+	var out bytes.Buffer
+	problems := append(
+		whatTheResolutionAlreadyKnows(registry.Resolved{
+			Refused: []registry.Defect{{Section: "mempool", Err: errors.New("two keys share a spelling")}},
+		}),
+		"mempool.size: sei.toml writes this and no section declares it, so it has no effect")
+	for _, line := range problems {
+		report(&out, line)
+	}
+
+	cause := strings.Index(out.String(), "carries a defect")
+	symptom := strings.Index(out.String(), "no section declares it")
+	if cause == -1 || symptom == -1 {
+		t.Fatalf("both lines have to be present for the order to mean anything:\n%s", out.String())
+	}
+	if cause > symptom {
+		t.Errorf("the registration defect is printed after the key it explains, so an operator reading "+
+			"in order treats a valid key as their own typo:\n%s", out.String())
+	}
+}

--- a/cmd/seid/cmd/configmanager/check_test.go
+++ b/cmd/seid/cmd/configmanager/check_test.go
@@ -210,7 +210,7 @@ func TestCheckReportsAFileItCannotRead(t *testing.T) {
 
 			cmd := &cobra.Command{}
 			cmd.Flags().String(flags.FlagHome, home, "")
-			problems, found, err := checkSeiToml(cmd)
+			problems, _, found, err := checkSeiToml(cmd)
 			if err != nil {
 				t.Fatalf("checkSeiToml: %v", err)
 			}

--- a/cmd/seid/cmd/configmanager/check_test.go
+++ b/cmd/seid/cmd/configmanager/check_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/client/flags"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/server"
 	serverconfig "github.com/sei-protocol/sei-chain/sei-cosmos/server/config"
+	tmcfg "github.com/sei-protocol/sei-chain/sei-tendermint/config"
 	"github.com/sei-protocol/sei-chain/testutil/configtest"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel/sdk/trace"
@@ -21,6 +22,10 @@ import (
 // whether it failed.
 func runCheck(t *testing.T, body string) (string, error) {
 	t.Helper()
+	// Isolated because this resolves through the real environment and reads the gate out of it. A stray
+	// SEID_* or SEI_CONFIG_MANAGER on a developer's machine or a runner would change a resolved value and
+	// flip these assertions.
+	configtest.Isolate(t)
 	home := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(home, "config"), 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
@@ -29,6 +34,13 @@ func runCheck(t *testing.T, body string) (string, error) {
 		if err := os.WriteFile(filepath.Join(home, "config", seiTomlName), []byte(body), 0o600); err != nil {
 			t.Fatalf("write sei.toml: %v", err)
 		}
+	}
+	// A node's own configuration file, recording the same kind of node the header below writes. Without it
+	// every case here also carries a disagreement about what kind of node this is, which is a different
+	// test's subject.
+	if err := os.WriteFile(filepath.Join(home, "config", "config.toml"),
+		[]byte("mode = \"validator\"\n"), 0o600); err != nil {
+		t.Fatalf("write config.toml: %v", err)
 	}
 
 	cmd := CheckCmd()
@@ -175,6 +187,7 @@ func TestApplyReportsADisagreementAboutTheKindOfNode(t *testing.T) {
 // schema this binary does not know, or names no node kind, is the case where the answer matters most, and
 // answering that the node has no file is both wrong and the answer least likely to make anyone look.
 func TestCheckReportsAFileItCannotRead(t *testing.T) {
+	configtest.Isolate(t)
 	for _, tc := range []struct {
 		name string
 		body string
@@ -226,12 +239,16 @@ func TestTheCheckSaysWhetherABootWouldReadTheFileAtAll(t *testing.T) {
 		{"v2", "v2", false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			var out bytes.Buffer
-			reportWhetherABootWouldReadThisFile(&out, func(string) string { return tc.value })
-			said := strings.Contains(out.String(), "reads none of this file")
+			problems, notes := whatTheGateSays(func(string) string { return tc.value })
+			said := strings.Contains(strings.Join(notes, "\n"), "reads none of this file")
 			if said != tc.says {
-				t.Errorf("with %s=%q the command says a boot reads none of the file: %v, want %v.\n%s",
-					EnvVar, tc.value, said, tc.says, out.String())
+				t.Errorf("with %s=%q the command says a boot reads none of the file: %v, want %v.\n%v",
+					EnvVar, tc.value, said, tc.says, notes)
+			}
+			// A gate that is off is not a problem: the file is still worth checking, and the exit status
+			// has to stay usable on every node that has not switched yet.
+			if len(problems) != 0 {
+				t.Errorf("with %s=%q the gate is reported as a problem: %v", EnvVar, tc.value, problems)
 			}
 		})
 	}
@@ -242,17 +259,23 @@ func TestTheCheckSaysWhetherABootWouldReadTheFileAtAll(t *testing.T) {
 // The gate is matched exactly and never falls back, so a misspelling stops the node before it reaches any
 // file. A check that reported only on the file would pass, and the node would not start.
 func TestTheCheckSaysWhenTheGateItselfIsWrong(t *testing.T) {
-	var out bytes.Buffer
-	reportWhetherABootWouldReadThisFile(&out, func(string) string { return "V2" })
-	if !strings.Contains(out.String(), "does not accept") {
-		t.Errorf("a gate value this binary refuses is not reported, so the check passes for a node that "+
-			"would not start:\n%s", out.String())
+	problems, _ := whatTheGateSays(func(string) string { return "V2" })
+	if len(problems) == 0 {
+		t.Fatal("a gate value this binary refuses is not reported as a problem, so the command exits " +
+			"zero for a node that cannot start")
+	}
+	if !strings.Contains(strings.Join(problems, "\n"), "does not accept") {
+		t.Errorf("the problem does not say the value was refused: %v", problems)
 	}
 }
 
 // runCheckWithNodeFile runs the command against a home holding both files.
 func runCheckWithNodeFile(t *testing.T, seiToml, configToml string) (string, error) {
 	t.Helper()
+	// Isolated because this resolves through the real environment and reads the gate out of it. A stray
+	// SEID_* or SEI_CONFIG_MANAGER on a developer's machine or a runner would change a resolved value and
+	// flip these assertions.
+	configtest.Isolate(t)
 	home := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(home, "config"), 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
@@ -308,12 +331,26 @@ func TestTheCheckFindsADisagreementAboutWhatKindOfNodeThisIs(t *testing.T) {
 		}
 	})
 
-	t.Run("a node with no configuration file of its own has nothing to disagree with", func(t *testing.T) {
-		// Every node is in this state before it is initialised, and answering that it disagrees with a file
-		// it does not have would fail the check on a correct sei.toml.
+	t.Run("no configuration file of its own is compared against what a boot would compute", func(t *testing.T) {
+		// A boot does not see an absent mode. It starts from this binary's defaults and writes the file
+		// itself, so a node with sei.toml naming a different kind reports the disagreement at its loudest
+		// level on the next start. Answering "nothing to disagree with" here would pass that node.
 		out, err := runCheckWithNodeFile(t, seiToml, "")
+		if err == nil {
+			t.Errorf("sei.toml says validator, a boot would compute a different kind for a node with no "+
+				"configuration file, and the check passed:\n%s", out)
+		}
+		if !strings.Contains(out, "node's own") {
+			t.Errorf("the report does not name the disagreement:\n%s", out)
+		}
+	})
+
+	t.Run("no configuration file of its own and a matching kind passes", func(t *testing.T) {
+		matching := "schema_version = 1\nnode_mode = \"" + tmcfg.DefaultConfig().Mode +
+			"\"\n\n[mempool]\nsize = 4321\n"
+		out, err := runCheckWithNodeFile(t, matching, "")
 		if err != nil {
-			t.Errorf("a node with no configuration file of its own failed the check: %v\n%s", err, out)
+			t.Errorf("sei.toml names the kind a boot would compute and the check failed: %v\n%s", err, out)
 		}
 	})
 }

--- a/cmd/seid/cmd/configmanager/check_test.go
+++ b/cmd/seid/cmd/configmanager/check_test.go
@@ -8,10 +8,12 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/sei-protocol/sei-chain/config/registry"
+	"github.com/sei-protocol/sei-chain/config/tendermintbase"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/client/flags"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/server"
 	serverconfig "github.com/sei-protocol/sei-chain/sei-cosmos/server/config"
@@ -496,5 +498,181 @@ func TestTheCountsAddUpAndNameTheRightSource(t *testing.T) {
 	}
 	if elsewhere != 1 {
 		t.Errorf("one flag answered a declared key and the line says %d", elsewhere)
+	}
+}
+
+// theTwoVerdicts is what the check and the boot's delivery each made of one input.
+type theTwoVerdicts struct {
+	// The sections each refused, sorted.
+	byTheCheck, byTheDelivery []string
+	// The configuration the delivery published into, which is what a boot would go on to run.
+	delivered *tmcfg.Config
+}
+
+// rehearseAndDeliver runs the check's rehearsal and the boot's delivery over one resolution.
+//
+// Driven from one resolution and one node configuration, because the two verdicts are only comparable for
+// the same input. Each side is handed a copy of that configuration, since the delivery publishes into the
+// one it is given.
+func rehearseAndDeliver(t *testing.T, own *tmcfg.Config, file map[string]any) theTwoVerdicts {
+	t.Helper()
+	resolved, err := registry.Resolve(registry.ModeValidator, registry.Sources{
+		File:      file,
+		LookupEnv: func(string) (string, bool) { return "", false },
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	for key := range file {
+		if _, declared := resolved.Values[key]; !declared {
+			t.Fatalf("no section declares %s, so the file writes nothing and both verdicts are about a "+
+				"resolution that carries none of this fixture", key)
+		}
+	}
+
+	forTheCheck, err := copyNodeConfig(own)
+	if err != nil {
+		t.Fatalf("copy the node's configuration: %v", err)
+	}
+	forTheDelivery, err := copyNodeConfig(own)
+	if err != nil {
+		t.Fatalf("copy the node's configuration: %v", err)
+	}
+
+	capture := &capturingHandler{}
+	log := slog.New(capture)
+	ctx := &server.Context{Config: forTheDelivery}
+	bySection, _ := registry.ResolvedAndOwnedByDecodedSections(resolved)
+	deliverDecodedSections(ctx, bySection, log, log.Info)
+
+	return theTwoVerdicts{
+		byTheCheck:    sectionsTheCheckNamed(whatADecodeWouldRefuse(resolved, forTheCheck)),
+		byTheDelivery: sectionsTheDeliveryNamed(capture.records),
+		delivered:     ctx.Config,
+	}
+}
+
+// sectionsTheCheckNamed reads the section out of each problem the check reported, which names it first in
+// brackets.
+//
+// A problem naming no section is kept whole rather than dropped. Dropped, a report that stopped naming
+// sections would compare equal to a run that refused nothing.
+func sectionsTheCheckNamed(problems []string) []string {
+	out := make([]string, 0, len(problems))
+	for _, problem := range problems {
+		closing := strings.Index(problem, "]")
+		if !strings.HasPrefix(problem, "[") || closing < 0 {
+			out = append(out, problem)
+			continue
+		}
+		out = append(out, problem[1:closing])
+	}
+	sort.Strings(out)
+	return out
+}
+
+// sectionsTheDeliveryNamed reads the section off every refusal the delivery logged. A refusal is what it
+// reports at its error level, and each one carries the section it cost.
+func sectionsTheDeliveryNamed(records []slog.Record) []string {
+	out := make([]string, 0, len(records))
+	for _, record := range records {
+		if record.Level < slog.LevelError {
+			continue
+		}
+		named := ""
+		record.Attrs(func(a slog.Attr) bool {
+			if a.Key == "section" {
+				named = a.Value.String()
+			}
+			return true
+		})
+		out = append(out, named)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestTheCheckDoesNotFailASectionTheDeliveryApplies is why this command sits on top of the delivery.
+//
+// The answer is a prediction, and a prediction is worth its exit status only when it comes from the code
+// that would refuse the value at boot. The delivery holds a section to that section's own rules. Asking the
+// whole configuration instead reports a failure standing anywhere in config.toml as this section's values
+// being refused, so a fleet reading the exit status holds a change back over a node that would take it.
+func TestTheCheckDoesNotFailASectionTheDeliveryApplies(t *testing.T) {
+	configtest.Isolate(t)
+	const written = tendermintbase.RPCSectionName + ".max-open-connections"
+
+	// State sync is on with no servers to reach, which is a state its own rules refuse and an operator's
+	// config.toml can be in for months without it mattering.
+	own := tmcfg.DefaultConfig()
+	own.StateSync.Enable = true
+	if whatTheSectionsOwnRulesSay(own, []string{tendermintbase.StateSyncSectionName + ".enable"}) == nil {
+		t.Fatal("this fixture passes state sync's own rules, so there is no standing failure for the " +
+			"check to attribute to another section")
+	}
+	if own.ValidateBasic() == nil {
+		t.Fatal("this fixture passes the whole configuration's rules, so asking those answers the same " +
+			"as asking one section's and nothing here separates the two questions")
+	}
+	// The delivery takes sections in sorted order, so the written section has to sort first. A standing
+	// failure in a section delivered earlier is corrected by that section's own declared values before the
+	// written one is reached, and the case would not arise.
+	if tendermintbase.RPCSectionName >= tendermintbase.StateSyncSectionName {
+		t.Fatalf("[%s] does not sort before [%s], so the standing failure is corrected before the "+
+			"written section is rehearsed", tendermintbase.RPCSectionName,
+			tendermintbase.StateSyncSectionName)
+	}
+
+	got := rehearseAndDeliver(t, own, map[string]any{written: 111})
+
+	if runs := got.delivered.RPC.MaxOpenConnections; runs != 111 {
+		t.Fatalf("the delivery left max-open-connections at %d with 111 in the file, so it refused the "+
+			"section and there is no applied section for the check to disagree about", runs)
+	}
+	if strings.Join(got.byTheCheck, ",") != strings.Join(got.byTheDelivery, ",") {
+		t.Errorf("the check refused %v and the delivery refused %v for the same input. A failure "+
+			"standing in [%s] is reported as another section's values being refused, and the command "+
+			"exits non-zero on a file a boot applies",
+			got.byTheCheck, got.byTheDelivery, tendermintbase.StateSyncSectionName)
+	}
+}
+
+// TestTheCheckRefusesWhatTheDeliveryRefuses holds the command to still failing on what a boot drops.
+//
+// Asking one section's rules rather than the whole configuration's is only right while it refuses what the
+// boot refuses. The keys at the root of the file are the case to watch: the registry names that section for
+// its reports and the node's own type carries no tag of that name, so a section picked out by name states
+// no rules and every value in it passes.
+func TestTheCheckRefusesWhatTheDeliveryRefuses(t *testing.T) {
+	for _, tc := range []struct {
+		section string
+		file    map[string]any
+	}{
+		{tendermintbase.RPCSectionName, map[string]any{
+			tendermintbase.RPCSectionName + ".max-open-connections": -1}},
+		{tendermintbase.MempoolSectionName, map[string]any{
+			tendermintbase.MempoolSectionName + ".size": -1}},
+		{tendermintbase.RootSectionName, map[string]any{"log-format": "nonsense"}},
+	} {
+		t.Run(tc.section, func(t *testing.T) {
+			configtest.Isolate(t)
+			own := tmcfg.DefaultConfig()
+			if err := own.ValidateBasic(); err != nil {
+				t.Fatalf("this fixture's node configuration fails on its own, so a refusal here says "+
+					"nothing about the written value: %v", err)
+			}
+
+			got := rehearseAndDeliver(t, own, tc.file)
+
+			if strings.Join(got.byTheDelivery, ",") != tc.section {
+				t.Fatalf("the delivery refused %v, want exactly [%s]. The fixture does not write a value "+
+					"a boot refuses, so this case cannot show the check refusing one",
+					got.byTheDelivery, tc.section)
+			}
+			if strings.Join(got.byTheCheck, ",") != tc.section {
+				t.Errorf("the check refused %v where the delivery refused %v. A value a boot drops "+
+					"passes the command an operator runs to find it", got.byTheCheck, got.byTheDelivery)
+			}
+		})
 	}
 }

--- a/cmd/seid/cmd/configmanager/doc.go
+++ b/cmd/seid/cmd/configmanager/doc.go
@@ -39,4 +39,15 @@
 //
 // The cost is that an unusable value is reported rather than refused. These reports are the only signal an
 // operator has.
+//
+// # Asking before a restart
+//
+// This package also owns `seid config check`. It answers what a node's sei.toml reaches without starting
+// the node. It resolves the file the way a boot resolves it. Then it reports every value a delivery would
+// refuse, every key no section declares, a disagreement about what kind of node this is, and whether the
+// gate would make a boot read the file at all. Its exit status is the answer: anything that would stop the
+// node exits non-zero.
+//
+// It exists because a boot cannot refuse a file. Every failure there is a report on a node that has already
+// restarted, and the same questions have exact answers beforehand.
 package configmanager

--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -145,6 +145,7 @@ func initRootCmd(
 		tmcli.NewCompletionCmd(rootCmd, true),
 		debugCmd,
 		config.Cmd(),
+		seiConfigCmd(),
 		tools.ToolCmd(),
 		SnapshotCmd(),
 		LogLevelCmd(),
@@ -476,4 +477,17 @@ supply_enabled = {{ .LightInvariance.SupplyEnabled }}
 `
 
 	return customAppTemplate, customAppConfig
+}
+
+// seiConfigCmd groups the commands that answer questions about a node's sei.toml.
+//
+// Its own group rather than a subcommand of the existing configuration command, which reads and writes the
+// files this one is about rather than the file that replaces them.
+func seiConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sei-config",
+		Short: "Inspect the node's sei.toml",
+	}
+	cmd.AddCommand(configmanager.CheckCmd())
+	return cmd
 }

--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -129,6 +129,11 @@ func initRootCmd(
 	// extend debug command
 	debugCmd := debug.Cmd()
 
+	// One namespace for configuration. The existing command reads and writes client.toml; check reads the
+	// node's sei.toml and writes nothing.
+	configCmd := config.Cmd()
+	configCmd.AddCommand(configmanager.CheckCmd())
+
 	rootCmd.AddCommand(
 		InitCmd(app.ModuleBasics, app.DefaultNodeHome),
 		genutilcli.CollectGenTxsCmd(banktypes.GenesisBalancesIterator{}, app.DefaultNodeHome),
@@ -144,8 +149,7 @@ func initRootCmd(
 		AddGenesisWasmMsgCmd(app.DefaultNodeHome),
 		tmcli.NewCompletionCmd(rootCmd, true),
 		debugCmd,
-		config.Cmd(),
-		seiConfigCmd(),
+		configCmd,
 		tools.ToolCmd(),
 		SnapshotCmd(),
 		LogLevelCmd(),
@@ -477,28 +481,4 @@ supply_enabled = {{ .LightInvariance.SupplyEnabled }}
 `
 
 	return customAppTemplate, customAppConfig
-}
-
-// seiConfigCmd groups the commands that answer questions about a node's sei.toml.
-//
-// Its own group rather than a subcommand of the existing configuration command, which reads and writes the
-// files this one is about rather than the file that replaces them.
-func seiConfigCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "sei-config",
-		Short: "Inspect the node's sei.toml",
-		// A hook of its own, which stops the root one from running. Two things follow, and both are
-		// required rather than convenient.
-		//
-		// The root hook writes files. It runs the configuration handler, which generates config.toml and
-		// app.toml when they are absent, so a command that answers a question about a file would create
-		// two others as a side effect.
-		//
-		// It also copies configuration values into flags and marks them changed, which is exactly the
-		// state that makes a flag indistinguishable from a key an operator's app.toml holds. A command
-		// reading its flags after that cannot tell what was typed, and it reports on what was typed.
-		PersistentPreRunE: func(*cobra.Command, []string) error { return nil },
-	}
-	cmd.AddCommand(configmanager.CheckCmd())
-	return cmd
 }

--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -487,6 +487,17 @@ func seiConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sei-config",
 		Short: "Inspect the node's sei.toml",
+		// A hook of its own, which stops the root one from running. Two things follow, and both are
+		// required rather than convenient.
+		//
+		// The root hook writes files. It runs the configuration handler, which generates config.toml and
+		// app.toml when they are absent, so a command that answers a question about a file would create
+		// two others as a side effect.
+		//
+		// It also copies configuration values into flags and marks them changed, which is exactly the
+		// state that makes a flag indistinguishable from a key an operator's app.toml holds. A command
+		// reading its flags after that cannot tell what was typed, and it reports on what was typed.
+		PersistentPreRunE: func(*cobra.Command, []string) error { return nil },
 	}
 	cmd.AddCommand(configmanager.CheckCmd())
 	return cmd


### PR DESCRIPTION
A command that answers what a node's `sei.toml` reaches, without starting the node. Second of two.

    seid config check

It reports which declared keys the file states, which names in it reach nothing, and which written
values a delivery would decline. Its exit status is the answer.

### What it answers

A file that will not parse, records a schema version this binary does not know, or names no node
kind exits non-zero. A node with no file has nothing that could be wrong, and stays quiet.

It names a disagreement about what kind of node this is. Two files record that under different
names, and a node whose `sei.toml` says validator while its own file says full resolves a
validator's answers and serves queries.

It says whether the gate would make a boot read the file at all, so a pass is not read as "in use
and correct". The prediction comes from the same code that would decline the value at boot.

### Where it lives

Under the existing `config` command, which reads and writes `client.toml`. Neither shadows the
other. Its own pre-run hook stops a question about one file generating two others.

### Verified

Formatters, `go vet` and `golangci-lint` clean. `-race -count=2 -shuffle` clean. Driven against a
built binary for the new command and for `seid config <key> [value]` beside it.
