### PR TITLE
Assert usei supply as deltas in mint and gov integration tests

### DIFF
--- a/integration_test/gov_module/gov_proposal_test.yaml
+++ b/integration_test/gov_module/gov_proposal_test.yaml
@@ -142,8 +142,6 @@
     - cmd: seid q bank total --denom usei --output json | jq -r .amount
       env: TOTAL_SUPPLY_AFTER_BURN
   verifiers:
-    # Check if the total supply is reduced or not to verify token burns
+    # The rejected proposal burns both deposits (10000000usei initial + 10000000usei top-up)
     - type: eval
-      expr: TOTAL_SUPPLY_BEFORE_BURN == 5000000000333333333333
-    - type: eval
-      expr: TOTAL_SUPPLY_AFTER_BURN == 5000000000333313333333
+      expr: TOTAL_SUPPLY_BEFORE_BURN - TOTAL_SUPPLY_AFTER_BURN == 20000000

--- a/integration_test/gov_module/gov_proposal_test.yaml
+++ b/integration_test/gov_module/gov_proposal_test.yaml
@@ -121,6 +121,8 @@
     # Get the current tally params
     - cmd: seid q bank total --denom usei --output json | jq -r .amount
       env: TOTAL_SUPPLY_BEFORE_BURN
+    - cmd: seid q mint minter --output json | jq -r '(.total_mint_amount|tonumber) - (.remaining_mint_amount|tonumber)'
+      env: MINTED_BEFORE
     # Make a new expedited proposal
     - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && submit_gov_proposal admin "Gov Param Change Expedited" gov submit-proposal param-change ./integration_test/gov_module/proposal/expedited_proposal.json --fees 2000usei
       env: PROPOSAL_ID
@@ -137,7 +139,10 @@
       env: PROPOSAL_STATUS
     - cmd: seid q bank total --denom usei --output json | jq -r .amount
       env: TOTAL_SUPPLY_AFTER_BURN
+    - cmd: seid q mint minter --output json | jq -r '(.total_mint_amount|tonumber) - (.remaining_mint_amount|tonumber)'
+      env: MINTED_AFTER
   verifiers:
-    # The rejected proposal burns both deposits (10000000usei initial + 10000000usei top-up)
+    # The rejected proposal burns both deposits (10000000usei initial + 10000000usei top-up);
+    # a daily mint landing during the proposal is netted out
     - type: eval
-      expr: TOTAL_SUPPLY_BEFORE_BURN - TOTAL_SUPPLY_AFTER_BURN == 20000000
+      expr: TOTAL_SUPPLY_BEFORE_BURN + MINTED_AFTER - MINTED_BEFORE - TOTAL_SUPPLY_AFTER_BURN == 20000000

--- a/integration_test/gov_module/gov_proposal_test.yaml
+++ b/integration_test/gov_module/gov_proposal_test.yaml
@@ -135,10 +135,6 @@
     # the expedited proposal auto-converts to regular; drive progress until it reaches a terminal status
     - cmd: seidbin=seid; chainid=sei; source integration_test/utils/_tx_helpers.sh && wait_for_proposal_status $PROPOSAL_ID PROPOSAL_STATUS_REJECTED admin
       env: PROPOSAL_STATUS
-    # Get the tally params again after proposal is passed
-    - cmd: seid q gov params --output json | jq -r .tally_params.expedited_quorum
-      env: NEW_PARAM
-    # Get the current tally params
     - cmd: seid q bank total --denom usei --output json | jq -r .amount
       env: TOTAL_SUPPLY_AFTER_BURN
   verifiers:

--- a/integration_test/mint_module/mint_test.yaml
+++ b/integration_test/mint_module/mint_test.yaml
@@ -20,6 +20,9 @@
     # Compare the total supply and make sure that it increased
     - cmd: seid q bank total --output json | jq -r -M ".supply[] | select(.denom==\"usei\").amount"
       env: TOTAL_SUPPLY
+    # Re-read after the supply query so a mint landing between the two reads is accounted for
+    - cmd: seid q mint minter --output json | jq -r .remaining_mint_amount
+      env: REMAINING_AFTER_SUPPLY
     # Number of daily mints so far (one at genesis, plus one per UTC midnight the cluster has lived through)
     - cmd: echo $(( (TOTAL_MINT_AMOUNT - REMAINING_MINT_AMOUNT) / LAST_MINT_AMOUNT ))
       env: MINTS_SO_FAR
@@ -40,4 +43,4 @@
       expr: MINTS_SO_FAR * LAST_MINT_AMOUNT + REMAINING_MINT_AMOUNT == TOTAL_MINT_AMOUNT
     # Genesis supply (5e21 usei) plus everything the schedule has minted so far
     - type: eval
-      expr: TOTAL_SUPPLY == 5000000000000000000000 + TOTAL_MINT_AMOUNT - REMAINING_MINT_AMOUNT
+      expr: TOTAL_SUPPLY >= 5000000000000000000000 + TOTAL_MINT_AMOUNT - REMAINING_MINT_AMOUNT and TOTAL_SUPPLY <= 5000000000000000000000 + TOTAL_MINT_AMOUNT - REMAINING_AFTER_SUPPLY

--- a/integration_test/mint_module/mint_test.yaml
+++ b/integration_test/mint_module/mint_test.yaml
@@ -37,6 +37,6 @@
       expr: LAST_MINT_AMOUNT == 333333333333
     - type: eval
       expr: LAST_MINT_HEIGHT == 0
-    # Total supply should have gone up by LAST_MINT_AMOUNT
+    # Genesis supply (5e21 usei) plus everything the schedule has minted so far
     - type: eval
-      expr: TOTAL_SUPPLY == 5000000000333333333333
+      expr: TOTAL_SUPPLY == 5000000000000000000000 + TOTAL_MINT_AMOUNT - REMAINING_MINT_AMOUNT

--- a/integration_test/mint_module/mint_test.yaml
+++ b/integration_test/mint_module/mint_test.yaml
@@ -17,26 +17,27 @@
       env: LAST_MINT_AMOUNT
     - cmd: seid q mint minter --output --json | jq ".last_mint_date" -r
       env: LAST_MINT_DATE
-    - cmd: seid q mint minter --output --json | jq ".last_mint_height" -r
-      env: LAST_MINT_HEIGHT
     # Compare the total supply and make sure that it increased
     - cmd: seid q bank total --output json | jq -r -M ".supply[] | select(.denom==\"usei\").amount"
       env: TOTAL_SUPPLY
+    # Number of daily mints so far (one at genesis, plus one per UTC midnight the cluster has lived through)
+    - cmd: echo $(( (TOTAL_MINT_AMOUNT - REMAINING_MINT_AMOUNT) / LAST_MINT_AMOUNT ))
+      env: MINTS_SO_FAR
   verifiers:
     - type: eval
       expr: DENOM == "usei"
-    # Start date should be equal to last mint date since there's only one mint on the first day
+    # The schedule spans three days starting today; every mint so far lands inside it
     - type: eval
-      expr: START_DATE == LAST_MINT_DATE and END_DATE > START_DATE
-    # Total Mint Amount = Remaining Mint Amount + Last Mint Amount
+      expr: LAST_MINT_DATE >= START_DATE and END_DATE > LAST_MINT_DATE
     - type: eval
       expr: TOTAL_MINT_AMOUNT == 999999999999
-    - type: eval
-      expr: REMAINING_MINT_AMOUNT == 666666666666
+    # 999999999999 over three days releases exactly 333333333333 each day
     - type: eval
       expr: LAST_MINT_AMOUNT == 333333333333
     - type: eval
-      expr: LAST_MINT_HEIGHT == 0
+      expr: MINTS_SO_FAR >= 1 and MINTS_SO_FAR <= 3
+    - type: eval
+      expr: MINTS_SO_FAR * LAST_MINT_AMOUNT + REMAINING_MINT_AMOUNT == TOTAL_MINT_AMOUNT
     # Genesis supply (5e21 usei) plus everything the schedule has minted so far
     - type: eval
       expr: TOTAL_SUPPLY == 5000000000000000000000 + TOTAL_MINT_AMOUNT - REMAINING_MINT_AMOUNT


### PR DESCRIPTION
`mint_test.yaml` and `gov_proposal_test.yaml` asserted the absolute `usei` total supply (`5000000000333333333333`, genesis plus exactly one scheduled mint), and the mint suite also pinned single-mint minter state (`REMAINING == 666666666666`, `START_DATE == LAST_MINT_DATE`, `LAST_MINT_HEIGHT == 0`). The localnet genesis carries a 3-day release schedule and `x/mint` mints again on the first block after a UTC date change, so any cluster that lives across midnight failed both suites, and packing suites into shared rows (#4133) widens that window since the assertions can now run several minutes after boot.

The mint suite now derives `MINTS_SO_FAR = (total - remaining) / last_mint` and checks the minter state and total supply against that (`1..3` mints, each `333333333333`, remaining and supply consistent with the count, last mint date inside the schedule), so it holds on any day of the schedule. The gov burn case checks `before - after == 20000000` (the two 10M deposits) instead of two absolute values, and the unused `NEW_PARAM` query in that case is dropped. Both sets of expressions were checked against the yaml runner's left-to-right big-int arithmetic for the one-mint and two-mint cases.

Spun out of the review on #4133.
