### PR TITLE
chore(monitoring): remove legacy go-metrics dual-emission from x/evm (PLT-330)

### DIFF
--- a/sei-cosmos/telemetry/wrapper.go
+++ b/sei-cosmos/telemetry/wrapper.go
@@ -9,7 +9,6 @@ import (
 // Common metric key constants
 const (
 	MetricKeyBeginBlocker = "begin_blocker"
-	MetricKeyMidBlocker   = "mid_blocker"
 	MetricKeyEndBlocker   = "end_blocker"
 	MetricLabelNameModule = "module"
 	MessageCount          = "message"

--- a/utils/metrics/metrics_util.go
+++ b/utils/metrics/metrics_util.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/big"
 	"os"
 	"runtime/debug"
 
@@ -115,30 +114,6 @@ func SafeTelemetryIncrCounterWithLabels(keys []string, val float32, labels []met
 	telemetry.IncrCounterWithLabels(keys, val, labels)
 }
 
-// sei_evm_zero_storage_pruned_keys
-func IncrEvmZeroStoragePrunedKeys(count uint64) {
-	SafeTelemetryIncrCounter(
-		float32(count),
-		"sei", "evm", "zero", "storage", "pruned", "keys",
-	)
-}
-
-// sei_evm_zero_storage_processed_keys
-func IncrEvmZeroStorageProcessedKeys(count uint64) {
-	SafeTelemetryIncrCounter(
-		float32(count),
-		"sei", "evm", "zero", "storage", "processed", "keys",
-	)
-}
-
-// sei_evm_zero_storage_pruned_bytes
-func IncrEvmZeroStoragePrunedBytes(bytes uint64) {
-	SafeTelemetryIncrCounter(
-		float32(bytes),
-		"sei", "evm", "zero", "storage", "pruned", "bytes",
-	)
-}
-
 func IncrementErrorMetrics(scenario string, err error) {
 	if err == nil {
 		return
@@ -159,45 +134,5 @@ func IncrementAssociationError(scenario string, err types.AssociationMissingErr)
 			telemetry.NewLabel("scenario", scenario),
 			telemetry.NewLabel("type", err.AddressType()),
 		},
-	)
-}
-
-func IncrementNonceMismatch(tooHigh bool) {
-	cause := "too_low"
-	if tooHigh {
-		cause = "too_high"
-	}
-	SafeTelemetryIncrCounterWithLabels(
-		[]string{"sei", "nonce", "mismatch"},
-		1,
-		[]metrics.Label{
-			telemetry.NewLabel("cause", cause),
-		},
-	)
-}
-
-func AddHistogramMetric(key []string, value float32) {
-	metrics.AddSample(key, value)
-}
-
-// Gauge for gas price paid for transactions
-// Metric Name:
-//
-// sei_evm_effective_gas_price
-func HistogramEvmEffectiveGasPrice(gasPrice *big.Int) {
-	AddHistogramMetric(
-		[]string{"sei", "evm", "effective", "gas", "price"},
-		float32(gasPrice.Uint64()),
-	)
-}
-
-// Gauge for block base fee
-// Metric Name:
-//
-// sei_evm_block_base_fee
-func GaugeEvmBlockBaseFee(baseFee *big.Int, blockHeight int64) {
-	metrics.SetGauge(
-		[]string{"sei", "evm", "block", "base", "fee"},
-		float32(baseFee.Uint64()),
 	)
 }

--- a/x/evm/ante/fee.go
+++ b/x/evm/ante/fee.go
@@ -13,7 +13,6 @@ import (
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
 	upgradekeeper "github.com/sei-protocol/sei-chain/sei-cosmos/x/upgrade/keeper"
 	"github.com/sei-protocol/sei-chain/utils"
-	utilmetrics "github.com/sei-protocol/sei-chain/utils/metrics"
 	"github.com/sei-protocol/sei-chain/x/evm/derived"
 	evmkeeper "github.com/sei-protocol/sei-chain/x/evm/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
@@ -128,7 +127,6 @@ func (fc EVMFeeCheckDecorator) getMinimumFee(ctx sdk.Context) *big.Int {
 func (fc EVMFeeCheckDecorator) CalculatePriority(ctx sdk.Context, txData ethtx.TxData) *big.Int {
 	gp := txData.EffectiveGasPrice(utils.Big0)
 	if !ctx.IsCheckTx() && !ctx.IsReCheckTx() {
-		utilmetrics.HistogramEvmEffectiveGasPrice(gp) // TODO(PLT-330): remove once evm_effective_gas_price verified
 		evmAnteMetrics.effectiveGasPrice.Record(ctx.Context(), effectiveGasPriceHistogramSample(gp))
 	}
 	priority := sdk.NewDecFromBigInt(gp).Quo(fc.evmKeeper.GetPriorityNormalizer(ctx)).TruncateInt().BigInt()

--- a/x/evm/ante/preprocess.go
+++ b/x/evm/ante/preprocess.go
@@ -22,7 +22,6 @@ import (
 	otelmetric "go.opentelemetry.io/otel/metric"
 
 	"github.com/sei-protocol/sei-chain/utils"
-	utilmetrics "github.com/sei-protocol/sei-chain/utils/metrics"
 	"github.com/sei-protocol/sei-chain/x/evm/derived"
 	evmkeeper "github.com/sei-protocol/sei-chain/x/evm/keeper"
 	evmtypes "github.com/sei-protocol/sei-chain/x/evm/types"
@@ -81,7 +80,6 @@ func (p *EVMPreprocessDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate
 		// check if the account has enough balance (without charging)
 		if !p.IsAccountBalancePositive(ctx, seiAddr, evmAddr) {
 			assocErr := evmtypes.NewAssociationMissingErr(seiAddr.String())
-			utilmetrics.IncrementAssociationError("associate_tx_insufficient_funds", assocErr) // TODO(PLT-330): remove once evm_association_error_total verified
 			evmAnteMetrics.associationError.Add(ctx.Context(), 1, otelmetric.WithAttributes(attribute.String("scenario", "associate_tx_insufficient_funds"), attribute.String("type", assocErr.AddressType())))
 			return ctx, sdkerrors.Wrap(sdkerrors.ErrInsufficientFunds, "account needs to have at least 1 wei to force association")
 		}

--- a/x/evm/ante/sig.go
+++ b/x/evm/ante/sig.go
@@ -11,7 +11,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
 
-	utilmetrics "github.com/sei-protocol/sei-chain/utils/metrics"
 	evmkeeper "github.com/sei-protocol/sei-chain/x/evm/keeper"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
@@ -74,7 +73,6 @@ func (svd *EVMSigVerifyDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulat
 		ctx = ctx.WithEVMRequiredBalance(fee)
 	} else if txNonce != nextNonce {
 		tooHigh := txNonce > nextNonce
-		utilmetrics.IncrementNonceMismatch(tooHigh) // TODO(PLT-330): remove once evm_nonce_mismatch_total verified
 		evmAnteMetrics.nonceMismatch.Add(ctx.Context(), 1, otelmetric.WithAttributes(attribute.Bool("too_high", tooHigh)))
 		return ctx, sdkerrors.ErrWrongSequence
 	}

--- a/x/evm/keeper/abci.go
+++ b/x/evm/keeper/abci.go
@@ -9,12 +9,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	authtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/types"
 	abci "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
 	"github.com/sei-protocol/sei-chain/utils"
-	utilmetrics "github.com/sei-protocol/sei-chain/utils/metrics"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
@@ -22,7 +20,6 @@ import (
 func (k *Keeper) BeginBlock(ctx sdk.Context) {
 	beginBlockerStart := time.Now()
 	defer func() {
-		telemetry.ModuleMeasureSince(types.ModuleName, beginBlockerStart, telemetry.MetricKeyBeginBlocker) // TODO(PLT-330): remove once evm_abci_begin_blocker_duration_seconds verified
 		evmKeeperMetrics.beginBlockerDuration.Record(ctx.Context(), time.Since(beginBlockerStart).Seconds())
 	}()
 	// clear tx/tx responses from last block
@@ -66,7 +63,6 @@ func (k *Keeper) BeginBlock(ctx sdk.Context) {
 func (k *Keeper) EndBlock(ctx sdk.Context, height int64, blockGasUsed int64) {
 	endBlockerStart := time.Now()
 	defer func() {
-		telemetry.ModuleMeasureSince(types.ModuleName, endBlockerStart, telemetry.MetricKeyEndBlocker) // TODO(PLT-330): remove once evm_abci_end_blocker_duration_seconds verified
 		evmKeeperMetrics.endBlockerDuration.Record(ctx.Context(), time.Since(endBlockerStart).Seconds())
 	}()
 	// Bake height-1: at EndBlock(N) the indexer's safe latest is N-1. When
@@ -100,7 +96,6 @@ func (k *Keeper) EndBlock(ctx sdk.Context, height int64, blockGasUsed int64) {
 	newBaseFee := k.AdjustDynamicBaseFeePerGas(ctx, uint64(blockGasUsed)) // nolint:gosec
 	if newBaseFee != nil {
 		baseFeeBI := newBaseFee.TruncateInt().BigInt()
-		utilmetrics.GaugeEvmBlockBaseFee(baseFeeBI, height) // TODO(PLT-330): remove once evm_block_base_fee verified
 		evmKeeperMetrics.blockBaseFee.Record(ctx.Context(), bigIntToFloat64(baseFeeBI))
 	}
 	var coinbase sdk.AccAddress

--- a/x/evm/keeper/evm.go
+++ b/x/evm/keeper/evm.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/sei-protocol/sei-chain/precompiles/solo"
 	"github.com/sei-protocol/sei-chain/utils"
-	utilmetrics "github.com/sei-protocol/sei-chain/utils/metrics"
 	"github.com/sei-protocol/sei-chain/x/evm/state"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
@@ -67,7 +66,6 @@ func (k *Keeper) HandleInternalEVMDelegateCall(ctx sdk.Context, req *types.MsgIn
 	senderEvmAddr, found := k.GetEVMAddress(ctx, senderAddr)
 	if !found {
 		err := types.NewAssociationMissingErr(req.Sender)
-		utilmetrics.IncrementAssociationError("evm_handle_internal_evm_delegate_call", err) // TODO(PLT-330): remove once evm_association_error_total verified
 		evmKeeperMetrics.associationError.Add(ctx.Context(), 1, otelmetric.WithAttributes(attribute.String("scenario", "evm_handle_internal_evm_delegate_call"), attribute.String("type", err.AddressType())))
 		return nil, err
 	}

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -10,7 +10,6 @@ import (
 	"runtime/debug"
 	"strings"
 
-	armonmetrics "github.com/armon/go-metrics"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -25,7 +24,6 @@ import (
 
 	"github.com/sei-protocol/sei-chain/precompiles/wasmd"
 	"github.com/sei-protocol/sei-chain/utils"
-	seimetrics "github.com/sei-protocol/sei-chain/utils/metrics"
 	"github.com/sei-protocol/sei-chain/x/evm/artifacts/erc1155"
 	"github.com/sei-protocol/sei-chain/x/evm/artifacts/erc20"
 	"github.com/sei-protocol/sei-chain/x/evm/artifacts/erc721"
@@ -85,7 +83,6 @@ func (server msgServer) EVMTransaction(goCtx context.Context, msg *types.MsgEVMT
 			if !strings.Contains(fmt.Sprintf("%s", pe), occtypes.ErrReadEstimate.Error()) {
 				debug.PrintStack()
 				logger.Error("EVM PANIC", "err", pe)
-				seimetrics.SafeTelemetryIncrCounter(1, types.ModuleName, "panics") // TODO(PLT-330): remove once evm_panics_total verified
 				evmKeeperMetrics.panics.Add(goCtx, 1)
 			}
 			panic(pe)
@@ -93,7 +90,6 @@ func (server msgServer) EVMTransaction(goCtx context.Context, msg *types.MsgEVMT
 		if err != nil {
 			logger.Error("Got EVM state transition error (not VM error)", "err", err)
 
-			seimetrics.SafeTelemetryIncrCounterWithLabels([]string{types.ModuleName, "errors", "state_transition"}, 1, []armonmetrics.Label{{Name: "type", Value: err.Error()}}) // TODO(PLT-330): remove once evm_errors_total verified
 			evmKeeperMetrics.errors.Add(goCtx, 1, otelmetric.WithAttributes(attribute.String("type", "state_transition")))
 			return
 		}
@@ -103,7 +99,6 @@ func (server msgServer) EVMTransaction(goCtx context.Context, msg *types.MsgEVMT
 			err = ferr
 			logger.Error("failed to finalize EVM stateDB", "err", err)
 
-			seimetrics.SafeTelemetryIncrCounterWithLabels([]string{types.ModuleName, "errors", "stateDB_finalize"}, 1, []armonmetrics.Label{{Name: "type", Value: err.Error()}}) // TODO(PLT-330): remove once evm_errors_total verified
 			evmKeeperMetrics.errors.Add(goCtx, 1, otelmetric.WithAttributes(attribute.String("type", "stateDB_finalize")))
 			return
 		}
@@ -132,17 +127,14 @@ func (server msgServer) EVMTransaction(goCtx context.Context, msg *types.MsgEVMT
 			err = rerr
 			logger.Error("failed to write EVM receipt", "err", err)
 
-			seimetrics.SafeTelemetryIncrCounterWithLabels([]string{types.ModuleName, "errors", "write_receipt"}, 1, []armonmetrics.Label{{Name: "type", Value: err.Error()}}) // TODO(PLT-330): remove once evm_errors_total verified
 			evmKeeperMetrics.errors.Add(goCtx, 1, otelmetric.WithAttributes(attribute.String("type", "write_receipt")))
 			return
 		}
 
 		// Add metrics for receipt status
 		if receipt.Status == uint32(ethtypes.ReceiptStatusFailed) {
-			seimetrics.SafeTelemetryIncrCounter(1, "receipt", "status", "failed") // TODO(PLT-330): remove once evm_receipt_status_total verified
 			evmKeeperMetrics.receiptStatus.Add(goCtx, 1, otelmetric.WithAttributes(attribute.String("status", "failed")))
 		} else {
-			seimetrics.SafeTelemetryIncrCounter(1, "receipt", "status", "success") // TODO(PLT-330): remove once evm_receipt_status_total verified
 			evmKeeperMetrics.receiptStatus.Add(goCtx, 1, otelmetric.WithAttributes(attribute.String("status", "success")))
 		}
 
@@ -173,7 +165,6 @@ func (server msgServer) EVMTransaction(goCtx context.Context, msg *types.MsgEVMT
 		serverRes.GasUsed = tx.Gas()
 		preExecutionFailure = true
 
-		seimetrics.SafeTelemetryIncrCounterWithLabels([]string{types.ModuleName, "errors", "apply_message"}, 1, []armonmetrics.Label{{Name: "type", Value: applyErr.Error()}}) // TODO(PLT-330): remove once evm_errors_total verified
 		evmKeeperMetrics.errors.Add(goCtx, 1, otelmetric.WithAttributes(attribute.String("type", "apply_message")))
 
 		return
@@ -183,7 +174,6 @@ func (server msgServer) EVMTransaction(goCtx context.Context, msg *types.MsgEVMT
 	if res.Err != nil {
 		serverRes.VmError = res.Err.Error()
 
-		seimetrics.SafeTelemetryIncrCounterWithLabels([]string{types.ModuleName, "errors", "vm_execution"}, 1, []armonmetrics.Label{{Name: "type", Value: serverRes.VmError}}) // TODO(PLT-330): remove once evm_errors_total verified
 		evmKeeperMetrics.errors.Add(goCtx, 1, otelmetric.WithAttributes(attribute.String("type", "vm_execution")))
 	}
 

--- a/x/evm/keeper/storage_cleanup.go
+++ b/x/evm/keeper/storage_cleanup.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
-	seimetrics "github.com/sei-protocol/sei-chain/utils/metrics"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 )
 
@@ -85,12 +84,9 @@ func (k *Keeper) PruneZeroStorageSlots(ctx sdk.Context, limit int) (int, int) {
 		k.setZeroStorageCleanupCheckpoint(ctx, nil)
 	}
 
-	seimetrics.IncrEvmZeroStorageProcessedKeys(processedMetric)                          // TODO(PLT-330): remove once evm_zero_storage_processed_keys_total verified
 	evmKeeperMetrics.zeroStorageProcessedKeys.Add(ctx.Context(), int64(processedMetric)) //nolint:gosec
 
 	if deleted > 0 {
-		seimetrics.IncrEvmZeroStoragePrunedKeys(deletedMetric)                          // TODO(PLT-330): remove once evm_zero_storage_pruned_keys_total verified
-		seimetrics.IncrEvmZeroStoragePrunedBytes(bytesPruned)                           // TODO(PLT-330): remove once evm_zero_storage_pruned_bytes_total verified
 		evmKeeperMetrics.zeroStoragePrunedKeys.Add(ctx.Context(), int64(deletedMetric)) //nolint:gosec
 		evmKeeperMetrics.zeroStoragePrunedBytes.Add(ctx.Context(), int64(bytesPruned))  //nolint:gosec
 		logger.Info("pruned zero storage slots", "processed", processed, "deleted", deleted, "bytes_saved", bytesPruned)


### PR DESCRIPTION
## Describe your changes and provide context

Completes PLT-330 by dropping the legacy `armon/go-metrics` (Cosmos `telemetry`) emissions that were running in parallel with the OpenTelemetry instruments in `x/evm`. The OTel counterparts have been verified in the dashboards, so the dual-emission scaffolding and its `TODO(PLT-330)` markers are no longer needed.

Removed legacy emissions (OTel instrument that replaces each one):

| Legacy metric | OTel replacement |
| --- | --- |
| `sei_evm_effective_gas_price` | `evm_effective_gas_price` |
| `sei_evm_block_base_fee` | `evm_block_base_fee` |
| `sei_nonce_mismatch` | `evm_nonce_mismatch_total` |
| `sei_evm_association_error` | `evm_association_error_total` |
| `evm_panics` | `evm_panics_total` |
| `evm_errors_*` (state_transition, stateDB_finalize, write_receipt, apply_message, vm_execution) | `evm_errors_total` |
| `receipt_status_{success,failed}` | `evm_receipt_status_total` |
| `evm_begin_blocker` / `evm_end_blocker` | `evm_abci_{begin,end}_blocker_duration_seconds` |
| `sei_evm_zero_storage_{processed_keys,pruned_keys,pruned_bytes}` | `evm_zero_storage_*_total` |

Also drops the now-unused helpers in `utils/metrics/metrics_util.go` (`HistogramEvmEffectiveGasPrice`, `GaugeEvmBlockBaseFee`, `AddHistogramMetric`, `IncrementNonceMismatch`, `IncrEvmZeroStorage*`) and the unreferenced `MetricKeyMidBlocker` constant.

No behavioral change outside telemetry — every removed line had an OTel record/add on the adjacent line that stays.

Follows the same pattern as #4060 (PLT-336).

Related: https://github.com/sei-protocol/platform/pull/1609/ — dashboard/alerting side of the migration off the legacy series.

## Testing performed to validate your change

- `make fmtcheck` clean.
- `go build ./...` succeeds.
- `go test ./x/evm/... ./utils/metrics/...` passes.
- Grepped the tree for the removed helpers, `MetricKeyMidBlocker`, and `TODO(PLT-330)` markers — no remaining references.
