### PR TITLE
chore(monitoring): remove legacy go-metrics dual-emission (PLT-336)

### DIFF
--- a/sei-cosmos/telemetry/wrapper.go
+++ b/sei-cosmos/telemetry/wrapper.go
@@ -32,17 +32,6 @@ func ModuleMeasureSince(module string, start time.Time, keys ...string) {
 	)
 }
 
-// ModuleSetGauge provides a short hand method for emitting a gauge metric for a
-// module with a given set of keys. If any global labels are defined, they will
-// be added to the module label.
-func ModuleSetGauge(module string, val float32, keys ...string) {
-	metrics.SetGaugeWithLabels(
-		keys,
-		val,
-		append([]metrics.Label{NewLabel(MetricLabelNameModule, module)}, globalLabels...),
-	)
-}
-
 // IncrCounter provides a wrapper functionality for emitting a counter metric with
 // global labels (if any).
 func IncrCounter(val float32, keys ...string) {

--- a/utils/metrics/metrics_util.go
+++ b/utils/metrics/metrics_util.go
@@ -115,26 +115,6 @@ func SafeTelemetryIncrCounterWithLabels(keys []string, val float32, labels []met
 	telemetry.IncrCounterWithLabels(keys, val, labels)
 }
 
-// sei_oracle_vote_penalty_count
-func SetOracleVotePenaltyCount(count uint64, valAddr string, penaltyType string) {
-	metrics.SetGaugeWithLabels(
-		[]string{"sei", "oracle", "vote", "penalty", "count"},
-		float32(count),
-		[]metrics.Label{
-			telemetry.NewLabel("type", penaltyType),
-			telemetry.NewLabel("validator", valAddr),
-		},
-	)
-}
-
-// sei_epoch_new
-func SetEpochNew(epochNum uint64) {
-	metrics.SetGauge(
-		[]string{"sei", "epoch", "new"},
-		float32(epochNum),
-	)
-}
-
 // sei_evm_zero_storage_pruned_keys
 func IncrEvmZeroStoragePrunedKeys(count uint64) {
 	SafeTelemetryIncrCounter(
@@ -156,30 +136,6 @@ func IncrEvmZeroStoragePrunedBytes(bytes uint64) {
 	SafeTelemetryIncrCounter(
 		float32(bytes),
 		"sei", "evm", "zero", "storage", "pruned", "bytes",
-	)
-}
-
-// Measures number of times a denom's price is updated
-// Metric Name:
-//
-//	sei_oracle_price_update_count
-func IncrPriceUpdateDenom(denom string) {
-	SafeTelemetryIncrCounterWithLabels(
-		[]string{"sei", "oracle", "price", "update"},
-		1,
-		[]metrics.Label{telemetry.NewLabel("denom", denom)},
-	)
-}
-
-// Measures number of times a denom's price is updated
-// Metric Name:
-//
-//	sei_oracle_price_update_count
-func SetCoinsMinted(amount uint64, denom string) {
-	telemetry.SetGaugeWithLabels(
-		[]string{"sei", "mint", "coins"},
-		float32(amount),
-		[]metrics.Label{telemetry.NewLabel("denom", denom)},
 	)
 }
 

--- a/x/epoch/keeper/abci.go
+++ b/x/epoch/keeper/abci.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
-	"github.com/sei-protocol/sei-chain/utils/metrics"
 	"github.com/sei-protocol/sei-chain/x/epoch/types"
 	"github.com/sei-protocol/seilog"
 )
@@ -17,8 +15,6 @@ func (k Keeper) BeginBlock(ctx sdk.Context) {
 	start := time.Now()
 	defer func() {
 		epochMetrics.beginBlockerDuration.Record(ctx.Context(), time.Since(start).Seconds())
-		// TODO(PLT-336): remove once epoch_begin_blocker_duration_seconds verified
-		telemetry.ModuleMeasureSince(types.ModuleName, start, telemetry.MetricKeyBeginBlocker)
 	}()
 	lastEpoch := k.GetEpoch(ctx)
 	logger.Info(" Block time", "current", ctx.BlockTime(), "last", lastEpoch.CurrentEpochStartTime, "epoch-duration", lastEpoch.EpochDuration)
@@ -45,7 +41,5 @@ func (k Keeper) BeginBlock(ctx sdk.Context) {
 		)
 
 		epochMetrics.epochNew.Record(ctx.Context(), int64(newEpoch.CurrentEpoch)) //nolint:gosec
-		// TODO(PLT-336): remove once epoch_new verified
-		metrics.SetEpochNew(newEpoch.CurrentEpoch)
 	}
 }

--- a/x/mint/types/minter.go
+++ b/x/mint/types/minter.go
@@ -1,14 +1,13 @@
 package types
 
 import (
-	fmt "fmt"
+	"fmt"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
 
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
-	"github.com/sei-protocol/sei-chain/utils/metrics"
 	epochTypes "github.com/sei-protocol/sei-chain/x/epoch/types"
 )
 
@@ -102,8 +101,6 @@ func (m *Minter) RecordSuccessfulMint(ctx sdk.Context, epoch epochTypes.Epoch, m
 	m.LastMintHeight = uint64(epoch.CurrentEpochHeight) //nolint:gosec
 	m.LastMintAmount = mintedAmount
 	mintMetrics.coinsMinted.Record(ctx.Context(), int64(mintedAmount), otelmetric.WithAttributes(attribute.String("denom", m.GetDenom()))) //nolint:gosec
-	// TODO(PLT-336): remove once mint_coins_minted verified
-	metrics.SetCoinsMinted(mintedAmount, m.GetDenom())
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			EventTypeMint,

--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -7,12 +7,10 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
 
-	"github.com/sei-protocol/sei-chain/utils/metrics"
 	"github.com/sei-protocol/sei-chain/x/oracle/keeper"
 	"github.com/sei-protocol/sei-chain/x/oracle/types"
 	"github.com/sei-protocol/sei-chain/x/oracle/utils"
 
-	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 )
 
@@ -20,8 +18,6 @@ func MidBlocker(ctx sdk.Context, k keeper.Keeper) {
 	start := time.Now()
 	defer func() {
 		oracleMetrics.midBlockerDuration.Record(ctx.Context(), time.Since(start).Seconds())
-		// TODO(PLT-336): remove once oracle_mid_blocker_duration_seconds verified
-		telemetry.ModuleMeasureSince(types.ModuleName, start, telemetry.MetricKeyMidBlocker)
 	}()
 
 	params := k.GetParams(ctx)
@@ -100,8 +96,6 @@ func MidBlocker(ctx sdk.Context, k keeper.Keeper) {
 
 				// Set the exchange rate, emit ABCI event
 				oracleMetrics.priceUpdateTotal.Add(ctx.Context(), 1, otelmetric.WithAttributes(attribute.String("denom", denom)))
-				// TODO(PLT-336): remove once oracle_price_update_total verified
-				metrics.IncrPriceUpdateDenom(denom)
 				k.SetBaseExchangeRateWithEvent(ctx, denom, exchangeRate)
 			}
 		}
@@ -153,8 +147,6 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
 	start := time.Now()
 	defer func() {
 		oracleMetrics.endBlockerDuration.Record(ctx.Context(), time.Since(start).Seconds())
-		// TODO(PLT-336): remove once oracle_end_blocker_duration_seconds verified
-		telemetry.ModuleMeasureSince(types.ModuleName, start, telemetry.MetricKeyEndBlocker)
 	}()
 
 	params := k.GetParams(ctx)

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -9,14 +9,12 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
 
-	"github.com/sei-protocol/sei-chain/utils/datastructures"
-	"github.com/sei-protocol/sei-chain/utils/metrics"
-
 	"github.com/sei-protocol/sei-chain/sei-cosmos/codec"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
 	paramstypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/params/types"
 	stakingtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/staking/types"
+	"github.com/sei-protocol/sei-chain/utils/datastructures"
 
 	"github.com/sei-protocol/sei-chain/x/oracle/types"
 )
@@ -210,10 +208,6 @@ func (k Keeper) SetVotePenaltyCounter(ctx sdk.Context, operator sdk.ValAddress, 
 		oracleKeeperMetrics.votePenaltyCount.Record(ctx.Context(), int64(missCount), otelmetric.WithAttributes(valLabel, missTypeAttribute))       //nolint:gosec
 		oracleKeeperMetrics.votePenaltyCount.Record(ctx.Context(), int64(abstainCount), otelmetric.WithAttributes(valLabel, abstainTypeAttribute)) //nolint:gosec
 		oracleKeeperMetrics.votePenaltyCount.Record(ctx.Context(), int64(successCount), otelmetric.WithAttributes(valLabel, successTypeAttribute)) //nolint:gosec
-		// TODO(PLT-336): remove once oracle_vote_penalty_count verified
-		metrics.SetOracleVotePenaltyCount(missCount, operator.String(), "miss")
-		metrics.SetOracleVotePenaltyCount(abstainCount, operator.String(), "abstain")
-		metrics.SetOracleVotePenaltyCount(successCount, operator.String(), "success")
 	}()
 
 	store := ctx.KVStore(k.storeKey)
@@ -258,10 +252,6 @@ func (k Keeper) DeleteVotePenaltyCounter(ctx sdk.Context, operator sdk.ValAddres
 		oracleKeeperMetrics.votePenaltyCount.Record(ctx.Context(), 0, otelmetric.WithAttributes(valLabel, missTypeAttribute))
 		oracleKeeperMetrics.votePenaltyCount.Record(ctx.Context(), 0, otelmetric.WithAttributes(valLabel, abstainTypeAttribute))
 		oracleKeeperMetrics.votePenaltyCount.Record(ctx.Context(), 0, otelmetric.WithAttributes(valLabel, successTypeAttribute))
-		// TODO(PLT-336): remove once oracle_vote_penalty_count verified
-		metrics.SetOracleVotePenaltyCount(0, operator.String(), "miss")
-		metrics.SetOracleVotePenaltyCount(0, operator.String(), "abstain")
-		metrics.SetOracleVotePenaltyCount(0, operator.String(), "success")
 	}()
 
 	store := ctx.KVStore(k.storeKey)

--- a/x/oracle/keeper/slash.go
+++ b/x/oracle/keeper/slash.go
@@ -6,7 +6,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
 
-	cosmostelemetry "github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	"github.com/sei-protocol/sei-chain/x/oracle/types"
 	"github.com/sei-protocol/seilog"
@@ -51,8 +50,6 @@ func (k Keeper) SlashAndResetCounters(ctx sdk.Context) {
 				)
 				k.StakingKeeper.Jail(ctx, consAddr)
 				oracleKeeperMetrics.validatorSlashedTotal.Add(ctx.Context(), 1, otelmetric.WithAttributes(attribute.String("validator", consAddr.String()), attribute.String("type", "oracle")))
-				// TODO(PLT-336): remove once oracle_validator_slashed_total verified
-				cosmostelemetry.IncrValidatorSlashedCounter(consAddr.String(), "oracle")
 			}
 		}
 


### PR DESCRIPTION
## Summary

Removes legacy go-metrics emissions that were kept as dual-write duplicates while OTel instruments were verified. OTel metrics remain the sole source for these signals.

Companion dashboard migration: https://github.com/sei-protocol/platform/pull/1598

## Legacy metrics removed

| Legacy (go-metrics) | OTel replacement (kept) |
|---|---|
| `sei_oracle_vote_penalty_count` | `oracle_vote_penalty_count` |
| `sei_epoch_new` | `epoch_new` |
| `sei_oracle_price_update` | `oracle_price_update_total` |
| `sei_mint_coins` | `mint_coins_minted` |
| `telemetry.ModuleMeasureSince` in epoch/oracle ABCI | `epoch_begin_blocker_duration`, `oracle_mid/end_blocker_duration` |
| `IncrValidatorSlashedCounter(..., "oracle")` | `oracle_validator_slashed` |

Also removes the unused `ModuleSetGauge` helper and dead helpers in `utils/metrics/metrics_util.go`.

## Platform impact

- **Alerts:** none — validator safety rules use `cosmos_validators_jailed`, not these series.
- **Dashboards:** the **Validators Jailed** panel in Sei Chain Monitoring / `sei_node_monitoring` queried legacy `validator_slashed` and Platform PR #1598 migrates that panel to OTel.
