### PR TITLE
(Autobahn) Reject missing AppProposal.app_hash on proto decode

### DIFF
--- a/sei-tendermint/autobahn/types/app_proposal.go
+++ b/sei-tendermint/autobahn/types/app_proposal.go
@@ -86,6 +86,9 @@ var AppProposalConv = protoutils.Conv[*AppProposal, *pb.AppProposal]{
 		if m.GlobalNext == nil {
 			return nil, fmt.Errorf("global_next: missing")
 		}
+		if len(m.AppHash) == 0 {
+			return nil, fmt.Errorf("app_hash: missing")
+		}
 		return &AppProposal{
 			epochIndex: EpochIndex(*m.EpochIndex),
 			roadIndex:  RoadIndex(*m.RoadIndex),

--- a/sei-tendermint/autobahn/types/types_test.go
+++ b/sei-tendermint/autobahn/types/types_test.go
@@ -139,6 +139,35 @@ func TestTimeoutQCConvDecode_EmptyVotesReturnsError(t *testing.T) {
 	}
 }
 
+func TestAppProposalConvDecode_RequiredFields(t *testing.T) {
+	rng := utils.TestRng()
+	base := AppProposalConv.Encode(GenAppProposal(rng))
+	if _, err := AppProposalConv.Decode(base); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name string
+		mut  func(*pb.AppProposal)
+	}{
+		{"road_index", func(p *pb.AppProposal) { p.RoadIndex = nil }},
+		{"epoch_index", func(p *pb.AppProposal) { p.EpochIndex = nil }},
+		{"global_first", func(p *pb.AppProposal) { p.GlobalFirst = nil }},
+		{"global_next", func(p *pb.AppProposal) { p.GlobalNext = nil }},
+		{"app_hash nil", func(p *pb.AppProposal) { p.AppHash = nil }},
+		{"app_hash empty", func(p *pb.AppProposal) { p.AppHash = []byte{} }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := AppProposalConv.Encode(GenAppProposal(rng))
+			tc.mut(p)
+			if _, err := AppProposalConv.Decode(p); err == nil {
+				t.Fatal("Decode() succeeded, want error")
+			}
+		})
+	}
+}
+
 // TestNewTimeoutQC_MixedPrepareQCs verifies quorum-intersection behavior:
 // even if only one vote carries a PrepareQC, NewTimeoutQC picks it up
 // and Verify accepts the result.


### PR DESCRIPTION
## Summary
- In Autobahn, `AppProposal.app_hash` is proto `// required` but Decode accepted nil/empty hashes.
- Reject `len(app_hash) == 0` at the converter (same choke point as the other AppProposal scalars).
- Cover missing required fields, including nil and empty `app_hash`, in `TestAppProposalConvDecode_RequiredFields`.

Made with [Cursor](https://cursor.com)