### PR TITLE
Fix flaky TestHTTPSimple by raising rpctest broadcast_tx_commit timeout

### DIFF
--- a/sei-tendermint/rpc/test/helpers.go
+++ b/sei-tendermint/rpc/test/helpers.go
@@ -69,6 +69,10 @@ func CreateConfig(t *testing.T, testName string) (*config.Config, error) {
 	c.P2P.ListenAddress = p2pAddr
 	c.RPC.ListenAddress = rpcAddr
 	c.RPC.EventLogWindowSize = 5 * time.Minute
+	// Loaded CI runners can take longer than the 10s default to produce the
+	// first block; timeout-write must stay above this value.
+	c.RPC.TimeoutBroadcastTxCommit = 60 * time.Second
+	c.RPC.TimeoutWrite = 90 * time.Second
 	c.Consensus.WalPath = "rpc-test"
 	c.RPC.CORSAllowedOrigins = []string{"https://tendermint.com/"}
 	return c, nil


### PR DESCRIPTION
`TestHTTPSimple` broadcasts a tx with `broadcast_tx_commit` against a freshly started in-process node. The rpctest config leaves `RPC.TimeoutBroadcastTxCommit` at the production default of 10s, and on a loaded runner the node can take longer than that to produce its first block, so the call fails with `timeout waiting for commit of tx`.

The fix raises the test node's `TimeoutBroadcastTxCommit` to 60s and `TimeoutWrite` to 90s in `rpctest.CreateConfig` (config validation requires `TimeoutWrite > TimeoutBroadcastTxCommit`). Only the test harness config changes; a real failure still surfaces immediately.

Flaked in: https://github.com/sei-protocol/sei-chain/actions/runs/33929655800/job/101205498465, https://github.com/sei-protocol/sei-chain/actions/runs/33621264921/job/100218567244