### PR TITLE
feat(app): record app_block_gas_used per finalized block

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1327,7 +1327,7 @@ func (app *App) FinalizeBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock)
 			cms := app.WriteState()
 			app.LightInvarianceChecks(ctx.Context(), cms, app.lightInvarianceConfig)
 			appHash := app.GetWorkingHash()
-			resp := app.getFinalizeBlockResponse(appHash, events, txRes, endBlockResp, consensusParamUpdates)
+			resp := app.getFinalizeBlockResponse(ctx.Context(), appHash, events, txRes, endBlockResp, consensusParamUpdates)
 			if hasHeadNotifier {
 				headNotifier.Stash(req, &resp)
 			}
@@ -1357,7 +1357,7 @@ func (app *App) FinalizeBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock)
 	cms := app.WriteState()
 	app.LightInvarianceChecks(ctx.Context(), cms, app.lightInvarianceConfig)
 	appHash := app.GetWorkingHash()
-	resp := app.getFinalizeBlockResponse(appHash, events, txResults, endBlockResp, consensusParamUpdates)
+	resp := app.getFinalizeBlockResponse(ctx.Context(), appHash, events, txResults, endBlockResp, consensusParamUpdates)
 	if hasHeadNotifier {
 		headNotifier.Stash(req, &resp)
 	}
@@ -2318,6 +2318,7 @@ func (app *App) DecodeTransactionsConcurrently(ctx sdk.Context, txs [][]byte) []
 }
 
 func (app *App) getFinalizeBlockResponse(
+	ctx context.Context,
 	appHash []byte,
 	events []abci.Event,
 	txResults []*abci.ExecTxResult,
@@ -2327,6 +2328,14 @@ func (app *App) getFinalizeBlockResponse(
 	if app.EvmKeeper.EthReplayConfig.Enabled || app.EvmKeeper.EthBlockTestConfig.Enabled {
 		return abci.ResponseFinalizeBlock{}
 	}
+
+	// Both FinalizeBlocker paths that build a response converge here, so this records once
+	// per finalized block; ProcessBlock runs twice for a height whose optimistic result is
+	// discarded.
+	if gasUsed, ok := sumBlockGasUsed(txResults); ok {
+		appMetrics.blockGasUsed.Record(ctx, gasUsed)
+	}
+
 	return abci.ResponseFinalizeBlock{
 		Events:    events,
 		TxResults: txResults,
@@ -2339,6 +2348,24 @@ func (app *App) getFinalizeBlockResponse(
 		ConsensusParamUpdates: cloneConsensusParams(consensusParamUpdates),
 		AppHash:               appHash,
 	}
+}
+
+// sumBlockGasUsed totals the gas consumed by every non-nil transaction result in a block.
+// It reports false when a result carries negative gas or when the total overflows int64;
+// the total is then meaningless and callers must discard it.
+func sumBlockGasUsed(txResults []*abci.ExecTxResult) (int64, bool) {
+	var total int64
+	for _, txResult := range txResults {
+		if txResult == nil {
+			continue
+		}
+		gasUsed := txResult.GasUsed
+		if gasUsed < 0 || total > math.MaxInt64-gasUsed {
+			return 0, false
+		}
+		total += gasUsed
+	}
+	return total, true
 }
 
 func cloneConsensusParams(params *tmproto.ConsensusParams) *tmproto.ConsensusParams {

--- a/app/block_gas_used_test.go
+++ b/app/block_gas_used_test.go
@@ -1,0 +1,61 @@
+package app
+
+import (
+	"math"
+	"testing"
+
+	"github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
+	"github.com/stretchr/testify/require"
+)
+
+// gasUsedResults builds one ExecTxResult per gas value, matching the shape
+// FinalizeBlock hands to sumBlockGasUsed.
+func gasUsedResults(gasUsed ...int64) []*types.ExecTxResult {
+	results := make([]*types.ExecTxResult, 0, len(gasUsed))
+	for _, g := range gasUsed {
+		results = append(results, &types.ExecTxResult{GasUsed: g})
+	}
+	return results
+}
+
+// TestSumBlockGasUsedEmptyBlock records a zero total for a block with no transactions, so
+// the histogram carries one sample per finalized block.
+func TestSumBlockGasUsedEmptyBlock(t *testing.T) {
+	total, ok := sumBlockGasUsed(nil)
+	require.True(t, ok)
+	require.Zero(t, total)
+}
+
+// TestSumBlockGasUsedSumsResults covers the ordinary path.
+func TestSumBlockGasUsedSumsResults(t *testing.T) {
+	total, ok := sumBlockGasUsed(gasUsedResults(21_000, 100_000, 0, 5_000_000))
+	require.True(t, ok)
+	require.Equal(t, int64(5_121_000), total)
+}
+
+// TestSumBlockGasUsedSkipsNilResults exercises the nil-entry branch of the accounting loop.
+func TestSumBlockGasUsedSkipsNilResults(t *testing.T) {
+	results := []*types.ExecTxResult{nil, {GasUsed: 21_000}, nil, {GasUsed: 42_000}}
+	total, ok := sumBlockGasUsed(results)
+	require.True(t, ok)
+	require.Equal(t, int64(63_000), total)
+}
+
+// TestSumBlockGasUsedRejectsNegativeGas exercises the negative-gas branch.
+func TestSumBlockGasUsedRejectsNegativeGas(t *testing.T) {
+	_, ok := sumBlockGasUsed(gasUsedResults(21_000, -1))
+	require.False(t, ok)
+}
+
+// TestSumBlockGasUsedRejectsOverflow exercises the int64 overflow branch.
+func TestSumBlockGasUsedRejectsOverflow(t *testing.T) {
+	_, ok := sumBlockGasUsed(gasUsedResults(math.MaxInt64, 1))
+	require.False(t, ok)
+}
+
+// TestSumBlockGasUsedAcceptsExactInt64Max confirms the overflow guard is not off by one.
+func TestSumBlockGasUsedAcceptsExactInt64Max(t *testing.T) {
+	total, ok := sumBlockGasUsed(gasUsedResults(math.MaxInt64-1, 1))
+	require.True(t, ok)
+	require.Equal(t, int64(math.MaxInt64), total)
+}

--- a/app/consensus_params_test.go
+++ b/app/consensus_params_test.go
@@ -56,6 +56,7 @@ func TestGetFinalizeBlockResponsePropagatesFullConsensusParams(t *testing.T) {
 
 	app := &App{}
 	resp := app.getFinalizeBlockResponse(
+		t.Context(),
 		[]byte("hash"),
 		nil,
 		nil,

--- a/app/metrics.go
+++ b/app/metrics.go
@@ -25,7 +25,9 @@ var (
 		0.000025, 0.000050, 0.0001, 0.0005, 0.001, 0.0025, 0.005, 0.010, 0.020, 0.050, 0.075, 0.1, 0.25, 0.5, 1, 10,
 	)
 
-	// blockGasWantedBuckets covers the 0–50 M gas range (current MaxGasWanted cap)
+	// blockGasWantedBuckets covers the 0–50 M gas range (current MaxGasWanted cap).
+	// The per-block gas wanted and gas used histograms share it: a transaction's gas
+	// used is bounded by its gas wanted, so the same cap bounds both block totals.
 	blockGasWantedBuckets = metric.WithExplicitBucketBoundaries(
 		10e3, 25e3, 50e3, 100e3, 250e3, 500e3,
 		1e6, 2.5e6, 5e6, 10e6, 12.5e6, 25e6, 50e6,
@@ -66,6 +68,7 @@ var (
 		// Per-block gas utilisation
 		blockGasWanted      metric.Int64Histogram
 		blockGasWantedRatio metric.Float64Histogram
+		blockGasUsed        metric.Int64Histogram
 
 		// Light invariance check
 		invarianceDuration      metric.Float64Histogram
@@ -178,6 +181,16 @@ var (
 			metric.WithDescription("Per-block ratio of total gas wanted to MaxGasWanted consensus parameter"),
 			metric.WithUnit("1"),
 			blockGasWantedRatioBuckets,
+		)),
+
+		blockGasUsed: must(meter.Int64Histogram(
+			"app_block_gas_used",
+			metric.WithDescription("Per-block total gas used across all transactions. Recorded on "+
+				"FinalizeBlock, so unlike app_block_gas_wanted (recorded on ProcessProposal) it has "+
+				"samples during block/state sync with no matching gas_wanted sample -- do not divide "+
+				"the two without accounting for that"),
+			metric.WithUnit("{gas}"),
+			blockGasWantedBuckets,
 		)),
 
 		invarianceDuration: must(meter.Float64Histogram(


### PR DESCRIPTION
## Why

sei-load's Load Test Client dashboard has a Gas Used panel that depends on sei-load's own `--track-blocks` WebSocket subscription, which most load profiles run without — so the panel shows no data. The fix is to repoint the dashboard at a node-side metric instead of sei-load's own observation of the chain.

Block Number and Block Time already have exact node-side equivalents (`tendermint_consensus_latest_block_height`, `tendermint_consensus_block_interval_seconds_bucket`). Gas Used did not: `app_tx_gas{type="gas_used"}` is a per-tx cumulative counter with no block-height label (a rate, not a per-block distribution), and it also misses both giga execution paths. `app_block_gas_wanted` is per-block but measures *wanted*, not *used*.

## What

Adds `app_block_gas_used`, an OTel histogram recorded once per finalized block, mirroring `app_block_gas_wanted`'s shape:

- Recorded inside `getFinalizeBlockResponse`, the one place both `FinalizeBlocker` return paths that build a response converge — so it fires exactly once per finalized block, not once per `ProcessBlock` call (which can run twice for a height whose optimistic result is discarded).
- `sumBlockGasUsed` totals `ExecTxResult.GasUsed` across the block, skipping nil entries and guarding int64 overflow. On overflow or a negative entry it skips the record rather than recording a wrapped value — unreachable in practice (would need ~9.2e18 gas against a 50M `MaxGasWanted` cap) but consensus-critical code gets the defensive guard anyway.
- Reuses `blockGasWantedBuckets`: a tx's gas used is bounded by its gas wanted, so both block totals sit under the same 50M cap.
- `app_block_gas_used` and `app_block_gas_wanted` record on different ABCI phases (FinalizeBlock vs. ProcessProposal), so a block-syncing or state-syncing node emits `gas_used` samples with no matching `gas_wanted` sample. Documented on the metric description rather than fixed — nothing depends on dividing the two today.

## Verification

```
gofmt -l app/metrics.go app/app.go app/consensus_params_test.go app/block_gas_used_test.go   # exit 0
go vet ./app/...                                                                              # exit 0
go build ./app/...                                                                            # exit 0
go test ./app/ -run 'TestSumBlockGasUsed|TestGetFinalizeBlockResponsePropagatesFullConsensusParams' -count=1   # PASS, 7/7
go test ./app/ -race -run '<same>' -count=1                                                  # PASS
golangci-lint run ./app/...                                                                   # one pre-existing goconst finding, confirmed unrelated by diffing against a stash
```

Not run: the full `./app/...` test suite (out of scope for a single new metric touching no existing behavior) and CI-pinned `golangci-lint` v2.8.0 (local run used v2.12.2).

## Blast radius

`getFinalizeBlockResponse` is unexported; its only callers are the two `FinalizeBlocker` paths (`app/app.go`) plus one test (`app/consensus_params_test.go`), all updated for the new leading `context.Context` parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)