### PR TITLE
Remove legacy go-metrics telemetry superseded by OTel (PLT-353)

### DIFF
--- a/sei-cosmos/baseapp/abci.go
+++ b/sei-cosmos/baseapp/abci.go
@@ -12,12 +12,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/armon/go-metrics"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/codec"
 	snapshottypes "github.com/sei-protocol/sei-chain/sei-cosmos/snapshots/types"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store/types"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/tasks"
-	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/types/legacytm"
@@ -118,8 +116,6 @@ func (app *BaseApp) MidBlock(ctx sdk.Context, height int64) (events []abci.Event
 	start := time.Now()
 	defer func() {
 		baseappMetrics.midBlockDuration.Record(ctx.Context(), time.Since(start).Seconds())
-		// TODO(PLT-353): remove once baseapp_mid_block_duration verified
-		telemetry.MeasureSince(start, "abci", "mid_block")
 	}()
 
 	if app.midBlocker != nil {
@@ -135,8 +131,6 @@ func (app *BaseApp) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) (res abc
 	start := time.Now()
 	defer func() {
 		baseappMetrics.endBlockDuration.Record(ctx.Context(), time.Since(start).Seconds())
-		// TODO(PLT-353): remove once baseapp_end_block_duration verified
-		telemetry.MeasureSince(start, "abci", "end_block")
 	}()
 
 	if app.endBlocker != nil {
@@ -195,20 +189,10 @@ func (app *BaseApp) DeliverTx(ctx sdk.Context, req abci.RequestDeliverTxV2, tx s
 
 	defer func() {
 		baseappMetrics.deliverTxDuration.Record(ctx.Context(), time.Since(deliverTxStart).Seconds())
-		// TODO(PLT-353): remove once baseapp_deliver_tx_duration verified
-		telemetry.MeasureSince(deliverTxStart, "abci", "deliver_tx")
 		baseappMetrics.txCount.Add(ctx.Context(), 1)
-		// TODO(PLT-353): remove once baseapp_tx_count verified
-		telemetry.IncrCounter(1, "tx", "count")
 		baseappMetrics.txResult.Add(ctx.Context(), 1, otelmetric.WithAttributes(attribute.String("result", resultStr)))
-		// TODO(PLT-353): remove once baseapp_tx_result verified
-		telemetry.IncrCounter(1, "tx", resultStr)
-		baseappMetrics.txGasUsed.Record(ctx.Context(), int64(gInfo.GasUsed)) //nolint:gosec
-		// TODO(PLT-353): remove once baseapp_tx_gas_used verified
-		telemetry.SetGauge(float32(gInfo.GasUsed), "tx", "gas", "used")
+		baseappMetrics.txGasUsed.Record(ctx.Context(), int64(gInfo.GasUsed))     //nolint:gosec
 		baseappMetrics.txGasWanted.Record(ctx.Context(), int64(gInfo.GasWanted)) //nolint:gosec
-		// TODO(PLT-353): remove once baseapp_tx_gas_wanted verified
-		telemetry.SetGauge(float32(gInfo.GasWanted), "tx", "gas", "wanted")
 	}()
 
 	runTxRes, err := app.runTx(ctx.WithTxBytes(req.Tx).WithTxSum(checksum), runTxModeDeliver, tx, checksum)
@@ -281,8 +265,6 @@ func (app *BaseApp) Commit(ctx context.Context) (res *abci.ResponseCommit, err e
 	commitStart := time.Now()
 	defer func() {
 		baseappMetrics.commitDuration.Record(ctx, time.Since(commitStart).Seconds())
-		// TODO(PLT-353): remove once baseapp_commit_duration verified
-		telemetry.MeasureSince(commitStart, "abci", "commit")
 	}()
 	app.commitLock.Lock()
 	defer app.commitLock.Unlock()
@@ -441,8 +423,6 @@ func (app *BaseApp) Query(ctx context.Context, req *abci.RequestQuery) (res *abc
 	defer func() {
 		route := app.abciQueryMetricRoute(req.Path)
 		baseappMetrics.abciQueryDuration.Record(ctx, time.Since(queryStart).Seconds(), otelmetric.WithAttributes(attribute.String(abciQueryMetricRouteLabel, route)))
-		// TODO(PLT-353): remove once baseapp_abci_query_duration verified
-		telemetry.MeasureSinceWithLabels([]string{"abci", "query"}, queryStart, []metrics.Label{{Name: "path", Value: req.Path}})
 	}()
 
 	// Add panic recovery for all queries.
@@ -1001,8 +981,6 @@ func (app *BaseApp) ProcessProposal(ctx context.Context, req *abci.RequestProces
 	processProposalStart := time.Now()
 	defer func() {
 		baseappMetrics.processProposalDuration.Record(ctx, time.Since(processProposalStart).Seconds())
-		// TODO(PLT-353): remove once baseapp_process_proposal_duration verified
-		telemetry.MeasureSince(processProposalStart, "abci", "process_proposal")
 	}()
 	defer func() { app.execProcessProposalMs = time.Since(processProposalStart).Milliseconds() }()
 	if app.ChainID != req.Header.ChainID {
@@ -1068,8 +1046,6 @@ func (app *BaseApp) FinalizeBlock(ctx context.Context, req *abci.RequestFinalize
 	finalizeBlockStart := time.Now()
 	defer func() {
 		baseappMetrics.finalizeBlockDuration.Record(ctx, time.Since(finalizeBlockStart).Seconds())
-		// TODO(PLT-353): remove once baseapp_finalize_block_duration verified
-		telemetry.MeasureSince(finalizeBlockStart, "abci", "finalize_block")
 	}()
 	app.execBlockTxCount = len(req.Txs)
 	defer func() { app.execFinalizeBlockMs = time.Since(finalizeBlockStart).Milliseconds() }()
@@ -1146,8 +1122,6 @@ func (app *BaseApp) GetTxPriorityHint(ctx context.Context, req *abci.RequestGetT
 	priorityHintStart := time.Now()
 	defer func() {
 		baseappMetrics.getTxPriorityHintDuration.Record(ctx, time.Since(priorityHintStart).Seconds())
-		// TODO(PLT-353): remove once baseapp_get_tx_priority_hint_duration verified
-		telemetry.MeasureSince(priorityHintStart, "abci", "get_tx_priority_hint")
 	}()
 
 	tx, err := app.txDecoder(req.Tx)

--- a/sei-cosmos/baseapp/baseapp.go
+++ b/sei-cosmos/baseapp/baseapp.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/armon/go-metrics"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gogo/protobuf/proto"
 	"github.com/holiman/uint256"
@@ -17,7 +16,6 @@ import (
 	servertypes "github.com/sei-protocol/sei-chain/sei-cosmos/server/types"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/snapshots"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store"
-	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/utils/tracing"
@@ -882,14 +880,6 @@ func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, tx sdk.Tx, checksum [
 	runTxStart := time.Now()
 	defer func() {
 		baseappMetrics.runTxDuration.Record(ctx.Context(), time.Since(runTxStart).Seconds(), otelmetric.WithAttributes(attribute.String("mode", modeKeyToString[mode])))
-		// TODO(PLT-353): remove once baseapp_run_tx_duration verified
-		telemetry.MeasureThroughputSinceWithLabels(
-			telemetry.TxCount,
-			[]metrics.Label{
-				telemetry.NewLabel("mode", modeKeyToString[mode]),
-			},
-			runTxStart,
-		)
 	}()
 
 	// check for existing parent tracer, and if applicable, use it
@@ -1041,14 +1031,6 @@ func (app *BaseApp) RunMsgs(ctx sdk.Context, msgs []sdk.Msg) (*sdk.Result, error
 	runMsgsStart := time.Now()
 	defer func() {
 		baseappMetrics.runMsgsDuration.Record(ctx.Context(), time.Since(runMsgsStart).Seconds())
-		// TODO(PLT-353): remove once baseapp_run_msgs_duration verified
-		telemetry.MeasureThroughputSinceWithLabels(
-			telemetry.MessageCount,
-			[]metrics.Label{
-				telemetry.NewLabel("mode", "deliver"),
-			},
-			runMsgsStart,
-		)
 	}()
 
 	defer func() {
@@ -1084,12 +1066,6 @@ func (app *BaseApp) RunMsgs(ctx sdk.Context, msgs []sdk.Msg) (*sdk.Result, error
 			msgResult, err = handler(msgCtx, msg)
 			eventMsgName = sdk.MsgTypeURL(msg)
 			baseappMetrics.runMsgLatency.Record(ctx.Context(), time.Since(startTime).Seconds(), otelmetric.WithAttributes(attribute.String("type", eventMsgName)))
-			// TODO(PLT-353): remove once baseapp_run_msg_latency verified
-			metrics.MeasureSinceWithLabels(
-				[]string{"sei", "cosmos", "run", "msg", "latency"},
-				startTime,
-				[]metrics.Label{{Name: "type", Value: eventMsgName}},
-			)
 		} else if legacyMsg, ok := msg.(legacytx.LegacyMsg); ok {
 			// legacy sdk.Msg routing
 			// Assuming that the app developer has migrated all their Msgs to
@@ -1104,12 +1080,6 @@ func (app *BaseApp) RunMsgs(ctx sdk.Context, msgs []sdk.Msg) (*sdk.Result, error
 			}
 			msgResult, err = handler(msgCtx, msg)
 			baseappMetrics.runMsgLatency.Record(ctx.Context(), time.Since(startTime).Seconds(), otelmetric.WithAttributes(attribute.String("type", eventMsgName)))
-			// TODO(PLT-353): remove once baseapp_run_msg_latency verified
-			metrics.MeasureSinceWithLabels(
-				[]string{"cosmos", "run", "msg", "latency"},
-				startTime,
-				[]metrics.Label{{Name: "type", Value: eventMsgName}},
-			)
 		} else {
 			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "can't route message %+v", msg)
 		}

--- a/sei-cosmos/store/types/cache.go
+++ b/sei-cosmos/store/types/cache.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/armon/go-metrics"
-	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
 )
@@ -50,8 +48,7 @@ type BoundedCache struct {
 	CacheBackend
 	limit int
 
-	mu         *sync.Mutex
-	metricName []string
+	mu *sync.Mutex
 }
 
 func NewBoundedCache(backend CacheBackend, limit int) *BoundedCache {
@@ -62,19 +59,11 @@ func NewBoundedCache(backend CacheBackend, limit int) *BoundedCache {
 		CacheBackend: backend,
 		limit:        limit,
 		mu:           &sync.Mutex{},
-		// cosmos_bounded_cache
-		metricName: []string{"cosmos", "bounded", "cache"},
 	}
 }
 
 func (c *BoundedCache) emitKeysEvictedMetrics(keysToEvict int) {
 	storeMetrics.boundedCache.Record(context.Background(), int64(keysToEvict), otelmetric.WithAttributes(attribute.String("type", "keys_evicted")))
-	// TODO(PLT-353): remove once store_bounded_cache verified
-	telemetry.SetGaugeWithLabels(
-		c.metricName,
-		float32(keysToEvict),
-		[]metrics.Label{telemetry.NewLabel("type", "keys_evicted")},
-	)
 }
 
 func (c *BoundedCache) Set(key string, val *CValue) {

--- a/sei-cosmos/store/types/gas.go
+++ b/sei-cosmos/store/types/gas.go
@@ -6,8 +6,6 @@ import (
 	"math"
 	"sync"
 
-	"github.com/armon/go-metrics"
-	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
 )
@@ -114,19 +112,12 @@ func (g *basicGasMeter) ConsumeGas(amount Gas, descriptor string) {
 	}
 }
 
-// cosmos_tx_gas_exceeded
 func (g *basicGasMeter) incrGasExceededCounter(errorType string, descriptor string) {
 	storeMetrics.gasExceeded.Add(context.Background(), 1, otelmetric.WithAttributes(
 		attribute.String("error", errorType),
+		// descriptor distinguishes between different gas meters (e.g block vs tx)
 		attribute.String("descriptor", descriptor),
 	))
-	// TODO(PLT-353): remove once store_gas_exceeded verified
-	telemetry.IncrCounterWithLabels(
-		[]string{"gas", "exceeded"},
-		1,
-		// descriptor is a label to distinguish between different gas meters (e.g block vs tx)
-		[]metrics.Label{telemetry.NewLabel("error", errorType), telemetry.NewLabel("descriptor", descriptor)},
-	)
 }
 
 // RefundGas will deduct the given amount from the gas consumed. If the amount is greater than the

--- a/sei-cosmos/storev2/rootmulti/store.go
+++ b/sei-cosmos/storev2/rootmulti/store.go
@@ -6,13 +6,11 @@ import (
 	"io"
 	"math"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"cosmossdk.io/errors"
-	"github.com/armon/go-metrics"
 	"github.com/sei-protocol/seilog"
 	"go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
@@ -28,7 +26,6 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/storev2/commitment"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/storev2/query"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/storev2/state"
-	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
 	commonerrors "github.com/sei-protocol/sei-chain/sei-db/common/errors"
 	"github.com/sei-protocol/sei-chain/sei-db/config"
@@ -213,8 +210,6 @@ func (rs *Store) Commit(bumpVersion bool) types.CommitID {
 	commitStartTime := time.Now()
 	defer func() {
 		storev2Metrics.scCommitLatency.Record(context.Background(), time.Since(commitStartTime).Seconds())
-		// TODO(PLT-353): remove once storev2_sc_commit_latency verified
-		telemetry.MeasureSince(commitStartTime, "storeV2", "sc", "commit", "latency")
 	}()
 	if err := rs.flush(); err != nil {
 		panic(err)
@@ -323,8 +318,6 @@ func (rs *Store) flush() error {
 				return err
 			}
 			storev2Metrics.ssVersion.Record(context.Background(), currentVersion)
-			// TODO(PLT-353): remove once storev2_ss_version verified
-			telemetry.SetGauge(float32(currentVersion), "storeV2", "ss", "version")
 		}
 	} else {
 		// ensure the state store watermark advances even for empty blocks
@@ -333,8 +326,6 @@ func (rs *Store) flush() error {
 				panic(err)
 			}
 			storev2Metrics.ssVersion.Record(context.Background(), currentVersion)
-			// TODO(PLT-353): remove once storev2_ss_version verified
-			telemetry.SetGauge(float32(currentVersion), "storeV2", "ss", "version")
 		}
 	}
 	// Both branches above have finished handing currentVersion to SS and have
@@ -1041,26 +1032,12 @@ func (rs *Store) Query(ctx context.Context, req abci.RequestQuery) abci.Response
 				attribute.Bool("success", false),
 				attribute.Bool("proof", needProof),
 			))
-			// TODO(PLT-353): remove once storev2_historical_abci_query verified
-			telemetry.IncrCounterWithLabels([]string{"historical", "abci", "query"},
-				1,
-				[]metrics.Label{
-					telemetry.NewLabel("success", "false"),
-					telemetry.NewLabel("proof", strconv.FormatBool(needProof)),
-				})
 			return sdkerrors.QueryResult(err)
 		} else {
 			storev2Metrics.historicalAbciQuery.Add(ctx, 1, otelmetric.WithAttributes(
 				attribute.Bool("success", true),
 				attribute.Bool("proof", needProof),
 			))
-			// TODO(PLT-353): remove once storev2_historical_abci_query verified
-			telemetry.IncrCounterWithLabels([]string{"historical", "abci", "query"},
-				1,
-				[]metrics.Label{
-					telemetry.NewLabel("success", "true"),
-					telemetry.NewLabel("proof", strconv.FormatBool(needProof)),
-				})
 		}
 		defer rs.releaseHistProofPermit()
 
@@ -1374,30 +1351,12 @@ func (rs *Store) Snapshot(height uint64, protoWriter protoio.Writer) error {
 			if err == commonerrors.ErrorExportDone {
 				for k, v := range keySizePerStore {
 					storev2Metrics.iavlTotalKeyBytes.Record(context.Background(), v, otelmetric.WithAttributes(attribute.String("store_name", k)))
-					// TODO(PLT-353): remove once storev2_iavl_total_key_bytes verified
-					telemetry.SetGaugeWithLabels(
-						[]string{"iavl", "store", "total_key_bytes"},
-						float32(v),
-						[]metrics.Label{telemetry.NewLabel("store_name", k)},
-					)
 				}
 				for k, v := range valueSizePerStore {
 					storev2Metrics.iavlTotalValueBytes.Record(context.Background(), v, otelmetric.WithAttributes(attribute.String("store_name", k)))
-					// TODO(PLT-353): remove once storev2_iavl_total_value_bytes verified
-					telemetry.SetGaugeWithLabels(
-						[]string{"iavl", "store", "total_value_bytes"},
-						float32(v),
-						[]metrics.Label{telemetry.NewLabel("store_name", k)},
-					)
 				}
 				for k, v := range numKeysPerStore {
 					storev2Metrics.iavlTotalNumKeys.Record(context.Background(), v, otelmetric.WithAttributes(attribute.String("store_name", k)))
-					// TODO(PLT-353): remove once storev2_iavl_total_num_keys verified
-					telemetry.SetGaugeWithLabels(
-						[]string{"iavl", "store", "total_num_keys"},
-						float32(v),
-						[]metrics.Label{telemetry.NewLabel("store_name", k)},
-					)
 				}
 				break
 			}
@@ -1421,8 +1380,6 @@ func (rs *Store) Snapshot(height uint64, protoWriter protoio.Writer) error {
 			valueSizePerStore[currentStoreName] += int64(len(item.Value))
 			numKeysPerStore[currentStoreName] += 1
 			storev2Metrics.stateSyncKeysExported.Add(context.Background(), 1)
-			// TODO(PLT-353): remove once storev2_state_sync_keys_exported verified
-			telemetry.IncrCounter(1, "state_sync", "num_keys_exported")
 		case string:
 			if err := protoWriter.WriteMsg(&snapshottypes.SnapshotItem{
 				Item: &snapshottypes.SnapshotItem_Store{

--- a/sei-cosmos/tasks/scheduler.go
+++ b/sei-cosmos/tasks/scheduler.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store/multiversion"
 	store "github.com/sei-protocol/sei-chain/sei-cosmos/store/types"
-	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/types/occ"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/utils/tracing"
@@ -273,11 +272,7 @@ func (s *scheduler) emitMetrics(ctx context.Context) {
 			fmt.Fprintf(os.Stderr, "telemetry panic: %v\n%s", e, debug.Stack())
 		}
 	}()
-	// TODO(PLT-353): remove once scheduler_retries verified
-	telemetry.IncrCounter(float32(s.metrics.retries), "scheduler", "retries")
 	taskMetrics.retries.Add(ctx, int64(s.metrics.retries))
-	// TODO(PLT-353): remove once scheduler_incarnations verified
-	telemetry.IncrCounter(float32(s.metrics.maxIncarnation), "scheduler", "incarnations")
 	taskMetrics.incarnations.Add(ctx, int64(s.metrics.maxIncarnation))
 }
 

--- a/sei-cosmos/telemetry/wrapper.go
+++ b/sei-cosmos/telemetry/wrapper.go
@@ -11,7 +11,6 @@ const (
 	MetricKeyBeginBlocker = "begin_blocker"
 	MetricKeyEndBlocker   = "end_blocker"
 	MetricLabelNameModule = "module"
-	MessageCount          = "message"
 	TxCount               = "transaction"
 )
 
@@ -59,12 +58,6 @@ func SetGaugeWithLabels(keys []string, val float32, labels []metrics.Label) {
 // metric with global labels (if any).
 func MeasureSince(start time.Time, keys ...string) {
 	metrics.MeasureSinceWithLabels(keys, start.UTC(), globalLabels)
-}
-
-// MeasureSinceWithLabels provides a wrapper functionality for emitting a a time measure
-// metric with custom labels (if any)
-func MeasureSinceWithLabels(keys []string, start time.Time, labels []metrics.Label) {
-	metrics.MeasureSinceWithLabels(keys, start.UTC(), labels)
 }
 
 // Measure Validator slashing events

--- a/sei-cosmos/x/bank/keeper/msg_server.go
+++ b/sei-cosmos/x/bank/keeper/msg_server.go
@@ -3,8 +3,6 @@ package keeper
 import (
 	"context"
 
-	"github.com/armon/go-metrics"
-
 	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
@@ -59,12 +57,6 @@ func (k msgServer) Send(goCtx context.Context, msg *types.MsgSend) (*types.MsgSe
 		for _, a := range msg.Amount {
 			if a.Amount.IsInt64() {
 				bankMetrics.sendAmount.Record(goCtx, a.Amount.Int64(), otelmetric.WithAttributes(attribute.String("denom_class", telemetry.DenomClass(a.Denom))))
-				// TODO(PLT-353): remove once bank_send_amount verified
-				telemetry.SetGaugeWithLabels(
-					[]string{"tx", "msg", "send"},
-					float32(a.Amount.Int64()),
-					[]metrics.Label{telemetry.NewLabel("denom", a.Denom)},
-				)
 			}
 		}
 	}()

--- a/sei-cosmos/x/distribution/keeper/msg_server.go
+++ b/sei-cosmos/x/distribution/keeper/msg_server.go
@@ -3,8 +3,6 @@ package keeper
 import (
 	"context"
 
-	"github.com/armon/go-metrics"
-
 	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/x/distribution/types"
@@ -71,12 +69,6 @@ func (k msgServer) WithdrawDelegatorReward(goCtx context.Context, msg *types.Msg
 		for _, a := range amount {
 			if a.Amount.IsInt64() {
 				distributionMetrics.withdrawRewardAmount.Record(goCtx, a.Amount.Int64(), otelmetric.WithAttributes(attribute.String("denom_class", telemetry.DenomClass(a.Denom))))
-				// TODO(PLT-353): remove once distribution_withdraw_reward_amount verified
-				telemetry.SetGaugeWithLabels(
-					[]string{"tx", "msg", "withdraw_reward"},
-					float32(a.Amount.Int64()),
-					[]metrics.Label{telemetry.NewLabel("denom", a.Denom)},
-				)
 			}
 		}
 	}()
@@ -107,12 +99,6 @@ func (k msgServer) WithdrawValidatorCommission(goCtx context.Context, msg *types
 		for _, a := range amount {
 			if a.Amount.IsInt64() {
 				distributionMetrics.withdrawCommissionAmount.Record(goCtx, a.Amount.Int64(), otelmetric.WithAttributes(attribute.String("denom_class", telemetry.DenomClass(a.Denom))))
-				// TODO(PLT-353): remove once distribution_withdraw_commission_amount verified
-				telemetry.SetGaugeWithLabels(
-					[]string{"tx", "msg", "withdraw_commission"},
-					float32(a.Amount.Int64()),
-					[]metrics.Label{telemetry.NewLabel("denom", a.Denom)},
-				)
 			}
 		}
 	}()

--- a/sei-cosmos/x/gov/keeper/msg_server.go
+++ b/sei-cosmos/x/gov/keeper/msg_server.go
@@ -3,11 +3,7 @@ package keeper
 import (
 	"context"
 	"fmt"
-	"strconv"
 
-	"github.com/armon/go-metrics"
-
-	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/x/gov/types"
 )
@@ -36,8 +32,6 @@ func (k msgServer) SubmitProposal(goCtx context.Context, msg *types.MsgSubmitPro
 
 	defer func() {
 		govMetrics.proposalTotal.Add(goCtx, 1)
-		// TODO(PLT-353): remove once gov_proposal_total verified
-		telemetry.IncrCounter(1, types.ModuleName, "proposal")
 	}()
 
 	votingStarted, err := k.AddDeposit(ctx, proposal.ProposalId, msg.GetProposer(), msg.GetInitialDeposit())
@@ -80,14 +74,6 @@ func (k msgServer) Vote(goCtx context.Context, msg *types.MsgVote) (*types.MsgVo
 
 	defer func() {
 		govMetrics.voteTotal.Add(goCtx, 1)
-		// TODO(PLT-353): remove once gov_vote_total verified
-		telemetry.IncrCounterWithLabels(
-			[]string{types.ModuleName, "vote"},
-			1,
-			[]metrics.Label{
-				telemetry.NewLabel("proposal_id", strconv.FormatUint(msg.ProposalId, 10)),
-			},
-		)
 	}()
 
 	ctx.EventManager().EmitEvent(
@@ -114,14 +100,6 @@ func (k msgServer) VoteWeighted(goCtx context.Context, msg *types.MsgVoteWeighte
 
 	defer func() {
 		govMetrics.voteTotal.Add(goCtx, 1)
-		// TODO(PLT-353): remove once gov_vote_total verified
-		telemetry.IncrCounterWithLabels(
-			[]string{types.ModuleName, "vote"},
-			1,
-			[]metrics.Label{
-				telemetry.NewLabel("proposal_id", strconv.FormatUint(msg.ProposalId, 10)),
-			},
-		)
 	}()
 
 	ctx.EventManager().EmitEvent(
@@ -148,14 +126,6 @@ func (k msgServer) Deposit(goCtx context.Context, msg *types.MsgDeposit) (*types
 
 	defer func() {
 		govMetrics.depositTotal.Add(goCtx, 1)
-		// TODO(PLT-353): remove once gov_deposit_total verified
-		telemetry.IncrCounterWithLabels(
-			[]string{types.ModuleName, "deposit"},
-			1,
-			[]metrics.Label{
-				telemetry.NewLabel("proposal_id", strconv.FormatUint(msg.ProposalId, 10)),
-			},
-		)
 	}()
 
 	ctx.EventManager().EmitEvent(

--- a/sei-cosmos/x/staking/keeper/msg_server.go
+++ b/sei-cosmos/x/staking/keeper/msg_server.go
@@ -4,10 +4,7 @@ import (
 	"context"
 	"time"
 
-	metrics "github.com/armon/go-metrics"
-
 	cryptotypes "github.com/sei-protocol/sei-chain/sei-cosmos/crypto/types"
-	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/utils"
@@ -226,15 +223,7 @@ func (k msgServer) Delegate(goCtx context.Context, msg *types.MsgDelegate) (*typ
 	if msg.Amount.Amount.IsInt64() {
 		defer func() {
 			stakingMetrics.delegateTotal.Add(goCtx, 1)
-			// TODO(PLT-353): remove once staking_delegate_total verified
-			telemetry.IncrCounter(1, types.ModuleName, "delegate")
 			stakingMetrics.delegateAmount.Record(goCtx, msg.Amount.Amount.Int64())
-			// TODO(PLT-353): remove once staking_delegate_amount verified
-			telemetry.SetGaugeWithLabels(
-				[]string{"tx", "msg", msg.Type()},
-				float32(msg.Amount.Amount.Int64()),
-				[]metrics.Label{telemetry.NewLabel("denom", msg.Amount.Denom)},
-			)
 		}()
 	}
 
@@ -295,15 +284,7 @@ func (k msgServer) BeginRedelegate(goCtx context.Context, msg *types.MsgBeginRed
 	if msg.Amount.Amount.IsInt64() {
 		defer func() {
 			stakingMetrics.redelegateTotal.Add(goCtx, 1)
-			// TODO(PLT-353): remove once staking_redelegate_total verified
-			telemetry.IncrCounter(1, types.ModuleName, "redelegate")
 			stakingMetrics.redelegateAmount.Record(goCtx, msg.Amount.Amount.Int64())
-			// TODO(PLT-353): remove once staking_redelegate_amount verified
-			telemetry.SetGaugeWithLabels(
-				[]string{"tx", "msg", msg.Type()},
-				float32(msg.Amount.Amount.Int64()),
-				[]metrics.Label{telemetry.NewLabel("denom", msg.Amount.Denom)},
-			)
 		}()
 	}
 
@@ -361,15 +342,7 @@ func (k msgServer) Undelegate(goCtx context.Context, msg *types.MsgUndelegate) (
 	if msg.Amount.Amount.IsInt64() {
 		defer func() {
 			stakingMetrics.undelegateTotal.Add(goCtx, 1)
-			// TODO(PLT-353): remove once staking_undelegate_total verified
-			telemetry.IncrCounter(1, types.ModuleName, "undelegate")
 			stakingMetrics.undelegateAmount.Record(goCtx, msg.Amount.Amount.Int64())
-			// TODO(PLT-353): remove once staking_undelegate_amount verified
-			telemetry.SetGaugeWithLabels(
-				[]string{"tx", "msg", msg.Type()},
-				float32(msg.Amount.Amount.Int64()),
-				[]metrics.Label{telemetry.NewLabel("denom", msg.Amount.Denom)},
-			)
 		}()
 	}
 

--- a/sei-cosmos/x/upgrade/abci.go
+++ b/sei-cosmos/x/upgrade/abci.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/armon/go-metrics"
-	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/x/upgrade/keeper"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/x/upgrade/types"
@@ -33,8 +31,6 @@ func BeginBlocker(k keeper.Keeper, ctx sdk.Context) {
 	beginBlockerStart := time.Now()
 	defer func() {
 		upgradeMetrics.beginBlockerDuration.Record(ctx.Context(), time.Since(beginBlockerStart).Seconds())
-		// TODO(PLT-353): remove once upgrade_begin_blocker_duration verified
-		telemetry.ModuleMeasureSince(types.ModuleName, beginBlockerStart, telemetry.MetricKeyBeginBlocker)
 	}()
 
 	plan, planFound := k.GetUpgradePlan(ctx)
@@ -61,15 +57,6 @@ func BeginBlocker(k keeper.Keeper, ctx sdk.Context) {
 	upgradeMetrics.planHeight.Record(ctx.Context(), plan.Height, otelmetric.WithAttributes(
 		attribute.String("name", plan.Name),
 	))
-	// TODO(PLT-353): remove once upgrade_plan_height verified
-	telemetry.SetGaugeWithLabels(
-		[]string{"cosmos", "upgrade", "plan", "height"},
-		float32(plan.Height),
-		[]metrics.Label{
-			{Name: "name", Value: plan.Name},
-			{Name: "info", Value: plan.Info},
-		},
-	)
 
 	// If the plan's block height has passed, then it must be the executed version
 	// All major and minor releases are REQUIRED to execute on the scheduled block height

--- a/sei-cosmos/x/upgrade/keeper/keeper.go
+++ b/sei-cosmos/x/upgrade/keeper/keeper.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/armon/go-metrics"
 	tmos "github.com/sei-protocol/sei-chain/sei-tendermint/libs/os"
 	"go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
@@ -17,7 +16,6 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/codec"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store/prefix"
 	store "github.com/sei-protocol/sei-chain/sei-cosmos/store/types"
-	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/types/module"
@@ -210,15 +208,6 @@ func (k Keeper) ScheduleUpgrade(ctx sdk.Context, plan types.Plan) error {
 	upgradeKeeperMetrics.pendingPlanHeight.Record(ctx.Context(), plan.Height, otelmetric.WithAttributes(
 		attribute.String("name", plan.Name),
 	))
-	// TODO(PLT-353): remove once upgrade_pending_plan_height verified
-	telemetry.SetGaugeWithLabels(
-		[]string{"cosmos", "upgrade", "plan", "height"},
-		float32(plan.Height),
-		[]metrics.Label{
-			{Name: "name", Value: plan.Name},
-			{Name: "info", Value: plan.Info},
-		},
-	)
 	return nil
 }
 


### PR DESCRIPTION
## Describe your changes and provide context

Removes the legacy `go-metrics`/`telemetry` emissions that were kept alongside the OTel
instrumentation during the PLT-353 migration. The OTel equivalents (`baseapp_*`, storev2,
scheduler, and module metrics) have been verified in place, so the duplicate emitters and
their `TODO(PLT-353)` markers are now deleted.

Removed from:
- `baseapp` — ABCI duration/tx count/gas gauges, throughput measures
- `storev2/rootmulti` — commit latency, SS version, historical query counters, store-size gauges, state-sync key counter
- `store/types` — cache eviction gauge, gas error counter
- `tasks/scheduler` — retry/incarnation counters
- `x/{auth/vesting,bank,distribution,gov,staking,upgrade}` — msg-server and begin-blocker telemetry
- `telemetry/wrapper.go` — now-unused `MeasureSinceWithLabels` and `MessageCount`

No behavior change beyond metric emission.

## Testing performed to validate your change

- `go build ./...` and `go vet ./...`
- Package tests for the touched packages (`baseapp`, `store/...`, `tasks`, `x/...`)
- Confirmed no remaining `TODO(PLT-353)` references in the tree that is safe to remove for V6.6.
