### PR TITLE
Backport `release/v6.7`: Update changelog in prep to cut v6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
-## Unreleased
+## v6.7
 
 ### Improvements
 * [#3818](https://github.com/sei-protocol/sei-chain/pull/3818) feat(evmrpc): extend HTTP admission control (`max_request_body_bytes`, `max_concurrent_request_bytes`, `ws_admission_timeout`) to the WebSocket plane (:8546). WS oversize frames close with WebSocket close code 1009; budget-wait timeouts return JSON-RPC error `-32005` before the connection closes. `evmrpc_requests_rejected_total` gains a `protocol` label (`http` / `ws`).
@@ -44,6 +44,286 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * **WebSocket frame size default drops from 10 MiB to 5 MiB.** Before this release, :8546 used a hardcoded 10 MiB frame cap. Both HTTP and WebSocket now share `[evm].max_request_body_bytes`, whose default is 5 MiB (`5242880`). WS clients that send frames in the 5-10 MiB range (large `eth_sendRawTransaction` batches, wide filter payloads, etc.) will be disconnected after upgrade unless the limit is raised. **Operators who relied on the old 10 MiB WS cap should set `max_request_body_bytes = 10485760` in `app.toml` before upgrading.** This also raises the HTTP body limit to 10 MiB. The exported `DefaultWebsocketMaxMessageSize` constant was removed; use the config knob instead.
 * [#3984](https://github.com/sei-protocol/sei-chain/pull/3984) **ABCI/gRPC pagination is now capped by default.** Untrusted callers requesting `limit` above 1000, `offset` above 10000, or a scan that exceeds 11000 total iterations now get `InvalidArgument` (over-cap) or a partial page with `next_key` (budget exhausted) instead of the previously unbounded scan. Clients that page with large limits/offsets, or trusted internal indexers, should either follow `next_key` for resumption or be added to the new `[query] trusted-cidrs` allowlist (or set `[query] disable-limits = true`) before upgrading.
 * [#3927](https://github.com/sei-protocol/sei-chain/pull/3927) **Legacy Sei JSON-RPC and CLI removal.** Removes `sei_associate`, `sei_getBlockByHash`, `sei_getBlockByHashExcludeTraceFail`, `sei_getBlockTransactionCountByHash`, `sei_getBlockTransactionCountByNumber`, `sei_getEvmTx`, `sei_getFilterChanges`, `sei_getFilterLogs`, `sei_getLogs`, `sei_getTransactionByBlockHashAndIndex`, `sei_getTransactionByBlockNumberAndIndex`, `sei_getTransactionByHash`, `sei_getTransactionCount`, `sei_getTransactionErrorByHash`, `sei_getTransactionReceiptExcludeTraceFail`, `sei_getVMError`, `sei_newBlockFilter`, `sei_newFilter`, `sei_sign`, and `sei_uninstallFilter`. Use standard `eth_*` methods for EVM-originated data and `seid tx evm native-associate <custom-message> -y` for address association. There is no block- or filter-level replacement for discovering Cosmos-originated synthetic logs; clients that know the synthetic transaction hash can enable `sei_getTransactionReceipt`.
+
+sei-chain
+* [#4095](https://github.com/sei-protocol/sei-chain/pull/4095) Backport `release/v6.7`: fix FlatKV cache memory leak
+* [#4074](https://github.com/sei-protocol/sei-chain/pull/4074) Backport `release/v6.7`: fix(precompiles): disable Wasmd execute_batch
+* [#4063](https://github.com/sei-protocol/sei-chain/pull/4063) Backport `release/v6.7`: Upgrade UCI AI review to latest and allow review of PRs from seidroid
+* [#4054](https://github.com/sei-protocol/sei-chain/pull/4054) Backport `release/v6.7`: Validate snapshots before publication
+* [#4051](https://github.com/sei-protocol/sei-chain/pull/4051) Backport `release/v6.7`: Fix memiavl snapshot race condition
+* [#4049](https://github.com/sei-protocol/sei-chain/pull/4049) Backport `release/v6.7`: Bound frozen RPC router batch allocations
+* [#4047](https://github.com/sei-protocol/sei-chain/pull/4047) Backport `release/v6.7`: Attach a static linux/arm64 seid binary to releases
+* [#4035](https://github.com/sei-protocol/sei-chain/pull/4035) Backport `release/v6.7`: Bound block reference parsing depth
+* [#4017](https://github.com/sei-protocol/sei-chain/pull/4017) Preserve legacy IBC governance decoding
+* [#4016](https://github.com/sei-protocol/sei-chain/pull/4016) Remove stale ibc from v6.7 module version map
+* [#4015](https://github.com/sei-protocol/sei-chain/pull/4015) Remove unreferenced IBC core
+* [#4014](https://github.com/sei-protocol/sei-chain/pull/4014) Detach applications from retired IBC core
+* [#4013](https://github.com/sei-protocol/sei-chain/pull/4013) Fix intermittent failures in buf breaking change check
+* [#4010](https://github.com/sei-protocol/sei-chain/pull/4010) Simplify retired IBC transaction rejection
+* [#4008](https://github.com/sei-protocol/sei-chain/pull/4008) Retire remaining CosmWasm IBC execution
+* [#4003](https://github.com/sei-protocol/sei-chain/pull/4003) Use iterative traversal for memiavl snapshot writes
+* [#4002](https://github.com/sei-protocol/sei-chain/pull/4002) Remove retired IBC query APIs
+* [#4001](https://github.com/sei-protocol/sei-chain/pull/4001) Stop AI workflows from running on submitted reviews
+* [#3997](https://github.com/sei-protocol/sei-chain/pull/3997) feat(cosmos): return errors from NewDecCoinsFromCoins (CON-370)
+* [#3996](https://github.com/sei-protocol/sei-chain/pull/3996) fix(sei-tendermint): address mac/linux test node divergence
+* [#3991](https://github.com/sei-protocol/sei-chain/pull/3991) fix(metrics): wire pending nonce events in mempool OTel counter (PLT-1017)
+* [#3990](https://github.com/sei-protocol/sei-chain/pull/3990) Disable mempool traffic in freeze mode
+* [#3989](https://github.com/sei-protocol/sei-chain/pull/3989) Add frozen RPC router and Docker integration cluster
+* [#3988](https://github.com/sei-protocol/sei-chain/pull/3988) Remove unreachable IBC channel handshake logic
+* [#3987](https://github.com/sei-protocol/sei-chain/pull/3987) Test gas gating in weighted vote
+* [#3984](https://github.com/sei-protocol/sei-chain/pull/3984) feat(query): origin-aware pagination limits for ABCI queries
+* [#3982](https://github.com/sei-protocol/sei-chain/pull/3982) Upgrade to latest UCI AI review
+* [#3981](https://github.com/sei-protocol/sei-chain/pull/3981) Remove live IBC transfer module
+* [#3980](https://github.com/sei-protocol/sei-chain/pull/3980) Remove capability module
+* [#3977](https://github.com/sei-protocol/sei-chain/pull/3977) [ConfigManager] Register Sections 4/4
+* [#3976](https://github.com/sei-protocol/sei-chain/pull/3976) [ConfigManager] Register Sections 3/4
+* [#3975](https://github.com/sei-protocol/sei-chain/pull/3975) [ConfigManager] Register Sections 2/4
+* [#3974](https://github.com/sei-protocol/sei-chain/pull/3974) [ConfigManager] Register Sections 1/4
+* [#3973](https://github.com/sei-protocol/sei-chain/pull/3973) [ConfigManager] Install resolved configuration into the boot source
+* [#3971](https://github.com/sei-protocol/sei-chain/pull/3971) script for running tests in RAM
+* [#3970](https://github.com/sei-protocol/sei-chain/pull/3970) fix(types): return false for coin denomination mismatches
+* [#3969](https://github.com/sei-protocol/sei-chain/pull/3969) Separate BlockStore and BlockDB interface
+* [#3968](https://github.com/sei-protocol/sei-chain/pull/3968) Upgrade to AI review to the latest UCI v0.0.18
+* [#3967](https://github.com/sei-protocol/sei-chain/pull/3967) feat(sei-db): roll back state store from snapshot and WAL
+* [#3964](https://github.com/sei-protocol/sei-chain/pull/3964) Update v6.6 change log in prep to cut v6.6.2 patch
+* [#3963](https://github.com/sei-protocol/sei-chain/pull/3963) utility for running unit tests against RAM disk
+* [#3962](https://github.com/sei-protocol/sei-chain/pull/3962) Handle new modules and common files in version bump
+* [#3961](https://github.com/sei-protocol/sei-chain/pull/3961) Generate v6.7 precompiles
+* [#3959](https://github.com/sei-protocol/sei-chain/pull/3959) test(sei-db): wait for the flush before releasing the snapshot
+* [#3958](https://github.com/sei-protocol/sei-chain/pull/3958) Remove feegrant module
+* [#3956](https://github.com/sei-protocol/sei-chain/pull/3956) fix(gov): harden deposit refund handling
+* [#3955](https://github.com/sei-protocol/sei-chain/pull/3955) fix(bank): reduce complexity in multisend validation
+* [#3952](https://github.com/sei-protocol/sei-chain/pull/3952) [ConfigManager] Sei Config File
+* [#3950](https://github.com/sei-protocol/sei-chain/pull/3950) fix(evmrpc): unexport RPC-adjacent helper methods to prevent unintended JSON-RPC registration
+* [#3949](https://github.com/sei-protocol/sei-chain/pull/3949) metrics: refine block gas histogram buckets (PLT-1002)
+* [#3947](https://github.com/sei-protocol/sei-chain/pull/3947) Deprecate IBC write handlers
+* [#3945](https://github.com/sei-protocol/sei-chain/pull/3945) Remove support for `sei_getTransactionReceipt` API
+* [#3944](https://github.com/sei-protocol/sei-chain/pull/3944) Deprecate oracle message and query handlers
+* [#3943](https://github.com/sei-protocol/sei-chain/pull/3943) [ConfigManager] Config Registry
+* [#3942](https://github.com/sei-protocol/sei-chain/pull/3942) [ConfigManager] Remove redundant test coverage
+* [#3940](https://github.com/sei-protocol/sei-chain/pull/3940) Add context cancellation to SS DB layer
+* [#3937](https://github.com/sei-protocol/sei-chain/pull/3937) Remove legacy commit hash validation fallback
+* [#3936](https://github.com/sei-protocol/sei-chain/pull/3936) Refine review config to consider on chain params
+* [#3935](https://github.com/sei-protocol/sei-chain/pull/3935) fix(evmrpc): don't charge an innocent client's per-IP bucket on mid-read budget exhaustion
+* [#3934](https://github.com/sei-protocol/sei-chain/pull/3934) removed consensus timeout overrides from config
+* [#3933](https://github.com/sei-protocol/sei-chain/pull/3933) Refine review context on cosmos gasless tx
+* [#3932](https://github.com/sei-protocol/sei-chain/pull/3932) Split the musl cgo link path by architecture
+* [#3929](https://github.com/sei-protocol/sei-chain/pull/3929) Complete multi-epoch ownership across Autobahn layers (CON-358)
+* [#3928](https://github.com/sei-protocol/sei-chain/pull/3928) Remove metadata DB
+* [#3927](https://github.com/sei-protocol/sei-chain/pull/3927) Remove remaining unused legacy sei_* APIs
+* [#3926](https://github.com/sei-protocol/sei-chain/pull/3926) Remove support for eth_getProof
+* [#3924](https://github.com/sei-protocol/sei-chain/pull/3924) Remove unused legacy `sei_*` block APIs
+* [#3923](https://github.com/sei-protocol/sei-chain/pull/3923) Use unique hashes in concurrent nonce test
+* [#3922](https://github.com/sei-protocol/sei-chain/pull/3922) removed defaults for RouterOptions.Dial/AcceptRate
+* [#3921](https://github.com/sei-protocol/sei-chain/pull/3921) Fix UCI AI review trigger for explicit review ask
+* [#3920](https://github.com/sei-protocol/sei-chain/pull/3920) Bump sei go-ethereum to v1.15.7-sei-20
+* [#3919](https://github.com/sei-protocol/sei-chain/pull/3919) feat(seidb): add exact-version state store snapshots
+* [#3916](https://github.com/sei-protocol/sei-chain/pull/3916) fix(p2p): bound the inbound node-info exchange by the handshake deadline
+* [#3915](https://github.com/sei-protocol/sei-chain/pull/3915) Upgreade UCI AI review and assist pipeline to latest
+* [#3914](https://github.com/sei-protocol/sei-chain/pull/3914) fix(evmrpc): honor trace_timeout in profiled debug_traceBlock path (PLT-989)
+* [#3912](https://github.com/sei-protocol/sei-chain/pull/3912) Remove `sei2_*` API support and implementation
+* [#3911](https://github.com/sei-protocol/sei-chain/pull/3911) Add per-IP rate limiting to CometBFT RPC HTTP
+* [#3910](https://github.com/sei-protocol/sei-chain/pull/3910) Add freeze mode for historical EVM RPC
+* [#3909](https://github.com/sei-protocol/sei-chain/pull/3909) fix(evmrpc): fail closed on pruned receipt heights for getBlock* endpoints (PLT-979)
+* [#3906](https://github.com/sei-protocol/sei-chain/pull/3906) Recognize live AppHash rejection as loud failure
+* [#3905](https://github.com/sei-protocol/sei-chain/pull/3905) block production fix + loadtest-related utilities
+* [#3901](https://github.com/sei-protocol/sei-chain/pull/3901) Revert "Enable seidroid xreview on sei-chain (#3830)"
+* [#3899](https://github.com/sei-protocol/sei-chain/pull/3899) fix(p2p): make the inbound accept rate configurable and raise its default
+* [#3893](https://github.com/sei-protocol/sei-chain/pull/3893) feat(precompiles): add scoped module authorizations
+* [#3887](https://github.com/sei-protocol/sei-chain/pull/3887) fix(flatkv): report snapshots a rollback could not remove
+* [#3886](https://github.com/sei-protocol/sei-chain/pull/3886) test(receipt): pin logHeapStructOverhead against types.Log layout (PLT-958)
+* [#3885](https://github.com/sei-protocol/sei-chain/pull/3885) feat(seeds): ship Sei Labs seeds as the default bootstrap-peers
+* [#3882](https://github.com/sei-protocol/sei-chain/pull/3882) Remove all IBC code in test scope
+* [#3881](https://github.com/sei-protocol/sei-chain/pull/3881) Remove interchain swagger API and protos
+* [#3879](https://github.com/sei-protocol/sei-chain/pull/3879) Update go-releaser heading with experimental notice
+* [#3876](https://github.com/sei-protocol/sei-chain/pull/3876) Update v6.6 changelog in prep to cut patch release
+* [#3875](https://github.com/sei-protocol/sei-chain/pull/3875) Remove unused interchain accounts implementation
+* [#3872](https://github.com/sei-protocol/sei-chain/pull/3872) Close temporary rootmulti store in connection types setup
+* [#3871](https://github.com/sei-protocol/sei-chain/pull/3871) fix(evm): count post-admission apply failures in dynamic base-fee gas (CON-359)
+* [#3870](https://github.com/sei-protocol/sei-chain/pull/3870) test(config): complete the GetConfig read-site coverage (PLT-893)
+* [#3869](https://github.com/sei-protocol/sei-chain/pull/3869) fix(flatkv): preserve empty misc values and reject malformed empty node imports
+* [#3868](https://github.com/sei-protocol/sei-chain/pull/3868) Implement new Giga GarbageCollector interface
+* [#3867](https://github.com/sei-protocol/sei-chain/pull/3867) Restore LCD pagination while preserving v6.6 precompile semantics
+* [#3863](https://github.com/sei-protocol/sei-chain/pull/3863) Require matching ModeInfo and nested signature counts (CON-393)
+* [#3862](https://github.com/sei-protocol/sei-chain/pull/3862) feat(autobahn): implement new lane ID for epoch (CON-358)
+* [#3861](https://github.com/sei-protocol/sei-chain/pull/3861) test(config): extend golden value test coverage (PLT-893)
+* [#3859](https://github.com/sei-protocol/sei-chain/pull/3859) Migrate precompiles/bank and giga/deps metrics to OTel (PLT-912)
+* [#3858](https://github.com/sei-protocol/sei-chain/pull/3858) Migrate evmrpc, gaskv, and bank new-account metrics to OTel (PLT-911)
+* [#3856](https://github.com/sei-protocol/sei-chain/pull/3856) goreleaser: drop duplicate changelog + Full Changelog link from release notes
+* [#3855](https://github.com/sei-protocol/sei-chain/pull/3855) test(config): check which indexer and whether tracing is off, and stop one test changing another's config (PLT-893)
+* [#3853](https://github.com/sei-protocol/sei-chain/pull/3853) Fix edge case for per module lattice hash updates
+* [#3852](https://github.com/sei-protocol/sei-chain/pull/3852) Migrate sei-wasmd keeper contract and IBC relay metrics to OTel (PLT-910)
+* [#3851](https://github.com/sei-protocol/sei-chain/pull/3851) test(config): make a renamed configuration key fail the suite (PLT-893)
+* [#3850](https://github.com/sei-protocol/sei-chain/pull/3850) scripts: load generator for arctic-1 and atlantic-2
+* [#3849](https://github.com/sei-protocol/sei-chain/pull/3849) Refactor separating AppQC from CommitQC
+* [#3847](https://github.com/sei-protocol/sei-chain/pull/3847) Remove redundant libstdc++6 installation
+* [#3846](https://github.com/sei-protocol/sei-chain/pull/3846) feat(precompiles): add scoped vote authorization flow
+* [#3844](https://github.com/sei-protocol/sei-chain/pull/3844) Replace legacy WAL
+* [#3843](https://github.com/sei-protocol/sei-chain/pull/3843) perf(evm): memoize deliver GetCode (+ giga); fix pointer upsert Multistore write target (CON-361)
+* [#3841](https://github.com/sei-protocol/sei-chain/pull/3841) Bump sei go-ethereum to v1.15.7-sei-19
+* [#3839](https://github.com/sei-protocol/sei-chain/pull/3839) Extend tx decoder canonical-size check to AuthInfo (CON-343)
+* [#3838](https://github.com/sei-protocol/sei-chain/pull/3838) fix(seidb-bench): stop the state-store bench backends fail on a nil config
+* [#3837](https://github.com/sei-protocol/sei-chain/pull/3837) test(config): pin the section-level env shadow, and make the parity comparison deterministic (PLT-775)
+* [#3836](https://github.com/sei-protocol/sei-chain/pull/3836) fix(evmrpc): stream request-body budget charging to close slowloris gap (PLT-780)
+* [#3835](https://github.com/sei-protocol/sei-chain/pull/3835) StateWAL + FlatKV
+* [#3833](https://github.com/sei-protocol/sei-chain/pull/3833) fix(evidence): remove unused GetAllEvidence call in AllEvidence query
+* [#3832](https://github.com/sei-protocol/sei-chain/pull/3832) Bump goja version (CON-366)
+* [#3831](https://github.com/sei-protocol/sei-chain/pull/3831) fix(autobahn): prevent block-sync livelock after restart catch-up
+* [#3830](https://github.com/sei-protocol/sei-chain/pull/3830) Enable seidroid xreview on sei-chain
+* [#3829](https://github.com/sei-protocol/sei-chain/pull/3829) Add giga config and unify garbage collector logic
+* [#3827](https://github.com/sei-protocol/sei-chain/pull/3827) (Autobahn) load Block DB at the app tip on restart (CON-272)
+* [#3826](https://github.com/sei-protocol/sei-chain/pull/3826) fix(receipt): correct log heap struct overhead in eth_getLogs budget (PLT-862)
+* [#3825](https://github.com/sei-protocol/sei-chain/pull/3825) feat(precompiles): expose module Msg rpcs as precompile methods
+* [#3824](https://github.com/sei-protocol/sei-chain/pull/3824) fix(seidb): give FlatKV and memIAVL latency histograms explicit buckets
+* [#3823](https://github.com/sei-protocol/sei-chain/pull/3823) Fix PebbleDB iterator stack overflow
+* [#3819](https://github.com/sei-protocol/sei-chain/pull/3819) feat(seed): serve Prometheus metrics in seed mode
+* [#3818](https://github.com/sei-protocol/sei-chain/pull/3818) evmrpc: extend admission control to the WebSocket plane
+* [#3817](https://github.com/sei-protocol/sei-chain/pull/3817) fix(ss/composite): gate EVM kind parsing on the evm module in convertFlatKVNodes
+* [#3816](https://github.com/sei-protocol/sei-chain/pull/3816) test(config): characterize the legacy configuration surface with native fuzzing (PLT-775)
+* [#3814](https://github.com/sei-protocol/sei-chain/pull/3814) (CI) Remove redundant Docker Hub login from integration-tests matrix job
+* [#3813](https://github.com/sei-protocol/sei-chain/pull/3813) precompile: convert json/pointerview/p256 to dynamic-gas precompiles
+* [#3812](https://github.com/sei-protocol/sei-chain/pull/3812) fix(giga): fix flaky TestAvailClientServer test
+* [#3811](https://github.com/sei-protocol/sei-chain/pull/3811) perf(evm): cache BLOCKHASH via 32-byte hash ring (CON-372)
+* [#3810](https://github.com/sei-protocol/sei-chain/pull/3810) Align multisig SignatureData with bitarray invariants (CON-371)
+* [#3809](https://github.com/sei-protocol/sei-chain/pull/3809) perf(params): validate ConsensusParams once per change set (CON-312)
+* [#3808](https://github.com/sei-protocol/sei-chain/pull/3808) Snapshot Engine
+* [#3807](https://github.com/sei-protocol/sei-chain/pull/3807) Tolerate failed Codex review executions
+* [#3806](https://github.com/sei-protocol/sei-chain/pull/3806) Allow iteration to start at a specific key in littDB/blockDB
+* [#3805](https://github.com/sei-protocol/sei-chain/pull/3805) Upgrade to lates UCI AI review for skip label support
+* [#3804](https://github.com/sei-protocol/sei-chain/pull/3804) Bump sei-protocol/go-ethereum to v1.15.7-sei-18
+* [#3803](https://github.com/sei-protocol/sei-chain/pull/3803) Make boot-smoke gate deterministic (first boot RAYON_NUM_THREADS=1)
+* [#3801](https://github.com/sei-protocol/sei-chain/pull/3801) Harden GHCR image tag cleanup workflow
+* [#3799](https://github.com/sei-protocol/sei-chain/pull/3799) Add codecs for ReceiptDB with txIndex
+* [#3798](https://github.com/sei-protocol/sei-chain/pull/3798) fix(evmrpc): floor `earliest` state height at genesis InitialHeight (SEI-10383)
+* [#3795](https://github.com/sei-protocol/sei-chain/pull/3795) test(solo): add SIGN_MODE_LEGACY_AMINO_JSON test coverage (PLT-827)
+* [#3794](https://github.com/sei-protocol/sei-chain/pull/3794) Close merkle suite store during teardown
+* [#3793](https://github.com/sei-protocol/sei-chain/pull/3793) fix(ante): address association parity across EVM ante paths
+* [#3792](https://github.com/sei-protocol/sei-chain/pull/3792) fix(distribution): align withdraw-address checks with bank send restrictions
+* [#3791](https://github.com/sei-protocol/sei-chain/pull/3791) Harden account key validation
+* [#3790](https://github.com/sei-protocol/sei-chain/pull/3790) ci(PLT-825): run all Autobahn integration tests on every PR
+* [#3789](https://github.com/sei-protocol/sei-chain/pull/3789) Add new Storage interface for Giga executor
+* [#3788](https://github.com/sei-protocol/sei-chain/pull/3788) Add CommitBlock API for FlatKV
+* [#3787](https://github.com/sei-protocol/sei-chain/pull/3787) storage manager
+* [#3786](https://github.com/sei-protocol/sei-chain/pull/3786) Tests: Precompile Tests Phase 2 (PLT-372)
+* [#3785](https://github.com/sei-protocol/sei-chain/pull/3785) fix(evm/state): key overlay by address, journal SetStorage install, fix giga-path SetStorage
+* [#3784](https://github.com/sei-protocol/sei-chain/pull/3784) (autobahn-only) Reject empty tipcuts in Proposal.Verify
+* [#3779](https://github.com/sei-protocol/sei-chain/pull/3779) PLT-819: Wire fail-closed rate limiter + MethodParser into EVM JSON-RPC HTTP (:8545)
+* [#3777](https://github.com/sei-protocol/sei-chain/pull/3777) Tests: Precompile Tests Phase 1 (PLT-372)
+* [#3775](https://github.com/sei-protocol/sei-chain/pull/3775) WAL Benchmark
+* [#3774](https://github.com/sei-protocol/sei-chain/pull/3774) Add REVIEW.md guidelines for AI PR reviewers
+* [#3773](https://github.com/sei-protocol/sei-chain/pull/3773) special error when reading below watermark
+* [#3772](https://github.com/sei-protocol/sei-chain/pull/3772) feat(seidb-bench): add write-set replay adapter for opcode storage-cost measurement
+* [#3770](https://github.com/sei-protocol/sei-chain/pull/3770) fix(seidb-bench): tolerate nil FlatKV config in bench wrapper factory
+* [#3769](https://github.com/sei-protocol/sei-chain/pull/3769) LittDB compression
+* [#3768](https://github.com/sei-protocol/sei-chain/pull/3768) fix(giga): fall back to v2 on execution errors
+* [#3767](https://github.com/sei-protocol/sei-chain/pull/3767) feat(precompiles): expose module Query rpcs as precompile methods
+* [#3765](https://github.com/sei-protocol/sei-chain/pull/3765) Update v6.6 changelog in prep to cut rc4
+* [#3763](https://github.com/sei-protocol/sei-chain/pull/3763) fix stale blockDB godocs
+* [#3762](https://github.com/sei-protocol/sei-chain/pull/3762) ci: prevent runner disk exhaustion in integration + lint jobs (PLT-807)
+* [#3759](https://github.com/sei-protocol/sei-chain/pull/3759) feat(evmrpc): bound eth_getLogs peak memory with matched-log count and byte budgets
+* [#3758](https://github.com/sei-protocol/sei-chain/pull/3758) feature(sei-db) LTHash refactory for adding per module hash and stats
+* [#3755](https://github.com/sei-protocol/sei-chain/pull/3755) feat(ratelimiter): add MethodParser for pre-decode JSON-RPC method extraction (PLT-800)
+* [#3753](https://github.com/sei-protocol/sei-chain/pull/3753) fix(giga): route EVM validation failures to v2 fallback (CON-368)
+* [#3751](https://github.com/sei-protocol/sei-chain/pull/3751) feat(scripts): add SC read-path RPC probe (consistency check + load)
+* [#3750](https://github.com/sei-protocol/sei-chain/pull/3750) Use DBImpl for giga mock balance validation
+* [#3749](https://github.com/sei-protocol/sei-chain/pull/3749) Fix static seid SIGSEGV (pin pre-gcc-12 libgcc unwinder), add boot smoke gate, build binaries on manual tag pushes
+* [#3745](https://github.com/sei-protocol/sei-chain/pull/3745) Align FlatKV snapshot config with MemIAVL
+* [#3744](https://github.com/sei-protocol/sei-chain/pull/3744) Update v6.6 changelog in prep to cut rc3
+* [#3741](https://github.com/sei-protocol/sei-chain/pull/3741) feat(cosmos): range-check Dec conversions and DecCoin validation (CON-369)
+* [#3740](https://github.com/sei-protocol/sei-chain/pull/3740) fix(consensus): guard /consensus_state RPC against empty-validator-set divide-by-zero
+* [#3739](https://github.com/sei-protocol/sei-chain/pull/3739) fixed support for AllowEmptyBlocks = false for autobahn
+* [#3738](https://github.com/sei-protocol/sei-chain/pull/3738) fix(distribution): make delegation-reward queries read-only
+* [#3737](https://github.com/sei-protocol/sei-chain/pull/3737) precompile: price dynamic-gas calldata decoding by supplied gas
+* [#3734](https://github.com/sei-protocol/sei-chain/pull/3734) BlockDB: no orphaned blocks
+* [#3733](https://github.com/sei-protocol/sei-chain/pull/3733) Make telemetry metrics emission deterministic
+* [#3730](https://github.com/sei-protocol/sei-chain/pull/3730) Update v6.6 changelog in prep to cut rc2
+* [#3729](https://github.com/sei-protocol/sei-chain/pull/3729) fix(logging): demote per-mint bank log to Debug (mock_balances top-off spam)
+* [#3728](https://github.com/sei-protocol/sei-chain/pull/3728) Polish EVM migration logs
+* [#3727](https://github.com/sei-protocol/sei-chain/pull/3727) fix(docker): giga-mixed cluster silently ran all-giga; write explicit executor config + role guard
+* [#3726](https://github.com/sei-protocol/sei-chain/pull/3726) Make memiavl iterator snapshot rewrite deterministic
+* [#3725](https://github.com/sei-protocol/sei-chain/pull/3725) Revert "Fix seid rollback after deprecating cosmos pruning strategy"
+* [#3724](https://github.com/sei-protocol/sei-chain/pull/3724) fix(sei-tendermint): make empty validator-set proto round-trip lossless so state-sync can boot on gentx chains
+* [#3723](https://github.com/sei-protocol/sei-chain/pull/3723) ci: retry docker registry push/pull in integration tests via shared helper
+* [#3722](https://github.com/sei-protocol/sei-chain/pull/3722) fix(evmrpc): mask state overrides with a simulation-local storage overlay
+* [#3720](https://github.com/sei-protocol/sei-chain/pull/3720) fix(mock_balances): mempool readiness gate must see the mock top-off (empty-blocks regression)
+* [#3718](https://github.com/sei-protocol/sei-chain/pull/3718) Disable JS debug tracers by default with native tracer allowlist
+* [#3716](https://github.com/sei-protocol/sei-chain/pull/3716) Fix address distro bug
+* [#3715](https://github.com/sei-protocol/sei-chain/pull/3715) Stabilize websocket writeChan leak regression tests
+* [#3714](https://github.com/sei-protocol/sei-chain/pull/3714) deprecate vesting module while preserving all store/state
+* [#3713](https://github.com/sei-protocol/sei-chain/pull/3713) fix(evm): bound store-cache depth amplification from stacked EVM snapshots
+* [#3711](https://github.com/sei-protocol/sei-chain/pull/3711) feat(seidb): composite + replay digest modes and migration-boundary omission for evm-logical-digest
+* [#3710](https://github.com/sei-protocol/sei-chain/pull/3710) fix(feegrant): bound DenomsSubsetOf cost and cap allowance denoms
+* [#3708](https://github.com/sei-protocol/sei-chain/pull/3708) feat(indexer): push result cap and ordering into KV tx search (PLT-748)
+* [#3707](https://github.com/sei-protocol/sei-chain/pull/3707) feat(data): integrate LittDB-backed BlockDB into autobahn data layer (CON-272)
+* [#3705](https://github.com/sei-protocol/sei-chain/pull/3705) fix(composite): reset sticky commit-info latches on rollback across migration boundaries
+* [#3704](https://github.com/sei-protocol/sei-chain/pull/3704) Accept legacy cosmos_only SC write mode
+* [#3703](https://github.com/sei-protocol/sei-chain/pull/3703) add block number to ReadBlockByHash
+* [#3701](https://github.com/sei-protocol/sei-chain/pull/3701) State WAL replacement
+* [#3700](https://github.com/sei-protocol/sei-chain/pull/3700) Avoid localnode generated-dir cleanup race
+* [#3696](https://github.com/sei-protocol/sei-chain/pull/3696) refactor of sei-tendermint metrics
+* [#3693](https://github.com/sei-protocol/sei-chain/pull/3693) Fix rpc hash race condition
+* [#3692](https://github.com/sei-protocol/sei-chain/pull/3692) Add chain_id label to OTel metrics
+* [#3691](https://github.com/sei-protocol/sei-chain/pull/3691) feat(replay): historical_replay build tag for lenient tx decoder
+* [#3690](https://github.com/sei-protocol/sei-chain/pull/3690) Close temporary rootmulti store in channel types setup
+* [#3689](https://github.com/sei-protocol/sei-chain/pull/3689) feat(indexer): push result cap and ordering into KV block search (PLT-748)
+* [#3685](https://github.com/sei-protocol/sei-chain/pull/3685) Update changelog in prep to cut 6.6 RC1
+* [#3684](https://github.com/sei-protocol/sei-chain/pull/3684) Add offline rollback utility for LittDB
+* [#3683](https://github.com/sei-protocol/sei-chain/pull/3683) Cleanup blocksim benchmarks
+* [#3682](https://github.com/sei-protocol/sei-chain/pull/3682) prometheus metrics for autobahn/avail, autobahn/data and p2p/mux
+* [#3680](https://github.com/sei-protocol/sei-chain/pull/3680) Pin priority-fee assertions to stable heads
+* [#3678](https://github.com/sei-protocol/sei-chain/pull/3678) feat(configmanager): SeiConfigManager v2 body — validate-passthrough (PLT-775 PR2)
+* [#3677](https://github.com/sei-protocol/sei-chain/pull/3677) feat(evmrpc): bound debug_trace struct-logger memory via max_trace_struct_log_bytes (PLT-205)
+* [#3676](https://github.com/sei-protocol/sei-chain/pull/3676) hashlog cli
+* [#3675](https://github.com/sei-protocol/sei-chain/pull/3675) State Store: Compact pruned key range after each prune
+* [#3674](https://github.com/sei-protocol/sei-chain/pull/3674) Retry npm install for disable wasm integration test
+* [#3671](https://github.com/sei-protocol/sei-chain/pull/3671) feat(seid): ConfigManager selection seam (PLT-775 PR1)
+* [#3670](https://github.com/sei-protocol/sei-chain/pull/3670) chore: replace OLD red SeiLogo banner in README with new 2026 Sei lockup
+* [#3668](https://github.com/sei-protocol/sei-chain/pull/3668) Require absolute path for evmone lib
+* [#3667](https://github.com/sei-protocol/sei-chain/pull/3667) Make autobahn block production check wait for progress
+* [#3666](https://github.com/sei-protocol/sei-chain/pull/3666) fix(evmrpc): apply getLogs maxLog cap during merge instead of after (PLT-687)
+* [#3665](https://github.com/sei-protocol/sei-chain/pull/3665) feat(seidb): dump-flatkv computes per-bucket/total LtHash
+* [#3664](https://github.com/sei-protocol/sei-chain/pull/3664) fix(sei-tendermint): prevent readRoutine goroutine leak on /websocket when writeChan is full (PLT-707)
+* [#3663](https://github.com/sei-protocol/sei-chain/pull/3663) feat(consensus): mock_chain_validation replay build + memIAVL state-sync restore fixes
+* [#3660](https://github.com/sei-protocol/sei-chain/pull/3660) Per-block littidx flush + single shard (gated on #3645)
+* [#3659](https://github.com/sei-protocol/sei-chain/pull/3659) Upodate checkout GHA step across all workflows
+* [#3658](https://github.com/sei-protocol/sei-chain/pull/3658) [codex] add evm-only executor load test harness
+* [#3657](https://github.com/sei-protocol/sei-chain/pull/3657) [codex] bump go-ethereum to v1.15.7-sei-17
+* [#3656](https://github.com/sei-protocol/sei-chain/pull/3656) [codex] Harden multiversion iterator validation
+* [#3653](https://github.com/sei-protocol/sei-chain/pull/3653) fix(evmrpc): bound debug_traceStateAccess memory and add trace admission control (PLT-360)
+* [#3652](https://github.com/sei-protocol/sei-chain/pull/3652) Parallelize littidx eth_getLogs across blocks
+* [#3651](https://github.com/sei-protocol/sei-chain/pull/3651) Enable UCI AI review and assist
+* [#3650](https://github.com/sei-protocol/sei-chain/pull/3650) Add gov proposal based migration trigger
+* [#3649](https://github.com/sei-protocol/sei-chain/pull/3649) ci(PLT-766): cancel superseded PR runs for remaining workflows
+* [#3648](https://github.com/sei-protocol/sei-chain/pull/3648) feat(evmrpc): pre-decode request size admission control (PLT-295)
+* [#3647](https://github.com/sei-protocol/sei-chain/pull/3647) integrate hashlogger
+* [#3646](https://github.com/sei-protocol/sei-chain/pull/3646) fix(evmrpc): acquire requestLimiter in eth_createAccessList
+* [#3645](https://github.com/sei-protocol/sei-chain/pull/3645) LittDB: Keymap threading improvements
+* [#3643](https://github.com/sei-protocol/sei-chain/pull/3643) fixed the header number limit for FullCommitQC (PLT-764)
+* [#3642](https://github.com/sei-protocol/sei-chain/pull/3642) feat(inprocess): in-process N-validator harness
+* [#3641](https://github.com/sei-protocol/sei-chain/pull/3641) feat(grpc): add keepalive, LimitListener, and MaxRecvMsgSize to gRPC server :9090 (PLT-705)
+* [#3640](https://github.com/sei-protocol/sei-chain/pull/3640) fix(metrics): Prometheus metrics output
+* [#3639](https://github.com/sei-protocol/sei-chain/pull/3639) ci(PLT-761): cancel superseded integration-test PR runs and defer Autobahn Gov/Mint/Upgrade to merge queue
+* [#3637](https://github.com/sei-protocol/sei-chain/pull/3637) fix(evmrpc): limit listener max open connections, configurable via max_open_connections (PLT-704)
+* [#3636](https://github.com/sei-protocol/sei-chain/pull/3636) feat(evmrpc): configurable batch request limit and batch response size
+* [#3634](https://github.com/sei-protocol/sei-chain/pull/3634) Generate v6.6 CHANGELOG
+* [#3633](https://github.com/sei-protocol/sei-chain/pull/3633) downgrading logging levels in p2p
+* [#3632](https://github.com/sei-protocol/sei-chain/pull/3632) feat(autobahn): Add epoch.Registry to maintain committee/stake (CON-358)
+* [#3631](https://github.com/sei-protocol/sei-chain/pull/3631) fix(evmrpc): Cap calls in eth_estimateGasAfterCalls
+* [#3629](https://github.com/sei-protocol/sei-chain/pull/3629) revisited autobahn msg buffers
+* [#3628](https://github.com/sei-protocol/sei-chain/pull/3628) HashLogger
+* [#3626](https://github.com/sei-protocol/sei-chain/pull/3626) Co-broadcast rich block CW20 transfer with EVM batch
+* [#3621](https://github.com/sei-protocol/sei-chain/pull/3621) fix(evmrpc): cap eth_getBlockReceipts fan-out and concurrent logs subscriptions (PLT-701)
+* [#3620](https://github.com/sei-protocol/sei-chain/pull/3620) ReceiptStore Add littidx backend (LittDB bodies + pebble tag index)
+* [#3619](https://github.com/sei-protocol/sei-chain/pull/3619) MaxSize computation for sized proto messages
+* [#3615](https://github.com/sei-protocol/sei-chain/pull/3615) feat(protoutils): UnmarshalWithLimit — pre-decode allocation estimate
+* [#3605](https://github.com/sei-protocol/sei-chain/pull/3605) fix(grpc-web): set ReadTimeout, WriteTimeout, IdleTimeout, and MaxOpenConnections
+* [#3602](https://github.com/sei-protocol/sei-chain/pull/3602) Autobahn hashvault integration
+* [#3600](https://github.com/sei-protocol/sei-chain/pull/3600) block store implementation (littDB)
+* [#3583](https://github.com/sei-protocol/sei-chain/pull/3583) [codex] add evm-only giga executor path
+* [#3581](https://github.com/sei-protocol/sei-chain/pull/3581) dynamic router switching
+* [#3566](https://github.com/sei-protocol/sei-chain/pull/3566) Storage read visiblity
+* [#3525](https://github.com/sei-protocol/sei-chain/pull/3525) Add Autobahn fullnode (CON-309)
+* [#3425](https://github.com/sei-protocol/sei-chain/pull/3425) Add GoReleaser release pipeline for static seid binaries
 
 ## v6.6
 sei-chain


### PR DESCRIPTION
Backport of #4110 to `release/v6.7`.

Opened by hand rather than via the backport label: the `## Unreleased` hunk in #4110 does not cherry-pick cleanly onto `release/v6.7`, which lacks the `main`-only entries (#4009, #4032, #4021, #4078) that stay under `## Unreleased` there.

Made with [Cursor](https://cursor.com)