### PR TITLE
Fix flaky TestStore_Delete by waiting for Save to finish

### DIFF
--- a/sei-cosmos/snapshots/store_test.go
+++ b/sei-cosmos/snapshots/store_test.go
@@ -89,7 +89,9 @@ func TestStore_Delete(t *testing.T) {
 		saved <- err
 	}()
 
-	time.Sleep(10 * time.Millisecond)
+	// An unbuffered send completes only once Save is receiving chunks, i.e.
+	// after it has marked the height as being saved.
+	ch <- io.NopCloser(bytes.NewBuffer([]byte{1, 2, 3}))
 	err = store.Delete(9, 1)
 	require.Error(t, err)
 

--- a/sei-cosmos/snapshots/store_test.go
+++ b/sei-cosmos/snapshots/store_test.go
@@ -83,7 +83,11 @@ func TestStore_Delete(t *testing.T) {
 
 	// Deleting a snapshot being saved should error
 	ch := make(chan io.ReadCloser)
-	go store.Save(9, 1, ch)
+	saved := make(chan error, 1)
+	go func() {
+		_, err := store.Save(9, 1, ch)
+		saved <- err
+	}()
 
 	time.Sleep(10 * time.Millisecond)
 	err = store.Delete(9, 1)
@@ -91,7 +95,7 @@ func TestStore_Delete(t *testing.T) {
 
 	// But after it's saved it should work
 	close(ch)
-	time.Sleep(10 * time.Millisecond)
+	require.NoError(t, <-saved)
 	err = store.Delete(9, 1)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
`TestStore_Delete` starts a `Save` in a goroutine, checks that `Delete` fails while the save is in progress, then closes the chunk channel and sleeps 10ms before expecting `Delete` to succeed. After the channel closes `Save` still writes the final chunk and the index, so on a slow runner the second `Delete` races with it and fails with `snapshot for height 9 format 1 is currently being saved: conflict`.

The fix has the `Save` goroutine report its result on a channel and waits for it before the second `Delete`, replacing the sleep. The in-progress assertion also drops its 10ms sleep: the test sends one chunk on the unbuffered channel first, which only completes once `Save` has marked the height as being saved.

Flaked in: https://github.com/sei-protocol/sei-chain/actions/runs/33499386206/job/99828924778, https://github.com/sei-protocol/sei-chain/actions/runs/32858354658/job/97835827371