### PR TITLE
Shard the race-detection run so the merge queue is no longer bound by it

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -20,7 +20,7 @@ env:
   STATE_DB_PKG_PREFIX: github.com/sei-protocol/sei-chain/sei-db/state_db
 
 jobs:
-  # The race run fans out over RACE_SHARDS runners. The shards and the upgrade
+  # The race run fans out over the shard matrix. The shards and the upgrade
   # tests all roll up into the `Race Detection` job below, which is the single
   # check name branch protection and the merge queue require.
   race-shard:
@@ -31,7 +31,6 @@ jobs:
       matrix:
         shard: [0, 1, 2, 3]
     env:
-      RACE_SHARDS: 4
       GOFLAGS: -race -tags=ledger,test_ledger_mock
     steps:
       # See: https://github.com/actions/checkout/releases/tag/v7.0.0
@@ -61,13 +60,13 @@ jobs:
           # Round-robin over the sorted package list: neighbouring packages
           # (sei-db/*, sei-cosmos/x/*) are the slow ones, so contiguous slices
           # would leave one shard with most of the test time.
-          go list -f '{{ if (or .TestGoFiles .XTestGoFiles) }}{{ .ImportPath }}{{ end }}' ./... \
-            | grep . \
+          go list ./... \
             | grep -v "^${STATE_DB_PKG_PREFIX}" \
             | sort \
-            | awk -v n="${RACE_SHARDS}" -v s="${{ matrix.shard }}" '(NR - 1) % n == s' > packages.txt
-          echo "Shard ${{ matrix.shard }}/${RACE_SHARDS}: $(wc -l < packages.txt) packages"
-          xargs go test -timeout=${{ env.GO_TEST_TIMEOUT }} < packages.txt
+            | awk -v n="${{ strategy.job-total }}" -v s="${{ matrix.shard }}" '(NR - 1) % n == s' > packages.txt
+          [[ -s packages.txt ]] || { echo "shard ${{ matrix.shard }} received no packages"; exit 1; }
+          echo "Shard ${{ matrix.shard }}/${{ strategy.job-total }}: $(wc -l < packages.txt) packages"
+          xargs -r go test -timeout=${{ env.GO_TEST_TIMEOUT }} < packages.txt
 
   upgrade-test:
     name: Upgrade tests

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -20,23 +20,41 @@ env:
   STATE_DB_PKG_PREFIX: github.com/sei-protocol/sei-chain/sei-db/state_db
 
 jobs:
-  test:
-    name: Race Detection
+  # The race run fans out over RACE_SHARDS runners. The shards and the upgrade
+  # tests all roll up into the `Race Detection` job below, which is the single
+  # check name branch protection and the merge queue require.
+  race-shard:
+    name: Race Detection (shard ${{ matrix.shard }})
     runs-on: uci-default
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
     env:
+      RACE_SHARDS: 4
       GOFLAGS: -race -tags=ledger,test_ledger_mock
     steps:
       # See: https://github.com/actions/checkout/releases/tag/v7.0.0
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-        with:
-          # upgrade-test-vet resolves historical offline phases from release
-          # branches, so checkout must include their remote refs.
-          fetch-depth: 0
 
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
+
+      # The build cache is keyed per shard because each shard compiles a
+      # different slice of the tree under -race; restore-keys lets a shard warm
+      # up from the previous go.sum generation instead of a cold build.
+      - name: Restore Go build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-race-shard${{ matrix.shard }}-${{ runner.os }}-${{ hashFiles('go.sum') }}-${{ github.run_id }}
+          restore-keys: |
+            go-race-shard${{ matrix.shard }}-${{ runner.os }}-${{ hashFiles('go.sum') }}-
+            go-race-shard${{ matrix.shard }}-${{ runner.os }}-
 
       - name: Login to Docker Hub
         # See: https://github.com/docker/login-action/releases/tag/v4.2.0
@@ -54,12 +72,40 @@ jobs:
       - name: Go test
         run: |
           set -euo pipefail
-          PKGS=$(go list ./... | grep -v "^${STATE_DB_PKG_PREFIX}")
-          echo "$PKGS" | xargs go test \
-            -timeout=${{ env.GO_TEST_TIMEOUT }}
+          # Round-robin over the sorted package list: neighbouring packages
+          # (sei-db/*, sei-cosmos/x/*) are the slow ones, so contiguous slices
+          # would leave one shard with most of the test time.
+          go list -f '{{ if (or .TestGoFiles .XTestGoFiles) }}{{ .ImportPath }}{{ end }}' ./... \
+            | grep . \
+            | grep -v "^${STATE_DB_PKG_PREFIX}" \
+            | sort \
+            | awk -v n="${RACE_SHARDS}" -v s="${{ matrix.shard }}" '(NR - 1) % n == s' > packages.txt
+          echo "Shard ${{ matrix.shard }}/${RACE_SHARDS}: $(wc -l < packages.txt) packages"
+          xargs go test -timeout=${{ env.GO_TEST_TIMEOUT }} < packages.txt
+
+  upgrade-test:
+    name: Upgrade tests
+    runs-on: uci-default
+    env:
+      GOFLAGS: -race -tags=ledger,test_ledger_mock
+    steps:
+      # See: https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          # upgrade-test-vet resolves historical offline phases from release
+          # branches, so checkout must include their remote refs.
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+
+      - name: Download modules
+        run: go mod download
 
       # The file describing the upgrade being shipped sits behind a build tag,
-      # so the run above compiles none of it. The target derives the tag from
+      # so the shards above compile none of it. The target derives the tag from
       # app/tags rather than taking one from here, which is what stops this step
       # from going on running an upgrade that already shipped.
       - name: Minor upgrade test
@@ -69,6 +115,24 @@ jobs:
       # to keep compiling. The run above and golangci-lint both skip them.
       - name: Minor upgrade tests compile
         run: make upgrade-test-vet
+
+  test:
+    name: Race Detection
+    runs-on: ubuntu-latest
+    needs: [ race-shard, upgrade-test ]
+    if: always()
+    steps:
+      - name: Verify race shards and upgrade tests succeeded
+        run: |
+          if [[ "${{ needs.race-shard.result }}" != "success" ]]; then
+            echo "race shards did not succeed (${{ needs.race-shard.result }})"
+            exit 1
+          fi
+          if [[ "${{ needs.upgrade-test.result }}" != "success" ]]; then
+            echo "upgrade tests did not succeed (${{ needs.upgrade-test.result }})"
+            exit 1
+          fi
+          echo "All race shards and upgrade tests passed."
 
   coverage:
     name: Coverage

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -62,7 +62,7 @@ jobs:
           # would leave one shard with most of the test time.
           go list ./... \
             | grep -v "^${STATE_DB_PKG_PREFIX}" \
-            | sort \
+            | LC_ALL=C sort \
             | awk -v n="${{ strategy.job-total }}" -v s="${{ matrix.shard }}" '(NR - 1) % n == s' > packages.txt
           [[ -s packages.txt ]] || { echo "shard ${{ matrix.shard }} received no packages"; exit 1; }
           echo "Shard ${{ matrix.shard }}/${{ strategy.job-total }}: $(wc -l < packages.txt) packages"

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -42,20 +42,6 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
 
-      # The build cache is keyed per shard because each shard compiles a
-      # different slice of the tree under -race; restore-keys lets a shard warm
-      # up from the previous go.sum generation instead of a cold build.
-      - name: Restore Go build cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: go-race-shard${{ matrix.shard }}-${{ runner.os }}-${{ hashFiles('go.sum') }}-${{ github.run_id }}
-          restore-keys: |
-            go-race-shard${{ matrix.shard }}-${{ runner.os }}-${{ hashFiles('go.sum') }}-
-            go-race-shard${{ matrix.shard }}-${{ runner.os }}-
-
       - name: Login to Docker Hub
         # See: https://github.com/docker/login-action/releases/tag/v4.2.0
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee


### PR DESCRIPTION
The merge queue's clean-group floor is about 19–20 minutes, and it is set by a single job: `Race Detection` in the Go Test workflow. It runs `go test -race` over the whole tree in one invocation (~15.7 min wall-clock across roughly 84 package-minutes of test time) and then runs `make upgrade-test` and `make upgrade-test-vet` serially on top (~2.8 min), with no build cache. Every other required workflow finishes in 12–14 minutes or less, so this one job decides how fast a group can land.

This splits the race run into four matrix shards and moves the upgrade tests into their own job. Packages are assigned round-robin over the sorted list rather than in contiguous slices: the slow packages cluster under `sei-db/*` and `sei-cosmos/x/*`, and a contiguous split from the last green run would have put 32 minutes of test time on one shard and 8 on another, whereas round-robin lands at 18–24 minutes each. Coverage is unchanged: the same packages run with the same `-race -tags=ledger,test_ledger_mock` flags, and `state_db` is still excluded because `sei-db-tests.yml` owns it. The shards and the upgrade job roll up into a job that keeps the `Race Detection` name, so the required-check configuration for branch protection and the merge queue does not need to change.
