### PR TITLE
Fix flaky/environment-dependent tests (macOS)

### DIFF
--- a/evmrpc/utils.go
+++ b/evmrpc/utils.go
@@ -370,6 +370,7 @@ type ParallelRunner struct {
 
 var panicHook atomic.Value
 
+// SetPanicHook sets a handler that replaces default recovered-panic logging.
 func SetPanicHook(h func(interface{})) {
 	panicHook.Store(h)
 }
@@ -399,13 +400,14 @@ func runWithRecovery(f func()) {
 
 func recoverAndLog() {
 	if e := recover(); e != nil {
-		fmt.Printf("Panic recovered: %s\n", e)
-		debug.PrintStack()
 		if v := panicHook.Load(); v != nil {
 			if hook, ok := v.(func(interface{})); ok && hook != nil {
 				hook(e)
+				return
 			}
 		}
+		fmt.Printf("Panic recovered: %s\n", e)
+		debug.PrintStack()
 	}
 }
 

--- a/giga/deps/testutil/processblock/genesismint.go
+++ b/giga/deps/testutil/processblock/genesismint.go
@@ -7,11 +7,13 @@ import (
 )
 
 func (a *App) NewMinter(amount uint64) {
-	today := time.Now()
-	dayAfterTomorrow := today.Add(48 * time.Hour)
+	// UTC calendar dates so DaysBetween(blockTime, end) matches the
+	// formatted start/end regardless of local timezone.
+	today := time.Now().UTC()
+	start := time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, time.UTC)
 	a.MintKeeper.SetMinter(a.Ctx(), minttypes.Minter{
-		StartDate:           today.Format(minttypes.TokenReleaseDateFormat),
-		EndDate:             dayAfterTomorrow.Format(minttypes.TokenReleaseDateFormat),
+		StartDate:           start.Format(minttypes.TokenReleaseDateFormat),
+		EndDate:             start.AddDate(0, 0, 2).Format(minttypes.TokenReleaseDateFormat),
 		Denom:               "usei",
 		TotalMintAmount:     amount,
 		RemainingMintAmount: amount,

--- a/giga/deps/testutil/processblock/verify/mint.go
+++ b/giga/deps/testutil/processblock/verify/mint.go
@@ -2,12 +2,11 @@ package verify
 
 import (
 	"testing"
-	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/signing"
 	"github.com/sei-protocol/sei-chain/testutil/processblock"
-	minttypes "github.com/sei-protocol/sei-chain/x/mint/types"
-	"github.com/stretchr/testify/require"
 )
 
 func MintRelease(t *testing.T, app *processblock.App, f BlockRunnable, _ []signing.Tx) BlockRunnable {
@@ -23,15 +22,7 @@ func MintRelease(t *testing.T, app *processblock.App, f BlockRunnable, _ []signi
 		}
 		newPoch := app.EpochKeeper.GetEpoch(app.Ctx())
 		require.Equal(t, oldEpoch.CurrentEpoch+1, newPoch.CurrentEpoch)
-		startDate, err := time.Parse(minttypes.TokenReleaseDateFormat, oldMinter.StartDate)
-		if err != nil {
-			panic(err)
-		}
-		endDate, err := time.Parse(minttypes.TokenReleaseDateFormat, oldMinter.EndDate)
-		if err != nil {
-			panic(err)
-		}
-		expectedMintedAmount := oldMinter.TotalMintAmount / uint64(endDate.Sub(startDate)/(24*time.Hour)) //nolint:gosec
+		expectedMintedAmount := oldMinter.GetReleaseAmountToday(oldEpoch.CurrentEpochStartTime.UTC()).AmountOf("usei").Uint64()
 		require.Equal(t, expectedMintedAmount, oldMinter.RemainingMintAmount-newMinter.RemainingMintAmount)
 		newSupply := app.BankKeeper.GetSupply(app.Ctx(), "usei")
 		require.Equal(t, expectedMintedAmount, uint64(newSupply.Amount.Int64()-oldSupply.Amount.Int64())) //nolint:gosec

--- a/sei-tendermint/node/freeze_test.go
+++ b/sei-tendermint/node/freeze_test.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"errors"
-	"fmt"
 	"math"
 	"slices"
 	"testing"
@@ -10,7 +9,6 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/config"
 	mempoolreactor "github.com/sei-protocol/sei-chain/sei-tendermint/internal/mempool/reactor"
 	rpccore "github.com/sei-protocol/sei-chain/sei-tendermint/internal/rpc/core"
-	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/tcp"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/rpc/coretypes"
 	"github.com/sei-protocol/sei-chain/sei-tendermint/types"
 )
@@ -78,7 +76,10 @@ func TestFreezeModeDisablesMempoolTraffic(t *testing.T) {
 		t.Fatal(err)
 	}
 	cfg.Mode = config.ModeFull
-	cfg.RPC.ListenAddress = fmt.Sprintf("tcp://%s", tcp.TestReserveAddr())
+	// Broadcast checks below call rpcEnv in-process; skip the TCP listener
+	// so Start does not race a freeLoopbackAddr (net.Listen cannot adopt a
+	// TestReserveAddr, and a closed :0 bind is stealable on macOS).
+	cfg.RPC.ListenAddress = ""
 	nodeService, err := newLocalNodeService(t.Context(), cfg, WithFreezeHeight(2))
 	if err != nil {
 		t.Fatal(err)

--- a/testutil/processblock/genesismint.go
+++ b/testutil/processblock/genesismint.go
@@ -7,11 +7,13 @@ import (
 )
 
 func (a *App) NewMinter(amount uint64) {
-	today := time.Now()
-	dayAfterTomorrow := today.Add(48 * time.Hour)
+	// UTC calendar dates so DaysBetween(blockTime, end) matches the
+	// formatted start/end regardless of local timezone.
+	today := time.Now().UTC()
+	start := time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, time.UTC)
 	a.MintKeeper.SetMinter(a.Ctx(), minttypes.Minter{
-		StartDate:           today.Format(minttypes.TokenReleaseDateFormat),
-		EndDate:             dayAfterTomorrow.Format(minttypes.TokenReleaseDateFormat),
+		StartDate:           start.Format(minttypes.TokenReleaseDateFormat),
+		EndDate:             start.AddDate(0, 0, 2).Format(minttypes.TokenReleaseDateFormat),
 		Denom:               "usei",
 		TotalMintAmount:     amount,
 		RemainingMintAmount: amount,

--- a/testutil/processblock/verify/mint.go
+++ b/testutil/processblock/verify/mint.go
@@ -22,7 +22,7 @@ func MintRelease(t *testing.T, app *processblock.App, f BlockRunnable, _ []signi
 		}
 		newPoch := app.EpochKeeper.GetEpoch(app.Ctx())
 		require.Equal(t, oldEpoch.CurrentEpoch+1, newPoch.CurrentEpoch)
-		expectedMintedAmount := oldMinter.GetReleaseAmountToday(app.Ctx().BlockTime()).AmountOf("usei").Uint64()
+		expectedMintedAmount := oldMinter.GetReleaseAmountToday(oldEpoch.CurrentEpochStartTime.UTC()).AmountOf("usei").Uint64()
 		require.Equal(t, expectedMintedAmount, oldMinter.RemainingMintAmount-newMinter.RemainingMintAmount)
 		newSupply := app.BankKeeper.GetSupply(app.Ctx(), "usei")
 		require.Equal(t, expectedMintedAmount, uint64(newSupply.Amount.Int64()-oldSupply.Amount.Int64())) //nolint:gosec

--- a/testutil/processblock/verify/mint.go
+++ b/testutil/processblock/verify/mint.go
@@ -2,12 +2,11 @@ package verify
 
 import (
 	"testing"
-	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/signing"
 	"github.com/sei-protocol/sei-chain/testutil/processblock"
-	minttypes "github.com/sei-protocol/sei-chain/x/mint/types"
-	"github.com/stretchr/testify/require"
 )
 
 func MintRelease(t *testing.T, app *processblock.App, f BlockRunnable, _ []signing.Tx) BlockRunnable {
@@ -23,15 +22,7 @@ func MintRelease(t *testing.T, app *processblock.App, f BlockRunnable, _ []signi
 		}
 		newPoch := app.EpochKeeper.GetEpoch(app.Ctx())
 		require.Equal(t, oldEpoch.CurrentEpoch+1, newPoch.CurrentEpoch)
-		startDate, err := time.Parse(minttypes.TokenReleaseDateFormat, oldMinter.StartDate)
-		if err != nil {
-			panic(err)
-		}
-		endDate, err := time.Parse(minttypes.TokenReleaseDateFormat, oldMinter.EndDate)
-		if err != nil {
-			panic(err)
-		}
-		expectedMintedAmount := oldMinter.TotalMintAmount / uint64(endDate.Sub(startDate)/(24*time.Hour)) //nolint:gosec
+		expectedMintedAmount := oldMinter.GetReleaseAmountToday(app.Ctx().BlockTime()).AmountOf("usei").Uint64()
 		require.Equal(t, expectedMintedAmount, oldMinter.RemainingMintAmount-newMinter.RemainingMintAmount)
 		newSupply := app.BankKeeper.GetSupply(app.Ctx(), "usei")
 		require.Equal(t, expectedMintedAmount, uint64(newSupply.Amount.Int64()-oldSupply.Amount.Int64())) //nolint:gosec


### PR DESCRIPTION
## Summary
- Stop double-logging recovered panics in evmrpc once a panic hook is set (the hook currently has a single caller, a test, that only needs the notification and never depended on the print/stack trace also firing)
- Fix `TestFreezeModeDisablesMempoolTraffic` flaking on macOS: it reserved a listen address via `TestReserveAddr` and handed it to `node.Start`, but `net.Listen` can't adopt that reservation and the freed `:0` bind is stealable by another process in the window before `Start` runs; the test only calls `rpcEnv` in-process, so skip the TCP listener entirely
- Fix a timezone-dependent flake in the mint-release test: `NewMinter` derived start/end dates from local wall-clock time instead of UTC calendar dates, and `MintRelease` re-derived the expected release amount by hand instead of via `Minter.GetReleaseAmountToday`

## Test plan
- [ ] `go test ./evmrpc/...`
- [ ] `go test ./sei-tendermint/node/...`
- [ ] `go test ./testutil/processblock/...`