### PR TITLE
Fix TestGCFifo hang that times out the Coverage shard

### DIFF
--- a/sei-tendermint/internal/libs/clist/clist_test.go
+++ b/sei-tendermint/internal/libs/clist/clist_test.go
@@ -56,9 +56,12 @@ func TestSmall(t *testing.T) {
 func TestGCFifo(t *testing.T) {
 	// SetFinalizer doesn't work well with circular structures,
 	// so we construct a trivial non-circular structure to
-	// track.
+	// track. The struct is padded to 16 bytes so it is not served by the
+	// tiny allocator, which packs several pointer-free objects into one
+	// block and only finalizes them once the whole block is unreachable.
 	type value struct {
 		Int int
+		_   int
 	}
 
 	const numElements = 10000
@@ -109,9 +112,12 @@ func TestGCFifo(t *testing.T) {
 func TestGCRandom(t *testing.T) {
 	// SetFinalizer doesn't work well with circular structures,
 	// so we construct a trivial non-circular structure to
-	// track.
+	// track. The struct is padded to 16 bytes so it is not served by the
+	// tiny allocator, which packs several pointer-free objects into one
+	// block and only finalizes them once the whole block is unreachable.
 	type value struct {
 		Int int
+		_   int
 	}
 
 	const numElements = 10000


### PR DESCRIPTION
`TestGCFifo` allocates 10,000 `value` structs, attaches a finalizer to each, drops them from the list and then blocks until every finalizer has run. `value` is an 8-byte pointer-free struct, so Go's tiny allocator packs several of them into a single 16-byte block, and a finalizer on a tiny object only runs once the whole block is unreachable. If any value shares a block with a longer-lived tiny allocation (more likely under `-race -coverpkg` instrumentation), that finalizer never fires and the test blocks until the 30m job timeout kills the whole Coverage shard.

The fix pads `value` to 16 bytes so it is allocated as a regular small object with its own block, making the finalizer deterministic once the value is unreachable. The same shape in `TestGCRandom` is padded too.

Flaked in: https://github.com/sei-protocol/sei-chain/actions/runs/34386122278/job/102582709570, https://github.com/sei-protocol/sei-chain/actions/runs/33858474862/job/100977162536, https://github.com/sei-protocol/sei-chain/actions/runs/33503230070/job/99841166324