### PR TITLE
ci: drop unused Chrome/Microsoft apt sources before apt-get update

### DIFF
--- a/.github/scripts/ci-drop-third-party-apt-sources.sh
+++ b/.github/scripts/ci-drop-third-party-apt-sources.sh
@@ -6,20 +6,15 @@
 # `apt-get update` — even one that only wants build-essential — fails the job.
 #
 # Safe on any ubuntu-* runner: every removal is guarded so a change to the
-# runner image layout can never fail the job.
+# runner image layout can never fail the job. Filenames are globbed so a
+# renamed chrome/microsoft list still gets dropped.
 set -euo pipefail
 
-sources=(
-  /etc/apt/sources.list.d/google-chrome.list
-  /etc/apt/sources.list.d/google-chrome.sources
-  /etc/apt/sources.list.d/google.list
-  /etc/apt/sources.list.d/microsoft-prod.list
-  /etc/apt/sources.list.d/microsoft-prod.sources
-)
+# Unmatched globs must not be treated as literal paths.
+shopt -s nullglob
 
-for src in "${sources[@]}"; do
-  if [ -e "$src" ]; then
-    echo "Removing $src"
-    sudo rm -f "$src"
-  fi
+for src in /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources \
+  /etc/apt/sources.list.d/*microsoft*.list /etc/apt/sources.list.d/*microsoft*.sources; do
+  echo "Removing $src"
+  sudo rm -f "$src"
 done

--- a/.github/scripts/ci-drop-third-party-apt-sources.sh
+++ b/.github/scripts/ci-drop-third-party-apt-sources.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Drop third-party apt sources that GitHub's ubuntu-* images ship and that we
+# never install from. Those repos (Google Chrome, Microsoft) periodically serve
+# a Packages.gz whose hash does not match the signed Release file, so any
+# `apt-get update` — even one that only wants build-essential — fails the job.
+#
+# Safe on any ubuntu-* runner: every removal is guarded so a change to the
+# runner image layout can never fail the job.
+set -euo pipefail
+
+sources=(
+  /etc/apt/sources.list.d/google-chrome.list
+  /etc/apt/sources.list.d/google-chrome.sources
+  /etc/apt/sources.list.d/google.list
+  /etc/apt/sources.list.d/microsoft-prod.list
+  /etc/apt/sources.list.d/microsoft-prod.sources
+)
+
+for src in "${sources[@]}"; do
+  if [ -e "$src" ]; then
+    echo "Removing $src"
+    sudo rm -f "$src"
+  fi
+done

--- a/.github/scripts/ci-drop-third-party-apt-sources.sh
+++ b/.github/scripts/ci-drop-third-party-apt-sources.sh
@@ -16,5 +16,5 @@ shopt -s nullglob
 for src in /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources \
   /etc/apt/sources.list.d/*microsoft*.list /etc/apt/sources.list.d/*microsoft*.sources; do
   echo "Removing $src"
-  sudo rm -f "$src"
+  sudo rm -f "$src" || true
 done

--- a/.github/workflows/cross-arch-build.yml
+++ b/.github/workflows/cross-arch-build.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Install system dependencies
         run: |
+          bash .github/scripts/ci-drop-third-party-apt-sources.sh
           sudo apt-get update
           sudo apt-get install -y build-essential
 
@@ -70,6 +71,7 @@ jobs:
 
       - name: Install system dependencies
         run: |
+          bash .github/scripts/ci-drop-third-party-apt-sources.sh
           sudo apt-get update
           sudo apt-get install -y build-essential
 

--- a/.github/workflows/rocksdb-unit_tests.yml
+++ b/.github/workflows/rocksdb-unit_tests.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Install RocksDB dependencies
         run: |
+          bash .github/scripts/ci-drop-third-party-apt-sources.sh
           sudo apt-get update
           sudo apt-get install -y build-essential pkg-config cmake git zlib1g-dev libbz2-dev libsnappy-dev liblz4-dev libzstd-dev libjemalloc-dev libgflags-dev liburing-dev
 


### PR DESCRIPTION
## Summary
- GitHub `ubuntu-*` runners ship Google Chrome (and Microsoft) apt sources. `apt-get update` then fetches `dl.google.com` even when the job only installs Ubuntu packages (`build-essential`, RocksDB deps).
- That repo periodically returns a `Packages.gz` whose hash does not match the signed `Release` file, failing Cross-Architecture Build and RocksDB Tests (e.g. attempts on #4108).
- Drop those unused sources before `apt-get update`. We do not install or need Chrome.

## Test plan
- [x] Confirm Cross-Architecture Build Test → Linux AMD64 `Install system dependencies` no longer hits `dl.google.com/linux/chrome-stable`.
- [x] Confirm sei-db → RocksDB Tests `Install RocksDB dependencies` succeeds without hash-sum mismatch.
- [x] Confirm both jobs still install `build-essential` (and RocksDB deps) from Ubuntu.


Made with [Cursor](https://cursor.com)