### PR TITLE
Upgrade UCI AI review to latest and allow review of PRs from seidroid

### DIFF
--- a/.github/workflows/ai-assist.yml
+++ b/.github/workflows/ai-assist.yml
@@ -6,8 +6,8 @@ on:
     types: [ created ]
 jobs:
   assistant:
-    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.19
-    uses: sei-protocol/uci/.github/workflows/ai-assistant.yml@eb65d6d3f967c661f6af91cfac599fd355445f71
+    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.20
+    uses: sei-protocol/uci/.github/workflows/ai-assistant.yml@68010d0ab76554da91c320511fb14a7af1af4245
     permissions:
       contents: read
       pull-requests: write
@@ -15,6 +15,6 @@ jobs:
       id-token: write
     secrets: inherit
     with:
-      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.19
-      uci-ref: eb65d6d3f967c661f6af91cfac599fd355445f71
+      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.20
+      uci-ref: 68010d0ab76554da91c320511fb14a7af1af4245
       allowed-team: 'sei-protocol/sei-core'

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
     secrets: inherit
     with:
-      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.220
+      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.20
       uci-ref: 68010d0ab76554da91c320511fb14a7af1af4245
       allowed-team: 'sei-protocol/sei-core'
       allowed-bots: '["seidroid[bot]"]' # To allow AI review on automatically backported PRs.

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -9,8 +9,8 @@ on:
 jobs:
   ai-review:
     if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
-    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.19
-    uses: sei-protocol/uci/.github/workflows/ai-review.yml@eb65d6d3f967c661f6af91cfac599fd355445f71
+    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.20
+    uses: sei-protocol/uci/.github/workflows/ai-review.yml@68010d0ab76554da91c320511fb14a7af1af4245
     permissions:
       contents: read
       pull-requests: write
@@ -18,7 +18,8 @@ jobs:
       id-token: write
     secrets: inherit
     with:
-      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.19
-      uci-ref: eb65d6d3f967c661f6af91cfac599fd355445f71
+      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.220
+      uci-ref: 68010d0ab76554da91c320511fb14a7af1af4245
       allowed-team: 'sei-protocol/sei-core'
+      allowed-bots: '["seidroid[bot]"]' # To allow AI review on automatically backported PRs.
       enable-cursor: false # Disabled for now since there is a dedicated Bugbot flow built into Cursor currently enabled on repo.


### PR DESCRIPTION
Upgrade to the latest UCI version for AI review and comments, which most notably: reduces cancellation noise further, and optionally allows review of PRs created by non-humans.

This repo will only accept PRs created by `seidroid`. Note that the only CI workflow that allows seidroid to create PRs is auto backporting workflow.
