### PR TITLE
Validate block part Merkle proof totals (CON-412)

### DIFF
--- a/sei-tendermint/types/part_set.go
+++ b/sei-tendermint/types/part_set.go
@@ -302,6 +302,11 @@ func (ps *PartSet) AddPart(part *Part) (bool, error) {
 		return false, nil
 	}
 
+	// The proof should be compatible with the number of parts.
+	if part.Proof.Total != int64(ps.total) {
+		return false, ErrPartSetInvalidProof
+	}
+
 	// Check hash proof
 	if part.Proof.Verify(ps.Hash(), part.Bytes) != nil {
 		return false, ErrPartSetInvalidProof

--- a/sei-tendermint/types/part_set_test.go
+++ b/sei-tendermint/types/part_set_test.go
@@ -114,6 +114,43 @@ func TestAddPartWithSwappedProof(t *testing.T) {
 	assert.Contains(t, err.Error(), "does not match proof index")
 }
 
+func TestAddPartRejectsMismatchedProofTotal(t *testing.T) {
+	// Setup: 3-part set so the last leaf is the right child of the root.
+	data := tmrand.Bytes(testPartSize * 3)
+	source := NewPartSetFromData(data, testPartSize)
+	require.EqualValues(t, 3, source.Total())
+	last := source.GetPart(2)
+	genuine := source.GetPart(1)
+
+	// Relabel the last part into slot 1 as a 2-leaf tree; keep the same aunts.
+	proof := last.Proof
+	proof.Index = 1
+	proof.Total = 2
+	malicious := &Part{
+		Index: 1,
+		Bytes: last.Bytes,
+		Proof: proof,
+	}
+
+	// Test: CON-20 and Merkle verification both accept the relabelled part.
+	require.NoError(t, malicious.ValidateBasic())
+	require.NoError(t, malicious.Proof.Verify(source.Hash(), malicious.Bytes))
+
+	collector := NewPartSetFromHeader(source.Header())
+	added, err := collector.AddPart(malicious)
+
+	// Verify: AddPart rejects the forged total and still accepts the genuine slot.
+	assert.False(t, added)
+	assert.ErrorIs(t, err, ErrPartSetInvalidProof)
+	assert.Nil(t, collector.GetPart(1))
+	assert.EqualValues(t, 0, collector.Count())
+
+	added, err = collector.AddPart(genuine)
+	require.True(t, added)
+	require.NoError(t, err)
+	assert.Equal(t, genuine.Bytes, collector.GetPart(1).Bytes)
+}
+
 func TestPartSetHeaderValidateBasic(t *testing.T) {
 	testCases := []struct {
 		testName              string


### PR DESCRIPTION
## Summary
- Reject block parts whose Merkle `Proof.Total` does not match the PartSet size, so a non-power-of-two last leaf cannot be relabelled into an earlier first-writer-wins slot.
- Same guard CometBFT already has in `PartSet.AddPart`; CON-20's index check is not enough because the attacker sets `Part.Index == Proof.Index` on the stolen slot.
- Add a 3-part test where `ValidateBasic` and `Proof.Verify` still succeed, `AddPart` rejects, and the genuine part still fills the slot.

## Test plan
- [x] `go test ./sei-tendermint/types/... -run 'TestAddPartRejectsMismatchedProofTotal|TestBasicPartSet|TestWrongProof|TestAddPartWithSwappedProof'`
- [ ] New test fails without the `Proof.Total` guard and passes with it


Made with [Cursor](https://cursor.com)