### PR TITLE
Fix flaky TestTrackReads readCount assertion

### DIFF
--- a/sei-db/db_engine/litt/benchmark/data_tracker_test.go
+++ b/sei-db/db_engine/litt/benchmark/data_tracker_test.go
@@ -171,8 +171,9 @@ func TestTrackReads(t *testing.T) {
 
 		keyToIndexMap[string(writeInfo.Key)] = writeInfo.KeyIndex
 
-		if rand.Float64() < 0.1 && i > 2*config.CohortSize {
-			// Advance the highest written index.
+		// Advance the highest written index at random, and always on the last iteration so that
+		// at least one full cohort is reported written before the loop ends.
+		if (rand.Float64() < 0.1 || i == keyCount-1) && i > 2*config.CohortSize {
 			possibleIndex := rand.Uint64Range(i-config.CohortSize*2, i)
 			if int(possibleIndex) > highestWrittenIndex {
 				highestWrittenIndex = int(possibleIndex)
@@ -190,11 +191,12 @@ func TestTrackReads(t *testing.T) {
 
 		// Read a random value.
 		var readInfo *ReadInfo
-		if readCount == 0 {
-			// We are reading the first value, so one might not be available yet. Don't block forever.
+		if highestWrittenIndex < int(config.CohortSize) {
+			// No cohort has been fully reported written yet, so a value might not be available. Don't block forever.
 			readInfo = dataTracker.GetReadInfoWithTimeout(time.Millisecond)
 		} else {
-			// After we read the first value, we should never block.
+			// The genesis cohort (key indices 0..CohortSize) has been fully reported written, so a read
+			// must eventually become available.
 			readInfo = dataTracker.GetReadInfo()
 		}
 		if readInfo != nil {


### PR DESCRIPTION
`TestTrackReads` drives a `DataTracker` with a loop that reports writes at random and reads back keys, asserting at the end that at least one read happened. Reads only become available after the background generator has ingested the reported writes and marked a full cohort complete, but every read made before the first successful one used a 1ms timeout, and the write-reporting branch only fires with probability 0.1 per iteration. Under `-race` on a loaded runner the generator can miss every 1ms window, or the loop can finish without a complete cohort ever being reported, leaving `readCount == 0`.

The fix forces the write report on the last iteration so the genesis cohort is always fully reported, and only uses the 1ms-timeout read while `highestWrittenIndex < CohortSize`; once the genesis cohort is reported written a read is guaranteed to become available, so the test blocks on `GetReadInfo()` instead of racing a timeout. The `index <= highestWrittenIndex` check on every read is unchanged.

Flaked in: https://github.com/sei-protocol/sei-chain/actions/runs/33499386206/job/99828924778