### PR TITLE
Rollback tooling for LittDB / recieptDB

### DIFF
--- a/sei-db/db_engine/litt/disktable/forward_iterator.go
+++ b/sei-db/db_engine/litt/disktable/forward_iterator.go
@@ -20,8 +20,11 @@ var _ litt.Iterator = (*forwardIterator)(nil)
 // segments, so their files remain on disk until Close releases them — even if garbage collection collects those
 // segments meanwhile. Close is therefore mandatory: a leaked iterator pins its segments' files indefinitely.
 type forwardIterator struct {
-	// table is the owning disk table, used to issue the close request.
-	table *DiskTable
+	// onClose is called once, by Close, after the buffered reader is closed. It performs whatever
+	// cleanup this iterator's owner requires: for a live table, releasing the reservation on each
+	// snapshot segment and notifying the control loop; for an offline iterator, releasing a directory
+	// lock instead.
+	onClose func() error
 
 	// segs is the ordered (lowest-to-highest index) snapshot of sealed segments in scope.
 	segs []*segment.Segment
@@ -63,12 +66,13 @@ type forwardIterator struct {
 	groupValue []byte
 }
 
-// newForwardIterator creates a forward iterator over the given snapshot of sealed segments.
+// newForwardIterator creates a forward iterator over the given snapshot of sealed segments, owned by a
+// live table.
 func newForwardIterator(table *DiskTable, segs []*segment.Segment) *forwardIterator {
 	return &forwardIterator{
-		table:  table,
-		segs:   segs,
-		segPos: 0,
+		onClose: closeLiveIterator(table, segs),
+		segs:    segs,
+		segPos:  0,
 	}
 }
 
@@ -84,11 +88,25 @@ func newForwardIteratorAt(
 	keyPos int,
 ) *forwardIterator {
 	return &forwardIterator{
-		table:  table,
+		onClose: closeLiveIterator(table, segs),
+		segs:    segs,
+		segPos:  segPos,
+		keys:    keys,
+		keyPos:  keyPos,
+	}
+}
+
+// NewOfflineForwardIterator creates a forward iterator over the given snapshot of segments, gathered
+// directly from disk rather than from a live table. release is called once, by Close, in place of the
+// live path's segment-reservation release and control-loop notification.
+func NewOfflineForwardIterator(segs []*segment.Segment, release func()) litt.Iterator {
+	return &forwardIterator{
+		onClose: func() error {
+			release()
+			return nil
+		},
 		segs:   segs,
-		segPos: segPos,
-		keys:   keys,
-		keyPos: keyPos,
+		segPos: 0,
 	}
 }
 
@@ -236,8 +254,7 @@ func (it *forwardIterator) secondaryWithinGroup(addr types.Address) bool {
 		uint64(addr.Offset())+uint64(addr.ValueSize()) <= end
 }
 
-// Close releases the resources held by the iterator, including the reservations on its snapshot segments
-// (allowing any segment GC collected while it was open to finally be deleted from disk).
+// Close releases the resources held by the iterator, via onClose.
 func (it *forwardIterator) Close() error {
 	if it.closed {
 		return nil
@@ -251,27 +268,37 @@ func (it *forwardIterator) Close() error {
 		it.reader = nil
 	}
 
-	// Release the reservation on each snapshot segment. This must happen even on the error paths below: a missed
-	// release pins those segments' files on disk indefinitely.
-	for _, seg := range it.segs {
-		seg.Release()
-	}
+	closeErr := it.onClose()
 	it.segs = nil
 
-	// Notify the control loop so the open-iterator metric is updated.
-	request := &controlLoopCloseIteratorRequest{
-		completionChan: make(chan struct{}, 1),
-	}
-	err := it.table.controlLoop.enqueue(request)
-	if err != nil {
-		return fmt.Errorf("failed to send close iterator request: %w", err)
-	}
-	_, err = util.Await(it.table.errorMonitor, request.completionChan)
-	if err != nil {
-		return fmt.Errorf("failed to await iterator close: %w", err)
-	}
 	if readerErr != nil {
 		return fmt.Errorf("failed to close segment reader: %w", readerErr)
 	}
-	return nil
+	return closeErr
+}
+
+// closeLiveIterator returns the onClose function for an iterator owned by a live table: it releases the
+// reservation on each snapshot segment (allowing any segment GC collected while the iterator was open to
+// finally be deleted from disk), then notifies the control loop so the open-iterator metric is updated.
+func closeLiveIterator(table *DiskTable, segs []*segment.Segment) func() error {
+	return func() error {
+		// This must happen even if the notification below fails: a missed release pins those segments'
+		// files on disk indefinitely.
+		for _, seg := range segs {
+			seg.Release()
+		}
+
+		request := &controlLoopCloseIteratorRequest{
+			completionChan: make(chan struct{}, 1),
+		}
+		err := table.controlLoop.enqueue(request)
+		if err != nil {
+			return fmt.Errorf("failed to send close iterator request: %w", err)
+		}
+		_, err = util.Await(table.errorMonitor, request.completionChan)
+		if err != nil {
+			return fmt.Errorf("failed to await iterator close: %w", err)
+		}
+		return nil
+	}
 }

--- a/sei-db/db_engine/litt/disktable/reverse_iterator.go
+++ b/sei-db/db_engine/litt/disktable/reverse_iterator.go
@@ -6,7 +6,6 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-db/db_engine/litt"
 	"github.com/sei-protocol/sei-chain/sei-db/db_engine/litt/disktable/segment"
 	"github.com/sei-protocol/sei-chain/sei-db/db_engine/litt/types"
-	"github.com/sei-protocol/sei-chain/sei-db/db_engine/litt/util"
 )
 
 var _ litt.Iterator = (*reverseIterator)(nil)
@@ -20,8 +19,10 @@ var _ litt.Iterator = (*reverseIterator)(nil)
 // segments, so their files remain on disk until Close releases them — even if garbage collection collects those
 // segments meanwhile. Close is therefore mandatory: a leaked iterator pins its segments' files indefinitely.
 type reverseIterator struct {
-	// table is the owning disk table, used to issue the close request.
-	table *DiskTable
+	// onClose is called once, by Close. It performs whatever cleanup this iterator's owner requires:
+	// for a live table, releasing the reservation on each snapshot segment and notifying the control
+	// loop; for an offline iterator, releasing a directory lock instead.
+	onClose func() error
 
 	// segs is the ordered (lowest-to-highest index) snapshot of sealed segments in scope.
 	segs []*segment.Segment
@@ -45,12 +46,13 @@ type reverseIterator struct {
 	closed bool
 }
 
-// newReverseIterator creates a reverse iterator over the given snapshot of sealed segments.
+// newReverseIterator creates a reverse iterator over the given snapshot of sealed segments, owned by a
+// live table.
 func newReverseIterator(table *DiskTable, segs []*segment.Segment) *reverseIterator {
 	return &reverseIterator{
-		table:  table,
-		segs:   segs,
-		segPos: len(segs) - 1,
+		onClose: closeLiveIterator(table, segs),
+		segs:    segs,
+		segPos:  len(segs) - 1,
 	}
 }
 
@@ -66,11 +68,25 @@ func newReverseIteratorAt(
 	keyPos int,
 ) *reverseIterator {
 	return &reverseIterator{
-		table:  table,
+		onClose: closeLiveIterator(table, segs),
+		segs:    segs,
+		segPos:  segPos,
+		keys:    keys,
+		keyPos:  keyPos,
+	}
+}
+
+// NewOfflineReverseIterator creates a reverse iterator over the given snapshot of segments, gathered
+// directly from disk rather than from a live table. release is called once, by Close, in place of the
+// live path's segment-reservation release and control-loop notification.
+func NewOfflineReverseIterator(segs []*segment.Segment, release func()) litt.Iterator {
+	return &reverseIterator{
+		onClose: func() error {
+			release()
+			return nil
+		},
 		segs:   segs,
-		segPos: segPos,
-		keys:   keys,
-		keyPos: keyPos,
+		segPos: len(segs) - 1,
 	}
 }
 
@@ -143,32 +159,14 @@ func (it *reverseIterator) GetValue() (value []byte, err error) {
 	return value, nil
 }
 
-// Close releases the resources held by the iterator, including the reservations on its snapshot segments
-// (allowing any segment GC collected while it was open to finally be deleted from disk).
+// Close releases the resources held by the iterator, via onClose.
 func (it *reverseIterator) Close() error {
 	if it.closed {
 		return nil
 	}
 	it.closed = true
 
-	// Release the reservation on each snapshot segment. This must happen even on the error paths below: a missed
-	// release pins those segments' files on disk indefinitely.
-	for _, seg := range it.segs {
-		seg.Release()
-	}
+	closeErr := it.onClose()
 	it.segs = nil
-
-	// Notify the control loop so the open-iterator metric is updated.
-	request := &controlLoopCloseIteratorRequest{
-		completionChan: make(chan struct{}, 1),
-	}
-	err := it.table.controlLoop.enqueue(request)
-	if err != nil {
-		return fmt.Errorf("failed to send close iterator request: %w", err)
-	}
-	_, err = util.Await(it.table.errorMonitor, request.completionChan)
-	if err != nil {
-		return fmt.Errorf("failed to await iterator close: %w", err)
-	}
-	return nil
+	return closeErr
 }

--- a/sei-db/db_engine/litt/offline/iterator.go
+++ b/sei-db/db_engine/litt/offline/iterator.go
@@ -1,0 +1,126 @@
+package offline
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"time"
+
+	"github.com/sei-protocol/sei-chain/sei-db/db_engine/litt"
+	"github.com/sei-protocol/sei-chain/sei-db/db_engine/litt/disktable"
+	"github.com/sei-protocol/sei-chain/sei-db/db_engine/litt/disktable/segment"
+	"github.com/sei-protocol/sei-chain/sei-db/db_engine/litt/util"
+)
+
+// NewIterator opens an offline iterator over the table at tableName under config.Paths, without starting
+// a live database. It iterates oldest-to-newest if reverse is false, newest-to-oldest if reverse is true.
+//
+// The database must NOT be running while this is called: NewIterator takes the same directory lock the
+// database uses, held for the iterator's lifetime and released by Close, so it will fail rather than read
+// alongside a live database.
+func NewIterator(config *litt.Config, tableName string, reverse bool) (litt.Iterator, error) {
+	logger := slog.Default()
+
+	if config == nil || len(config.Paths) == 0 {
+		return nil, fmt.Errorf("at least one path must be provided")
+	}
+	if err := config.SanitizePaths(); err != nil {
+		return nil, fmt.Errorf("failed to sanitize data directories: %w", err)
+	}
+	roots := config.Paths
+
+	for _, root := range roots {
+		if err := util.EnsureDirectoryExists(root, config.Fsync); err != nil {
+			return nil, fmt.Errorf("failed to ensure data directory %q: %w", root, err)
+		}
+	}
+
+	releaseLocks, err := util.LockDirectories(logger, roots, util.LockfileName, config.Fsync)
+	if err != nil {
+		return nil, fmt.Errorf("failed to lock data directories %v: %w", roots, err)
+	}
+
+	segs, err := gatherOrderedSegments(logger, roots, tableName, config.Fsync)
+	if err != nil {
+		releaseLocks()
+		return nil, err
+	}
+
+	if reverse {
+		return disktable.NewOfflineReverseIterator(segs, releaseLocks), nil
+	}
+	return disktable.NewOfflineForwardIterator(segs, releaseLocks), nil
+}
+
+// gatherOrderedSegments enumerates a table's segments across roots, offline, and returns them ordered from
+// lowest to highest index. Segments already logically garbage collected (below the table's durable
+// gc-watermark) are excluded, matching what a live table's own reads would see. Returns an empty slice, not
+// an error, if the table has no segments.
+func gatherOrderedSegments(
+	logger *slog.Logger,
+	roots []string,
+	tableName string,
+	fsync bool,
+) ([]*segment.Segment, error) {
+	exists, err := tableExists(roots, tableName)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, nil
+	}
+
+	errorMonitor := util.NewErrorMonitor(context.Background(), logger, nil)
+
+	segmentPaths, err := segment.BuildSegmentPaths(roots, "", tableName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build segment paths: %w", err)
+	}
+
+	lowestSegmentIndex, highestSegmentIndex, segments, err := segment.GatherSegmentFiles(
+		logger, errorMonitor, segmentPaths, false /* snapshottingEnabled */, time.Now(),
+		true /* cleanOrphans */, fsync)
+	if err != nil {
+		return nil, fmt.Errorf("failed to gather segment files: %w", err)
+	}
+	if len(segments) == 0 {
+		return nil, nil
+	}
+
+	watermark, defined, err := highestGCWatermark(roots, tableName)
+	if err != nil {
+		return nil, err
+	}
+	if defined && watermark > highestSegmentIndex {
+		// Everything present is below the watermark; no readable segments remain.
+		return nil, nil
+	}
+	floor := lowestSegmentIndex
+	if defined && watermark > floor {
+		floor = watermark
+	}
+
+	ordered := make([]*segment.Segment, 0, highestSegmentIndex-floor+1)
+	for index := floor; index <= highestSegmentIndex; index++ {
+		ordered = append(ordered, segments[index])
+	}
+	return ordered, nil
+}
+
+// tableExists reports whether tableName has ever been created under any of roots. A table that has never
+// been written has no segments directory, and scanning for its segment files would otherwise fail with a
+// "no such file or directory" error rather than reporting it as merely empty.
+func tableExists(roots []string, tableName string) (bool, error) {
+	for _, root := range roots {
+		segmentsDir := filepath.Join(root, tableName, segment.SegmentDirectory)
+		isDir, err := util.IsDirectory(segmentsDir)
+		if err != nil {
+			return false, fmt.Errorf("failed to check directory %s: %w", segmentsDir, err)
+		}
+		if isDir {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/sei-db/db_engine/litt/offline/iterator_test.go
+++ b/sei-db/db_engine/litt/offline/iterator_test.go
@@ -1,0 +1,245 @@
+package offline
+
+import (
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/sei-protocol/sei-chain/sei-db/db_engine/litt"
+	"github.com/sei-protocol/sei-chain/sei-db/db_engine/litt/disktable"
+	"github.com/sei-protocol/sei-chain/sei-db/db_engine/litt/littbuilder"
+	"github.com/sei-protocol/sei-chain/sei-db/db_engine/litt/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOfflineIteratorForwardOrder verifies that a forward offline iterator returns keys in insertion
+// order with correct values, matching the live forward iterator's contract.
+func TestOfflineIteratorForwardOrder(t *testing.T) {
+	t.Parallel()
+	const count = 20
+
+	config, _ := newRollbackTestDB(t)
+	values := writeSequentialKeys(t, config, count)
+
+	it, err := NewIterator(config, rollbackTestTable, false)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, it.Close()) }()
+
+	for i := 0; i < count; i++ {
+		hasNext, err := it.Next()
+		require.NoError(t, err)
+		require.True(t, hasNext)
+
+		key, isPrimary, err := it.GetKey()
+		require.NoError(t, err)
+		require.True(t, isPrimary)
+		require.Equal(t, i, indexFromKey(t, key))
+
+		value, err := it.GetValue()
+		require.NoError(t, err)
+		require.Equal(t, values[i], value)
+	}
+
+	hasNext, err := it.Next()
+	require.NoError(t, err)
+	require.False(t, hasNext)
+}
+
+// TestOfflineIteratorReverseOrder verifies that a reverse offline iterator returns keys in exact
+// reverse insertion order with correct values.
+func TestOfflineIteratorReverseOrder(t *testing.T) {
+	t.Parallel()
+	const count = 20
+
+	config, _ := newRollbackTestDB(t)
+	values := writeSequentialKeys(t, config, count)
+
+	it, err := NewIterator(config, rollbackTestTable, true)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, it.Close()) }()
+
+	for i := count - 1; i >= 0; i-- {
+		hasNext, err := it.Next()
+		require.NoError(t, err)
+		require.True(t, hasNext)
+
+		key, isPrimary, err := it.GetKey()
+		require.NoError(t, err)
+		require.True(t, isPrimary)
+		require.Equal(t, i, indexFromKey(t, key))
+
+		value, err := it.GetValue()
+		require.NoError(t, err)
+		require.Equal(t, values[i], value)
+	}
+
+	hasNext, err := it.Next()
+	require.NoError(t, err)
+	require.False(t, hasNext)
+}
+
+// TestOfflineIteratorEmptyTable verifies that an offline iterator over an existing but empty table
+// reports no keys, rather than erroring.
+func TestOfflineIteratorEmptyTable(t *testing.T) {
+	t.Parallel()
+	config, _ := newRollbackTestDB(t)
+
+	db, err := littbuilder.NewDB(config)
+	require.NoError(t, err)
+	_, err = db.BuildTable(litt.DefaultTableConfig(rollbackTestTable))
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	it, err := NewIterator(config, rollbackTestTable, false)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, it.Close()) }()
+
+	hasNext, err := it.Next()
+	require.NoError(t, err)
+	require.False(t, hasNext)
+}
+
+// TestOfflineIteratorSecondaryKeys verifies group handling on both directions: forward iteration
+// visits a primary immediately followed by its secondary (both serving the same value), and reverse
+// iteration visits the secondary first, reading its value directly since the group optimization does
+// not apply in reverse.
+func TestOfflineIteratorSecondaryKeys(t *testing.T) {
+	t.Parallel()
+	const count = 30
+
+	config, _ := newRollbackTestDB(t)
+
+	db, err := littbuilder.NewDB(config)
+	require.NoError(t, err)
+	tableConfig := litt.DefaultTableConfig(rollbackTestTable)
+	tableConfig.ShardingFactor = 2
+	table, err := db.BuildTable(tableConfig)
+	require.NoError(t, err)
+
+	primaryKey := func(i int) []byte { return []byte(fmt.Sprintf("pk-%05d", i)) }
+	secondaryKey := func(i int) []byte { return []byte(fmt.Sprintf("sk-%05d", i)) }
+
+	values := make(map[int][]byte, count)
+	for i := 0; i < count; i++ {
+		value := []byte(fmt.Sprintf("value-%05d", i))
+		secondary := &types.SecondaryKey{Key: secondaryKey(i), Offset: 0, Length: uint32(len(value))}
+		require.NoError(t, table.Put(primaryKey(i), value, secondary))
+		values[i] = value
+	}
+	require.NoError(t, table.Flush())
+	require.NoError(t, db.Close())
+
+	forward, err := NewIterator(config, rollbackTestTable, false)
+	require.NoError(t, err)
+	for i := 0; i < count; i++ {
+		hasNext, err := forward.Next()
+		require.NoError(t, err)
+		require.True(t, hasNext)
+		key, isPrimary, err := forward.GetKey()
+		require.NoError(t, err)
+		require.True(t, isPrimary)
+		require.Equal(t, primaryKey(i), key)
+		value, err := forward.GetValue()
+		require.NoError(t, err)
+		require.Equal(t, values[i], value)
+
+		hasNext, err = forward.Next()
+		require.NoError(t, err)
+		require.True(t, hasNext)
+		key, isPrimary, err = forward.GetKey()
+		require.NoError(t, err)
+		require.False(t, isPrimary)
+		require.Equal(t, secondaryKey(i), key)
+		value, err = forward.GetValue()
+		require.NoError(t, err)
+		require.Equal(t, values[i], value)
+	}
+	hasNext, err := forward.Next()
+	require.NoError(t, err)
+	require.False(t, hasNext)
+	require.NoError(t, forward.Close())
+
+	reverse, err := NewIterator(config, rollbackTestTable, true)
+	require.NoError(t, err)
+	for i := count - 1; i >= 0; i-- {
+		hasNext, err := reverse.Next()
+		require.NoError(t, err)
+		require.True(t, hasNext)
+		key, isPrimary, err := reverse.GetKey()
+		require.NoError(t, err)
+		require.False(t, isPrimary)
+		require.Equal(t, secondaryKey(i), key)
+		value, err := reverse.GetValue()
+		require.NoError(t, err)
+		require.Equal(t, values[i], value)
+
+		hasNext, err = reverse.Next()
+		require.NoError(t, err)
+		require.True(t, hasNext)
+		key, isPrimary, err = reverse.GetKey()
+		require.NoError(t, err)
+		require.True(t, isPrimary)
+		require.Equal(t, primaryKey(i), key)
+		value, err = reverse.GetValue()
+		require.NoError(t, err)
+		require.Equal(t, values[i], value)
+	}
+	hasNext, err = reverse.Next()
+	require.NoError(t, err)
+	require.False(t, hasNext)
+	require.NoError(t, reverse.Close())
+}
+
+// TestOfflineIteratorExcludesBelowGCWatermark verifies that segments already logically garbage
+// collected are excluded from an offline iterator, matching what a live table's own reads would see.
+func TestOfflineIteratorExcludesBelowGCWatermark(t *testing.T) {
+	t.Parallel()
+	const count = 50
+
+	config, roots := newRollbackTestDB(t)
+	writeSequentialKeys(t, config, count)
+
+	segsBefore, err := gatherOrderedSegments(slog.Default(), roots, rollbackTestTable, config.Fsync)
+	require.NoError(t, err)
+	require.Greaterf(t, len(segsBefore), 1, "test requires multiple segments to be meaningful")
+	highestIndex := segsBefore[len(segsBefore)-1].SegmentIndex()
+	expectedKeys, err := segsBefore[len(segsBefore)-1].GetKeys()
+	require.NoError(t, err)
+
+	tableDir := filepath.Join(roots[0], rollbackTestTable)
+	watermark, err := disktable.LoadGCWatermarkFile(tableDir)
+	require.NoError(t, err)
+	require.NoError(t, watermark.Update(highestIndex))
+
+	it, err := NewIterator(config, rollbackTestTable, false)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, it.Close()) }()
+
+	gotKeys := 0
+	for {
+		hasNext, err := it.Next()
+		require.NoError(t, err)
+		if !hasNext {
+			break
+		}
+		gotKeys++
+	}
+	require.Equal(t, len(expectedKeys), gotKeys, "only the segment at/above the watermark should be visible")
+}
+
+// TestOfflineIteratorFailsWhileLive verifies that opening an offline iterator against a table a live
+// database still has open fails, rather than reading alongside it.
+func TestOfflineIteratorFailsWhileLive(t *testing.T) {
+	t.Parallel()
+	config, _ := newRollbackTestDB(t)
+
+	db, err := littbuilder.NewDB(config)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+	_, err = db.BuildTable(litt.DefaultTableConfig(rollbackTestTable))
+	require.NoError(t, err)
+
+	_, err = NewIterator(config, rollbackTestTable, false)
+	require.Error(t, err)
+}

--- a/sei-db/db_engine/litt/offline/rollback.go
+++ b/sei-db/db_engine/litt/offline/rollback.go
@@ -23,8 +23,12 @@ import (
 // from the most recently written key to the oldest. tableName identifies the table the record belongs to:
 // key schemas differ across tables, so the filter must decode the key in a table-aware way. isPrimary is
 // true for primary keys (standalone primaries and primaries that own secondary keys) and false for
-// secondary keys. The first record for which the filter returns true is the rollback point: that record's
-// group is kept along with everything written before it, and everything written after the group is discarded.
+// secondary keys.
+//
+// The first record for which the filter returns true is the rollback point: that record's group is kept
+// along with everything written before it, and everything written after the group is discarded. Returning
+// true for no record in a table therefore asks for a table that retains nothing, and deletes it outright.
+// A filter must not use false to mean "not my table" — every table under config.Paths is subject to it.
 type RollbackFilter func(tableName string, key []byte, isPrimary bool) (bool, error)
 
 // RollbackLittDB performs an offline rollback of the LittDB instance stored across config.Paths (the same
@@ -34,14 +38,16 @@ type RollbackFilter func(tableName string, key []byte, isPrimary bool) (bool, er
 // oldest and invokes rollbackFilter(tableName, key, isPrimary) for each record. The first key for which the
 // filter returns true marks the rollback point: that key's group (a primary plus any secondary keys
 // written with it) and everything written before it are retained; everything written after the group is
-// permanently deleted from the segment files. A table for which the filter never returns true is left
-// unchanged.
+// permanently deleted from the segment files. A table for which the filter never returns true retains
+// nothing, and is deleted in its entirety.
 //
 // The keymap and any snapshot are discarded rather than edited: the database rebuilds both from the
 // truncated segment files the next time it starts, which keeps them exactly consistent with the
-// rolled-back data (the same approach cli/prune.go uses after an offline mutation). The durable gc-watermark
-// is deliberately left in place; rolling a table back below its gc-watermark — into data that garbage
-// collection has already reclaimed — is refused, because that state cannot be faithfully reconstructed.
+// rolled-back data (the same approach cli/prune.go uses after an offline mutation). A table that retains
+// some of its records keeps its durable gc-watermark, and a rollback point below that watermark — into data
+// that garbage collection has already reclaimed — is refused, because that state cannot be faithfully
+// reconstructed. A table that retains nothing has no such floor to respect: its watermark is deleted along
+// with the rest of it.
 //
 // The database must NOT be running while this is called. RollbackLittDB takes the same directory locks the
 // database uses, so it will fail rather than corrupt a live database, and it assumes nothing else mutates
@@ -135,8 +141,8 @@ func rollbackTable(
 		return err
 	}
 	if pivot == nil {
-		logger.Warn("no rollback point found, leaving table unchanged", "table", tableName)
-		return nil
+		logger.Info("no record to retain, deleting table", "table", tableName)
+		return deleteTable(roots, tableName)
 	}
 
 	// Refuse to roll back below the durable gc-watermark. Segments below it are logically garbage collected
@@ -243,6 +249,23 @@ func groupEndIndex(keys []*types.ScopedKey, i int) (int, error) {
 		}
 	}
 	return 0, fmt.Errorf("key group starting at record %d has no terminating final-secondary record", i)
+}
+
+// deleteTable removes a table's entire on-disk footprint from every root, leaving the roots as if the
+// table had never been created.
+//
+// A rollback that retains nothing resolves to this: every record the table holds lies after the rollback
+// point. The gc-watermark is deleted along with everything else, so unlike a partial rollback this cannot
+// leave a lowest-readable-segment pointing past the surviving data, and the below-watermark refusal does
+// not apply. Re-running over a partially deleted table completes the deletion.
+func deleteTable(roots []string, tableName string) error {
+	for _, root := range roots {
+		tableDirectory := filepath.Join(root, tableName)
+		if err := os.RemoveAll(tableDirectory); err != nil {
+			return fmt.Errorf("failed to remove table directory %s: %w", tableDirectory, err)
+		}
+	}
+	return nil
 }
 
 // discardDerivedState removes the keymap and snapshot directories for a table from every root. Both are

--- a/sei-db/db_engine/litt/offline/rollback.go
+++ b/sei-db/db_engine/litt/offline/rollback.go
@@ -1,7 +1,6 @@
-// Package rollback implements an offline rollback utility for LittDB. It rewinds a database to a chosen
-// point by discarding the most recently written keys, and is intended for operational use (for example,
-// rolling a node's state back to a specific block height) while the database is not running.
-package rollback
+// Package offline implements offline utilities for LittDB — operations that read or mutate a database's
+// files directly while it is not running, without starting a live instance.
+package offline
 
 import (
 	"context"
@@ -12,6 +11,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/sei-protocol/sei-chain/sei-db/db_engine/litt"
 	"github.com/sei-protocol/sei-chain/sei-db/db_engine/litt/disktable"
 	"github.com/sei-protocol/sei-chain/sei-db/db_engine/litt/disktable/keymap"
 	"github.com/sei-protocol/sei-chain/sei-db/db_engine/litt/disktable/segment"
@@ -27,14 +27,15 @@ import (
 // group is kept along with everything written before it, and everything written after the group is discarded.
 type RollbackFilter func(tableName string, key []byte, isPrimary bool) (bool, error)
 
-// RollbackLittDB performs an offline rollback of the LittDB instance stored across the given data
-// directories (the same paths passed to the database as its storage roots).
+// RollbackLittDB performs an offline rollback of the LittDB instance stored across config.Paths (the same
+// paths passed to the database as its storage roots).
 //
-// For every table found under dataDirs, RollbackLittDB walks that table's key files from newest to oldest
-// and invokes rollbackFilter(tableName, key, isPrimary) for each record. The first key for which the filter
-// returns true marks the rollback point: that key's group (a primary plus any secondary keys written with
-// it) and everything written before it are retained; everything written after the group is permanently
-// deleted from the segment files. A table for which the filter never returns true is left unchanged.
+// For every table found under config.Paths, RollbackLittDB walks that table's key files from newest to
+// oldest and invokes rollbackFilter(tableName, key, isPrimary) for each record. The first key for which the
+// filter returns true marks the rollback point: that key's group (a primary plus any secondary keys
+// written with it) and everything written before it are retained; everything written after the group is
+// permanently deleted from the segment files. A table for which the filter never returns true is left
+// unchanged.
 //
 // The keymap and any snapshot are discarded rather than edited: the database rebuilds both from the
 // truncated segment files the next time it starts, which keeps them exactly consistent with the
@@ -48,27 +49,22 @@ type RollbackFilter func(tableName string, key []byte, isPrimary bool) (bool, er
 //
 // The operation is idempotent and safe to re-run: re-running with the same filter completes (and repairs)
 // a rollback that was interrupted partway through.
-func RollbackLittDB(dataDirs []string, rollbackFilter RollbackFilter) error {
+func RollbackLittDB(config *litt.Config, rollbackFilter RollbackFilter) error {
 	logger := slog.Default()
 
-	if len(dataDirs) == 0 {
-		return fmt.Errorf("no data directories provided")
+	if config == nil || len(config.Paths) == 0 {
+		return fmt.Errorf("at least one path must be provided")
 	}
 	if rollbackFilter == nil {
 		return fmt.Errorf("rollback filter must not be nil")
 	}
-
-	roots := make([]string, len(dataDirs))
-	for i, dir := range dataDirs {
-		sanitized, err := util.SanitizePath(dir)
-		if err != nil {
-			return fmt.Errorf("invalid data directory %q: %w", dir, err)
-		}
-		roots[i] = sanitized
+	if err := config.SanitizePaths(); err != nil {
+		return fmt.Errorf("failed to sanitize data directories: %w", err)
 	}
+	roots := config.Paths
 
 	// Refuse to operate on a database that is in active use. The DB holds these same locks while running.
-	releaseLocks, err := util.LockDirectories(logger, roots, util.LockfileName, true)
+	releaseLocks, err := util.LockDirectories(logger, roots, util.LockfileName, config.Fsync)
 	if err != nil {
 		return fmt.Errorf("failed to lock data directories %v: %w", roots, err)
 	}
@@ -80,7 +76,7 @@ func RollbackLittDB(dataDirs []string, rollbackFilter RollbackFilter) error {
 	}
 
 	for _, table := range tables {
-		if err := rollbackTable(logger, roots, table, rollbackFilter); err != nil {
+		if err := rollbackTable(logger, roots, table, config.Fsync, rollbackFilter); err != nil {
 			return fmt.Errorf("failed to roll back table %q: %w", table, err)
 		}
 	}
@@ -101,6 +97,7 @@ func rollbackTable(
 	logger *slog.Logger,
 	roots []string,
 	tableName string,
+	fsync bool,
 	rollbackFilter RollbackFilter,
 ) error {
 	errorMonitor := util.NewErrorMonitor(context.Background(), logger, nil)
@@ -112,7 +109,7 @@ func rollbackTable(
 
 	lowestSegmentIndex, highestSegmentIndex, segments, err := segment.GatherSegmentFiles(
 		logger, errorMonitor, segmentPaths, false /* snapshottingEnabled */, time.Now(),
-		true /* cleanOrphans */, true /* fsync */)
+		true /* cleanOrphans */, fsync)
 	if err != nil {
 		return fmt.Errorf("failed to gather segment files: %w", err)
 	}

--- a/sei-db/db_engine/litt/offline/rollback_test.go
+++ b/sei-db/db_engine/litt/offline/rollback_test.go
@@ -133,22 +133,34 @@ func TestRollbackLittDB(t *testing.T) {
 	require.NoError(t, db.Close())
 }
 
-// TestRollbackNoMatch verifies that a table for which the filter never returns true is left untouched.
+// TestRollbackNoMatch verifies that a table for which the filter never returns true retains nothing, and
+// so is deleted outright: its directory is gone from every root and it reopens empty.
 func TestRollbackNoMatch(t *testing.T) {
 	t.Parallel()
 
 	const count = 50
 
-	config, _ := newRollbackTestDB(t)
-	values := writeSequentialKeys(t, config, count)
+	config, rootPaths := newRollbackTestDB(t)
+	writeSequentialKeys(t, config, count)
 
 	err := RollbackLittDB(config, func(tableName string, key []byte, isPrimary bool) (bool, error) {
 		return false, nil
 	})
 	require.NoError(t, err)
 
+	for _, root := range rootPaths {
+		exists, err := util.Exists(filepath.Join(root, rollbackTestTable))
+		require.NoError(t, err)
+		require.Falsef(t, exists, "table directory should be gone from root %s", root)
+	}
+
 	db, table := openTable(t, config)
-	assertSequentialState(t, table, count, count-1, values) // everything survives
+	require.Zero(t, table.KeyCount())
+	for i := 0; i < count; i++ {
+		_, ok, err := table.Get(keyForIndex(i))
+		require.NoError(t, err)
+		require.Falsef(t, ok, "key %d should have been deleted along with the table", i)
+	}
 	require.NoError(t, db.Close())
 }
 

--- a/sei-db/db_engine/litt/offline/rollback_test.go
+++ b/sei-db/db_engine/litt/offline/rollback_test.go
@@ -1,4 +1,4 @@
-package rollback
+package offline
 
 import (
 	"fmt"
@@ -116,10 +116,10 @@ func TestRollbackLittDB(t *testing.T) {
 	const count = 200
 	const keepThrough = 137
 
-	config, roots := newRollbackTestDB(t)
+	config, _ := newRollbackTestDB(t)
 	values := writeSequentialKeys(t, config, count)
 
-	err := RollbackLittDB(roots, func(tableName string, key []byte, isPrimary bool) (bool, error) {
+	err := RollbackLittDB(config, func(tableName string, key []byte, isPrimary bool) (bool, error) {
 		require.Equal(t, rollbackTestTable, tableName) // filter is invoked per table
 		require.True(t, isPrimary)                     // these are all standalone primary keys
 		return indexFromKey(t, key) <= keepThrough, nil
@@ -139,10 +139,10 @@ func TestRollbackNoMatch(t *testing.T) {
 
 	const count = 50
 
-	config, roots := newRollbackTestDB(t)
+	config, _ := newRollbackTestDB(t)
 	values := writeSequentialKeys(t, config, count)
 
-	err := RollbackLittDB(roots, func(tableName string, key []byte, isPrimary bool) (bool, error) {
+	err := RollbackLittDB(config, func(tableName string, key []byte, isPrimary bool) (bool, error) {
 		return false, nil
 	})
 	require.NoError(t, err)
@@ -158,10 +158,10 @@ func TestRollbackKeepsEverything(t *testing.T) {
 
 	const count = 50
 
-	config, roots := newRollbackTestDB(t)
+	config, _ := newRollbackTestDB(t)
 	values := writeSequentialKeys(t, config, count)
 
-	err := RollbackLittDB(roots, func(tableName string, key []byte, isPrimary bool) (bool, error) {
+	err := RollbackLittDB(config, func(tableName string, key []byte, isPrimary bool) (bool, error) {
 		return true, nil // the very first key visited (the newest) matches
 	})
 	require.NoError(t, err)
@@ -175,11 +175,11 @@ func TestRollbackKeepsEverything(t *testing.T) {
 func TestRollbackPropagatesFilterError(t *testing.T) {
 	t.Parallel()
 
-	config, roots := newRollbackTestDB(t)
+	config, _ := newRollbackTestDB(t)
 	writeSequentialKeys(t, config, 20)
 
 	wantErr := fmt.Errorf("boom")
-	err := RollbackLittDB(roots, func(tableName string, key []byte, isPrimary bool) (bool, error) {
+	err := RollbackLittDB(config, func(tableName string, key []byte, isPrimary bool) (bool, error) {
 		return false, wantErr
 	})
 	require.ErrorIs(t, err, wantErr)
@@ -194,7 +194,7 @@ func TestRollbackWithSecondaryKeys(t *testing.T) {
 	const count = 60
 	const keepThrough = 28
 
-	config, roots := newRollbackTestDB(t)
+	config, _ := newRollbackTestDB(t)
 
 	db, err := littbuilder.NewDB(config)
 	require.NoError(t, err)
@@ -217,7 +217,7 @@ func TestRollbackWithSecondaryKeys(t *testing.T) {
 	require.NoError(t, table.Flush())
 	require.NoError(t, db.Close())
 
-	err = RollbackLittDB(roots, func(tableName string, key []byte, isPrimary bool) (bool, error) {
+	err = RollbackLittDB(config, func(tableName string, key []byte, isPrimary bool) (bool, error) {
 		// Only primary keys carry an index we want to stop on; secondaries are reported with isPrimary=false.
 		if !isPrimary {
 			require.True(t, strings.HasPrefix(string(key), "sk-"))
@@ -276,7 +276,7 @@ func TestRollbackRefusesBelowGCWatermark(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, existsBefore)
 
-	err = RollbackLittDB(roots, func(tableName string, key []byte, isPrimary bool) (bool, error) {
+	err = RollbackLittDB(config, func(tableName string, key []byte, isPrimary bool) (bool, error) {
 		return indexFromKey(t, key) <= 10, nil
 	})
 	require.Error(t, err)
@@ -296,15 +296,15 @@ func TestRollbackIsIdempotent(t *testing.T) {
 	const count = 120
 	const keepThrough = 71
 
-	config, roots := newRollbackTestDB(t)
+	config, _ := newRollbackTestDB(t)
 	values := writeSequentialKeys(t, config, count)
 
 	filter := func(tableName string, key []byte, isPrimary bool) (bool, error) {
 		return indexFromKey(t, key) <= keepThrough, nil
 	}
 
-	require.NoError(t, RollbackLittDB(roots, filter))
-	require.NoError(t, RollbackLittDB(roots, filter)) // second run must be a safe no-op
+	require.NoError(t, RollbackLittDB(config, filter))
+	require.NoError(t, RollbackLittDB(config, filter)) // second run must be a safe no-op
 
 	db, table := openTable(t, config)
 	assertSequentialState(t, table, count, keepThrough, values)

--- a/sei-db/ledger_db/receipt/backend_marker.go
+++ b/sei-db/ledger_db/receipt/backend_marker.go
@@ -1,0 +1,117 @@
+package receipt
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// receiptBackendMarkerFileName is the file in a receipt store's directory naming the backend that owns it.
+const receiptBackendMarkerFileName = "receipt-backend.txt"
+
+// receiptBackendMarkerVersion is the marker format version this build writes.
+const receiptBackendMarkerVersion = 1
+
+// requireSupportedBackend fails if backend is not a receipt store backend this build implements. backend
+// must already be normalized.
+func requireSupportedBackend(backend string) error {
+	switch backend {
+	case receiptBackendLittIdx, receiptBackendPebble:
+		return nil
+	default:
+		return fmt.Errorf("unsupported receipt store backend: %s", backend)
+	}
+}
+
+// recordBackendType refuses dbDirectory if a different backend already owns it, and otherwise records
+// backend as its owner, creating the directory if it does not exist. A directory carrying no marker is
+// adopted rather than refused: it was either written before markers existed or is new, so backend is
+// taken to be its owner. backend must already be normalized.
+func recordBackendType(dbDirectory string, backend string) error {
+	if err := os.MkdirAll(dbDirectory, 0o750); err != nil {
+		return fmt.Errorf("failed to create receipt store directory %s: %w", dbDirectory, err)
+	}
+
+	owner, found, err := readBackendType(dbDirectory)
+	if err != nil {
+		return err
+	}
+	if found {
+		if owner != backend {
+			return backendMismatchError(dbDirectory, owner, backend)
+		}
+		return nil
+	}
+	return writeBackendType(dbDirectory, backend)
+}
+
+// requireBackendType fails if dbDirectory is marked as belonging to a backend other than want. A
+// directory carrying no marker is not a failure: it was written before markers existed, so want stands.
+// It does not write, so a caller pointed at the wrong directory does not record a type there.
+func requireBackendType(dbDirectory string, want string) error {
+	owner, found, err := readBackendType(dbDirectory)
+	if err != nil {
+		return err
+	}
+	if found && owner != want {
+		return backendMismatchError(dbDirectory, owner, want)
+	}
+	return nil
+}
+
+// readBackendType returns the backend recorded as the owner of dbDirectory. found is false when the
+// directory carries no marker. A marker that cannot be parsed, or that names a format version or a backend
+// this build does not know, is an error: the directory holds something this build cannot reason about, and
+// treating that as an absent marker would defeat the check.
+func readBackendType(dbDirectory string) (backend string, found bool, err error) {
+	filePath := filepath.Join(dbDirectory, receiptBackendMarkerFileName)
+
+	contents, err := os.ReadFile(filePath) //nolint:gosec // path within the configured store directory
+	if os.IsNotExist(err) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("failed to read receipt backend marker %s: %w", filePath, err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(contents)), "\n")
+	if len(lines) != 2 {
+		return "", false, fmt.Errorf("receipt backend marker %s is malformed: want 2 lines, got %d",
+			filePath, len(lines))
+	}
+
+	version, err := strconv.Atoi(strings.TrimSpace(lines[0]))
+	if err != nil {
+		return "", false, fmt.Errorf("receipt backend marker %s has an unparseable version %q: %w",
+			filePath, lines[0], err)
+	}
+	if version != receiptBackendMarkerVersion {
+		return "", false, fmt.Errorf("receipt backend marker %s has unsupported version %d (want %d)",
+			filePath, version, receiptBackendMarkerVersion)
+	}
+
+	backend = strings.TrimSpace(lines[1])
+	if err := requireSupportedBackend(backend); err != nil {
+		return "", false, fmt.Errorf("receipt backend marker %s: %w", filePath, err)
+	}
+	return backend, true, nil
+}
+
+// writeBackendType records backend as the owner of dbDirectory, which must already exist.
+func writeBackendType(dbDirectory string, backend string) error {
+	filePath := filepath.Join(dbDirectory, receiptBackendMarkerFileName)
+	contents := fmt.Sprintf("%d\n%s\n", receiptBackendMarkerVersion, backend)
+	if err := os.WriteFile(filePath, []byte(contents), 0o600); err != nil {
+		return fmt.Errorf("failed to write receipt backend marker %s: %w", filePath, err)
+	}
+	return nil
+}
+
+// backendMismatchError describes a store directory that one backend owns being opened as another.
+func backendMismatchError(dbDirectory string, owner string, want string) error {
+	return fmt.Errorf("receipt store at %s belongs to the %q backend, but the %q backend was requested; "+
+		"point at that backend's store directory or configure the backend that owns this one",
+		dbDirectory, owner, want)
+}

--- a/sei-db/ledger_db/receipt/backend_marker_internal_test.go
+++ b/sei-db/ledger_db/receipt/backend_marker_internal_test.go
@@ -1,0 +1,213 @@
+package receipt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	dbconfig "github.com/sei-protocol/sei-chain/sei-db/config"
+	"github.com/stretchr/testify/require"
+)
+
+// openBackend builds a receipt store of the named backend in dir and closes it again, leaving whatever
+// that backend puts on disk — including its ownership marker.
+func openBackend(t *testing.T, dir string, backend string) {
+	t.Helper()
+	cfg := dbconfig.DefaultReceiptStoreConfig()
+	cfg.Backend = backend
+	cfg.DBDirectory = dir
+	store, err := NewReceiptStore(cfg, nil)
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+}
+
+// writeRawMarker replaces dir's marker with arbitrary contents, standing in for a marker written by a
+// build that disagrees with this one.
+func writeRawMarker(t *testing.T, dir string, contents string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, receiptBackendMarkerFileName), []byte(contents), 0o600))
+}
+
+func TestBackendTypeRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	backend, found, err := readBackendType(dir)
+	require.NoError(t, err)
+	require.False(t, found, "an unmarked directory must report no owner rather than erroring")
+	require.Empty(t, backend)
+
+	require.NoError(t, recordBackendType(dir, receiptBackendLittIdx))
+
+	backend, found, err = readBackendType(dir)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, receiptBackendLittIdx, backend)
+}
+
+// TestBackendTypeRecordCreatesDirectory verifies that recording a type works on a store directory that
+// does not exist yet, which is the state of every freshly configured node.
+func TestBackendTypeRecordCreatesDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "receipt")
+	require.NoError(t, recordBackendType(dir, receiptBackendPebble))
+
+	backend, found, err := readBackendType(dir)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, receiptBackendPebble, backend)
+}
+
+func TestBackendTypeRecordIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, recordBackendType(dir, receiptBackendLittIdx))
+	require.NoError(t, recordBackendType(dir, receiptBackendLittIdx))
+}
+
+// TestBackendTypeRecordRefusesAnotherOwner verifies that recording a mismatched type fails and leaves the
+// existing marker in place, so the directory still reports its real owner afterwards.
+func TestBackendTypeRecordRefusesAnotherOwner(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, recordBackendType(dir, receiptBackendPebble))
+
+	err := recordBackendType(dir, receiptBackendLittIdx)
+	require.ErrorContains(t, err, receiptBackendPebble)
+	require.ErrorContains(t, err, receiptBackendLittIdx)
+
+	backend, found, err := readBackendType(dir)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, receiptBackendPebble, backend)
+}
+
+func TestBackendTypeRequire(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, requireBackendType(dir, receiptBackendLittIdx), "an unmarked directory must pass")
+
+	require.NoError(t, recordBackendType(dir, receiptBackendLittIdx))
+	require.NoError(t, requireBackendType(dir, receiptBackendLittIdx))
+	require.Error(t, requireBackendType(dir, receiptBackendPebble))
+}
+
+// TestBackendTypeRejectsUnreadableMarkers verifies that a marker this build cannot reason about is an
+// error rather than being treated as absent, which would defeat the check.
+func TestBackendTypeRejectsUnreadableMarkers(t *testing.T) {
+	for name, contents := range map[string]string{
+		"empty":            "",
+		"one line":         "1",
+		"three lines":      "1\nlittidx\nextra",
+		"unparsed version": "v1\nlittidx",
+		"future version":   "2\nlittidx",
+		"unknown backend":  "1\nrocksdb",
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeRawMarker(t, dir, contents)
+
+			_, found, err := readBackendType(dir)
+			require.Error(t, err)
+			require.False(t, found)
+			require.Error(t, requireBackendType(dir, receiptBackendLittIdx))
+		})
+	}
+}
+
+// TestNewReceiptStoreRefusesAnotherBackendsDirectory verifies that opening a store directory as the wrong
+// backend fails loudly instead of presenting the operator with a silently empty store.
+func TestNewReceiptStoreRefusesAnotherBackendsDirectory(t *testing.T) {
+	littDir := t.TempDir()
+	openBackend(t, littDir, receiptBackendLittIdx)
+	cfg := dbconfig.DefaultReceiptStoreConfig()
+	cfg.Backend = receiptBackendPebble
+	cfg.DBDirectory = littDir
+	_, err := NewReceiptStore(cfg, nil)
+	require.ErrorContains(t, err, receiptBackendLittIdx)
+
+	pebbleDir := t.TempDir()
+	openBackend(t, pebbleDir, receiptBackendPebble)
+	cfg = dbconfig.DefaultReceiptStoreConfig()
+	cfg.Backend = receiptBackendLittIdx
+	cfg.DBDirectory = pebbleDir
+	_, err = NewReceiptStore(cfg, nil)
+	require.ErrorContains(t, err, receiptBackendPebble)
+}
+
+// TestNewReceiptStoreAdoptsUnmarkedDirectory verifies the backwards-compatibility case: a store written
+// before markers existed opens as configured, is stamped on the way through, and reopens afterwards.
+func TestNewReceiptStoreAdoptsUnmarkedDirectory(t *testing.T) {
+	dir := t.TempDir()
+	openBackend(t, dir, receiptBackendLittIdx)
+	require.NoError(t, os.Remove(filepath.Join(dir, receiptBackendMarkerFileName)))
+
+	openBackend(t, dir, receiptBackendLittIdx)
+
+	backend, found, err := readBackendType(dir)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, receiptBackendLittIdx, backend)
+
+	openBackend(t, dir, receiptBackendLittIdx)
+}
+
+// TestNewReceiptStoreRejectsUnsupportedBackendBeforeRecording verifies that an unsupported backend is
+// refused without stamping the directory, which would otherwise leave a marker no build can read.
+func TestNewReceiptStoreRejectsUnsupportedBackendBeforeRecording(t *testing.T) {
+	dir := t.TempDir()
+	cfg := dbconfig.DefaultReceiptStoreConfig()
+	cfg.Backend = "rocksdb"
+	cfg.DBDirectory = dir
+	_, err := NewReceiptStore(cfg, nil)
+	require.ErrorContains(t, err, "unsupported receipt store backend")
+
+	_, found, err := readBackendType(dir)
+	require.NoError(t, err)
+	require.False(t, found, "a refused backend must not record a type")
+}
+
+// TestNewReceiptStoreRejectsBadConfigBeforeRecording verifies that a config the pebble backend refuses is
+// rejected without stamping the directory, so correcting the config to littidx is not then refused by a
+// marker left behind by the failed attempt.
+func TestNewReceiptStoreRejectsBadConfigBeforeRecording(t *testing.T) {
+	dir := t.TempDir()
+	cfg := dbconfig.DefaultReceiptStoreConfig()
+	cfg.Backend = receiptBackendPebble
+	cfg.DBDirectory = dir
+	cfg.ExternalPruning = true
+	_, err := NewReceiptStore(cfg, nil)
+	require.ErrorContains(t, err, "does not support external pruning")
+
+	_, found, err := readBackendType(dir)
+	require.NoError(t, err)
+	require.False(t, found, "a rejected config must not record a type")
+
+	cfg.Backend = receiptBackendLittIdx
+	store, err := NewReceiptStore(cfg, nil)
+	require.NoError(t, err, "the corrected config must not be refused by the failed attempt")
+	require.NoError(t, store.Close())
+}
+
+// TestOfflineRefusesNonLittIdxStore verifies that the offline entry points refuse a store they cannot
+// read, and refuse it before creating littidx's subdirectories inside it.
+func TestOfflineRefusesNonLittIdxStore(t *testing.T) {
+	dir := t.TempDir()
+	openBackend(t, dir, receiptBackendPebble)
+
+	cfg := dbconfig.DefaultReceiptStoreConfig()
+	cfg.DBDirectory = dir
+	require.Equal(t, receiptBackendPebble, normalizeReceiptBackend(cfg.Backend), "default backend assumption")
+
+	_, _, _, err := GetRange(cfg)
+	require.ErrorContains(t, err, receiptBackendLittIdx)
+	require.ErrorContains(t, PruneAfter(cfg, 0), receiptBackendLittIdx)
+
+	// A littidx-configured caller pointed at this directory is refused by the marker rather than the
+	// config, which is the mistake the config check cannot see.
+	cfg.Backend = receiptBackendLittIdx
+	_, _, _, err = GetRange(cfg)
+	require.ErrorContains(t, err, receiptBackendPebble)
+	require.ErrorContains(t, PruneAfter(cfg, 0), receiptBackendPebble)
+
+	for _, subdirectory := range []string{littValuesDirName, littIndexDirName} {
+		_, err := os.Stat(filepath.Join(dir, subdirectory))
+		require.Truef(t, os.IsNotExist(err), "%s must not have been created in a refused store", subdirectory)
+	}
+}

--- a/sei-db/ledger_db/receipt/litt_receipt_store.go
+++ b/sei-db/ledger_db/receipt/litt_receipt_store.go
@@ -89,6 +89,12 @@ const (
 	receiptBackendLittIdx = "littidx"
 
 	littReceiptTableName = "receipts"
+	// littValuesDirName is the store-directory subdirectory holding the littdb
+	// receipt bodies.
+	littValuesDirName = "littdb"
+	// littIndexDirName is the store-directory subdirectory holding the pebble tag
+	// index and the store's version metadata.
+	littIndexDirName = "log-index"
 	// littFlushInterval is roughly one flush per block at Giga throughput (a
 	// block is ~7ms), bounding crash loss to about a single block. Flushing this
 	// often is only cheap because litt flushes its keymap asynchronously, off the
@@ -138,7 +144,7 @@ func newLittReceiptStore(cfg dbconfig.ReceiptStoreConfig, storeKey sdk.StoreKey)
 	if err := os.MkdirAll(cfg.DBDirectory, 0o750); err != nil {
 		return nil, fmt.Errorf("failed to create receipt store directory: %w", err)
 	}
-	littConfig, err := litt.DefaultConfig(filepath.Join(cfg.DBDirectory, "littdb"))
+	littConfig, err := litt.DefaultConfig(filepath.Join(cfg.DBDirectory, littValuesDirName))
 	if err != nil {
 		return nil, fmt.Errorf("failed to build littdb config: %w", err)
 	}
@@ -189,7 +195,7 @@ func newLittReceiptStore(cfg dbconfig.ReceiptStoreConfig, storeKey sdk.StoreKey)
 	}
 
 	indexCfg := pebbledb.DefaultConfig()
-	indexCfg.DataDir = filepath.Join(cfg.DBDirectory, "log-index")
+	indexCfg.DataDir = filepath.Join(cfg.DBDirectory, littIndexDirName)
 	index, err := pebbledb.Open(context.Background(), &indexCfg)
 	if err != nil {
 		_ = values.Close()

--- a/sei-db/ledger_db/receipt/offline.go
+++ b/sei-db/ledger_db/receipt/offline.go
@@ -1,0 +1,166 @@
+package receipt
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"path/filepath"
+
+	dbconfig "github.com/sei-protocol/sei-chain/sei-db/config"
+	"github.com/sei-protocol/sei-chain/sei-db/db_engine/litt"
+	"github.com/sei-protocol/sei-chain/sei-db/db_engine/litt/offline"
+	"github.com/sei-protocol/sei-chain/sei-db/db_engine/pebbledb"
+	dbtypes "github.com/sei-protocol/sei-chain/sei-db/db_engine/types"
+)
+
+// GetRange reports the lowest and highest block heights present on disk for the receipt store described
+// by cfg, without opening the store. ok is false if no receipts are present.
+func GetRange(cfg dbconfig.ReceiptStoreConfig) (ok bool, lowestBlock uint64, highestBlock uint64, err error) {
+	littConfig, err := litt.DefaultConfig(filepath.Join(cfg.DBDirectory, "littdb"))
+	if err != nil {
+		return false, 0, 0, fmt.Errorf("failed to build littdb config: %w", err)
+	}
+
+	newest, err := offline.NewIterator(littConfig, littReceiptTableName, true)
+	if err != nil {
+		return false, 0, 0, fmt.Errorf("failed to open reverse iterator: %w", err)
+	}
+	highestBlock, ok, err = firstPrimaryKeyHeight(newest)
+	closeErr := newest.Close()
+	if err != nil {
+		return false, 0, 0, err
+	}
+	if closeErr != nil {
+		return false, 0, 0, fmt.Errorf("failed to close reverse iterator: %w", closeErr)
+	}
+	if !ok {
+		return false, 0, 0, nil
+	}
+
+	oldest, err := offline.NewIterator(littConfig, littReceiptTableName, false)
+	if err != nil {
+		return false, 0, 0, fmt.Errorf("failed to open forward iterator: %w", err)
+	}
+	defer func() { _ = oldest.Close() }()
+	lowestBlock, ok, err = firstPrimaryKeyHeight(oldest)
+	if err != nil {
+		return false, 0, 0, err
+	}
+	if !ok {
+		return false, 0, 0, nil
+	}
+
+	return true, lowestBlock, highestBlock, nil
+}
+
+// PruneAfter deletes every receipt for a block height greater than highestBlockToKeep from the receipt
+// store described by cfg, without opening the store. It refuses if highestBlockToKeep falls below the
+// store's retention floor, since that data has already been pruned and cannot be faithfully restored —
+// checked before any mutation, so a refusal leaves the store untouched. Otherwise it rolls back the
+// litt-backed receipt bodies, then deletes the pebble tag-index entries above highestBlockToKeep and moves
+// the store's latest-block metadata back to match.
+func PruneAfter(cfg dbconfig.ReceiptStoreConfig, highestBlockToKeep uint64) error {
+	indexCfg := pebbledb.DefaultConfig()
+	indexCfg.DataDir = filepath.Join(cfg.DBDirectory, "log-index")
+	index, err := pebbledb.Open(context.Background(), &indexCfg)
+	if err != nil {
+		return fmt.Errorf("failed to open receipt log index: %w", err)
+	}
+	defer func() { _ = index.Close() }()
+
+	earliest, err := readMetaOffline(index, receiptEarliestVersionKey)
+	if err != nil {
+		return err
+	}
+	if earliest > 0 && highestBlockToKeep < earliest {
+		return fmt.Errorf("cannot roll back receipt store to block %d: it is below the retention floor "+
+			"(earliest readable block %d); that data has already been pruned", highestBlockToKeep, earliest)
+	}
+
+	latest, err := readMetaOffline(index, receiptLatestVersionKey)
+	if err != nil {
+		return err
+	}
+	if latest <= highestBlockToKeep {
+		return nil
+	}
+
+	littConfig, err := litt.DefaultConfig(filepath.Join(cfg.DBDirectory, "littdb"))
+	if err != nil {
+		return fmt.Errorf("failed to build littdb config: %w", err)
+	}
+	filter := func(tableName string, key []byte, isPrimary bool) (bool, error) {
+		if tableName != littReceiptTableName || !isPrimary {
+			return false, nil
+		}
+		height, err := decodePartKeyHeight(key)
+		if err != nil {
+			return false, err
+		}
+		return height <= highestBlockToKeep, nil
+	}
+	if err := offline.RollbackLittDB(littConfig, filter); err != nil {
+		return fmt.Errorf("failed to roll back littdb receipts: %w", err)
+	}
+
+	rd, ok := index.(rangeDeleter)
+	if !ok {
+		return fmt.Errorf("receipt index %T does not support range delete", index)
+	}
+	lower := littTagBlockKey(highestBlockToKeep + 1)
+	upper := prefixSuccessor([]byte{littTagKeyPrefix})
+	if err := rd.DeleteRange(lower, upper, dbtypes.WriteOptions{}); err != nil {
+		return fmt.Errorf("failed to delete tag index entries above block %d: %w", highestBlockToKeep, err)
+	}
+	newLatest := encodeBlockNumber(highestBlockToKeep)
+	if err := index.Set(receiptLatestVersionKey, newLatest, dbtypes.WriteOptions{}); err != nil {
+		return fmt.Errorf("failed to update latest block metadata: %w", err)
+	}
+	return nil
+}
+
+// firstPrimaryKeyHeight advances it to the first primary key found and decodes the block height from its
+// littPartKey encoding. Secondary keys (tx-hash aliases) carry no height and are skipped. ok is false if
+// the iterator has no primary keys at all.
+func firstPrimaryKeyHeight(it litt.Iterator) (height uint64, ok bool, err error) {
+	for {
+		hasNext, err := it.Next()
+		if err != nil {
+			return 0, false, fmt.Errorf("failed to advance iterator: %w", err)
+		}
+		if !hasNext {
+			return 0, false, nil
+		}
+		key, isPrimary, err := it.GetKey()
+		if err != nil {
+			return 0, false, fmt.Errorf("failed to read key: %w", err)
+		}
+		if !isPrimary {
+			continue
+		}
+		height, err = decodePartKeyHeight(key)
+		if err != nil {
+			return 0, false, err
+		}
+		return height, true, nil
+	}
+}
+
+// decodePartKeyHeight decodes the block height encoded in a receipts-table primary key (see littPartKey).
+func decodePartKeyHeight(key []byte) (uint64, error) {
+	if len(key) != blockNumLen+littPartCountLen {
+		return 0, fmt.Errorf("unexpected primary receipt key length %d (want %d)",
+			len(key), blockNumLen+littPartCountLen)
+	}
+	return binary.BigEndian.Uint64(key[:blockNumLen]), nil
+}
+
+// readMetaOffline reads a version-metadata key directly from the receipt index, without a live store.
+// Returns 0 if the key is absent, malformed, or unreadable, matching littReceiptStore.readMeta's behavior.
+func readMetaOffline(index dbtypes.KeyValueDB, key []byte) (uint64, error) {
+	val, err := index.Get(key)
+	if err != nil || len(val) != blockNumLen {
+		return 0, nil
+	}
+	return decodeBlockNumber(val), nil
+}

--- a/sei-db/ledger_db/receipt/offline.go
+++ b/sei-db/ledger_db/receipt/offline.go
@@ -3,9 +3,11 @@ package receipt
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"path/filepath"
 
+	errorutils "github.com/sei-protocol/sei-chain/sei-db/common/errors"
 	dbconfig "github.com/sei-protocol/sei-chain/sei-db/config"
 	"github.com/sei-protocol/sei-chain/sei-db/db_engine/litt"
 	"github.com/sei-protocol/sei-chain/sei-db/db_engine/litt/offline"
@@ -69,7 +71,7 @@ func GetRange(cfg dbconfig.ReceiptStoreConfig) (ok bool, lowestBlock uint64, hig
 // Both are checked before any receipt is touched, so a refusal leaves the store's data unchanged.
 //
 // Only a littidx-backed store is supported; any other backend is refused rather than silently left alone.
-func PruneAfter(cfg dbconfig.ReceiptStoreConfig, highestBlockToKeep uint64) error {
+func PruneAfter(cfg dbconfig.ReceiptStoreConfig, highestBlockToKeep uint64) (err error) {
 	if err := requireLittIdxStore(cfg); err != nil {
 		return err
 	}
@@ -80,20 +82,26 @@ func PruneAfter(cfg dbconfig.ReceiptStoreConfig, highestBlockToKeep uint64) erro
 	if err != nil {
 		return fmt.Errorf("failed to open receipt log index: %w", err)
 	}
-	defer func() { _ = index.Close() }()
+	// WriteOptions{} does not fsync, so Close is where this function's writes are committed. A failed
+	// close means they may not have landed, which must not read as a successful prune.
+	defer func() { err = errors.Join(err, index.Close()) }()
 
-	earliest, err := readMetaOffline(index, receiptEarliestVersionKey)
+	earliest, earliestFound, err := readMetaOffline(index, receiptEarliestVersionKey)
 	if err != nil {
 		return err
 	}
-	if earliest > 0 && highestBlockToKeep < earliest {
+	if earliestFound && highestBlockToKeep < earliest {
 		return fmt.Errorf("cannot roll back receipt store to block %d: it is below the retention floor "+
 			"(earliest readable block %d); that data has already been pruned", highestBlockToKeep, earliest)
 	}
 
-	latest, err := readMetaOffline(index, receiptLatestVersionKey)
+	latest, latestFound, err := readMetaOffline(index, receiptLatestVersionKey)
 	if err != nil {
 		return err
+	}
+	if !latestFound {
+		// No head has ever been recorded, so there is nothing above highestBlockToKeep to remove.
+		return nil
 	}
 	if latest <= highestBlockToKeep {
 		return nil
@@ -226,11 +234,21 @@ func decodePartKeyHeight(key []byte) (uint64, error) {
 }
 
 // readMetaOffline reads a version-metadata key directly from the receipt index, without a live store.
-// Returns 0 if the key is absent, malformed, or unreadable, matching littReceiptStore.readMeta's behavior.
-func readMetaOffline(index dbtypes.KeyValueDB, key []byte) (uint64, error) {
+// found is false only when the key is absent, which is the state of a store that has never recorded that
+// version. A failed read, or a value of the wrong width, is an error: this metadata decides which of
+// PruneAfter's refusals apply, so metadata that cannot be trusted has to stop the rollback rather than
+// read as zero.
+func readMetaOffline(index dbtypes.KeyValueDB, key []byte) (version uint64, found bool, err error) {
 	val, err := index.Get(key)
-	if err != nil || len(val) != blockNumLen {
-		return 0, nil
+	if errorutils.IsNotFound(err) {
+		return 0, false, nil
 	}
-	return decodeBlockNumber(val), nil
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to read receipt store metadata key %q: %w", key, err)
+	}
+	if len(val) != blockNumLen {
+		return 0, false, fmt.Errorf("receipt store metadata key %q holds %d bytes, want %d",
+			key, len(val), blockNumLen)
+	}
+	return decodeBlockNumber(val), true, nil
 }

--- a/sei-db/ledger_db/receipt/offline.go
+++ b/sei-db/ledger_db/receipt/offline.go
@@ -54,11 +54,13 @@ func GetRange(cfg dbconfig.ReceiptStoreConfig) (ok bool, lowestBlock uint64, hig
 }
 
 // PruneAfter deletes every receipt for a block height greater than highestBlockToKeep from the receipt
-// store described by cfg, without opening the store. It refuses if highestBlockToKeep falls below the
-// store's retention floor, since that data has already been pruned and cannot be faithfully restored —
-// checked before any mutation, so a refusal leaves the store untouched. Otherwise it rolls back the
-// litt-backed receipt bodies, then deletes the pebble tag-index entries above highestBlockToKeep and moves
-// the store's latest-block metadata back to match.
+// store described by cfg, without opening the store. It rolls back the litt-backed receipt bodies, then
+// deletes the pebble tag-index entries above highestBlockToKeep and moves the store's latest-block metadata
+// back to match. A highestBlockToKeep at or above the store's head is a no-op.
+//
+// It refuses a highestBlockToKeep below the store's retention floor, and one below the oldest receipt still
+// on disk: the former names data that has already been pruned, the latter would leave no receipt at all.
+// Both are checked before any receipt is touched, so a refusal leaves the store's data unchanged.
 func PruneAfter(cfg dbconfig.ReceiptStoreConfig, highestBlockToKeep uint64) error {
 	indexCfg := pebbledb.DefaultConfig()
 	indexCfg.DataDir = filepath.Join(cfg.DBDirectory, "log-index")
@@ -85,12 +87,23 @@ func PruneAfter(cfg dbconfig.ReceiptStoreConfig, highestBlockToKeep uint64) erro
 		return nil
 	}
 
+	if err := requireTargetWithinStoredRange(cfg, highestBlockToKeep, latest); err != nil {
+		return err
+	}
+
 	littConfig, err := litt.DefaultConfig(filepath.Join(cfg.DBDirectory, "littdb"))
 	if err != nil {
 		return fmt.Errorf("failed to build littdb config: %w", err)
 	}
 	filter := func(tableName string, key []byte, isPrimary bool) (bool, error) {
-		if tableName != littReceiptTableName || !isPrimary {
+		if tableName != littReceiptTableName {
+			// RollbackLittDB deletes any table its filter never matches, so returning false for a table
+			// this filter cannot decode would destroy it rather than leave it alone.
+			return false, fmt.Errorf("unexpected table %q under the receipt littdb", tableName)
+		}
+		if !isPrimary {
+			// Secondary keys are tx-hash aliases and carry no height, so they are never rollback points.
+			// Every group has a primary, so this never suppresses a whole table.
 			return false, nil
 		}
 		height, err := decodePartKeyHeight(key)
@@ -115,6 +128,34 @@ func PruneAfter(cfg dbconfig.ReceiptStoreConfig, highestBlockToKeep uint64) erro
 	newLatest := encodeBlockNumber(highestBlockToKeep)
 	if err := index.Set(receiptLatestVersionKey, newLatest, dbtypes.WriteOptions{}); err != nil {
 		return fmt.Errorf("failed to update latest block metadata: %w", err)
+	}
+	return nil
+}
+
+// requireTargetWithinStoredRange refuses a rollback target below the oldest receipt still on disk. Such a
+// target retains no receipts, so the caller almost certainly named a height the store never held; a caller
+// that does mean to discard the store entirely can delete its directory. latest is the head the index
+// reports, used only to describe an index that claims receipts the litt store does not have.
+//
+// This must run to completion before the rollback starts: it reads through an offline iterator that holds
+// the same litt directory locks the rollback takes.
+func requireTargetWithinStoredRange(
+	cfg dbconfig.ReceiptStoreConfig,
+	highestBlockToKeep uint64,
+	latest uint64,
+) error {
+	ok, lowestBlock, _, err := GetRange(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to read the receipt store's block range: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("cannot roll back receipt store to block %d: the index reports a head at block "+
+			"%d but no receipts are present on disk", highestBlockToKeep, latest)
+	}
+	if highestBlockToKeep < lowestBlock {
+		return fmt.Errorf("cannot roll back receipt store to block %d: the oldest receipt on disk is for "+
+			"block %d, so no receipt would survive; delete %s to discard the store entirely",
+			highestBlockToKeep, lowestBlock, cfg.DBDirectory)
 	}
 	return nil
 }

--- a/sei-db/ledger_db/receipt/offline.go
+++ b/sei-db/ledger_db/receipt/offline.go
@@ -15,8 +15,14 @@ import (
 
 // GetRange reports the lowest and highest block heights present on disk for the receipt store described
 // by cfg, without opening the store. ok is false if no receipts are present.
+//
+// Only a littidx-backed store is supported; any other backend is refused rather than reported as empty.
 func GetRange(cfg dbconfig.ReceiptStoreConfig) (ok bool, lowestBlock uint64, highestBlock uint64, err error) {
-	littConfig, err := litt.DefaultConfig(filepath.Join(cfg.DBDirectory, "littdb"))
+	if err := requireLittIdxStore(cfg); err != nil {
+		return false, 0, 0, err
+	}
+
+	littConfig, err := litt.DefaultConfig(filepath.Join(cfg.DBDirectory, littValuesDirName))
 	if err != nil {
 		return false, 0, 0, fmt.Errorf("failed to build littdb config: %w", err)
 	}
@@ -61,9 +67,15 @@ func GetRange(cfg dbconfig.ReceiptStoreConfig) (ok bool, lowestBlock uint64, hig
 // It refuses a highestBlockToKeep below the store's retention floor, and one below the oldest receipt still
 // on disk: the former names data that has already been pruned, the latter would leave no receipt at all.
 // Both are checked before any receipt is touched, so a refusal leaves the store's data unchanged.
+//
+// Only a littidx-backed store is supported; any other backend is refused rather than silently left alone.
 func PruneAfter(cfg dbconfig.ReceiptStoreConfig, highestBlockToKeep uint64) error {
+	if err := requireLittIdxStore(cfg); err != nil {
+		return err
+	}
+
 	indexCfg := pebbledb.DefaultConfig()
-	indexCfg.DataDir = filepath.Join(cfg.DBDirectory, "log-index")
+	indexCfg.DataDir = filepath.Join(cfg.DBDirectory, littIndexDirName)
 	index, err := pebbledb.Open(context.Background(), &indexCfg)
 	if err != nil {
 		return fmt.Errorf("failed to open receipt log index: %w", err)
@@ -91,7 +103,7 @@ func PruneAfter(cfg dbconfig.ReceiptStoreConfig, highestBlockToKeep uint64) erro
 		return err
 	}
 
-	littConfig, err := litt.DefaultConfig(filepath.Join(cfg.DBDirectory, "littdb"))
+	littConfig, err := litt.DefaultConfig(filepath.Join(cfg.DBDirectory, littValuesDirName))
 	if err != nil {
 		return fmt.Errorf("failed to build littdb config: %w", err)
 	}
@@ -130,6 +142,23 @@ func PruneAfter(cfg dbconfig.ReceiptStoreConfig, highestBlockToKeep uint64) erro
 		return fmt.Errorf("failed to update latest block metadata: %w", err)
 	}
 	return nil
+}
+
+// requireLittIdxStore refuses an offline operation on anything but a littidx receipt store. The other
+// backends keep receipts in a layout these operations cannot read, so they would report a full store as
+// empty rather than fail, and would create littidx's subdirectories inside a directory a live store may
+// be using.
+//
+// It checks both the backend the config asks for and the backend the store directory's marker names as its
+// owner, which catch different mistakes: the config check refuses a caller that asked for the wrong
+// backend, and the marker check refuses a littidx-configured caller pointed at another backend's store. A
+// directory carrying no marker predates the marker file, so the configured backend stands.
+func requireLittIdxStore(cfg dbconfig.ReceiptStoreConfig) error {
+	if backend := normalizeReceiptBackend(cfg.Backend); backend != receiptBackendLittIdx {
+		return fmt.Errorf("offline receipt store operations require the %q backend, but this store is "+
+			"configured for %q", receiptBackendLittIdx, backend)
+	}
+	return requireBackendType(cfg.DBDirectory, receiptBackendLittIdx)
 }
 
 // requireTargetWithinStoredRange refuses a rollback target below the oldest receipt still on disk. Such a

--- a/sei-db/ledger_db/receipt/offline_internal_test.go
+++ b/sei-db/ledger_db/receipt/offline_internal_test.go
@@ -1,0 +1,91 @@
+package receipt
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	dbconfig "github.com/sei-protocol/sei-chain/sei-db/config"
+	"github.com/sei-protocol/sei-chain/sei-db/db_engine/pebbledb"
+	dbtypes "github.com/sei-protocol/sei-chain/sei-db/db_engine/types"
+	"github.com/stretchr/testify/require"
+)
+
+// littIdxCfg returns the config the offline entry points expect for a littidx store at dir.
+func littIdxCfg(dir string) dbconfig.ReceiptStoreConfig {
+	cfg := dbconfig.DefaultReceiptStoreConfig()
+	cfg.Backend = receiptBackendLittIdx
+	cfg.DBDirectory = dir
+	return cfg
+}
+
+// writeLittIdxReceipts builds a littidx store at dir, writes one receipt for each block in [1, blocks],
+// and closes it, leaving well-formed version metadata behind in the index.
+func writeLittIdxReceipts(t *testing.T, dir string, blocks uint64) {
+	t.Helper()
+	ctx, storeKey := newTestContext()
+	store, err := NewReceiptStore(littIdxCfg(dir), storeKey)
+	require.NoError(t, err)
+
+	addr := common.HexToAddress("0xc0de")
+	topic := common.HexToHash("0xdead")
+	for block := uint64(1); block <= blocks; block++ {
+		txHash := common.BytesToHash([]byte{byte(block)})
+		record := ReceiptRecord{TxHash: txHash, Receipt: makeTestReceipt(txHash, block, 0, addr,
+			[]common.Hash{topic})}
+		//nolint:gosec // small test heights
+		require.NoError(t, store.SetReceipts(ctx.WithBlockHeight(int64(block)), []ReceiptRecord{record}))
+	}
+	require.NoError(t, store.Close())
+}
+
+// overwriteMeta replaces a version-metadata value in the store's index, standing in for metadata this
+// build cannot read: a corrupt value, or one written by a format it does not know.
+func overwriteMeta(t *testing.T, dir string, key []byte, value []byte) {
+	t.Helper()
+	indexCfg := pebbledb.DefaultConfig()
+	indexCfg.DataDir = filepath.Join(dir, littIndexDirName)
+	index, err := pebbledb.Open(context.Background(), &indexCfg)
+	require.NoError(t, err)
+	require.NoError(t, index.Set(key, value, dbtypes.WriteOptions{}))
+	require.NoError(t, index.Close())
+}
+
+// TestPruneAfterRejectsUnreadableLatest verifies that a head PruneAfter cannot read stops the rollback.
+// Read as zero it would take the nothing-to-do path, returning nil and reporting success for a rollback
+// that never happened.
+func TestPruneAfterRejectsUnreadableLatest(t *testing.T) {
+	dir := t.TempDir()
+	writeLittIdxReceipts(t, dir, 5)
+	overwriteMeta(t, dir, receiptLatestVersionKey, []byte{0x01, 0x02, 0x03})
+
+	require.ErrorContains(t, PruneAfter(littIdxCfg(dir), 2), "holds 3 bytes")
+}
+
+// TestPruneAfterRejectsUnreadableEarliest verifies the same for the retention floor. Read as zero it
+// would silently disable the below-the-floor refusal and let the rollback proceed.
+func TestPruneAfterRejectsUnreadableEarliest(t *testing.T) {
+	dir := t.TempDir()
+	writeLittIdxReceipts(t, dir, 5)
+	overwriteMeta(t, dir, receiptEarliestVersionKey, []byte{0x01, 0x02, 0x03})
+
+	cfg := littIdxCfg(dir)
+	require.ErrorContains(t, PruneAfter(cfg, 2), "holds 3 bytes")
+
+	// The refusal has to land before any receipt is touched, which is what the surviving range shows.
+	ok, lowestBlock, highestBlock, err := GetRange(cfg)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(1), lowestBlock)
+	require.Equal(t, uint64(5), highestBlock)
+}
+
+// TestPruneAfterAcceptsAbsentMetadata verifies that an absent key stays benign: a store that has never
+// recorded a version has nothing to roll back, which is not an error.
+func TestPruneAfterAcceptsAbsentMetadata(t *testing.T) {
+	dir := t.TempDir()
+	openBackend(t, dir, receiptBackendLittIdx)
+
+	require.NoError(t, PruneAfter(littIdxCfg(dir), 100))
+}

--- a/sei-db/ledger_db/receipt/offline_test.go
+++ b/sei-db/ledger_db/receipt/offline_test.go
@@ -1,0 +1,155 @@
+package receipt_test
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/eth/filters"
+	storetypes "github.com/sei-protocol/sei-chain/sei-cosmos/store/types"
+	"github.com/sei-protocol/sei-chain/sei-cosmos/testutil"
+	dbconfig "github.com/sei-protocol/sei-chain/sei-db/config"
+	"github.com/sei-protocol/sei-chain/sei-db/controller"
+	"github.com/sei-protocol/sei-chain/sei-db/ledger_db/receipt"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOfflineGetRangeEmpty verifies that GetRange on a directory with no receipt store reports no data,
+// rather than erroring.
+func TestOfflineGetRangeEmpty(t *testing.T) {
+	cfg := dbconfig.DefaultReceiptStoreConfig()
+	cfg.DBDirectory = t.TempDir()
+	ok, lowest, highest, err := receipt.GetRange(cfg)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Zero(t, lowest)
+	require.Zero(t, highest)
+}
+
+// TestOfflineGetRange verifies that GetRange reports the lowest and highest block heights written to
+// the store, without opening it.
+func TestOfflineGetRange(t *testing.T) {
+	dir := t.TempDir()
+	store, ctx := setupLittIdx(t, dir)
+
+	addr := common.HexToAddress("0xc0de")
+	topic := common.HexToHash("0xdead")
+	for block := uint64(3); block <= 9; block++ {
+		writeLitBlock(t, store, ctx, block, litReceipt(block, 0, addr, topic))
+	}
+	require.NoError(t, store.Close())
+
+	cfg := dbconfig.DefaultReceiptStoreConfig()
+	cfg.DBDirectory = dir
+	ok, lowest, highest, err := receipt.GetRange(cfg)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(3), lowest)
+	require.Equal(t, uint64(9), highest)
+}
+
+// TestOfflinePruneAfter verifies that PruneAfter discards receipt bodies and tag-index entries above
+// the target height, updates the store's latest-block metadata, and leaves everything at or below the
+// target intact and readable after reopening.
+func TestOfflinePruneAfter(t *testing.T) {
+	dir := t.TempDir()
+	store, ctx := setupLittIdx(t, dir)
+
+	addr := common.HexToAddress("0xc0de")
+	topic := common.HexToHash("0xdead")
+	const count = 10
+	const keepThrough = 6
+	for block := uint64(1); block <= count; block++ {
+		writeLitBlock(t, store, ctx, block, litReceipt(block, 0, addr, topic))
+	}
+	require.NoError(t, store.Close())
+
+	cfg := dbconfig.DefaultReceiptStoreConfig()
+	cfg.DBDirectory = dir
+	require.NoError(t, receipt.PruneAfter(cfg, keepThrough))
+
+	store, ctx = setupLittIdx(t, dir)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	require.Equal(t, int64(keepThrough), store.LatestVersion())
+
+	for block := uint64(1); block <= count; block++ {
+		r, err := store.GetReceiptFromStore(ctx, litTxHash(block, 0))
+		if block <= keepThrough {
+			require.NoErrorf(t, err, "block %d should survive", block)
+			require.Equal(t, block, r.BlockNumber)
+		} else {
+			require.ErrorIsf(t, err, receipt.ErrNotFound, "block %d should have been rolled back", block)
+		}
+	}
+
+	logs, err := store.FilterLogs(ctx, 1, count, filters.FilterCriteria{Addresses: []common.Address{addr}}, nil)
+	require.NoError(t, err)
+	require.Len(t, logs, keepThrough, "tag index should only report surviving blocks")
+}
+
+// TestOfflinePruneAfterNoOp verifies that pruning to a height at or above the current head leaves the
+// store unchanged.
+func TestOfflinePruneAfterNoOp(t *testing.T) {
+	dir := t.TempDir()
+	store, ctx := setupLittIdx(t, dir)
+
+	addr := common.HexToAddress("0xc0de")
+	topic := common.HexToHash("0xdead")
+	const count = 5
+	for block := uint64(1); block <= count; block++ {
+		writeLitBlock(t, store, ctx, block, litReceipt(block, 0, addr, topic))
+	}
+	require.NoError(t, store.Close())
+
+	cfg := dbconfig.DefaultReceiptStoreConfig()
+	cfg.DBDirectory = dir
+	require.NoError(t, receipt.PruneAfter(cfg, count+10))
+
+	store, ctx = setupLittIdx(t, dir)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	require.Equal(t, int64(count), store.LatestVersion())
+	for block := uint64(1); block <= count; block++ {
+		r, err := store.GetReceiptFromStore(ctx, litTxHash(block, 0))
+		require.NoError(t, err)
+		require.Equal(t, block, r.BlockNumber)
+	}
+}
+
+// TestOfflinePruneAfterRefusesBelowRetentionFloor verifies that PruneAfter refuses to roll back below
+// the store's retention floor, and mutates nothing when it does.
+func TestOfflinePruneAfterRefusesBelowRetentionFloor(t *testing.T) {
+	dir := t.TempDir()
+	storeKey := storetypes.NewKVStoreKey("evm")
+	tkey := storetypes.NewTransientStoreKey("evm_transient")
+	ctx := testutil.DefaultContext(storeKey, tkey).WithBlockHeight(1)
+
+	cfg := dbconfig.DefaultReceiptStoreConfig()
+	cfg.Backend = "littidx"
+	cfg.DBDirectory = dir
+	cfg.ExternalPruning = true // drive PruneHistory directly, no jittered background pruner racing the test
+	store, err := receipt.NewReceiptStore(cfg, storeKey)
+	require.NoError(t, err)
+
+	addr := common.HexToAddress("0xc0de")
+	topic := common.HexToHash("0xdead")
+	const count = 10
+	for block := uint64(1); block <= count; block++ {
+		writeLitBlock(t, store, ctx, block, litReceipt(block, 0, addr, topic))
+	}
+
+	prunable, ok := store.(controller.PrunableStore)
+	require.True(t, ok)
+	require.NoError(t, prunable.PruneHistory(6)) // retention floor now at block 6
+	require.NoError(t, store.Close())
+
+	err = receipt.PruneAfter(cfg, 3) // below the floor
+	require.ErrorContains(t, err, "retention floor")
+
+	// The refusal must not have mutated anything: reopening should show the store exactly as it was.
+	store, ctx = setupLittIdx(t, dir)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	require.Equal(t, int64(count), store.LatestVersion())
+	r, err := store.GetReceiptFromStore(ctx, litTxHash(count, 0))
+	require.NoError(t, err)
+	require.Equal(t, uint64(count), r.BlockNumber)
+}

--- a/sei-db/ledger_db/receipt/offline_test.go
+++ b/sei-db/ledger_db/receipt/offline_test.go
@@ -13,11 +13,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// offlineCfg returns the config the offline entry points expect for a littidx store at dir. The backend
+// must be set explicitly: the default is pebbledb, which these operations refuse.
+func offlineCfg(dir string) dbconfig.ReceiptStoreConfig {
+	cfg := dbconfig.DefaultReceiptStoreConfig()
+	cfg.Backend = "littidx"
+	cfg.DBDirectory = dir
+	return cfg
+}
+
 // TestOfflineGetRangeEmpty verifies that GetRange on a directory with no receipt store reports no data,
 // rather than erroring.
 func TestOfflineGetRangeEmpty(t *testing.T) {
-	cfg := dbconfig.DefaultReceiptStoreConfig()
-	cfg.DBDirectory = t.TempDir()
+	cfg := offlineCfg(t.TempDir())
 	ok, lowest, highest, err := receipt.GetRange(cfg)
 	require.NoError(t, err)
 	require.False(t, ok)
@@ -38,8 +46,7 @@ func TestOfflineGetRange(t *testing.T) {
 	}
 	require.NoError(t, store.Close())
 
-	cfg := dbconfig.DefaultReceiptStoreConfig()
-	cfg.DBDirectory = dir
+	cfg := offlineCfg(dir)
 	ok, lowest, highest, err := receipt.GetRange(cfg)
 	require.NoError(t, err)
 	require.True(t, ok)
@@ -63,8 +70,7 @@ func TestOfflinePruneAfter(t *testing.T) {
 	}
 	require.NoError(t, store.Close())
 
-	cfg := dbconfig.DefaultReceiptStoreConfig()
-	cfg.DBDirectory = dir
+	cfg := offlineCfg(dir)
 	require.NoError(t, receipt.PruneAfter(cfg, keepThrough))
 
 	store, ctx = setupLittIdx(t, dir)
@@ -101,8 +107,7 @@ func TestOfflinePruneAfterNoOp(t *testing.T) {
 	}
 	require.NoError(t, store.Close())
 
-	cfg := dbconfig.DefaultReceiptStoreConfig()
-	cfg.DBDirectory = dir
+	cfg := offlineCfg(dir)
 	require.NoError(t, receipt.PruneAfter(cfg, count+10))
 
 	store, ctx = setupLittIdx(t, dir)
@@ -123,9 +128,7 @@ func TestOfflinePruneAfterRefusesBelowRetentionFloor(t *testing.T) {
 	tkey := storetypes.NewTransientStoreKey("evm_transient")
 	ctx := testutil.DefaultContext(storeKey, tkey).WithBlockHeight(1)
 
-	cfg := dbconfig.DefaultReceiptStoreConfig()
-	cfg.Backend = "littidx"
-	cfg.DBDirectory = dir
+	cfg := offlineCfg(dir)
 	cfg.ExternalPruning = true // drive PruneHistory directly, no jittered background pruner racing the test
 	store, err := receipt.NewReceiptStore(cfg, storeKey)
 	require.NoError(t, err)
@@ -169,8 +172,7 @@ func TestOfflinePruneAfterRefusesBelowOldestReceipt(t *testing.T) {
 	}
 	require.NoError(t, store.Close())
 
-	cfg := dbconfig.DefaultReceiptStoreConfig()
-	cfg.DBDirectory = dir
+	cfg := offlineCfg(dir)
 	err := receipt.PruneAfter(cfg, lowest-1)
 	require.ErrorContains(t, err, "no receipt would survive")
 

--- a/sei-db/ledger_db/receipt/offline_test.go
+++ b/sei-db/ledger_db/receipt/offline_test.go
@@ -153,3 +153,40 @@ func TestOfflinePruneAfterRefusesBelowRetentionFloor(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(count), r.BlockNumber)
 }
+
+// TestOfflinePruneAfterRefusesBelowOldestReceipt verifies that PruneAfter refuses a target below the
+// oldest receipt on disk — the case an unset retention floor leaves uncovered — and mutates nothing.
+func TestOfflinePruneAfterRefusesBelowOldestReceipt(t *testing.T) {
+	dir := t.TempDir()
+	store, ctx := setupLittIdx(t, dir)
+
+	addr := common.HexToAddress("0xc0de")
+	topic := common.HexToHash("0xdead")
+	const lowest = 3
+	const highest = 9
+	for block := uint64(lowest); block <= highest; block++ {
+		writeLitBlock(t, store, ctx, block, litReceipt(block, 0, addr, topic))
+	}
+	require.NoError(t, store.Close())
+
+	cfg := dbconfig.DefaultReceiptStoreConfig()
+	cfg.DBDirectory = dir
+	err := receipt.PruneAfter(cfg, lowest-1)
+	require.ErrorContains(t, err, "no receipt would survive")
+
+	// The refusal must leave the receipts in place rather than silently emptying the store while rewinding
+	// the index — the failure this guard exists to prevent.
+	store, ctx = setupLittIdx(t, dir)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	require.Equal(t, int64(highest), store.LatestVersion())
+	for block := uint64(lowest); block <= highest; block++ {
+		r, err := store.GetReceiptFromStore(ctx, litTxHash(block, 0))
+		require.NoErrorf(t, err, "block %d should still be readable", block)
+		require.Equal(t, block, r.BlockNumber)
+	}
+
+	logs, err := store.FilterLogs(ctx, 1, highest, filters.FilterCriteria{Addresses: []common.Address{addr}}, nil)
+	require.NoError(t, err)
+	require.Len(t, logs, highest-lowest+1, "tag index should be untouched")
+}

--- a/sei-db/ledger_db/receipt/receipt_store.go
+++ b/sei-db/ledger_db/receipt/receipt_store.go
@@ -150,15 +150,27 @@ func newReceiptBackend(config dbconfig.ReceiptStoreConfig, storeKey sdk.StoreKey
 	}
 
 	backend := normalizeReceiptBackend(config.Backend)
+	if err := requireSupportedBackend(backend); err != nil {
+		return nil, err
+	}
+	if backend == receiptBackendPebble && config.ExternalPruning {
+		// This backend prunes itself on KeepRecent. Honoring ExternalPruning would stop that
+		// pruner with nothing in its place.
+		return nil, fmt.Errorf("receipt store backend %q does not support external pruning; use %q",
+			receiptBackendPebble, receiptBackendLittIdx)
+	}
+
+	// Runs after every config rejection above, and before either backend touches the directory: a config
+	// that is about to be rejected must not leave a recorded type behind that then refuses the corrected
+	// one.
+	if err := recordBackendType(config.DBDirectory, backend); err != nil {
+		return nil, err
+	}
+
 	switch backend {
 	case receiptBackendLittIdx:
 		return newLittReceiptStore(config, storeKey)
 	case receiptBackendPebble:
-		// This backend prunes itself on KeepRecent. Honoring ExternalPruning would stop that
-		// pruner with nothing in its place.
-		if config.ExternalPruning {
-			return nil, fmt.Errorf("receipt store backend %q does not support external pruning; use %q", receiptBackendPebble, receiptBackendLittIdx)
-		}
 		ssConfig := dbconfig.DefaultStateStoreConfig()
 		ssConfig.DBDirectory = config.DBDirectory
 		ssConfig.AsyncWriteBuffer = config.AsyncWriteBuffer


### PR DESCRIPTION
## Describe your changes and provide context

Tooling that allows the caller to get the blocks stored in the DB and to prune the DB before first starting it.

