### PR TITLE
Pin a stable head for every multi-read fee-market assertion

### DIFF
--- a/integration_test/rpc_tests/eth/eth_gasPrice.spec.ts
+++ b/integration_test/rpc_tests/eth/eth_gasPrice.spec.ts
@@ -5,8 +5,10 @@ import { EvmAccount } from '../utils/evmUtils';
 import { burnGasBurst } from '../utils/txUtils';
 import { HEX_QUANTITY } from '../utils/format';
 import {
+    atStableHead,
     gasPrice,
     gasPriceAtStableBlock,
+    maxPriorityFeePerGas,
     assertSeiGasPriceTracks,
     DEFAULT_PRIORITY_FEE_WEI,
     isCongested,
@@ -48,11 +50,11 @@ describe('eth_gasPrice', function () {
         });
 
         it('is at least the current base fee, so a tx priced at it is includable (both)', async () => {
-            const [sGas, sBlk, gGas, gBlk] = await Promise.all([
-                gasPrice(sei),
-                blockGasInfo(sei, 'latest'),
-                gasPrice(geth),
-                blockGasInfo(geth, 'latest'),
+            const priceAndBase = (p: typeof sei) =>
+                atStableHead(p, () => Promise.all([gasPrice(p), blockGasInfo(p, 'latest')]), 'gasPrice vs base fee');
+            const [{ value: [sGas, sBlk] }, { value: [gGas, gBlk] }] = await Promise.all([
+                priceAndBase(sei),
+                priceAndBase(geth),
             ]);
             expect(sGas >= sBlk.baseFee, `sei gasPrice ${sGas} < base ${sBlk.baseFee}`).to.equal(true);
             expect(gGas >= gBlk.baseFee, `geth gasPrice ${gGas} < base ${gBlk.baseFee}`).to.equal(true);
@@ -66,12 +68,16 @@ describe('eth_gasPrice', function () {
         });
 
         it('[geth] the gas price equals the base fee plus the suggested priority fee (exact)', async () => {
-            const [price, tip, blk] = await Promise.all([
-                gasPrice(geth),
-                BigInt(await geth.send('eth_maxPriorityFeePerGas', [])),
-                blockGasInfo(geth, 'latest'),
-            ]);
-            expect(price, 'geth gasPrice = baseFee + tip').to.equal(blk.baseFee + tip);
+            const {
+                value: [price, tip, blk],
+                block,
+            } = await atStableHead(
+                geth,
+                () => Promise.all([gasPrice(geth), maxPriorityFeePerGas(geth), blockGasInfo(geth, 'latest')]),
+                'geth gasPrice = baseFee + tip',
+            );
+            expect(blk.number, 'latest block read at the pinned head').to.equal(block);
+            expect(price, `geth gasPrice = baseFee + tip at block ${block}`).to.equal(blk.baseFee + tip);
         });
 
         it('[Sei] maxPriorityFeePerGas defaults to 1 gwei while the chain is uncongested', async () => {

--- a/integration_test/rpc_tests/eth/eth_maxPriorityFeePerGas.spec.ts
+++ b/integration_test/rpc_tests/eth/eth_maxPriorityFeePerGas.spec.ts
@@ -13,6 +13,7 @@ import {
     CONGESTION_THRESHOLD,
     isCongested,
     maxPriorityFeePerGasAtStableBlock,
+    atStableHead,
 } from '../utils/gasPriceUtils';
 
 describe('eth_maxPriorityFeePerGas', function () {
@@ -40,7 +41,13 @@ describe('eth_maxPriorityFeePerGas', function () {
         });
 
         it('stays within a sane bound (never more than the total gas price)', async () => {
-            const [tip, price] = await Promise.all([maxPriorityFeePerGas(sei), gasPrice(sei)]);
+            const {
+                value: [tip, price],
+            } = await atStableHead(
+                sei,
+                () => Promise.all([maxPriorityFeePerGas(sei), gasPrice(sei)]),
+                'tip <= gasPrice',
+            );
             expect(tip <= price, `tip ${tip} must be <= gasPrice ${price}`).to.equal(true);
         });
 
@@ -82,11 +89,15 @@ describe('eth_maxPriorityFeePerGas', function () {
             let sample: { tip: bigint; ratio: number; block: number } | null = null;
             const deadline = Date.now() + 90_000;
             while (Date.now() < deadline && !sample) {
-                const b1 = await sei.getBlockNumber();
-                const tip = await maxPriorityFeePerGas(sei);
-                const info = await blockGasInfo(sei, 'latest');
-                const b2 = await sei.getBlockNumber();
-                if (b1 === b2 && info.number === b1) {
+                // A single pinned try per poll: a head that moved is just skipped, not an error.
+                const pinned = await atStableHead(
+                    sei,
+                    () => Promise.all([maxPriorityFeePerGas(sei), blockGasInfo(sei, 'latest')]),
+                    'congested priority-fee head',
+                    1,
+                ).catch(() => null);
+                if (pinned && pinned.value[1].number === pinned.block) {
+                    const [tip, info] = pinned.value;
                     const ratio = Number(info.gasUsed) / Number(info.gasLimit);
                     if (ratio > 0.8) sample = { tip, ratio, block: info.number };
                 }

--- a/integration_test/rpc_tests/utils/gasPriceUtils.ts
+++ b/integration_test/rpc_tests/utils/gasPriceUtils.ts
@@ -21,6 +21,29 @@ export async function maxPriorityFeePerGas(provider: ethers.JsonRpcProvider): Pr
     return BigInt(await provider.send('eth_maxPriorityFeePerGas', []));
 }
 
+/**
+ * Run `sample` with the head pinned: the result is only accepted when no block landed
+ * across the call, so every untagged read inside it (eth_gasPrice, eth_maxPriorityFeePerGas,
+ * a `latest` block) provably derives from the same height. Every fee-market assertion that
+ * relates two or more such reads must go through this; on a chain sealing a block every few
+ * hundred milliseconds (Sei) or every second (geth --dev) a bare Promise.all of them
+ * straddles a boundary often enough to flake. Returns the sample and that height.
+ */
+export async function atStableHead<T>(
+    provider: ethers.JsonRpcProvider,
+    sample: () => Promise<T>,
+    label: string,
+    tries = 50,
+): Promise<{ value: T; block: number }> {
+    for (let i = 0; i < tries; i++) {
+        const b1 = await provider.getBlockNumber();
+        const value = await sample();
+        const b2 = await provider.getBlockNumber();
+        if (b1 === b2) return { value, block: b1 };
+    }
+    throw new Error(`${label}: block kept advancing across the sample (${tries} tries)`);
+}
+
 export interface PriorityFeeSample {
     tip: bigint;
     block: number;
@@ -39,25 +62,22 @@ export interface PriorityFeeSample {
 export async function maxPriorityFeePerGasAtStableBlock(
     provider: ethers.JsonRpcProvider,
 ): Promise<PriorityFeeSample> {
-    for (let i = 0; i < 50; i++) {
-        const b1 = await provider.getBlockNumber();
-        const tip = await maxPriorityFeePerGas(provider);
-        const b2 = await provider.getBlockNumber();
-        if (b1 !== b2) continue;
-
-        const info = await blockGasInfo(provider, b1);
-        const evmGasUsed = await evmGasUsedForBlock(provider, b1);
-        return {
-            tip,
-            block: info.number,
-            gasUsed: info.gasUsed,
-            evmGasUsed,
-            gasLimit: info.gasLimit,
-            ratio: Number(info.gasUsed) / Number(info.gasLimit),
-            evmRatio: Number(evmGasUsed) / Number(info.gasLimit),
-        };
-    }
-    throw new Error('maxPriorityFeePerGasAtStableBlock: block kept advancing across the sample');
+    const { value: tip, block } = await atStableHead(
+        provider,
+        () => maxPriorityFeePerGas(provider),
+        'maxPriorityFeePerGasAtStableBlock',
+    );
+    const info = await blockGasInfo(provider, block);
+    const evmGasUsed = await evmGasUsedForBlock(provider, block);
+    return {
+        tip,
+        block: info.number,
+        gasUsed: info.gasUsed,
+        evmGasUsed,
+        gasLimit: info.gasLimit,
+        ratio: Number(info.gasUsed) / Number(info.gasLimit),
+        evmRatio: Number(evmGasUsed) / Number(info.gasLimit),
+    };
 }
 
 export async function evmGasUsedForBlock(
@@ -83,13 +103,13 @@ export function isCongested(sample: { evmGasUsed: bigint; gasLimit: bigint }): b
 export async function gasPriceAtStableBlock(
     provider: ethers.JsonRpcProvider,
 ): Promise<{ gasPrice: bigint; block: number }> {
-    for (let i = 0; i < 20; i++) {
-        const b1 = await provider.getBlockNumber();
-        const price = await gasPrice(provider);
-        const b2 = await provider.getBlockNumber();
-        if (b1 === b2) return { gasPrice: price, block: b1 };
-    }
-    throw new Error('gasPriceAtStableBlock: block kept advancing across the gas price call');
+    const { value, block } = await atStableHead(
+        provider,
+        () => gasPrice(provider),
+        'gasPriceAtStableBlock',
+        20,
+    );
+    return { gasPrice: value, block };
 }
 
 /**


### PR DESCRIPTION
The geth `eth_gasPrice` parity test read `eth_gasPrice`, `eth_maxPriorityFeePerGas` and the `latest` block's base fee with a bare `Promise.all`. None of those RPCs take a block tag, so each answers against whatever geth's head is when it happens to be served; with `--dev.period 1` a block lands between the three requests often enough that the base fee and tip come from a different block than the gas price, and the exact equality fails (expected 1908832, got 1670229). The sibling Sei-side tests already pin a stable head before asserting, so the geth test was the odd one out, and the "at least the base fee" test had the same latent race on both chains.

The stable-head pinning is now a single generic helper, `atStableHead(provider, sample, label)`, which runs any sampler and only accepts the result when the block number is unchanged across it, returning the value together with that height. `gasPriceAtStableBlock` and `maxPriorityFeePerGasAtStableBlock` are rewritten on top of it, and every spec that relates multiple untagged fee reads (the geth exact check, the includability check on both chains, the tip <= gasPrice bound and the congested-tip poll in the maxPriorityFeePerGas spec) samples through it, so every fee-market comparison in the suite goes through one choke point instead of each test remembering to pin the head itself. The geth test additionally asserts that the `latest` block it read is the pinned height.

Flaked in: https://github.com/sei-protocol/sei-chain/actions/runs/34495035128/job/102932842492
