### PR TITLE
[Do Not Merge Yet] Complete PLT-910: remove legacy wasm dual metrics

### DIFF
--- a/sei-wasmd/x/wasm/keeper/keeper.go
+++ b/sei-wasmd/x/wasm/keeper/keeper.go
@@ -689,7 +689,7 @@ func (k Keeper) QuerySmart(ctx sdk.Context, contractAddr sdk.AccAddress, req []b
 		return nil, sdkerrors.Wrap(types.ErrQueryFailed, qErr.Error())
 	}
 
-	recordContractQuerySmartGasUsed(ctx.Context(), contractAddr.String(), gasUsed)
+	recordContractQuerySmartGasUsed(ctx.Context(), gasUsed)
 	return queryResult, nil
 }
 

--- a/sei-wasmd/x/wasm/keeper/keeper.go
+++ b/sei-wasmd/x/wasm/keeper/keeper.go
@@ -660,7 +660,6 @@ func (k Keeper) QuerySmartSafe(ctx sdk.Context, contractAddr sdk.AccAddress, req
 func (k Keeper) QuerySmart(ctx sdk.Context, contractAddr sdk.AccAddress, req []byte) ([]byte, error) {
 	start := time.Now()
 	defer func() { recordContractQuerySmartDuration(ctx.Context(), start) }()
-	recordContractQuerySmartInvocation(contractAddr.String())
 
 	// checks and increase query stack size
 	ctx, err := checkAndIncreaseQueryStackSize(ctx, k.maxQueryStackSize)

--- a/sei-wasmd/x/wasm/keeper/metrics.go
+++ b/sei-wasmd/x/wasm/keeper/metrics.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/armon/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	wasmvmtypes "github.com/sei-protocol/sei-chain/sei-wasmvm/types"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
@@ -88,49 +86,26 @@ func must[V any](v V, err error) V {
 
 func recordContractInstantiateDuration(ctx context.Context, start time.Time) {
 	wasmKeeperMetrics.contractInstantiateDuration.Record(ctx, time.Since(start).Seconds())
-	// TODO(PLT-910): remove once wasm_contract_instantiate_duration verified
-	telemetry.MeasureSince(start, "wasm", "contract", "instantiate")
 }
 
 func recordContractExecuteDuration(ctx context.Context, start time.Time) {
 	wasmKeeperMetrics.contractExecuteDuration.Record(ctx, time.Since(start).Seconds())
-	// TODO(PLT-910): remove once wasm_contract_execute_duration verified
-	telemetry.MeasureSince(start, "wasm", "contract", "execute")
 }
 
 func recordContractMigrateDuration(ctx context.Context, start time.Time) {
 	wasmKeeperMetrics.contractMigrateDuration.Record(ctx, time.Since(start).Seconds())
-	// TODO(PLT-910): remove once wasm_contract_migrate_duration verified
-	telemetry.MeasureSince(start, "wasm", "contract", "migrate")
 }
 
 func recordContractSudoDuration(ctx context.Context, start time.Time) {
 	wasmKeeperMetrics.contractSudoDuration.Record(ctx, time.Since(start).Seconds())
-	// TODO(PLT-910): remove once wasm_contract_sudo_duration verified
-	telemetry.MeasureSince(start, "wasm", "contract", "sudo")
 }
 
 func recordContractQuerySmartDuration(ctx context.Context, start time.Time) {
 	wasmKeeperMetrics.contractQuerySmartDuration.Record(ctx, time.Since(start).Seconds())
-	// TODO(PLT-910): remove once wasm_contract_query_smart_duration verified
-	telemetry.MeasureSince(start, "wasm", "contract", "query-smart")
 }
 
 func recordContractQueryRawDuration(ctx context.Context, start time.Time) {
 	wasmKeeperMetrics.contractQueryRawDuration.Record(ctx, time.Since(start).Seconds())
-	// TODO(PLT-910): remove once wasm_contract_query_raw_duration verified
-	telemetry.MeasureSince(start, "wasm", "contract", "query-raw")
-}
-
-func recordContractQuerySmartInvocation(contractAddress string) {
-	// No OTel counter here: it would be redundant with wasm_contract_query_smart_duration's
-	// count, which is recorded unconditionally on every QuerySmart call just like this one.
-	// TODO(PLT-910): remove once wasm_contract_query_smart_duration verified
-	telemetry.IncrCounterWithLabels(
-		[]string{"wasm", "contract", "query-smart", "invocation"},
-		1,
-		[]metrics.Label{telemetry.NewLabel("contract_address", contractAddress)},
-	)
 }
 
 func recordContractQuerySmartGasUsed(ctx context.Context, contractAddress string, gasUsed uint64) {
@@ -138,12 +113,6 @@ func recordContractQuerySmartGasUsed(ctx context.Context, contractAddress string
 	// OTel SDK has no series expiration, so a per-contract label here would retain one series
 	// per distinct contract address queried for the process lifetime.
 	wasmKeeperMetrics.contractQuerySmartGasUsed.Record(ctx, int64(gasUsed)) //nolint:gosec
-	// TODO(PLT-910): remove once wasm_contract_query_smart_gas_used verified
-	telemetry.SetGaugeWithLabels(
-		[]string{"wasm", "contract", "query-smart", "gas-used"},
-		float32(gasUsed),
-		[]metrics.Label{telemetry.NewLabel("contract_address", contractAddress)},
-	)
 }
 
 const (

--- a/sei-wasmd/x/wasm/keeper/metrics.go
+++ b/sei-wasmd/x/wasm/keeper/metrics.go
@@ -108,10 +108,7 @@ func recordContractQueryRawDuration(ctx context.Context, start time.Time) {
 	wasmKeeperMetrics.contractQueryRawDuration.Record(ctx, time.Since(start).Seconds())
 }
 
-func recordContractQuerySmartGasUsed(ctx context.Context, contractAddress string, gasUsed uint64) {
-	// contract_address omitted on the OTel histogram: unlike the legacy Prometheus sink, the
-	// OTel SDK has no series expiration, so a per-contract label here would retain one series
-	// per distinct contract address queried for the process lifetime.
+func recordContractQuerySmartGasUsed(ctx context.Context, gasUsed uint64) {
 	wasmKeeperMetrics.contractQuerySmartGasUsed.Record(ctx, int64(gasUsed)) //nolint:gosec
 }
 

--- a/sei-wasmd/x/wasm/keeper/msg_server.go
+++ b/sei-wasmd/x/wasm/keeper/msg_server.go
@@ -2,9 +2,7 @@ package keeper
 
 import (
 	"context"
-	"time"
 
-	"github.com/armon/go-metrics"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
 
@@ -85,11 +83,6 @@ func (m msgServer) ExecuteContract(goCtx context.Context, msg *types.MsgExecuteC
 	if err != nil {
 		return nil, sdkerrors.Wrap(err, "contract")
 	}
-	defer metrics.MeasureSinceWithLabels(
-		[]string{"wasmd", "execute", "contract", "latency"},
-		time.Now(),
-		[]metrics.Label{{Name: "contract", Value: contractAddr.String()}},
-	)
 
 	ctx.EventManager().EmitEvent(sdk.NewEvent(
 		sdk.EventTypeMessage,


### PR DESCRIPTION
## Important:
This PR should only be merged after release 6.7 landed, since its equivalent Otel metrics are only included in release 6.7.
Also there should be a corresponding Platform dashboard migration PR.

## Summary

Finishes the wasm keeper OTel migration (PLT-910) by removing legacy `telemetry`/`go-metrics` emission that duplicated the OpenTelemetry histograms already in place.

- Drop `telemetry.MeasureSince` fallbacks from contract duration recorders (instantiate, execute, migrate, sudo, query-smart, query-raw).
- Remove legacy per-contract execute latency and query-smart invocation/gas-used metrics now covered by OTel.
- Keep the OTel histograms as the single source of truth for wasm contract timing and gas usage.

Also addresses CON-336 and CON-337 unbounded cardinality issue.



