### PR TITLE
Remove PLT-343 legacy metrics superseded by OTel

### DIFF
--- a/app/legacyabci/begin_block.go
+++ b/app/legacyabci/begin_block.go
@@ -3,7 +3,6 @@ package legacyabci
 import (
 	"time"
 
-	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	abci "github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
 
@@ -44,8 +43,6 @@ func BeginBlock(
 	start := time.Now()
 	defer func() {
 		legacyAbciMetrics.totalBeginBlockDuration.Record(ctx.Context(), time.Since(start).Seconds())
-		// TODO(PLT-343): remove once begin_blocker_duration verified
-		telemetry.MeasureSince(start, "module", "total_begin_block")
 	}()
 
 	keepers.EpochKeeper.BeginBlock(ctx)

--- a/app/legacyabci/check_tx.go
+++ b/app/legacyabci/check_tx.go
@@ -10,10 +10,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
-	gometrics "github.com/armon/go-metrics"
 	"github.com/sei-protocol/sei-chain/app/ante"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/client"
-	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/utils/tracing"
@@ -56,14 +54,6 @@ func CheckTx(
 	txStart := time.Now()
 	defer func() {
 		legacyAbciMetrics.txDuration.Record(ctx.Context(), time.Since(txStart).Seconds(), otelmetric.WithAttributes(attribute.String("mode", label)))
-		// TODO(PLT-343): remove once tx_duration verified
-		telemetry.MeasureThroughputSinceWithLabels(
-			telemetry.TxCount,
-			[]gometrics.Label{
-				telemetry.NewLabel("mode", label),
-			},
-			txStart,
-		)
 	}()
 	spanCtx, span := tracingInfo.StartWithContext("CheckTx", ctx.TraceSpanContext())
 	defer span.End()

--- a/app/legacyabci/deliver_tx.go
+++ b/app/legacyabci/deliver_tx.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/armon/go-metrics"
 	"github.com/sei-protocol/sei-chain/app/ante"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/client"
-	"github.com/sei-protocol/sei-chain/sei-cosmos/telemetry"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/utils/tracing"
@@ -51,14 +49,6 @@ func DeliverTx(
 	txStart := time.Now()
 	defer func() {
 		legacyAbciMetrics.txDuration.Record(ctx.Context(), time.Since(txStart).Seconds(), otelmetric.WithAttributes(attribute.String("mode", "deliver")))
-		// TODO(PLT-343): remove once tx_duration verified
-		telemetry.MeasureThroughputSinceWithLabels(
-			telemetry.TxCount,
-			[]metrics.Label{
-				telemetry.NewLabel("mode", "deliver"),
-			},
-			txStart,
-		)
 	}()
 	// check for existing parent tracer, and if applicable, use it
 	spanCtx, span := tracingInfo.StartWithContext("DeliverTx", ctx.TraceSpanContext())

--- a/sei-cosmos/telemetry/wrapper.go
+++ b/sei-cosmos/telemetry/wrapper.go
@@ -11,7 +11,6 @@ const (
 	MetricKeyBeginBlocker = "begin_blocker"
 	MetricKeyEndBlocker   = "end_blocker"
 	MetricLabelNameModule = "module"
-	TxCount               = "transaction"
 )
 
 // NewLabel creates a new instance of Label with name and value
@@ -42,12 +41,6 @@ func IncrCounterWithLabels(keys []string, val float32, labels []metrics.Label) {
 	metrics.IncrCounterWithLabels(keys, val, append(labels, globalLabels...))
 }
 
-// SetGauge provides a wrapper functionality for emitting a gauge metric with
-// global labels (if any).
-func SetGauge(val float32, keys ...string) {
-	metrics.SetGaugeWithLabels(keys, val, globalLabels)
-}
-
 // SetGaugeWithLabels provides a wrapper functionality for emitting a gauge
 // metric with global labels (if any) along with the provided labels.
 func SetGaugeWithLabels(keys []string, val float32, labels []metrics.Label) {
@@ -70,17 +63,5 @@ func IncrValidatorSlashedCounter(validator string, slashingType string) {
 			NewLabel("type", slashingType),
 			NewLabel("validator", validator),
 		},
-	)
-}
-
-// Measures throughput
-// Metric Name:
-//
-//	sei_throughput_<metric_name>
-func MeasureThroughputSinceWithLabels(metricName string, labels []metrics.Label, start time.Time) {
-	metrics.MeasureSinceWithLabels(
-		[]string{"sei", "cosmos", "throughput", metricName},
-		start.UTC(),
-		labels,
 	)
 }

--- a/wasmbinding/metrics.go
+++ b/wasmbinding/metrics.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	sdkerrors "github.com/sei-protocol/sei-chain/sei-cosmos/types/errors"
-	"github.com/sei-protocol/sei-chain/utils/metrics"
 	evmtypes "github.com/sei-protocol/sei-chain/x/evm/types"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -55,6 +54,4 @@ func recordQueryError(ctx context.Context, scenario string, err error) {
 			attribute.String("codespace", codespace),
 		))
 	}
-	// TODO(PLT-343): remove once wasm_query_association_error and wasm_query_sdk_error verified
-	metrics.IncrementErrorMetrics(scenario, err)
 }


### PR DESCRIPTION
## Summary
- Drop go-metrics/telemetry calls flagged with PLT-343 now that OTel equivalents are in place
- Remove unused telemetry helpers (`TxCount`, `SetGauge`, `MeasureThroughputSinceWithLabels`)
- Touches legacy ABCI (begin block, check/deliver tx) and wasmbinding error metrics

Related dashboard migration pr: [1631](https://github.com/sei-protocol/platform/pull/1631)