### PR TITLE
Cap blob sidecar conversion before KZG allocation (CON-418)

### DIFF
--- a/giga/deps/xevm/types/ethtx/blob_tx.go
+++ b/giga/deps/xevm/types/ethtx/blob_tx.go
@@ -14,6 +14,10 @@ import (
 	"github.com/sei-protocol/sei-chain/utils"
 )
 
+// maxBlobSidecarItems is EIP-4844's initial maximum number of blobs,
+// commitments, or proofs a sidecar may carry.
+const maxBlobSidecarItems = 6
+
 func NewBlobTx(tx *ethtypes.Transaction) (*BlobTx, error) {
 	if err := ValidateEthTx(tx); err != nil {
 		return nil, err
@@ -311,11 +315,6 @@ func sidecarToEthSidecar(sidecar *BlobTxSidecar) *ethtypes.BlobTxSidecar {
 		Proofs:      utils.Map(sidecar.Proofs, func(p []byte) kzg4844.Proof { return kzg4844.Proof(p) }),
 	}
 }
-
-// maxBlobSidecarItems is the largest number of blobs, commitments, or proofs a
-// sidecar may carry. Each blob is 131072 bytes, so conversion must not allocate
-// from an attacker-controlled count.
-const maxBlobSidecarItems = 6
 
 // validateBlobTxSidecar returns an error if sidecar cannot be converted into
 // fixed-size KZG blobs, commitments, and proofs.

--- a/giga/deps/xevm/types/ethtx/blob_tx.go
+++ b/giga/deps/xevm/types/ethtx/blob_tx.go
@@ -250,6 +250,16 @@ func (tx BlobTx) Validate() error {
 		)
 	}
 
+	if len(tx.BlobHashes) > maxBlobSidecarItems {
+		return fmt.Errorf("too many blob hashes: have %d, permitted %d", len(tx.BlobHashes), maxBlobSidecarItems)
+	}
+	if err := validateBlobTxSidecar(tx.Sidecar); err != nil {
+		return err
+	}
+	if tx.Sidecar != nil && len(tx.BlobHashes) != len(tx.Sidecar.Blobs) {
+		return fmt.Errorf("invalid number of %d blobs compared to %d blob hashes", len(tx.Sidecar.Blobs), len(tx.BlobHashes))
+	}
+
 	return nil
 }
 
@@ -292,9 +302,63 @@ func sidecarToEthSidecar(sidecar *BlobTxSidecar) *ethtypes.BlobTxSidecar {
 	if sidecar == nil {
 		return nil
 	}
+	if err := validateBlobTxSidecar(sidecar); err != nil {
+		return nil
+	}
 	return &ethtypes.BlobTxSidecar{
 		Blobs:       utils.Map(sidecar.Blobs, func(b []byte) kzg4844.Blob { return kzg4844.Blob(b) }),
 		Commitments: utils.Map(sidecar.Commitments, func(b []byte) kzg4844.Commitment { return kzg4844.Commitment(b) }),
 		Proofs:      utils.Map(sidecar.Proofs, func(p []byte) kzg4844.Proof { return kzg4844.Proof(p) }),
 	}
+}
+
+// maxBlobSidecarItems is the largest number of blobs, commitments, or proofs a
+// sidecar may carry. Each blob is 131072 bytes, so conversion must not allocate
+// from an attacker-controlled count.
+const maxBlobSidecarItems = 6
+
+// validateBlobTxSidecar returns an error if sidecar cannot be converted into
+// fixed-size KZG blobs, commitments, and proofs.
+func validateBlobTxSidecar(sidecar *BlobTxSidecar) error {
+	if sidecar == nil {
+		return nil
+	}
+	if err := validateSidecarItemCount("blobs", len(sidecar.Blobs)); err != nil {
+		return err
+	}
+	if err := validateSidecarItemCount("commitments", len(sidecar.Commitments)); err != nil {
+		return err
+	}
+	if err := validateSidecarItemCount("proofs", len(sidecar.Proofs)); err != nil {
+		return err
+	}
+	if len(sidecar.Blobs) != len(sidecar.Commitments) || len(sidecar.Blobs) != len(sidecar.Proofs) {
+		return errors.New("sidecar blob, commitment, and proof counts do not match")
+	}
+	blobLen := len(kzg4844.Blob{})
+	commitmentLen := len(kzg4844.Commitment{})
+	proofLen := len(kzg4844.Proof{})
+	for i, b := range sidecar.Blobs {
+		if len(b) != blobLen {
+			return fmt.Errorf("invalid sidecar blob %d length: have %d, want %d", i, len(b), blobLen)
+		}
+	}
+	for i, c := range sidecar.Commitments {
+		if len(c) != commitmentLen {
+			return fmt.Errorf("invalid sidecar commitment %d length: have %d, want %d", i, len(c), commitmentLen)
+		}
+	}
+	for i, p := range sidecar.Proofs {
+		if len(p) != proofLen {
+			return fmt.Errorf("invalid sidecar proof %d length: have %d, want %d", i, len(p), proofLen)
+		}
+	}
+	return nil
+}
+
+func validateSidecarItemCount(name string, n int) error {
+	if n > maxBlobSidecarItems {
+		return fmt.Errorf("too many sidecar %s: have %d, permitted %d", name, n, maxBlobSidecarItems)
+	}
+	return nil
 }

--- a/giga/deps/xevm/types/ethtx/blob_tx_test.go
+++ b/giga/deps/xevm/types/ethtx/blob_tx_test.go
@@ -137,4 +137,67 @@ func TestValidateBlobTransaction(t *testing.T) {
 	tx.ChainID = nil
 	require.NotNil(t, tx.Validate())
 	tx.ChainID = chainID
+	hashes := tx.BlobHashes
+	tx.BlobHashes = make([][]byte, maxBlobSidecarItems+1)
+	require.NotNil(t, tx.Validate())
+	tx.BlobHashes = hashes
+}
+
+func TestSidecarConversionRejectsInvalidShape(t *testing.T) {
+	ethTx := mockBlobTransaction(uint256.NewInt(20))
+	tx, err := NewBlobTx(ethTx)
+	require.NoError(t, err)
+
+	t.Run("too many empty blobs", func(t *testing.T) {
+		n := 10_000
+		tx.Sidecar = &BlobTxSidecar{
+			Blobs:       make([][]byte, n),
+			Commitments: make([][]byte, n),
+			Proofs:      make([][]byte, n),
+		}
+		require.Error(t, tx.Validate())
+		require.NotPanics(t, func() {
+			data := tx.AsEthereumData().(*ethtypes.BlobTx)
+			require.Nil(t, data.Sidecar)
+		})
+	})
+
+	t.Run("short blob", func(t *testing.T) {
+		tx.Sidecar = &BlobTxSidecar{
+			Blobs:       [][]byte{{0x01}},
+			Commitments: [][]byte{make([]byte, len(kzg4844.Commitment{}))},
+			Proofs:      [][]byte{make([]byte, len(kzg4844.Proof{}))},
+		}
+		require.Error(t, tx.Validate())
+		require.NotPanics(t, func() {
+			data := tx.AsEthereumData().(*ethtypes.BlobTx)
+			require.Nil(t, data.Sidecar)
+		})
+	})
+
+	t.Run("mismatched counts", func(t *testing.T) {
+		tx.Sidecar = &BlobTxSidecar{
+			Blobs:       [][]byte{make([]byte, len(kzg4844.Blob{}))},
+			Commitments: [][]byte{make([]byte, len(kzg4844.Commitment{})), make([]byte, len(kzg4844.Commitment{}))},
+			Proofs:      [][]byte{make([]byte, len(kzg4844.Proof{}))},
+		}
+		require.Error(t, tx.Validate())
+		require.NotPanics(t, func() {
+			data := tx.AsEthereumData().(*ethtypes.BlobTx)
+			require.Nil(t, data.Sidecar)
+		})
+	})
+
+	t.Run("too many commitments only", func(t *testing.T) {
+		tx.Sidecar = &BlobTxSidecar{
+			Blobs:       [][]byte{make([]byte, len(kzg4844.Blob{}))},
+			Commitments: make([][]byte, maxBlobSidecarItems+1),
+			Proofs:      [][]byte{make([]byte, len(kzg4844.Proof{}))},
+		}
+		require.Error(t, tx.Validate())
+		require.NotPanics(t, func() {
+			data := tx.AsEthereumData().(*ethtypes.BlobTx)
+			require.Nil(t, data.Sidecar)
+		})
+	})
 }

--- a/x/evm/types/ethtx/blob_tx.go
+++ b/x/evm/types/ethtx/blob_tx.go
@@ -14,6 +14,10 @@ import (
 	"github.com/sei-protocol/sei-chain/utils"
 )
 
+// maxBlobSidecarItems is EIP-4844's initial maximum number of blobs,
+// commitments, or proofs a sidecar may carry.
+const maxBlobSidecarItems = 6
+
 func NewBlobTx(tx *ethtypes.Transaction) (*BlobTx, error) {
 	if err := ValidateEthTx(tx); err != nil {
 		return nil, err
@@ -311,11 +315,6 @@ func sidecarToEthSidecar(sidecar *BlobTxSidecar) *ethtypes.BlobTxSidecar {
 		Proofs:      utils.Map(sidecar.Proofs, func(p []byte) kzg4844.Proof { return kzg4844.Proof(p) }),
 	}
 }
-
-// maxBlobSidecarItems is the largest number of blobs, commitments, or proofs a
-// sidecar may carry. Each blob is 131072 bytes, so conversion must not allocate
-// from an attacker-controlled count.
-const maxBlobSidecarItems = 6
 
 // validateBlobTxSidecar returns an error if sidecar cannot be converted into
 // fixed-size KZG blobs, commitments, and proofs.

--- a/x/evm/types/ethtx/blob_tx.go
+++ b/x/evm/types/ethtx/blob_tx.go
@@ -250,6 +250,16 @@ func (tx BlobTx) Validate() error {
 		)
 	}
 
+	if len(tx.BlobHashes) > maxBlobSidecarItems {
+		return fmt.Errorf("too many blob hashes: have %d, permitted %d", len(tx.BlobHashes), maxBlobSidecarItems)
+	}
+	if err := validateBlobTxSidecar(tx.Sidecar); err != nil {
+		return err
+	}
+	if tx.Sidecar != nil && len(tx.BlobHashes) != len(tx.Sidecar.Blobs) {
+		return fmt.Errorf("invalid number of %d blobs compared to %d blob hashes", len(tx.Sidecar.Blobs), len(tx.BlobHashes))
+	}
+
 	return nil
 }
 
@@ -292,9 +302,63 @@ func sidecarToEthSidecar(sidecar *BlobTxSidecar) *ethtypes.BlobTxSidecar {
 	if sidecar == nil {
 		return nil
 	}
+	if err := validateBlobTxSidecar(sidecar); err != nil {
+		return nil
+	}
 	return &ethtypes.BlobTxSidecar{
 		Blobs:       utils.Map(sidecar.Blobs, func(b []byte) kzg4844.Blob { return kzg4844.Blob(b) }),
 		Commitments: utils.Map(sidecar.Commitments, func(b []byte) kzg4844.Commitment { return kzg4844.Commitment(b) }),
 		Proofs:      utils.Map(sidecar.Proofs, func(p []byte) kzg4844.Proof { return kzg4844.Proof(p) }),
 	}
+}
+
+// maxBlobSidecarItems is the largest number of blobs, commitments, or proofs a
+// sidecar may carry. Each blob is 131072 bytes, so conversion must not allocate
+// from an attacker-controlled count.
+const maxBlobSidecarItems = 6
+
+// validateBlobTxSidecar returns an error if sidecar cannot be converted into
+// fixed-size KZG blobs, commitments, and proofs.
+func validateBlobTxSidecar(sidecar *BlobTxSidecar) error {
+	if sidecar == nil {
+		return nil
+	}
+	if err := validateSidecarItemCount("blobs", len(sidecar.Blobs)); err != nil {
+		return err
+	}
+	if err := validateSidecarItemCount("commitments", len(sidecar.Commitments)); err != nil {
+		return err
+	}
+	if err := validateSidecarItemCount("proofs", len(sidecar.Proofs)); err != nil {
+		return err
+	}
+	if len(sidecar.Blobs) != len(sidecar.Commitments) || len(sidecar.Blobs) != len(sidecar.Proofs) {
+		return errors.New("sidecar blob, commitment, and proof counts do not match")
+	}
+	blobLen := len(kzg4844.Blob{})
+	commitmentLen := len(kzg4844.Commitment{})
+	proofLen := len(kzg4844.Proof{})
+	for i, b := range sidecar.Blobs {
+		if len(b) != blobLen {
+			return fmt.Errorf("invalid sidecar blob %d length: have %d, want %d", i, len(b), blobLen)
+		}
+	}
+	for i, c := range sidecar.Commitments {
+		if len(c) != commitmentLen {
+			return fmt.Errorf("invalid sidecar commitment %d length: have %d, want %d", i, len(c), commitmentLen)
+		}
+	}
+	for i, p := range sidecar.Proofs {
+		if len(p) != proofLen {
+			return fmt.Errorf("invalid sidecar proof %d length: have %d, want %d", i, len(p), proofLen)
+		}
+	}
+	return nil
+}
+
+func validateSidecarItemCount(name string, n int) error {
+	if n > maxBlobSidecarItems {
+		return fmt.Errorf("too many sidecar %s: have %d, permitted %d", name, n, maxBlobSidecarItems)
+	}
+	return nil
 }

--- a/x/evm/types/ethtx/blob_tx_test.go
+++ b/x/evm/types/ethtx/blob_tx_test.go
@@ -137,4 +137,67 @@ func TestValidateBlobTransaction(t *testing.T) {
 	tx.ChainID = nil
 	require.NotNil(t, tx.Validate())
 	tx.ChainID = chainID
+	hashes := tx.BlobHashes
+	tx.BlobHashes = make([][]byte, maxBlobSidecarItems+1)
+	require.NotNil(t, tx.Validate())
+	tx.BlobHashes = hashes
+}
+
+func TestSidecarConversionRejectsInvalidShape(t *testing.T) {
+	ethTx := mockBlobTransaction(uint256.NewInt(20))
+	tx, err := NewBlobTx(ethTx)
+	require.NoError(t, err)
+
+	t.Run("too many empty blobs", func(t *testing.T) {
+		n := 10_000
+		tx.Sidecar = &BlobTxSidecar{
+			Blobs:       make([][]byte, n),
+			Commitments: make([][]byte, n),
+			Proofs:      make([][]byte, n),
+		}
+		require.Error(t, tx.Validate())
+		require.NotPanics(t, func() {
+			data := tx.AsEthereumData().(*ethtypes.BlobTx)
+			require.Nil(t, data.Sidecar)
+		})
+	})
+
+	t.Run("short blob", func(t *testing.T) {
+		tx.Sidecar = &BlobTxSidecar{
+			Blobs:       [][]byte{{0x01}},
+			Commitments: [][]byte{make([]byte, len(kzg4844.Commitment{}))},
+			Proofs:      [][]byte{make([]byte, len(kzg4844.Proof{}))},
+		}
+		require.Error(t, tx.Validate())
+		require.NotPanics(t, func() {
+			data := tx.AsEthereumData().(*ethtypes.BlobTx)
+			require.Nil(t, data.Sidecar)
+		})
+	})
+
+	t.Run("mismatched counts", func(t *testing.T) {
+		tx.Sidecar = &BlobTxSidecar{
+			Blobs:       [][]byte{make([]byte, len(kzg4844.Blob{}))},
+			Commitments: [][]byte{make([]byte, len(kzg4844.Commitment{})), make([]byte, len(kzg4844.Commitment{}))},
+			Proofs:      [][]byte{make([]byte, len(kzg4844.Proof{}))},
+		}
+		require.Error(t, tx.Validate())
+		require.NotPanics(t, func() {
+			data := tx.AsEthereumData().(*ethtypes.BlobTx)
+			require.Nil(t, data.Sidecar)
+		})
+	})
+
+	t.Run("too many commitments only", func(t *testing.T) {
+		tx.Sidecar = &BlobTxSidecar{
+			Blobs:       [][]byte{make([]byte, len(kzg4844.Blob{}))},
+			Commitments: make([][]byte, maxBlobSidecarItems+1),
+			Proofs:      [][]byte{make([]byte, len(kzg4844.Proof{}))},
+		}
+		require.Error(t, tx.Validate())
+		require.NotPanics(t, func() {
+			data := tx.AsEthereumData().(*ethtypes.BlobTx)
+			require.Nil(t, data.Sidecar)
+		})
+	})
 }


### PR DESCRIPTION
## Describe your changes and provide context

`sidecarToEthSidecar` converted protobuf sidecar blobs into fixed-size 131,072-byte KZG blobs via `utils.Map`, which preallocates from the attacker-controlled entry count. Compact empty protobuf entries can therefore force a huge allocation on `AsTransaction` / `AsEthereumData` before ante rejects type 3.

This validates sidecar cardinality (max 6) and exact KZG element lengths **before** that allocation. Invalid sidecars return `nil` instead of converting. `BlobTx.Validate()` uses the same check so `ValidateBasic` rejects the tx. The same patch is mirrored in `giga/deps/xevm`.

Sei still does not execute blob txs, this is just enhanced parsing. The cap of 6 matches the Cancun per-tx count already noted in the commented ante checks; it can be fork-parameterized later if blob execution is enabled.

CON-418

## Testing performed to validate your change

- `go test ./x/evm/types/ethtx` — existing blob tx tests plus new cases for too many empty blobs, short elements, mismatched counts, and over-cap commitments
- `go test ./giga/deps/xevm/types/ethtx` — same coverage on the giga copy