### PR TITLE
Fix privval signer test race by swapping the validator under its mutex

### DIFF
--- a/sei-tendermint/privval/signer_client_test.go
+++ b/sei-tendermint/privval/signer_client_test.go
@@ -304,7 +304,7 @@ func TestSignerSignProposalErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer tc.closer()
 			// Replace service with a mock that always fails
-			tc.signerServer.privVal = types.NewErroringMockPV()
+			tc.signerServer.SetPrivValidator(types.NewErroringMockPV())
 			tc.mockPV = types.NewErroringMockPV()
 
 			ts := time.Now()
@@ -357,7 +357,7 @@ func TestSignerSignVoteErrors(t *testing.T) {
 			}
 
 			// Replace signer service privval with one that always fails
-			tc.signerServer.privVal = types.NewErroringMockPV()
+			tc.signerServer.SetPrivValidator(types.NewErroringMockPV())
 			tc.mockPV = types.NewErroringMockPV()
 
 			err := tc.signerClient.SignVote(ctx, tc.chainID, vote.ToProto())
@@ -405,7 +405,7 @@ func TestSignerUnexpectedResponse(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer tc.closer()
 
-			tc.signerServer.privVal = types.NewMockPV()
+			tc.signerServer.SetPrivValidator(types.NewMockPV())
 			tc.mockPV = types.NewMockPV()
 
 			tc.signerServer.SetRequestHandler(brokenHandler)

--- a/sei-tendermint/privval/signer_server.go
+++ b/sei-tendermint/privval/signer_server.go
@@ -22,9 +22,9 @@ type SignerServer struct {
 
 	endpoint *SignerDialerEndpoint
 	chainID  string
-	privVal  types.PrivValidator
 
 	handlerMtx               sync.Mutex
+	privVal                  types.PrivValidator
 	validationRequestHandler ValidationRequestHandlerFunc
 }
 
@@ -58,6 +58,13 @@ func (ss *SignerServer) SetRequestHandler(validationRequestHandler ValidationReq
 	ss.handlerMtx.Lock()
 	defer ss.handlerMtx.Unlock()
 	ss.validationRequestHandler = validationRequestHandler
+}
+
+// SetPrivValidator replaces the validator that services signing requests.
+func (ss *SignerServer) SetPrivValidator(privVal types.PrivValidator) {
+	ss.handlerMtx.Lock()
+	defer ss.handlerMtx.Unlock()
+	ss.privVal = privVal
 }
 
 func (ss *SignerServer) servicePendingRequest(ctx context.Context) {


### PR DESCRIPTION
`TestSignerSignVoteErrors`, `TestSignerSignProposalErrors` and `TestSignerUnexpectedResponse` swap the server's validator by assigning `signerServer.privVal` directly while the server's service loop is already running. `NewSignerClient` has by then exchanged a request with the server, so that goroutine has read `privVal` without any synchronization against the test's write, and the race detector reports it whenever the two accesses land in its history window.

`SignerServer` now exposes `SetPrivValidator`, which swaps the validator under the same mutex `servicePendingRequest` holds while dispatching a request (the one `SetRequestHandler` already uses), and the tests call it instead of writing the field.

Flaked in: https://github.com/sei-protocol/sei-chain/actions/runs/34629084626/job/103361238698
