### PR TITLE
Bump version to v6.7.0-rc1 in prep for release

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v6.1.12"
+  "version": "v6.7.0-rc1"
 }


### PR DESCRIPTION
## Summary
- Bump `version.json` from `v6.1.12` to `v6.7.0-rc1` to cut the first `v6.7` release candidate.

## Test plan
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)