### PR TITLE
(Autobahn) Cover timeout-vote aggregation (CON-423)

### DIFF
--- a/sei-tendermint/internal/autobahn/consensus/state.go
+++ b/sei-tendermint/internal/autobahn/consensus/state.go
@@ -221,7 +221,7 @@ func (s *State) PushTimeoutVote(vote *types.FullTimeoutVote) error {
 		return fmt.Errorf("vote.Verify(): %w", err)
 	}
 	for tv := range s.timeoutVotes.Lock() {
-		tv.pushVote(ep.Committee(), vote)
+		tv.pushVerifiedVote(ep.Committee(), vote)
 	}
 	return nil
 }

--- a/sei-tendermint/internal/autobahn/consensus/state_test.go
+++ b/sei-tendermint/internal/autobahn/consensus/state_test.go
@@ -326,3 +326,41 @@ func TestVoteTimeoutPrepareQC_PersistedRestart(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
+func TestPushTimeoutVote_FormsQC(t *testing.T) {
+	rng := utils.TestRng()
+	s, keys, _ := newTestState(rng)
+	vs := s.myView.Load()
+	view := vs.View()
+	c := vs.Epoch.Committee()
+
+	require.NoError(t, s.PushTimeoutVote(types.NewFullTimeoutVote(keys[0], view, utils.None[*types.PrepareQC]())))
+	require.False(t, s.timeoutQC().Load().IsPresent())
+
+	for _, k := range types.TestKeysWithWeight(c, keys, c.TimeoutQuorum()) {
+		require.NoError(t, s.PushTimeoutVote(types.NewFullTimeoutVote(k, view, utils.None[*types.PrepareQC]())))
+	}
+	got, ok := s.timeoutQC().Load().Get()
+	require.True(t, ok)
+	require.Equal(t, view, got.View())
+}
+
+func TestPushTimeoutVote_RejectsNonReplica(t *testing.T) {
+	rng := utils.TestRng()
+	s, _, _ := newTestState(rng)
+	vs := s.myView.Load()
+	view := vs.View()
+	outsider := types.GenSecretKey(rng)
+
+	require.Error(t, s.PushTimeoutVote(types.NewFullTimeoutVote(outsider, view, utils.None[*types.PrepareQC]())))
+}
+
+func TestPushTimeoutVote_RejectsWrongEpoch(t *testing.T) {
+	rng := utils.TestRng()
+	s, keys, _ := newTestState(rng)
+	vs := s.myView.Load()
+	view := vs.View()
+	view.EpochIndex++
+
+	require.Error(t, s.PushTimeoutVote(types.NewFullTimeoutVote(keys[0], view, utils.None[*types.PrepareQC]())))
+}

--- a/sei-tendermint/internal/autobahn/consensus/timeout_votes.go
+++ b/sei-tendermint/internal/autobahn/consensus/timeout_votes.go
@@ -19,6 +19,7 @@ func newTimeoutVotes() *timeoutVotes {
 	}
 }
 
+// pushVerifiedVote inserts a timeout vote the caller has already verified against c.
 func (tv *timeoutVotes) pushVerifiedVote(c *types.Committee, vote *types.FullTimeoutVote) {
 	key := vote.Vote().Key()
 	view := vote.Vote().Msg().View()

--- a/sei-tendermint/internal/autobahn/consensus/timeout_votes.go
+++ b/sei-tendermint/internal/autobahn/consensus/timeout_votes.go
@@ -19,8 +19,7 @@ func newTimeoutVotes() *timeoutVotes {
 	}
 }
 
-func (tv *timeoutVotes) pushVote(c *types.Committee, vote *types.FullTimeoutVote) {
-	// TODO: verify the vote.
+func (tv *timeoutVotes) pushVerifiedVote(c *types.Committee, vote *types.FullTimeoutVote) {
 	key := vote.Vote().Key()
 	view := vote.Vote().Msg().View()
 	if old, ok := tv.byKey[key]; ok {

--- a/sei-tendermint/internal/autobahn/consensus/timeout_votes_test.go
+++ b/sei-tendermint/internal/autobahn/consensus/timeout_votes_test.go
@@ -1,0 +1,119 @@
+package consensus
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sei-protocol/sei-chain/sei-tendermint/autobahn/types"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils"
+	"github.com/sei-protocol/sei-chain/sei-tendermint/libs/utils/require"
+)
+
+// timeoutEnv is a timeoutVotes aggregator over a 4-replica equal-weight committee.
+type timeoutEnv struct {
+	tv     *timeoutVotes
+	keys   []types.SecretKey
+	ep     *types.Epoch
+	view   types.View
+	quorum []types.SecretKey
+}
+
+func newTimeoutEnv(rng utils.Rng) timeoutEnv {
+	keys := utils.GenSliceN(rng, 4, types.GenSecretKey)
+	weights := make(map[types.PublicKey]uint64, len(keys))
+	for _, k := range keys {
+		weights[k.Public()] = 1
+	}
+	c := utils.OrPanic1(types.NewCommittee(weights))
+	ep := types.NewEpoch(0, types.OpenRoadRange(), time.Time{}, c, 0)
+	view := types.View{Index: 0, Number: 0, EpochIndex: ep.EpochIndex()}
+	quorum := types.TestKeysWithWeight(c, keys, c.TimeoutQuorum())
+	return timeoutEnv{
+		tv:     newTimeoutVotes(),
+		keys:   keys,
+		ep:     ep,
+		view:   view,
+		quorum: quorum,
+	}
+}
+
+func TestTimeoutVotes_BelowQuorumDoesNotFormQC(t *testing.T) {
+	e := newTimeoutEnv(utils.TestRng())
+	c := e.ep.Committee()
+
+	e.tv.pushVerifiedVote(c, types.NewFullTimeoutVote(e.keys[0], e.view, utils.None[*types.PrepareQC]()))
+	require.False(t, e.tv.qc.Load().IsPresent())
+}
+
+func TestTimeoutVotes_QuorumFormsQC(t *testing.T) {
+	rng := utils.TestRng()
+	e := newTimeoutEnv(rng)
+	c := e.ep.Committee()
+	pqc := makePrepareQC(e.keys, types.GenProposalForEpoch(rng, e.ep, e.view))
+
+	for _, k := range e.quorum {
+		e.tv.pushVerifiedVote(c, types.NewFullTimeoutVote(k, e.view, utils.Some(pqc)))
+	}
+	got, ok := e.tv.qc.Load().Get()
+	require.True(t, ok)
+	require.Equal(t, e.view, got.View())
+	require.NoError(t, got.Verify(e.ep, utils.None[*types.CommitQC]()))
+	require.True(t, got.LatestPrepareQC().IsPresent())
+}
+
+func TestTimeoutVotes_SameViewAfterQCDoesNotChangeView(t *testing.T) {
+	e := newTimeoutEnv(utils.TestRng())
+	c := e.ep.Committee()
+
+	for _, k := range e.quorum {
+		e.tv.pushVerifiedVote(c, types.NewFullTimeoutVote(k, e.view, utils.None[*types.PrepareQC]()))
+	}
+	require.True(t, e.tv.qc.Load().IsPresent())
+	e.tv.pushVerifiedVote(c, types.NewFullTimeoutVote(e.keys[3], e.view, utils.None[*types.PrepareQC]()))
+	got, ok := e.tv.qc.Load().Get()
+	require.True(t, ok)
+	require.Equal(t, e.view, got.View())
+}
+
+func TestTimeoutVotes_IgnoresStaleVoteFromSameKey(t *testing.T) {
+	e := newTimeoutEnv(utils.TestRng())
+	c := e.ep.Committee()
+	view1 := e.view.Next()
+
+	for _, k := range e.quorum {
+		e.tv.pushVerifiedVote(c, types.NewFullTimeoutVote(k, view1, utils.None[*types.PrepareQC]()))
+	}
+	got, ok := e.tv.qc.Load().Get()
+	require.True(t, ok)
+	require.Equal(t, view1, got.View())
+
+	e.tv.pushVerifiedVote(c, types.NewFullTimeoutVote(e.quorum[0], e.view, utils.None[*types.PrepareQC]()))
+	got, ok = e.tv.qc.Load().Get()
+	require.True(t, ok)
+	require.Equal(t, view1, got.View())
+}
+
+func TestTimeoutVotes_ReplacesOlderVoteAndAdvancesQC(t *testing.T) {
+	e := newTimeoutEnv(utils.TestRng())
+	c := e.ep.Committee()
+	view1 := e.view.Next()
+
+	for _, k := range e.quorum {
+		e.tv.pushVerifiedVote(c, types.NewFullTimeoutVote(k, e.view, utils.None[*types.PrepareQC]()))
+	}
+	got, ok := e.tv.qc.Load().Get()
+	require.True(t, ok)
+	require.Equal(t, e.view, got.View())
+
+	e.tv.pushVerifiedVote(c, types.NewFullTimeoutVote(e.quorum[0], view1, utils.None[*types.PrepareQC]()))
+	got, ok = e.tv.qc.Load().Get()
+	require.True(t, ok)
+	require.Equal(t, e.view, got.View())
+
+	for _, k := range e.quorum[1:] {
+		e.tv.pushVerifiedVote(c, types.NewFullTimeoutVote(k, view1, utils.None[*types.PrepareQC]()))
+	}
+	got, ok = e.tv.qc.Load().Get()
+	require.True(t, ok)
+	require.Equal(t, view1, got.View())
+}

--- a/sei-tendermint/internal/autobahn/consensus/timeout_votes_test.go
+++ b/sei-tendermint/internal/autobahn/consensus/timeout_votes_test.go
@@ -68,11 +68,12 @@ func TestTimeoutVotes_SameViewAfterQCDoesNotChangeView(t *testing.T) {
 	for _, k := range e.quorum {
 		e.tv.pushVerifiedVote(c, types.NewFullTimeoutVote(k, e.view, utils.None[*types.PrepareQC]()))
 	}
-	require.True(t, e.tv.qc.Load().IsPresent())
-	e.tv.pushVerifiedVote(c, types.NewFullTimeoutVote(e.keys[3], e.view, utils.None[*types.PrepareQC]()))
+	before, ok := e.tv.qc.Load().Get()
+	require.True(t, ok)
+	e.tv.pushVerifiedVote(c, types.NewFullTimeoutVote(e.keys[len(e.quorum)], e.view, utils.None[*types.PrepareQC]()))
 	got, ok := e.tv.qc.Load().Get()
 	require.True(t, ok)
-	require.Equal(t, e.view, got.View())
+	require.True(t, before == got)
 }
 
 func TestTimeoutVotes_IgnoresStaleVoteFromSameKey(t *testing.T) {


### PR DESCRIPTION
## Summary
- Rename the lock-held timeout ingest path to `pushVerifiedVote` and drop the unused verify TODO. `PushTimeoutVote` still verifies before taking the lock.
- Add `timeoutVotes` unit tests for QC formation, same-view leftover votes, and stale/newer vote replacement.
- Add `PushTimeoutVote` tests for quorum ingest plus outsider and wrong-epoch rejection.

## Test plan
- [x] `go test github.com/sei-protocol/sei-chain/sei-tendermint/internal/autobahn/consensus -count=1 -run 'TestTimeoutVotes_|TestPushTimeoutVote_'`


Made with [Cursor](https://cursor.com)