### PR TITLE
fix(wasm): bound legacy Prometheus cardinality for execute and QuerySmart (CON-336, CON-337)

### DIFF
--- a/sei-wasmd/x/wasm/keeper/keeper.go
+++ b/sei-wasmd/x/wasm/keeper/keeper.go
@@ -660,7 +660,6 @@ func (k Keeper) QuerySmartSafe(ctx sdk.Context, contractAddr sdk.AccAddress, req
 func (k Keeper) QuerySmart(ctx sdk.Context, contractAddr sdk.AccAddress, req []byte) ([]byte, error) {
 	start := time.Now()
 	defer func() { recordContractQuerySmartDuration(ctx.Context(), start) }()
-	recordContractQuerySmartInvocation(contractAddr.String())
 
 	// checks and increase query stack size
 	ctx, err := checkAndIncreaseQueryStackSize(ctx, k.maxQueryStackSize)
@@ -672,6 +671,7 @@ func (k Keeper) QuerySmart(ctx sdk.Context, contractAddr sdk.AccAddress, req []b
 	if err != nil {
 		return nil, err
 	}
+	recordContractQuerySmartInvocation()
 
 	smartQuerySetupCosts := k.gasRegister.InstantiateContractCosts(k.IsPinnedCode(ctx, contractInfo.CodeID), len(req))
 	ctx.GasMeter().ConsumeGas(smartQuerySetupCosts, "Loading CosmWasm module: query")
@@ -690,7 +690,7 @@ func (k Keeper) QuerySmart(ctx sdk.Context, contractAddr sdk.AccAddress, req []b
 		return nil, sdkerrors.Wrap(types.ErrQueryFailed, qErr.Error())
 	}
 
-	recordContractQuerySmartGasUsed(ctx.Context(), contractAddr.String(), gasUsed)
+	recordContractQuerySmartGasUsed(ctx.Context(), gasUsed)
 	return queryResult, nil
 }
 

--- a/sei-wasmd/x/wasm/keeper/metrics.go
+++ b/sei-wasmd/x/wasm/keeper/metrics.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/armon/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	wasmvmtypes "github.com/sei-protocol/sei-chain/sei-wasmvm/types"
@@ -122,28 +121,17 @@ func recordContractQueryRawDuration(ctx context.Context, start time.Time) {
 	telemetry.MeasureSince(start, "wasm", "contract", "query-raw")
 }
 
-func recordContractQuerySmartInvocation(contractAddress string) {
+func recordContractQuerySmartInvocation() {
 	// No OTel counter here: it would be redundant with wasm_contract_query_smart_duration's
 	// count, which is recorded unconditionally on every QuerySmart call just like this one.
 	// TODO(PLT-910): remove once wasm_contract_query_smart_duration verified
-	telemetry.IncrCounterWithLabels(
-		[]string{"wasm", "contract", "query-smart", "invocation"},
-		1,
-		[]metrics.Label{telemetry.NewLabel("contract_address", contractAddress)},
-	)
+	telemetry.IncrCounter(1, "wasm", "contract", "query-smart", "invocation")
 }
 
-func recordContractQuerySmartGasUsed(ctx context.Context, contractAddress string, gasUsed uint64) {
-	// contract_address omitted on the OTel histogram: unlike the legacy Prometheus sink, the
-	// OTel SDK has no series expiration, so a per-contract label here would retain one series
-	// per distinct contract address queried for the process lifetime.
+func recordContractQuerySmartGasUsed(ctx context.Context, gasUsed uint64) {
 	wasmKeeperMetrics.contractQuerySmartGasUsed.Record(ctx, int64(gasUsed)) //nolint:gosec
 	// TODO(PLT-910): remove once wasm_contract_query_smart_gas_used verified
-	telemetry.SetGaugeWithLabels(
-		[]string{"wasm", "contract", "query-smart", "gas-used"},
-		float32(gasUsed),
-		[]metrics.Label{telemetry.NewLabel("contract_address", contractAddress)},
-	)
+	telemetry.SetGauge(float32(gasUsed), "wasm", "contract", "query-smart", "gas-used")
 }
 
 const (

--- a/sei-wasmd/x/wasm/keeper/msg_server.go
+++ b/sei-wasmd/x/wasm/keeper/msg_server.go
@@ -2,9 +2,7 @@ package keeper
 
 import (
 	"context"
-	"time"
 
-	"github.com/armon/go-metrics"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
 
@@ -85,11 +83,6 @@ func (m msgServer) ExecuteContract(goCtx context.Context, msg *types.MsgExecuteC
 	if err != nil {
 		return nil, sdkerrors.Wrap(err, "contract")
 	}
-	defer metrics.MeasureSinceWithLabels(
-		[]string{"wasmd", "execute", "contract", "latency"},
-		time.Now(),
-		[]metrics.Label{{Name: "contract", Value: contractAddr.String()}},
-	)
 
 	ctx.EventManager().EmitEvent(sdk.NewEvent(
 		sdk.EventTypeMessage,


### PR DESCRIPTION
## Summary
- Remove the labeled `wasmd_execute_contract_latency` defer from `MsgExecuteContract`; execute latency remains on the keeper path via `wasm_contract_execute_duration` / `wasm.contract.execute`.
- Drop raw `contract_address` labels from QuerySmart legacy telemetry and record the invocation counter only after contract lookup succeeds.

Closes the Immunefi RPC OOM vectors in CON-336 and CON-337 where unique valid `sei...` addresses could retain unbounded in-process Prometheus series.
