### PR TITLE
Pin the state-store watermark after SetupBlocks appends blocks

### DIFF
--- a/evmrpc/tests/utils.go
+++ b/evmrpc/tests/utils.go
@@ -40,8 +40,9 @@ type TestServer struct {
 	evmrpc.EVMServer
 	port int
 
-	mockClient *MockClient
-	app        *app.App
+	mockClient  *MockClient
+	app         *app.App
+	ctxProvider func(int64) sdk.Context
 }
 
 func (ts TestServer) Run(r func(port int)) {
@@ -71,7 +72,7 @@ func (ts TestServer) SetupBlocks(blocks [][][]byte, initializer ...func(sdk.Cont
 		_, _ = ts.app.Commit(context.Background())
 		ts.mockClient.recordBlockResult(res.TxResults, res.ConsensusParamUpdates, res.Events)
 	}
-	pinStateStoreLatestVersion(ts.app, ts.app.RPCContextProvider)
+	pinStateStoreLatestVersion(ts.app, ts.ctxProvider)
 }
 
 // pinStateStoreLatestVersion advances the state store's latest version to the app's
@@ -192,7 +193,7 @@ func setupTestServer(
 		}
 		_ = store.SetEarliestVersion(1)
 	}
-	return TestServer{EVMServer: s, port: port, mockClient: mockClient, app: a}
+	return TestServer{EVMServer: s, port: port, mockClient: mockClient, app: a, ctxProvider: ctxProvider}
 }
 
 func sendRequestWithNamespace(namespace string, port int, method string, params ...interface{}) map[string]interface{} {

--- a/evmrpc/tests/utils.go
+++ b/evmrpc/tests/utils.go
@@ -71,6 +71,22 @@ func (ts TestServer) SetupBlocks(blocks [][][]byte, initializer ...func(sdk.Cont
 		_, _ = ts.app.Commit(context.Background())
 		ts.mockClient.recordBlockResult(res.TxResults, res.ConsensusParamUpdates, res.Events)
 	}
+	pinStateStoreLatestVersion(ts.app, ts.app.RPCContextProvider)
+}
+
+// pinStateStoreLatestVersion advances the state store's latest version to the app's
+// committed height so the RPC watermark does not lag behind the asynchronous SS writer.
+func pinStateStoreLatestVersion(a *app.App, ctxProvider func(int64) sdk.Context) {
+	stateStore := a.GetStateStore()
+	if stateStore == nil {
+		return
+	}
+	latest := ctxProvider(evmrpc.LatestCtxHeight).BlockHeight()
+	if stateStore.GetLatestVersion() < latest {
+		if err := stateStore.SetLatestVersion(latest); err != nil {
+			panic(err)
+		}
+	}
 }
 
 func initializeApp(
@@ -168,14 +184,7 @@ func setupTestServer(
 	if err != nil {
 		panic(err)
 	}
-	if stateStore := a.GetStateStore(); stateStore != nil {
-		latest := ctxProvider(evmrpc.LatestCtxHeight).BlockHeight()
-		if stateStore.GetLatestVersion() < latest {
-			if err := stateStore.SetLatestVersion(latest); err != nil {
-				panic(err)
-			}
-		}
-	}
+	pinStateStoreLatestVersion(a, ctxProvider)
 	if store := a.EvmKeeper.ReceiptStore(); store != nil {
 		latest := int64(math.MaxInt64)
 		if err := store.SetLatestVersion(latest); err != nil {


### PR DESCRIPTION
TestGetBlockAfterBaseFeeChange panics on `eth_getBlockByNumber("0x4")` returning `null`. The test apps run with SeiDB SS enabled, and SS commits are applied by an asynchronous writer, so right after `Commit` the state store's latest version can still trail the app's committed height. The RPC watermark takes the minimum across Tendermint, the app context, the receipt store and the state store, so a request for the just-committed height lands above the safe latest and is answered with `null`. `setupTestServer` already pins the state store to the committed height for exactly this reason, but `SetupBlocks`, which appends blocks after the server exists, did not, so any test that appends blocks and reads them straight away races the writer.

The pin is moved into a helper that both `setupTestServer` and `SetupBlocks` call, so every block-appending path in the harness advances the state store watermark before the test continues.

Flaked in: https://github.com/sei-protocol/sei-chain/actions/runs/34620197535/job/103331963799
