### PR TITLE
Bump version to v6.6.3 in prep for patch release

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v6.6.2"
+  "version": "v6.6.3"
 }


### PR DESCRIPTION
## Summary
- Bump `version.json` from `v6.6.2` to `v6.6.3` for the patch release.

## Test plan
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)