### PR TITLE
metrics: remove legacy go-metrics dual-write emitters (PLT-327)

### DIFF
--- a/app/abci.go
+++ b/app/abci.go
@@ -15,12 +15,10 @@ import (
 	"github.com/sei-protocol/sei-chain/app/legacyabci"
 	"github.com/sei-protocol/sei-chain/app/migration"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/tasks"
-	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/types/legacytm"
 	abci "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
-	utilmetrics "github.com/sei-protocol/sei-chain/utils/metrics"
 )
 
 func (app *App) BeginBlock(
@@ -36,7 +34,6 @@ func (app *App) BeginBlock(
 	ctx = ctx.WithEventManager(sdk.NewEventManager())
 	beginBlockStart := time.Now()
 	defer func() {
-		telemetry.MeasureSince(beginBlockStart, "abci", "begin_block") // TODO(PLT-327): remove once app_abci_begin_block_duration_seconds verified
 		appMetrics.beginBlockDuration.Record(ctx.Context(), time.Since(beginBlockStart).Seconds())
 	}()
 	// inline begin block
@@ -45,7 +42,6 @@ func (app *App) BeginBlock(
 			panic(err)
 		}
 	}
-	utilmetrics.GaugeSeidVersionAndCommit(app.versionInfo.Version, app.versionInfo.GitCommit) // TODO(PLT-327): remove once app_build_info observable gauge verified
 	// check if we've reached a target height, if so, execute any applicable handlers
 	if app.forkInitializer != nil {
 		app.forkInitializer(ctx)
@@ -115,13 +111,11 @@ func (app *App) EndBlock(ctx sdk.Context, height int64, blockGasUsed int64) (res
 	ctx = ctx.WithTraceSpanContext(spanCtx)
 	endBlockStart := time.Now()
 	defer func() {
-		telemetry.MeasureSince(endBlockStart, "abci", "end_block") // TODO(PLT-327): remove once app_abci_end_block_duration_seconds verified
 		appMetrics.endBlockDuration.Record(ctx.Context(), time.Since(endBlockStart).Seconds())
 	}()
 	ctx = ctx.WithEventManager(sdk.NewEventManager())
 	moduleEndBlockStart := time.Now()
 	defer func() {
-		telemetry.MeasureSince(moduleEndBlockStart, "module", "total_end_block") // TODO(PLT-327): remove once app_abci_module_end_block_duration_seconds verified
 		appMetrics.moduleEndBlockDuration.Record(ctx.Context(), time.Since(moduleEndBlockStart).Seconds())
 	}()
 	res.ValidatorUpdates = legacyabci.EndBlock(ctx, height, blockGasUsed, app.EndBlockKeepers)
@@ -147,7 +141,6 @@ func (app *App) CheckTx(ctx context.Context, req *abci.RequestCheckTxV2) *abci.R
 	defer span.End()
 	checkTxStart := time.Now()
 	defer func() {
-		telemetry.MeasureSince(checkTxStart, "abci", "check_tx") // TODO(PLT-327): remove once app_abci_check_tx_duration_seconds verified
 		appMetrics.checkTxDuration.Record(ctx, time.Since(checkTxStart).Seconds())
 	}()
 	sdkCtx := app.GetCheckTxContext(req.Tx, req.Type == abci.CheckTxTypeV2Recheck)
@@ -214,19 +207,12 @@ func (app *App) DeliverTx(ctx sdk.Context, req abci.RequestDeliverTxV2, tx sdk.T
 	// update context with trace span new context
 	ctx = ctx.WithTraceSpanContext(spanCtx)
 	defer func() {
-		utilmetrics.MeasureDeliverTxDuration(deliverTxStart)         // TODO(PLT-327): remove once app_abci_deliver_tx_duration_seconds verified
-		telemetry.MeasureSince(deliverTxStart, "abci", "deliver_tx") // TODO(PLT-327): remove once app_abci_deliver_tx_duration_seconds verified
 		appMetrics.deliverTxDuration.Record(ctx.Context(), time.Since(deliverTxStart).Seconds())
 	}()
 
-	gInfo := sdk.GasInfo{}
 	resultStr := "successful"
 
 	defer func() {
-		telemetry.IncrCounter(1, "tx", "count")                             // TODO(PLT-327): remove once app_tx_count_total verified
-		telemetry.IncrCounter(1, "tx", resultStr)                           // TODO(PLT-327): remove once app_tx_count_total verified
-		telemetry.SetGauge(float32(gInfo.GasUsed), "tx", "gas", "used")     // TODO(PLT-327): remove once app_tx_gas_used verified
-		telemetry.SetGauge(float32(gInfo.GasWanted), "tx", "gas", "wanted") // TODO(PLT-327): remove once app_tx_gas_wanted verified
 		appMetrics.txCount.Add(ctx.Context(), 1, otelmetrics.WithAttributes(attribute.String("result", resultStr)))
 	}()
 	gInfo, result, anteEvents, resCtx, err := legacyabci.DeliverTx(ctx.WithTxBytes(req.Tx).WithTxSum(checksum), tx, app.GetTxConfig(), &app.DeliverTxKeepers, checksum, func(ctx sdk.Context) (sdk.Context, sdk.CacheMultiStore) {
@@ -270,7 +256,6 @@ func (app *App) DeliverTx(ctx sdk.Context, req abci.RequestDeliverTxV2, tx sdk.T
 func (app *App) DeliverTxBatch(ctx sdk.Context, req sdk.DeliverTxBatchRequest) (res sdk.DeliverTxBatchResponse) {
 	deliverBatchStart := time.Now()
 	defer func() {
-		utilmetrics.MeasureDeliverBatchTxDuration(deliverBatchStart) // TODO(PLT-327): remove once app_abci_deliver_batch_tx_duration_seconds verified
 		appMetrics.deliverBatchTxDuration.Record(ctx.Context(), time.Since(deliverBatchStart).Seconds())
 	}()
 	spanCtx, span := app.GetBaseApp().TracingInfo.StartWithContext("DeliverTxBatch", ctx.TraceSpanContext())
@@ -303,7 +288,7 @@ func (app *App) Commit(ctx context.Context) (res *abci.ResponseCommit, err error
 	start := time.Now()
 	res, err = app.BaseApp.Commit(ctx)
 	elapsed := time.Since(start)
-	// legacy: telemetry.MeasureSince in sei-cosmos/baseapp/abci.go TODO(PLT-327)
+	// legacy: telemetry.MeasureSince in sei-cosmos/baseapp/abci.go TODO(PLT-353)
 	appMetrics.commitDuration.Record(ctx, elapsed.Seconds())
 	app.RecordBenchmarkCommitTime(elapsed)
 	// After a successful Commit, publish the pending eth_newHeads event

--- a/app/app.go
+++ b/app/app.go
@@ -1189,7 +1189,6 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 
 	typedTxs, err := app.DecodeTxBytesConcurrently(ctx.Context(), req.Txs)
 	if err != nil {
-		utilmetrics.IncrFailedTotalGasWantedCheck(string(req.Header.ProposerAddress)) // TODO(PLT-327): remove once app_failed_total_gas_wanted_check_total verified
 		appMetrics.failedGasWantedCheck.Add(ctx.Context(), 1,
 			otelmetric.WithAttributes(attribute.String("proposer", hex.EncodeToString(req.Header.ProposerAddress))))
 		return &abci.ResponseProcessProposal{
@@ -1204,7 +1203,6 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 	// Invariant: at this point nil entries in typedTxs are proto decode failures only.
 	// EVM preprocessing runs later inside ProcessBlock; do not reorder that before this check.
 	if !app.checkTotalBlockGas(checkCtx, typedTxs) {
-		utilmetrics.IncrFailedTotalGasWantedCheck(string(req.Header.ProposerAddress)) // TODO(PLT-327): remove once app_failed_total_gas_wanted_check_total verified
 		appMetrics.failedGasWantedCheck.Add(ctx.Context(), 1,
 			otelmetric.WithAttributes(attribute.String("proposer", hex.EncodeToString(req.Header.ProposerAddress))))
 		return &abci.ResponseProcessProposal{
@@ -1314,7 +1312,6 @@ func (app *App) FinalizeBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock)
 		app.optimisticProcessingInfoMutex.RUnlock()
 
 		if !aborted && bytes.Equal(finalHash, req.Hash) {
-			utilmetrics.IncrementOptimisticProcessingCounter(true) // TODO(PLT-327): remove once app_optimistic_processing_total verified
 			appMetrics.optimisticProcessing.Add(ctx.Context(), 1,
 				otelmetric.WithAttributes(attribute.Bool("enabled", true)))
 			app.SetProcessProposalStateToCommit()
@@ -1332,7 +1329,6 @@ func (app *App) FinalizeBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock)
 			return &resp, nil
 		}
 	}
-	utilmetrics.IncrementOptimisticProcessingCounter(false) // TODO(PLT-327): remove once app_optimistic_processing_total verified
 	appMetrics.optimisticProcessing.Add(ctx.Context(), 1,
 		otelmetric.WithAttributes(attribute.Bool("enabled", false)))
 	logger.Info("optimistic processing ineligible")
@@ -1368,8 +1364,6 @@ func (app *App) DeliverTxWithResult(ctx sdk.Context, tx []byte, typedTx sdk.Tx) 
 		Tx: tx,
 	}, typedTx, sha256.Sum256(tx))
 
-	utilmetrics.IncrGasCounter("gas_used", deliverTxResp.GasUsed)     // TODO(PLT-327): remove once app_tx_gas_total verified
-	utilmetrics.IncrGasCounter("gas_wanted", deliverTxResp.GasWanted) // TODO(PLT-327): remove once app_tx_gas_total verified
 	appMetrics.txGas.Add(ctx.Context(), deliverTxResp.GasUsed,
 		otelmetric.WithAttributes(attribute.String("type", "gas_used")))
 	appMetrics.txGas.Add(ctx.Context(), deliverTxResp.GasWanted,
@@ -1391,7 +1385,6 @@ func (app *App) DeliverTxWithResult(ctx sdk.Context, tx []byte, typedTx sdk.Tx) 
 func (app *App) ProcessTxsSynchronousV2(ctx sdk.Context, txs [][]byte, typedTxs []sdk.Tx) []*abci.ExecTxResult {
 	blockProcessStart := time.Now()
 	defer func() {
-		utilmetrics.BlockProcessLatency(blockProcessStart, utilmetrics.Synchronous) // TODO(PLT-327): remove once app_block_process_duration_seconds verified
 		appMetrics.blockProcessDuration.Record(ctx.Context(), time.Since(blockProcessStart).Seconds(),
 			otelmetric.WithAttributes(attribute.String("type", utilmetrics.Synchronous)))
 	}()
@@ -1401,7 +1394,6 @@ func (app *App) ProcessTxsSynchronousV2(ctx sdk.Context, txs [][]byte, typedTxs 
 		ctx = ctx.WithTxIndex(i)
 		res := app.DeliverTxWithResult(ctx, tx, typedTxs[i])
 		txResults = append(txResults, res)
-		utilmetrics.IncrTxProcessTypeCounter(utilmetrics.Synchronous) // TODO(PLT-327): remove once app_tx_process_type_total verified
 		appMetrics.txProcessType.Add(ctx.Context(), 1,
 			otelmetric.WithAttributes(attribute.String("type", utilmetrics.Synchronous)))
 	}
@@ -1411,7 +1403,6 @@ func (app *App) ProcessTxsSynchronousV2(ctx sdk.Context, txs [][]byte, typedTxs 
 func (app *App) ProcessTxsSynchronousGiga(ctx sdk.Context, txs [][]byte, typedTxs []sdk.Tx) []*abci.ExecTxResult {
 	blockProcessGigaStart := time.Now()
 	defer func() {
-		utilmetrics.BlockProcessLatency(blockProcessGigaStart, utilmetrics.Synchronous) // TODO(PLT-327): remove once app_block_process_duration_seconds verified
 		appMetrics.blockProcessDuration.Record(ctx.Context(), time.Since(blockProcessGigaStart).Seconds(),
 			otelmetric.WithAttributes(attribute.String("type", utilmetrics.SynchronousGiga)))
 	}()
@@ -1491,7 +1482,6 @@ func (app *App) ProcessTxsSynchronousGiga(ctx sdk.Context, txs [][]byte, typedTx
 
 		// Store-iteration panic: re-run via v2 so the result matches v2 exactly.
 		if fallbackToV2 {
-			utilmetrics.IncrGigaFallbackToV2Counter() // TODO(PLT-327): remove once app_giga_fallback_to_v2_total verified
 			appMetrics.gigaFallback.Add(ctx.Context(), 1,
 				otelmetric.WithAttributes(
 					attribute.String("reason", gigaFallbackStoreIterator),
@@ -1506,7 +1496,6 @@ func (app *App) ProcessTxsSynchronousGiga(ctx sdk.Context, txs [][]byte, typedTx
 			// Abort errors (validation failure, balance migration, self-destruct,
 			// cosmos-precompile interop) re-run this tx via v2.
 			if gigautils.ShouldExecutionAbort(execErr) {
-				utilmetrics.IncrGigaFallbackToV2Counter() // TODO(PLT-327): remove once app_giga_fallback_to_v2_total verified
 				appMetrics.gigaFallback.Add(ctx.Context(), 1,
 					otelmetric.WithAttributes(
 						attribute.String("reason", gigaFallbackReason(execErr)),
@@ -1525,7 +1514,6 @@ func (app *App) ProcessTxsSynchronousGiga(ctx sdk.Context, txs [][]byte, typedTx
 
 		txResults[i] = result
 		ctx.GigaMultiStore().WriteGiga()
-		utilmetrics.IncrTxProcessTypeCounter(utilmetrics.Synchronous) // TODO(PLT-327): remove once app_tx_process_type_total verified
 		appMetrics.txProcessType.Add(ctx.Context(), 1,
 			otelmetric.WithAttributes(attribute.String("type", utilmetrics.SynchronousGiga)))
 	}
@@ -1614,12 +1602,9 @@ func (app *App) ProcessTXsWithOCCV2(ctx sdk.Context, txs [][]byte, typedTxs []sd
 
 	execResults := make([]*abci.ExecTxResult, 0, len(batchResult.Results))
 	for _, r := range batchResult.Results {
-		utilmetrics.IncrTxProcessTypeCounter(utilmetrics.OccConcurrent) // TODO(PLT-327): remove once app_tx_process_type_total verified
 		appMetrics.txProcessType.Add(ctx.Context(), 1,
 			otelmetric.WithAttributes(attribute.String("type", utilmetrics.OccConcurrent)))
 
-		utilmetrics.IncrGasCounter("gas_used", r.Response.GasUsed)     // TODO(PLT-327): remove once app_tx_gas_total verified
-		utilmetrics.IncrGasCounter("gas_wanted", r.Response.GasWanted) // TODO(PLT-327): remove once app_tx_gas_total verified
 		appMetrics.txGas.Add(ctx.Context(), r.Response.GasUsed,
 			otelmetric.WithAttributes(attribute.String("type", "gas_used")))
 		appMetrics.txGas.Add(ctx.Context(), r.Response.GasWanted,
@@ -1715,7 +1700,6 @@ func (app *App) ProcessTXsWithOCCGiga(ctx sdk.Context, txs [][]byte, typedTxs []
 		}
 
 		if fallbackToV2 {
-			utilmetrics.IncrGigaFallbackToV2Counter() // TODO(PLT-327): remove once app_giga_fallback_to_v2_total verified
 			appMetrics.gigaFallback.Add(ctx.Context(), 1,
 				otelmetric.WithAttributes(
 					attribute.String("reason", fallbackReason),

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -689,11 +689,11 @@ func TestTransactionExtremeGasValue(t *testing.T) {
 	attackTxBytes, err := sei.GetTxConfig().TxEncoder()(attackTx)
 	require.NoError(t, err)
 
-	// Gas metrics have overflow protection in IncrGasCounter.
+	// app_tx_gas is an int64 counter, so an extreme gas limit records without overflow.
 	require.NotPanics(t, func() {
 		result := sei.DeliverTxWithResult(ctx, attackTxBytes, attackTx)
 		require.NotNil(t, result)
-	}, "Extreme gas values should never cause panic due to overflow protection")
+	}, "Extreme gas values should never cause panic")
 }
 
 // TestProcessProposalHandlerPanicRecovery tests the panic recovery mechanism in ProcessProposalHandler.

--- a/app/invariance.go
+++ b/app/invariance.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	armonmetrics "github.com/armon/go-metrics"
 	servertypes "github.com/sei-protocol/sei-chain/sei-cosmos/server/types"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/storev2/commitment"
 	"github.com/spf13/cast"
@@ -16,8 +15,6 @@ import (
 
 	bankkeeper "github.com/sei-protocol/sei-chain/sei-cosmos/x/bank/keeper"
 	banktypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/bank/types"
-
-	seimetrics "github.com/sei-protocol/sei-chain/utils/metrics"
 )
 
 type LightInvarianceConfig struct {
@@ -57,7 +54,6 @@ func (app *App) LightInvarianceChecks(ctx context.Context, cms sdk.CommitMultiSt
 func (app *App) LightInvarianceTotalSupply(ctx context.Context, cms sdk.CommitMultiStore) {
 	invarianceStart := time.Now()
 	defer func() {
-		armonmetrics.MeasureSince([]string{"sei", "lightinvariance_supply", "milliseconds"}, invarianceStart.UTC()) // TODO(PLT-327): remove once app_lightinvariance_supply_duration_seconds verified
 		appMetrics.invarianceDuration.Record(ctx, time.Since(invarianceStart).Seconds())
 	}()
 	ckv, ok := cms.GetStore(app.BankKeeper.GetStoreKey()).(*commitment.Store)
@@ -71,7 +67,6 @@ func (app *App) LightInvarianceTotalSupply(ctx context.Context, cms sdk.CommitMu
 	for _, p := range balanceChangePairs {
 		if len(p.Key) < 2 {
 			// invalid key; ignore
-			seimetrics.SafeMetricsIncrCounterWithLabels([]string{"sei", "lightinvariance_supply", "invalid_changed_key"}, 1, []armonmetrics.Label{{Name: "type", Value: "sei"}}) // TODO(PLT-327): remove once app_lightinvariance_supply_invalid_key_total verified
 			appMetrics.invarianceInvalidKey.Add(ctx, 1, otelmetrics.WithAttributes(attribute.String("type", "sei")))
 			logger.Error("invalid changed pair key for usei", "key", fmt.Sprintf("%X", p.Key))
 			continue
@@ -79,7 +74,6 @@ func (app *App) LightInvarianceTotalSupply(ctx context.Context, cms sdk.CommitMu
 		addrLen := int(p.Key[1])
 		if len(p.Key) < addrLen+2 {
 			// invalid key length; ignore
-			seimetrics.SafeMetricsIncrCounterWithLabels([]string{"sei", "lightinvariance_supply", "invalid_changed_key"}, 1, []armonmetrics.Label{{Name: "type", Value: "sei"}}) // TODO(PLT-327): remove once app_lightinvariance_supply_invalid_key_total verified
 			appMetrics.invarianceInvalidKey.Add(ctx, 1, otelmetrics.WithAttributes(attribute.String("type", "sei")))
 			logger.Error("invalid changed pair key for usei", "key", fmt.Sprintf("%X", p.Key))
 			continue
@@ -92,7 +86,6 @@ func (app *App) LightInvarianceTotalSupply(ctx context.Context, cms sdk.CommitMu
 		if !p.Delete {
 			var balance sdk.Coin
 			if err := balance.Unmarshal(p.Value); err != nil {
-				seimetrics.SafeMetricsIncrCounterWithLabels([]string{"sei", "lightinvariance_supply", "unmarshal_failure"}, 1, []armonmetrics.Label{{Name: "type", Value: "usei"}, {Name: "step", Value: "post_block"}}) // TODO(PLT-327): remove once app_lightinvariance_supply_unmarshal_failure_total verified
 				appMetrics.invarianceUnmarshalFail.Add(ctx, 1, otelmetrics.WithAttributes(attribute.String("type", "usei"), attribute.String("step", "post_block")))
 				logger.Error("failed to unmarshal balance", "err", err)
 				continue
@@ -113,7 +106,6 @@ func (app *App) LightInvarianceTotalSupply(ctx context.Context, cms sdk.CommitMu
 		}
 		var balance sdk.Coin
 		if err := balance.Unmarshal(val); err != nil {
-			seimetrics.SafeMetricsIncrCounterWithLabels([]string{"sei", "lightinvariance_supply", "unmarshal_failure"}, 1, []armonmetrics.Label{{Name: "type", Value: "usei"}, {Name: "step", Value: "pre_block"}}) // TODO(PLT-327): remove once app_lightinvariance_supply_unmarshal_failure_total verified
 			appMetrics.invarianceUnmarshalFail.Add(ctx, 1, otelmetrics.WithAttributes(attribute.String("type", "usei"), attribute.String("step", "pre_block")))
 			logger.Error("failed to unmarshal preblock balance", "err", err)
 			continue
@@ -126,14 +118,12 @@ func (app *App) LightInvarianceTotalSupply(ctx context.Context, cms sdk.CommitMu
 	for _, p := range weiChangePairs {
 		var amt sdk.Int
 		if len(p.Key) < 1 {
-			seimetrics.SafeMetricsIncrCounterWithLabels([]string{"sei", "lightinvariance_supply", "invalid_changed_key"}, 1, []armonmetrics.Label{{Name: "type", Value: "wei"}}) // TODO(PLT-327): remove once app_lightinvariance_supply_invalid_key_total verified
 			appMetrics.invarianceInvalidKey.Add(ctx, 1, otelmetrics.WithAttributes(attribute.String("type", "wei")))
 			logger.Error("invalid changed pair key", "key", fmt.Sprintf("%X", p.Key))
 			continue
 		}
 		if !p.Delete {
 			if err := amt.Unmarshal(p.Value); err != nil {
-				seimetrics.SafeMetricsIncrCounterWithLabels([]string{"sei", "lightinvariance_supply", "unmarshal_failure"}, 1, []armonmetrics.Label{{Name: "type", Value: "wei"}, {Name: "step", Value: "post_block"}}) // TODO(PLT-327): remove once app_lightinvariance_supply_unmarshal_failure_total verified
 				appMetrics.invarianceUnmarshalFail.Add(ctx, 1, otelmetrics.WithAttributes(attribute.String("type", "wei"), attribute.String("step", "post_block")))
 				logger.Error("failed to unmarshal wei balance", "err", err)
 				continue
@@ -154,7 +144,6 @@ func (app *App) LightInvarianceTotalSupply(ctx context.Context, cms sdk.CommitMu
 		}
 		var amt sdk.Int
 		if err := amt.Unmarshal(val); err != nil {
-			seimetrics.SafeMetricsIncrCounterWithLabels([]string{"sei", "lightinvariance_supply", "unmarshal_failure"}, 1, []armonmetrics.Label{{Name: "type", Value: "wei"}, {Name: "step", Value: "pre_block"}}) // TODO(PLT-327): remove once app_lightinvariance_supply_unmarshal_failure_total verified
 			appMetrics.invarianceUnmarshalFail.Add(ctx, 1, otelmetrics.WithAttributes(attribute.String("type", "wei"), attribute.String("step", "pre_block")))
 			logger.Error("failed to unmarshal preblock wei balance", "err", err)
 			continue
@@ -167,7 +156,6 @@ func (app *App) LightInvarianceTotalSupply(ctx context.Context, cms sdk.CommitMu
 	if bz := ckv.Get(append(banktypes.SupplyKey, []byte(sdk.MustGetBaseDenom())...)); bz != nil {
 		var amt sdk.Int
 		if err := amt.Unmarshal(bz); err != nil {
-			seimetrics.SafeMetricsIncrCounterWithLabels([]string{"sei", "lightinvariance_supply", "unmarshal_failure"}, 1, []armonmetrics.Label{{Name: "type", Value: "total_supply"}, {Name: "step", Value: "pre_block"}}) // TODO(PLT-327): remove once app_lightinvariance_supply_unmarshal_failure_total verified
 			appMetrics.invarianceUnmarshalFail.Add(ctx, 1, otelmetrics.WithAttributes(attribute.String("type", "total_supply"), attribute.String("step", "pre_block")))
 			logger.Error("failed to unmarshal pre total supply", "err", err)
 			return
@@ -181,7 +169,6 @@ func (app *App) LightInvarianceTotalSupply(ctx context.Context, cms sdk.CommitMu
 			} else {
 				var amt sdk.Int
 				if err := amt.Unmarshal(p.Value); err != nil {
-					seimetrics.SafeMetricsIncrCounterWithLabels([]string{"sei", "lightinvariance_supply", "unmarshal_failure"}, 1, []armonmetrics.Label{{Name: "type", Value: "total_supply"}, {Name: "step", Value: "post_block"}}) // TODO(PLT-327): remove once app_lightinvariance_supply_unmarshal_failure_total verified
 					appMetrics.invarianceUnmarshalFail.Add(ctx, 1, otelmetrics.WithAttributes(attribute.String("type", "total_supply"), attribute.String("step", "post_block")))
 					logger.Error("failed to unmarshal total supply", "err", err)
 				} else {

--- a/app/metrics.go
+++ b/app/metrics.go
@@ -200,7 +200,6 @@ var (
 		)),
 
 		// The callback fires on every Prometheus scrape; no per-block call site is needed.
-		// TODO(PLT-327): remove metrics.GaugeSeidVersionAndCommit call in abci.go once app_build_info verified
 		versionInfo: must(meter.Int64ObservableGauge(
 			"app_build_info",
 			metric.WithDescription("Running binary build info; value is always 1"),

--- a/utils/metrics/metrics_util.go
+++ b/utils/metrics/metrics_util.go
@@ -7,8 +7,6 @@ import (
 	"math/big"
 	"os"
 	"runtime/debug"
-	"strconv"
-	"time"
 
 	metrics "github.com/armon/go-metrics"
 	"github.com/prometheus/otlptranslator"
@@ -117,86 +115,6 @@ func SafeTelemetryIncrCounterWithLabels(keys []string, val float32, labels []met
 	telemetry.IncrCounterWithLabels(keys, val, labels)
 }
 
-func SafeMetricsIncrCounterWithLabels(keys []string, val float32, labels []metrics.Label) {
-	defer func() {
-		if e := recover(); e != nil {
-			debug.PrintStack()
-			return
-		}
-	}()
-	metrics.IncrCounterWithLabels(keys, val, labels)
-}
-
-// Gauge metric with seid version and git commit as labels
-// Metric Name:
-//
-//	seid_version_and_commit
-func GaugeSeidVersionAndCommit(version string, commit string) {
-	telemetry.SetGaugeWithLabels(
-		[]string{"seid_version_and_commit"},
-		1,
-		[]metrics.Label{telemetry.NewLabel("seid_version", version), telemetry.NewLabel("commit", commit)},
-	)
-}
-
-// sei_tx_process_type_count
-func IncrTxProcessTypeCounter(processType string) {
-	SafeMetricsIncrCounterWithLabels(
-		[]string{"sei", "tx", "process", "type"},
-		1,
-		[]metrics.Label{telemetry.NewLabel("type", processType)},
-	)
-}
-
-// sei_giga_fallback_to_v2_count
-func IncrGigaFallbackToV2Counter() {
-	SafeMetricsIncrCounterWithLabels(
-		[]string{"sei", "giga", "fallback", "to", "v2", "count"},
-		1,
-		[]metrics.Label{},
-	)
-}
-
-// Measures the time taken to process a block by the process type
-// Metric Names:
-//
-//	sei_process_block_miliseconds
-//	sei_process_block_miliseconds_count
-//	sei_process_block_miliseconds_sum
-func BlockProcessLatency(start time.Time, processType string) {
-	metrics.MeasureSinceWithLabels(
-		[]string{"sei", "process", "block", "milliseconds"},
-		start.UTC(),
-		[]metrics.Label{telemetry.NewLabel("type", processType)},
-	)
-}
-
-// Measures the time taken to execute a sudo msg
-// Metric Names:
-//
-//	sei_deliver_tx_duration_miliseconds
-//	sei_deliver_tx_duration_miliseconds_count
-//	sei_deliver_tx_duration_miliseconds_sum
-func MeasureDeliverTxDuration(start time.Time) {
-	metrics.MeasureSince(
-		[]string{"sei", "deliver", "tx", "milliseconds"},
-		start.UTC(),
-	)
-}
-
-// Measures the time taken to execute a batch tx
-// Metric Names:
-//
-//	sei_deliver_batch_tx_duration_miliseconds
-//	sei_deliver_batch_tx_duration_miliseconds_count
-//	sei_deliver_batch_tx_duration_miliseconds_sum
-func MeasureDeliverBatchTxDuration(start time.Time) {
-	metrics.MeasureSince(
-		[]string{"sei", "deliver", "batch", "tx", "milliseconds"},
-		start.UTC(),
-	)
-}
-
 // sei_oracle_vote_penalty_count
 func SetOracleVotePenaltyCount(count uint64, valAddr string, penaltyType string) {
 	metrics.SetGaugeWithLabels(
@@ -253,18 +171,6 @@ func IncrPriceUpdateDenom(denom string) {
 	)
 }
 
-// Measures the number of times the total block gas wanted in the proposal exceeds the max
-// Metric Name:
-//
-//	sei_failed_total_gas_wanted_check
-func IncrFailedTotalGasWantedCheck(proposer string) {
-	SafeTelemetryIncrCounterWithLabels(
-		[]string{"sei", "failed", "total", "gas", "wanted", "check"},
-		1,
-		[]metrics.Label{telemetry.NewLabel("proposer", proposer)},
-	)
-}
-
 // Measures number of times a denom's price is updated
 // Metric Name:
 //
@@ -274,58 +180,6 @@ func SetCoinsMinted(amount uint64, denom string) {
 		[]string{"sei", "mint", "coins"},
 		float32(amount),
 		[]metrics.Label{telemetry.NewLabel("denom", denom)},
-	)
-}
-
-// Measures the number of times the total block gas wanted in the proposal exceeds the max
-// Metric Name:
-//
-//	sei_tx_gas_counter
-func IncrGasCounter(gasType string, value int64) {
-	const maxSafeFloat32 = 1<<24 - 1 // Maximum safe integer representable in float32 (16,777,215)
-
-	if value < 0 {
-		// Log negative values but don't panic - this shouldn't happen in normal operation
-		telemetry.IncrCounterWithLabels(
-			[]string{"sei", "tx", "gas", "counter", "error"},
-			1,
-			[]metrics.Label{
-				telemetry.NewLabel("type", gasType),
-				telemetry.NewLabel("error", "negative_value"),
-			},
-		)
-		return
-	}
-
-	if value > maxSafeFloat32 {
-		// Cap the value to prevent overflow while logging the incident
-		telemetry.IncrCounterWithLabels(
-			[]string{"sei", "tx", "gas", "counter", "overflow"},
-			1,
-			[]metrics.Label{
-				telemetry.NewLabel("type", gasType),
-				telemetry.NewLabel("original_value", "capped"),
-			},
-		)
-		value = maxSafeFloat32
-	}
-
-	SafeTelemetryIncrCounterWithLabels(
-		[]string{"sei", "tx", "gas", "counter"},
-		float32(value),
-		[]metrics.Label{telemetry.NewLabel("type", gasType)},
-	)
-}
-
-// Measures the number of times optimistic processing runs
-// Metric Name:
-//
-//	sei_optimistic_processing_counter
-func IncrementOptimisticProcessingCounter(enabled bool) {
-	SafeTelemetryIncrCounterWithLabels(
-		[]string{"sei", "optimistic", "processing", "counter"},
-		float32(1),
-		[]metrics.Label{telemetry.NewLabel("enabled", strconv.FormatBool(enabled))},
 	)
 }
 


### PR DESCRIPTION
## Describe your changes and provide context

Removes the legacy go-metrics/telemetry half of every dual write marked `TODO(PLT-327)` — 39 call sites in `app/abci.go`, `app/app.go`, `app/invariance.go`, plus the `utils/metrics` helpers behind them. Counterpart to [sei-protocol/platform#1578](https://github.com/sei-protocol/platform/pull/1578), which repointed the protocol dashboards at the OTel `sei_chain_app_*` series. All 22 removed series were confirmed to have zero references across that repo's dashboards and alert rules.

| File | Legacy series |
| --- | --- |
| `app/abci.go` | `abci_begin_block`, `abci_end_block`, `abci_check_tx`, `abci_deliver_tx`, `module_total_end_block`, `seid_version_and_commit`, `tx_count`, `tx_<result>`, `tx_gas_used`, `tx_gas_wanted`, `sei_deliver_tx_milliseconds`, `sei_deliver_batch_tx_milliseconds` |
| `app/app.go` | `sei_failed_total_gas_wanted_check`, `sei_optimistic_processing_counter`, `sei_tx_gas_counter`, `sei_process_block_milliseconds`, `sei_tx_process_type`, `sei_giga_fallback_to_v2_count` |
| `app/invariance.go` | `sei_lightinvariance_supply_{milliseconds,invalid_changed_key,unmarshal_failure}` |

The ten uncallable `utils/metrics` helpers are deleted rather than left in place, so a later caller cannot resurrect a series no dashboard reads. `SafeTelemetryIncrCounterWithLabels` stays — `x/evm` still uses it under `TODO(PLT-330)`.

Two follow-ons: `gInfo := sdk.GasInfo{}` in `DeliverTx` existed only for the deferred `SetGauge` closure and is now `ineffassign`-flagged, so it's dropped; and the pointer comment on `Commit` referenced PLT-327 for an emitter tagged `TODO(PLT-353)` at its own site in sei-cosmos, so it's retagged (that emitter is untouched).

⚠️ **Merge ordering:** [Platform PR](https://github.com/sei-protocol/platform/pull/1578) is still open. Land this after it merges and the OTel series are confirmed on a live scrape — merging first opens a window where the dashboards read the new names and the binary no longer emits the old ones.

