### PR TITLE
Start the autobahn sidecar from the prebuilt rpcnode image

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -481,6 +481,8 @@ jobs:
           # retagged as sei-chain/*; keeps a single tag per image.
           docker image rm "${GHCR_LOCALNODE}:${{ github.run_id }}" "${GHCR_RPCNODE}:${{ github.run_id }}" || true
       - name: Run autobahn integration tests
+        env:
+          AUTOBAHN_PREBUILT_IMAGES: "true"
         run: make autobahn-integration-test
       - name: Print node logs on failure
         if: ${{ failure() }}

--- a/Makefile
+++ b/Makefile
@@ -264,8 +264,11 @@ ensure-integration-ci-localnode-image:
 	@docker image inspect sei-chain/localnode >/dev/null 2>&1 || (echo "sei-chain/localnode image missing; pull from GHCR (see prepare-cluster job)" && exit 1)
 .PHONY: ensure-integration-ci-localnode-image
 
-ensure-integration-ci-images: ensure-integration-ci-localnode-image
+ensure-integration-ci-rpcnode-image:
 	@docker image inspect sei-chain/rpcnode >/dev/null 2>&1 || (echo "sei-chain/rpcnode image missing; pull from GHCR (see prepare-rpcnode job)" && exit 1)
+.PHONY: ensure-integration-ci-rpcnode-image
+
+ensure-integration-ci-images: ensure-integration-ci-localnode-image ensure-integration-ci-rpcnode-image
 .PHONY: ensure-integration-ci-images
 
 # Build seid once inside the localnode image (integration-test prepare job).
@@ -339,7 +342,8 @@ run-rpc-node: build-rpc-node
 	sei-chain/rpcnode
 .PHONY: run-rpc-node
 
-run-rpc-node-skipbuild: build-rpc-node
+# Run the rpc node container against a prebuilt seid (SKIP_BUILD=true) with the sei-chain/rpcnode image.
+define RUN_RPC_NODE_SKIPBUILD
 	docker run --rm \
 	--name sei-rpc-node \
 	--network docker_localnet \
@@ -359,7 +363,18 @@ run-rpc-node-skipbuild: build-rpc-node
 	--env CLUSTER_SIZE=${CLUSTER_SIZE} \
 	--env RECEIPT_BACKEND=${RECEIPT_BACKEND} \
 	sei-chain/rpcnode
-.PHONY: run-rpc-node
+endef
+
+run-rpc-node-skipbuild: build-rpc-node
+	$(RUN_RPC_NODE_SKIPBUILD)
+.PHONY: run-rpc-node-skipbuild
+
+# Integration-test CI: same as run-rpc-node-skipbuild but with the rpcnode image pulled from GHCR
+# (see prepare-rpcnode job) instead of rebuilt here, so image build time never lands inside a
+# test's readiness budget.
+run-rpc-node-skipbuild-ci: ensure-integration-ci-rpcnode-image
+	$(RUN_RPC_NODE_SKIPBUILD)
+.PHONY: run-rpc-node-skipbuild-ci
 
 # Integration-test CI: RPC node with prebuilt image and seid (see .github/workflows/integration-test.yml).
 # Wait for the localnode cluster to produce block 100 (the first snapshot-interval) before

--- a/Makefile
+++ b/Makefile
@@ -574,12 +574,12 @@ autobahn-integration-test:
 	@# The test drives cluster start/stop itself via TestMain — see
 	@# integration_test/autobahn/autobahn_test.go. GOWORK=off ignores an
 	@# ambient go.work so dependency resolution matches the module.
-	@GOWORK=off go test -tags autobahn_integration -v -count=1 -timeout 30m ./integration_test/autobahn/...
+	@GOWORK=off go test -tags autobahn_integration -v -count=1 -timeout 40m ./integration_test/autobahn/...
 .PHONY: autobahn-integration-test
 
 # Run the disk-backed EVM-only executor behind a four-validator Autobahn cluster.
 autobahn-evmonly-integration-test:
-	@AUTOBAHN_EVMONLY=true GOWORK=off go test -tags autobahn_integration -v -count=1 -timeout 30m ./integration_test/autobahn/...
+	@AUTOBAHN_EVMONLY=true GOWORK=off go test -tags autobahn_integration -v -count=1 -timeout 40m ./integration_test/autobahn/...
 .PHONY: autobahn-evmonly-integration-test
 
 # Run a mixed-mode cluster: node 0 uses GIGA_EXECUTOR with OCC, nodes 1-3 use standard V2.

--- a/integration_test/autobahn/autobahn_test.go
+++ b/integration_test/autobahn/autobahn_test.go
@@ -92,8 +92,8 @@ const (
 	haltStableTimeout = 2 * time.Minute
 	testRecipientEVM  = "0x1000000000000000000000000000000000000001"
 
-	// prebuiltImagesEnv selects the `*-ci` make targets, which run the already
-	// present sei-chain/* images instead of rebuilding them.
+	// prebuiltImagesEnv selects run-rpc-node-skipbuild-ci for the sidecar, which
+	// runs the already present sei-chain/rpcnode image instead of rebuilding it.
 	prebuiltImagesEnv = "AUTOBAHN_PREBUILT_IMAGES"
 
 	evmOnlyEnv         = "AUTOBAHN_EVMONLY"
@@ -530,6 +530,11 @@ func setupFullnodeNode() error {
 	// Phase 2: the node's own boot.
 	deadline := time.Now().Add(fullnodeBootTimeout)
 	for time.Now().Before(deadline) {
+		select {
+		case err := <-exited:
+			return fmt.Errorf("make %s exited while %s was booting: %v", target, fullnodeContainer, err)
+		default:
+		}
 		if fullnodeRunning() && fullnodeEVMReady() {
 			fmt.Println("fullnode sidecar is ready")
 			return nil

--- a/integration_test/autobahn/autobahn_test.go
+++ b/integration_test/autobahn/autobahn_test.go
@@ -65,9 +65,12 @@ const (
 	autobahnSettleDelay = 30 * time.Second
 
 	// Fullnode sidecar lifecycle (TestMain).
-	fullnodeContainer   = "sei-rpc-node"
-	fullnodeBootTimeout = 5 * time.Minute
-	fullnodeBootPoll    = 5 * time.Second
+	fullnodeContainer = "sei-rpc-node"
+	// fullnodeStartTimeout bounds `make` getting the container running (image
+	// build/pull); fullnodeBootTimeout bounds the node's own boot after that.
+	fullnodeStartTimeout = 10 * time.Minute
+	fullnodeBootTimeout  = 5 * time.Minute
+	fullnodeBootPoll     = 5 * time.Second
 	// evmRPCURLOnContainerLocalhost is the EVM RPC address inside the
 	// rpc-node container — used with `docker exec ... curl` for readiness
 	// checks (the rpc-node's 8545 isn't host-published).
@@ -88,6 +91,10 @@ const (
 	// CI runners are slower than local; 1m was tight enough to flake.
 	haltStableTimeout = 2 * time.Minute
 	testRecipientEVM  = "0x1000000000000000000000000000000000000001"
+
+	// prebuiltImagesEnv selects the `*-ci` make targets, which run the already
+	// present sei-chain/* images instead of rebuilding them.
+	prebuiltImagesEnv = "AUTOBAHN_PREBUILT_IMAGES"
 
 	evmOnlyEnv         = "AUTOBAHN_EVMONLY"
 	evmOnlyLoadTxs     = 4_000
@@ -222,6 +229,10 @@ func assertAutobahnEnabled(t *testing.T) {
 
 func evmOnlyEnabled() bool {
 	return os.Getenv(evmOnlyEnv) == "true"
+}
+
+func prebuiltImages() bool {
+	return os.Getenv(prebuiltImagesEnv) == "true"
 }
 
 func assertEVMOnlyEnabled(t *testing.T) {
@@ -484,18 +495,39 @@ func setupFullnodeNode() error {
 	if clusterSize == 0 {
 		return fmt.Errorf("no sei-node-* containers found; setupCluster must run first")
 	}
-	cmd := exec.Command("make", "run-rpc-node-skipbuild")
+	target := "run-rpc-node-skipbuild"
+	if prebuiltImages() {
+		target += "-ci"
+	}
+	cmd := exec.Command("make", target)
 	cmd.Env = append(os.Environ(), "AUTOBAHN=true", fmt.Sprintf("CLUSTER_SIZE=%d", clusterSize))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("start make run-rpc-node-skipbuild: %w", err)
+		return fmt.Errorf("start make %s: %w", target, err)
 	}
 	// Reap the process when it eventually exits (e.g. on container kill);
 	// not blocking on Wait here since the container runs for the duration
 	// of the test suite.
-	go func() { _ = cmd.Wait() }()
+	exited := make(chan error, 1)
+	go func() { exited <- cmd.Wait() }()
 
+	// Phase 1: wait for the container to exist and run. Anything `make` does
+	// before `docker run` (image build, pull) lands here, not in the boot budget.
+	startDeadline := time.Now().Add(fullnodeStartTimeout)
+	for !fullnodeRunning() {
+		select {
+		case err := <-exited:
+			return fmt.Errorf("make %s exited before %s was running: %v", target, fullnodeContainer, err)
+		default:
+		}
+		if !time.Now().Before(startDeadline) {
+			return fmt.Errorf("fullnode sidecar container didn't start within %s", fullnodeStartTimeout)
+		}
+		time.Sleep(fullnodeBootPoll)
+	}
+
+	// Phase 2: the node's own boot.
 	deadline := time.Now().Add(fullnodeBootTimeout)
 	for time.Now().Before(deadline) {
 		if fullnodeRunning() && fullnodeEVMReady() {
@@ -504,7 +536,7 @@ func setupFullnodeNode() error {
 		}
 		time.Sleep(fullnodeBootPoll)
 	}
-	return fmt.Errorf("fullnode sidecar didn't come up within %s", fullnodeBootTimeout)
+	return fmt.Errorf("fullnode sidecar didn't come up within %s of the container starting", fullnodeBootTimeout)
 }
 
 func fullnodeRunning() bool {


### PR DESCRIPTION
The Autobahn Basic job pulls the prebuilt rpcnode image from GHCR and tags it `sei-chain/rpcnode`, but `setupFullnodeNode` then runs `make run-rpc-node-skipbuild`, whose `build-rpc-node` prerequisite discards that image and rebuilds `docker/rpcnode` from scratch with no layer cache (apt-get, foundryup, Go toolchain download). The five-minute `fullnodeBootTimeout` starts ticking when `make` is invoked, so on a runner with a slow apt mirror the image build alone exhausts the budget and the job fails with `fullnode sidecar didn't come up within 5m0s` before the node is ever started. "skipbuild" only skips the seid build inside the container, not the image build.

Two changes close this categorically. `run-rpc-node-skipbuild-ci` runs the same `docker run` (shared via `RUN_RPC_NODE_SKIPBUILD`) but depends on `ensure-integration-ci-rpcnode-image` instead of `build-rpc-node`, matching how every other `*-ci` cluster target consumes the pulled images; the workflow selects it with `AUTOBAHN_PREBUILT_IMAGES=true`, so a test job never rebuilds an image again. Independently, `setupFullnodeNode` now waits in two phases: first for `docker ps` to show `sei-rpc-node` running (bounded by `fullnodeStartTimeout`, and failing immediately if `make` exits first), and only then starts the `fullnodeBootTimeout` clock for the node's own boot, so whatever `make` does before `docker run` can never be charged against the node's readiness budget. Both phases return `make`'s exit error as soon as it exits, so a crashing sidecar fails fast with the real cause instead of a timeout; the autobahn `go test -timeout` is widened to 40m to make room for the added start window under the job's 45m limit.

Flaked in: https://github.com/sei-protocol/sei-chain/actions/runs/34594546104/job/103248289599 and https://github.com/sei-protocol/sei-chain/actions/runs/34594546104/job/103255976142
