### PR TITLE
Pack the rich block within a time budget instead of a fixed attempt count

### DIFF
--- a/integration_test/rpc_tests/utils/txUtils.ts
+++ b/integration_test/rpc_tests/utils/txUtils.ts
@@ -245,6 +245,11 @@ async function waitForNextBlock(
     );
 }
 
+/** Wall-clock budget for packing the rich block; well under the 300s `before` hooks that build it. */
+const RICH_BLOCK_BUDGET_MS = 120_000;
+/** Attempt index past which fee/tip escalation and the per-attempt block back-off stop growing. */
+const RICH_BLOCK_MAX_ESCALATION = 5;
+
 const TRANSFER_VALUE = ethers.parseEther('0.001');
 const rand = (): string => ethers.Wallet.createRandom().address;
 
@@ -255,10 +260,18 @@ const ERC20_POINTER_IFACE = new ethers.Interface([
 
 /**
  * Broadcast one transaction of every kind, each from its own signer, and wait for
- * them to land in a single block. Retries the whole batch if the chain happens to
- * split them across blocks — each retry re-prices with a higher fee multiplier and
- * tip so the batch outbids its way into one block on a congested chain, and backs
- * off by one more block per attempt so a transient stall on the cluster (a slow
+ * them to land in a single block.
+ *
+ * Whether one broadcast burst lands in one block is a race the client cannot win
+ * deterministically: the cluster seals a block every ~200ms while the RPC node
+ * simulates, CheckTx-es and gossips each of the ~11 txs, so a proposer regularly
+ * cuts a block in the middle of the burst. The fixture therefore keeps retrying the
+ * whole batch until it packs, bounded by a wall-clock budget rather than a fixed
+ * attempt count — a run only fails when the chain cannot pack one block within
+ * `budgetMs`, which is a real cluster problem, not an unlucky sequence of coin
+ * flips. Early retries re-price with a higher fee multiplier and tip so the batch
+ * outbids its way into one block on a congested chain, and back off by one more
+ * block per attempt (both capped) so a transient stall on the cluster (a slow
  * proposer, a backlog left by a preceding load test) has time to clear. `signers`
  * must hold at least 9 funded accounts.
  *
@@ -273,7 +286,7 @@ export async function buildRichSeiBlock(
     provider: ethers.JsonRpcProvider,
     runtime: RuntimeState,
     signers: EvmAccount[],
-    attempts = 6,
+    budgetMs = RICH_BLOCK_BUDGET_MS,
 ): Promise<RichBlock> {
     if (signers.length < 9) {
         throw new Error(`buildRichSeiBlock needs >= 9 signers, got ${signers.length}`);
@@ -290,9 +303,11 @@ export async function buildRichSeiBlock(
         'function validators(string status, bytes pagination) returns (bytes,bytes)',
     ]).encodeFunctionData('validators', ['BOND_STATUS_BONDED', '0x']);
 
-    let lastErr: unknown;
-    for (let attempt = 0; attempt < attempts; attempt++) {
-        const p = await pricing(provider, BigInt(3 + attempt * 2), BigInt(1 + attempt));
+    const deadline = Date.now() + budgetMs;
+    const history: string[] = [];
+    for (let attempt = 0; attempt === 0 || Date.now() < deadline; attempt++) {
+        const escalation = Math.min(attempt, RICH_BLOCK_MAX_ESCALATION);
+        const p = await pricing(provider, BigInt(3 + escalation * 2), BigInt(1 + escalation));
         const [sLegacy, sAccess, s1559, sSetCode, sDeploy, sErc20, sPrecompile, sOutOfGas, sRevert] =
             signers;
         const [nLegacy, nAccess, n1559, nSetCode, nDeploy, nErc20, nPrecompile, nOutOfGas, nRevert] =
@@ -455,7 +470,7 @@ export async function buildRichSeiBlock(
             await waitForNextBlock(
                 provider,
                 `next Sei block before rich batch attempt ${attempt + 1}`,
-                1 + attempt,
+                1 + escalation,
             );
             const cosmosPending = preparedCosmos
                 ? preparedCosmos
@@ -516,7 +531,7 @@ export async function buildRichSeiBlock(
             const placement = specs
                 .map((s, i) => `${s.kind}@${receipts[i]?.blockNumber ?? 'none'}:${receipts[i]?.status ?? '?'}`)
                 .join(' ');
-            lastErr = new Error(
+            history.push(
                 `attempt ${attempt + 1}: EVM blocks ${[...uniqueBlocks].join(',')} [${placement}]` +
                     (wasm
                         ? `, cosmos cw20 ${cosmos ? `code ${cosmos.code} @ block ${cosmos.height}` : 'failed'} ` +
@@ -524,10 +539,13 @@ export async function buildRichSeiBlock(
                         : ''),
             );
         } catch (e) {
-            lastErr = e;
+            history.push(`attempt ${attempt + 1}: ${e instanceof Error ? e.message : String(e)}`);
         }
     }
-    throw new Error(`buildRichSeiBlock: could not pack one block after ${attempts} attempts: ${lastErr}`);
+    throw new Error(
+        `buildRichSeiBlock: could not pack one block within ${budgetMs}ms (${history.length} attempts):\n  ` +
+            history.join('\n  '),
+    );
 }
 
 // The serial runner (.mocharc.run.json) loads every spec into a single process, so this

--- a/integration_test/rpc_tests/utils/txUtils.ts
+++ b/integration_test/rpc_tests/utils/txUtils.ts
@@ -249,6 +249,10 @@ async function waitForNextBlock(
 const RICH_BLOCK_BUDGET_MS = 120_000;
 /** Attempt index past which fee/tip escalation and the per-attempt block back-off stop growing. */
 const RICH_BLOCK_MAX_ESCALATION = 5;
+/** Attempt ceiling so a deterministic (fast-throwing) breakage fails fast instead of spinning out the budget. */
+const RICH_BLOCK_MAX_ATTEMPTS = 30;
+/** Number of most recent attempt placements kept in the terminal error. */
+const RICH_BLOCK_HISTORY_TAIL = 10;
 
 const TRANSFER_VALUE = ethers.parseEther('0.001');
 const rand = (): string => ethers.Wallet.createRandom().address;
@@ -305,7 +309,11 @@ export async function buildRichSeiBlock(
 
     const deadline = Date.now() + budgetMs;
     const history: string[] = [];
-    for (let attempt = 0; attempt === 0 || Date.now() < deadline; attempt++) {
+    for (
+        let attempt = 0;
+        attempt === 0 || (attempt < RICH_BLOCK_MAX_ATTEMPTS && Date.now() < deadline);
+        attempt++
+    ) {
         const escalation = Math.min(attempt, RICH_BLOCK_MAX_ESCALATION);
         const p = await pricing(provider, BigInt(3 + escalation * 2), BigInt(1 + escalation));
         const [sLegacy, sAccess, s1559, sSetCode, sDeploy, sErc20, sPrecompile, sOutOfGas, sRevert] =
@@ -543,8 +551,9 @@ export async function buildRichSeiBlock(
         }
     }
     throw new Error(
-        `buildRichSeiBlock: could not pack one block within ${budgetMs}ms (${history.length} attempts):\n  ` +
-            history.join('\n  '),
+        `buildRichSeiBlock: could not pack one block within ${budgetMs}ms (${history.length} attempts, ` +
+            `showing last ${Math.min(history.length, RICH_BLOCK_HISTORY_TAIL)}):\n  ` +
+            history.slice(-RICH_BLOCK_HISTORY_TAIL).join('\n  '),
     );
 }
 
@@ -561,16 +570,15 @@ export async function sharedRichBlock(
     runtime: RuntimeState,
 ): Promise<RichBlock> {
     if (cachedRichBlock) return cachedRichBlock;
-    // Guard against two specs' `before` hooks racing the first build in the same process.
+    // Guard against two specs' `before` hooks racing the first build in the same process. The
+    // promise is kept on rejection too: the build already retried for its whole budget, so a
+    // failure is a cluster problem every dependent spec should fail on once, not re-spend on.
     if (!cachedRichBlockPromise) {
         cachedRichBlockPromise = (async () => {
             const signers = claimPool(runtime, provider, 9, 'shared-rich-block');
             cachedRichBlock = await buildRichSeiBlock(provider, runtime, signers);
             return cachedRichBlock;
-        })().catch(e => {
-            cachedRichBlockPromise = undefined;
-            throw e;
-        });
+        })();
     }
     return cachedRichBlockPromise;
 }


### PR DESCRIPTION
The rich-block fixture needs ~11 transactions (one of every EVM type plus a pure Cosmos CW20 transfer) to land in a single block, but the integration cluster seals a block every ~200ms while the RPC node simulates, CheckTx-es and gossips each tx of the burst. A proposer therefore regularly cuts a block in the middle of the burst, and which tx ends up on the wrong side is arbitrary: before #4136 it was the Cosmos transfer landing one height early, in the latest failure it was the EIP-7702 setCode tx alone landing one height late. Six fixed attempts is only a handful of coin flips against that race, so on a loaded runner all six lose and the whole `before all` hook fails.

`buildRichSeiBlock` now retries until it packs a block, bounded by a wall-clock budget (120s, well inside the 300s hook timeouts) rather than a handful of attempts; the fee/tip escalation and the per-attempt block back-off are capped so later attempts do not keep inflating, and a generous attempt ceiling (30) still fails a deterministic, fast-throwing breakage quickly instead of spinning out the budget. A run only fails when the chain cannot pack one block within the budget, which is a real cluster problem rather than an unlucky sequence; `sharedRichBlock` now memoizes that failure so the ~10 dependent spec hooks fail once instead of each re-spending the budget. The final error lists the last ten attempts' placements so a future failure shows whether the split is random or systematic.

Flaked in: https://github.com/sei-protocol/sei-chain/actions/runs/34435811371/job/102742076452, https://github.com/sei-protocol/sei-chain/actions/runs/34556392814/job/103130639686
